### PR TITLE
Fix draft PR rehydration for tracked issues (#7)

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -129,11 +129,36 @@ export class GitHubClient {
   }
 
   async getPullRequestIfExists(prNumber: number): Promise<GitHubPullRequest | null> {
-    try {
-      return await this.getPullRequest(prNumber);
-    } catch {
+    const result = await runCommand(
+      "gh",
+      [
+        "pr",
+        "view",
+        String(prNumber),
+        "--repo",
+        this.config.repoSlug,
+        "--json",
+        "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
+      ],
+      { allowExitCodes: [0, 1] },
+    );
+
+    if (result.exitCode === 0) {
+      return parseJson<GitHubPullRequest>(result.stdout);
+    }
+
+    const stderr = result.stderr.toLowerCase();
+    if (
+      stderr.includes("pull request not found") ||
+      stderr.includes("could not find pull request") ||
+      stderr.includes("no pull requests match")
+    ) {
       return null;
     }
+
+    throw new Error(
+      `Failed to get pull request #${prNumber}: ${result.stderr.trim() || `exit code ${result.exitCode}`}`,
+    );
   }
 
   async resolvePullRequestForBranch(

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -756,24 +756,22 @@ export class Supervisor {
     let checks: PullRequestCheck[] = [];
     let reviewThreads: ReviewThread[] = [];
 
-    if (activeRecord.pr_number !== null || activeRecord.branch) {
-      try {
-        pr = await this.github.resolvePullRequestForBranch(activeRecord.branch, activeRecord.pr_number);
-        if (isOpenPullRequest(pr)) {
-          checks = await this.github.getChecks(pr.number);
-          reviewThreads = await this.github.getUnresolvedCopilotReviewThreads(pr.number);
-        }
-      } catch (error) {
-        const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
-        return `${formatDetailedStatus({
-          activeRecord,
-          latestRecord,
-          trackedIssueCount: Object.keys(state.issues).length,
-          pr,
-          checks,
-          reviewThreads,
-        })}\nstatus_warning=${truncate(message, 200)}`;
+    try {
+      pr = await this.github.resolvePullRequestForBranch(activeRecord.branch, activeRecord.pr_number);
+      if (isOpenPullRequest(pr)) {
+        checks = await this.github.getChecks(pr.number);
+        reviewThreads = await this.github.getUnresolvedCopilotReviewThreads(pr.number);
       }
+    } catch (error) {
+      const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
+      return `${formatDetailedStatus({
+        activeRecord,
+        latestRecord,
+        trackedIssueCount: Object.keys(state.issues).length,
+        pr,
+        checks,
+        reviewThreads,
+      })}\nstatus_warning=${truncate(message, 200)}`;
     }
 
     return formatDetailedStatus({


### PR DESCRIPTION
Closes #7

## Summary
- rehydrate tracked PR state from the branch even when local state still has pr_number=null
- reuse the same PR resolution path in both runOnce and status so draft PRs are not shown as pr=none
- persist the discovered PR number and continue the draft -> ready transition flow once checks are green

## Verification
- npm run build