### PR TITLE
Add SQLite state backend (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Important fields:
 - `repoPath`: absolute path to the managed repository
 - `repoSlug`: `OWNER/REPO`
 - `workspaceRoot`: directory used for per-issue worktrees
+- `stateBackend`: `json` or `sqlite`
 - `stateFile`: local JSON state file
+- `stateBootstrapFile`: optional JSON file to import once when initializing a SQLite state database
 - `codexBinary`: path to the Codex CLI
 - `sharedMemoryFiles`: durable repo-memory files to reference every turn
 - `issueJournalRelativePath`: per-issue handoff journal inside each worktree
@@ -124,6 +126,34 @@ Template shared-memory files are included here:
 - [docs/shared-memory/constitution.example.md](./docs/shared-memory/constitution.example.md)
 - [docs/shared-memory/workflow.example.md](./docs/shared-memory/workflow.example.md)
 - [docs/shared-memory/decisions.example.md](./docs/shared-memory/decisions.example.md)
+
+## State backends
+
+The default state backend is JSON, but SQLite is also supported.
+
+- JSON: simple and easy to inspect, good for local prototypes
+- SQLite: better for schema evolution, recovery, and public/general use
+
+To switch to SQLite, set:
+
+```json
+{
+  "stateBackend": "sqlite",
+  "stateFile": "./.local/state.sqlite"
+}
+```
+
+If you already have JSON state and want a one-time bootstrap into SQLite, also set:
+
+```json
+{
+  "stateBackend": "sqlite",
+  "stateFile": "./.local/state.sqlite",
+  "stateBootstrapFile": "./.local/state.json"
+}
+```
+
+On first load, the supervisor imports the JSON state into SQLite if the SQLite database is empty.
 
 ## Issue metadata
 
@@ -184,7 +214,7 @@ If another supervisor process is already active, extra `loop` or `run-once` invo
 
 ## Current limitations
 
-- JSON state store, not SQLite
+- single state backend per config file
 - single active issue only
 - GitHub-specific workflow assumptions
 - no built-in multi-repo scheduler yet

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -10,6 +10,7 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
   "repoSlug": "TommyKammy/atlaspm",
   "defaultBranch": "main",
   "workspaceRoot": "/Users/yourname/Dev/atlaspm-worktrees",
+  "stateBackend": "json",
   "stateFile": "/Users/yourname/Dev/codex-supervisor/.local/state.json",
   "codexBinary": "/Applications/Codex.app/Contents/Resources/codex",
   "sharedMemoryFiles": [

--- a/docs/examples/atlaspm.supervisor.config.example.json
+++ b/docs/examples/atlaspm.supervisor.config.example.json
@@ -3,6 +3,7 @@
   "repoSlug": "TommyKammy/atlaspm",
   "defaultBranch": "main",
   "workspaceRoot": "/Users/yourname/Dev/atlaspm-worktrees",
+  "stateBackend": "json",
   "stateFile": "/Users/yourname/Dev/codex-supervisor/.local/state.json",
   "codexBinary": "/Applications/Codex.app/Contents/Resources/codex",
   "sharedMemoryFiles": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,15 @@ export function loadConfig(configPath?: string): SupervisorConfig {
     repoSlug: assertString(raw.repoSlug, "repoSlug"),
     defaultBranch: assertString(raw.defaultBranch, "defaultBranch"),
     workspaceRoot: resolveMaybeRelative(configDir, assertString(raw.workspaceRoot, "workspaceRoot")),
+    stateBackend:
+      raw.stateBackend === "sqlite" || raw.stateBackend === "json"
+        ? raw.stateBackend
+        : "json",
     stateFile: resolveMaybeRelative(configDir, assertString(raw.stateFile, "stateFile")),
+    stateBootstrapFile:
+      typeof raw.stateBootstrapFile === "string" && raw.stateBootstrapFile.trim() !== ""
+        ? resolveMaybeRelative(configDir, raw.stateBootstrapFile)
+        : undefined,
     codexBinary: resolveMaybeRelative(configDir, assertString(raw.codexBinary, "codexBinary")),
     sharedMemoryFiles: Array.isArray(raw.sharedMemoryFiles)
       ? raw.sharedMemoryFiles.filter((value): value is string => typeof value === "string")

--- a/src/state-store.ts
+++ b/src/state-store.ts
@@ -1,52 +1,116 @@
 import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { IssueRunRecord, SupervisorStateFile } from "./types";
-import { nowIso, writeJsonAtomic } from "./utils";
+import { ensureDir, nowIso, readJsonIfExists, writeJsonAtomic } from "./utils";
+
+interface StateStoreOptions {
+  backend: "json" | "sqlite";
+  bootstrapFilePath?: string;
+}
+
+const SQLITE_SCHEMA_VERSION = 1;
+
+function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
+  return {
+    ...value,
+    journal_path: value.journal_path ?? null,
+    review_wait_started_at: value.review_wait_started_at ?? null,
+    review_wait_head_sha: value.review_wait_head_sha ?? null,
+    codex_session_id: value.codex_session_id ?? null,
+    timeout_retry_count: value.timeout_retry_count ?? 0,
+    blocked_verification_retry_count: value.blocked_verification_retry_count ?? 0,
+    repeated_blocker_count: value.repeated_blocker_count ?? 0,
+    repeated_failure_signature_count: value.repeated_failure_signature_count ?? 0,
+    last_failure_kind: value.last_failure_kind ?? null,
+    last_failure_context: value.last_failure_context ?? null,
+    last_blocker_signature: value.last_blocker_signature ?? null,
+    last_failure_signature: value.last_failure_signature ?? null,
+    blocked_reason: value.blocked_reason ?? null,
+    processed_review_thread_ids: value.processed_review_thread_ids ?? [],
+  };
+}
+
+function normalizeState(raw: SupervisorStateFile | null | undefined): SupervisorStateFile {
+  const issues = Object.fromEntries(
+    Object.entries(raw?.issues ?? {}).map(([key, value]) => [key, normalizeIssueRecord(value as IssueRunRecord)]),
+  );
+
+  return {
+    activeIssueNumber: raw?.activeIssueNumber ?? null,
+    issues,
+  };
+}
+
+function initSqlite(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS issues (
+      issue_number INTEGER PRIMARY KEY,
+      record_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+
+  db.prepare(`
+    INSERT INTO metadata(key, value)
+    VALUES ('schemaVersion', ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(String(SQLITE_SCHEMA_VERSION));
+}
+
+function readSqliteState(db: DatabaseSync): SupervisorStateFile {
+  const activeRow = db
+    .prepare("SELECT value FROM metadata WHERE key = 'activeIssueNumber'")
+    .get() as { value?: string } | undefined;
+  const rows = db
+    .prepare("SELECT issue_number, record_json FROM issues ORDER BY issue_number ASC")
+    .all() as Array<{ issue_number: number; record_json: string }>;
+
+  const issues = Object.fromEntries(
+    rows.map((row) => {
+      const parsed = JSON.parse(row.record_json) as IssueRunRecord;
+      return [String(row.issue_number), normalizeIssueRecord(parsed)];
+    }),
+  );
+
+  return {
+    activeIssueNumber:
+      activeRow?.value && activeRow.value.trim() !== "" ? Number.parseInt(activeRow.value, 10) : null,
+    issues,
+  };
+}
+
+async function readJsonStateFromFile(filePath: string): Promise<SupervisorStateFile | null> {
+  const raw = await readJsonIfExists<SupervisorStateFile>(filePath);
+  return raw ? normalizeState(raw) : null;
+}
 
 export class StateStore {
-  constructor(private readonly stateFilePath: string) {}
+  constructor(
+    private readonly stateFilePath: string,
+    private readonly options: StateStoreOptions,
+  ) {}
 
   async load(): Promise<SupervisorStateFile> {
-    try {
-      const raw = await fs.readFile(this.stateFilePath, "utf8");
-      const parsed = JSON.parse(raw) as SupervisorStateFile;
-      const issues = Object.fromEntries(
-        Object.entries(parsed.issues ?? {}).map(([key, value]) => [
-          key,
-          {
-            ...value,
-            journal_path: value.journal_path ?? null,
-            review_wait_started_at: value.review_wait_started_at ?? null,
-            review_wait_head_sha: value.review_wait_head_sha ?? null,
-            codex_session_id: value.codex_session_id ?? null,
-            timeout_retry_count: value.timeout_retry_count ?? 0,
-            blocked_verification_retry_count: value.blocked_verification_retry_count ?? 0,
-            repeated_blocker_count: value.repeated_blocker_count ?? 0,
-            repeated_failure_signature_count: value.repeated_failure_signature_count ?? 0,
-            last_failure_kind: value.last_failure_kind ?? null,
-            last_failure_context: value.last_failure_context ?? null,
-            last_blocker_signature: value.last_blocker_signature ?? null,
-            last_failure_signature: value.last_failure_signature ?? null,
-            blocked_reason: value.blocked_reason ?? null,
-            processed_review_thread_ids: value.processed_review_thread_ids ?? [],
-          },
-        ]),
-      );
-      return {
-        activeIssueNumber: parsed.activeIssueNumber ?? null,
-        issues,
-      };
-    } catch (error) {
-      const maybeErr = error as NodeJS.ErrnoException;
-      if (maybeErr.code === "ENOENT") {
-        return this.emptyState();
-      }
-
-      throw error;
+    if (this.options.backend === "sqlite") {
+      return this.loadFromSqlite();
     }
+
+    return this.loadFromJson(this.stateFilePath);
   }
 
   async save(state: SupervisorStateFile): Promise<void> {
-    await writeJsonAtomic(this.stateFilePath, state);
+    if (this.options.backend === "sqlite") {
+      await this.saveToSqlite(normalizeState(state));
+      return;
+    }
+
+    await writeJsonAtomic(this.stateFilePath, normalizeState(state));
   }
 
   touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
@@ -78,5 +142,82 @@ export class StateStore {
       activeIssueNumber: null,
       issues: {},
     };
+  }
+
+  private async loadFromJson(filePath: string): Promise<SupervisorStateFile> {
+    try {
+      const raw = await fs.readFile(filePath, "utf8");
+      return normalizeState(JSON.parse(raw) as SupervisorStateFile);
+    } catch (error) {
+      const maybeErr = error as NodeJS.ErrnoException;
+      if (maybeErr.code === "ENOENT") {
+        return this.emptyState();
+      }
+
+      throw error;
+    }
+  }
+
+  private async loadFromSqlite(): Promise<SupervisorStateFile> {
+    await ensureDir(path.dirname(this.stateFilePath));
+    const db = new DatabaseSync(this.stateFilePath);
+
+    try {
+      initSqlite(db);
+      const currentState = readSqliteState(db);
+      if (Object.keys(currentState.issues).length > 0 || currentState.activeIssueNumber !== null) {
+        return currentState;
+      }
+
+      if (!this.options.bootstrapFilePath) {
+        return this.emptyState();
+      }
+
+      const bootstrapState = await readJsonStateFromFile(this.options.bootstrapFilePath);
+      if (!bootstrapState) {
+        return this.emptyState();
+      }
+
+      await this.saveToSqlite(bootstrapState);
+      return bootstrapState;
+    } finally {
+      db.close();
+    }
+  }
+
+  private async saveToSqlite(state: SupervisorStateFile): Promise<void> {
+    await ensureDir(path.dirname(this.stateFilePath));
+    const db = new DatabaseSync(this.stateFilePath);
+
+    try {
+      initSqlite(db);
+      db.exec("BEGIN IMMEDIATE");
+
+      try {
+        db.prepare(`
+          INSERT INTO metadata(key, value)
+          VALUES (?, ?)
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        `).run("activeIssueNumber", state.activeIssueNumber === null ? "" : String(state.activeIssueNumber));
+
+        db.exec("DELETE FROM issues");
+        const insertIssue = db.prepare(`
+          INSERT INTO issues(issue_number, record_json, updated_at)
+          VALUES (?, ?, ?)
+        `);
+
+        for (const record of Object.values(state.issues)) {
+          const normalized = normalizeIssueRecord(record);
+          insertIssue.run(normalized.issue_number, JSON.stringify(normalized), normalized.updated_at);
+        }
+
+        db.exec("COMMIT");
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    } finally {
+      db.close();
+    }
   }
 }

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -584,7 +584,10 @@ export class Supervisor {
 
   constructor(private readonly config: SupervisorConfig) {
     this.github = new GitHubClient(config);
-    this.stateStore = new StateStore(config.stateFile);
+    this.stateStore = new StateStore(config.stateFile, {
+      backend: config.stateBackend,
+      bootstrapFilePath: config.stateBootstrapFile,
+    });
   }
 
   static fromConfig(configPath?: string): Supervisor {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,9 @@ export interface SupervisorConfig {
   repoSlug: string;
   defaultBranch: string;
   workspaceRoot: string;
+  stateBackend: "json" | "sqlite";
   stateFile: string;
+  stateBootstrapFile?: string;
   codexBinary: string;
   sharedMemoryFiles: string[];
   issueJournalRelativePath: string;

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -3,7 +3,9 @@
   "repoSlug": "OWNER/REPO",
   "defaultBranch": "main",
   "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
   "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
   "codexBinary": "/absolute/path/to/codex",
   "sharedMemoryFiles": [
     "README.md",


### PR DESCRIPTION
Closes #1

## Summary
- add selectable JSON and SQLite state backends
- support one-time JSON bootstrap into an empty SQLite state database
- document backend selection and migration in the README and examples

## Verification
- `npm run build`
- JSON load/save smoke test via `StateStore`
- SQLite bootstrap + save + reload smoke test via `StateStore`
