### PR TITLE
Issue #85: add durable external review guardrail candidates

### DIFF
--- a/src/external-review-durable-guardrail-candidates.test.ts
+++ b/src/external-review-durable-guardrail-candidates.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toDurableGuardrailCandidates } from "./external-review-durable-guardrail-candidates";
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+
+function createMissFinding(overrides: Partial<ExternalReviewMissFinding> = {}): ExternalReviewMissFinding {
+  return {
+    source: "external_bot",
+    reviewerLogin: "copilot-pull-request-reviewer",
+    threadId: "thread-1",
+    file: "src/auth.ts",
+    line: 42,
+    summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+    severity: "high",
+    confidence: 0.9,
+    url: "https://example.test/thread-1#comment-1",
+    classification: "missed_by_local_review",
+    matchedLocalReference: null,
+    matchReason: "no same-file local-review match",
+    ...overrides,
+  };
+}
+
+test("toDurableGuardrailCandidates emits explicit categories with deterministic provenance", () => {
+  const candidates = toDurableGuardrailCandidates({
+    issueNumber: 85,
+    prNumber: 144,
+    branch: "codex/issue-85",
+    headSha: "deadbeefcafebabe",
+    sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+    localReviewSummaryPath: "/tmp/head-deadbeef.md",
+    localReviewFindingsPath: "/tmp/head-deadbeef.json",
+    finding: createMissFinding(),
+  });
+
+  assert.deepEqual(candidates, [
+    {
+      id: "prompt_rubric|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "prompt_rubric",
+      title: "Promote prompt/rubric guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      file: "src/auth.ts",
+      line: 42,
+      summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      qualificationReasons: ["missed_by_local_review", "high_confidence", "file_scoped", "non_low_severity"],
+      provenance: {
+        issueNumber: 85,
+        prNumber: 144,
+        branch: "codex/issue-85",
+        headSha: "deadbeefcafebabe",
+        sourceThreadId: "thread-1",
+        sourceUrl: "https://example.test/thread-1#comment-1",
+        sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+        localReviewSummaryPath: "/tmp/head-deadbeef.md",
+        localReviewFindingsPath: "/tmp/head-deadbeef.json",
+        matchedLocalReference: null,
+        matchReason: "no same-file local-review match",
+      },
+    },
+    {
+      id: "verifier|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "verifier",
+      title: "Promote verifier guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      file: "src/auth.ts",
+      line: 42,
+      summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      qualificationReasons: ["missed_by_local_review", "high_confidence", "file_scoped", "high_severity", "line_scoped"],
+      provenance: {
+        issueNumber: 85,
+        prNumber: 144,
+        branch: "codex/issue-85",
+        headSha: "deadbeefcafebabe",
+        sourceThreadId: "thread-1",
+        sourceUrl: "https://example.test/thread-1#comment-1",
+        sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+        localReviewSummaryPath: "/tmp/head-deadbeef.md",
+        localReviewFindingsPath: "/tmp/head-deadbeef.json",
+        matchedLocalReference: null,
+        matchReason: "no same-file local-review match",
+      },
+    },
+    {
+      id: "regression_test|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "regression_test",
+      title: "Promote regression-test guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      file: "src/auth.ts",
+      line: 42,
+      summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      qualificationReasons: ["missed_by_local_review", "high_confidence", "file_scoped", "non_low_severity", "line_scoped"],
+      provenance: {
+        issueNumber: 85,
+        prNumber: 144,
+        branch: "codex/issue-85",
+        headSha: "deadbeefcafebabe",
+        sourceThreadId: "thread-1",
+        sourceUrl: "https://example.test/thread-1#comment-1",
+        sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+        localReviewSummaryPath: "/tmp/head-deadbeef.md",
+        localReviewFindingsPath: "/tmp/head-deadbeef.json",
+        matchedLocalReference: null,
+        matchReason: "no same-file local-review match",
+      },
+    },
+  ]);
+});
+
+test("toDurableGuardrailCandidates rejects weak or ambiguous misses deterministically", () => {
+  assert.deepEqual(
+    toDurableGuardrailCandidates({
+      issueNumber: 85,
+      prNumber: 144,
+      branch: "codex/issue-85",
+      headSha: "deadbeefcafebabe",
+      sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+      localReviewSummaryPath: "/tmp/head-deadbeef.md",
+      localReviewFindingsPath: "/tmp/head-deadbeef.json",
+      finding: createMissFinding({
+        severity: "low",
+      }),
+    }).map((candidate) => candidate.category),
+    [],
+  );
+
+  assert.deepEqual(
+    toDurableGuardrailCandidates({
+      issueNumber: 85,
+      prNumber: 144,
+      branch: "codex/issue-85",
+      headSha: "deadbeefcafebabe",
+      sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+      localReviewSummaryPath: "/tmp/head-deadbeef.md",
+      localReviewFindingsPath: "/tmp/head-deadbeef.json",
+      finding: createMissFinding({
+        severity: "medium",
+      }),
+    }).map((candidate) => candidate.category),
+    ["prompt_rubric", "regression_test"],
+  );
+
+  assert.deepEqual(
+    toDurableGuardrailCandidates({
+      issueNumber: 85,
+      prNumber: 144,
+      branch: "codex/issue-85",
+      headSha: "deadbeefcafebabe",
+      sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+      localReviewSummaryPath: "/tmp/head-deadbeef.md",
+      localReviewFindingsPath: "/tmp/head-deadbeef.json",
+      finding: createMissFinding({
+        confidence: 0.74,
+      }),
+    }),
+    [],
+  );
+
+  assert.deepEqual(
+    toDurableGuardrailCandidates({
+      issueNumber: 85,
+      prNumber: 144,
+      branch: "codex/issue-85",
+      headSha: "deadbeefcafebabe",
+      sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+      localReviewSummaryPath: "/tmp/head-deadbeef.md",
+      localReviewFindingsPath: "/tmp/head-deadbeef.json",
+      finding: createMissFinding({
+        line: null,
+      }),
+    }).map((candidate) => candidate.category),
+    ["prompt_rubric"],
+  );
+});

--- a/src/external-review-durable-guardrail-candidates.ts
+++ b/src/external-review-durable-guardrail-candidates.ts
@@ -1,0 +1,137 @@
+import { createExternalReviewRegressionCandidateId } from "./external-review-normalization";
+import { type ExternalReviewMissFinding } from "./external-review-classifier";
+import {
+  type ExternalReviewDurableGuardrailCandidate,
+  type ExternalReviewDurableGuardrailCandidateCategory,
+} from "./external-review-miss-artifact-types";
+
+interface CandidateQualificationRule {
+  reason: string;
+  passes: (finding: ExternalReviewMissFinding) => boolean;
+}
+
+interface CandidateSpec {
+  category: ExternalReviewDurableGuardrailCandidateCategory;
+  titlePrefix: string;
+  rules: CandidateQualificationRule[];
+}
+
+const COMMON_RULES: CandidateQualificationRule[] = [
+  {
+    reason: "missed_by_local_review",
+    passes: (finding) => finding.classification === "missed_by_local_review",
+  },
+  {
+    reason: "high_confidence",
+    passes: (finding) => finding.confidence >= 0.75,
+  },
+  {
+    reason: "file_scoped",
+    passes: (finding) => typeof finding.file === "string" && finding.file.trim() !== "",
+  },
+];
+
+const CANDIDATE_SPECS: CandidateSpec[] = [
+  {
+    category: "prompt_rubric",
+    titlePrefix: "Promote prompt/rubric guardrail for",
+    rules: [
+      ...COMMON_RULES,
+      {
+        reason: "non_low_severity",
+        passes: (finding) => finding.severity !== "low",
+      },
+    ],
+  },
+  {
+    category: "verifier",
+    titlePrefix: "Promote verifier guardrail for",
+    rules: [
+      ...COMMON_RULES,
+      {
+        reason: "high_severity",
+        passes: (finding) => finding.severity === "high",
+      },
+      {
+        reason: "line_scoped",
+        passes: (finding) => typeof finding.line === "number" && Number.isInteger(finding.line) && finding.line > 0,
+      },
+    ],
+  },
+  {
+    category: "regression_test",
+    titlePrefix: "Promote regression-test guardrail for",
+    rules: [
+      ...COMMON_RULES,
+      {
+        reason: "non_low_severity",
+        passes: (finding) => finding.severity !== "low",
+      },
+      {
+        reason: "line_scoped",
+        passes: (finding) => typeof finding.line === "number" && Number.isInteger(finding.line) && finding.line > 0,
+      },
+    ],
+  },
+];
+
+function qualifies(
+  finding: ExternalReviewMissFinding,
+  spec: CandidateSpec,
+): { qualified: boolean; qualificationReasons: string[] } {
+  const qualificationReasons = spec.rules
+    .filter((rule) => rule.passes(finding))
+    .map((rule) => rule.reason);
+
+  return {
+    qualified: qualificationReasons.length === spec.rules.length,
+    qualificationReasons,
+  };
+}
+
+function formatTitle(prefix: string, summary: string): string {
+  return `${prefix} ${summary.replace(/[.!?]+$/, "")}`;
+}
+
+export function toDurableGuardrailCandidates(args: {
+  issueNumber: number;
+  prNumber: number;
+  branch: string;
+  headSha: string;
+  sourceArtifactPath: string;
+  localReviewSummaryPath: string | null;
+  localReviewFindingsPath: string | null;
+  finding: ExternalReviewMissFinding;
+}): ExternalReviewDurableGuardrailCandidate[] {
+  return CANDIDATE_SPECS.flatMap((spec) => {
+    const { qualified, qualificationReasons } = qualifies(args.finding, spec);
+    if (!qualified || !args.finding.file) {
+      return [];
+    }
+
+    return [{
+      id: `${spec.category}|${createExternalReviewRegressionCandidateId(args.finding)}`,
+      category: spec.category,
+      title: formatTitle(spec.titlePrefix, args.finding.summary),
+      reviewerLogin: args.finding.reviewerLogin,
+      file: args.finding.file,
+      line: args.finding.line,
+      summary: args.finding.summary,
+      rationale: args.finding.rationale,
+      qualificationReasons,
+      provenance: {
+        issueNumber: args.issueNumber,
+        prNumber: args.prNumber,
+        branch: args.branch,
+        headSha: args.headSha,
+        sourceThreadId: args.finding.threadId,
+        sourceUrl: args.finding.url ?? null,
+        sourceArtifactPath: args.sourceArtifactPath,
+        localReviewSummaryPath: args.localReviewSummaryPath,
+        localReviewFindingsPath: args.localReviewFindingsPath,
+        matchedLocalReference: args.finding.matchedLocalReference,
+        matchReason: args.finding.matchReason,
+      },
+    }];
+  });
+}

--- a/src/external-review-miss-artifact-types.ts
+++ b/src/external-review-miss-artifact-types.ts
@@ -30,6 +30,36 @@ export interface ExternalReviewRegressionCandidate {
   qualificationReasons: string[];
 }
 
+export type ExternalReviewDurableGuardrailCandidateCategory =
+  | "prompt_rubric"
+  | "verifier"
+  | "regression_test";
+
+export interface ExternalReviewDurableGuardrailCandidate {
+  id: string;
+  category: ExternalReviewDurableGuardrailCandidateCategory;
+  title: string;
+  reviewerLogin: string;
+  file: string;
+  line: number | null;
+  summary: string;
+  rationale: string;
+  qualificationReasons: string[];
+  provenance: {
+    issueNumber: number;
+    prNumber: number;
+    branch: string;
+    headSha: string;
+    sourceThreadId: string;
+    sourceUrl: string | null;
+    sourceArtifactPath: string;
+    localReviewSummaryPath: string | null;
+    localReviewFindingsPath: string | null;
+    matchedLocalReference: string | null;
+    matchReason: string;
+  };
+}
+
 export interface DurableExternalReviewGuardrails {
   version: 1;
   patterns: ExternalReviewMissPattern[];
@@ -45,6 +75,7 @@ export interface ExternalReviewMissArtifact {
   localReviewFindingsPath: string | null;
   findings: ExternalReviewMissFinding[];
   reusableMissPatterns: ExternalReviewMissPattern[];
+  durableGuardrailCandidates: ExternalReviewDurableGuardrailCandidate[];
   regressionTestCandidates: ExternalReviewRegressionCandidate[];
   counts: {
     matched: number;

--- a/src/external-review-miss-persistence.ts
+++ b/src/external-review-miss-persistence.ts
@@ -12,10 +12,12 @@ import {
 } from "./external-review-normalization";
 import {
   type ExternalReviewMissArtifact,
+  type ExternalReviewDurableGuardrailCandidate,
   type ExternalReviewMissContext,
   type ExternalReviewMissPattern,
   type ExternalReviewRegressionCandidate,
 } from "./external-review-miss-artifact-types";
+import { toDurableGuardrailCandidates } from "./external-review-durable-guardrail-candidates";
 import { toReusableMissPattern } from "./external-review-miss-patterns";
 import { toRegressionTestCandidate } from "./external-review-regression-candidates";
 import { loadLocalReviewArtifact } from "./external-review-local-artifact-io";
@@ -85,6 +87,18 @@ function buildExternalReviewMissArtifact(args: {
   const reusableMissPatterns: ExternalReviewMissPattern[] = args.findings
     .filter((finding) => finding.classification === "missed_by_local_review" && typeof finding.file === "string" && finding.file.trim() !== "")
     .map((finding) => toReusableMissPattern(finding, args.artifactPath, args.headSha, generatedAt));
+  const durableGuardrailCandidates: ExternalReviewDurableGuardrailCandidate[] = args.findings.flatMap((finding) =>
+    toDurableGuardrailCandidates({
+      issueNumber: args.issueNumber,
+      prNumber: args.prNumber,
+      branch: args.branch,
+      headSha: args.headSha,
+      sourceArtifactPath: args.artifactPath,
+      localReviewSummaryPath: args.localReviewSummaryPath,
+      localReviewFindingsPath: args.localReviewFindingsPath,
+      finding,
+    }),
+  );
   const regressionTestCandidates = args.findings
     .map((finding) => toRegressionTestCandidate(finding))
     .filter((candidate): candidate is ExternalReviewRegressionCandidate => candidate !== null);
@@ -99,6 +113,7 @@ function buildExternalReviewMissArtifact(args: {
     localReviewFindingsPath: args.localReviewFindingsPath,
     findings: args.findings,
     reusableMissPatterns,
+    durableGuardrailCandidates,
     regressionTestCandidates,
     counts: {
       matched: args.findings.filter((finding) => finding.classification === "matched").length,

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -382,6 +382,20 @@ test("writeExternalReviewMissArtifact derives deterministic regression-test cand
   const artifact = JSON.parse(
     await fs.readFile(context?.artifactPath ?? "", "utf8"),
   ) as {
+    durableGuardrailCandidates: Array<{
+      category: string;
+      title: string;
+      qualificationReasons: string[];
+      provenance: {
+        issueNumber: number;
+        prNumber: number;
+        headSha: string;
+        sourceThreadId: string;
+        sourceArtifactPath: string;
+        localReviewSummaryPath: string | null;
+        localReviewFindingsPath: string | null;
+      };
+    }>;
     regressionTestCandidates: Array<{
       id: string;
       file: string;
@@ -390,6 +404,57 @@ test("writeExternalReviewMissArtifact derives deterministic regression-test cand
       qualificationReasons: string[];
     }>;
   };
+
+  assert.deepEqual(artifact.durableGuardrailCandidates, [
+    {
+      id: "prompt_rubric|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "prompt_rubric",
+      title: "Promote prompt/rubric guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      file: "src/auth.ts",
+      line: 42,
+      summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      qualificationReasons: ["missed_by_local_review", "high_confidence", "file_scoped", "non_low_severity"],
+      provenance: {
+        issueNumber: 63,
+        prNumber: 91,
+        branch: "codex/issue-63",
+        headSha: "deadbeefcafebabe",
+        sourceThreadId: "thread-strong",
+        sourceUrl: "https://example.test/thread-strong#comment-1",
+        sourceArtifactPath: context?.artifactPath ?? "",
+        localReviewSummaryPath,
+        localReviewFindingsPath,
+        matchedLocalReference: null,
+        matchReason: "no same-file local-review match",
+      },
+    },
+    {
+      id: "regression_test|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "regression_test",
+      title: "Promote regression-test guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      file: "src/auth.ts",
+      line: 42,
+      summary: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      qualificationReasons: ["missed_by_local_review", "high_confidence", "file_scoped", "non_low_severity", "line_scoped"],
+      provenance: {
+        issueNumber: 63,
+        prNumber: 91,
+        branch: "codex/issue-63",
+        headSha: "deadbeefcafebabe",
+        sourceThreadId: "thread-strong",
+        sourceUrl: "https://example.test/thread-strong#comment-1",
+        sourceArtifactPath: context?.artifactPath ?? "",
+        localReviewSummaryPath,
+        localReviewFindingsPath,
+        matchedLocalReference: null,
+        matchReason: "no same-file local-review match",
+      },
+    },
+  ]);
 
   assert.deepEqual(artifact.regressionTestCandidates, [
     {

--- a/src/external-review-misses.ts
+++ b/src/external-review-misses.ts
@@ -9,6 +9,7 @@ import {
   type LocalReviewArtifactLike,
 } from "./external-review-classifier";
 import {
+  type ExternalReviewDurableGuardrailCandidate,
   type ExternalReviewMissArtifact,
   type ExternalReviewMissContext,
   type ExternalReviewMissPattern,
@@ -23,6 +24,7 @@ export {
   normalizeExternalReviewFinding,
   type ExternalReviewMissArtifact,
   type ExternalReviewMatch,
+  type ExternalReviewDurableGuardrailCandidate,
   type ExternalReviewMissContext,
   type ExternalReviewMissFinding,
   type ExternalReviewMissPattern,


### PR DESCRIPTION
## Summary
- persist explicit durable guardrail candidates for confirmed external misses
- record deterministic qualification reasons and provenance for each candidate
- cover qualifying and rejected promotion paths with focused tests

Closes #85

## Testing
- npm run build
- npm test