### PR TITLE
Refactor local-review.ts into focused modules

### DIFF
--- a/src/local-review-artifacts.ts
+++ b/src/local-review-artifacts.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { type LocalReviewRoleSelection } from "./review-role-detector";
+import { type SupervisorConfig } from "./types";
+import { type FinalizedLocalReview, type LocalReviewFinding, type LocalReviewResult, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
+
+function safeSlug(input: string): string {
+  return input.replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
+
+export function reviewDir(config: SupervisorConfig, issueNumber: number): string {
+  return path.join(config.localReviewArtifactDir, safeSlug(config.repoSlug), `issue-${issueNumber}`);
+}
+
+function summarizeRoles(roleResults: LocalReviewRoleResult[]): string {
+  const summaries = roleResults
+    .map((result) => `- ${result.role}: ${result.summary}`)
+    .slice(0, 10);
+
+  return summaries.length > 0
+    ? summaries.join("\n")
+    : "- local review completed without structured role summaries.";
+}
+
+function formatRoleSelectionReason(reason: LocalReviewRoleSelection["reasons"][number]): string {
+  const suffix = reason.paths.length > 0 ? ` (${reason.paths.join(", ")})` : "";
+  switch (reason.kind) {
+    case "baseline":
+      return `baseline${suffix}`;
+    case "config_signal":
+      return `${reason.signal}${suffix}`;
+    case "repo_signal":
+      return `${reason.signal}${suffix}`;
+  }
+}
+
+function summarizeAutoDetectedRoles(detectedRoles: LocalReviewRoleSelection[]): string[] {
+  const specialistSelections = detectedRoles.filter(
+    (selection) => selection.role !== "reviewer" && selection.role !== "explorer",
+  );
+  if (specialistSelections.length === 0) {
+    return ["- No specialist roles were auto-detected beyond the baseline reviewer/explorer pair."];
+  }
+
+  return specialistSelections
+    .slice(0, 10)
+    .map((selection) => `- ${selection.role}: ${selection.reasons.map(formatRoleSelectionReason).join("; ")}`);
+}
+
+export function renderLines(finding: Pick<LocalReviewFinding, "start" | "end">): string {
+  if (finding.start == null) {
+    return "?";
+  }
+
+  return finding.end && finding.end !== finding.start
+    ? `${finding.start}-${finding.end}`
+    : `${finding.start}`;
+}
+
+export async function writeLocalReviewArtifacts(args: {
+  config: SupervisorConfig;
+  issueNumber: number;
+  branch: string;
+  prUrl: string;
+  headSha: string;
+  roles: string[];
+  ranAt: string;
+  finalized: FinalizedLocalReview;
+  roleResults: LocalReviewRoleResult[];
+  verifierReport: LocalReviewVerifierReport | null;
+}): Promise<Pick<LocalReviewResult, "summaryPath" | "findingsPath" | "rawOutput">> {
+  const dirPath = reviewDir(args.config, args.issueNumber);
+  const baseName = `head-${args.headSha.slice(0, 12)}`;
+  const summaryPath = path.join(dirPath, `${baseName}.md`);
+  const findingsPath = path.join(dirPath, `${baseName}.json`);
+  const rawOutput = args.roleResults
+    .map((result) => `## ${result.role}\n\n${result.rawOutput}`)
+    .concat(args.verifierReport ? [`## verifier\n\n${args.verifierReport.rawOutput}`] : [])
+    .join("\n\n");
+
+  await fs.writeFile(
+    summaryPath,
+    [
+      `# Local Review for Issue #${args.issueNumber}`,
+      "",
+      `- PR: ${args.prUrl}`,
+      `- Branch: ${args.branch}`,
+      `- Head SHA: ${args.headSha}`,
+      `- Ran at: ${args.ranAt}`,
+      `- Roles: ${args.roles.join(", ")}`,
+      `- Confidence threshold: ${args.config.localReviewConfidenceThreshold.toFixed(2)}`,
+      `- Actionable findings: ${args.finalized.findingsCount}`,
+      `- Root causes: ${args.finalized.rootCauseCount}`,
+      `- Max severity: ${args.finalized.maxSeverity}`,
+      `- Verified findings: ${args.finalized.verifiedFindingsCount}`,
+      `- Verified max severity: ${args.finalized.verifiedMaxSeverity}`,
+      `- Recommendation: ${args.finalized.recommendation}`,
+      `- Degraded: ${args.finalized.degraded ? "yes" : "no"}`,
+      "",
+      "## Auto-detected roles",
+      ...summarizeAutoDetectedRoles(args.finalized.artifact.autoDetectedRoles),
+      "",
+      "## Role summaries",
+      summarizeRoles(args.roleResults),
+      "",
+      "## Actionable findings",
+      ...(args.finalized.actionableFindings.length > 0
+        ? args.finalized.actionableFindings.map((finding, index) =>
+            [
+              `### ${index + 1}. ${finding.title}`,
+              `- Role: ${finding.role}`,
+              `- Severity: ${finding.severity}`,
+              `- Confidence: ${finding.confidence.toFixed(2)}`,
+              `- File: ${finding.file ?? "none"}`,
+              `- Lines: ${renderLines(finding)}`,
+              `- Category: ${finding.category ?? "none"}`,
+              `- Body: ${finding.body}`,
+              ...(finding.evidence ? [`- Evidence: ${finding.evidence}`] : []),
+              "",
+            ].join("\n"),
+          )
+        : ["- No actionable findings above the confidence threshold.", ""]),
+      "## Root-cause summaries",
+      ...(args.finalized.rootCauseSummaries.length > 0
+        ? args.finalized.rootCauseSummaries.map((rootCause, index) =>
+            [
+              `### Root cause ${index + 1}`,
+              `- Severity: ${rootCause.severity}`,
+              `- Findings: ${rootCause.findingsCount}`,
+              `- Roles: ${rootCause.roles.join(", ")}`,
+              `- File: ${rootCause.file ?? "multiple"}`,
+              `- Lines: ${rootCause.file ? renderLines(rootCause) : "multiple"}`,
+              `- Category: ${rootCause.category ?? "none"}`,
+              `- Summary: ${rootCause.summary}`,
+              "",
+            ].join("\n"),
+          )
+        : ["- No compressed root causes.", ""]),
+      "## High-Severity Verification",
+      `- Required: ${args.finalized.artifact.verification.required ? "yes" : "no"}`,
+      `- Summary: ${args.finalized.artifact.verification.summary}`,
+      `- Recommendation: ${args.finalized.artifact.verification.recommendation}`,
+      `- Degraded: ${args.finalized.artifact.verification.degraded ? "yes" : "no"}`,
+      `- Verified findings: ${args.finalized.verifiedFindingsCount}`,
+      `- Verified max severity: ${args.finalized.verifiedMaxSeverity}`,
+      ...(args.finalized.artifact.verification.findings.length > 0
+        ? [
+            "",
+            ...args.finalized.artifact.verification.findings.map((finding, index) =>
+              [
+                `### Verification ${index + 1}`,
+                `- Finding key: ${finding.findingKey}`,
+                `- Verdict: ${finding.verdict}`,
+                `- Rationale: ${finding.rationale}`,
+                "",
+              ].join("\n"),
+            ),
+          ]
+        : [""]),
+      "## Raw role outputs",
+      rawOutput,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await fs.writeFile(
+    findingsPath,
+    `${JSON.stringify(args.finalized.artifact, null, 2)}\n`,
+    "utf8",
+  );
+
+  return { summaryPath, findingsPath, rawOutput };
+}
+

--- a/src/local-review-finalize.ts
+++ b/src/local-review-finalize.ts
@@ -1,0 +1,301 @@
+import { type LocalReviewRoleSelection } from "./review-role-detector";
+import { type SupervisorConfig } from "./types";
+import { truncate } from "./utils";
+import {
+  type FinalizedLocalReview,
+  type LocalReviewArtifact,
+  type LocalReviewFinding,
+  type LocalReviewResult,
+  type LocalReviewRootCauseSummary,
+  type LocalReviewRoleResult,
+  type LocalReviewSeverity,
+  type LocalReviewVerifierReport,
+} from "./local-review-types";
+
+function severityWeight(severity: LocalReviewFinding["severity"]): number {
+  switch (severity) {
+    case "high":
+      return 3;
+    case "medium":
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+export function dedupeFindings(findings: LocalReviewFinding[]): LocalReviewFinding[] {
+  const deduped = new Map<string, LocalReviewFinding>();
+  for (const finding of findings) {
+    const key = [
+      finding.file ?? "",
+      finding.start ?? "",
+      finding.end ?? "",
+      finding.title.toLowerCase(),
+      finding.body.toLowerCase(),
+    ].join("|");
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, finding);
+      continue;
+    }
+
+    if (
+      severityWeight(finding.severity) > severityWeight(existing.severity) ||
+      (severityWeight(finding.severity) === severityWeight(existing.severity) && finding.confidence > existing.confidence)
+    ) {
+      deduped.set(key, finding);
+    }
+  }
+
+  return [...deduped.values()].sort((left, right) => {
+    const severityDelta = severityWeight(right.severity) - severityWeight(left.severity);
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+
+    return right.confidence - left.confidence;
+  });
+}
+
+export function findingKey(finding: LocalReviewFinding): string {
+  return [
+    finding.file ?? "",
+    finding.start ?? "",
+    finding.end ?? "",
+    finding.title.toLowerCase(),
+    finding.body.toLowerCase(),
+  ].join("|");
+}
+
+const FINDING_STOPWORDS = new Set(["this", "that", "with", "from", "when", "only", "still", "have", "does", "into"]);
+
+function tokenizeFindingText(value: string): Set<string> {
+  const tokens = value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 4)
+    .filter((token) => !FINDING_STOPWORDS.has(token));
+  return new Set(tokens);
+}
+
+function overlapCount(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const token of left) {
+    if (right.has(token)) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function lineDistance(left: LocalReviewFinding, right: LocalReviewFinding): number | null {
+  if (left.start == null || right.start == null) {
+    return null;
+  }
+
+  const leftEnd = left.end ?? left.start;
+  const rightEnd = right.end ?? right.start;
+  if (leftEnd >= right.start && rightEnd >= left.start) {
+    return 0;
+  }
+
+  return Math.min(Math.abs(leftEnd - right.start), Math.abs(rightEnd - left.start));
+}
+
+function findingsOverlap(left: LocalReviewFinding, right: LocalReviewFinding): boolean {
+  if (left.file == null || right.file == null || left.file !== right.file) {
+    return false;
+  }
+
+  const distance = lineDistance(left, right);
+  if (distance == null || distance > 6) {
+    return false;
+  }
+
+  if (left.category && right.category && left.category !== right.category) {
+    return false;
+  }
+
+  const leftTokens = tokenizeFindingText(`${left.title} ${left.body} ${left.evidence ?? ""}`);
+  const rightTokens = tokenizeFindingText(`${right.title} ${right.body} ${right.evidence ?? ""}`);
+  return overlapCount(leftTokens, rightTokens) >= 3;
+}
+
+function summarizeRootCause(findings: LocalReviewFinding[]): LocalReviewRootCauseSummary {
+  const sorted = [...findings].sort((left, right) => {
+    const severityDelta = severityWeight(right.severity) - severityWeight(left.severity);
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+
+    return right.confidence - left.confidence;
+  });
+  const primary = sorted[0]!;
+  const sameFile = sorted.every((finding) => finding.file === primary.file);
+  const starts = sorted.map((finding) => finding.start).filter((value): value is number => value != null);
+  const ends = sorted.map((finding) => finding.end ?? finding.start).filter((value): value is number => value != null);
+
+  return {
+    summary: primary.body,
+    severity: sorted.some((finding) => finding.severity === "high")
+      ? "high"
+      : sorted.some((finding) => finding.severity === "medium")
+        ? "medium"
+        : "low",
+    category: primary.category,
+    file: sameFile ? primary.file : null,
+    start: sameFile && starts.length > 0 ? Math.min(...starts) : null,
+    end: sameFile && ends.length > 0 ? Math.max(...ends) : null,
+    roles: [...new Set(sorted.map((finding) => finding.role))],
+    findingsCount: sorted.length,
+    findingKeys: sorted.map((finding) => findingKey(finding)),
+  };
+}
+
+function compressRootCauses(findings: LocalReviewFinding[]): LocalReviewRootCauseSummary[] {
+  const groups: LocalReviewFinding[][] = [];
+  for (const finding of findings) {
+    const overlappingGroupIndexes: number[] = [];
+    for (let index = 0; index < groups.length; index += 1) {
+      const candidate = groups[index];
+      if (candidate?.some((existing) => findingsOverlap(existing, finding))) {
+        overlappingGroupIndexes.push(index);
+      }
+    }
+
+    if (overlappingGroupIndexes.length > 0) {
+      const targetGroup = groups[overlappingGroupIndexes[0]!]!;
+      targetGroup.push(finding);
+      for (let index = overlappingGroupIndexes.length - 1; index >= 1; index -= 1) {
+        const groupIndex = overlappingGroupIndexes[index]!;
+        const groupToMerge = groups[groupIndex]!;
+        targetGroup.push(...groupToMerge);
+        groups.splice(groupIndex, 1);
+      }
+      continue;
+    }
+
+    groups.push([finding]);
+  }
+
+  return groups
+    .map((group) => summarizeRootCause(group))
+    .sort((left, right) => {
+      const severityDelta = severityWeight(right.severity) - severityWeight(left.severity);
+      if (severityDelta !== 0) {
+        return severityDelta;
+      }
+
+      return right.findingsCount - left.findingsCount;
+    });
+}
+
+function maxSeverity(findings: LocalReviewFinding[]): LocalReviewSeverity {
+  if (findings.some((finding) => finding.severity === "high")) {
+    return "high";
+  }
+  if (findings.some((finding) => finding.severity === "medium")) {
+    return "medium";
+  }
+  if (findings.some((finding) => finding.severity === "low")) {
+    return "low";
+  }
+
+  return "none";
+}
+
+export function finalizeLocalReview(args: {
+  config: Pick<SupervisorConfig, "localReviewConfidenceThreshold">;
+  issueNumber: number;
+  prNumber: number;
+  branch: string;
+  headSha: string;
+  detectedRoles?: LocalReviewRoleSelection[];
+  roleResults: LocalReviewRoleResult[];
+  verifierReport: LocalReviewVerifierReport | null;
+  ranAt: string;
+}): FinalizedLocalReview {
+  const roles = args.roleResults.map((result) => result.role);
+  const allFindings = args.roleResults.flatMap((result) => result.findings);
+  const actionableFindings = dedupeFindings(
+    allFindings.filter((finding) => finding.confidence >= args.config.localReviewConfidenceThreshold),
+  );
+  const rootCauseSummaries = compressRootCauses(actionableFindings);
+  const degraded = args.roleResults.some((result) => result.degraded) || (args.verifierReport?.degraded ?? false);
+  const summary = truncate(
+    `Roles run: ${roles.join(", ")}. Actionable findings above confidence ${args.config.localReviewConfidenceThreshold.toFixed(2)}: ${actionableFindings.length}. Root causes: ${rootCauseSummaries.length}. Degraded roles: ${args.roleResults.filter((result) => result.degraded).length}.`,
+    500,
+  ) ?? "";
+  const recommendation: LocalReviewResult["recommendation"] =
+    degraded ? "unknown" : actionableFindings.length > 0 ? "changes_requested" : "ready";
+  const actionableHighSeverityFindings = actionableFindings.filter((finding) => finding.severity === "high");
+  const verificationByKey = new Map(args.verifierReport?.findings.map((finding) => [finding.findingKey, finding]) ?? []);
+  const verifiedFindings = actionableHighSeverityFindings.filter(
+    (finding) => verificationByKey.get(findingKey(finding))?.verdict === "confirmed",
+  );
+  const verifiedMaxSeverity = maxSeverity(verifiedFindings);
+  const artifact: LocalReviewArtifact = {
+    issueNumber: args.issueNumber,
+    prNumber: args.prNumber,
+    branch: args.branch,
+    headSha: args.headSha,
+    ranAt: args.ranAt,
+    confidenceThreshold: args.config.localReviewConfidenceThreshold,
+    roles,
+    autoDetectedRoles: args.detectedRoles ?? [],
+    summary,
+    recommendation,
+    degraded,
+    findingsCount: actionableFindings.length,
+    rootCauseCount: rootCauseSummaries.length,
+    maxSeverity: maxSeverity(actionableFindings),
+    actionableFindings,
+    rootCauseSummaries,
+    verification: {
+      required: actionableHighSeverityFindings.length > 0,
+      summary: args.verifierReport?.summary ?? (actionableHighSeverityFindings.length > 0 ? "Verification not run." : "No high-severity findings required verification."),
+      recommendation: args.verifierReport?.recommendation ?? "unknown",
+      degraded: args.verifierReport?.degraded ?? false,
+      findingsCount: args.verifierReport?.findings.length ?? 0,
+      verifiedFindingsCount: verifiedFindings.length,
+      verifiedMaxSeverity,
+      findings: args.verifierReport?.findings ?? [],
+    },
+    verifiedFindings,
+    roleReports: args.roleResults.map((result) => ({
+      role: result.role,
+      exitCode: result.exitCode,
+      degraded: result.degraded,
+      summary: result.summary,
+      recommendation: result.recommendation,
+      findings: result.findings,
+    })),
+    verifierReport: args.verifierReport
+      ? {
+          role: args.verifierReport.role,
+          exitCode: args.verifierReport.exitCode,
+          degraded: args.verifierReport.degraded,
+          summary: args.verifierReport.summary,
+          recommendation: args.verifierReport.recommendation,
+          findings: args.verifierReport.findings,
+        }
+      : null,
+  };
+
+  return {
+    summary,
+    recommendation,
+    degraded,
+    findingsCount: actionableFindings.length,
+    rootCauseCount: rootCauseSummaries.length,
+    maxSeverity: maxSeverity(actionableFindings),
+    verifiedFindingsCount: verifiedFindings.length,
+    verifiedMaxSeverity,
+    actionableFindings,
+    rootCauseSummaries,
+    verifiedFindings,
+    artifact,
+  };
+}

--- a/src/local-review-prompt.ts
+++ b/src/local-review-prompt.ts
@@ -1,0 +1,370 @@
+import { type ExternalReviewMissPattern } from "./external-review-misses";
+import { type GitHubIssue, type GitHubPullRequest } from "./types";
+import { truncate } from "./utils";
+import { renderLines } from "./local-review-artifacts";
+import { findingKey } from "./local-review-finalize";
+import {
+  type LocalReviewFinding,
+  type LocalReviewVerificationFinding,
+  type ParsedRoleFooter,
+  type ParsedVerifierFooter,
+} from "./local-review-types";
+
+interface RolePromptArgs {
+  repoSlug: string;
+  issue: GitHubIssue;
+  branch: string;
+  workspacePath: string;
+  defaultBranch: string;
+  pr: GitHubPullRequest;
+  role: string;
+  alwaysReadFiles: string[];
+  onDemandFiles: string[];
+  confidenceThreshold: number;
+  priorMissPatterns: ExternalReviewMissPattern[];
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeSeverity(value: unknown): LocalReviewFinding["severity"] | null {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (normalized === "low" || normalized === "medium" || normalized === "high") {
+    return normalized;
+  }
+
+  return null;
+}
+
+function normalizeConfidence(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeFinding(role: string, value: unknown): LocalReviewFinding | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const title = typeof record.title === "string" ? normalizeWhitespace(record.title) : "";
+  const body = typeof record.body === "string" ? normalizeWhitespace(record.body) : "";
+  const severity = normalizeSeverity(record.severity);
+  const confidence = normalizeConfidence(record.confidence);
+  if (!title || !body || !severity || confidence === null) {
+    return null;
+  }
+
+  let start =
+    typeof record.start === "number" && Number.isInteger(record.start) && record.start > 0
+      ? record.start
+      : null;
+  let end =
+    typeof record.end === "number" && Number.isInteger(record.end) && record.end > 0
+      ? record.end
+      : start;
+
+  if (start === null && end !== null) {
+    start = end;
+  }
+
+  return {
+    role,
+    title,
+    body,
+    file: typeof record.file === "string" && record.file.trim() !== "" ? record.file.trim() : null,
+    start,
+    end,
+    severity,
+    confidence,
+    category: typeof record.category === "string" && record.category.trim() !== "" ? record.category.trim() : null,
+    evidence: typeof record.evidence === "string" && record.evidence.trim() !== "" ? truncate(record.evidence.trim(), 500) : null,
+  };
+}
+
+function normalizeVerificationVerdict(value: unknown): LocalReviewVerificationFinding["verdict"] | null {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (normalized === "confirmed" || normalized === "dismissed" || normalized === "unclear") {
+    return normalized;
+  }
+
+  return null;
+}
+
+function normalizeVerificationFinding(value: unknown): LocalReviewVerificationFinding | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const findingKey = typeof record.findingKey === "string" ? normalizeWhitespace(record.findingKey) : "";
+  const verdict = normalizeVerificationVerdict(record.verdict);
+  const rationale = typeof record.rationale === "string" ? normalizeWhitespace(record.rationale) : "";
+  if (!findingKey || !verdict || !rationale) {
+    return null;
+  }
+
+  return {
+    findingKey,
+    verdict,
+    rationale: truncate(rationale, 500) ?? rationale,
+  };
+}
+
+export function parseRoleFooter(role: string, output: string): ParsedRoleFooter {
+  const summaryMatch = output.match(/Review summary:\s*(.+)/i);
+  const recommendationMatch = output.match(/Recommendation:\s*(ready|changes_requested)/i);
+  const jsonMatch = output.match(/REVIEW_FINDINGS_JSON_START\s*([\s\S]*?)\s*REVIEW_FINDINGS_JSON_END/i);
+
+  let findings: LocalReviewFinding[] = [];
+
+  if (jsonMatch?.[1]) {
+    try {
+      const parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+      if (Array.isArray(parsed.findings)) {
+        findings = parsed.findings
+          .map((item) => normalizeFinding(role, item))
+          .filter((item): item is LocalReviewFinding => item !== null);
+      }
+    } catch {
+      findings = [];
+    }
+  }
+
+  return {
+    summary: truncate(summaryMatch?.[1]?.trim() ?? `${role} review completed without a structured summary.`, 500) ?? "",
+    recommendation: (recommendationMatch?.[1]?.toLowerCase() as "ready" | "changes_requested" | undefined) ?? "unknown",
+    findings,
+  };
+}
+
+export function parseVerifierFooter(output: string): ParsedVerifierFooter {
+  const summaryMatch = output.match(/Verification summary:\s*(.+)/i);
+  const recommendationMatch = output.match(/Recommendation:\s*(ready|changes_requested)/i);
+  const jsonMatch = output.match(/REVIEW_VERIFIER_JSON_START\s*([\s\S]*?)\s*REVIEW_VERIFIER_JSON_END/i);
+
+  let findings: LocalReviewVerificationFinding[] = [];
+
+  if (jsonMatch?.[1]) {
+    try {
+      const parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
+      if (Array.isArray(parsed.findings)) {
+        findings = parsed.findings
+          .map((item) => normalizeVerificationFinding(item))
+          .filter((item): item is LocalReviewVerificationFinding => item !== null);
+      }
+    } catch {
+      findings = [];
+    }
+  }
+
+  return {
+    summary: truncate(summaryMatch?.[1]?.trim() ?? "Verifier completed without a structured summary.", 500) ?? "",
+    recommendation: (recommendationMatch?.[1]?.toLowerCase() as "ready" | "changes_requested" | undefined) ?? "unknown",
+    findings,
+  };
+}
+
+export function compareRef(defaultBranch: string): string {
+  return `origin/${defaultBranch}...HEAD`;
+}
+
+function roleGoal(role: string): string[] {
+  switch (role) {
+    case "explorer":
+      return [
+        "- Start with the diff and identify the narrowest set of risky code paths.",
+        "- Focus on missing context, hidden coupling, and files that deserve deeper review.",
+        "- Report only actionable engineering findings, not generic suggestions.",
+      ];
+    case "reviewer":
+      return [
+        "- Focus on correctness, regressions, edge cases, and missing tests in the changed code paths.",
+        "- Prefer precise findings tied to a specific file and line whenever possible.",
+        "- Ignore style nits unless they could hide a bug or maintenance trap.",
+      ];
+    case "docs_researcher":
+      return [
+        "- Open durable memory files only if the diff or issue suggests a workflow, architecture, or policy mismatch.",
+        "- Focus on requirements drift, contract mismatches, and contradictions with repo guidance.",
+        "- Do not report docs-only wording concerns unless they reveal a code or workflow defect.",
+      ];
+    case "prisma_postgres_reviewer":
+      return [
+        "- Focus on Prisma schema, migration SQL, PostgreSQL uniqueness semantics, nullability, and relation invariants.",
+        "- Look for places where application code assumes a database guarantee that the schema or migration does not actually enforce.",
+        "- Prefer findings around unique indexes, partial indexes, check constraints, nullable uniqueness, and schema/migration drift.",
+      ];
+    case "migration_invariant_reviewer":
+      return [
+        "- Focus on persisted-state invariants that should be enforced by the database, not just by application validation.",
+        "- Look for invalid row combinations, missing CHECK constraints, unsafe defaults, and migrations that allow data shapes the code treats as impossible.",
+        "- Report only concrete invariant gaps that could survive into production data.",
+      ];
+    case "contract_consistency_reviewer":
+      return [
+        "- Compare API contracts, TypeScript types, schema fields, docs, and tests for drift.",
+        "- Look for dropped required fields, widened enums, missing audit fields, and response shapes that no longer match documented behavior.",
+        "- Focus on contract mismatches that can break callers or hide data needed for downstream logic.",
+      ];
+    case "ui_regression_reviewer":
+      return [
+        "- Focus on UI or browser-flow regressions suggested by the diff, especially around Playwright-covered surfaces.",
+        "- Look for changed selectors, state transitions, form flows, and rendering assumptions that could break existing end-to-end tests.",
+        "- Report concrete regressions, not general UX suggestions.",
+      ];
+    case "github_actions_semantics_reviewer":
+      return [
+        "- Focus on GitHub Actions semantics, event context, concurrency behavior, expression safety, and PR check surface behavior.",
+        "- Look for cases where workflow changes can appear green locally but behave differently under pull_request, push, merge queue, or cancelled-run scenarios.",
+        "- Prefer findings about incorrect event assumptions, stale cancelled checks, ref collisions, or unsafe workflow expressions.",
+      ];
+    case "workflow_test_reviewer":
+      return [
+        "- Focus on tests that validate workflow files or CI behavior.",
+        "- Look for brittle regex assertions, newline-sensitive matching, path assumptions, and tests that depend on repo root or exact YAML formatting.",
+        "- Prefer findings where a workflow test can pass today but break on harmless formatting changes or different execution environments.",
+      ];
+    case "portability_reviewer":
+      return [
+        "- Focus on portability across shells, operating systems, path layouts, and line endings.",
+        "- Look for shell-glob assumptions, cwd-sensitive file access, hard-coded separators, and constructs that behave differently on macOS, Linux, or Windows.",
+        "- Report only concrete portability risks that could break local development or CI execution.",
+      ];
+    default:
+      return [
+        `- Operate as a specialized reviewer named ${role}.`,
+        "- Focus on concrete, actionable defects in the current diff.",
+        "- Keep context narrow and avoid speculative findings.",
+      ];
+  }
+}
+
+export function buildRolePrompt(args: RolePromptArgs): string {
+  const ref = compareRef(args.defaultBranch);
+  const priorMissLines =
+    args.priorMissPatterns.length > 0
+      ? [
+          "Relevant prior confirmed external misses for this diff:",
+          "- Use these as targeted checks for blind spots that local review previously missed.",
+          ...args.priorMissPatterns.map((pattern, index) =>
+            [
+              `- Prior miss ${index + 1}: file=${pattern.file}:${pattern.line ?? "?"} reviewer=${pattern.reviewerLogin}`,
+              `  summary=${pattern.summary}`,
+              `  rationale=${pattern.rationale}`,
+            ].join("\n"),
+          ),
+          "",
+        ]
+      : [];
+
+  return [
+    `You are performing a local pre-ready ${args.role} review for ${args.repoSlug}.`,
+    `Issue: #${args.issue.number} ${args.issue.title}`,
+    `Issue URL: ${args.issue.url}`,
+    `PR: #${args.pr.number} ${args.pr.url}`,
+    `Branch: ${args.branch}`,
+    `Workspace: ${args.workspacePath}`,
+    `Compare diff against: ${ref}`,
+    "",
+    "Goal:",
+    ...roleGoal(args.role),
+    "",
+    "Constraints:",
+    "- Do not edit files, do not commit, and do not push.",
+    "- Review the current branch only.",
+    `- Confidence threshold for actionable findings: ${args.confidenceThreshold.toFixed(2)}.`,
+    "- Report only findings that you can justify from the diff and any narrowly targeted reads.",
+    "",
+    ...(args.alwaysReadFiles.length > 0
+      ? [
+          "Always-read memory files:",
+          ...args.alwaysReadFiles.map((filePath) => `- ${filePath}`),
+          "",
+          "On-demand durable memory files:",
+          ...(args.onDemandFiles.length > 0 ? args.onDemandFiles.map((filePath) => `- ${filePath}`) : ["- none configured"]),
+          "",
+          "Memory policy:",
+          "- Read the always-read files first.",
+          "- Use the context index to decide whether any on-demand file is worth opening.",
+          "- Do not bulk-read every durable memory file just because multiple reviewer roles exist.",
+          "- Keep this role narrow: diff first, then the smallest number of targeted file reads.",
+          "",
+        ]
+      : []),
+    ...priorMissLines,
+    "Suggested commands:",
+    `- git diff --stat ${ref}`,
+    `- git diff ${ref}`,
+    "",
+    "Respond with a concise review and end with this exact footer:",
+    "Review summary: <short summary>",
+    "Recommendation: <ready|changes_requested>",
+    "REVIEW_FINDINGS_JSON_START",
+    '{"findings":[{"title":"short label","body":"one-paragraph explanation","file":"path/or/null","start":10,"end":12,"severity":"low|medium|high","confidence":0.0,"category":"optional short tag","evidence":"optional short supporting detail"}]}',
+    "REVIEW_FINDINGS_JSON_END",
+    "",
+    "Return an empty findings array when you have no actionable findings.",
+  ].join("\n");
+}
+
+export function buildVerifierPrompt(args: {
+  repoSlug: string;
+  issue: GitHubIssue;
+  branch: string;
+  workspacePath: string;
+  defaultBranch: string;
+  pr: GitHubPullRequest;
+  findings: LocalReviewFinding[];
+}): string {
+  const ref = compareRef(args.defaultBranch);
+  const findingsBlock = args.findings
+    .map((finding, index) =>
+      [
+        `- Finding ${index + 1}`,
+        `  key: ${findingKey(finding)}`,
+        `  title: ${finding.title}`,
+        `  severity: ${finding.severity}`,
+        `  file: ${finding.file ?? "none"}`,
+        `  lines: ${renderLines(finding)}`,
+        `  body: ${finding.body}`,
+        ...(finding.evidence ? [`  evidence: ${finding.evidence}`] : []),
+      ].join("\n"),
+    )
+    .join("\n");
+
+  return [
+    `You are performing a verifier pass for high-severity local review findings in ${args.repoSlug}.`,
+    `Issue: #${args.issue.number} ${args.issue.title}`,
+    `Issue URL: ${args.issue.url}`,
+    `PR: #${args.pr.number} ${args.pr.url}`,
+    `Branch: ${args.branch}`,
+    `Workspace: ${args.workspacePath}`,
+    `Compare diff against: ${ref}`,
+    "",
+    "Goal:",
+    "- Re-check only the listed high-severity findings.",
+    "- Confirm a finding only when the diff and narrowly targeted reads support the original concern.",
+    "- Dismiss findings that appear to be false positives or overstated.",
+    "- Use `unclear` when the evidence is inconclusive from the available local context.",
+    "",
+    "Constraints:",
+    "- Do not edit files, do not commit, and do not push.",
+    "- Keep reads narrow and tied to the listed findings.",
+    "",
+    "High-severity findings to verify:",
+    findingsBlock,
+    "",
+    "Respond with a concise verification and end with this exact footer:",
+    "Verification summary: <short summary>",
+    "Recommendation: <ready|changes_requested>",
+    "REVIEW_VERIFIER_JSON_START",
+    '{"findings":[{"findingKey":"exact key from prompt","verdict":"confirmed|dismissed|unclear","rationale":"short evidence-based explanation"}]}',
+    "REVIEW_VERIFIER_JSON_END",
+  ].join("\n");
+}
+

--- a/src/local-review-runner.ts
+++ b/src/local-review-runner.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCommand } from "./command";
+import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
+import { type ExternalReviewMissPattern } from "./external-review-misses";
+import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./local-review-prompt";
+import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
+import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
+
+function safeSlug(input: string): string {
+  return input.replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
+
+async function runCodexReviewTurn(args: {
+  config: SupervisorConfig;
+  workspacePath: string;
+  outputFileName: string;
+  prompt: string;
+}): Promise<{ exitCode: number; rawOutput: string }> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
+  const messageFile = path.join(tempDir, args.outputFileName);
+  const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(args.config, "local_review"));
+  const result = await runCommand(
+    args.config.codexBinary,
+    [
+      "exec",
+      ...overrideArgs,
+      "--json",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "-C",
+      args.workspacePath,
+      "-o",
+      messageFile,
+      args.prompt,
+    ],
+    {
+      cwd: args.workspacePath,
+      allowExitCodes: [0, 1],
+      env: {
+        ...process.env,
+        npm_config_yes: "true",
+        CI: "1",
+      },
+      timeoutMs: args.config.codexExecTimeoutMinutes * 60_000,
+    },
+  );
+
+  let rawOutput = "";
+  try {
+    rawOutput = (await fs.readFile(messageFile, "utf8")).trim();
+  } catch {
+    rawOutput = [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n").trim();
+  }
+  await fs.rm(tempDir, { recursive: true, force: true });
+
+  return {
+    exitCode: result.exitCode,
+    rawOutput,
+  };
+}
+
+export async function runRoleReview(args: {
+  config: SupervisorConfig;
+  issue: GitHubIssue;
+  branch: string;
+  workspacePath: string;
+  defaultBranch: string;
+  pr: GitHubPullRequest;
+  role: string;
+  alwaysReadFiles: string[];
+  onDemandFiles: string[];
+  priorMissPatterns: ExternalReviewMissPattern[];
+}): Promise<LocalReviewRoleResult> {
+  const prompt = buildRolePrompt({
+    repoSlug: args.config.repoSlug,
+    issue: args.issue,
+    branch: args.branch,
+    workspacePath: args.workspacePath,
+    defaultBranch: args.defaultBranch,
+    pr: args.pr,
+    role: args.role,
+    alwaysReadFiles: args.alwaysReadFiles,
+    onDemandFiles: args.onDemandFiles,
+    confidenceThreshold: args.config.localReviewConfidenceThreshold,
+    priorMissPatterns: args.priorMissPatterns,
+  });
+  const result = await runCodexReviewTurn({
+    config: args.config,
+    workspacePath: args.workspacePath,
+    outputFileName: `${safeSlug(args.role)}.txt`,
+    prompt,
+  });
+  const parsed = parseRoleFooter(args.role, result.rawOutput);
+
+  return {
+    role: args.role,
+    rawOutput: result.rawOutput,
+    exitCode: result.exitCode,
+    degraded: result.exitCode !== 0,
+    ...parsed,
+  };
+}
+
+export async function runVerifierReview(args: {
+  config: SupervisorConfig;
+  issue: GitHubIssue;
+  branch: string;
+  workspacePath: string;
+  defaultBranch: string;
+  pr: GitHubPullRequest;
+  findings: LocalReviewFinding[];
+}): Promise<LocalReviewVerifierReport> {
+  const prompt = buildVerifierPrompt({
+    repoSlug: args.config.repoSlug,
+    issue: args.issue,
+    branch: args.branch,
+    workspacePath: args.workspacePath,
+    defaultBranch: args.defaultBranch,
+    pr: args.pr,
+    findings: args.findings,
+  });
+  const result = await runCodexReviewTurn({
+    config: args.config,
+    workspacePath: args.workspacePath,
+    outputFileName: "verifier.txt",
+    prompt,
+  });
+  const parsed = parseVerifierFooter(result.rawOutput);
+
+  return {
+    role: "verifier",
+    rawOutput: result.rawOutput,
+    exitCode: result.exitCode,
+    degraded: result.exitCode !== 0,
+    ...parsed,
+  };
+}

--- a/src/local-review-types.ts
+++ b/src/local-review-types.ts
@@ -1,0 +1,146 @@
+import { type LocalReviewRoleSelection } from "./review-role-detector";
+
+export type LocalReviewSeverity = "none" | "low" | "medium" | "high";
+
+export type ActionableSeverity = Exclude<LocalReviewSeverity, "none">;
+export type VerificationVerdict = "confirmed" | "dismissed" | "unclear";
+
+export interface ParsedRoleFooter {
+  summary: string;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  findings: LocalReviewFinding[];
+}
+
+export interface ParsedVerifierFooter {
+  summary: string;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  findings: LocalReviewVerificationFinding[];
+}
+
+export interface LocalReviewFinding {
+  role: string;
+  title: string;
+  body: string;
+  file: string | null;
+  start: number | null;
+  end: number | null;
+  severity: ActionableSeverity;
+  confidence: number;
+  category: string | null;
+  evidence: string | null;
+}
+
+export interface LocalReviewVerificationFinding {
+  findingKey: string;
+  verdict: VerificationVerdict;
+  rationale: string;
+}
+
+export interface LocalReviewRootCauseSummary {
+  summary: string;
+  severity: ActionableSeverity;
+  category: string | null;
+  file: string | null;
+  start: number | null;
+  end: number | null;
+  roles: string[];
+  findingsCount: number;
+  findingKeys: string[];
+}
+
+export interface LocalReviewRoleResult {
+  role: string;
+  summary: string;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  findings: LocalReviewFinding[];
+  rawOutput: string;
+  exitCode: number;
+  degraded: boolean;
+}
+
+export interface LocalReviewVerifierReport {
+  role: "verifier";
+  summary: string;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  findings: LocalReviewVerificationFinding[];
+  rawOutput: string;
+  exitCode: number;
+  degraded: boolean;
+}
+
+export interface LocalReviewArtifact {
+  issueNumber: number;
+  prNumber: number;
+  branch: string;
+  headSha: string;
+  ranAt: string;
+  confidenceThreshold: number;
+  roles: string[];
+  autoDetectedRoles: LocalReviewRoleSelection[];
+  summary: string;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  degraded: boolean;
+  findingsCount: number;
+  rootCauseCount: number;
+  maxSeverity: LocalReviewSeverity;
+  actionableFindings: LocalReviewFinding[];
+  rootCauseSummaries: LocalReviewRootCauseSummary[];
+  verification: {
+    required: boolean;
+    summary: string;
+    recommendation: "ready" | "changes_requested" | "unknown";
+    degraded: boolean;
+    findingsCount: number;
+    verifiedFindingsCount: number;
+    verifiedMaxSeverity: LocalReviewSeverity;
+    findings: LocalReviewVerificationFinding[];
+  };
+  verifiedFindings: LocalReviewFinding[];
+  roleReports: Array<{
+    role: string;
+    exitCode: number;
+    degraded: boolean;
+    summary: string;
+    recommendation: "ready" | "changes_requested" | "unknown";
+    findings: LocalReviewFinding[];
+  }>;
+  verifierReport: {
+    role: "verifier";
+    exitCode: number;
+    degraded: boolean;
+    summary: string;
+    recommendation: "ready" | "changes_requested" | "unknown";
+    findings: LocalReviewVerificationFinding[];
+  } | null;
+}
+
+export interface FinalizedLocalReview {
+  summary: string;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  degraded: boolean;
+  findingsCount: number;
+  rootCauseCount: number;
+  maxSeverity: LocalReviewSeverity;
+  verifiedFindingsCount: number;
+  verifiedMaxSeverity: LocalReviewSeverity;
+  actionableFindings: LocalReviewFinding[];
+  rootCauseSummaries: LocalReviewRootCauseSummary[];
+  verifiedFindings: LocalReviewFinding[];
+  artifact: LocalReviewArtifact;
+}
+
+export interface LocalReviewResult {
+  ranAt: string;
+  summaryPath: string;
+  findingsPath: string;
+  summary: string;
+  findingsCount: number;
+  rootCauseCount: number;
+  maxSeverity: LocalReviewSeverity;
+  verifiedFindingsCount: number;
+  verifiedMaxSeverity: LocalReviewSeverity;
+  recommendation: "ready" | "changes_requested" | "unknown";
+  degraded: boolean;
+  rawOutput: string;
+}
+

--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildRolePrompt, finalizeLocalReview, shouldRunLocalReview } from "./local-review";
+import { localReviewHasActionableFindings, shouldRunLocalReview } from "./local-review";
+import { finalizeLocalReview } from "./local-review-finalize";
+import { buildRolePrompt } from "./local-review-prompt";
 import { LocalReviewRoleSelection } from "./review-role-detector";
 import { GitHubPullRequest, SupervisorConfig } from "./types";
 
@@ -140,6 +142,34 @@ test("shouldRunLocalReview covers draft and ready policy gating combinations", (
 
     assert.equal(shouldRunLocalReview(config, record, pr), testCase.expected, testCase.name);
   }
+});
+
+test("localReviewHasActionableFindings requires the current head and a non-ready result", () => {
+  const pr = createPullRequest({ headRefOid: "newhead123" });
+
+  assert.equal(localReviewHasActionableFindings({
+    local_review_head_sha: "newhead123",
+    local_review_findings_count: 0,
+    local_review_recommendation: "ready",
+  }, pr), false);
+
+  assert.equal(localReviewHasActionableFindings({
+    local_review_head_sha: "oldhead456",
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+  }, pr), false);
+
+  assert.equal(localReviewHasActionableFindings({
+    local_review_head_sha: "newhead123",
+    local_review_findings_count: 1,
+    local_review_recommendation: "ready",
+  }, pr), true);
+
+  assert.equal(localReviewHasActionableFindings({
+    local_review_head_sha: "newhead123",
+    local_review_findings_count: 0,
+    local_review_recommendation: "changes_requested",
+  }, pr), true);
 });
 
 test("finalizeLocalReview keeps raw high-severity findings separate from dismissed verifier results", () => {

--- a/src/local-review.ts
+++ b/src/local-review.ts
@@ -1,156 +1,29 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import { detectLocalReviewRoleSelections } from "./review-role-detector";
 import { runCommand } from "./command";
-import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
-import { ExternalReviewMissPattern, loadRelevantExternalReviewMissPatterns } from "./external-review-misses";
-import { detectLocalReviewRoleSelections, type LocalReviewRoleSelection } from "./review-role-detector";
+import { loadRelevantExternalReviewMissPatterns } from "./external-review-misses";
+import { ensureDir, nowIso } from "./utils";
+import { compareRef } from "./local-review-prompt";
+import { dedupeFindings, finalizeLocalReview } from "./local-review-finalize";
+import { reviewDir, writeLocalReviewArtifacts } from "./local-review-artifacts";
+import { runRoleReview, runVerifierReview } from "./local-review-runner";
 import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "./types";
-import { ensureDir, nowIso, truncate } from "./utils";
+import { type FinalizedLocalReview, type LocalReviewResult, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
 
-export type LocalReviewSeverity = "none" | "low" | "medium" | "high";
-
-type ActionableSeverity = Exclude<LocalReviewSeverity, "none">;
-type VerificationVerdict = "confirmed" | "dismissed" | "unclear";
-
-interface ParsedRoleFooter {
-  summary: string;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  findings: LocalReviewFinding[];
-}
-
-interface ParsedVerifierFooter {
-  summary: string;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  findings: LocalReviewVerificationFinding[];
-}
-
-export interface LocalReviewFinding {
-  role: string;
-  title: string;
-  body: string;
-  file: string | null;
-  start: number | null;
-  end: number | null;
-  severity: ActionableSeverity;
-  confidence: number;
-  category: string | null;
-  evidence: string | null;
-}
-
-export interface LocalReviewVerificationFinding {
-  findingKey: string;
-  verdict: VerificationVerdict;
-  rationale: string;
-}
-
-export interface LocalReviewRootCauseSummary {
-  summary: string;
-  severity: ActionableSeverity;
-  category: string | null;
-  file: string | null;
-  start: number | null;
-  end: number | null;
-  roles: string[];
-  findingsCount: number;
-  findingKeys: string[];
-}
-
-export interface LocalReviewRoleResult {
-  role: string;
-  summary: string;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  findings: LocalReviewFinding[];
-  rawOutput: string;
-  exitCode: number;
-  degraded: boolean;
-}
-
-export interface LocalReviewVerifierReport {
-  role: "verifier";
-  summary: string;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  findings: LocalReviewVerificationFinding[];
-  rawOutput: string;
-  exitCode: number;
-  degraded: boolean;
-}
-
-interface LocalReviewArtifact {
-  issueNumber: number;
-  prNumber: number;
-  branch: string;
-  headSha: string;
-  ranAt: string;
-  confidenceThreshold: number;
-  roles: string[];
-  autoDetectedRoles: LocalReviewRoleSelection[];
-  summary: string;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  degraded: boolean;
-  findingsCount: number;
-  rootCauseCount: number;
-  maxSeverity: LocalReviewSeverity;
-  actionableFindings: LocalReviewFinding[];
-  rootCauseSummaries: LocalReviewRootCauseSummary[];
-  verification: {
-    required: boolean;
-    summary: string;
-    recommendation: "ready" | "changes_requested" | "unknown";
-    degraded: boolean;
-    findingsCount: number;
-    verifiedFindingsCount: number;
-    verifiedMaxSeverity: LocalReviewSeverity;
-    findings: LocalReviewVerificationFinding[];
-  };
-  verifiedFindings: LocalReviewFinding[];
-  roleReports: Array<{
-    role: string;
-    exitCode: number;
-    degraded: boolean;
-    summary: string;
-    recommendation: "ready" | "changes_requested" | "unknown";
-    findings: LocalReviewFinding[];
-  }>;
-  verifierReport: {
-    role: "verifier";
-    exitCode: number;
-    degraded: boolean;
-    summary: string;
-    recommendation: "ready" | "changes_requested" | "unknown";
-    findings: LocalReviewVerificationFinding[];
-  } | null;
-}
-
-export interface FinalizedLocalReview {
-  summary: string;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  degraded: boolean;
-  findingsCount: number;
-  rootCauseCount: number;
-  maxSeverity: LocalReviewSeverity;
-  verifiedFindingsCount: number;
-  verifiedMaxSeverity: LocalReviewSeverity;
-  actionableFindings: LocalReviewFinding[];
-  rootCauseSummaries: LocalReviewRootCauseSummary[];
-  verifiedFindings: LocalReviewFinding[];
-  artifact: LocalReviewArtifact;
-}
-
-export interface LocalReviewResult {
-  ranAt: string;
-  summaryPath: string;
-  findingsPath: string;
-  summary: string;
-  findingsCount: number;
-  rootCauseCount: number;
-  maxSeverity: LocalReviewSeverity;
-  verifiedFindingsCount: number;
-  verifiedMaxSeverity: LocalReviewSeverity;
-  recommendation: "ready" | "changes_requested" | "unknown";
-  degraded: boolean;
-  rawOutput: string;
-}
+export type {
+  ActionableSeverity,
+  FinalizedLocalReview,
+  LocalReviewArtifact,
+  LocalReviewFinding,
+  LocalReviewResult,
+  LocalReviewRootCauseSummary,
+  LocalReviewRoleResult,
+  LocalReviewSeverity,
+  LocalReviewVerificationFinding,
+  LocalReviewVerifierReport,
+  ParsedRoleFooter,
+  ParsedVerifierFooter,
+  VerificationVerdict,
+} from "./local-review-types";
 
 export function localReviewHasActionableFindings(
   record: Pick<IssueRunRecordLike, "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation">,
@@ -171,818 +44,110 @@ interface IssueRunRecordLike {
   local_review_recommendation: "ready" | "changes_requested" | "unknown" | null;
 }
 
-interface RolePromptArgs {
-  repoSlug: string;
-  issue: GitHubIssue;
-  branch: string;
-  workspacePath: string;
-  defaultBranch: string;
-  pr: GitHubPullRequest;
-  role: string;
-  alwaysReadFiles: string[];
-  onDemandFiles: string[];
-  confidenceThreshold: number;
-  priorMissPatterns: ExternalReviewMissPattern[];
-}
-
-function safeSlug(input: string): string {
-  return input.replace(/[^a-zA-Z0-9._-]+/g, "-");
-}
-
-function reviewDir(config: SupervisorConfig, issueNumber: number): string {
-  return path.join(config.localReviewArtifactDir, safeSlug(config.repoSlug), `issue-${issueNumber}`);
-}
-
-function normalizeWhitespace(value: string): string {
-  return value.replace(/\s+/g, " ").trim();
-}
-
-function normalizeSeverity(value: unknown): ActionableSeverity | null {
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-  if (normalized === "low" || normalized === "medium" || normalized === "high") {
-    return normalized;
+function selectLocalReviewRoles(args: {
+  config: SupervisorConfig;
+  detectedRoles: Awaited<ReturnType<typeof detectLocalReviewRoleSelections>>;
+}): string[] {
+  if (args.config.localReviewRoles.length > 0) {
+    return args.config.localReviewRoles;
+  }
+  if (args.detectedRoles.length > 0) {
+    return args.detectedRoles.map((selection) => selection.role);
   }
 
-  return null;
+  return ["reviewer", "explorer"];
 }
 
-function normalizeConfidence(value: unknown): number | null {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return null;
-  }
-
-  return Math.max(0, Math.min(1, value));
-}
-
-function normalizeFinding(role: string, value: unknown): LocalReviewFinding | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-
-  const record = value as Record<string, unknown>;
-  const title = typeof record.title === "string" ? normalizeWhitespace(record.title) : "";
-  const body = typeof record.body === "string" ? normalizeWhitespace(record.body) : "";
-  const severity = normalizeSeverity(record.severity);
-  const confidence = normalizeConfidence(record.confidence);
-  if (!title || !body || !severity || confidence === null) {
-    return null;
-  }
-
-  let start =
-    typeof record.start === "number" && Number.isInteger(record.start) && record.start > 0
-      ? record.start
-      : null;
-  let end =
-    typeof record.end === "number" && Number.isInteger(record.end) && record.end > 0
-      ? record.end
-      : start;
-
-  if (start === null && end !== null) {
-    start = end;
-  }
-
-  return {
-    role,
-    title,
-    body,
-    file: typeof record.file === "string" && record.file.trim() !== "" ? record.file.trim() : null,
-    start,
-    end,
-    severity,
-    confidence,
-    category: typeof record.category === "string" && record.category.trim() !== "" ? record.category.trim() : null,
-    evidence: typeof record.evidence === "string" && record.evidence.trim() !== "" ? truncate(record.evidence.trim(), 500) : null,
-  };
-}
-
-function normalizeVerificationVerdict(value: unknown): VerificationVerdict | null {
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-  if (normalized === "confirmed" || normalized === "dismissed" || normalized === "unclear") {
-    return normalized;
-  }
-
-  return null;
-}
-
-function normalizeVerificationFinding(value: unknown): LocalReviewVerificationFinding | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-
-  const record = value as Record<string, unknown>;
-  const findingKey = typeof record.findingKey === "string" ? normalizeWhitespace(record.findingKey) : "";
-  const verdict = normalizeVerificationVerdict(record.verdict);
-  const rationale = typeof record.rationale === "string" ? normalizeWhitespace(record.rationale) : "";
-  if (!findingKey || !verdict || !rationale) {
-    return null;
-  }
-
-  return {
-    findingKey,
-    verdict,
-    rationale: truncate(rationale, 500) ?? rationale,
-  };
-}
-
-function parseRoleFooter(role: string, output: string): ParsedRoleFooter {
-  const summaryMatch = output.match(/Review summary:\s*(.+)/i);
-  const recommendationMatch = output.match(/Recommendation:\s*(ready|changes_requested)/i);
-  const jsonMatch = output.match(/REVIEW_FINDINGS_JSON_START\s*([\s\S]*?)\s*REVIEW_FINDINGS_JSON_END/i);
-
-  let findings: LocalReviewFinding[] = [];
-
-  if (jsonMatch?.[1]) {
-    try {
-      const parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
-      if (Array.isArray(parsed.findings)) {
-        findings = parsed.findings
-          .map((item) => normalizeFinding(role, item))
-          .filter((item): item is LocalReviewFinding => item !== null);
-      }
-    } catch {
-      findings = [];
-    }
-  }
-
-  return {
-    summary: truncate(summaryMatch?.[1]?.trim() ?? `${role} review completed without a structured summary.`, 500) ?? "",
-    recommendation: (recommendationMatch?.[1]?.toLowerCase() as "ready" | "changes_requested" | undefined) ?? "unknown",
-    findings,
-  };
-}
-
-function parseVerifierFooter(output: string): ParsedVerifierFooter {
-  const summaryMatch = output.match(/Verification summary:\s*(.+)/i);
-  const recommendationMatch = output.match(/Recommendation:\s*(ready|changes_requested)/i);
-  const jsonMatch = output.match(/REVIEW_VERIFIER_JSON_START\s*([\s\S]*?)\s*REVIEW_VERIFIER_JSON_END/i);
-
-  let findings: LocalReviewVerificationFinding[] = [];
-
-  if (jsonMatch?.[1]) {
-    try {
-      const parsed = JSON.parse(jsonMatch[1]) as Record<string, unknown>;
-      if (Array.isArray(parsed.findings)) {
-        findings = parsed.findings
-          .map((item) => normalizeVerificationFinding(item))
-          .filter((item): item is LocalReviewVerificationFinding => item !== null);
-      }
-    } catch {
-      findings = [];
-    }
-  }
-
-  return {
-    summary: truncate(summaryMatch?.[1]?.trim() ?? "Verifier completed without a structured summary.", 500) ?? "",
-    recommendation: (recommendationMatch?.[1]?.toLowerCase() as "ready" | "changes_requested" | undefined) ?? "unknown",
-    findings,
-  };
-}
-
-function compareRef(defaultBranch: string): string {
-  return `origin/${defaultBranch}...HEAD`;
-}
-
-function roleGoal(role: string): string[] {
-  switch (role) {
-    case "explorer":
-      return [
-        "- Start with the diff and identify the narrowest set of risky code paths.",
-        "- Focus on missing context, hidden coupling, and files that deserve deeper review.",
-        "- Report only actionable engineering findings, not generic suggestions.",
-      ];
-    case "reviewer":
-      return [
-        "- Focus on correctness, regressions, edge cases, and missing tests in the changed code paths.",
-        "- Prefer precise findings tied to a specific file and line whenever possible.",
-        "- Ignore style nits unless they could hide a bug or maintenance trap.",
-      ];
-    case "docs_researcher":
-      return [
-        "- Open durable memory files only if the diff or issue suggests a workflow, architecture, or policy mismatch.",
-        "- Focus on requirements drift, contract mismatches, and contradictions with repo guidance.",
-        "- Do not report docs-only wording concerns unless they reveal a code or workflow defect.",
-      ];
-    case "prisma_postgres_reviewer":
-      return [
-        "- Focus on Prisma schema, migration SQL, PostgreSQL uniqueness semantics, nullability, and relation invariants.",
-        "- Look for places where application code assumes a database guarantee that the schema or migration does not actually enforce.",
-        "- Prefer findings around unique indexes, partial indexes, check constraints, nullable uniqueness, and schema/migration drift.",
-      ];
-    case "migration_invariant_reviewer":
-      return [
-        "- Focus on persisted-state invariants that should be enforced by the database, not just by application validation.",
-        "- Look for invalid row combinations, missing CHECK constraints, unsafe defaults, and migrations that allow data shapes the code treats as impossible.",
-        "- Report only concrete invariant gaps that could survive into production data.",
-      ];
-    case "contract_consistency_reviewer":
-      return [
-        "- Compare API contracts, TypeScript types, schema fields, docs, and tests for drift.",
-        "- Look for dropped required fields, widened enums, missing audit fields, and response shapes that no longer match documented behavior.",
-        "- Focus on contract mismatches that can break callers or hide data needed for downstream logic.",
-      ];
-    case "ui_regression_reviewer":
-      return [
-        "- Focus on UI or browser-flow regressions suggested by the diff, especially around Playwright-covered surfaces.",
-        "- Look for changed selectors, state transitions, form flows, and rendering assumptions that could break existing end-to-end tests.",
-        "- Report concrete regressions, not general UX suggestions.",
-      ];
-    case "github_actions_semantics_reviewer":
-      return [
-        "- Focus on GitHub Actions semantics, event context, concurrency behavior, expression safety, and PR check surface behavior.",
-        "- Look for cases where workflow changes can appear green locally but behave differently under pull_request, push, merge queue, or cancelled-run scenarios.",
-        "- Prefer findings about incorrect event assumptions, stale cancelled checks, ref collisions, or unsafe workflow expressions.",
-      ];
-    case "workflow_test_reviewer":
-      return [
-        "- Focus on tests that validate workflow files or CI behavior.",
-        "- Look for brittle regex assertions, newline-sensitive matching, path assumptions, and tests that depend on repo root or exact YAML formatting.",
-        "- Prefer findings where a workflow test can pass today but break on harmless formatting changes or different execution environments.",
-      ];
-    case "portability_reviewer":
-      return [
-        "- Focus on portability across shells, operating systems, path layouts, and line endings.",
-        "- Look for shell-glob assumptions, cwd-sensitive file access, hard-coded separators, and constructs that behave differently on macOS, Linux, or Windows.",
-        "- Report only concrete portability risks that could break local development or CI execution.",
-      ];
-    default:
-      return [
-        `- Operate as a specialized reviewer named ${role}.`,
-        "- Focus on concrete, actionable defects in the current diff.",
-        "- Keep context narrow and avoid speculative findings.",
-      ];
-  }
-}
-
-export function buildRolePrompt(args: RolePromptArgs): string {
-  const ref = compareRef(args.defaultBranch);
-  const priorMissLines =
-    args.priorMissPatterns.length > 0
-      ? [
-          "Relevant prior confirmed external misses for this diff:",
-          "- Use these as targeted checks for blind spots that local review previously missed.",
-          ...args.priorMissPatterns.map((pattern, index) =>
-            [
-              `- Prior miss ${index + 1}: file=${pattern.file}:${pattern.line ?? "?"} reviewer=${pattern.reviewerLogin}`,
-              `  summary=${pattern.summary}`,
-              `  rationale=${pattern.rationale}`,
-            ].join("\n"),
-          ),
-          "",
-        ]
-      : [];
-
-  return [
-    `You are performing a local pre-ready ${args.role} review for ${args.repoSlug}.`,
-    `Issue: #${args.issue.number} ${args.issue.title}`,
-    `Issue URL: ${args.issue.url}`,
-    `PR: #${args.pr.number} ${args.pr.url}`,
-    `Branch: ${args.branch}`,
-    `Workspace: ${args.workspacePath}`,
-    `Compare diff against: ${ref}`,
-    "",
-    "Goal:",
-    ...roleGoal(args.role),
-    "",
-    "Constraints:",
-    "- Do not edit files, do not commit, and do not push.",
-    "- Review the current branch only.",
-    `- Confidence threshold for actionable findings: ${args.confidenceThreshold.toFixed(2)}.`,
-    "- Report only findings that you can justify from the diff and any narrowly targeted reads.",
-    "",
-    ...(args.alwaysReadFiles.length > 0
-      ? [
-          "Always-read memory files:",
-          ...args.alwaysReadFiles.map((filePath) => `- ${filePath}`),
-          "",
-          "On-demand durable memory files:",
-          ...(args.onDemandFiles.length > 0 ? args.onDemandFiles.map((filePath) => `- ${filePath}`) : ["- none configured"]),
-          "",
-          "Memory policy:",
-          "- Read the always-read files first.",
-          "- Use the context index to decide whether any on-demand file is worth opening.",
-          "- Do not bulk-read every durable memory file just because multiple reviewer roles exist.",
-          "- Keep this role narrow: diff first, then the smallest number of targeted file reads.",
-          "",
-        ]
-      : []),
-    ...priorMissLines,
-    "Suggested commands:",
-    `- git diff --stat ${ref}`,
-    `- git diff ${ref}`,
-    "",
-    "Respond with a concise review and end with this exact footer:",
-    "Review summary: <short summary>",
-    "Recommendation: <ready|changes_requested>",
-    "REVIEW_FINDINGS_JSON_START",
-    '{"findings":[{"title":"short label","body":"one-paragraph explanation","file":"path/or/null","start":10,"end":12,"severity":"low|medium|high","confidence":0.0,"category":"optional short tag","evidence":"optional short supporting detail"}]}',
-    "REVIEW_FINDINGS_JSON_END",
-    "",
-    "Return an empty findings array when you have no actionable findings.",
-  ].join("\n");
-}
-
-function severityWeight(severity: ActionableSeverity): number {
-  switch (severity) {
-    case "high":
-      return 3;
-    case "medium":
-      return 2;
-    default:
-      return 1;
-  }
-}
-
-function dedupeFindings(findings: LocalReviewFinding[]): LocalReviewFinding[] {
-  const deduped = new Map<string, LocalReviewFinding>();
-  for (const finding of findings) {
-    const key = [
-      finding.file ?? "",
-      finding.start ?? "",
-      finding.end ?? "",
-      finding.title.toLowerCase(),
-      finding.body.toLowerCase(),
-    ].join("|");
-    const existing = deduped.get(key);
-    if (!existing) {
-      deduped.set(key, finding);
-      continue;
-    }
-
-    if (
-      severityWeight(finding.severity) > severityWeight(existing.severity) ||
-      (severityWeight(finding.severity) === severityWeight(existing.severity) && finding.confidence > existing.confidence)
-    ) {
-      deduped.set(key, finding);
-    }
-  }
-
-  return [...deduped.values()].sort((left, right) => {
-    const severityDelta = severityWeight(right.severity) - severityWeight(left.severity);
-    if (severityDelta !== 0) {
-      return severityDelta;
-    }
-
-    return right.confidence - left.confidence;
-  });
-}
-
-function findingKey(finding: LocalReviewFinding): string {
-  return [
-    finding.file ?? "",
-    finding.start ?? "",
-    finding.end ?? "",
-    finding.title.toLowerCase(),
-    finding.body.toLowerCase(),
-  ].join("|");
-}
-
-const FINDING_STOPWORDS = new Set(["this", "that", "with", "from", "when", "only", "still", "have", "does", "into"]);
-
-function tokenizeFindingText(value: string): Set<string> {
-  const tokens = value
-    .toLowerCase()
-    .split(/[^a-z0-9]+/i)
-    .map((token) => token.trim())
-    .filter((token) => token.length >= 4)
-    .filter((token) => !FINDING_STOPWORDS.has(token));
-  return new Set(tokens);
-}
-
-function overlapCount(left: Set<string>, right: Set<string>): number {
-  let count = 0;
-  for (const token of left) {
-    if (right.has(token)) {
-      count += 1;
-    }
-  }
-
-  return count;
-}
-
-function lineDistance(left: LocalReviewFinding, right: LocalReviewFinding): number | null {
-  if (left.start == null || right.start == null) {
-    return null;
-  }
-
-  const leftEnd = left.end ?? left.start;
-  const rightEnd = right.end ?? right.start;
-  if (leftEnd >= right.start && rightEnd >= left.start) {
-    return 0;
-  }
-
-  return Math.min(Math.abs(leftEnd - right.start), Math.abs(rightEnd - left.start));
-}
-
-function findingsOverlap(left: LocalReviewFinding, right: LocalReviewFinding): boolean {
-  if (left.file == null || right.file == null || left.file !== right.file) {
-    return false;
-  }
-
-  const distance = lineDistance(left, right);
-  if (distance == null || distance > 6) {
-    return false;
-  }
-
-  if (left.category && right.category && left.category !== right.category) {
-    return false;
-  }
-
-  const leftTokens = tokenizeFindingText(`${left.title} ${left.body} ${left.evidence ?? ""}`);
-  const rightTokens = tokenizeFindingText(`${right.title} ${right.body} ${right.evidence ?? ""}`);
-  return overlapCount(leftTokens, rightTokens) >= 3;
-}
-
-function summarizeRootCause(findings: LocalReviewFinding[]): LocalReviewRootCauseSummary {
-  const sorted = [...findings].sort((left, right) => {
-    const severityDelta = severityWeight(right.severity) - severityWeight(left.severity);
-    if (severityDelta !== 0) {
-      return severityDelta;
-    }
-
-    return right.confidence - left.confidence;
-  });
-  const primary = sorted[0]!;
-  const sameFile = sorted.every((finding) => finding.file === primary.file);
-  const starts = sorted.map((finding) => finding.start).filter((value): value is number => value != null);
-  const ends = sorted.map((finding) => finding.end ?? finding.start).filter((value): value is number => value != null);
-
-  return {
-    summary: primary.body,
-    severity: sorted.some((finding) => finding.severity === "high")
-      ? "high"
-      : sorted.some((finding) => finding.severity === "medium")
-        ? "medium"
-        : "low",
-    category: primary.category,
-    file: sameFile ? primary.file : null,
-    start: sameFile && starts.length > 0 ? Math.min(...starts) : null,
-    end: sameFile && ends.length > 0 ? Math.max(...ends) : null,
-    roles: [...new Set(sorted.map((finding) => finding.role))],
-    findingsCount: sorted.length,
-    findingKeys: sorted.map((finding) => findingKey(finding)),
-  };
-}
-
-function compressRootCauses(findings: LocalReviewFinding[]): LocalReviewRootCauseSummary[] {
-  const groups: LocalReviewFinding[][] = [];
-  for (const finding of findings) {
-    const overlappingGroupIndexes: number[] = [];
-    for (let index = 0; index < groups.length; index += 1) {
-      const candidate = groups[index];
-      if (candidate?.some((existing) => findingsOverlap(existing, finding))) {
-        overlappingGroupIndexes.push(index);
-      }
-    }
-
-    if (overlappingGroupIndexes.length > 0) {
-      const targetGroup = groups[overlappingGroupIndexes[0]!]!;
-      targetGroup.push(finding);
-      for (let index = overlappingGroupIndexes.length - 1; index >= 1; index -= 1) {
-        const groupIndex = overlappingGroupIndexes[index]!;
-        const groupToMerge = groups[groupIndex]!;
-        targetGroup.push(...groupToMerge);
-        groups.splice(groupIndex, 1);
-      }
-      continue;
-    }
-
-    groups.push([finding]);
-  }
-
-  return groups
-    .map((group) => summarizeRootCause(group))
-    .sort((left, right) => {
-      const severityDelta = severityWeight(right.severity) - severityWeight(left.severity);
-      if (severityDelta !== 0) {
-        return severityDelta;
-      }
-
-      return right.findingsCount - left.findingsCount;
-    });
-}
-
-function maxSeverity(findings: LocalReviewFinding[]): LocalReviewSeverity {
-  if (findings.some((finding) => finding.severity === "high")) {
-    return "high";
-  }
-  if (findings.some((finding) => finding.severity === "medium")) {
-    return "medium";
-  }
-  if (findings.some((finding) => finding.severity === "low")) {
-    return "low";
-  }
-
-  return "none";
-}
-
-function summarizeRoles(roleResults: LocalReviewRoleResult[]): string {
-  const summaries = roleResults
-    .map((result) => `- ${result.role}: ${result.summary}`)
-    .slice(0, 10);
-
-  return summaries.length > 0
-    ? summaries.join("\n")
-    : "- local review completed without structured role summaries.";
-}
-
-function formatRoleSelectionReason(reason: LocalReviewRoleSelection["reasons"][number]): string {
-  const suffix = reason.paths.length > 0 ? ` (${reason.paths.join(", ")})` : "";
-  switch (reason.kind) {
-    case "baseline":
-      return `baseline${suffix}`;
-    case "config_signal":
-      return `${reason.signal}${suffix}`;
-    case "repo_signal":
-      return `${reason.signal}${suffix}`;
-  }
-}
-
-function summarizeAutoDetectedRoles(detectedRoles: LocalReviewRoleSelection[]): string[] {
-  const specialistSelections = detectedRoles.filter(
-    (selection) => selection.role !== "reviewer" && selection.role !== "explorer",
-  );
-  if (specialistSelections.length === 0) {
-    return ["- No specialist roles were auto-detected beyond the baseline reviewer/explorer pair."];
-  }
-
-  return specialistSelections
-    .slice(0, 10)
-    .map((selection) => `- ${selection.role}: ${selection.reasons.map(formatRoleSelectionReason).join("; ")}`);
-}
-
-function renderLines(finding: Pick<LocalReviewFinding, "start" | "end">): string {
-  if (finding.start == null) {
-    return "?";
-  }
-
-  return finding.end && finding.end !== finding.start
-    ? `${finding.start}-${finding.end}`
-    : `${finding.start}`;
-}
-
-async function runRoleReview(args: {
+async function runLocalReviewRoles(args: {
   config: SupervisorConfig;
   issue: GitHubIssue;
   branch: string;
   workspacePath: string;
   defaultBranch: string;
   pr: GitHubPullRequest;
-  role: string;
+  roles: string[];
   alwaysReadFiles: string[];
   onDemandFiles: string[];
-  priorMissPatterns: ExternalReviewMissPattern[];
-}): Promise<LocalReviewRoleResult> {
-  const prompt = buildRolePrompt({
-    repoSlug: args.config.repoSlug,
+  priorMissPatterns: Awaited<ReturnType<typeof loadRelevantExternalReviewMissPatterns>>;
+}): Promise<LocalReviewRoleResult[]> {
+  const roleResults: LocalReviewRoleResult[] = new Array(args.roles.length);
+  const concurrency = Math.min(2, args.roles.length);
+  let currentIndex = 0;
+
+  async function runNextRole(): Promise<void> {
+    while (true) {
+      const index = currentIndex;
+      if (index >= args.roles.length) {
+        return;
+      }
+      currentIndex += 1;
+      roleResults[index] = await runRoleReview({
+        config: args.config,
+        issue: args.issue,
+        branch: args.branch,
+        workspacePath: args.workspacePath,
+        defaultBranch: args.defaultBranch,
+        pr: args.pr,
+        role: args.roles[index]!,
+        alwaysReadFiles: args.alwaysReadFiles,
+        onDemandFiles: args.onDemandFiles,
+        priorMissPatterns: args.priorMissPatterns,
+      });
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => runNextRole()));
+  return roleResults;
+}
+
+async function runLocalReviewVerifier(args: {
+  config: SupervisorConfig;
+  issue: GitHubIssue;
+  branch: string;
+  workspacePath: string;
+  defaultBranch: string;
+  pr: GitHubPullRequest;
+  roleResults: LocalReviewRoleResult[];
+}): Promise<LocalReviewVerifierReport | null> {
+  const rawActionableHighSeverityFindings = dedupeFindings(
+    args.roleResults
+      .flatMap((result) => result.findings)
+      .filter((finding) => finding.confidence >= args.config.localReviewConfidenceThreshold && finding.severity === "high"),
+  );
+
+  if (rawActionableHighSeverityFindings.length === 0) {
+    return null;
+  }
+
+  return runVerifierReview({
+    config: args.config,
     issue: args.issue,
     branch: args.branch,
     workspacePath: args.workspacePath,
     defaultBranch: args.defaultBranch,
     pr: args.pr,
-    role: args.role,
-    alwaysReadFiles: args.alwaysReadFiles,
-    onDemandFiles: args.onDemandFiles,
-    confidenceThreshold: args.config.localReviewConfidenceThreshold,
-    priorMissPatterns: args.priorMissPatterns,
+    findings: rawActionableHighSeverityFindings,
   });
-
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
-  const messageFile = path.join(tempDir, `${safeSlug(args.role)}.txt`);
-  const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(args.config, "local_review"));
-  const result = await runCommand(
-    args.config.codexBinary,
-    [
-      "exec",
-      ...overrideArgs,
-      "--json",
-      "--dangerously-bypass-approvals-and-sandbox",
-      "-C",
-      args.workspacePath,
-      "-o",
-      messageFile,
-      prompt,
-    ],
-    {
-      cwd: args.workspacePath,
-      allowExitCodes: [0, 1],
-      env: {
-        ...process.env,
-        npm_config_yes: "true",
-        CI: "1",
-      },
-      timeoutMs: args.config.codexExecTimeoutMinutes * 60_000,
-    },
-  );
-
-  let rawOutput = "";
-  try {
-    rawOutput = (await fs.readFile(messageFile, "utf8")).trim();
-  } catch {
-    rawOutput = [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n").trim();
-  }
-  await fs.rm(tempDir, { recursive: true, force: true });
-
-  const parsed = parseRoleFooter(args.role, rawOutput);
-  return {
-    role: args.role,
-    rawOutput,
-    exitCode: result.exitCode,
-    degraded: result.exitCode !== 0,
-    ...parsed,
-  };
 }
 
-async function runVerifierReview(args: {
-  config: SupervisorConfig;
-  issue: GitHubIssue;
-  branch: string;
-  workspacePath: string;
-  defaultBranch: string;
-  pr: GitHubPullRequest;
-  findings: LocalReviewFinding[];
-}): Promise<LocalReviewVerifierReport> {
-  const ref = compareRef(args.defaultBranch);
-  const findingsBlock = args.findings
-    .map((finding, index) =>
-      [
-        `- Finding ${index + 1}`,
-        `  key: ${findingKey(finding)}`,
-        `  title: ${finding.title}`,
-        `  severity: ${finding.severity}`,
-        `  file: ${finding.file ?? "none"}`,
-        `  lines: ${renderLines(finding)}`,
-        `  body: ${finding.body}`,
-        ...(finding.evidence ? [`  evidence: ${finding.evidence}`] : []),
-      ].join("\n"),
-    )
-    .join("\n");
-  const prompt = [
-    `You are performing a verifier pass for high-severity local review findings in ${args.config.repoSlug}.`,
-    `Issue: #${args.issue.number} ${args.issue.title}`,
-    `Issue URL: ${args.issue.url}`,
-    `PR: #${args.pr.number} ${args.pr.url}`,
-    `Branch: ${args.branch}`,
-    `Workspace: ${args.workspacePath}`,
-    `Compare diff against: ${ref}`,
-    "",
-    "Goal:",
-    "- Re-check only the listed high-severity findings.",
-    "- Confirm a finding only when the diff and narrowly targeted reads support the original concern.",
-    "- Dismiss findings that appear to be false positives or overstated.",
-    "- Use `unclear` when the evidence is inconclusive from the available local context.",
-    "",
-    "Constraints:",
-    "- Do not edit files, do not commit, and do not push.",
-    "- Keep reads narrow and tied to the listed findings.",
-    "",
-    "High-severity findings to verify:",
-    findingsBlock,
-    "",
-    "Respond with a concise verification and end with this exact footer:",
-    "Verification summary: <short summary>",
-    "Recommendation: <ready|changes_requested>",
-    "REVIEW_VERIFIER_JSON_START",
-    '{"findings":[{"findingKey":"exact key from prompt","verdict":"confirmed|dismissed|unclear","rationale":"short evidence-based explanation"}]}',
-    "REVIEW_VERIFIER_JSON_END",
-  ].join("\n");
-
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
-  const messageFile = path.join(tempDir, "verifier.txt");
-  const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(args.config, "local_review"));
-  const result = await runCommand(
-    args.config.codexBinary,
-    [
-      "exec",
-      ...overrideArgs,
-      "--json",
-      "--dangerously-bypass-approvals-and-sandbox",
-      "-C",
-      args.workspacePath,
-      "-o",
-      messageFile,
-      prompt,
-    ],
-    {
-      cwd: args.workspacePath,
-      allowExitCodes: [0, 1],
-      env: {
-        ...process.env,
-        npm_config_yes: "true",
-        CI: "1",
-      },
-      timeoutMs: args.config.codexExecTimeoutMinutes * 60_000,
-    },
-  );
-
-  let rawOutput = "";
-  try {
-    rawOutput = (await fs.readFile(messageFile, "utf8")).trim();
-  } catch {
-    rawOutput = [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n").trim();
-  }
-  await fs.rm(tempDir, { recursive: true, force: true });
-
-  const parsed = parseVerifierFooter(rawOutput);
-  return {
-    role: "verifier",
-    rawOutput,
-    exitCode: result.exitCode,
-    degraded: result.exitCode !== 0,
-    ...parsed,
-  };
-}
-
-export function finalizeLocalReview(args: {
-  config: Pick<SupervisorConfig, "localReviewConfidenceThreshold">;
-  issueNumber: number;
-  prNumber: number;
-  branch: string;
-  headSha: string;
-  detectedRoles?: LocalReviewRoleSelection[];
-  roleResults: LocalReviewRoleResult[];
-  verifierReport: LocalReviewVerifierReport | null;
+function formatLocalReviewResult(args: {
   ranAt: string;
-}): FinalizedLocalReview {
-  const roles = args.roleResults.map((result) => result.role);
-  const allFindings = args.roleResults.flatMap((result) => result.findings);
-  const actionableFindings = dedupeFindings(
-    allFindings.filter((finding) => finding.confidence >= args.config.localReviewConfidenceThreshold),
-  );
-  const rootCauseSummaries = compressRootCauses(actionableFindings);
-  const degraded = args.roleResults.some((result) => result.degraded) || (args.verifierReport?.degraded ?? false);
-  const summary = truncate(
-    `Roles run: ${roles.join(", ")}. Actionable findings above confidence ${args.config.localReviewConfidenceThreshold.toFixed(2)}: ${actionableFindings.length}. Root causes: ${rootCauseSummaries.length}. Degraded roles: ${args.roleResults.filter((result) => result.degraded).length}.`,
-    500,
-  ) ?? "";
-  const recommendation: LocalReviewResult["recommendation"] =
-    degraded ? "unknown" : actionableFindings.length > 0 ? "changes_requested" : "ready";
-  const actionableHighSeverityFindings = actionableFindings.filter((finding) => finding.severity === "high");
-  const verificationByKey = new Map(args.verifierReport?.findings.map((finding) => [finding.findingKey, finding]) ?? []);
-  const verifiedFindings = actionableHighSeverityFindings.filter(
-    (finding) => verificationByKey.get(findingKey(finding))?.verdict === "confirmed",
-  );
-  const verifiedMaxSeverity = maxSeverity(verifiedFindings);
-  const artifact: LocalReviewArtifact = {
-    issueNumber: args.issueNumber,
-    prNumber: args.prNumber,
-    branch: args.branch,
-    headSha: args.headSha,
-    ranAt: args.ranAt,
-    confidenceThreshold: args.config.localReviewConfidenceThreshold,
-    roles,
-    autoDetectedRoles: args.detectedRoles ?? [],
-    summary,
-    recommendation,
-    degraded,
-    findingsCount: actionableFindings.length,
-    rootCauseCount: rootCauseSummaries.length,
-    maxSeverity: maxSeverity(actionableFindings),
-    actionableFindings,
-    rootCauseSummaries,
-    verification: {
-      required: actionableHighSeverityFindings.length > 0,
-      summary: args.verifierReport?.summary ?? (actionableHighSeverityFindings.length > 0 ? "Verification not run." : "No high-severity findings required verification."),
-      recommendation: args.verifierReport?.recommendation ?? "unknown",
-      degraded: args.verifierReport?.degraded ?? false,
-      findingsCount: args.verifierReport?.findings.length ?? 0,
-      verifiedFindingsCount: verifiedFindings.length,
-      verifiedMaxSeverity,
-      findings: args.verifierReport?.findings ?? [],
-    },
-    verifiedFindings,
-    roleReports: args.roleResults.map((result) => ({
-      role: result.role,
-      exitCode: result.exitCode,
-      degraded: result.degraded,
-      summary: result.summary,
-      recommendation: result.recommendation,
-      findings: result.findings,
-    })),
-    verifierReport: args.verifierReport
-      ? {
-          role: args.verifierReport.role,
-          exitCode: args.verifierReport.exitCode,
-          degraded: args.verifierReport.degraded,
-          summary: args.verifierReport.summary,
-          recommendation: args.verifierReport.recommendation,
-          findings: args.verifierReport.findings,
-        }
-      : null,
-  };
-
+  finalized: FinalizedLocalReview;
+  artifacts: Pick<LocalReviewResult, "summaryPath" | "findingsPath" | "rawOutput">;
+}): LocalReviewResult {
   return {
-    summary,
-    recommendation,
-    degraded,
-    findingsCount: actionableFindings.length,
-    rootCauseCount: rootCauseSummaries.length,
-    maxSeverity: maxSeverity(actionableFindings),
-    verifiedFindingsCount: verifiedFindings.length,
-    verifiedMaxSeverity,
-    actionableFindings,
-    rootCauseSummaries,
-    verifiedFindings,
-    artifact,
+    ranAt: args.ranAt,
+    summaryPath: args.artifacts.summaryPath,
+    findingsPath: args.artifacts.findingsPath,
+    summary: args.finalized.summary,
+    findingsCount: args.finalized.findingsCount,
+    rootCauseCount: args.finalized.rootCauseCount,
+    maxSeverity: args.finalized.maxSeverity,
+    verifiedFindingsCount: args.finalized.verifiedFindingsCount,
+    verifiedMaxSeverity: args.finalized.verifiedMaxSeverity,
+    recommendation: args.finalized.recommendation,
+    degraded: args.finalized.degraded,
+    rawOutput: args.artifacts.rawOutput,
   };
 }
 
@@ -1032,52 +197,22 @@ export async function runLocalReview(args: {
     args.config.localReviewRoles.length === 0 && args.config.localReviewAutoDetect
       ? await detectLocalReviewRoleSelections(args.config)
       : [];
-  const roles =
-    args.config.localReviewRoles.length > 0
-      ? args.config.localReviewRoles
-      : detectedRoles.length > 0
-        ? detectedRoles.map((selection) => selection.role)
-        : ["reviewer", "explorer"];
-  const roleResults: LocalReviewRoleResult[] = new Array(roles.length);
-  const concurrency = Math.min(2, roles.length);
-  let currentIndex = 0;
-
-  async function runNextRole(): Promise<void> {
-    while (true) {
-      const index = currentIndex;
-      if (index >= roles.length) {
-        return;
-      }
-      currentIndex += 1;
-      roleResults[index] = await runRoleReview({
-        ...args,
-        role: roles[index],
-        priorMissPatterns,
-      });
-    }
-  }
-
-  await Promise.all(Array.from({ length: concurrency }, () => runNextRole()));
+  const roles = selectLocalReviewRoles({
+    config: args.config,
+    detectedRoles,
+  });
+  const roleResults = await runLocalReviewRoles({
+    ...args,
+    roles,
+    priorMissPatterns,
+  });
   const ranAt = nowIso();
   const dirPath = reviewDir(args.config, args.issue.number);
   await ensureDir(dirPath);
-  const rawActionableHighSeverityFindings = dedupeFindings(
-    roleResults
-      .flatMap((result) => result.findings)
-      .filter((finding) => finding.confidence >= args.config.localReviewConfidenceThreshold && finding.severity === "high"),
-  );
-  const verifierReport =
-    rawActionableHighSeverityFindings.length > 0
-      ? await runVerifierReview({
-          config: args.config,
-          issue: args.issue,
-          branch: args.branch,
-          workspacePath: args.workspacePath,
-          defaultBranch: args.defaultBranch,
-          pr: args.pr,
-          findings: rawActionableHighSeverityFindings,
-        })
-      : null;
+  const verifierReport = await runLocalReviewVerifier({
+    ...args,
+    roleResults,
+  });
   const finalized = finalizeLocalReview({
     config: args.config,
     issueNumber: args.issue.number,
@@ -1089,119 +224,22 @@ export async function runLocalReview(args: {
     verifierReport,
     ranAt,
   });
-
-  const baseName = `head-${args.pr.headRefOid.slice(0, 12)}`;
-  const summaryPath = path.join(dirPath, `${baseName}.md`);
-  const findingsPath = path.join(dirPath, `${baseName}.json`);
-  const rawOutput = roleResults
-    .map((result) => `## ${result.role}\n\n${result.rawOutput}`)
-    .concat(verifierReport ? [`## verifier\n\n${verifierReport.rawOutput}`] : [])
-    .join("\n\n");
-
-  await fs.writeFile(
-    summaryPath,
-    [
-      `# Local Review for Issue #${args.issue.number}`,
-      "",
-      `- PR: ${args.pr.url}`,
-      `- Branch: ${args.branch}`,
-      `- Head SHA: ${args.pr.headRefOid}`,
-      `- Ran at: ${ranAt}`,
-      `- Roles: ${roles.join(", ")}`,
-      `- Confidence threshold: ${args.config.localReviewConfidenceThreshold.toFixed(2)}`,
-      `- Actionable findings: ${finalized.findingsCount}`,
-      `- Root causes: ${finalized.rootCauseCount}`,
-      `- Max severity: ${finalized.maxSeverity}`,
-      `- Verified findings: ${finalized.verifiedFindingsCount}`,
-      `- Verified max severity: ${finalized.verifiedMaxSeverity}`,
-      `- Recommendation: ${finalized.recommendation}`,
-      `- Degraded: ${finalized.degraded ? "yes" : "no"}`,
-      "",
-      "## Auto-detected roles",
-      ...summarizeAutoDetectedRoles(finalized.artifact.autoDetectedRoles),
-      "",
-      "## Role summaries",
-      summarizeRoles(roleResults),
-      "",
-      "## Actionable findings",
-      ...(finalized.actionableFindings.length > 0
-        ? finalized.actionableFindings.map((finding, index) =>
-            [
-              `### ${index + 1}. ${finding.title}`,
-              `- Role: ${finding.role}`,
-              `- Severity: ${finding.severity}`,
-              `- Confidence: ${finding.confidence.toFixed(2)}`,
-              `- File: ${finding.file ?? "none"}`,
-              `- Lines: ${renderLines(finding)}`,
-              `- Category: ${finding.category ?? "none"}`,
-              `- Body: ${finding.body}`,
-              ...(finding.evidence ? [`- Evidence: ${finding.evidence}`] : []),
-              "",
-            ].join("\n"),
-          )
-        : ["- No actionable findings above the confidence threshold.", ""]),
-      "## Root-cause summaries",
-      ...(finalized.rootCauseSummaries.length > 0
-        ? finalized.rootCauseSummaries.map((rootCause, index) =>
-            [
-              `### Root cause ${index + 1}`,
-              `- Severity: ${rootCause.severity}`,
-              `- Findings: ${rootCause.findingsCount}`,
-              `- Roles: ${rootCause.roles.join(", ")}`,
-              `- File: ${rootCause.file ?? "multiple"}`,
-              `- Lines: ${rootCause.file ? renderLines(rootCause) : "multiple"}`,
-              `- Category: ${rootCause.category ?? "none"}`,
-              `- Summary: ${rootCause.summary}`,
-              "",
-            ].join("\n"),
-          )
-        : ["- No compressed root causes.", ""]),
-      "## High-Severity Verification",
-      `- Required: ${finalized.artifact.verification.required ? "yes" : "no"}`,
-      `- Summary: ${finalized.artifact.verification.summary}`,
-      `- Recommendation: ${finalized.artifact.verification.recommendation}`,
-      `- Degraded: ${finalized.artifact.verification.degraded ? "yes" : "no"}`,
-      `- Verified findings: ${finalized.verifiedFindingsCount}`,
-      `- Verified max severity: ${finalized.verifiedMaxSeverity}`,
-      ...(finalized.artifact.verification.findings.length > 0
-        ? [
-            "",
-            ...finalized.artifact.verification.findings.map((finding, index) =>
-              [
-                `### Verification ${index + 1}`,
-                `- Finding key: ${finding.findingKey}`,
-                `- Verdict: ${finding.verdict}`,
-                `- Rationale: ${finding.rationale}`,
-                "",
-              ].join("\n"),
-            ),
-          ]
-        : [""]),
-      "## Raw role outputs",
-      rawOutput,
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-
-  await fs.writeFile(
-    findingsPath,
-    `${JSON.stringify(finalized.artifact, null, 2)}\n`,
-    "utf8",
-  );
-
-  return {
+  const artifacts = await writeLocalReviewArtifacts({
+    config: args.config,
+    issueNumber: args.issue.number,
+    branch: args.branch,
+    prUrl: args.pr.url,
+    headSha: args.pr.headRefOid,
+    roles,
     ranAt,
-    summaryPath,
-    findingsPath,
-    summary: finalized.summary,
-    findingsCount: finalized.findingsCount,
-    rootCauseCount: finalized.rootCauseCount,
-    maxSeverity: finalized.maxSeverity,
-    verifiedFindingsCount: finalized.verifiedFindingsCount,
-    verifiedMaxSeverity: finalized.verifiedMaxSeverity,
-    recommendation: finalized.recommendation,
-    degraded: finalized.degraded,
-    rawOutput,
-  };
+    finalized,
+    roleResults,
+    verifierReport,
+  });
+
+  return formatLocalReviewResult({
+    ranAt,
+    finalized,
+    artifacts,
+  });
 }


### PR DESCRIPTION
## Summary
- split local-review types into a dedicated module
- move prompt/parsing, finalization, runner, and artifact helpers into focused modules
- keep src/local-review.ts as orchestration glue and add a focused export-surface test

## Verification
- npm test -- src/local-review.test.ts src/external-review-misses.test.ts
- npm run build