### PR TITLE
Improve status output and observability (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ node dist/index.js run-once
 node dist/index.js loop
 ```
 
-`status` is intended to be the first place to look during operations. It reports the active issue, current phase, retry counters, failure signature, and live PR/check/review context when a PR exists. If there is no active issue, it reports the latest tracked record instead of only printing an empty state.
+`status` is intended to be the first place to look during operations. It reports the active issue, current state, retry counters, failure signature, and live PR/check/review context when a PR exists. If there is no active issue, it reports the latest tracked record instead of only printing an empty state.
 
 ## Runtime
 

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -472,6 +472,14 @@ function formatStatus(record: IssueRunRecord | null): string {
   ].join(" ");
 }
 
+function sanitizeStatusValue(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value.replace(/\r?\n/g, "\\n");
+}
+
 function summarizeCheckBuckets(checks: PullRequestCheck[]): string {
   if (checks.length === 0) {
     return "none";
@@ -554,7 +562,8 @@ function formatDetailedStatus(args: {
   ];
 
   if (activeRecord.last_error) {
-    lines.push(`last_error=${truncate(activeRecord.last_error, 300)}`);
+    const sanitizedLastError = sanitizeStatusValue(activeRecord.last_error);
+    lines.push(`last_error=${truncate(sanitizedLastError, 300)}`);
   }
 
   if (pr) {
@@ -718,8 +727,12 @@ export class Supervisor {
     const state = await this.stateStore.load();
     const activeRecord =
       state.activeIssueNumber !== null ? state.issues[String(state.activeIssueNumber)] ?? null : null;
-    const latestRecord =
-      Object.values(state.issues).sort((left, right) => right.updated_at.localeCompare(left.updated_at))[0] ?? null;
+    let latestRecord: IssueRunRecord | null = null;
+    for (const record of Object.values(state.issues)) {
+      if (latestRecord === null || record.updated_at.localeCompare(latestRecord.updated_at) > 0) {
+        latestRecord = record;
+      }
+    }
 
     if (!activeRecord) {
       return formatDetailedStatus({
@@ -742,7 +755,7 @@ export class Supervisor {
         checks = await this.github.getChecks(activeRecord.pr_number);
         reviewThreads = await this.github.getUnresolvedCopilotReviewThreads(activeRecord.pr_number);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
         return `${formatDetailedStatus({
           activeRecord,
           latestRecord,


### PR DESCRIPTION
Closes #2

## Summary
- expand `status` to show active issue phase, retries, failure context, and live PR/check/review details
- show the latest tracked record when there is no active issue
- document `status` as the primary operational entry point

## Verification
- `npm run build`
- active-issue status smoke test with a temporary config/state file
- no-active-issue status smoke test with a temporary config/state file
