### PR TITLE
Add table-driven coverage for local review gating policies (#40)

### DIFF
--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -81,20 +81,65 @@ function createDetectedRoles(): LocalReviewRoleSelection[] {
   ];
 }
 
-test("shouldRunLocalReview reruns on ready PR head updates when block_merge is enabled", () => {
-  const config = createConfig({ localReviewPolicy: "block_merge" });
-  const record = { local_review_head_sha: "oldhead" };
-  const pr = createPullRequest({ isDraft: false, headRefOid: "newhead" });
+test("shouldRunLocalReview covers draft and ready policy gating combinations", () => {
+  const cases: Array<{
+    name: string;
+    config: Partial<SupervisorConfig>;
+    recordHead: string | null;
+    pr: Partial<GitHubPullRequest>;
+    expected: boolean;
+  }> = [
+    {
+      name: "draft PR runs review before first ready transition across policies",
+      config: { localReviewPolicy: "advisory" },
+      recordHead: null,
+      pr: { isDraft: true, headRefOid: "newhead" },
+      expected: true,
+    },
+    {
+      name: "draft PR does not rerun when the head sha is unchanged",
+      config: { localReviewPolicy: "block_ready" },
+      recordHead: "samehead",
+      pr: { isDraft: true, headRefOid: "samehead" },
+      expected: false,
+    },
+    {
+      name: "ready PR reruns on head updates when block_merge is enabled",
+      config: { localReviewPolicy: "block_merge" },
+      recordHead: "oldhead",
+      pr: { isDraft: false, headRefOid: "newhead" },
+      expected: true,
+    },
+    {
+      name: "ready PR does not rerun on head updates in advisory mode",
+      config: { localReviewPolicy: "advisory" },
+      recordHead: "oldhead",
+      pr: { isDraft: false, headRefOid: "newhead" },
+      expected: false,
+    },
+    {
+      name: "ready PR does not rerun on head updates in block_ready mode",
+      config: { localReviewPolicy: "block_ready" },
+      recordHead: "oldhead",
+      pr: { isDraft: false, headRefOid: "newhead" },
+      expected: false,
+    },
+    {
+      name: "local review disabled suppresses draft gating",
+      config: { localReviewEnabled: false, localReviewPolicy: "block_merge" },
+      recordHead: null,
+      pr: { isDraft: true, headRefOid: "newhead" },
+      expected: false,
+    },
+  ];
 
-  assert.equal(shouldRunLocalReview(config, record, pr), true);
-});
+  for (const testCase of cases) {
+    const config = createConfig(testCase.config);
+    const record = { local_review_head_sha: testCase.recordHead };
+    const pr = createPullRequest(testCase.pr);
 
-test("shouldRunLocalReview does not rerun on ready PR head updates in advisory mode", () => {
-  const config = createConfig({ localReviewPolicy: "advisory" });
-  const record = { local_review_head_sha: "oldhead" };
-  const pr = createPullRequest({ isDraft: false, headRefOid: "newhead" });
-
-  assert.equal(shouldRunLocalReview(config, record, pr), false);
+    assert.equal(shouldRunLocalReview(config, record, pr), testCase.expected, testCase.name);
+  }
 });
 
 test("finalizeLocalReview keeps raw high-severity findings separate from dismissed verifier results", () => {

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -306,6 +306,161 @@ test("inferStateFromPullRequest forces implementing for actionable high local-re
   assert.equal(inferStateFromPullRequest(config, record, pr, [], []), "implementing");
 });
 
+test("inferStateFromPullRequest covers local review policy gating combinations", () => {
+  const cases: Array<{
+    name: string;
+    config: Partial<SupervisorConfig>;
+    record: Partial<IssueRunRecord>;
+    pr: Partial<GitHubPullRequest>;
+    expected: IssueRunRecord["state"];
+  }> = [
+    {
+      name: "block_ready keeps draft PRs in draft_pr when raw findings exist on the current head",
+      config: { localReviewEnabled: true, localReviewPolicy: "block_ready", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "draft_pr",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 2,
+        local_review_recommendation: "changes_requested",
+      },
+      pr: { isDraft: true, headRefOid: "head123" },
+      expected: "draft_pr",
+    },
+    {
+      name: "block_ready does not block a ready PR after it becomes ready",
+      config: { localReviewEnabled: true, localReviewPolicy: "block_ready", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 2,
+        local_review_recommendation: "changes_requested",
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "ready_to_merge",
+    },
+    {
+      name: "block_merge blocks merge for ready PRs with actionable findings on the current head",
+      config: { localReviewEnabled: true, localReviewPolicy: "block_merge", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 2,
+        local_review_recommendation: "changes_requested",
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "blocked",
+    },
+    {
+      name: "block_merge stops gating once the review head becomes stale",
+      config: { localReviewEnabled: true, localReviewPolicy: "block_merge", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "oldhead",
+        local_review_findings_count: 2,
+        local_review_recommendation: "changes_requested",
+      },
+      pr: { isDraft: false, headRefOid: "newhead" },
+      expected: "ready_to_merge",
+    },
+    {
+      name: "advisory never blocks merge for ready PRs with raw findings",
+      config: { localReviewEnabled: true, localReviewPolicy: "advisory", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 2,
+        local_review_recommendation: "changes_requested",
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "ready_to_merge",
+    },
+    {
+      name: "retry escalates verifier-confirmed high severity findings back to implementing",
+      config: {
+        localReviewEnabled: true,
+        localReviewPolicy: "block_merge",
+        localReviewHighSeverityAction: "retry",
+        copilotReviewWaitMinutes: 0,
+      },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 3,
+        local_review_recommendation: "changes_requested",
+        local_review_verified_max_severity: "high",
+        local_review_verified_findings_count: 1,
+        repeated_local_review_signature_count: 1,
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "implementing",
+    },
+    {
+      name: "blocked escalates verifier-confirmed high severity findings to blocked",
+      config: {
+        localReviewEnabled: true,
+        localReviewPolicy: "block_merge",
+        localReviewHighSeverityAction: "blocked",
+        copilotReviewWaitMinutes: 0,
+      },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 3,
+        local_review_recommendation: "changes_requested",
+        local_review_verified_max_severity: "high",
+        local_review_verified_findings_count: 1,
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "blocked",
+    },
+    {
+      name: "advisory suppresses high severity retry escalation",
+      config: {
+        localReviewEnabled: true,
+        localReviewPolicy: "advisory",
+        localReviewHighSeverityAction: "retry",
+        copilotReviewWaitMinutes: 0,
+      },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 3,
+        local_review_recommendation: "changes_requested",
+        local_review_verified_max_severity: "high",
+        local_review_verified_findings_count: 1,
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "ready_to_merge",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const config = createConfig(testCase.config);
+    const record = createRecord(testCase.record);
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-01T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      ...testCase.pr,
+    };
+
+    assert.equal(
+      inferStateFromPullRequest(config, record, pr, [], []),
+      testCase.expected,
+      testCase.name,
+    );
+  }
+});
+
 test("inferStateFromPullRequest blocks stalled identical high local-review retries", () => {
   const config = createConfig({
     localReviewEnabled: true,


### PR DESCRIPTION
Closes #40
This PR was opened by codex-supervisor.
Latest Codex summary:

Added table-driven coverage for local review gating in [src/local-review.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-40/src/local-review.test.ts) and [src/supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-40/src/supervisor.test.ts). The new cases cover draft vs ready PR behavior, ready-head reruns, `advisory` / `block_ready` / `block_merge`, and high-severity `retry` / `blocked` escalation paths through `inferStateFromPullRequest`.

I also updated the local issue journal and created checkpoint commit `8a7999e` (`Add table-driven local review policy tests`).

Summary: Added table-driven local review policy tests and verified the focused matrix passes
State hint: stabilizing
Blocked reason: none
Tests: `npm ci`; `npx tsx --test src/local-review.test.ts src/supervisor.test.ts`
Failure signature: none
Next action: Run the full test suite if broader verification is needed, then open or update the draft PR for this checkpoint