### PR TITLE
Report auto-detect reasons for local review roles (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ If `localReviewRoles` is empty and `localReviewAutoDetect` is enabled, the super
 - adds `workflow_test_reviewer` when workflow-oriented test files are present
 - adds `portability_reviewer` for repos where shell/runtime portability is likely to matter
 
+The local review artifacts explain these choices in two forms: the Markdown summary has a concise `Auto-detected roles` section, and the JSON artifact includes machine-readable `autoDetectedRoles` entries with `kind`, `signal`, and `paths`. If you later want deterministic manual control, inspect those reasons, copy the roles you want into `localReviewRoles`, and disable `localReviewAutoDetect`.
+
 Use explicit `localReviewRoles` when you want full manual control.
 
 This review does not mutate code. By default, `localReviewPolicy` is `block_ready`, so actionable findings keep a draft PR from becoming ready until the branch is updated and re-reviewed.

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -234,6 +234,13 @@ baseline は次です。
 - workflow 向け test がある -> `workflow_test_reviewer`
 - Node/script-heavy または workflow-heavy な repo -> `portability_reviewer`
 
+生成される local review artifact には、各 auto-detected role が選ばれた理由も入ります。
+
+- Markdown summary には `Auto-detected roles` セクションが追加され、signal を短く確認できます
+- JSON artifact には `autoDetectedRoles` が入り、role ごとに `kind`、`signal`、`paths` を machine-readable に保存します
+
+manual override に切り替えたいときは、まずこの理由データを見て必要な role だけを `localReviewRoles` にコピーし、`localReviewAutoDetect` を `false` にします。これで specialist を維持しつつ、role 選択を deterministic にできます。
+
 初回セットアップでは、最初から role 設計を細かくしなくてよいので、この方法が扱いやすいです。
 
 ### 方法 2: role を明示指定する

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -228,6 +228,13 @@ Then the supervisor adds specialists when the repo suggests them. For example:
 - workflow-focused tests present -> `workflow_test_reviewer`
 - Node/script-heavy or workflow-heavy repo -> `portability_reviewer`
 
+The generated local review artifacts now show why each auto-detected role was selected:
+
+- the Markdown summary includes an `Auto-detected roles` section with concise signal summaries
+- the JSON artifact includes `autoDetectedRoles`, with machine-readable `kind`, `signal`, and `paths` fields for each selected role
+
+When you want to override auto-detect manually, inspect those reasons first, then copy only the roles you want into `localReviewRoles` and set `localReviewAutoDetect` to `false`. That preserves the useful specialists while making the swarm deterministic.
+
 This works well for first-time setup because you do not need to design the swarm up front.
 
 ### Option 2: Explicit roles

--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { finalizeLocalReview, shouldRunLocalReview } from "./local-review";
+import { LocalReviewRoleSelection } from "./review-role-detector";
 import { GitHubPullRequest, SupervisorConfig } from "./types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -65,6 +66,19 @@ function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPu
     headRefOid: "abcdef1234567890",
     ...overrides,
   };
+}
+
+function createDetectedRoles(): LocalReviewRoleSelection[] {
+  return [
+    {
+      role: "reviewer",
+      reasons: [{ kind: "baseline", signal: "default", paths: [] }],
+    },
+    {
+      role: "prisma_postgres_reviewer",
+      reasons: [{ kind: "repo_signal", signal: "prisma", paths: ["prisma/schema.prisma"] }],
+    },
+  ];
 }
 
 test("shouldRunLocalReview reruns on ready PR head updates when block_merge is enabled", () => {
@@ -200,4 +214,39 @@ test("finalizeLocalReview propagates verifier degradation to top-level result", 
   assert.equal(result.recommendation, "unknown");
   assert.equal(result.artifact.degraded, true);
   assert.equal(result.artifact.verification.degraded, true);
+});
+
+test("finalizeLocalReview includes auto-detect reasons in the artifact", () => {
+  const result = finalizeLocalReview({
+    config: createConfig({ localReviewConfidenceThreshold: 0.7 }),
+    issueNumber: 39,
+    prNumber: 13,
+    branch: "codex/issue-39",
+    headSha: "feedfacecafebeef",
+    detectedRoles: createDetectedRoles(),
+    roleResults: [
+      {
+        role: "reviewer",
+        summary: "No issues found.",
+        recommendation: "ready",
+        degraded: false,
+        exitCode: 0,
+        rawOutput: "review raw output",
+        findings: [],
+      },
+      {
+        role: "prisma_postgres_reviewer",
+        summary: "Checked schema and migrations.",
+        recommendation: "ready",
+        degraded: false,
+        exitCode: 0,
+        rawOutput: "prisma raw output",
+        findings: [],
+      },
+    ],
+    verifierReport: null,
+    ranAt: "2026-03-12T01:00:00Z",
+  });
+
+  assert.deepEqual(result.artifact.autoDetectedRoles, createDetectedRoles());
 });

--- a/src/local-review.ts
+++ b/src/local-review.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { runCommand } from "./command";
 import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
-import { detectLocalReviewRoles } from "./review-role-detector";
+import { detectLocalReviewRoleSelections, type LocalReviewRoleSelection } from "./review-role-detector";
 import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "./types";
 import { ensureDir, nowIso, truncate } from "./utils";
 
@@ -71,6 +71,7 @@ interface LocalReviewArtifact {
   ranAt: string;
   confidenceThreshold: number;
   roles: string[];
+  autoDetectedRoles: LocalReviewRoleSelection[];
   summary: string;
   recommendation: "ready" | "changes_requested" | "unknown";
   degraded: boolean;
@@ -524,6 +525,31 @@ function summarizeRoles(roleResults: LocalReviewRoleResult[]): string {
     : "- local review completed without structured role summaries.";
 }
 
+function formatRoleSelectionReason(reason: LocalReviewRoleSelection["reasons"][number]): string {
+  const suffix = reason.paths.length > 0 ? ` (${reason.paths.join(", ")})` : "";
+  switch (reason.kind) {
+    case "baseline":
+      return `baseline${suffix}`;
+    case "config_signal":
+      return `${reason.signal}${suffix}`;
+    case "repo_signal":
+      return `${reason.signal}${suffix}`;
+  }
+}
+
+function summarizeAutoDetectedRoles(detectedRoles: LocalReviewRoleSelection[]): string[] {
+  const specialistSelections = detectedRoles.filter(
+    (selection) => selection.role !== "reviewer" && selection.role !== "explorer",
+  );
+  if (specialistSelections.length === 0) {
+    return ["- No specialist roles were auto-detected beyond the baseline reviewer/explorer pair."];
+  }
+
+  return specialistSelections
+    .slice(0, 10)
+    .map((selection) => `- ${selection.role}: ${selection.reasons.map(formatRoleSelectionReason).join("; ")}`);
+}
+
 function renderLines(finding: LocalReviewFinding): string {
   if (finding.start == null) {
     return "?";
@@ -710,6 +736,7 @@ export function finalizeLocalReview(args: {
   prNumber: number;
   branch: string;
   headSha: string;
+  detectedRoles?: LocalReviewRoleSelection[];
   roleResults: LocalReviewRoleResult[];
   verifierReport: LocalReviewVerifierReport | null;
   ranAt: string;
@@ -740,6 +767,7 @@ export function finalizeLocalReview(args: {
     ranAt: args.ranAt,
     confidenceThreshold: args.config.localReviewConfidenceThreshold,
     roles,
+    autoDetectedRoles: args.detectedRoles ?? [],
     summary,
     recommendation,
     degraded,
@@ -813,11 +841,15 @@ export async function runLocalReview(args: {
   alwaysReadFiles: string[];
   onDemandFiles: string[];
 }): Promise<LocalReviewResult> {
+  const detectedRoles =
+    args.config.localReviewRoles.length === 0 && args.config.localReviewAutoDetect
+      ? await detectLocalReviewRoleSelections(args.config)
+      : [];
   const roles =
     args.config.localReviewRoles.length > 0
       ? args.config.localReviewRoles
-      : args.config.localReviewAutoDetect
-        ? await detectLocalReviewRoles(args.config)
+      : detectedRoles.length > 0
+        ? detectedRoles.map((selection) => selection.role)
         : ["reviewer", "explorer"];
   const roleResults: LocalReviewRoleResult[] = new Array(roles.length);
   const concurrency = Math.min(2, roles.length);
@@ -864,6 +896,7 @@ export async function runLocalReview(args: {
     prNumber: args.pr.number,
     branch: args.branch,
     headSha: args.pr.headRefOid,
+    detectedRoles,
     roleResults,
     verifierReport,
     ranAt,
@@ -894,6 +927,9 @@ export async function runLocalReview(args: {
       `- Verified max severity: ${finalized.verifiedMaxSeverity}`,
       `- Recommendation: ${finalized.recommendation}`,
       `- Degraded: ${finalized.degraded ? "yes" : "no"}`,
+      "",
+      "## Auto-detected roles",
+      ...summarizeAutoDetectedRoles(finalized.artifact.autoDetectedRoles),
       "",
       "## Role summaries",
       summarizeRoles(roleResults),

--- a/src/review-role-detector.test.ts
+++ b/src/review-role-detector.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { detectLocalReviewRoles } from "./review-role-detector";
+import { detectLocalReviewRoleSelections, detectLocalReviewRoles } from "./review-role-detector";
 import { SupervisorConfig } from "./types";
 
 function createConfig(repoPath: string, overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -78,6 +78,48 @@ test("detectLocalReviewRoles adds prisma specialists for prisma repos", async (t
     "contract_consistency_reviewer",
     "portability_reviewer",
   ]);
+});
+
+test("detectLocalReviewRoleSelections records machine-readable reasons for auto-detected roles", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-roles-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.writeFile(path.join(repoPath, "package.json"), "{}\n", "utf8");
+  await fs.mkdir(path.join(repoPath, "prisma"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, "prisma", "schema.prisma"), "datasource db { provider = \"postgresql\" }\n", "utf8");
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, "docs", "architecture.md"), "# Architecture\n", "utf8");
+  await fs.mkdir(path.join(repoPath, "apps", "core-api", "prisma", "migrations"), { recursive: true });
+  await fs.mkdir(path.join(repoPath, "packages", "contracts"), { recursive: true });
+
+  const selections = await detectLocalReviewRoleSelections(createConfig(repoPath));
+
+  assert.deepEqual(
+    selections.map((selection) => ({
+      role: selection.role,
+      reasonKinds: selection.reasons.map((reason) => reason.kind),
+    })),
+    [
+      { role: "reviewer", reasonKinds: ["baseline"] },
+      { role: "explorer", reasonKinds: ["baseline"] },
+      { role: "docs_researcher", reasonKinds: ["repo_signal"] },
+      { role: "prisma_postgres_reviewer", reasonKinds: ["repo_signal"] },
+      { role: "migration_invariant_reviewer", reasonKinds: ["repo_signal", "repo_signal"] },
+      { role: "contract_consistency_reviewer", reasonKinds: ["repo_signal", "repo_signal"] },
+      { role: "portability_reviewer", reasonKinds: ["repo_signal"] },
+    ],
+  );
+  assert.deepEqual(selections[2]?.reasons[0], {
+    kind: "repo_signal",
+    signal: "docs",
+    paths: ["docs"],
+  });
+  assert.deepEqual(selections[3]?.reasons[0], {
+    kind: "repo_signal",
+    signal: "prisma",
+    paths: ["prisma/schema.prisma"],
+  });
 });
 
 test("detectLocalReviewRoles adds UI reviewer for playwright repos", async (t) => {

--- a/src/review-role-detector.ts
+++ b/src/review-role-detector.ts
@@ -2,6 +2,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SupervisorConfig } from "./types";
 
+export interface LocalReviewRoleReason {
+  kind: "baseline" | "repo_signal" | "config_signal";
+  signal: string;
+  paths: string[];
+}
+
+export interface LocalReviewRoleSelection {
+  role: string;
+  reasons: LocalReviewRoleReason[];
+}
+
 async function existsAt(repoPath: string, relativePath: string): Promise<boolean> {
   try {
     await fs.access(path.join(repoPath, relativePath));
@@ -11,57 +22,58 @@ async function existsAt(repoPath: string, relativePath: string): Promise<boolean
   }
 }
 
-async function existsAny(repoPath: string, relativePaths: string[]): Promise<boolean> {
+async function matchingPaths(repoPath: string, relativePaths: string[]): Promise<string[]> {
+  const matches: string[] = [];
   for (const relativePath of relativePaths) {
     if (await existsAt(repoPath, relativePath)) {
-      return true;
+      matches.push(relativePath);
     }
   }
 
-  return false;
+  return matches;
 }
 
 async function detectRepoSignals(repoPath: string): Promise<{
-  hasDocs: boolean;
-  hasTypescript: boolean;
-  hasPython: boolean;
-  hasGo: boolean;
-  hasRust: boolean;
-  hasElixir: boolean;
-  hasRuby: boolean;
-  hasPrisma: boolean;
-  hasMigrations: boolean;
-  hasContracts: boolean;
-  hasPlaywright: boolean;
-  hasGithubActions: boolean;
-  hasWorkflowTests: boolean;
-  hasNodeScripts: boolean;
+  docs: string[];
+  typescript: string[];
+  python: string[];
+  go: string[];
+  rust: string[];
+  elixir: string[];
+  ruby: string[];
+  prisma: string[];
+  migrations: string[];
+  contracts: string[];
+  playwright: string[];
+  githubActions: string[];
+  workflowTests: string[];
+  nodeScripts: string[];
 }> {
   const [
-    hasDocs,
-    hasTypescript,
-    hasPython,
-    hasGo,
-    hasRust,
-    hasElixir,
-    hasRuby,
-    hasPrisma,
-    hasMigrations,
-    hasContracts,
-    hasPlaywright,
-    hasGithubActions,
-    hasWorkflowTests,
-    hasNodeScripts,
+    docs,
+    typescript,
+    python,
+    go,
+    rust,
+    elixir,
+    ruby,
+    prisma,
+    migrations,
+    contracts,
+    playwright,
+    githubActions,
+    workflowTests,
+    nodeScripts,
   ] = await Promise.all([
-    existsAny(repoPath, ["docs", "README.md", "PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"]),
-    existsAny(repoPath, ["package.json", "tsconfig.json"]),
-    existsAny(repoPath, ["pyproject.toml", "requirements.txt", "setup.py"]),
-    existsAny(repoPath, ["go.mod"]),
-    existsAny(repoPath, ["Cargo.toml"]),
-    existsAny(repoPath, ["mix.exs"]),
-    existsAny(repoPath, ["Gemfile"]),
-    existsAny(repoPath, ["prisma/schema.prisma", "apps/core-api/prisma/schema.prisma"]),
-    existsAny(repoPath, [
+    matchingPaths(repoPath, ["docs", "README.md", "PROJECT.md", "REQUIREMENTS.md", "ROADMAP.md", "STATE.md"]),
+    matchingPaths(repoPath, ["package.json", "tsconfig.json"]),
+    matchingPaths(repoPath, ["pyproject.toml", "requirements.txt", "setup.py"]),
+    matchingPaths(repoPath, ["go.mod"]),
+    matchingPaths(repoPath, ["Cargo.toml"]),
+    matchingPaths(repoPath, ["mix.exs"]),
+    matchingPaths(repoPath, ["Gemfile"]),
+    matchingPaths(repoPath, ["prisma/schema.prisma", "apps/core-api/prisma/schema.prisma"]),
+    matchingPaths(repoPath, [
       "prisma/migrations",
       "apps/core-api/prisma/migrations",
       "migrations",
@@ -70,7 +82,7 @@ async function detectRepoSignals(repoPath: string): Promise<{
       "alembic",
       "alembic.ini",
     ]),
-    existsAny(repoPath, [
+    matchingPaths(repoPath, [
       "contracts",
       "openapi.yaml",
       "openapi.yml",
@@ -79,75 +91,147 @@ async function detectRepoSignals(repoPath: string): Promise<{
       "apps/core-api/src/contracts",
       "packages/contracts",
     ]),
-    existsAny(repoPath, ["playwright.config.ts", "playwright.config.js", "e2e/playwright"]),
-    existsAny(repoPath, [".github/workflows"]),
-    existsAny(repoPath, [
+    matchingPaths(repoPath, ["playwright.config.ts", "playwright.config.js", "e2e/playwright"]),
+    matchingPaths(repoPath, [".github/workflows"]),
+    matchingPaths(repoPath, [
       "src/ci-workflow.test.ts",
       "src/workflow.test.ts",
       "test/ci-workflow.test.ts",
       "tests/ci-workflow.test.ts",
     ]),
-    existsAny(repoPath, ["package.json"]),
+    matchingPaths(repoPath, ["package.json"]),
   ]);
 
   return {
-    hasDocs,
-    hasTypescript,
-    hasPython,
-    hasGo,
-    hasRust,
-    hasElixir,
-    hasRuby,
-    hasPrisma,
-    hasMigrations,
-    hasContracts,
-    hasPlaywright,
-    hasGithubActions,
-    hasWorkflowTests,
-    hasNodeScripts,
+    docs,
+    typescript,
+    python,
+    go,
+    rust,
+    elixir,
+    ruby,
+    prisma,
+    migrations,
+    contracts,
+    playwright,
+    githubActions,
+    workflowTests,
+    nodeScripts,
   };
 }
 
-export async function detectLocalReviewRoles(config: SupervisorConfig): Promise<string[]> {
-  const roles = new Set<string>(["reviewer", "explorer"]);
+function hasMatches(paths: string[]): boolean {
+  return paths.length > 0;
+}
+
+function addSelection(
+  selections: LocalReviewRoleSelection[],
+  role: string,
+  reasons: LocalReviewRoleReason[],
+): void {
+  if (reasons.length === 0) {
+    return;
+  }
+  selections.push({ role, reasons });
+}
+
+export async function detectLocalReviewRoleSelections(config: SupervisorConfig): Promise<LocalReviewRoleSelection[]> {
   const signals = await detectRepoSignals(config.repoPath);
-  const hasDurableMemorySignals =
-    config.sharedMemoryFiles.length > 0 ||
-    (config.gsdEnabled === true &&
-      config.gsdPlanningFiles.length > 0 &&
-      (await existsAny(config.repoPath, config.gsdPlanningFiles)));
+  const selections: LocalReviewRoleSelection[] = [
+    {
+      role: "reviewer",
+      reasons: [{ kind: "baseline", signal: "default", paths: [] }],
+    },
+    {
+      role: "explorer",
+      reasons: [{ kind: "baseline", signal: "default", paths: [] }],
+    },
+  ];
+  const durableMemoryPaths =
+    config.gsdEnabled === true && config.gsdPlanningFiles.length > 0
+      ? await matchingPaths(config.repoPath, config.gsdPlanningFiles)
+      : [];
 
-  if (signals.hasDocs || hasDurableMemorySignals) {
-    roles.add("docs_researcher");
+  const docsReasons: LocalReviewRoleReason[] = [];
+  if (hasMatches(signals.docs)) {
+    docsReasons.push({ kind: "repo_signal", signal: "docs", paths: signals.docs });
+  }
+  if (config.sharedMemoryFiles.length > 0) {
+    docsReasons.push({ kind: "config_signal", signal: "shared_memory_files", paths: config.sharedMemoryFiles });
+  }
+  if (durableMemoryPaths.length > 0) {
+    docsReasons.push({ kind: "config_signal", signal: "gsd_planning_files", paths: durableMemoryPaths });
+  }
+  addSelection(selections, "docs_researcher", docsReasons);
+
+  if (hasMatches(signals.prisma)) {
+    addSelection(selections, "prisma_postgres_reviewer", [
+      { kind: "repo_signal", signal: "prisma", paths: signals.prisma },
+    ]);
   }
 
-  if (signals.hasPrisma) {
-    roles.add("prisma_postgres_reviewer");
+  if (
+    hasMatches(signals.migrations) &&
+    (hasMatches(signals.typescript) ||
+      hasMatches(signals.python) ||
+      hasMatches(signals.go) ||
+      hasMatches(signals.elixir) ||
+      hasMatches(signals.ruby))
+  ) {
+    const reasons: LocalReviewRoleReason[] = [{ kind: "repo_signal", signal: "migrations", paths: signals.migrations }];
+    if (hasMatches(signals.typescript)) {
+      reasons.push({ kind: "repo_signal", signal: "typescript", paths: signals.typescript });
+    } else if (hasMatches(signals.python)) {
+      reasons.push({ kind: "repo_signal", signal: "python", paths: signals.python });
+    } else if (hasMatches(signals.go)) {
+      reasons.push({ kind: "repo_signal", signal: "go", paths: signals.go });
+    } else if (hasMatches(signals.elixir)) {
+      reasons.push({ kind: "repo_signal", signal: "elixir", paths: signals.elixir });
+    } else if (hasMatches(signals.ruby)) {
+      reasons.push({ kind: "repo_signal", signal: "ruby", paths: signals.ruby });
+    }
+    addSelection(selections, "migration_invariant_reviewer", reasons);
   }
 
-  if (signals.hasMigrations && (signals.hasTypescript || signals.hasPython || signals.hasGo || signals.hasElixir || signals.hasRuby)) {
-    roles.add("migration_invariant_reviewer");
+  if (hasMatches(signals.contracts) && (hasMatches(signals.typescript) || hasMatches(signals.python))) {
+    addSelection(selections, "contract_consistency_reviewer", [
+      { kind: "repo_signal", signal: "contracts", paths: signals.contracts },
+      hasMatches(signals.typescript)
+        ? { kind: "repo_signal", signal: "typescript", paths: signals.typescript }
+        : { kind: "repo_signal", signal: "python", paths: signals.python },
+    ]);
   }
 
-  if (signals.hasContracts && (signals.hasTypescript || signals.hasPython)) {
-    roles.add("contract_consistency_reviewer");
+  if (hasMatches(signals.playwright)) {
+    addSelection(selections, "ui_regression_reviewer", [
+      { kind: "repo_signal", signal: "playwright", paths: signals.playwright },
+    ]);
   }
 
-  if (signals.hasPlaywright) {
-    roles.add("ui_regression_reviewer");
+  if (hasMatches(signals.githubActions)) {
+    addSelection(selections, "github_actions_semantics_reviewer", [
+      { kind: "repo_signal", signal: "github_actions", paths: signals.githubActions },
+    ]);
   }
 
-  if (signals.hasGithubActions) {
-    roles.add("github_actions_semantics_reviewer");
+  if (hasMatches(signals.githubActions) && hasMatches(signals.workflowTests)) {
+    addSelection(selections, "workflow_test_reviewer", [
+      { kind: "repo_signal", signal: "github_actions", paths: signals.githubActions },
+      { kind: "repo_signal", signal: "workflow_tests", paths: signals.workflowTests },
+    ]);
   }
 
-  if (signals.hasGithubActions && signals.hasWorkflowTests) {
-    roles.add("workflow_test_reviewer");
+  if (hasMatches(signals.nodeScripts) || hasMatches(signals.githubActions)) {
+    addSelection(selections, "portability_reviewer", [
+      hasMatches(signals.nodeScripts)
+        ? { kind: "repo_signal", signal: "node_scripts", paths: signals.nodeScripts }
+        : { kind: "repo_signal", signal: "github_actions", paths: signals.githubActions },
+    ]);
   }
 
-  if (signals.hasNodeScripts || signals.hasGithubActions) {
-    roles.add("portability_reviewer");
-  }
+  return selections;
+}
 
-  return [...roles];
+export async function detectLocalReviewRoles(config: SupervisorConfig): Promise<string[]> {
+  return (await detectLocalReviewRoleSelections(config)).map((selection) => selection.role);
 }


### PR DESCRIPTION
Closes #39
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the issue end-to-end on `codex/issue-39` in commit `66bb86c` (`Report local review auto-detect reasons`).

The main change is that auto-detected local review roles now carry structured reason data from the detector through to the saved artifact. The detector in [src/review-role-detector.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/src/review-role-detector.ts) now returns per-role reason objects (`kind`, `signal`, `paths`), [src/local-review.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/src/local-review.ts) writes those into the JSON artifact as `autoDetectedRoles`, and the Markdown summary now includes a concise `Auto-detected roles` section explaining specialist-role selection. Focused regression coverage was added in [src/review-role-detector.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/src/review-role-detector.test.ts) and [src/local-review.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/src/local-review.test.ts).

I also updated the operator docs in [docs/getting-started.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/docs/getting-started.md), [docs/getting-started.ja.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/docs/getting-started.ja.md), and [README.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-39/README.md) to explain where to find the reason data and how to use it when switching from auto-detect to explicit `localReviewRoles`.

Verification: `...