### PR TITLE
Fallback check lookup to PR status rollup

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -270,8 +270,12 @@ export class GitHubClient {
     );
 
     const trimmed = result.stdout.trim();
-    if (result.exitCode === 0 && trimmed !== "") {
-      return parseJson<PullRequestCheck[]>(trimmed);
+    if (trimmed !== "") {
+      try {
+        return parseJson<PullRequestCheck[]>(trimmed);
+      } catch {
+        // Fall back to statusCheckRollup when gh pr checks emitted non-JSON or incompatible JSON.
+      }
     }
 
     const fallback = await runCommand(


### PR DESCRIPTION
## Summary\n- stop silently treating check lookup failures as no checks\n- fall back from `gh pr checks --json` to `gh pr view --json statusCheckRollup`\n- keep CI repair logic working on hosts with older or field-incompatible gh versions\n\n## Testing\n- npm run build\n- node -e "const {GitHubClient}=require('./dist/github.js'); ... getChecks(257)"