### PR TITLE
Local review: generate regression-test candidates from confirmed external misses (#63)

### DIFF
--- a/src/codex.test.ts
+++ b/src/codex.test.ts
@@ -226,6 +226,20 @@ test("buildCodexPrompt surfaces saved external review misses during addressing_r
       matchedCount: 0,
       nearMatchCount: 1,
       missedCount: 4,
+      regressionTestCandidates: [
+        {
+          id: "src/auth.ts|42|permission-guard-is-bypassed",
+          title: "Add regression coverage for Permission guard is bypassed",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+          sourceThreadId: "thread-1",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          sourceUrl: "https://example.test/thread-1#comment-1",
+          qualificationReasons: ["missed_by_local_review", "non_low_severity", "high_confidence", "file_scoped", "line_scoped"],
+        },
+      ],
       missedFindings: [
         {
           reviewerLogin: "copilot-pull-request-reviewer",
@@ -265,6 +279,9 @@ test("buildCodexPrompt surfaces saved external review misses during addressing_r
 
   assert.match(prompt, /External review miss context:/);
   assert.match(prompt, /matched=0 near_match=1 missed=4/);
+  assert.match(prompt, /Regression-test candidates from confirmed misses:/);
+  assert.match(prompt, /Add regression coverage for Permission guard is bypassed/);
+  assert.match(prompt, /qualified_by=missed_by_local_review, non_low_severity, high_confidence, file_scoped, line_scoped/);
   assert.match(prompt, /Permission guard is bypassed\./);
   assert.match(prompt, /copilot-pull-request-reviewer/);
   assert.match(prompt, /Additional missed findings omitted: 1/);

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -329,6 +329,23 @@ export function buildCodexPrompt(input: {
             ? [
                 `- Artifact: ${input.externalReviewMissContext.artifactPath}`,
                 `- Classified findings: matched=${input.externalReviewMissContext.matchedCount} near_match=${input.externalReviewMissContext.nearMatchCount} missed=${input.externalReviewMissContext.missedCount}`,
+                ...(input.externalReviewMissContext.regressionTestCandidates.length > 0
+                  ? [
+                      "- Regression-test candidates from confirmed misses:",
+                      ...input.externalReviewMissContext.regressionTestCandidates.slice(0, 3).map((candidate, index) =>
+                        [
+                          `  - ${index + 1}. title=${truncate(candidate.title, 160) ?? ""}`,
+                          `    file=${candidate.file}:${candidate.line}`,
+                          `    summary=${truncate(candidate.summary, 160) ?? ""}`,
+                          `    qualified_by=${candidate.qualificationReasons.join(", ")}`,
+                          `    url=${candidate.sourceUrl ?? "n/a"}`,
+                        ].join("\n"),
+                      ),
+                      ...(input.externalReviewMissContext.regressionTestCandidates.length > 3
+                        ? [`  - Additional regression-test candidates omitted: ${input.externalReviewMissContext.regressionTestCandidates.length - 3}`]
+                        : []),
+                    ]
+                  : ["- Regression-test candidates from confirmed misses: none"]),
                 ...(input.externalReviewMissContext.missedFindings.length > 0
                   ? [
                       "- Missed-by-local-review findings to validate first:",

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -241,6 +241,103 @@ test("writeExternalReviewMissArtifact persists missed external findings for the 
   ]);
 });
 
+test("writeExternalReviewMissArtifact derives deterministic regression-test candidates from confirmed misses", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-miss-test-"));
+  const localReviewSummaryPath = path.join(tempDir, "head-deadbeef.md");
+  const localReviewFindingsPath = path.join(tempDir, "head-deadbeef.json");
+  await fs.writeFile(localReviewSummaryPath, "# summary\n", "utf8");
+  await fs.writeFile(
+    localReviewFindingsPath,
+    `${JSON.stringify({
+      actionableFindings: [],
+      rootCauseSummaries: [],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const context = await writeExternalReviewMissArtifact({
+    artifactDir: tempDir,
+    issueNumber: 63,
+    prNumber: 91,
+    branch: "codex/issue-63",
+    headSha: "deadbeefcafebabe",
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-strong",
+        path: "src/auth.ts",
+        line: 42,
+        comments: {
+          nodes: [
+            {
+              id: "comment-strong",
+              body: "This fallback skips the permission guard and lets unauthorized callers update records.",
+              createdAt: "2026-03-12T00:00:00Z",
+              url: "https://example.test/thread-strong#comment-1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-low",
+        path: "src/docs.ts",
+        line: 10,
+        comments: {
+          nodes: [
+            {
+              id: "comment-low",
+              body: "Nit: docs wording should be clearer here.",
+              createdAt: "2026-03-12T00:01:00Z",
+              url: "https://example.test/thread-low#comment-1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    localReviewSummaryPath,
+  });
+
+  assert.ok(context);
+  assert.equal(context?.regressionTestCandidates.length, 1);
+  assert.equal(context?.regressionTestCandidates[0]?.file, "src/auth.ts");
+  assert.match(context?.regressionTestCandidates[0]?.title ?? "", /permission guard/i);
+
+  const artifact = JSON.parse(
+    await fs.readFile(context?.artifactPath ?? "", "utf8"),
+  ) as {
+    regressionTestCandidates: Array<{
+      id: string;
+      file: string;
+      line: number;
+      sourceThreadId: string;
+      qualificationReasons: string[];
+    }>;
+  };
+
+  assert.deepEqual(artifact.regressionTestCandidates, [
+    {
+      id: "src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      title: "Add regression coverage for This fallback skips the permission guard and lets unauthorized callers update records",
+      file: "src/auth.ts",
+      line: 42,
+      summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      sourceThreadId: "thread-strong",
+      sourceUrl: "https://example.test/thread-strong#comment-1",
+      qualificationReasons: ["missed_by_local_review", "non_low_severity", "high_confidence", "file_scoped", "line_scoped"],
+    },
+  ]);
+});
+
 test("writeExternalReviewMissArtifact skips persistence when the local review artifact is unavailable", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-miss-test-"));
 

--- a/src/external-review-misses.ts
+++ b/src/external-review-misses.ts
@@ -73,6 +73,7 @@ export interface ExternalReviewMissArtifact {
   localReviewFindingsPath: string | null;
   findings: ExternalReviewMissFinding[];
   reusableMissPatterns: ExternalReviewMissPattern[];
+  regressionTestCandidates: ExternalReviewRegressionCandidate[];
   counts: {
     matched: number;
     nearMatch: number;
@@ -83,6 +84,7 @@ export interface ExternalReviewMissArtifact {
 export interface ExternalReviewMissContext {
   artifactPath: string;
   missedFindings: ExternalReviewPromptFinding[];
+  regressionTestCandidates: ExternalReviewRegressionCandidate[];
   matchedCount: number;
   nearMatchCount: number;
   missedCount: number;
@@ -98,6 +100,19 @@ export interface ExternalReviewMissPattern {
   sourceArtifactPath: string;
   sourceHeadSha: string;
   lastSeenAt: string;
+}
+
+export interface ExternalReviewRegressionCandidate {
+  id: string;
+  title: string;
+  file: string;
+  line: number;
+  summary: string;
+  rationale: string;
+  reviewerLogin: string;
+  sourceThreadId: string;
+  sourceUrl: string | null;
+  qualificationReasons: string[];
 }
 
 interface LocalComparisonCandidate {
@@ -154,6 +169,61 @@ function summarizeComment(body: string): string {
 
   const sentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/)?.[1] ?? normalized;
   return truncate(sentence, 180) ?? "External review finding";
+}
+
+function createRegressionCandidateId(finding: ExternalReviewMissFinding): string {
+  return [
+    finding.file ?? "",
+    finding.line ?? "",
+    normalizeWhitespace(finding.rationale).toLowerCase(),
+  ].join("|");
+}
+
+function toRegressionTestCandidate(
+  finding: ExternalReviewMissFinding,
+): ExternalReviewRegressionCandidate | null {
+  if (finding.classification !== "missed_by_local_review") {
+    return null;
+  }
+
+  const qualificationReasons: string[] = ["missed_by_local_review"];
+  if (finding.severity !== "low") {
+    qualificationReasons.push("non_low_severity");
+  }
+  if (finding.confidence >= 0.75) {
+    qualificationReasons.push("high_confidence");
+  }
+  if (typeof finding.file === "string" && finding.file.trim() !== "") {
+    qualificationReasons.push("file_scoped");
+  }
+  if (typeof finding.line === "number" && Number.isInteger(finding.line) && finding.line > 0) {
+    qualificationReasons.push("line_scoped");
+  }
+
+  if (
+    !qualificationReasons.includes("non_low_severity") ||
+    !qualificationReasons.includes("high_confidence") ||
+    !qualificationReasons.includes("file_scoped") ||
+    !qualificationReasons.includes("line_scoped") ||
+    !finding.file ||
+    finding.line == null
+  ) {
+    return null;
+  }
+
+  const trimmedSummary = finding.summary.replace(/[.!?]+$/, "");
+  return {
+    id: createRegressionCandidateId(finding),
+    title: `Add regression coverage for ${trimmedSummary}`,
+    file: finding.file,
+    line: finding.line,
+    summary: finding.summary,
+    rationale: finding.rationale,
+    reviewerLogin: finding.reviewerLogin,
+    sourceThreadId: finding.threadId,
+    sourceUrl: finding.url ?? null,
+    qualificationReasons,
+  };
 }
 
 function inferSeverity(body: string): Exclude<LocalReviewSeverity, "none"> {
@@ -410,6 +480,7 @@ interface ExternalReviewMissArtifactLike {
   generatedAt?: string;
   findings?: ExternalReviewMissFinding[];
   reusableMissPatterns?: ExternalReviewMissPattern[];
+  regressionTestCandidates?: ExternalReviewRegressionCandidate[];
 }
 
 function legacyReusableMissPatterns(
@@ -534,6 +605,7 @@ export async function writeExternalReviewMissArtifact(args: {
     localReviewFindingsPath,
     findings,
     reusableMissPatterns: [],
+    regressionTestCandidates: [],
     counts: {
       matched: findings.filter((finding) => finding.classification === "matched").length,
       nearMatch: findings.filter((finding) => finding.classification === "near_match").length,
@@ -546,11 +618,15 @@ export async function writeExternalReviewMissArtifact(args: {
   artifact.reusableMissPatterns = findings
     .filter((finding) => finding.classification === "missed_by_local_review" && typeof finding.file === "string" && finding.file.trim() !== "")
     .map((finding) => toReusableMissPattern(finding, artifactPath, args.headSha, artifact.generatedAt));
+  artifact.regressionTestCandidates = findings
+    .map((finding) => toRegressionTestCandidate(finding))
+    .filter((candidate): candidate is ExternalReviewRegressionCandidate => candidate !== null);
   await fs.writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
 
   return {
     artifactPath,
     missedFindings: findings.filter((finding) => finding.classification === "missed_by_local_review"),
+    regressionTestCandidates: artifact.regressionTestCandidates,
     matchedCount: artifact.counts.matched,
     nearMatchCount: artifact.counts.nearMatch,
     missedCount: artifact.counts.missedByLocalReview,


### PR DESCRIPTION
Closes #63
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the regression-candidate path for confirmed external misses. The external miss artifact now includes a structured `regressionTestCandidates` array with explicit qualification reasons, and the `addressing_review` prompt surfaces those candidates deterministically without depending on raw review-thread logs. I added a focused end-to-end artifact test plus prompt coverage in [src/external-review-misses.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-63/src/external-review-misses.test.ts) and [src/codex.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-63/src/codex.test.ts), with implementation in [src/external-review-misses.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-63/src/external-review-misses.ts) and [src/codex.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-63/src/codex.ts). I also updated the issue journal working notes.

Committed on `codex/issue-63` as `6137620` (`Add regression candidates for confirmed external misses`).

Summary: Added deterministic regression-test candidates for confirmed external misses and surfaced them in addressing-review context.
State hint: draft_pr
Blocked reason: none
Tests: `npm test`
Failure signature: none
Next action: Open or update a draft PR for the committed regression-candidate checkpoint.