### PR TITLE
Local review: improve external miss matching with change-intent signals (#62)

### DIFF
--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -141,6 +141,14 @@ test("classifyExternalReviewFinding marks same-hunk findings as matched even wit
   const classified = classifyExternalReviewFinding(normalized, {
     actionableFindings: [
       {
+        title: "Authorization check missing in a nearby helper",
+        body: "This branch runs the fallback write before the authorization check and capability gate.",
+        file: "src/auth.ts",
+        start: 60,
+        end: 64,
+        severity: "medium",
+      },
+      {
         title: "Guard ordering bug in fallback branch",
         body: "Delay the persistence path until the capability gate passes.",
         file: "src/auth.ts",
@@ -153,8 +161,9 @@ test("classifyExternalReviewFinding marks same-hunk findings as matched even wit
   });
 
   assert.equal(classified.classification, "matched");
-  assert.equal(classified.matchedLocalReference, "actionable:1");
-  assert.match(classified.matchReason, /same_hunk/);
+  assert.equal(classified.matchedLocalReference, "actionable:2");
+  assert.match(classified.matchReason, /^same-hunk/);
+  assert.match(classified.matchReason, /\bsame_hunk=yes\b/);
 });
 
 test("writeExternalReviewMissArtifact persists missed external findings for the current review head", async () => {

--- a/src/external-review-misses.ts
+++ b/src/external-review-misses.ts
@@ -278,6 +278,30 @@ function formatMatchReason(prefix: string, score: LocalMatchScore): string {
   return `${prefix} overlap=${score.overlap.toFixed(2)} line_distance=${score.distance ?? "na"} same_hunk=${score.sameHunk ? "yes" : "no"}`;
 }
 
+function isBetterMatch(candidate: LocalMatchScore, bestMatch: LocalMatchScore | null): boolean {
+  if (!bestMatch) {
+    return true;
+  }
+
+  if (candidate.sameHunk && !bestMatch.sameHunk) {
+    return true;
+  }
+
+  if (candidate.sameHunk !== bestMatch.sameHunk) {
+    return false;
+  }
+
+  if (candidate.overlap > bestMatch.overlap) {
+    return true;
+  }
+
+  if (candidate.overlap < bestMatch.overlap) {
+    return false;
+  }
+
+  return (candidate.distance ?? 9999) < (bestMatch.distance ?? 9999);
+}
+
 function buildLocalCandidates(artifact: LocalReviewArtifactLike): LocalComparisonCandidate[] {
   const actionable = (artifact.actionableFindings ?? []).map((finding, index) => ({
     reference: `actionable:${index + 1}`,
@@ -320,13 +344,9 @@ export function classifyExternalReviewFinding(
     const overlap = overlapScore(`${finding.summary} ${finding.rationale}`, candidate.text);
     const distance = lineDistance(finding, candidate);
     const sameHunk = isSameHunk(finding, candidate);
-    if (
-      !bestMatch ||
-      sameHunk !== bestMatch.sameHunk ||
-      overlap > bestMatch.overlap ||
-      (overlap === bestMatch.overlap && (distance ?? 9999) < (bestMatch.distance ?? 9999))
-    ) {
-      bestMatch = { candidate, overlap, distance, sameHunk };
+    const score = { candidate, overlap, distance, sameHunk };
+    if (isBetterMatch(score, bestMatch)) {
+      bestMatch = score;
     }
   }
 


### PR DESCRIPTION
Closes #62
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused reproducer in [src/external-review-misses.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-62/src/external-review-misses.test.ts) for the actual gap: same-hunk external feedback with low wording overlap was only landing in `near_match`. Then I updated [src/external-review-misses.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-62/src/external-review-misses.ts) so `classifyExternalReviewFinding` uses an explicit deterministic `sameHunk` signal when the external line falls inside a local finding range. The promotion stays conservative by requiring a small overlap floor, and `matchReason` now explains the signal with `same_hunk=yes|no`.

I also updated the local issue journal handoff in `.codex-supervisor/issue-journal.md` and committed the code checkpoint as `6d7c518` (`Improve same-hunk external review matching`).

Summary: Added focused same-hunk reproducer, implemented conservative same-hunk match promotion, committed checkpoint `6d7c518`
State hint: local_review
Blocked reason: none
Tests: `npm test -- --test-name-pattern='classifyExternalReviewFinding|writeExternalReviewMissArtifact|loadRelevantExternalReviewMissPatterns'`
Failure signature: none
Next action: Run one broader local verification pass for external review miss handling, then continue classification improvements if more non-overlap cases remain