### PR TITLE
Config bug: relative codexBinary is resolved against config directory and can spawn a nonexistent path (#56)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -5,8 +5,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { loadConfig } from "./config";
 
-test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", async () => {
+test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
   const configPath = path.join(tempDir, "supervisor.config.json");
 
   await fs.writeFile(
@@ -31,8 +34,11 @@ test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", asy
   assert.equal(config.stateFile, path.join(tempDir, "state.json"));
 });
 
-test("loadConfig still resolves codexBinary when it is an explicit relative path", async () => {
+test("loadConfig still resolves codexBinary when it is an explicit relative path", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
   const configPath = path.join(tempDir, "supervisor.config.json");
 
   await fs.writeFile(
@@ -52,4 +58,30 @@ test("loadConfig still resolves codexBinary when it is an explicit relative path
   const config = loadConfig(configPath);
 
   assert.equal(config.codexBinary, path.join(tempDir, "bin", "codex"));
+});
+
+test("loadConfig treats backslash-separated codexBinary values as explicit relative paths", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: ".\\bin\\codex",
+      branchPrefix: "codex/issue-",
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+
+  assert.equal(config.codexBinary, path.resolve(tempDir, ".\\bin\\codex"));
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ function resolveCommandLikeValue(baseDir: string, value: string): string {
     return value;
   }
 
-  return value.includes(path.sep) ? path.resolve(baseDir, value) : value;
+  return /[\\/]/.test(value) ? resolveMaybeRelative(baseDir, value) : value;
 }
 
 function assertString(value: unknown, label: string): string {


### PR DESCRIPTION
Closes #56
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the fix in [src/config.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-56/src/config.ts) so `codexBinary` is only resolved as a filesystem path when it is already absolute or contains a path separator. Bare commands like `"codex"` now pass through unchanged and rely on `PATH`, which avoids the `/tmp/codex` spawn failure.

Added regression coverage in [src/config.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-56/src/config.test.ts) for both cases: bare command stays bare, explicit relative path still resolves against the config directory. I also updated the local issue journal and committed the code as `0c655c4` (`Fix codexBinary config resolution`).

Summary: Fixed `codexBinary` resolution so bare commands are not rewritten relative to the config directory; added focused regression tests and committed the change.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/config.test.ts`; `npm test`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for commit `0c655c4` and report the passing regression coverage.