### PR TITLE
Accept Part of: in parent issue metadata parsing

### DIFF
--- a/src/issue-metadata.test.ts
+++ b/src/issue-metadata.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { findParentIssuesReadyToClose, parseIssueMetadata } from "./issue-metadata";
+import { GitHubIssue } from "./types";
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 1,
+    title: "Issue",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.com/issues/1",
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+test("parseIssueMetadata accepts both parent issue metadata formats", () => {
+  const legacyFormat = createIssue({
+    body: "Part of #123",
+  });
+  const templateFormat = createIssue({
+    body: "Part of: #123",
+  });
+
+  assert.equal(parseIssueMetadata(legacyFormat).parentIssueNumber, 123);
+  assert.equal(parseIssueMetadata(templateFormat).parentIssueNumber, 123);
+});
+
+test("findParentIssuesReadyToClose treats both parent metadata formats as the same parent", () => {
+  const readyToClose = findParentIssuesReadyToClose([
+    createIssue({ number: 123, state: "OPEN" }),
+    createIssue({ number: 201, state: "CLOSED", body: "Part of #123" }),
+    createIssue({ number: 202, state: "CLOSED", body: "Part of: #123" }),
+  ]);
+
+  assert.deepEqual(
+    readyToClose.map((candidate) => ({
+      parentIssueNumber: candidate.parentIssue.number,
+      childIssueNumbers: candidate.childIssues.map((issue) => issue.number),
+    })),
+    [
+      {
+        parentIssueNumber: 123,
+        childIssueNumbers: [201, 202],
+      },
+    ],
+  );
+});

--- a/src/issue-metadata.ts
+++ b/src/issue-metadata.ts
@@ -37,7 +37,7 @@ function parseList(input: string): string[] {
 }
 
 export function parseIssueMetadata(issue: GitHubIssue): IssueMetadata {
-  const parentMatch = issue.body.match(/^\s*Part of #(\d+)\s*$/im);
+  const parentMatch = issue.body.match(/^\s*Part of:?\s+#(\d+)\s*$/im);
   const orderMatch = issue.body.match(/^\s*##\s*Execution order\s*$[\r\n]+^\s*(\d+)\s+of\s+(\d+)\s*$/im);
   const dependsOnMatch = issue.body.match(/^\s*Depends on:\s*(.+)\s*$/im);
   const parallelGroupMatch = issue.body.match(/^\s*Parallel group:\s*(.+)\s*$/im);


### PR DESCRIPTION
## Summary
- accept both  and  when parsing parent issue metadata
- add focused regression coverage for metadata parsing and parent-ready-to-close detection

Closes #92

## Testing
- npm test -- --test src/issue-metadata.test.ts