### PR TITLE
Fix Copilot ready-for-review propagation race

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -535,6 +535,74 @@ test("inferStateFromPullRequest does not wait for Copilot when no lifecycle sign
   assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
 });
 
+test("inferStateFromPullRequest waits briefly after ready-for-review for Copilot request propagation", () => {
+  withStubbedDateNow("2026-03-13T05:42:40Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
+    const record = createRecord({
+      state: "pr_open",
+      review_wait_started_at: "2026-03-13T05:42:36Z",
+      review_wait_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-13T05:40:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "waiting_ci");
+  });
+});
+
+test("inferStateFromPullRequest allows merge after the Copilot propagation grace window expires", () => {
+  withStubbedDateNow("2026-03-13T05:42:42Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
+    const record = createRecord({
+      state: "pr_open",
+      review_wait_started_at: "2026-03-13T05:42:36Z",
+      review_wait_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-13T05:40:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
+  });
+});
+
 test("inferStateFromPullRequest keeps waiting when Copilot review was explicitly requested", () => {
   withStubbedDateNow("2026-03-11T00:10:00Z", () => {
     const config = createConfig({ copilotReviewWaitMinutes: 10 });

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -91,6 +91,8 @@ function createIssueRecord(config: SupervisorConfig, issueNumber: number): Issue
 }
 
 const MAX_PROCESSED_REVIEW_THREAD_IDS = 200;
+const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
+const COPILOT_REVIEWER_LOGIN = "copilot-pull-request-reviewer";
 
 function trimProcessedReviewThreadIds(ids: string[]): string[] {
   if (ids.length <= MAX_PROCESSED_REVIEW_THREAD_IDS) {
@@ -933,6 +935,42 @@ function determineCopilotReviewTimeout(
   };
 }
 
+function repoExpectsCopilotReview(config: SupervisorConfig): boolean {
+  return config.reviewBotLogins.includes(COPILOT_REVIEWER_LOGIN);
+}
+
+function shouldWaitForCopilotReviewPropagation(
+  config: SupervisorConfig,
+  record: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">,
+  pr: GitHubPullRequest,
+): boolean {
+  if (
+    !repoExpectsCopilotReview(config) ||
+    config.copilotReviewWaitMinutes <= 0 ||
+    pr.isDraft ||
+    pr.headRefOid !== record.review_wait_head_sha
+  ) {
+    return false;
+  }
+
+  const lifecycleState = pr.copilotReviewState ?? "not_requested";
+  if (lifecycleState === "requested" || lifecycleState === "arrived") {
+    return false;
+  }
+
+  const startedAt = record.review_wait_started_at;
+  if (!startedAt) {
+    return false;
+  }
+
+  const startedAtMs = Date.parse(startedAt);
+  if (Number.isNaN(startedAtMs)) {
+    return false;
+  }
+
+  return Date.now() < startedAtMs + COPILOT_REVIEW_PROPAGATION_GRACE_MS;
+}
+
 function buildCopilotReviewTimeoutFailureContext(
   config: SupervisorConfig,
   record: IssueRunRecord,
@@ -1140,6 +1178,10 @@ export function inferStateFromPullRequest(
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
   if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
     return "blocked";
+  }
+
+  if (shouldWaitForCopilotReviewPropagation(config, record, pr)) {
+    return "waiting_ci";
   }
 
   if ((pr.copilotReviewState ?? "not_requested") === "requested" && !copilotTimeout.timedOut) {


### PR DESCRIPTION
## Summary
- add a focused regression test for the ready-for-review to Copilot request propagation race
- hold ready PRs in waiting_ci for a short propagation grace window before allowing ready_to_merge
- keep existing behavior for repos that do not configure Copilot review

## Testing
- npm test -- --test src/supervisor.test.ts

Closes #94