### PR TITLE
Supervisor: wait for Copilot review arrival, not only request creation, before merge (#107)

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -57,6 +57,7 @@ test("inferCopilotReviewLifecycle returns not_requested when no Copilot signal e
     {
       reviewRequests: [],
       reviews: [],
+      comments: [],
       timeline: [],
     },
     ["copilot-pull-request-reviewer"],
@@ -74,6 +75,7 @@ test("inferCopilotReviewLifecycle returns requested when Copilot was requested b
     {
       reviewRequests: ["copilot-pull-request-reviewer"],
       reviews: [],
+      comments: [],
       timeline: [
         {
           type: "requested",
@@ -102,6 +104,7 @@ test("inferCopilotReviewLifecycle returns arrived when Copilot review exists", (
           submittedAt: "2026-03-13T02:03:04Z",
         },
       ],
+      comments: [],
       timeline: [
         {
           type: "requested",
@@ -117,6 +120,35 @@ test("inferCopilotReviewLifecycle returns arrived when Copilot review exists", (
     state: "arrived",
     requestedAt: "2026-03-13T01:02:03Z",
     arrivedAt: "2026-03-13T02:03:04Z",
+  });
+});
+
+test("inferCopilotReviewLifecycle returns arrived when Copilot comments on a review thread", () => {
+  const lifecycle = inferCopilotReviewLifecycle(
+    {
+      reviewRequests: [],
+      reviews: [],
+      comments: [
+        {
+          authorLogin: "copilot-pull-request-reviewer",
+          createdAt: "2026-03-13T02:04:05Z",
+        },
+      ],
+      timeline: [
+        {
+          type: "requested",
+          createdAt: "2026-03-13T01:02:03Z",
+          reviewerLogin: "copilot-pull-request-reviewer",
+        },
+      ],
+    },
+    ["copilot-pull-request-reviewer"],
+  );
+
+  assert.deepEqual(lifecycle, {
+    state: "arrived",
+    requestedAt: "2026-03-13T01:02:03Z",
+    arrivedAt: "2026-03-13T02:04:05Z",
   });
 });
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -91,6 +91,18 @@ interface PullRequestCopilotReviewLifecycleResponse {
       submittedAt?: string | null;
     } | null>;
   } | null;
+  reviewThreads?: {
+    nodes?: Array<{
+      comments?: {
+        nodes?: Array<{
+          createdAt?: string | null;
+          author?: {
+            login?: string | null;
+          } | null;
+        } | null>;
+      } | null;
+    } | null>;
+  } | null;
   timelineItems?: {
     nodes?: Array<{
       __typename?: "ReviewRequestedEvent" | "ReviewRequestRemovedEvent" | string | null;
@@ -105,6 +117,10 @@ export interface CopilotReviewLifecycleFacts {
   reviews: Array<{
     authorLogin: string | null;
     submittedAt: string | null;
+  }>;
+  comments: Array<{
+    authorLogin: string | null;
+    createdAt: string | null;
   }>;
   timeline: Array<{
     type: "requested" | "removed";
@@ -195,11 +211,16 @@ export function inferCopilotReviewLifecycle(
     return { state: "not_requested", requestedAt: null, arrivedAt: null };
   }
 
-  const matchingReviews = facts.reviews.filter((review) => {
+  const matchingReviewTimes = facts.reviews.flatMap((review) => {
     const authorLogin = normalizeLogin(review.authorLogin);
-    return authorLogin ? configuredReviewBots.has(authorLogin) : false;
+    return authorLogin && configuredReviewBots.has(authorLogin) ? [review.submittedAt] : [];
   });
-  if (matchingReviews.length > 0) {
+  const matchingCommentTimes = facts.comments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin && configuredReviewBots.has(authorLogin) ? [comment.createdAt] : [];
+  });
+  const arrivedAt = latestTimestamp([...matchingReviewTimes, ...matchingCommentTimes]);
+  if (arrivedAt) {
     return {
       state: "arrived",
       requestedAt: latestTimestamp(
@@ -207,7 +228,7 @@ export function inferCopilotReviewLifecycle(
           .filter((event) => event.type === "requested" && event.reviewerLogin && configuredReviewBots.has(event.reviewerLogin))
           .map((event) => event.createdAt),
       ),
-      arrivedAt: latestTimestamp(matchingReviews.map((review) => review.submittedAt)),
+      arrivedAt,
     };
   }
 
@@ -913,6 +934,18 @@ export class GitHubClient {
                 }
               }
             }
+            reviewThreads(first: 100) {
+              nodes {
+                comments(first: 20) {
+                  nodes {
+                    createdAt
+                    author {
+                      login
+                    }
+                  }
+                }
+              }
+            }
             timelineItems(last: 100, itemTypes: [REVIEW_REQUESTED_EVENT, REVIEW_REQUEST_REMOVED_EVENT]) {
               nodes {
                 __typename
@@ -989,6 +1022,13 @@ export class GitHubClient {
           authorLogin: normalizeLogin(node?.author?.login ?? null),
           submittedAt: node?.submittedAt ?? null,
         })) ?? [],
+      comments:
+        lifecycle?.reviewThreads?.nodes?.flatMap((thread) =>
+          (thread?.comments?.nodes ?? []).map((comment) => ({
+            authorLogin: normalizeLogin(comment?.author?.login ?? null),
+            createdAt: comment?.createdAt ?? null,
+          })),
+        ) ?? [],
       timeline:
         lifecycle?.timelineItems?.nodes
           ?.map((node) => {

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -1043,6 +1043,39 @@ test("inferStateFromPullRequest keeps waiting when Copilot review was explicitly
   });
 });
 
+test("inferStateFromPullRequest keeps waiting when a Copilot request was observed on the current head but has not arrived", () => {
+  withStubbedDateNow("2026-03-11T00:10:00Z", () => {
+    const config = createConfig({ copilotReviewWaitMinutes: 10 });
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: "2026-03-11T00:00:00Z",
+      review_wait_head_sha: "head123",
+      copilot_review_requested_observed_at: "2026-03-11T00:05:00Z",
+      copilot_review_requested_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-11T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "waiting_ci");
+  });
+});
+
 test("inferStateFromPullRequest does not start Copilot timeout from the generic review wait window", () => {
   withStubbedDateNow("2026-03-11T00:30:00Z", () => {
     const config = createConfig({ copilotReviewWaitMinutes: 10, copilotReviewTimeoutAction: "block" });

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -887,8 +887,24 @@ interface CopilotReviewTimeoutStatus {
   reason: string | null;
 }
 
+function copilotReviewArrived(pr: GitHubPullRequest): boolean {
+  return (pr.copilotReviewState ?? "not_requested") === "arrived" || Boolean(pr.copilotReviewArrivedAt);
+}
+
+function hasObservedCopilotRequest(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  return Boolean(record.copilot_review_requested_observed_at && record.copilot_review_requested_head_sha === pr.headRefOid);
+}
+
+function copilotReviewPending(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  if (pr.isDraft || copilotReviewArrived(pr)) {
+    return false;
+  }
+
+  return (pr.copilotReviewState ?? "not_requested") === "requested" || hasObservedCopilotRequest(record, pr);
+}
+
 function copilotReviewTimeoutStart(record: IssueRunRecord, pr: GitHubPullRequest): string | null {
-  if (pr.isDraft || (pr.copilotReviewState ?? "not_requested") !== "requested") {
+  if (!copilotReviewPending(record, pr)) {
     return null;
   }
 
@@ -1051,7 +1067,7 @@ function syncReviewWaitWindow(record: IssueRunRecord, pr: GitHubPullRequest): Pa
 }
 
 function syncCopilotReviewRequestObservation(record: IssueRunRecord, pr: GitHubPullRequest): Partial<IssueRunRecord> {
-  if (pr.isDraft || (pr.copilotReviewState ?? "not_requested") !== "requested") {
+  if (pr.isDraft || copilotReviewArrived(pr)) {
     return {
       copilot_review_requested_observed_at: null,
       copilot_review_requested_head_sha: null,
@@ -1075,9 +1091,16 @@ function syncCopilotReviewRequestObservation(record: IssueRunRecord, pr: GitHubP
     };
   }
 
+  if (hasObservedCopilotRequest(record, pr)) {
+    return {
+      copilot_review_requested_observed_at: record.copilot_review_requested_observed_at,
+      copilot_review_requested_head_sha: record.copilot_review_requested_head_sha,
+    };
+  }
+
   return {
-    copilot_review_requested_observed_at: nowIso(),
-    copilot_review_requested_head_sha: pr.headRefOid,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
   };
 }
 
@@ -1184,7 +1207,7 @@ export function inferStateFromPullRequest(
     return "waiting_ci";
   }
 
-  if ((pr.copilotReviewState ?? "not_requested") === "requested" && !copilotTimeout.timedOut) {
+  if (copilotReviewPending(record, pr) && !copilotTimeout.timedOut) {
     return "waiting_ci";
   }
 


### PR DESCRIPTION
Closes #107
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Copilot merge-gating fix in commit `b4678ef`.

The change now preserves an observed Copilot review request on the current PR head until either Copilot review content actually arrives or the configured timeout expires, instead of falling back to `ready_to_merge` as soon as GitHub stops reporting the active request. I also extended Copilot lifecycle arrival detection so review-thread comments from Copilot count as arrival, not just submitted reviews. Focused coverage was added in [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-107/src/supervisor.test.ts) and [src/github.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-107/src/github.test.ts), with the implementation in [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-107/src/supervisor.ts) and [src/github.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-107/src/github.ts).

Verification passed with `npm test -- --test-name-pattern="Copilot" src/supervisor.test.ts src/github.test.ts` and `npm run build`. The issue journal was updated locally as requested; it remains uncommitted because `.codex-supervisor/issue-journal.md` is gitignored.

Summary: Preserved observed Copilot review requests until arrival/timeout and count Copilot review-thread comments as arrival; committed as `b4678ef`.
State hint: implementing
Blocked reason: none
Tests: `npm test -- --test-name-pattern...