### PR TITLE
Supervisor refactor: extract issue selection and workspace/PR preparation from runOnce (#97)

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -15,7 +15,7 @@ import {
   shouldAutoRetryHandoffMissing,
   summarizeChecks,
 } from "./supervisor";
-import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "./types";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, SupervisorStateFile } from "./types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -433,6 +433,99 @@ test("runOnce recovers when post-codex refresh throws after leaving a dirty work
 
   const issueLockPath = path.join(path.dirname(fixture.stateFile), "locks", "issues", `issue-${issueNumber}.lock`);
   await assert.rejects(fs.access(issueLockPath));
+});
+
+test("runOnce dry-run selects an issue and hydrates workspace and PR context before Codex", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 91;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Extract supervisor setup helpers",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 112,
+    title: "Draft setup refactor",
+    url: "https://example.test/pr/112",
+    state: "OPEN",
+    createdAt: "2026-03-13T00:10:00Z",
+    isDraft: true,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: "head-112",
+    mergedAt: null,
+  };
+  const checks: PullRequestCheck[] = [];
+  const reviewThreads: ReviewThread[] = [];
+
+  let resolveCalls = 0;
+  let checksCalls = 0;
+  let reviewThreadCalls = 0;
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      resolveCalls += 1;
+      assert.equal(branchName, branch);
+      assert.equal(prNumber, null);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      checksCalls += 1;
+      assert.equal(prNumber, pr.number);
+      return checks;
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      reviewThreadCalls += 1;
+      assert.equal(prNumber, pr.number);
+      return reviewThreads;
+    },
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
+  assert.match(message, /state=draft_pr/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(persisted.activeIssueNumber, issueNumber);
+  assert.equal(record.issue_number, issueNumber);
+  assert.equal(record.branch, branch);
+  assert.equal(record.pr_number, pr.number);
+  assert.equal(record.state, "draft_pr");
+  assert.equal(record.blocked_reason, null);
+  assert.equal(record.workspace, path.join(fixture.workspaceRoot, `issue-${issueNumber}`));
+  assert.equal(record.journal_path, path.join(record.workspace, ".codex-supervisor", "issue-journal.md"));
+  assert.ok(record.last_head_sha);
+  await fs.access(record.workspace);
+  await fs.access(record.journal_path ?? "");
+  assert.equal(resolveCalls, 1);
+  assert.equal(checksCalls, 1);
+  assert.equal(reviewThreadCalls, 1);
 });
 
 function branchName(config: SupervisorConfig, issueNumber: number): string {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1290,6 +1290,34 @@ async function buildReadinessSummary(
   ];
 }
 
+type IssueJournalSync = (record: IssueRunRecord) => Promise<void>;
+type MemoryArtifacts = Awaited<ReturnType<typeof syncMemoryArtifacts>>;
+
+interface SelectedIssueResult {
+  kind: "selected";
+  record: IssueRunRecord;
+}
+
+interface PreparedWorkspaceContext {
+  record: IssueRunRecord;
+  issue: GitHubIssue;
+  previousCodexSummary: string | null;
+  previousError: string | null;
+  workspacePath: string;
+  journalPath: string;
+  syncJournal: IssueJournalSync;
+  memoryArtifacts: MemoryArtifacts;
+  workspaceStatus: WorkspaceStatus;
+}
+
+interface HydratedPullRequestContext {
+  record: IssueRunRecord;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  workspaceStatus: WorkspaceStatus;
+}
+
 function formatStatus(record: IssueRunRecord | null): string {
   if (!record) {
     return "No active issue.";
@@ -1889,6 +1917,169 @@ export class Supervisor {
     return path.resolve(path.dirname(this.config.stateFile), "locks", kind, `${safeKey}.lock`);
   }
 
+  private async selectIssueRecord(
+    state: SupervisorStateFile,
+    currentRecord: IssueRunRecord | null,
+  ): Promise<SelectedIssueResult | string> {
+    let record = currentRecord;
+
+    if (!record || !isEligibleForSelection(record, this.config)) {
+      record = await selectNextIssue(this.github, this.config, state);
+      if (!record) {
+        state.activeIssueNumber = null;
+        await this.stateStore.save(state);
+        return "No matching open issue found.";
+      }
+
+      state.activeIssueNumber = record.issue_number;
+      state.issues[String(record.issue_number)] = record;
+      await this.stateStore.save(state);
+    }
+
+    if (!record) {
+      throw new Error("Invariant violation: active issue record is missing after selection.");
+    }
+
+    return {
+      kind: "selected",
+      record,
+    };
+  }
+
+  private async prepareWorkspaceContext(
+    state: SupervisorStateFile,
+    record: IssueRunRecord,
+    issue: GitHubIssue,
+  ): Promise<PreparedWorkspaceContext> {
+    const previousCodexSummary = record.last_codex_summary;
+    const previousError = record.last_error;
+    const workspacePath = await ensureWorkspace(this.config, record.issue_number, record.branch);
+    const journalPath = issueJournalPath(workspacePath, this.config.issueJournalRelativePath);
+    const syncJournal: IssueJournalSync = async (currentRecord: IssueRunRecord): Promise<void> => {
+      await syncIssueJournal({
+        issue,
+        record: currentRecord,
+        journalPath,
+        maxChars: this.config.issueJournalMaxChars,
+      });
+    };
+
+    const preparedRecord = this.stateStore.touch(record, {
+      workspace: workspacePath,
+      journal_path: journalPath,
+      state: record.implementation_attempt_count === 0 ? "planning" : record.state,
+      last_error: null,
+      last_failure_kind: null,
+      blocked_reason: null,
+    });
+    state.issues[String(preparedRecord.issue_number)] = preparedRecord;
+    await this.stateStore.save(state);
+    await syncJournal(preparedRecord);
+
+    const memoryArtifacts = await syncMemoryArtifacts({
+      config: this.config,
+      issueNumber: preparedRecord.issue_number,
+      workspacePath,
+      journalPath,
+    });
+
+    const workspaceStatus = await getWorkspaceStatus(workspacePath, preparedRecord.branch, this.config.defaultBranch);
+    const hydratedRecord = this.stateStore.touch(preparedRecord, { last_head_sha: workspaceStatus.headSha });
+    state.issues[String(hydratedRecord.issue_number)] = hydratedRecord;
+    await this.stateStore.save(state);
+
+    return {
+      record: hydratedRecord,
+      issue,
+      previousCodexSummary,
+      previousError,
+      workspacePath,
+      journalPath,
+      syncJournal,
+      memoryArtifacts,
+      workspaceStatus,
+    };
+  }
+
+  private async hydratePullRequestContext(
+    state: SupervisorStateFile,
+    record: IssueRunRecord,
+    issue: GitHubIssue,
+    workspacePath: string,
+    workspaceStatus: WorkspaceStatus,
+    syncJournal: IssueJournalSync,
+    options: Pick<CliOptions, "dryRun">,
+  ): Promise<HydratedPullRequestContext | string> {
+    let nextWorkspaceStatus = workspaceStatus;
+    if (nextWorkspaceStatus.remoteBranchExists && nextWorkspaceStatus.remoteAhead > 0) {
+      await pushBranch(workspacePath, record.branch, true);
+      nextWorkspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, this.config.defaultBranch);
+    }
+
+    const resolvedPr = await this.github.resolvePullRequestForBranch(record.branch, record.pr_number);
+    let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
+    let checks = pr ? await this.github.getChecks(pr.number) : [];
+    let reviewThreads = pr ? await this.github.getUnresolvedReviewThreads(pr.number) : [];
+
+    if (!pr) {
+      if (!resolvedPr) {
+        // No current or historical PR for this branch; continue with normal branch/PR flow.
+      } else if (resolvedPr.mergedAt || resolvedPr.state === "MERGED") {
+        const doneRecord = this.stateStore.touch(record, {
+          pr_number: resolvedPr.number,
+          state: "done",
+          last_head_sha: resolvedPr.headRefOid,
+        });
+        state.issues[String(doneRecord.issue_number)] = doneRecord;
+        state.activeIssueNumber = null;
+        await this.stateStore.save(state);
+        return await this.runOnce(options);
+      } else if (resolvedPr.state === "CLOSED") {
+        const failureContext = buildCodexFailureContext(
+          "manual",
+          `PR #${resolvedPr.number} was closed without merge.`,
+          ["Manual intervention is required before the supervisor can continue this issue."],
+        );
+        const blockedRecord = this.stateStore.touch(record, {
+          pr_number: resolvedPr.number,
+          state: "blocked",
+          last_error:
+            `PR #${resolvedPr.number} was closed without merge. ` +
+            `Manual intervention is required before issue #${record.issue_number} can continue.`,
+          last_failure_kind: null,
+          last_failure_context: failureContext,
+          ...applyFailureSignature(record, failureContext),
+          blocked_reason: "manual_pr_closed",
+        });
+        state.issues[String(blockedRecord.issue_number)] = blockedRecord;
+        state.activeIssueNumber = null;
+        await this.stateStore.save(state);
+        await syncJournal(blockedRecord);
+        return `Issue #${blockedRecord.issue_number} blocked because PR #${resolvedPr.number} was closed without merge.`;
+      }
+    }
+
+    if (
+      !pr &&
+      nextWorkspaceStatus.baseAhead > 0 &&
+      !nextWorkspaceStatus.hasUncommittedChanges &&
+      record.implementation_attempt_count >= this.config.draftPrAfterAttempt
+    ) {
+      await pushBranch(workspacePath, record.branch, nextWorkspaceStatus.remoteBranchExists);
+      pr = await this.github.createPullRequest(issue, record, { draft: true });
+      checks = await this.github.getChecks(pr.number);
+      reviewThreads = await this.github.getUnresolvedReviewThreads(pr.number);
+    }
+
+    return {
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      workspaceStatus: nextWorkspaceStatus,
+    };
+  }
+
   async acquireSupervisorLock(label: "loop" | "run-once"): Promise<LockHandle> {
     return acquireFileLock(this.lockPath("supervisor", "run"), `supervisor-${label}`);
   }
@@ -2007,22 +2198,11 @@ export class Supervisor {
       await this.stateStore.save(state);
     }
 
-    if (!record || !isEligibleForSelection(record, this.config)) {
-      record = await selectNextIssue(this.github, this.config, state);
-      if (!record) {
-        state.activeIssueNumber = null;
-        await this.stateStore.save(state);
-        return "No matching open issue found.";
-      }
-
-      state.activeIssueNumber = record.issue_number;
-      state.issues[String(record.issue_number)] = record;
-      await this.stateStore.save(state);
+    const selectedIssue = await this.selectIssueRecord(state, record);
+    if (typeof selectedIssue === "string") {
+      return selectedIssue;
     }
-
-    if (!record) {
-      throw new Error("Invariant violation: active issue record is missing after selection.");
-    }
+    record = selectedIssue.record;
 
     const issueLock = await acquireFileLock(
       this.lockPath("issues", `issue-${record.issue_number}`),
@@ -2041,9 +2221,6 @@ export class Supervisor {
         await this.stateStore.save(state);
         return this.runOnce(options);
       }
-
-      const previousCodexSummary = record.last_codex_summary;
-      const previousError = record.last_error;
 
       const candidateIssues = await this.github.listCandidateIssues();
       const blockingIssue = findBlockingIssue(issue, candidateIssues, state);
@@ -2088,98 +2265,35 @@ export class Supervisor {
         return `Issue #${record.issue_number} reached max ${budgetLaneBeforeWorkspace} Codex attempts.`;
       }
 
-      const workspacePath = await ensureWorkspace(this.config, record.issue_number, record.branch);
-      const journalPath = issueJournalPath(workspacePath, this.config.issueJournalRelativePath);
-      const syncJournal = async (currentRecord: IssueRunRecord): Promise<void> => {
-        await syncIssueJournal({
-          issue,
-          record: currentRecord,
-          journalPath,
-          maxChars: this.config.issueJournalMaxChars,
-        });
-      };
-      record = this.stateStore.touch(record, {
-        workspace: workspacePath,
-        journal_path: journalPath,
-        state: record.implementation_attempt_count === 0 ? "planning" : record.state,
-        last_error: null,
-        last_failure_kind: null,
-        blocked_reason: null,
-      });
-      state.issues[String(record.issue_number)] = record;
-      await this.stateStore.save(state);
-      await syncJournal(record);
-      const memoryArtifacts = await syncMemoryArtifacts({
-        config: this.config,
-        issueNumber: record.issue_number,
+      const {
+        previousCodexSummary,
+        previousError,
         workspacePath,
         journalPath,
-      });
+        syncJournal,
+        memoryArtifacts,
+        workspaceStatus: preparedWorkspaceStatus,
+        record: workspaceRecord,
+      } = await this.prepareWorkspaceContext(state, record, issue);
+      record = workspaceRecord;
 
-      let workspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, this.config.defaultBranch);
-      record = this.stateStore.touch(record, { last_head_sha: workspaceStatus.headSha });
-      state.issues[String(record.issue_number)] = record;
-      await this.stateStore.save(state);
-
-      if (workspaceStatus.remoteBranchExists && workspaceStatus.remoteAhead > 0) {
-        await pushBranch(workspacePath, record.branch, true);
-        workspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, this.config.defaultBranch);
+      const hydratedPullRequest = await this.hydratePullRequestContext(
+        state,
+        record,
+        issue,
+        workspacePath,
+        preparedWorkspaceStatus,
+        syncJournal,
+        options,
+      );
+      if (typeof hydratedPullRequest === "string") {
+        return hydratedPullRequest;
       }
 
-      let resolvedPr = await this.github.resolvePullRequestForBranch(record.branch, record.pr_number);
-      let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
-      let checks = pr ? await this.github.getChecks(pr.number) : [];
-      let reviewThreads = pr ? await this.github.getUnresolvedReviewThreads(pr.number) : [];
-
-      if (!pr) {
-        if (!resolvedPr) {
-          // No current or historical PR for this branch; continue with normal branch/PR flow.
-        } else if (resolvedPr.mergedAt || resolvedPr.state === "MERGED") {
-          record = this.stateStore.touch(record, {
-            pr_number: resolvedPr.number,
-            state: "done",
-            last_head_sha: resolvedPr.headRefOid,
-          });
-          state.issues[String(record.issue_number)] = record;
-          state.activeIssueNumber = null;
-          await this.stateStore.save(state);
-          return this.runOnce(options);
-        } else if (resolvedPr.state === "CLOSED") {
-          const failureContext = buildCodexFailureContext(
-            "manual",
-            `PR #${resolvedPr.number} was closed without merge.`,
-            ["Manual intervention is required before the supervisor can continue this issue."],
-          );
-          record = this.stateStore.touch(record, {
-            pr_number: resolvedPr.number,
-            state: "blocked",
-            last_error:
-              `PR #${resolvedPr.number} was closed without merge. ` +
-              `Manual intervention is required before issue #${record.issue_number} can continue.`,
-            last_failure_kind: null,
-            last_failure_context: failureContext,
-            ...applyFailureSignature(record, failureContext),
-            blocked_reason: "manual_pr_closed",
-          });
-          state.issues[String(record.issue_number)] = record;
-          state.activeIssueNumber = null;
-          await this.stateStore.save(state);
-          await syncJournal(record);
-          return `Issue #${record.issue_number} blocked because PR #${resolvedPr.number} was closed without merge.`;
-        }
-      }
-
-      if (
-        !pr &&
-        workspaceStatus.baseAhead > 0 &&
-        !workspaceStatus.hasUncommittedChanges &&
-        record.implementation_attempt_count >= this.config.draftPrAfterAttempt
-      ) {
-        await pushBranch(workspacePath, record.branch, workspaceStatus.remoteBranchExists);
-        pr = await this.github.createPullRequest(issue, record, { draft: true });
-        checks = await this.github.getChecks(pr.number);
-        reviewThreads = await this.github.getUnresolvedReviewThreads(pr.number);
-      }
+      let workspaceStatus = hydratedPullRequest.workspaceStatus;
+      let pr = hydratedPullRequest.pr;
+      let checks = hydratedPullRequest.checks;
+      let reviewThreads = hydratedPullRequest.reviewThreads;
 
       if (pr) {
         const failureContext = inferFailureContext(this.config, record, pr, checks, reviewThreads);
@@ -2473,8 +2587,8 @@ export class Supervisor {
         workspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, this.config.defaultBranch);
       }
 
-      resolvedPr = await this.github.resolvePullRequestForBranch(record.branch, record.pr_number);
-      pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
+      const refreshedResolvedPr = await this.github.resolvePullRequestForBranch(record.branch, record.pr_number);
+      pr = isOpenPullRequest(refreshedResolvedPr) ? refreshedResolvedPr : null;
       if (
         !pr &&
         workspaceStatus.baseAhead > 0 &&


### PR DESCRIPTION
Closes #97
This PR was opened by codex-supervisor.
Latest Codex summary:

Refactored the pre-turn setup path in [supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-97/src/supervisor.ts) by extracting three focused helpers from `runOnce`: issue selection, workspace/journal preparation, and initial PR/check/thread hydration. The main flow still keeps the same recursive early returns and state/persistence behavior.

Added a focused regression in [supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-97/src/supervisor.test.ts) that proves `runOnce({ dryRun: true })` selects an issue, prepares the workspace, hydrates PR context, and stops before Codex. Verification passed with `npm run build` and `npm test -- src/supervisor.test.ts`. Checkpoint commit: `d48839e` (`Refactor supervisor pre-turn setup`). The issue journal was updated for handoff.

Summary: Extracted supervisor pre-turn setup from `runOnce`, added a focused dry-run regression test, and committed the checkpoint as `d48839e`.
State hint: implementing
Blocked reason: none
Tests: `npm run build`; `npm test -- src/supervisor.test.ts`
Failure signature: none
Next action: Decide whether to open/update a draft PR for `codex/issue-97` or continue with follow-on review cleanup