### PR TITLE
External review misses: extract normalization and classifier modules (#77)

### DIFF
--- a/src/external-review-classifier.ts
+++ b/src/external-review-classifier.ts
@@ -1,0 +1,217 @@
+import { type LocalReviewSeverity } from "./local-review-types";
+import { type NormalizedExternalReviewFinding } from "./external-review-normalization";
+
+export type ExternalReviewMatch = "matched" | "near_match" | "missed_by_local_review";
+
+export interface LocalReviewArtifactLike {
+  issueNumber?: number;
+  prNumber?: number;
+  branch?: string;
+  headSha?: string;
+  actionableFindings?: Array<{
+    title?: string;
+    body?: string;
+    file?: string | null;
+    start?: number | null;
+    end?: number | null;
+    severity?: LocalReviewSeverity;
+    category?: string | null;
+  }>;
+  rootCauseSummaries?: Array<{
+    summary?: string;
+    file?: string | null;
+    start?: number | null;
+    end?: number | null;
+    severity?: LocalReviewSeverity;
+    category?: string | null;
+  }>;
+  verifiedFindings?: Array<{
+    title?: string;
+    body?: string;
+    file?: string | null;
+    start?: number | null;
+    end?: number | null;
+    severity?: LocalReviewSeverity;
+    category?: string | null;
+  }>;
+}
+
+export interface ExternalReviewMissFinding extends NormalizedExternalReviewFinding {
+  classification: ExternalReviewMatch;
+  matchedLocalReference: string | null;
+  matchReason: string;
+}
+
+interface LocalComparisonCandidate {
+  reference: string;
+  file: string | null;
+  start: number | null;
+  end: number | null;
+  text: string;
+}
+
+interface LocalMatchScore {
+  candidate: LocalComparisonCandidate;
+  overlap: number;
+  distance: number | null;
+  sameHunk: boolean;
+}
+
+function tokenize(value: string): Set<string> {
+  const stopWords = new Set(["the", "and", "that", "this", "with", "from", "into", "when", "then", "than", "they", "them", "their", "there", "would", "should", "could", "because", "while", "after", "before", "about", "have", "has", "had", "been", "being", "your", "will", "does", "only", "just"]);
+  return new Set(
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " ")
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3 && !stopWords.has(token)),
+  );
+}
+
+function overlapScore(left: string, right: string): number {
+  const leftTokens = tokenize(left);
+  const rightTokens = tokenize(right);
+  if (leftTokens.size === 0 || rightTokens.size === 0) {
+    return 0;
+  }
+
+  let overlap = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) {
+      overlap += 1;
+    }
+  }
+
+  return overlap / Math.max(leftTokens.size, rightTokens.size);
+}
+
+function lineDistance(finding: NormalizedExternalReviewFinding, candidate: LocalComparisonCandidate): number | null {
+  if (finding.line == null || candidate.start == null) {
+    return null;
+  }
+
+  const candidateEnd = candidate.end ?? candidate.start;
+  if (finding.line >= candidate.start && finding.line <= candidateEnd) {
+    return 0;
+  }
+
+  return Math.min(Math.abs(finding.line - candidate.start), Math.abs(finding.line - candidateEnd));
+}
+
+function isSameHunk(finding: NormalizedExternalReviewFinding, candidate: LocalComparisonCandidate): boolean {
+  if (finding.line == null || candidate.start == null) {
+    return false;
+  }
+
+  const candidateEnd = candidate.end ?? candidate.start;
+  return finding.line >= candidate.start && finding.line <= candidateEnd;
+}
+
+function formatMatchReason(prefix: string, score: LocalMatchScore): string {
+  return `${prefix} overlap=${score.overlap.toFixed(2)} line_distance=${score.distance ?? "na"} same_hunk=${score.sameHunk ? "yes" : "no"}`;
+}
+
+function isBetterMatch(candidate: LocalMatchScore, bestMatch: LocalMatchScore | null): boolean {
+  if (!bestMatch) {
+    return true;
+  }
+
+  if (candidate.sameHunk && !bestMatch.sameHunk) {
+    return true;
+  }
+
+  if (candidate.sameHunk !== bestMatch.sameHunk) {
+    return false;
+  }
+
+  if (candidate.overlap > bestMatch.overlap) {
+    return true;
+  }
+
+  if (candidate.overlap < bestMatch.overlap) {
+    return false;
+  }
+
+  return (candidate.distance ?? 9999) < (bestMatch.distance ?? 9999);
+}
+
+function buildLocalCandidates(artifact: LocalReviewArtifactLike): LocalComparisonCandidate[] {
+  const actionable = (artifact.actionableFindings ?? []).map((finding, index) => ({
+    reference: `actionable:${index + 1}`,
+    file: finding.file ?? null,
+    start: finding.start ?? null,
+    end: finding.end ?? finding.start ?? null,
+    text: [finding.title, finding.body, finding.category ?? undefined].filter(Boolean).join(" "),
+  }));
+  const rootCauses = (artifact.rootCauseSummaries ?? []).map((finding, index) => ({
+    reference: `root_cause:${index + 1}`,
+    file: finding.file ?? null,
+    start: finding.start ?? null,
+    end: finding.end ?? finding.start ?? null,
+    text: [finding.summary, finding.category ?? undefined].filter(Boolean).join(" "),
+  }));
+  const verified = (artifact.verifiedFindings ?? []).map((finding, index) => ({
+    reference: `verified:${index + 1}`,
+    file: finding.file ?? null,
+    start: finding.start ?? null,
+    end: finding.end ?? finding.start ?? null,
+    text: [finding.title, finding.body, finding.category ?? undefined].filter(Boolean).join(" "),
+  }));
+  return [...actionable, ...rootCauses, ...verified].filter((candidate) => candidate.text.trim().length > 0);
+}
+
+export function classifyExternalReviewFinding(
+  finding: NormalizedExternalReviewFinding,
+  localArtifact: LocalReviewArtifactLike | null,
+): ExternalReviewMissFinding {
+  const candidates = localArtifact ? buildLocalCandidates(localArtifact) : [];
+  let bestMatch: LocalMatchScore | null = null;
+
+  for (const candidate of candidates) {
+    const sameFile =
+      finding.file === null || candidate.file === null ? false : finding.file === candidate.file;
+    if (!sameFile) {
+      continue;
+    }
+
+    const overlap = overlapScore(`${finding.summary} ${finding.rationale}`, candidate.text);
+    const distance = lineDistance(finding, candidate);
+    const sameHunk = isSameHunk(finding, candidate);
+    const score = { candidate, overlap, distance, sameHunk };
+    if (isBetterMatch(score, bestMatch)) {
+      bestMatch = score;
+    }
+  }
+
+  if (bestMatch) {
+    if (
+      bestMatch.overlap >= 0.28 ||
+      (bestMatch.distance !== null && bestMatch.distance <= 3 && bestMatch.overlap >= 0.18) ||
+      (bestMatch.sameHunk && bestMatch.overlap >= 0.08)
+    ) {
+      return {
+        ...finding,
+        classification: "matched",
+        matchedLocalReference: bestMatch.candidate.reference,
+        matchReason: formatMatchReason(bestMatch.sameHunk ? "same-hunk" : "same-file", bestMatch),
+      };
+    }
+
+    if (bestMatch.overlap >= 0.12 || (bestMatch.distance !== null && bestMatch.distance <= 10)) {
+      return {
+        ...finding,
+        classification: "near_match",
+        matchedLocalReference: bestMatch.candidate.reference,
+        matchReason: formatMatchReason(bestMatch.sameHunk ? "same-hunk" : "same-file", bestMatch),
+      };
+    }
+  }
+
+  return {
+    ...finding,
+    classification: "missed_by_local_review",
+    matchedLocalReference: bestMatch?.candidate.reference ?? null,
+    matchReason: bestMatch ? formatMatchReason("insufficient", bestMatch) : "no same-file local-review match",
+  };
+}

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -166,6 +166,49 @@ test("classifyExternalReviewFinding marks same-hunk findings as matched even wit
   assert.match(classified.matchReason, /\bsame_hunk=yes\b/);
 });
 
+test("classifyExternalReviewFinding keeps nearby same-file findings as near_match with stable match reasons", () => {
+  const normalized = normalizeExternalReviewFinding(
+    createReviewThread({
+      path: "src/auth.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Fallback writes bypass authorization and can update records without the guard.",
+            createdAt: "2026-03-12T00:00:00Z",
+            url: "https://example.test/thread-1#comment-1",
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    ["copilot-pull-request-reviewer"],
+  );
+  assert.ok(normalized);
+
+  const classified = classifyExternalReviewFinding(normalized, {
+    actionableFindings: [
+      {
+        title: "Nearby authorization concern",
+        body: "Capability gate ordering is wrong in this helper path.",
+        file: "src/auth.ts",
+        start: 50,
+        end: 54,
+        severity: "medium",
+      },
+    ],
+    rootCauseSummaries: [],
+  });
+
+  assert.equal(classified.classification, "near_match");
+  assert.equal(classified.matchedLocalReference, "actionable:1");
+  assert.equal(classified.matchReason, "same-file overlap=0.11 line_distance=8 same_hunk=no");
+});
+
 test("writeExternalReviewMissArtifact persists missed external findings for the current review head", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-miss-test-"));
   const localReviewSummaryPath = path.join(tempDir, "head-deadbeef.md");

--- a/src/external-review-misses.ts
+++ b/src/external-review-misses.ts
@@ -1,62 +1,19 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ensureDir, nowIso, parseJson, truncate } from "./utils";
-import { ReviewThread } from "./types";
-
-type LocalReviewSeverity = "none" | "low" | "medium" | "high";
-type ExternalReviewMatch = "matched" | "near_match" | "missed_by_local_review";
-
-interface LocalReviewArtifactLike {
-  issueNumber?: number;
-  prNumber?: number;
-  branch?: string;
-  headSha?: string;
-  actionableFindings?: Array<{
-    title?: string;
-    body?: string;
-    file?: string | null;
-    start?: number | null;
-    end?: number | null;
-    severity?: LocalReviewSeverity;
-    category?: string | null;
-  }>;
-  rootCauseSummaries?: Array<{
-    summary?: string;
-    file?: string | null;
-    start?: number | null;
-    end?: number | null;
-    severity?: LocalReviewSeverity;
-    category?: string | null;
-  }>;
-  verifiedFindings?: Array<{
-    title?: string;
-    body?: string;
-    file?: string | null;
-    start?: number | null;
-    end?: number | null;
-    severity?: LocalReviewSeverity;
-    category?: string | null;
-  }>;
-}
-
-export interface NormalizedExternalReviewFinding {
-  source: "external_bot";
-  reviewerLogin: string;
-  threadId: string;
-  file: string | null;
-  line: number | null;
-  summary: string;
-  rationale: string;
-  severity: Exclude<LocalReviewSeverity, "none">;
-  confidence: number;
-  url: string | null;
-}
-
-export interface ExternalReviewMissFinding extends NormalizedExternalReviewFinding {
-  classification: ExternalReviewMatch;
-  matchedLocalReference: string | null;
-  matchReason: string;
-}
+import {
+  createExternalReviewMissPatternFingerprint,
+  createExternalReviewRegressionCandidateId,
+  normalizeExternalReviewFinding,
+  type NormalizedExternalReviewFinding,
+} from "./external-review-normalization";
+import {
+  classifyExternalReviewFinding,
+  type ExternalReviewMatch,
+  type ExternalReviewMissFinding,
+  type LocalReviewArtifactLike,
+} from "./external-review-classifier";
+import { type ReviewThread } from "./types";
 
 export type ExternalReviewPromptFinding = Pick<
   ExternalReviewMissFinding,
@@ -115,31 +72,8 @@ export interface ExternalReviewRegressionCandidate {
   qualificationReasons: string[];
 }
 
-interface LocalComparisonCandidate {
-  reference: string;
-  file: string | null;
-  start: number | null;
-  end: number | null;
-  text: string;
-}
-
-interface LocalMatchScore {
-  candidate: LocalComparisonCandidate;
-  overlap: number;
-  distance: number | null;
-  sameHunk: boolean;
-}
-
-function normalizeWhitespace(value: string): string {
-  return value.replace(/\s+/g, " ").trim();
-}
-
 function createMissPatternFingerprint(finding: Pick<ExternalReviewPromptFinding, "file" | "summary" | "rationale">): string {
-  return [
-    finding.file ?? "",
-    normalizeWhitespace(finding.summary).toLowerCase(),
-    truncate(normalizeWhitespace(finding.rationale).toLowerCase(), 200) ?? "",
-  ].join("|");
+  return createExternalReviewMissPatternFingerprint(finding);
 }
 
 function toReusableMissPattern(
@@ -161,22 +95,8 @@ function toReusableMissPattern(
   };
 }
 
-function summarizeComment(body: string): string {
-  const normalized = normalizeWhitespace(body);
-  if (normalized.length === 0) {
-    return "External review finding";
-  }
-
-  const sentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/)?.[1] ?? normalized;
-  return truncate(sentence, 180) ?? "External review finding";
-}
-
 function createRegressionCandidateId(finding: ExternalReviewMissFinding): string {
-  return [
-    finding.file ?? "",
-    finding.line ?? "",
-    normalizeWhitespace(finding.rationale).toLowerCase(),
-  ].join("|");
+  return createExternalReviewRegressionCandidateId(finding);
 }
 
 function toRegressionTestCandidate(
@@ -223,232 +143,6 @@ function toRegressionTestCandidate(
     sourceThreadId: finding.threadId,
     sourceUrl: finding.url ?? null,
     qualificationReasons,
-  };
-}
-
-function inferSeverity(body: string): Exclude<LocalReviewSeverity, "none"> {
-  const normalized = body.toLowerCase();
-  if (/\b(security|privilege|secret|panic|crash|corrupt|deadlock|critical|data loss)\b/.test(normalized)) {
-    return "high";
-  }
-
-  if (/\b(nit|style|format|typo|wording|docs?)\b/.test(normalized)) {
-    return "low";
-  }
-
-  return "medium";
-}
-
-function inferConfidence(body: string): number {
-  const normalized = body.toLowerCase();
-  if (/\b(will|can|break|fails?|throws?|incorrect|bug|missing|never|always)\b/.test(normalized)) {
-    return 0.9;
-  }
-
-  if (/\b(nit|style|format|typo|wording|docs?)\b/.test(normalized)) {
-    return 0.55;
-  }
-
-  return 0.75;
-}
-
-function latestConfiguredBotComment(thread: ReviewThread, reviewBotLogins: string[]) {
-  const allowed = new Set(reviewBotLogins.map((login) => login.toLowerCase()));
-  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
-    const comment = thread.comments.nodes[index];
-    const login = comment.author?.login?.toLowerCase();
-    if (login && allowed.has(login)) {
-      return comment;
-    }
-  }
-
-  return null;
-}
-
-export function normalizeExternalReviewFinding(
-  thread: ReviewThread,
-  reviewBotLogins: string[],
-): NormalizedExternalReviewFinding | null {
-  const comment = latestConfiguredBotComment(thread, reviewBotLogins);
-  if (!comment) {
-    return null;
-  }
-
-  const rationale = normalizeWhitespace(comment.body);
-  if (rationale.length === 0) {
-    return null;
-  }
-
-  return {
-    source: "external_bot",
-    reviewerLogin: comment.author?.login ?? "unknown",
-    threadId: thread.id,
-    file: thread.path ?? null,
-    line: thread.line ?? null,
-    summary: summarizeComment(comment.body),
-    rationale,
-    severity: inferSeverity(comment.body),
-    confidence: inferConfidence(comment.body),
-    url: comment.url ?? null,
-  };
-}
-
-function tokenize(value: string): Set<string> {
-  const stopWords = new Set(["the", "and", "that", "this", "with", "from", "into", "when", "then", "than", "they", "them", "their", "there", "would", "should", "could", "because", "while", "after", "before", "about", "have", "has", "had", "been", "being", "your", "will", "does", "only", "just"]);
-  return new Set(
-    value
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, " ")
-      .split(/\s+/)
-      .map((token) => token.trim())
-      .filter((token) => token.length >= 3 && !stopWords.has(token)),
-  );
-}
-
-function overlapScore(left: string, right: string): number {
-  const leftTokens = tokenize(left);
-  const rightTokens = tokenize(right);
-  if (leftTokens.size === 0 || rightTokens.size === 0) {
-    return 0;
-  }
-
-  let overlap = 0;
-  for (const token of leftTokens) {
-    if (rightTokens.has(token)) {
-      overlap += 1;
-    }
-  }
-
-  return overlap / Math.max(leftTokens.size, rightTokens.size);
-}
-
-function lineDistance(finding: NormalizedExternalReviewFinding, candidate: LocalComparisonCandidate): number | null {
-  if (finding.line == null || candidate.start == null) {
-    return null;
-  }
-
-  const candidateEnd = candidate.end ?? candidate.start;
-  if (finding.line >= candidate.start && finding.line <= candidateEnd) {
-    return 0;
-  }
-
-  return Math.min(Math.abs(finding.line - candidate.start), Math.abs(finding.line - candidateEnd));
-}
-
-function isSameHunk(finding: NormalizedExternalReviewFinding, candidate: LocalComparisonCandidate): boolean {
-  if (finding.line == null || candidate.start == null) {
-    return false;
-  }
-
-  const candidateEnd = candidate.end ?? candidate.start;
-  return finding.line >= candidate.start && finding.line <= candidateEnd;
-}
-
-function formatMatchReason(prefix: string, score: LocalMatchScore): string {
-  return `${prefix} overlap=${score.overlap.toFixed(2)} line_distance=${score.distance ?? "na"} same_hunk=${score.sameHunk ? "yes" : "no"}`;
-}
-
-function isBetterMatch(candidate: LocalMatchScore, bestMatch: LocalMatchScore | null): boolean {
-  if (!bestMatch) {
-    return true;
-  }
-
-  if (candidate.sameHunk && !bestMatch.sameHunk) {
-    return true;
-  }
-
-  if (candidate.sameHunk !== bestMatch.sameHunk) {
-    return false;
-  }
-
-  if (candidate.overlap > bestMatch.overlap) {
-    return true;
-  }
-
-  if (candidate.overlap < bestMatch.overlap) {
-    return false;
-  }
-
-  return (candidate.distance ?? 9999) < (bestMatch.distance ?? 9999);
-}
-
-function buildLocalCandidates(artifact: LocalReviewArtifactLike): LocalComparisonCandidate[] {
-  const actionable = (artifact.actionableFindings ?? []).map((finding, index) => ({
-    reference: `actionable:${index + 1}`,
-    file: finding.file ?? null,
-    start: finding.start ?? null,
-    end: finding.end ?? finding.start ?? null,
-    text: [finding.title, finding.body, finding.category ?? undefined].filter(Boolean).join(" "),
-  }));
-  const rootCauses = (artifact.rootCauseSummaries ?? []).map((finding, index) => ({
-    reference: `root_cause:${index + 1}`,
-    file: finding.file ?? null,
-    start: finding.start ?? null,
-    end: finding.end ?? finding.start ?? null,
-    text: [finding.summary, finding.category ?? undefined].filter(Boolean).join(" "),
-  }));
-  const verified = (artifact.verifiedFindings ?? []).map((finding, index) => ({
-    reference: `verified:${index + 1}`,
-    file: finding.file ?? null,
-    start: finding.start ?? null,
-    end: finding.end ?? finding.start ?? null,
-    text: [finding.title, finding.body, finding.category ?? undefined].filter(Boolean).join(" "),
-  }));
-  return [...actionable, ...rootCauses, ...verified].filter((candidate) => candidate.text.trim().length > 0);
-}
-
-export function classifyExternalReviewFinding(
-  finding: NormalizedExternalReviewFinding,
-  localArtifact: LocalReviewArtifactLike | null,
-): ExternalReviewMissFinding {
-  const candidates = localArtifact ? buildLocalCandidates(localArtifact) : [];
-  let bestMatch: LocalMatchScore | null = null;
-
-  for (const candidate of candidates) {
-    const sameFile =
-      finding.file === null || candidate.file === null ? false : finding.file === candidate.file;
-    if (!sameFile) {
-      continue;
-    }
-
-    const overlap = overlapScore(`${finding.summary} ${finding.rationale}`, candidate.text);
-    const distance = lineDistance(finding, candidate);
-    const sameHunk = isSameHunk(finding, candidate);
-    const score = { candidate, overlap, distance, sameHunk };
-    if (isBetterMatch(score, bestMatch)) {
-      bestMatch = score;
-    }
-  }
-
-  if (bestMatch) {
-    if (
-      bestMatch.overlap >= 0.28 ||
-      (bestMatch.distance !== null && bestMatch.distance <= 3 && bestMatch.overlap >= 0.18) ||
-      (bestMatch.sameHunk && bestMatch.overlap >= 0.08)
-    ) {
-      return {
-        ...finding,
-        classification: "matched",
-        matchedLocalReference: bestMatch.candidate.reference,
-        matchReason: formatMatchReason(bestMatch.sameHunk ? "same-hunk" : "same-file", bestMatch),
-      };
-    }
-
-    if (bestMatch.overlap >= 0.12 || (bestMatch.distance !== null && bestMatch.distance <= 10)) {
-      return {
-        ...finding,
-        classification: "near_match",
-        matchedLocalReference: bestMatch.candidate.reference,
-        matchReason: formatMatchReason(bestMatch.sameHunk ? "same-hunk" : "same-file", bestMatch),
-      };
-    }
-  }
-
-  return {
-    ...finding,
-    classification: "missed_by_local_review",
-    matchedLocalReference: bestMatch?.candidate.reference ?? null,
-    matchReason: bestMatch ? formatMatchReason("insufficient", bestMatch) : "no same-file local-review match",
   };
 }
 
@@ -632,3 +326,12 @@ export async function writeExternalReviewMissArtifact(args: {
     missedCount: artifact.counts.missedByLocalReview,
   };
 }
+
+export {
+  classifyExternalReviewFinding,
+  normalizeExternalReviewFinding,
+  type ExternalReviewMatch,
+  type ExternalReviewMissFinding,
+  type LocalReviewArtifactLike,
+  type NormalizedExternalReviewFinding,
+};

--- a/src/external-review-normalization.ts
+++ b/src/external-review-normalization.ts
@@ -1,0 +1,117 @@
+import { truncate } from "./utils";
+import { ReviewThread } from "./types";
+import { type LocalReviewSeverity } from "./local-review-types";
+
+export interface NormalizedExternalReviewFinding {
+  source: "external_bot";
+  reviewerLogin: string;
+  threadId: string;
+  file: string | null;
+  line: number | null;
+  summary: string;
+  rationale: string;
+  severity: Exclude<LocalReviewSeverity, "none">;
+  confidence: number;
+  url: string | null;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function summarizeComment(body: string): string {
+  const normalized = normalizeWhitespace(body);
+  if (normalized.length === 0) {
+    return "External review finding";
+  }
+
+  const sentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/)?.[1] ?? normalized;
+  return truncate(sentence, 180) ?? "External review finding";
+}
+
+function inferSeverity(body: string): Exclude<LocalReviewSeverity, "none"> {
+  const normalized = body.toLowerCase();
+  if (/\b(security|privilege|secret|panic|crash|corrupt|deadlock|critical|data loss)\b/.test(normalized)) {
+    return "high";
+  }
+
+  if (/\b(nit|style|format|typo|wording|docs?)\b/.test(normalized)) {
+    return "low";
+  }
+
+  return "medium";
+}
+
+function inferConfidence(body: string): number {
+  const normalized = body.toLowerCase();
+  if (/\b(will|can|break|fails?|throws?|incorrect|bug|missing|never|always)\b/.test(normalized)) {
+    return 0.9;
+  }
+
+  if (/\b(nit|style|format|typo|wording|docs?)\b/.test(normalized)) {
+    return 0.55;
+  }
+
+  return 0.75;
+}
+
+function latestConfiguredBotComment(thread: ReviewThread, reviewBotLogins: string[]) {
+  const allowed = new Set(reviewBotLogins.map((login) => login.toLowerCase()));
+  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
+    const comment = thread.comments.nodes[index];
+    const login = comment.author?.login?.toLowerCase();
+    if (login && allowed.has(login)) {
+      return comment;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeExternalReviewFinding(
+  thread: ReviewThread,
+  reviewBotLogins: string[],
+): NormalizedExternalReviewFinding | null {
+  const comment = latestConfiguredBotComment(thread, reviewBotLogins);
+  if (!comment) {
+    return null;
+  }
+
+  const rationale = normalizeWhitespace(comment.body);
+  if (rationale.length === 0) {
+    return null;
+  }
+
+  return {
+    source: "external_bot",
+    reviewerLogin: comment.author?.login ?? "unknown",
+    threadId: thread.id,
+    file: thread.path ?? null,
+    line: thread.line ?? null,
+    summary: summarizeComment(comment.body),
+    rationale,
+    severity: inferSeverity(comment.body),
+    confidence: inferConfidence(comment.body),
+    url: comment.url ?? null,
+  };
+}
+
+export function createExternalReviewMissPatternFingerprint(
+  finding: Pick<NormalizedExternalReviewFinding, "file" | "summary" | "rationale">,
+): string {
+  return [
+    finding.file ?? "",
+    normalizeWhitespace(finding.summary).toLowerCase(),
+    truncate(normalizeWhitespace(finding.rationale).toLowerCase(), 200) ?? "",
+  ].join("|");
+}
+
+export function createExternalReviewRegressionCandidateId(
+  finding: Pick<NormalizedExternalReviewFinding, "file" | "line" | "rationale">,
+): string {
+  return [
+    finding.file ?? "",
+    finding.line ?? "",
+    normalizeWhitespace(finding.rationale).toLowerCase(),
+  ].join("|");
+}


### PR DESCRIPTION
Closes #77
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the pure external-review seams into [src/external-review-normalization.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-77/src/external-review-normalization.ts) and [src/external-review-classifier.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-77/src/external-review-classifier.ts), with [src/external-review-misses.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-77/src/external-review-misses.ts) kept as the public entrypoint by re-exporting `normalizeExternalReviewFinding` and `classifyExternalReviewFinding`. The scoring thresholds, same-hunk handling, and `matchReason` formatting were preserved.

I also tightened coverage in [src/external-review-misses.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-77/src/external-review-misses.test.ts) with a focused `near_match` assertion that locks the same-file classifier path and exact `matchReason` output. The issue journal was updated locally, and the code changes were committed as `b0d01aa` (`Refactor external review normalization and classifier`).

Verification: `npm test -- src/external-review-misses.test.ts` and `npm run build` both passed.

Summary: Extracted external review normalization/classification into dedicated modules, preserved public exports, added a focused near-match regression test, and committed the refactor as `b0d01aa`.
State hint: draft_pr
Blocked reason: none
Tests: `npm test -- src/external-...