### PR TITLE
Wait for actual requested Copilot review before merge

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -340,6 +340,35 @@ test("inferStateFromPullRequest does not wait for Copilot when no lifecycle sign
   assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
 });
 
+test("inferStateFromPullRequest keeps waiting when Copilot review was explicitly requested", () => {
+  const config = createConfig({ copilotReviewWaitMinutes: 10 });
+  const record = createRecord({
+    state: "waiting_ci",
+    review_wait_started_at: "2026-03-11T00:00:00Z",
+    review_wait_head_sha: "head123",
+  });
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "head123",
+    mergedAt: null,
+    copilotReviewState: "requested",
+    copilotReviewRequestedAt: "2026-03-11T00:05:00Z",
+    copilotReviewArrivedAt: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "waiting_ci");
+});
+
 test("inferStateFromPullRequest covers local review policy gating combinations", () => {
   const cases: Array<{
     name: string;

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -844,26 +844,6 @@ function syncReviewWaitWindow(record: IssueRunRecord, pr: GitHubPullRequest): Pa
   };
 }
 
-function copilotReviewGraceExpired(
-  record: IssueRunRecord,
-  pr: GitHubPullRequest,
-  config: SupervisorConfig,
-): boolean {
-  if (config.copilotReviewWaitMinutes <= 0) {
-    return true;
-  }
-
-  const anchor =
-    pr.copilotReviewRequestedAt ??
-    (!pr.isDraft && record.review_wait_started_at ? record.review_wait_started_at : pr.createdAt);
-  const createdAtMs = Date.parse(anchor);
-  if (Number.isNaN(createdAtMs)) {
-    return false;
-  }
-
-  return Date.now() - createdAtMs >= config.copilotReviewWaitMinutes * 60_000;
-}
-
 export function inferStateFromPullRequest(
   config: SupervisorConfig,
   record: IssueRunRecord,
@@ -932,7 +912,7 @@ export function inferStateFromPullRequest(
     return "draft_pr";
   }
 
-  if ((pr.copilotReviewState ?? "not_requested") === "requested" && !copilotReviewGraceExpired(record, pr, config)) {
+  if ((pr.copilotReviewState ?? "not_requested") === "requested") {
     return "waiting_ci";
   }
 


### PR DESCRIPTION
## Summary
- keep PRs in waiting state when GitHub shows Copilot review was explicitly requested
- allow ready PRs to merge without Copilot wait when no request exists
- add a focused regression test covering requested-vs-not-requested behavior

Closes #71