### PR TITLE
Add durable external review guardrails

### DIFF
--- a/docs/shared-memory/external-review-guardrails.json
+++ b/docs/shared-memory/external-review-guardrails.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "patterns": []
+}

--- a/docs/shared-memory/external-review-guardrails.schema.json
+++ b/docs/shared-memory/external-review-guardrails.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/external-review-guardrails.schema.json",
+  "title": "Durable External Review Guardrails",
+  "description": "Repo-committed durable memory for promoted external-review lessons.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "patterns"],
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "Schema version for durable external-review guardrails."
+    },
+    "patterns": {
+      "type": "array",
+      "description": "Promoted reusable miss patterns consumed as durable guardrails during local review.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "fingerprint",
+          "reviewerLogin",
+          "file",
+          "line",
+          "summary",
+          "rationale",
+          "sourceArtifactPath",
+          "sourceHeadSha",
+          "lastSeenAt"
+        ],
+        "properties": {
+          "fingerprint": { "type": "string", "minLength": 1 },
+          "reviewerLogin": { "type": "string", "minLength": 1 },
+          "file": { "type": "string", "minLength": 1 },
+          "line": {
+            "type": ["integer", "null"],
+            "minimum": 1
+          },
+          "summary": { "type": "string", "minLength": 1 },
+          "rationale": { "type": "string", "minLength": 1 },
+          "sourceArtifactPath": { "type": "string", "minLength": 1 },
+          "sourceHeadSha": { "type": "string", "minLength": 1 },
+          "lastSeenAt": {
+            "type": "string",
+            "minLength": 1,
+            "description": "ISO-8601 timestamp used for deterministic ordering."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/external-review-miss-artifact-types.ts
+++ b/src/external-review-miss-artifact-types.ts
@@ -30,6 +30,11 @@ export interface ExternalReviewRegressionCandidate {
   qualificationReasons: string[];
 }
 
+export interface DurableExternalReviewGuardrails {
+  version: 1;
+  patterns: ExternalReviewMissPattern[];
+}
+
 export interface ExternalReviewMissArtifact {
   issueNumber: number;
   prNumber: number;

--- a/src/external-review-miss-history.ts
+++ b/src/external-review-miss-history.ts
@@ -4,6 +4,7 @@ import { parseJson } from "./utils";
 import { legacyReusableMissPatterns } from "./external-review-miss-patterns";
 import { type ExternalReviewMissFinding } from "./external-review-classifier";
 import {
+  type DurableExternalReviewGuardrails,
   type ExternalReviewMissPattern,
   type ExternalReviewRegressionCandidate,
 } from "./external-review-miss-artifact-types";
@@ -17,31 +18,189 @@ interface ExternalReviewMissArtifactLike {
   regressionTestCandidates?: ExternalReviewRegressionCandidate[];
 }
 
+const DURABLE_EXTERNAL_REVIEW_GUARDRAILS_PATH = path.join(
+  "docs",
+  "shared-memory",
+  "external-review-guardrails.json",
+);
+const DURABLE_EXTERNAL_REVIEW_GUARDRAILS_VERSION = 1;
+const DURABLE_EXTERNAL_REVIEW_GUARDRAILS_MAX_BYTES = 256 * 1024;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return value === null || typeof value === "number";
+}
+
+function compareMissPatternPriority(left: ExternalReviewMissPattern, right: ExternalReviewMissPattern): number {
+  const lastSeenComparison = right.lastSeenAt.localeCompare(left.lastSeenAt);
+  if (lastSeenComparison !== 0) {
+    return lastSeenComparison;
+  }
+
+  const fileComparison = left.file.localeCompare(right.file);
+  if (fileComparison !== 0) {
+    return fileComparison;
+  }
+
+  const lineComparison = (left.line ?? Number.MAX_SAFE_INTEGER) - (right.line ?? Number.MAX_SAFE_INTEGER);
+  if (lineComparison !== 0) {
+    return lineComparison;
+  }
+
+  const fingerprintComparison = left.fingerprint.localeCompare(right.fingerprint);
+  if (fingerprintComparison !== 0) {
+    return fingerprintComparison;
+  }
+
+  const headShaComparison = left.sourceHeadSha.localeCompare(right.sourceHeadSha);
+  if (headShaComparison !== 0) {
+    return headShaComparison;
+  }
+
+  return left.sourceArtifactPath.localeCompare(right.sourceArtifactPath);
+}
+
+function validateDurableMissPattern(value: unknown, source: string, index: number): ExternalReviewMissPattern {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}] must be an object.`);
+  }
+
+  const pattern = value as Record<string, unknown>;
+  if (!isNonEmptyString(pattern.fingerprint)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].fingerprint must be a non-empty string.`);
+  }
+  if (!isNonEmptyString(pattern.reviewerLogin)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].reviewerLogin must be a non-empty string.`);
+  }
+  if (!isNonEmptyString(pattern.file)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].file must be a non-empty string.`);
+  }
+  if (!isNullableNumber(pattern.line)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].line must be a number or null.`);
+  }
+  if (!isNonEmptyString(pattern.summary)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].summary must be a non-empty string.`);
+  }
+  if (!isNonEmptyString(pattern.rationale)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].rationale must be a non-empty string.`);
+  }
+  if (!isNonEmptyString(pattern.sourceArtifactPath)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].sourceArtifactPath must be a non-empty string.`);
+  }
+  if (!isNonEmptyString(pattern.sourceHeadSha)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].sourceHeadSha must be a non-empty string.`);
+  }
+  if (!isNonEmptyString(pattern.lastSeenAt)) {
+    throw new Error(`Invalid durable external review guardrails in ${source}: patterns[${index}].lastSeenAt must be a non-empty string.`);
+  }
+
+  return {
+    fingerprint: pattern.fingerprint,
+    reviewerLogin: pattern.reviewerLogin,
+    file: pattern.file,
+    line: pattern.line,
+    summary: pattern.summary,
+    rationale: pattern.rationale,
+    sourceArtifactPath: pattern.sourceArtifactPath,
+    sourceHeadSha: pattern.sourceHeadSha,
+    lastSeenAt: pattern.lastSeenAt,
+  };
+}
+
+async function loadDurableExternalReviewGuardrails(workspacePath: string): Promise<ExternalReviewMissPattern[]> {
+  const guardrailPath = path.join(workspacePath, DURABLE_EXTERNAL_REVIEW_GUARDRAILS_PATH);
+  let stat;
+  try {
+    stat = await fs.stat(guardrailPath);
+  } catch (error) {
+    const maybeErr = error as NodeJS.ErrnoException;
+    if (maybeErr.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  }
+
+  if (stat.size === 0) {
+    return [];
+  }
+  if (stat.size > DURABLE_EXTERNAL_REVIEW_GUARDRAILS_MAX_BYTES) {
+    throw new Error(
+      `Durable external review guardrails at ${guardrailPath} exceed ${DURABLE_EXTERNAL_REVIEW_GUARDRAILS_MAX_BYTES} bytes.`,
+    );
+  }
+
+  const raw = await fs.readFile(guardrailPath, "utf8");
+  if (raw.trim() === "") {
+    return [];
+  }
+
+  const parsed = parseJson<DurableExternalReviewGuardrails & { version?: unknown; patterns?: unknown }>(raw, guardrailPath);
+  if (parsed.version !== DURABLE_EXTERNAL_REVIEW_GUARDRAILS_VERSION) {
+    throw new Error(
+      `Invalid durable external review guardrails in ${guardrailPath}: version must be ${DURABLE_EXTERNAL_REVIEW_GUARDRAILS_VERSION}.`,
+    );
+  }
+  if (!Array.isArray(parsed.patterns)) {
+    throw new Error(`Invalid durable external review guardrails in ${guardrailPath}: patterns must be an array.`);
+  }
+
+  return parsed.patterns.map((pattern, index) => validateDurableMissPattern(pattern, guardrailPath, index));
+}
+
+function mergeRelevantPatterns(
+  deduped: Map<string, ExternalReviewMissPattern>,
+  patterns: ExternalReviewMissPattern[],
+  changedFileSet: ReadonlySet<string>,
+): void {
+  for (const pattern of patterns) {
+    if (!changedFileSet.has(pattern.file)) {
+      continue;
+    }
+
+    const existing = deduped.get(pattern.fingerprint);
+    if (!existing || compareMissPatternPriority(pattern, existing) < 0) {
+      deduped.set(pattern.fingerprint, pattern);
+    }
+  }
+}
+
 export async function loadRelevantExternalReviewMissPatterns(args: {
   artifactDir: string;
   branch: string;
   currentHeadSha: string;
   changedFiles: string[];
   limit?: number;
+  workspacePath?: string;
 }): Promise<ExternalReviewMissPattern[]> {
   const changedFiles = [...new Set(args.changedFiles.filter((filePath) => filePath.trim() !== ""))].sort();
   if (changedFiles.length === 0) {
     return [];
   }
 
+  const changedFileSet = new Set(changedFiles);
+  const deduped = new Map<string, ExternalReviewMissPattern>();
+
+  if (args.workspacePath) {
+    mergeRelevantPatterns(deduped, await loadDurableExternalReviewGuardrails(args.workspacePath), changedFileSet);
+  }
+
   let entries: string[];
   try {
     entries = await fs.readdir(args.artifactDir);
   } catch {
-    return [];
+    return [...deduped.values()]
+      .sort(compareMissPatternPriority)
+      .slice(0, Math.max(0, args.limit ?? 3));
   }
 
   const artifactPaths = entries
     .filter((entry) => /^external-review-misses-head-.*\.json$/i.test(entry))
     .sort()
     .map((entry) => path.join(args.artifactDir, entry));
-  const changedFileSet = new Set(changedFiles);
-  const deduped = new Map<string, ExternalReviewMissPattern>();
 
   for (const artifactPath of artifactPaths) {
     let raw: string;
@@ -60,36 +219,10 @@ export async function loadRelevantExternalReviewMissPatterns(args: {
       Array.isArray(artifact.reusableMissPatterns) && artifact.reusableMissPatterns.length > 0
         ? artifact.reusableMissPatterns
         : legacyReusableMissPatterns(artifact, artifactPath);
-    for (const pattern of reusableMissPatterns) {
-      if (!pattern.file || !changedFileSet.has(pattern.file)) {
-        continue;
-      }
-
-      const existing = deduped.get(pattern.fingerprint);
-      if (!existing || pattern.lastSeenAt > existing.lastSeenAt) {
-        deduped.set(pattern.fingerprint, pattern);
-      }
-    }
+    mergeRelevantPatterns(deduped, reusableMissPatterns, changedFileSet);
   }
 
   return [...deduped.values()]
-    .sort((left, right) => {
-      const lastSeenComparison = right.lastSeenAt.localeCompare(left.lastSeenAt);
-      if (lastSeenComparison !== 0) {
-        return lastSeenComparison;
-      }
-
-      const fileComparison = left.file.localeCompare(right.file);
-      if (fileComparison !== 0) {
-        return fileComparison;
-      }
-
-      const lineComparison = (left.line ?? Number.MAX_SAFE_INTEGER) - (right.line ?? Number.MAX_SAFE_INTEGER);
-      if (lineComparison !== 0) {
-        return lineComparison;
-      }
-
-      return left.fingerprint.localeCompare(right.fingerprint);
-    })
+    .sort(compareMissPatternPriority)
     .slice(0, Math.max(0, args.limit ?? 3));
 }

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -539,3 +539,191 @@ test("loadRelevantExternalReviewMissPatterns keeps relevant historical misses or
     ],
   );
 });
+
+test("loadRelevantExternalReviewMissPatterns reads repo-committed durable guardrails when local artifacts are absent", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-durable-guardrails-test-"));
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.writeFile(
+    durableGuardrailPath,
+    JSON.stringify({
+      version: 1,
+      patterns: [
+        {
+          fingerprint: "src/auth.ts|permission",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Check the permission guard before the fallback write path.",
+          sourceArtifactPath: "external-review-misses-head-middle.json",
+          sourceHeadSha: "middlehead",
+          lastSeenAt: "2026-03-11T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  const patterns = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: path.join(workspaceDir, ".local", "reviews"),
+    branch: "codex/issue-61",
+    currentHeadSha: "currenthead",
+    changedFiles: ["src/auth.ts"],
+    limit: 3,
+    workspacePath: workspaceDir,
+  });
+
+  assert.deepEqual(
+    patterns.map((pattern) => ({ file: pattern.file, summary: pattern.summary, lastSeenAt: pattern.lastSeenAt })),
+    [
+      {
+        file: "src/auth.ts",
+        summary: "Permission guard is bypassed.",
+        lastSeenAt: "2026-03-11T00:00:00Z",
+      },
+    ],
+  );
+});
+
+test("loadRelevantExternalReviewMissPatterns returns an empty list when durable guardrail files are absent or blank", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-durable-guardrails-empty-test-"));
+
+  const absent = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: path.join(workspaceDir, ".local", "reviews"),
+    branch: "codex/issue-61",
+    currentHeadSha: "currenthead",
+    changedFiles: ["src/auth.ts"],
+    workspacePath: workspaceDir,
+  });
+  assert.deepEqual(absent, []);
+
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.writeFile(durableGuardrailPath, "", "utf8");
+
+  const blank = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: path.join(workspaceDir, ".local", "reviews"),
+    branch: "codex/issue-61",
+    currentHeadSha: "currenthead",
+    changedFiles: ["src/auth.ts"],
+    workspacePath: workspaceDir,
+  });
+  assert.deepEqual(blank, []);
+});
+
+test("loadRelevantExternalReviewMissPatterns validates and orders durable guardrails deterministically", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-durable-guardrails-ordered-test-"));
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.writeFile(
+    durableGuardrailPath,
+    JSON.stringify({
+      version: 1,
+      patterns: [
+        {
+          fingerprint: "src/retry.ts|later",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/retry.ts",
+          line: 15,
+          summary: "Retry loop never stops on fatal errors.",
+          rationale: "Exit the retry loop once the fatal predicate matches.",
+          sourceArtifactPath: "external-review-misses-head-newer.json",
+          sourceHeadSha: "newerhead",
+          lastSeenAt: "2026-03-09T00:00:00Z",
+        },
+        {
+          fingerprint: "src/auth.ts|permission",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Check the permission guard before the fallback write path.",
+          sourceArtifactPath: "external-review-misses-head-old.json",
+          sourceHeadSha: "oldhead",
+          lastSeenAt: "2026-03-10T00:00:00Z",
+        },
+        {
+          fingerprint: "src/auth.ts|permission",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Check the permission guard before the fallback write path.",
+          sourceArtifactPath: "external-review-misses-head-new.json",
+          sourceHeadSha: "newhead",
+          lastSeenAt: "2026-03-11T00:00:00Z",
+        },
+        {
+          fingerprint: "src/api.ts|required-field",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/api.ts",
+          line: 8,
+          summary: "Response omits a required field.",
+          rationale: "Return the required field from the success response.",
+          sourceArtifactPath: "external-review-misses-head-middle.json",
+          sourceHeadSha: "middlehead",
+          lastSeenAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  const patterns = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: path.join(workspaceDir, ".local", "reviews"),
+    branch: "codex/issue-61",
+    currentHeadSha: "currenthead",
+    changedFiles: ["src/api.ts", "src/auth.ts", "src/retry.ts"],
+    limit: 2,
+    workspacePath: workspaceDir,
+  });
+
+  assert.deepEqual(
+    patterns.map((pattern) => ({
+      fingerprint: pattern.fingerprint,
+      file: pattern.file,
+      lastSeenAt: pattern.lastSeenAt,
+      sourceHeadSha: pattern.sourceHeadSha,
+    })),
+    [
+      {
+        fingerprint: "src/auth.ts|permission",
+        file: "src/auth.ts",
+        lastSeenAt: "2026-03-11T00:00:00Z",
+        sourceHeadSha: "newhead",
+      },
+      {
+        fingerprint: "src/api.ts|required-field",
+        file: "src/api.ts",
+        lastSeenAt: "2026-03-10T00:00:00Z",
+        sourceHeadSha: "middlehead",
+      },
+    ],
+  );
+});
+
+test("loadRelevantExternalReviewMissPatterns rejects durable guardrails with an unsupported schema version", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-durable-guardrails-invalid-test-"));
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.writeFile(
+    durableGuardrailPath,
+    JSON.stringify({
+      version: 2,
+      patterns: [],
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => loadRelevantExternalReviewMissPatterns({
+      artifactDir: path.join(workspaceDir, ".local", "reviews"),
+      branch: "codex/issue-61",
+      currentHeadSha: "currenthead",
+      changedFiles: ["src/auth.ts"],
+      workspacePath: workspaceDir,
+    }),
+    /version must be 1/,
+  );
+});

--- a/src/local-review.ts
+++ b/src/local-review.ts
@@ -192,6 +192,7 @@ export async function runLocalReview(args: {
     currentHeadSha: args.pr.headRefOid,
     changedFiles,
     limit: 3,
+    workspacePath: args.workspacePath,
   });
   const detectedRoles =
     args.config.localReviewRoles.length === 0 && args.config.localReviewAutoDetect


### PR DESCRIPTION
## Summary\n- add a repo-committed durable guardrail file and JSON schema under docs/shared-memory\n- load durable external-review miss patterns from the workspace alongside local miss artifacts\n- cover durable guardrail parsing, deterministic ordering, and empty-state behavior with focused tests\n\nCloses #84