### PR TITLE
Local review: feed confirmed external misses into future review prompts (#61)

### DIFF
--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
-import { classifyExternalReviewFinding, normalizeExternalReviewFinding, writeExternalReviewMissArtifact } from "./external-review-misses";
+import {
+  classifyExternalReviewFinding,
+  loadRelevantExternalReviewMissPatterns,
+  normalizeExternalReviewFinding,
+  writeExternalReviewMissArtifact,
+} from "./external-review-misses";
 import { ReviewThread } from "./types";
 
 function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
@@ -160,11 +165,15 @@ test("writeExternalReviewMissArtifact persists missed external findings for the 
   const artifactPath = context?.artifactPath ?? "";
   const artifact = JSON.parse(await fs.readFile(artifactPath, "utf8")) as {
     headSha: string;
+    reusableMissPatterns: Array<{ file: string; summary: string }>;
     counts: { missedByLocalReview: number };
     findings: Array<{ classification: string; reviewerLogin: string; file: string | null; line: number | null }>;
   };
   assert.equal(artifact.headSha, "deadbeefcafebabe");
   assert.equal(artifact.counts.missedByLocalReview, 1);
+  assert.equal(artifact.reusableMissPatterns.length, 1);
+  assert.equal(artifact.reusableMissPatterns[0]?.file, "src/auth.ts");
+  assert.match(artifact.reusableMissPatterns[0]?.summary ?? "", /permission guard/i);
   assert.deepEqual(artifact.findings.map((finding) => ({
     classification: finding.classification,
     reviewerLogin: finding.reviewerLogin,
@@ -195,4 +204,120 @@ test("writeExternalReviewMissArtifact skips persistence when the local review ar
   });
 
   assert.equal(context, null);
+});
+
+test("loadRelevantExternalReviewMissPatterns keeps relevant historical misses ordered and bounded", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-rubric-test-"));
+  await fs.writeFile(
+    path.join(tempDir, "external-review-misses-head-oldest.json"),
+    JSON.stringify({
+      branch: "codex/issue-61",
+      headSha: "oldesthead",
+      generatedAt: "2026-03-10T00:00:00Z",
+      reusableMissPatterns: [
+        {
+          fingerprint: "src/auth.ts|permission",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 10,
+          summary: "Old duplicate that should lose to a newer artifact.",
+          rationale: "Older duplicate rationale.",
+          sourceArtifactPath: path.join(tempDir, "external-review-misses-head-oldest.json"),
+          sourceHeadSha: "oldesthead",
+          lastSeenAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(tempDir, "external-review-misses-head-middle.json"),
+    JSON.stringify({
+      branch: "codex/issue-61",
+      headSha: "middlehead",
+      generatedAt: "2026-03-11T00:00:00Z",
+      reusableMissPatterns: [
+        {
+          fingerprint: "src/auth.ts|permission",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Check the permission guard before the fallback write path.",
+          sourceArtifactPath: path.join(tempDir, "external-review-misses-head-middle.json"),
+          sourceHeadSha: "middlehead",
+          lastSeenAt: "2026-03-11T00:00:00Z",
+        },
+        {
+          fingerprint: "src/retry.ts|state",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/retry.ts",
+          line: 18,
+          summary: "Retry path can reuse stale state.",
+          rationale: "Reinitialize state on retry.",
+          sourceArtifactPath: path.join(tempDir, "external-review-misses-head-middle.json"),
+          sourceHeadSha: "middlehead",
+          lastSeenAt: "2026-03-11T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(tempDir, "external-review-misses-head-newest.json"),
+    JSON.stringify({
+      branch: "codex/issue-61",
+      headSha: "newesthead",
+      generatedAt: "2026-03-12T00:00:00Z",
+      reusableMissPatterns: [
+        {
+          fingerprint: "src/api.ts|contract",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/api.ts",
+          line: 88,
+          summary: "Response omits a required field.",
+          rationale: "Preserve required fields in the API response.",
+          sourceArtifactPath: path.join(tempDir, "external-review-misses-head-newest.json"),
+          sourceHeadSha: "newesthead",
+          lastSeenAt: "2026-03-12T00:00:00Z",
+        },
+        {
+          fingerprint: "src/ignored.ts|unrelated",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/ignored.ts",
+          line: 5,
+          summary: "Unrelated miss should not be injected.",
+          rationale: "This file is not part of the current diff.",
+          sourceArtifactPath: path.join(tempDir, "external-review-misses-head-newest.json"),
+          sourceHeadSha: "newesthead",
+          lastSeenAt: "2026-03-12T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  const patterns = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: tempDir,
+    branch: "codex/issue-61",
+    currentHeadSha: "currenthead",
+    changedFiles: ["src/api.ts", "src/auth.ts", "src/retry.ts"],
+    limit: 2,
+  });
+
+  assert.deepEqual(
+    patterns.map((pattern) => ({ file: pattern.file, summary: pattern.summary, lastSeenAt: pattern.lastSeenAt })),
+    [
+      {
+        file: "src/api.ts",
+        summary: "Response omits a required field.",
+        lastSeenAt: "2026-03-12T00:00:00Z",
+      },
+      {
+        file: "src/auth.ts",
+        summary: "Permission guard is bypassed.",
+        lastSeenAt: "2026-03-11T00:00:00Z",
+      },
+    ],
+  );
 });

--- a/src/external-review-misses.ts
+++ b/src/external-review-misses.ts
@@ -72,6 +72,7 @@ export interface ExternalReviewMissArtifact {
   localReviewSummaryPath: string | null;
   localReviewFindingsPath: string | null;
   findings: ExternalReviewMissFinding[];
+  reusableMissPatterns: ExternalReviewMissPattern[];
   counts: {
     matched: number;
     nearMatch: number;
@@ -87,6 +88,18 @@ export interface ExternalReviewMissContext {
   missedCount: number;
 }
 
+export interface ExternalReviewMissPattern {
+  fingerprint: string;
+  reviewerLogin: string;
+  file: string;
+  line: number | null;
+  summary: string;
+  rationale: string;
+  sourceArtifactPath: string;
+  sourceHeadSha: string;
+  lastSeenAt: string;
+}
+
 interface LocalComparisonCandidate {
   reference: string;
   file: string | null;
@@ -97,6 +110,33 @@ interface LocalComparisonCandidate {
 
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+function createMissPatternFingerprint(finding: Pick<ExternalReviewPromptFinding, "file" | "summary" | "rationale">): string {
+  return [
+    finding.file ?? "",
+    normalizeWhitespace(finding.summary).toLowerCase(),
+    truncate(normalizeWhitespace(finding.rationale).toLowerCase(), 200) ?? "",
+  ].join("|");
+}
+
+function toReusableMissPattern(
+  finding: ExternalReviewMissFinding,
+  sourceArtifactPath: string,
+  sourceHeadSha: string,
+  lastSeenAt: string,
+): ExternalReviewMissPattern {
+  return {
+    fingerprint: createMissPatternFingerprint(finding),
+    reviewerLogin: finding.reviewerLogin,
+    file: finding.file ?? "unknown",
+    line: finding.line,
+    summary: finding.summary,
+    rationale: truncate(finding.rationale, 280) ?? finding.rationale,
+    sourceArtifactPath,
+    sourceHeadSha,
+    lastSeenAt,
+  };
 }
 
 function summarizeComment(body: string): string {
@@ -314,6 +354,102 @@ async function loadLocalReviewArtifact(summaryPath: string | null): Promise<{
   }
 }
 
+interface ExternalReviewMissArtifactLike {
+  branch?: string;
+  headSha?: string;
+  generatedAt?: string;
+  findings?: ExternalReviewMissFinding[];
+  reusableMissPatterns?: ExternalReviewMissPattern[];
+}
+
+function legacyReusableMissPatterns(
+  artifact: ExternalReviewMissArtifactLike,
+  artifactPath: string,
+): ExternalReviewMissPattern[] {
+  const generatedAt = typeof artifact.generatedAt === "string" ? artifact.generatedAt : "";
+  const headSha = typeof artifact.headSha === "string" ? artifact.headSha : "";
+  return (artifact.findings ?? [])
+    .filter((finding) => finding.classification === "missed_by_local_review" && typeof finding.file === "string" && finding.file.trim() !== "")
+    .map((finding) => toReusableMissPattern(finding, artifactPath, headSha, generatedAt));
+}
+
+export async function loadRelevantExternalReviewMissPatterns(args: {
+  artifactDir: string;
+  branch: string;
+  currentHeadSha: string;
+  changedFiles: string[];
+  limit?: number;
+}): Promise<ExternalReviewMissPattern[]> {
+  const changedFiles = [...new Set(args.changedFiles.filter((filePath) => filePath.trim() !== ""))].sort();
+  if (changedFiles.length === 0) {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(args.artifactDir);
+  } catch {
+    return [];
+  }
+
+  const artifactPaths = entries
+    .filter((entry) => /^external-review-misses-head-.*\.json$/i.test(entry))
+    .sort()
+    .map((entry) => path.join(args.artifactDir, entry));
+  const changedFileSet = new Set(changedFiles);
+  const deduped = new Map<string, ExternalReviewMissPattern>();
+
+  for (const artifactPath of artifactPaths) {
+    let raw: string;
+    try {
+      raw = await fs.readFile(artifactPath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const artifact = parseJson<ExternalReviewMissArtifactLike>(raw, artifactPath);
+    if (artifact.branch !== args.branch || artifact.headSha === args.currentHeadSha) {
+      continue;
+    }
+
+    const reusableMissPatterns =
+      Array.isArray(artifact.reusableMissPatterns) && artifact.reusableMissPatterns.length > 0
+        ? artifact.reusableMissPatterns
+        : legacyReusableMissPatterns(artifact, artifactPath);
+    for (const pattern of reusableMissPatterns) {
+      if (!pattern.file || !changedFileSet.has(pattern.file)) {
+        continue;
+      }
+
+      const existing = deduped.get(pattern.fingerprint);
+      if (!existing || pattern.lastSeenAt > existing.lastSeenAt) {
+        deduped.set(pattern.fingerprint, pattern);
+      }
+    }
+  }
+
+  return [...deduped.values()]
+    .sort((left, right) => {
+      const lastSeenComparison = right.lastSeenAt.localeCompare(left.lastSeenAt);
+      if (lastSeenComparison !== 0) {
+        return lastSeenComparison;
+      }
+
+      const fileComparison = left.file.localeCompare(right.file);
+      if (fileComparison !== 0) {
+        return fileComparison;
+      }
+
+      const lineComparison = (left.line ?? Number.MAX_SAFE_INTEGER) - (right.line ?? Number.MAX_SAFE_INTEGER);
+      if (lineComparison !== 0) {
+        return lineComparison;
+      }
+
+      return left.fingerprint.localeCompare(right.fingerprint);
+    })
+    .slice(0, Math.max(0, args.limit ?? 3));
+}
+
 export async function writeExternalReviewMissArtifact(args: {
   artifactDir: string;
   issueNumber: number;
@@ -347,6 +483,7 @@ export async function writeExternalReviewMissArtifact(args: {
     localReviewSummaryPath: args.localReviewSummaryPath,
     localReviewFindingsPath,
     findings,
+    reusableMissPatterns: [],
     counts: {
       matched: findings.filter((finding) => finding.classification === "matched").length,
       nearMatch: findings.filter((finding) => finding.classification === "near_match").length,
@@ -356,6 +493,9 @@ export async function writeExternalReviewMissArtifact(args: {
 
   await ensureDir(args.artifactDir);
   const artifactPath = path.join(args.artifactDir, `external-review-misses-head-${args.headSha.slice(0, 12)}.json`);
+  artifact.reusableMissPatterns = findings
+    .filter((finding) => finding.classification === "missed_by_local_review" && typeof finding.file === "string" && finding.file.trim() !== "")
+    .map((finding) => toReusableMissPattern(finding, artifactPath, args.headSha, artifact.generatedAt));
   await fs.writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
 
   return {

--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { finalizeLocalReview, shouldRunLocalReview } from "./local-review";
+import { buildRolePrompt, finalizeLocalReview, shouldRunLocalReview } from "./local-review";
 import { LocalReviewRoleSelection } from "./review-role-detector";
 import { GitHubPullRequest, SupervisorConfig } from "./types";
 
@@ -473,4 +473,72 @@ test("finalizeLocalReview does not compress findings without file locations", ()
 
   assert.equal(result.findingsCount, 2);
   assert.equal(result.rootCauseCount, 2);
+});
+
+test("buildRolePrompt includes bounded relevant prior external misses", () => {
+  const prompt = buildRolePrompt({
+    repoSlug: "owner/repo",
+    issue: {
+      number: 61,
+      title: "Teach local review from prior misses",
+      body: "",
+      url: "https://example.test/issues/61",
+      createdAt: "2026-03-12T00:00:00Z",
+      updatedAt: "2026-03-12T00:00:00Z",
+      labels: [],
+    },
+    branch: "codex/issue-61",
+    workspacePath: "/tmp/workspaces/issue-61",
+    defaultBranch: "main",
+    pr: createPullRequest({
+      number: 61,
+      url: "https://example.test/pr/61",
+      headRefOid: "newhead123",
+    }),
+    role: "reviewer",
+    alwaysReadFiles: ["/tmp/workspaces/issue-61/.codex-supervisor/issue-journal.md"],
+    onDemandFiles: ["/tmp/workspaces/issue-61/docs/architecture.md"],
+    confidenceThreshold: 0.7,
+    priorMissPatterns: [
+      {
+        fingerprint: "src/auth.ts|permission",
+        reviewerLogin: "copilot-pull-request-reviewer",
+        file: "src/auth.ts",
+        line: 42,
+        summary: "Permission guard is bypassed.",
+        rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+        sourceArtifactPath: "/tmp/reviews/issue-61/external-review-misses-head-old.json",
+        sourceHeadSha: "oldhead123",
+        lastSeenAt: "2026-03-12T00:00:00Z",
+      },
+      {
+        fingerprint: "src/retry.ts|missing",
+        reviewerLogin: "copilot-pull-request-reviewer",
+        file: "src/retry.ts",
+        line: 15,
+        summary: "Retry path can reuse stale state.",
+        rationale: "The retry branch keeps stale cached state after the first failure.",
+        sourceArtifactPath: "/tmp/reviews/issue-61/external-review-misses-head-old-2.json",
+        sourceHeadSha: "olderhead456",
+        lastSeenAt: "2026-03-11T00:00:00Z",
+      },
+      {
+        fingerprint: "src/api.ts|contract",
+        reviewerLogin: "copilot-pull-request-reviewer",
+        file: "src/api.ts",
+        line: 88,
+        summary: "Response omits a required field.",
+        rationale: "The new response path drops the field that downstream logic still treats as required.",
+        sourceArtifactPath: "/tmp/reviews/issue-61/external-review-misses-head-old-3.json",
+        sourceHeadSha: "olderhead789",
+        lastSeenAt: "2026-03-10T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.match(prompt, /Relevant prior confirmed external misses for this diff:/);
+  assert.match(prompt, /Prior miss 1: file=src\/auth\.ts:42 reviewer=copilot-pull-request-reviewer/);
+  assert.match(prompt, /Permission guard is bypassed\./);
+  assert.match(prompt, /Retry path can reuse stale state\./);
+  assert.match(prompt, /Response omits a required field\./);
 });

--- a/src/local-review.ts
+++ b/src/local-review.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { runCommand } from "./command";
 import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
+import { ExternalReviewMissPattern, loadRelevantExternalReviewMissPatterns } from "./external-review-misses";
 import { detectLocalReviewRoleSelections, type LocalReviewRoleSelection } from "./review-role-detector";
 import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "./types";
 import { ensureDir, nowIso, truncate } from "./utils";
@@ -181,6 +182,7 @@ interface RolePromptArgs {
   alwaysReadFiles: string[];
   onDemandFiles: string[];
   confidenceThreshold: number;
+  priorMissPatterns: ExternalReviewMissPattern[];
 }
 
 function safeSlug(input: string): string {
@@ -411,8 +413,23 @@ function roleGoal(role: string): string[] {
   }
 }
 
-function buildRolePrompt(args: RolePromptArgs): string {
+export function buildRolePrompt(args: RolePromptArgs): string {
   const ref = compareRef(args.defaultBranch);
+  const priorMissLines =
+    args.priorMissPatterns.length > 0
+      ? [
+          "Relevant prior confirmed external misses for this diff:",
+          "- Use these as targeted checks for blind spots that local review previously missed.",
+          ...args.priorMissPatterns.map((pattern, index) =>
+            [
+              `- Prior miss ${index + 1}: file=${pattern.file}:${pattern.line ?? "?"} reviewer=${pattern.reviewerLogin}`,
+              `  summary=${pattern.summary}`,
+              `  rationale=${pattern.rationale}`,
+            ].join("\n"),
+          ),
+          "",
+        ]
+      : [];
 
   return [
     `You are performing a local pre-ready ${args.role} review for ${args.repoSlug}.`,
@@ -448,6 +465,7 @@ function buildRolePrompt(args: RolePromptArgs): string {
           "",
         ]
       : []),
+    ...priorMissLines,
     "Suggested commands:",
     `- git diff --stat ${ref}`,
     `- git diff ${ref}`,
@@ -712,6 +730,7 @@ async function runRoleReview(args: {
   role: string;
   alwaysReadFiles: string[];
   onDemandFiles: string[];
+  priorMissPatterns: ExternalReviewMissPattern[];
 }): Promise<LocalReviewRoleResult> {
   const prompt = buildRolePrompt({
     repoSlug: args.config.repoSlug,
@@ -724,6 +743,7 @@ async function runRoleReview(args: {
     alwaysReadFiles: args.alwaysReadFiles,
     onDemandFiles: args.onDemandFiles,
     confidenceThreshold: args.config.localReviewConfidenceThreshold,
+    priorMissPatterns: args.priorMissPatterns,
   });
 
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
@@ -988,6 +1008,26 @@ export async function runLocalReview(args: {
   alwaysReadFiles: string[];
   onDemandFiles: string[];
 }): Promise<LocalReviewResult> {
+  const ref = compareRef(args.defaultBranch);
+  const changedFilesResult = await runCommand(
+    "git",
+    ["diff", "--name-only", ref],
+    {
+      cwd: args.workspacePath,
+      env: process.env,
+    },
+  );
+  const changedFiles = changedFilesResult.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const priorMissPatterns = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: reviewDir(args.config, args.issue.number),
+    branch: args.branch,
+    currentHeadSha: args.pr.headRefOid,
+    changedFiles,
+    limit: 3,
+  });
   const detectedRoles =
     args.config.localReviewRoles.length === 0 && args.config.localReviewAutoDetect
       ? await detectLocalReviewRoleSelections(args.config)
@@ -1012,6 +1052,7 @@ export async function runLocalReview(args: {
       roleResults[index] = await runRoleReview({
         ...args,
         role: roles[index],
+        priorMissPatterns,
       });
     }
   }


### PR DESCRIPTION
Closes #61
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the feedback loop for local review prompts.

The change adds a reusable miss-pattern layer in [src/external-review-misses.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-61/src/external-review-misses.ts) and feeds the top relevant historical misses into role prompts from [src/local-review.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-61/src/local-review.ts). Relevance is bounded and deterministic: only prior `missed_by_local_review` findings from the same issue branch, excluding the current head, and only for files in the current diff, limited to 3 entries.

Focused coverage was added in [src/external-review-misses.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-61/src/external-review-misses.test.ts) and [src/local-review.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-61/src/local-review.test.ts) for prompt inclusion, ordering, and size limits. Checkpoint commit: `90bab8e` (`Feed prior external misses into local review prompts`).

Summary: Added bounded reusable external-miss patterns and injected relevant prior misses into future local review prompts; focused tests and build pass.
State hint: local_review
Blocked reason: none
Tests: `npm test -- src/external-review-misses.test.ts src/local-review.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR with commit `90bab8e` and proceed to broader verification if...