### PR TITLE
Add global supervisor lock (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Both installers render a local service file from templates and inject the curren
 ## Safety model
 
 - never pushes directly to the default branch
+- acquires a global supervisor lock for every `run-once` / loop cycle before mutating state
 - uses issue-specific branches only
 - relies on branch protection for merge safety
 - uses issue locks and session locks to avoid duplicate turns
@@ -178,6 +179,8 @@ Both installers render a local service file from templates and inject the curren
 - handles CI repair, review response, and merge-conflict resolution as separate phases
 - closes merged issues automatically
 - closes parent epic issues automatically when every child issue is closed
+
+If another supervisor process is already active, extra `loop` or `run-once` invocations do not mutate state. They log a skip message and rely on stale-lock cleanup if the previous process died unexpectedly.
 
 ## Current limitations
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,23 @@ function parseArgs(argv: string[]): CliOptions {
   return { command, configPath, dryRun };
 }
 
+async function runOnceWithSupervisorLock(
+  supervisor: Supervisor,
+  command: "loop" | "run-once",
+  options: Pick<CliOptions, "dryRun">,
+): Promise<string> {
+  const lock = await supervisor.acquireSupervisorLock(command);
+  if (!lock.acquired) {
+    return `Skipped supervisor cycle: ${lock.reason}.`;
+  }
+
+  try {
+    return await supervisor.runOnce(options);
+  } finally {
+    await lock.release();
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   const supervisor = Supervisor.fromConfig(options.configPath);
@@ -46,13 +63,13 @@ async function main(): Promise<void> {
   }
 
   if (options.command === "run-once") {
-    console.log(await supervisor.runOnce({ dryRun: options.dryRun }));
+    console.log(await runOnceWithSupervisorLock(supervisor, "run-once", { dryRun: options.dryRun }));
     return;
   }
 
   while (true) {
     try {
-      const message = await supervisor.runOnce({ dryRun: options.dryRun });
+      const message = await runOnceWithSupervisorLock(supervisor, "loop", { dryRun: options.dryRun });
       console.log(`${new Date().toISOString()} ${message}`);
     } catch (error) {
       const message = error instanceof Error ? error.stack ?? error.message : String(error);

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -4,7 +4,7 @@ import { loadConfig } from "./config";
 import { GitHubClient } from "./github";
 import { findBlockingIssue, findParentIssuesReadyToClose } from "./issue-metadata";
 import { hasMeaningfulJournalHandoff, issueJournalPath, readIssueJournal, syncIssueJournal } from "./journal";
-import { acquireFileLock } from "./lock";
+import { acquireFileLock, LockHandle } from "./lock";
 import { StateStore } from "./state-store";
 import {
   CliOptions,
@@ -595,9 +595,13 @@ export class Supervisor {
     return this.config.pollIntervalSeconds * 1000;
   }
 
-  private lockPath(kind: "issues" | "sessions", key: string): string {
+  private lockPath(kind: "issues" | "sessions" | "supervisor", key: string): string {
     const safeKey = key.replace(/[^a-zA-Z0-9._-]/g, "_");
     return path.resolve(path.dirname(this.config.stateFile), "locks", kind, `${safeKey}.lock`);
+  }
+
+  async acquireSupervisorLock(label: "loop" | "run-once"): Promise<LockHandle> {
+    return acquireFileLock(this.lockPath("supervisor", "run"), `supervisor-${label}`);
   }
 
   async status(): Promise<string> {


### PR DESCRIPTION
Closes #3

## Summary
- add a process-wide supervisor lock used by both `loop` and `run-once`
- skip duplicate cycles instead of mutating state concurrently
- document the new runtime behavior in the README

## Verification
- `npm run build`
- node lock-acquisition smoke test against a temporary config
