### PR TITLE
Supervisor: retry transient gh and GitHub network failures instead of failing the issue (#105)

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,6 +1,56 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { inferCopilotReviewLifecycle } from "./github";
+import { GitHubClient, inferCopilotReviewLifecycle, isTransientGitHubCommandFailure } from "./github";
+import { SupervisorConfig } from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
 
 test("inferCopilotReviewLifecycle returns not_requested when no Copilot signal exists", () => {
   const lifecycle = inferCopilotReviewLifecycle(
@@ -68,4 +118,142 @@ test("inferCopilotReviewLifecycle returns arrived when Copilot review exists", (
     requestedAt: "2026-03-13T01:02:03Z",
     arrivedAt: "2026-03-13T02:03:04Z",
   });
+});
+
+test("isTransientGitHubCommandFailure matches connection reset GraphQL failures", () => {
+  assert.equal(
+    isTransientGitHubCommandFailure(
+      'Command failed: gh pr list --repo owner/repo\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+    ),
+    true,
+  );
+  assert.equal(
+    isTransientGitHubCommandFailure("Command failed: gh pr create --repo owner/repo\nexitCode=1\npull request create failed: No commits between main and branch"),
+    false,
+  );
+});
+
+test("GitHubClient retries transient gh failures and succeeds on a later attempt", async () => {
+  const config = createConfig();
+  const calls: Array<{ command: string; args: string[] }> = [];
+  let delayCalls = 0;
+  const client = new GitHubClient(
+    config,
+    async (command, args) => {
+      calls.push({ command, args });
+      if (args[0] === "pr" && args[1] === "list" && calls.filter((call) => call.args[0] === "pr" && call.args[1] === "list").length < 3) {
+        throw new Error(
+          'Command failed: gh pr list --repo owner/repo\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+        );
+      }
+
+      if (args[0] === "api" && args[1] === "graphql") {
+        return {
+          exitCode: 0,
+          stdout: '{"data":{"repository":{"pullRequest":{"reviewRequests":{"nodes":[]},"reviews":{"nodes":[]},"timelineItems":{"nodes":[]}}}}}',
+          stderr: "",
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout:
+          '[{"number":17,"title":"Retry gh","url":"https://example.test/pr/17","state":"OPEN","createdAt":"2026-03-13T00:00:00Z","updatedAt":"2026-03-13T00:00:00Z","isDraft":false,"reviewDecision":null,"mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","headRefName":"codex/issue-105","headRefOid":"deadbeef","mergedAt":null}]',
+        stderr: "",
+      };
+    },
+    async () => {
+      delayCalls += 1;
+    },
+  );
+
+  const pr = await client.findOpenPullRequest("codex/issue-105");
+
+  assert.equal(pr?.number, 17);
+  assert.equal(calls.filter((call) => call.args[0] === "pr" && call.args[1] === "list").length, 3);
+  assert.equal(calls.filter((call) => call.args[0] === "api" && call.args[1] === "graphql").length, 1);
+  assert.equal(delayCalls, 2);
+});
+
+test("GitHubClient does not retry non-transient gh failures", async () => {
+  const config = createConfig();
+  let calls = 0;
+  const client = new GitHubClient(
+    config,
+    async () => {
+      calls += 1;
+      throw new Error(
+        "Command failed: gh pr create --repo owner/repo\nexitCode=1\npull request create failed: No commits between main and codex/issue-105",
+      );
+    },
+    async () => undefined,
+  );
+
+  await assert.rejects(
+    () =>
+      client.createPullRequest(
+        {
+          number: 105,
+          title: "Retry transient gh failures",
+          body: "",
+          createdAt: "2026-03-13T00:00:00Z",
+          updatedAt: "2026-03-13T00:00:00Z",
+          url: "https://example.test/issues/105",
+          state: "OPEN",
+        },
+        {
+          issue_number: 105,
+          state: "draft_pr",
+          branch: "codex/issue-105",
+          pr_number: null,
+          workspace: "/tmp/workspaces/issue-105",
+          journal_path: null,
+          review_wait_started_at: null,
+          review_wait_head_sha: null,
+          copilot_review_requested_observed_at: null,
+          copilot_review_requested_head_sha: null,
+          copilot_review_timed_out_at: null,
+          copilot_review_timeout_action: null,
+          copilot_review_timeout_reason: null,
+          codex_session_id: null,
+          local_review_head_sha: null,
+          local_review_summary_path: null,
+          local_review_run_at: null,
+          local_review_max_severity: null,
+          local_review_findings_count: 0,
+          local_review_root_cause_count: 0,
+          local_review_verified_max_severity: null,
+          local_review_verified_findings_count: 0,
+          local_review_recommendation: null,
+          local_review_degraded: false,
+          last_local_review_signature: null,
+          repeated_local_review_signature_count: 0,
+          external_review_head_sha: null,
+          external_review_misses_path: null,
+          external_review_matched_findings_count: 0,
+          external_review_near_match_findings_count: 0,
+          external_review_missed_findings_count: 0,
+          attempt_count: 1,
+          implementation_attempt_count: 1,
+          repair_attempt_count: 0,
+          timeout_retry_count: 0,
+          blocked_verification_retry_count: 0,
+          repeated_blocker_count: 0,
+          repeated_failure_signature_count: 0,
+          last_head_sha: "deadbeef",
+          last_codex_summary: null,
+          last_error: null,
+          last_failure_kind: null,
+          last_failure_context: null,
+          last_blocker_signature: null,
+          last_failure_signature: null,
+          blocked_reason: null,
+          processed_review_thread_ids: [],
+          updated_at: "2026-03-13T00:00:00Z",
+        },
+      ),
+    /No commits between main and codex\/issue-105/,
+  );
+
+  assert.equal(calls, 1);
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -7,8 +7,54 @@ import {
   ReviewThread,
   SupervisorConfig,
 } from "./types";
-import { runCommand } from "./command";
+import { CommandOptions, CommandResult, runCommand } from "./command";
 import { parseJson, truncate } from "./utils";
+
+const TRANSIENT_GITHUB_RETRY_LIMIT = 2;
+const TRANSIENT_GITHUB_RETRY_BASE_DELAY_MS = 200;
+
+export type GitHubCommandRunner = (
+  command: string,
+  args: string[],
+  options?: CommandOptions,
+) => Promise<CommandResult>;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function isTransientGitHubCommandFailure(message: string | null | undefined): boolean {
+  if (!message) {
+    return false;
+  }
+
+  const lower = message.toLowerCase();
+  const githubRelated =
+    lower.includes("api.github.com") ||
+    lower.includes("github.com") ||
+    lower.includes("graphql") ||
+    lower.includes("gh ");
+  const transientSignal =
+    lower.includes("connection reset by peer") ||
+    lower.includes("unexpected eof") ||
+    lower.includes("eof") ||
+    lower.includes("tls handshake timeout") ||
+    lower.includes("i/o timeout") ||
+    lower.includes("timeout awaiting response headers") ||
+    lower.includes("temporary failure in name resolution") ||
+    lower.includes("no such host") ||
+    lower.includes("connection refused") ||
+    lower.includes("network is unreachable") ||
+    lower.includes("server closed idle connection") ||
+    lower.includes("http2: client connection lost") ||
+    lower.includes("stream error") ||
+    lower.includes("internal server error") ||
+    lower.includes("bad gateway") ||
+    lower.includes("service unavailable") ||
+    lower.includes("gateway timeout");
+
+  return githubRelated && transientSignal;
+}
 
 interface PullRequestStatusCheckRollupResponse {
   statusCheckRollup?: Array<{
@@ -262,7 +308,55 @@ function normalizeRollupChecks(rollup: PullRequestStatusCheckRollupResponse | nu
 export class GitHubClient {
   private readonly copilotReviewLifecycleCache = new Map<string, Promise<CopilotReviewLifecycle>>();
 
-  constructor(private readonly config: SupervisorConfig) {}
+  constructor(
+    private readonly config: SupervisorConfig,
+    private readonly commandRunner: GitHubCommandRunner = runCommand,
+    private readonly delay: (ms: number) => Promise<void> = sleep,
+  ) {}
+
+  private async runGhCommand(args: string[], options: CommandOptions = {}): Promise<CommandResult> {
+    let lastTransientMessage: string | null = null;
+
+    for (let attempt = 0; attempt <= TRANSIENT_GITHUB_RETRY_LIMIT; attempt += 1) {
+      try {
+        const result = await this.commandRunner("gh", args, options);
+        if (result.exitCode === 0 || !isTransientGitHubCommandFailure(`${result.stderr}\n${result.stdout}`)) {
+          return result;
+        }
+
+        lastTransientMessage = truncate(
+          [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n"),
+          500,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isTransientGitHubCommandFailure(message)) {
+          throw error;
+        }
+
+        lastTransientMessage = truncate(message, 500);
+      }
+
+      const nextAttempt = attempt + 1;
+      if (nextAttempt > TRANSIENT_GITHUB_RETRY_LIMIT) {
+        break;
+      }
+
+      console.warn(
+        `Transient GitHub CLI failure for gh ${args.join(" ")}; retry ${nextAttempt}/${TRANSIENT_GITHUB_RETRY_LIMIT}.`,
+      );
+      await this.delay(TRANSIENT_GITHUB_RETRY_BASE_DELAY_MS * nextAttempt);
+    }
+
+    throw new Error(
+      [
+        `Transient GitHub CLI failure after ${TRANSIENT_GITHUB_RETRY_LIMIT + 1} attempts: gh ${args.join(" ")}`,
+        lastTransientMessage ?? "Unknown transient GitHub failure.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
 
   private repoOwnerAndName(): { owner: string; repo: string } {
     const [owner, repo] = this.config.repoSlug.split("/", 2);
@@ -275,8 +369,7 @@ export class GitHubClient {
 
   async authStatus(): Promise<{ ok: boolean; message: string | null }> {
     try {
-      const result = await runCommand(
-        "gh",
+      const result = await this.runGhCommand(
         ["auth", "status", "--hostname", "github.com"],
         { allowExitCodes: [0, 1] },
       );
@@ -298,7 +391,7 @@ export class GitHubClient {
   }
 
   async listAllIssues(): Promise<GitHubIssue[]> {
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "issue",
       "list",
       "--repo",
@@ -335,13 +428,13 @@ export class GitHubClient {
       args.push("--search", this.config.issueSearch);
     }
 
-    const result = await runCommand("gh", args);
+    const result = await this.runGhCommand(args);
     const issues = parseJson<GitHubIssue[]>(result.stdout, "gh issue list --candidate");
     return issues.sort((left, right) => left.createdAt.localeCompare(right.createdAt));
   }
 
   async getIssue(issueNumber: number): Promise<GitHubIssue> {
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "issue",
       "view",
       String(issueNumber),
@@ -354,7 +447,7 @@ export class GitHubClient {
   }
 
   async findOpenPullRequest(branch: string): Promise<GitHubPullRequest | null> {
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "pr",
       "list",
       "--repo",
@@ -373,7 +466,7 @@ export class GitHubClient {
   }
 
   async findLatestPullRequestForBranch(branch: string): Promise<GitHubPullRequest | null> {
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "pr",
       "list",
       "--repo",
@@ -397,7 +490,7 @@ export class GitHubClient {
   }
 
   async getPullRequest(prNumber: number): Promise<GitHubPullRequest> {
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "pr",
       "view",
       String(prNumber),
@@ -411,8 +504,7 @@ export class GitHubClient {
   }
 
   async getPullRequestIfExists(prNumber: number): Promise<GitHubPullRequest | null> {
-    const result = await runCommand(
-      "gh",
+    const result = await this.runGhCommand(
       [
         "pr",
         "view",
@@ -491,7 +583,7 @@ export class GitHubClient {
       }
     `;
 
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "api",
       "graphql",
       "-f",
@@ -523,8 +615,7 @@ export class GitHubClient {
   }
 
   async getChecks(prNumber: number): Promise<PullRequestCheck[]> {
-    const result = await runCommand(
-      "gh",
+    const result = await this.runGhCommand(
       [
         "pr",
         "checks",
@@ -546,8 +637,7 @@ export class GitHubClient {
       }
     }
 
-    const fallback = await runCommand(
-      "gh",
+    const fallback = await this.runGhCommand(
       [
         "pr",
         "view",
@@ -590,7 +680,7 @@ export class GitHubClient {
       .filter(Boolean)
       .join("\n");
 
-    await runCommand("gh", [
+    await this.runGhCommand([
       "pr",
       "create",
       "--repo",
@@ -622,7 +712,7 @@ export class GitHubClient {
           ? "--rebase"
           : "--squash";
 
-    await runCommand("gh", [
+    await this.runGhCommand([
       "pr",
       "merge",
       String(prNumber),
@@ -637,8 +727,7 @@ export class GitHubClient {
   }
 
   async markPullRequestReady(prNumber: number): Promise<void> {
-    await runCommand(
-      "gh",
+    await this.runGhCommand(
       ["pr", "ready", String(prNumber), "--repo", this.config.repoSlug],
       { allowExitCodes: [0, 1] },
     );
@@ -657,7 +746,7 @@ export class GitHubClient {
       args.push("--comment", comment);
     }
 
-    await runCommand("gh", args, { allowExitCodes: [0, 1] });
+    await this.runGhCommand(args, { allowExitCodes: [0, 1] });
   }
 
   async closePullRequest(prNumber: number, comment?: string): Promise<void> {
@@ -673,7 +762,7 @@ export class GitHubClient {
       args.push("--comment", comment);
     }
 
-    await runCommand("gh", args, { allowExitCodes: [0, 1] });
+    await this.runGhCommand(args, { allowExitCodes: [0, 1] });
   }
 
   async getUnresolvedReviewThreads(prNumber: number): Promise<ReviewThread[]> {
@@ -709,7 +798,7 @@ export class GitHubClient {
       }
     `;
 
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "api",
       "graphql",
       "-f",
@@ -868,7 +957,7 @@ export class GitHubClient {
       }
     `;
 
-    const result = await runCommand("gh", [
+    const result = await this.runGhCommand([
       "api",
       "graphql",
       "-f",


### PR DESCRIPTION
Closes #105
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented bounded `gh` retry handling in [src/github.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-105/src/github.ts) by centralizing GitHub CLI execution behind a retrying helper. It retries classified transient GitHub/network failures like GraphQL connection resets up to 2 times with short backoff, logs each retry, and preserves fail-fast behavior for deterministic command errors.

Added focused regression coverage in [src/github.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-105/src/github.test.ts) for:
- a retryable `gh pr list` GraphQL connection reset that succeeds on a later attempt
- a non-retryable `gh pr create` failure that is not retried

Verification: `npx tsx --test src/github.test.ts`, `npm run build`, `npm test`. Checkpoint commit: `7a9e822` (`Retry transient GitHub CLI failures`).

Summary: Added bounded transient GitHub CLI/network retries in `GitHubClient` and focused tests proving retryable vs non-retryable `gh` failures.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/github.test.ts`; `npm run build`; `npm test`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-105` with the retry helper and regression tests.