### PR TITLE
Durable guardrails: consume committed guardrails in local review, verifier, and repair context (#86)

### DIFF
--- a/src/codex.test.ts
+++ b/src/codex.test.ts
@@ -62,6 +62,19 @@ test("buildCodexPrompt emphasizes compressed local-review root causes during loc
           lines: "92-101",
         },
       ],
+      priorMissPatterns: [
+        {
+          fingerprint: "src/supervisor.ts|retry-mode",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/supervisor.ts",
+          line: 761,
+          summary: "Repair retries can loop through the wrong state.",
+          rationale: "A prior external review caught a retry path that stayed in implementing instead of a dedicated repair state.",
+          sourceArtifactPath: "/tmp/reviews/issue-46/external-review-misses-head-old.json",
+          sourceHeadSha: "oldhead123",
+          lastSeenAt: "2026-03-12T00:00:00Z",
+        },
+      ],
     },
   });
 
@@ -70,6 +83,8 @@ test("buildCodexPrompt emphasizes compressed local-review root causes during loc
   assert.match(prompt, /Relevant files to inspect first:/);
   assert.match(prompt, /src\/supervisor\.ts/);
   assert.match(prompt, /State inference sends local-review retries/);
+  assert.match(prompt, /Committed regression-oriented guardrails:/);
+  assert.match(prompt, /Repair retries can loop through the wrong state\./);
 });
 
 test("buildCodexPrompt suppresses stale handoff next actions during local_review_fix", () => {
@@ -111,6 +126,7 @@ test("buildCodexPrompt suppresses stale handoff next actions during local_review
           lines: "1-200",
         },
       ],
+      priorMissPatterns: [],
     },
   });
 
@@ -156,6 +172,7 @@ test("buildCodexPrompt suppresses flat next-action bullet lists during local_rev
           lines: "1-200",
         },
       ],
+      priorMissPatterns: [],
     },
   });
 
@@ -201,6 +218,7 @@ test("buildCodexPrompt keeps explicit operator overrides during local_review_fix
           lines: "1-200",
         },
       ],
+      priorMissPatterns: [],
     },
   });
 
@@ -336,9 +354,80 @@ test("loadLocalReviewRepairContext derives the findings path and trims prompt co
       { severity: "medium", summary: "four", file: null, lines: "30-32" },
       { severity: "high", summary: "five", file: "src/file-4.ts", lines: "40" },
     ],
+    priorMissPatterns: [],
   });
 
   await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+test("loadLocalReviewRepairContext loads committed guardrails when local history is absent", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-fix-durable-guardrails-test-"));
+  const reviewDir = path.join(workspaceDir, "reviews");
+  const summaryPath = path.join(reviewDir, "head-deadbeef.md");
+  const findingsPath = path.join(reviewDir, "head-deadbeef.json");
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.mkdir(reviewDir, { recursive: true });
+  await fs.writeFile(summaryPath, "# summary\n", "utf8");
+  await fs.writeFile(
+    findingsPath,
+    JSON.stringify({
+      branch: "codex/issue-46",
+      headSha: "deadbeef",
+      actionableFindings: [{ file: "src/auth.ts" }],
+      rootCauseSummaries: [
+        { severity: "high", summary: "Permission guard retry path is fragile", file: "src/auth.ts", start: 40, end: 44 },
+      ],
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    durableGuardrailPath,
+    JSON.stringify({
+      version: 1,
+      patterns: [
+        {
+          fingerprint: "src/auth.ts|permission",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Add or validate regression coverage around the fallback permission check before clearing the repair.",
+          sourceArtifactPath: "/tmp/reviews/issue-46/external-review-misses-head-old.json",
+          sourceHeadSha: "oldhead123",
+          lastSeenAt: "2026-03-12T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  const context = await loadLocalReviewRepairContext(summaryPath, workspaceDir);
+
+  assert.deepEqual(context, {
+    summaryPath,
+    findingsPath,
+    relevantFiles: ["src/auth.ts"],
+    rootCauses: [
+      { severity: "high", summary: "Permission guard retry path is fragile", file: "src/auth.ts", lines: "40-44" },
+    ],
+    priorMissPatterns: [
+      {
+        fingerprint: "src/auth.ts|permission",
+        reviewerLogin: "copilot-pull-request-reviewer",
+        file: "src/auth.ts",
+        line: 42,
+        summary: "Permission guard is bypassed.",
+        rationale: "Add or validate regression coverage around the fallback permission check before clearing the repair.",
+        sourceArtifactPath: "/tmp/reviews/issue-46/external-review-misses-head-old.json",
+        sourceHeadSha: "oldhead123",
+        lastSeenAt: "2026-03-12T00:00:00Z",
+      },
+    ],
+  });
+
+  await fs.rm(workspaceDir, { recursive: true, force: true });
 });
 
 test("loadLocalReviewRepairContext returns null when the findings artifact is missing or invalid", async () => {

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { runCommand } from "./command";
 import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
-import { ExternalReviewMissContext } from "./external-review-misses";
+import { ExternalReviewMissContext, type ExternalReviewMissPattern } from "./external-review-misses";
 import {
   BlockedReason,
   CodexTurnResult,
@@ -28,6 +28,7 @@ export interface LocalReviewRepairContext {
     file: string | null;
     lines: string | null;
   }>;
+  priorMissPatterns: ExternalReviewMissPattern[];
 }
 
 export function extractStateHint(message: string): RunState | null {
@@ -314,6 +315,18 @@ export function buildCodexPrompt(input: {
                       ),
                     ]
                   : ["- Compressed root causes: none available"]),
+                ...(input.localReviewRepairContext.priorMissPatterns.length > 0
+                  ? [
+                      "- Committed regression-oriented guardrails:",
+                      ...input.localReviewRepairContext.priorMissPatterns.map((pattern, index) =>
+                        [
+                          `  - ${index + 1}. file=${pattern.file}:${pattern.line ?? "?"} reviewer=${pattern.reviewerLogin}`,
+                          `    summary=${truncate(pattern.summary, 160) ?? ""}`,
+                          `    follow_up=${truncate(pattern.rationale, 220) ?? ""}`,
+                        ].join("\n"),
+                      ),
+                    ]
+                  : ["- Committed regression-oriented guardrails: none identified"]),
               ]
             : [
                 "- No parsed local-review repair context was available. Read the local-review summary artifact before editing code.",

--- a/src/local-review-prompt.ts
+++ b/src/local-review-prompt.ts
@@ -24,6 +24,25 @@ interface RolePromptArgs {
   priorMissPatterns: ExternalReviewMissPattern[];
 }
 
+function renderPriorMissLines(patterns: ExternalReviewMissPattern[]): string[] {
+  if (patterns.length === 0) {
+    return [];
+  }
+
+  return [
+    "Relevant prior confirmed external misses for this diff:",
+    "- Use these as targeted checks for blind spots that local review previously missed.",
+    ...patterns.map((pattern, index) =>
+      [
+        `- Prior miss ${index + 1}: file=${pattern.file}:${pattern.line ?? "?"} reviewer=${pattern.reviewerLogin}`,
+        `  summary=${pattern.summary}`,
+        `  rationale=${pattern.rationale}`,
+      ].join("\n"),
+    ),
+    "",
+  ];
+}
+
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
@@ -246,21 +265,7 @@ function roleGoal(role: string): string[] {
 
 export function buildRolePrompt(args: RolePromptArgs): string {
   const ref = compareRef(args.defaultBranch);
-  const priorMissLines =
-    args.priorMissPatterns.length > 0
-      ? [
-          "Relevant prior confirmed external misses for this diff:",
-          "- Use these as targeted checks for blind spots that local review previously missed.",
-          ...args.priorMissPatterns.map((pattern, index) =>
-            [
-              `- Prior miss ${index + 1}: file=${pattern.file}:${pattern.line ?? "?"} reviewer=${pattern.reviewerLogin}`,
-              `  summary=${pattern.summary}`,
-              `  rationale=${pattern.rationale}`,
-            ].join("\n"),
-          ),
-          "",
-        ]
-      : [];
+  const priorMissLines = renderPriorMissLines(args.priorMissPatterns);
 
   return [
     `You are performing a local pre-ready ${args.role} review for ${args.repoSlug}.`,
@@ -320,8 +325,10 @@ export function buildVerifierPrompt(args: {
   defaultBranch: string;
   pr: GitHubPullRequest;
   findings: LocalReviewFinding[];
+  priorMissPatterns: ExternalReviewMissPattern[];
 }): string {
   const ref = compareRef(args.defaultBranch);
+  const priorMissLines = renderPriorMissLines(args.priorMissPatterns);
   const findingsBlock = args.findings
     .map((finding, index) =>
       [
@@ -356,6 +363,7 @@ export function buildVerifierPrompt(args: {
     "- Do not edit files, do not commit, and do not push.",
     "- Keep reads narrow and tied to the listed findings.",
     "",
+    ...priorMissLines,
     "High-severity findings to verify:",
     findingsBlock,
     "",
@@ -367,4 +375,3 @@ export function buildVerifierPrompt(args: {
     "REVIEW_VERIFIER_JSON_END",
   ].join("\n");
 }
-

--- a/src/local-review-runner.ts
+++ b/src/local-review-runner.ts
@@ -3,7 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { runCommand } from "./command";
 import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
-import { type ExternalReviewMissPattern } from "./external-review-misses";
+import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "./external-review-misses";
+import { reviewDir } from "./local-review-artifacts";
 import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./local-review-prompt";
 import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
 import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
@@ -111,6 +112,19 @@ export async function runVerifierReview(args: {
   pr: GitHubPullRequest;
   findings: LocalReviewFinding[];
 }): Promise<LocalReviewVerifierReport> {
+  const changedFiles = [...new Set(
+    args.findings
+      .map((finding) => (typeof finding.file === "string" && finding.file.trim() !== "" ? finding.file : null))
+      .filter((filePath): filePath is string => Boolean(filePath)),
+  )];
+  const priorMissPatterns = await loadRelevantExternalReviewMissPatterns({
+    artifactDir: reviewDir(args.config, args.issue.number),
+    branch: args.branch,
+    currentHeadSha: args.pr.headRefOid,
+    changedFiles,
+    limit: 3,
+    workspacePath: args.workspacePath,
+  });
   const prompt = buildVerifierPrompt({
     repoSlug: args.config.repoSlug,
     issue: args.issue,
@@ -119,6 +133,7 @@ export async function runVerifierReview(args: {
     defaultBranch: args.defaultBranch,
     pr: args.pr,
     findings: args.findings,
+    priorMissPatterns,
   });
   const result = await runCodexReviewTurn({
     config: args.config,

--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { localReviewHasActionableFindings, shouldRunLocalReview } from "./local-review";
 import { finalizeLocalReview } from "./local-review-finalize";
-import { buildRolePrompt } from "./local-review-prompt";
+import { buildRolePrompt, buildVerifierPrompt } from "./local-review-prompt";
 import { LocalReviewRoleSelection } from "./review-role-detector";
 import { GitHubPullRequest, SupervisorConfig } from "./types";
 
@@ -572,4 +572,70 @@ test("buildRolePrompt includes bounded relevant prior external misses", () => {
   assert.match(prompt, /Permission guard is bypassed\./);
   assert.match(prompt, /Retry path can reuse stale state\./);
   assert.match(prompt, /Response omits a required field\./);
+});
+
+test("buildVerifierPrompt includes bounded relevant prior external misses", () => {
+  const prompt = buildVerifierPrompt({
+    repoSlug: "owner/repo",
+    issue: {
+      number: 61,
+      title: "Teach verifier from prior misses",
+      body: "",
+      url: "https://example.test/issues/61",
+      createdAt: "2026-03-12T00:00:00Z",
+      updatedAt: "2026-03-12T00:00:00Z",
+      labels: [],
+    },
+    branch: "codex/issue-61",
+    workspacePath: "/tmp/workspaces/issue-61",
+    defaultBranch: "main",
+    pr: createPullRequest({
+      number: 61,
+      url: "https://example.test/pr/61",
+      headRefOid: "newhead123",
+    }),
+    findings: [
+      {
+        role: "reviewer",
+        title: "Potential permission bypass",
+        body: "The fallback path may skip the permission guard.",
+        file: "src/auth.ts",
+        start: 42,
+        end: 44,
+        severity: "high",
+        confidence: 0.95,
+        category: "correctness",
+        evidence: "The fallback returns the privileged branch without the permission check.",
+      },
+    ],
+    priorMissPatterns: [
+      {
+        fingerprint: "src/auth.ts|permission",
+        reviewerLogin: "copilot-pull-request-reviewer",
+        file: "src/auth.ts",
+        line: 42,
+        summary: "Permission guard is bypassed.",
+        rationale: "This fallback skips the permission guard and lets unauthorized callers update records.",
+        sourceArtifactPath: "/tmp/reviews/issue-61/external-review-misses-head-old.json",
+        sourceHeadSha: "oldhead123",
+        lastSeenAt: "2026-03-12T00:00:00Z",
+      },
+      {
+        fingerprint: "src/retry.ts|missing",
+        reviewerLogin: "copilot-pull-request-reviewer",
+        file: "src/retry.ts",
+        line: 15,
+        summary: "Retry path can reuse stale state.",
+        rationale: "The retry branch keeps stale cached state after the first failure.",
+        sourceArtifactPath: "/tmp/reviews/issue-61/external-review-misses-head-old-2.json",
+        sourceHeadSha: "olderhead456",
+        lastSeenAt: "2026-03-11T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.match(prompt, /Relevant prior confirmed external misses for this diff:/);
+  assert.match(prompt, /Prior miss 1: file=src\/auth\.ts:42 reviewer=copilot-pull-request-reviewer/);
+  assert.match(prompt, /Permission guard is bypassed\./);
+  assert.match(prompt, /Retry path can reuse stale state\./);
 });

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { buildCodexPrompt, extractBlockedReason, extractFailureSignature, extractStateHint, runCodexTurn } from "./codex";
 import { loadConfig } from "./config";
-import { ExternalReviewMissContext, writeExternalReviewMissArtifact } from "./external-review-misses";
+import { ExternalReviewMissContext, loadRelevantExternalReviewMissPatterns, writeExternalReviewMissArtifact } from "./external-review-misses";
 import { GitHubClient } from "./github";
 import { findBlockingIssue, findParentIssuesReadyToClose } from "./issue-metadata";
 import { describeGsdIntegration } from "./gsd";
@@ -157,6 +157,8 @@ export function localReviewHighSeverityNeedsRetry(
 }
 
 interface LocalReviewRepairArtifact {
+  branch?: string;
+  headSha?: string;
   actionableFindings?: Array<{ file?: string | null }>;
   rootCauseSummaries?: Array<{
     severity?: "low" | "medium" | "high";
@@ -167,7 +169,7 @@ interface LocalReviewRepairArtifact {
   }>;
 }
 
-export async function loadLocalReviewRepairContext(summaryPath: string | null) {
+export async function loadLocalReviewRepairContext(summaryPath: string | null, workspacePath?: string) {
   if (!summaryPath) {
     return null;
   }
@@ -207,12 +209,24 @@ export async function loadLocalReviewRepairContext(summaryPath: string | null) {
         .map((finding) => (typeof finding.file === "string" && finding.file.trim() !== "" ? finding.file : null))
         .filter((filePath): filePath is string => Boolean(filePath)),
     ])].slice(0, 10);
+    const priorMissPatterns =
+      workspacePath && typeof artifact.branch === "string" && typeof artifact.headSha === "string"
+        ? await loadRelevantExternalReviewMissPatterns({
+            artifactDir: path.dirname(summaryPath),
+            branch: artifact.branch,
+            currentHeadSha: artifact.headSha,
+            changedFiles: relevantFiles,
+            limit: 3,
+            workspacePath,
+          })
+        : [];
 
     return {
       summaryPath,
       findingsPath,
       relevantFiles,
       rootCauses,
+      priorMissPatterns,
     };
   } catch {
     return null;
@@ -2216,7 +2230,7 @@ export class Supervisor {
 
       const localReviewRepairContext =
         record.state === "local_review_fix"
-          ? await loadLocalReviewRepairContext(record.local_review_summary_path)
+          ? await loadLocalReviewRepairContext(record.local_review_summary_path, workspacePath)
           : null;
       const externalReviewMissContext: ExternalReviewMissContext | null =
         pr &&


### PR DESCRIPTION
Closes #86
This PR was opened by codex-supervisor.
Latest Codex summary:

Committed durable external-review guardrails now flow into verifier prompts and local-review repair context. I reused the existing relevant-pattern loader so inclusion stays file-scoped, bounded, and deterministic, and repair prompts now surface committed regression-oriented follow-up hints even when host-local miss history is absent. The focused coverage lives in [src/local-review.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-86/src/local-review.test.ts) and [src/codex.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-86/src/codex.test.ts); the implementation is in [src/local-review-prompt.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-86/src/local-review-prompt.ts), [src/local-review-runner.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-86/src/local-review-runner.ts), [src/codex.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-86/src/codex.ts), and [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-86/src/supervisor.ts).

I updated the issue journal locally and created commit `0322655` with message `Consume committed guardrails in verifier and repair prompts`.

Summary: Added committed durable guardrail consumption to verifier and repair prompt paths, with focused no-history tests and a checkpoint commit.
State hint: draft_pr
Blocked reason: none
Tests: `npm test -- src/local-review.test.ts src...