### PR TITLE
External review misses: extract miss-pattern and regression-candidate derivation (#78)

### DIFF
--- a/src/external-review-miss-artifact-types.ts
+++ b/src/external-review-miss-artifact-types.ts
@@ -1,0 +1,58 @@
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+
+export type ExternalReviewPromptFinding = Pick<
+  ExternalReviewMissFinding,
+  "reviewerLogin" | "file" | "line" | "summary" | "rationale" | "url"
+>;
+
+export interface ExternalReviewMissPattern {
+  fingerprint: string;
+  reviewerLogin: string;
+  file: string;
+  line: number | null;
+  summary: string;
+  rationale: string;
+  sourceArtifactPath: string;
+  sourceHeadSha: string;
+  lastSeenAt: string;
+}
+
+export interface ExternalReviewRegressionCandidate {
+  id: string;
+  title: string;
+  file: string;
+  line: number;
+  summary: string;
+  rationale: string;
+  reviewerLogin: string;
+  sourceThreadId: string;
+  sourceUrl: string | null;
+  qualificationReasons: string[];
+}
+
+export interface ExternalReviewMissArtifact {
+  issueNumber: number;
+  prNumber: number;
+  branch: string;
+  headSha: string;
+  generatedAt: string;
+  localReviewSummaryPath: string | null;
+  localReviewFindingsPath: string | null;
+  findings: ExternalReviewMissFinding[];
+  reusableMissPatterns: ExternalReviewMissPattern[];
+  regressionTestCandidates: ExternalReviewRegressionCandidate[];
+  counts: {
+    matched: number;
+    nearMatch: number;
+    missedByLocalReview: number;
+  };
+}
+
+export interface ExternalReviewMissContext {
+  artifactPath: string;
+  missedFindings: ExternalReviewPromptFinding[];
+  regressionTestCandidates: ExternalReviewRegressionCandidate[];
+  matchedCount: number;
+  nearMatchCount: number;
+  missedCount: number;
+}

--- a/src/external-review-miss-patterns.test.ts
+++ b/src/external-review-miss-patterns.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { legacyReusableMissPatterns, toReusableMissPattern } from "./external-review-miss-patterns";
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+
+function createMissFinding(overrides: Partial<ExternalReviewMissFinding> = {}): ExternalReviewMissFinding {
+  return {
+    source: "external_bot",
+    reviewerLogin: "copilot-pull-request-reviewer",
+    threadId: "thread-1",
+    file: "src/auth.ts",
+    line: 42,
+    summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    rationale:
+      "This fallback skips the permission guard and lets unauthorized callers update records while bypassing the capability check on the fallback path.",
+    severity: "medium",
+    confidence: 0.9,
+    url: "https://example.test/thread-1#comment-1",
+    classification: "missed_by_local_review",
+    matchedLocalReference: null,
+    matchReason: "no same-file local-review match",
+    ...overrides,
+  };
+}
+
+test("toReusableMissPattern preserves persisted fingerprinting and truncation behavior", () => {
+  const pattern = toReusableMissPattern(
+    createMissFinding({
+      rationale: "A".repeat(320),
+    }),
+    "/tmp/external-review-misses-head-deadbeef.json",
+    "deadbeef",
+    "2026-03-12T00:00:00Z",
+  );
+
+  assert.match(
+    pattern.fingerprint,
+    /^src\/auth\.ts\|this fallback skips the permission guard and lets unauthorized callers update records\.\|a{197}\.\.\.$/,
+  );
+  assert.equal(pattern.file, "src/auth.ts");
+  assert.equal(pattern.rationale.length, 280);
+  assert.equal(pattern.sourceHeadSha, "deadbeef");
+});
+
+test("legacyReusableMissPatterns only derives reusable entries from file-scoped confirmed misses", () => {
+  const patterns = legacyReusableMissPatterns(
+    {
+      generatedAt: "2026-03-12T00:00:00Z",
+      headSha: "deadbeef",
+      findings: [
+        createMissFinding(),
+        createMissFinding({
+          threadId: "thread-2",
+          file: null,
+        }),
+        createMissFinding({
+          threadId: "thread-3",
+          classification: "near_match",
+        }),
+      ],
+    },
+    "/tmp/external-review-misses-head-deadbeef.json",
+  );
+
+  assert.deepEqual(
+    patterns.map((pattern) => ({
+      fingerprint: pattern.fingerprint,
+      file: pattern.file,
+      line: pattern.line,
+      sourceHeadSha: pattern.sourceHeadSha,
+      lastSeenAt: pattern.lastSeenAt,
+    })),
+    [
+      {
+        fingerprint:
+          "src/auth.ts|this fallback skips the permission guard and lets unauthorized callers update records.|this fallback skips the permission guard and lets unauthorized callers update records while bypassing the capability check on the fallback path.",
+        file: "src/auth.ts",
+        line: 42,
+        sourceHeadSha: "deadbeef",
+        lastSeenAt: "2026-03-12T00:00:00Z",
+      },
+    ],
+  );
+});

--- a/src/external-review-miss-patterns.ts
+++ b/src/external-review-miss-patterns.ts
@@ -1,0 +1,57 @@
+import { truncate } from "./utils";
+import {
+  createExternalReviewMissPatternFingerprint,
+} from "./external-review-normalization";
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+import {
+  type ExternalReviewMissPattern,
+  type ExternalReviewPromptFinding,
+} from "./external-review-miss-artifact-types";
+
+interface ExternalReviewMissArtifactLike {
+  generatedAt?: string;
+  headSha?: string;
+  findings?: ExternalReviewMissFinding[];
+  reusableMissPatterns?: ExternalReviewMissPattern[];
+}
+
+export function createMissPatternFingerprint(
+  finding: Pick<ExternalReviewPromptFinding, "file" | "summary" | "rationale">,
+): string {
+  return createExternalReviewMissPatternFingerprint(finding);
+}
+
+export function toReusableMissPattern(
+  finding: ExternalReviewMissFinding,
+  sourceArtifactPath: string,
+  sourceHeadSha: string,
+  lastSeenAt: string,
+): ExternalReviewMissPattern {
+  return {
+    fingerprint: createMissPatternFingerprint(finding),
+    reviewerLogin: finding.reviewerLogin,
+    file: finding.file ?? "unknown",
+    line: finding.line,
+    summary: finding.summary,
+    rationale: truncate(finding.rationale, 280) ?? finding.rationale,
+    sourceArtifactPath,
+    sourceHeadSha,
+    lastSeenAt,
+  };
+}
+
+export function legacyReusableMissPatterns(
+  artifact: ExternalReviewMissArtifactLike,
+  artifactPath: string,
+): ExternalReviewMissPattern[] {
+  const generatedAt = typeof artifact.generatedAt === "string" ? artifact.generatedAt : "";
+  const headSha = typeof artifact.headSha === "string" ? artifact.headSha : "";
+  return (artifact.findings ?? [])
+    .filter(
+      (finding) =>
+        finding.classification === "missed_by_local_review" &&
+        typeof finding.file === "string" &&
+        finding.file.trim() !== "",
+    )
+    .map((finding) => toReusableMissPattern(finding, artifactPath, headSha, generatedAt));
+}

--- a/src/external-review-misses.ts
+++ b/src/external-review-misses.ts
@@ -1,9 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ensureDir, nowIso, parseJson, truncate } from "./utils";
+import { ensureDir, nowIso, parseJson } from "./utils";
 import {
-  createExternalReviewMissPatternFingerprint,
-  createExternalReviewRegressionCandidateId,
   normalizeExternalReviewFinding,
   type NormalizedExternalReviewFinding,
 } from "./external-review-normalization";
@@ -13,138 +11,16 @@ import {
   type ExternalReviewMissFinding,
   type LocalReviewArtifactLike,
 } from "./external-review-classifier";
+import {
+  type ExternalReviewMissArtifact,
+  type ExternalReviewMissContext,
+  type ExternalReviewMissPattern,
+  type ExternalReviewPromptFinding,
+  type ExternalReviewRegressionCandidate,
+} from "./external-review-miss-artifact-types";
+import { legacyReusableMissPatterns, toReusableMissPattern } from "./external-review-miss-patterns";
+import { toRegressionTestCandidate } from "./external-review-regression-candidates";
 import { type ReviewThread } from "./types";
-
-export type ExternalReviewPromptFinding = Pick<
-  ExternalReviewMissFinding,
-  "reviewerLogin" | "file" | "line" | "summary" | "rationale" | "url"
->;
-
-export interface ExternalReviewMissArtifact {
-  issueNumber: number;
-  prNumber: number;
-  branch: string;
-  headSha: string;
-  generatedAt: string;
-  localReviewSummaryPath: string | null;
-  localReviewFindingsPath: string | null;
-  findings: ExternalReviewMissFinding[];
-  reusableMissPatterns: ExternalReviewMissPattern[];
-  regressionTestCandidates: ExternalReviewRegressionCandidate[];
-  counts: {
-    matched: number;
-    nearMatch: number;
-    missedByLocalReview: number;
-  };
-}
-
-export interface ExternalReviewMissContext {
-  artifactPath: string;
-  missedFindings: ExternalReviewPromptFinding[];
-  regressionTestCandidates: ExternalReviewRegressionCandidate[];
-  matchedCount: number;
-  nearMatchCount: number;
-  missedCount: number;
-}
-
-export interface ExternalReviewMissPattern {
-  fingerprint: string;
-  reviewerLogin: string;
-  file: string;
-  line: number | null;
-  summary: string;
-  rationale: string;
-  sourceArtifactPath: string;
-  sourceHeadSha: string;
-  lastSeenAt: string;
-}
-
-export interface ExternalReviewRegressionCandidate {
-  id: string;
-  title: string;
-  file: string;
-  line: number;
-  summary: string;
-  rationale: string;
-  reviewerLogin: string;
-  sourceThreadId: string;
-  sourceUrl: string | null;
-  qualificationReasons: string[];
-}
-
-function createMissPatternFingerprint(finding: Pick<ExternalReviewPromptFinding, "file" | "summary" | "rationale">): string {
-  return createExternalReviewMissPatternFingerprint(finding);
-}
-
-function toReusableMissPattern(
-  finding: ExternalReviewMissFinding,
-  sourceArtifactPath: string,
-  sourceHeadSha: string,
-  lastSeenAt: string,
-): ExternalReviewMissPattern {
-  return {
-    fingerprint: createMissPatternFingerprint(finding),
-    reviewerLogin: finding.reviewerLogin,
-    file: finding.file ?? "unknown",
-    line: finding.line,
-    summary: finding.summary,
-    rationale: truncate(finding.rationale, 280) ?? finding.rationale,
-    sourceArtifactPath,
-    sourceHeadSha,
-    lastSeenAt,
-  };
-}
-
-function createRegressionCandidateId(finding: ExternalReviewMissFinding): string {
-  return createExternalReviewRegressionCandidateId(finding);
-}
-
-function toRegressionTestCandidate(
-  finding: ExternalReviewMissFinding,
-): ExternalReviewRegressionCandidate | null {
-  if (finding.classification !== "missed_by_local_review") {
-    return null;
-  }
-
-  const qualificationReasons: string[] = ["missed_by_local_review"];
-  if (finding.severity !== "low") {
-    qualificationReasons.push("non_low_severity");
-  }
-  if (finding.confidence >= 0.75) {
-    qualificationReasons.push("high_confidence");
-  }
-  if (typeof finding.file === "string" && finding.file.trim() !== "") {
-    qualificationReasons.push("file_scoped");
-  }
-  if (typeof finding.line === "number" && Number.isInteger(finding.line) && finding.line > 0) {
-    qualificationReasons.push("line_scoped");
-  }
-
-  if (
-    !qualificationReasons.includes("non_low_severity") ||
-    !qualificationReasons.includes("high_confidence") ||
-    !qualificationReasons.includes("file_scoped") ||
-    !qualificationReasons.includes("line_scoped") ||
-    !finding.file ||
-    finding.line == null
-  ) {
-    return null;
-  }
-
-  const trimmedSummary = finding.summary.replace(/[.!?]+$/, "");
-  return {
-    id: createRegressionCandidateId(finding),
-    title: `Add regression coverage for ${trimmedSummary}`,
-    file: finding.file,
-    line: finding.line,
-    summary: finding.summary,
-    rationale: finding.rationale,
-    reviewerLogin: finding.reviewerLogin,
-    sourceThreadId: finding.threadId,
-    sourceUrl: finding.url ?? null,
-    qualificationReasons,
-  };
-}
 
 async function loadLocalReviewArtifact(summaryPath: string | null): Promise<{
   findingsPath: string | null;
@@ -175,17 +51,6 @@ interface ExternalReviewMissArtifactLike {
   findings?: ExternalReviewMissFinding[];
   reusableMissPatterns?: ExternalReviewMissPattern[];
   regressionTestCandidates?: ExternalReviewRegressionCandidate[];
-}
-
-function legacyReusableMissPatterns(
-  artifact: ExternalReviewMissArtifactLike,
-  artifactPath: string,
-): ExternalReviewMissPattern[] {
-  const generatedAt = typeof artifact.generatedAt === "string" ? artifact.generatedAt : "";
-  const headSha = typeof artifact.headSha === "string" ? artifact.headSha : "";
-  return (artifact.findings ?? [])
-    .filter((finding) => finding.classification === "missed_by_local_review" && typeof finding.file === "string" && finding.file.trim() !== "")
-    .map((finding) => toReusableMissPattern(finding, artifactPath, headSha, generatedAt));
 }
 
 export async function loadRelevantExternalReviewMissPatterns(args: {
@@ -330,8 +195,13 @@ export async function writeExternalReviewMissArtifact(args: {
 export {
   classifyExternalReviewFinding,
   normalizeExternalReviewFinding,
+  type ExternalReviewMissArtifact,
   type ExternalReviewMatch,
+  type ExternalReviewMissContext,
   type ExternalReviewMissFinding,
+  type ExternalReviewMissPattern,
+  type ExternalReviewPromptFinding,
+  type ExternalReviewRegressionCandidate,
   type LocalReviewArtifactLike,
   type NormalizedExternalReviewFinding,
 };

--- a/src/external-review-regression-candidates.test.ts
+++ b/src/external-review-regression-candidates.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toRegressionTestCandidate } from "./external-review-regression-candidates";
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+
+function createMissFinding(overrides: Partial<ExternalReviewMissFinding> = {}): ExternalReviewMissFinding {
+  return {
+    source: "external_bot",
+    reviewerLogin: "copilot-pull-request-reviewer",
+    threadId: "thread-1",
+    file: "src/auth.ts",
+    line: 42,
+    summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    severity: "medium",
+    confidence: 0.9,
+    url: "https://example.test/thread-1#comment-1",
+    classification: "missed_by_local_review",
+    matchedLocalReference: null,
+    matchReason: "no same-file local-review match",
+    ...overrides,
+  };
+}
+
+test("toRegressionTestCandidate keeps persisted ids and qualification reasons stable", () => {
+  const candidate = toRegressionTestCandidate(createMissFinding());
+  assert.deepEqual(candidate, {
+    id: "src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+    title: "Add regression coverage for This fallback skips the permission guard and lets unauthorized callers update records",
+    file: "src/auth.ts",
+    line: 42,
+    summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    reviewerLogin: "copilot-pull-request-reviewer",
+    sourceThreadId: "thread-1",
+    sourceUrl: "https://example.test/thread-1#comment-1",
+    qualificationReasons: ["missed_by_local_review", "non_low_severity", "high_confidence", "file_scoped", "line_scoped"],
+  });
+});
+
+test("toRegressionTestCandidate rejects misses that do not meet the durable regression bar", () => {
+  assert.equal(
+    toRegressionTestCandidate(
+      createMissFinding({
+        severity: "low",
+      }),
+    ),
+    null,
+  );
+  assert.equal(
+    toRegressionTestCandidate(
+      createMissFinding({
+        confidence: 0.74,
+      }),
+    ),
+    null,
+  );
+  assert.equal(
+    toRegressionTestCandidate(
+      createMissFinding({
+        line: null,
+      }),
+    ),
+    null,
+  );
+});

--- a/src/external-review-regression-candidates.ts
+++ b/src/external-review-regression-candidates.ts
@@ -1,0 +1,54 @@
+import { createExternalReviewRegressionCandidateId } from "./external-review-normalization";
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+import { type ExternalReviewRegressionCandidate } from "./external-review-miss-artifact-types";
+
+export function createRegressionCandidateId(finding: ExternalReviewMissFinding): string {
+  return createExternalReviewRegressionCandidateId(finding);
+}
+
+export function toRegressionTestCandidate(
+  finding: ExternalReviewMissFinding,
+): ExternalReviewRegressionCandidate | null {
+  if (finding.classification !== "missed_by_local_review") {
+    return null;
+  }
+
+  const qualificationReasons: string[] = ["missed_by_local_review"];
+  if (finding.severity !== "low") {
+    qualificationReasons.push("non_low_severity");
+  }
+  if (finding.confidence >= 0.75) {
+    qualificationReasons.push("high_confidence");
+  }
+  if (typeof finding.file === "string" && finding.file.trim() !== "") {
+    qualificationReasons.push("file_scoped");
+  }
+  if (typeof finding.line === "number" && Number.isInteger(finding.line) && finding.line > 0) {
+    qualificationReasons.push("line_scoped");
+  }
+
+  if (
+    !qualificationReasons.includes("non_low_severity") ||
+    !qualificationReasons.includes("high_confidence") ||
+    !qualificationReasons.includes("file_scoped") ||
+    !qualificationReasons.includes("line_scoped") ||
+    !finding.file ||
+    finding.line == null
+  ) {
+    return null;
+  }
+
+  const trimmedSummary = finding.summary.replace(/[.!?]+$/, "");
+  return {
+    id: createRegressionCandidateId(finding),
+    title: `Add regression coverage for ${trimmedSummary}`,
+    file: finding.file,
+    line: finding.line,
+    summary: finding.summary,
+    rationale: finding.rationale,
+    reviewerLogin: finding.reviewerLogin,
+    sourceThreadId: finding.threadId,
+    sourceUrl: finding.url ?? null,
+    qualificationReasons,
+  };
+}


### PR DESCRIPTION
Closes #78
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the two derivation seams out of [`src/external-review-misses.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-78/src/external-review-misses.ts) into focused modules: [`src/external-review-miss-patterns.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-78/src/external-review-miss-patterns.ts) and [`src/external-review-regression-candidates.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-78/src/external-review-regression-candidates.ts). Shared artifact types now live in [`src/external-review-miss-artifact-types.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-78/src/external-review-miss-artifact-types.ts), and the original file keeps orchestration plus re-exports so external behavior stays stable.

I added direct seam tests in [`src/external-review-miss-patterns.test.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-78/src/external-review-miss-patterns.test.ts) and [`src/external-review-regression-candidates.test.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-78/src/external-review-regression-candidates.test.ts) to lock down persisted fingerprints, truncation, candidate IDs, and qualification gating. The required verification passed, and I recorded the work in the local issue journal before committing the code as `f66e39f` (`Refactor external review miss derivation`).

Summary: Extracted miss-pattern and regres...