### PR TITLE
Persist PR attachment before later transitions

### DIFF
--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1137,6 +1137,9 @@ export class Supervisor {
           ...applyFailureSignature(record, failureContext),
           blocked_reason: nextState === "blocked" ? blockedReasonFromReviewState(this.config, reviewThreads) : null,
         });
+        state.issues[String(record.issue_number)] = record;
+        await this.stateStore.save(state);
+
         if (failureContext && shouldStopForRepeatedFailureSignature(record, this.config)) {
           record = this.stateStore.touch(record, {
             state: "failed",


### PR DESCRIPTION
## Summary
- persist resolved PR metadata as soon as the supervisor rehydrates an open PR
- avoid leaving `pr=none` in state if a later transition in the same cycle throws or exits early
- keep draft PRs attached to the active issue during local review / ready transitions

## Testing
- npm run build