### PR TITLE
GitHub client: redact raw gh arguments from retry and failure logs (#112)

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -359,6 +359,82 @@ test("GitHubClient retries transient gh failures and succeeds on a later attempt
   assert.equal(delayCalls, 2);
 });
 
+test("GitHubClient retry warnings redact raw gh arguments", async () => {
+  const config = createConfig();
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (message?: unknown, ...args: unknown[]) => {
+    warnings.push([message, ...args].map((value) => String(value)).join(" "));
+  };
+
+  try {
+    let calls = 0;
+    const client = new GitHubClient(
+      config,
+      async (_command, args) => {
+        calls += 1;
+        if (args[0] === "api" && args[1] === "graphql" && calls === 1) {
+          throw new Error(
+            'Command failed: gh api graphql -f query=query { viewer { login secretField } }\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+          );
+        }
+
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                issue: {
+                  closedByPullRequestsReferences: {
+                    nodes: [],
+                  },
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      },
+      async () => undefined,
+    );
+
+    await client.getMergedPullRequestsClosingIssue(105);
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0] ?? "", /Transient GitHub CLI failure for gh api graphql/);
+    assert.match(warnings[0] ?? "", /\+\d+ arg/);
+    assert.doesNotMatch(warnings[0] ?? "", /secretField/);
+    assert.doesNotMatch(warnings[0] ?? "", /query=query/);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("GitHubClient terminal transient failure redacts raw gh arguments", async () => {
+  const config = createConfig();
+  const client = new GitHubClient(
+    config,
+    async () => {
+      throw new Error(
+        'Command failed: gh api graphql -f query=query { viewer { login secretField } }\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+      );
+    },
+    async () => undefined,
+  );
+
+  await assert.rejects(
+    () => client.getMergedPullRequestsClosingIssue(44),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Transient GitHub CLI failure after 3 attempts: gh api graphql/);
+      assert.match(error.message, /\+\d+ arg/);
+      assert.doesNotMatch(error.message, /secretField/);
+      assert.doesNotMatch(error.message, /query=query/);
+      return true;
+    },
+  );
+});
+
 test("GitHubClient does not retry non-transient gh failures", async () => {
   const config = createConfig();
   let calls = 0;

--- a/src/github.ts
+++ b/src/github.ts
@@ -326,6 +326,36 @@ function normalizeRollupChecks(rollup: PullRequestStatusCheckRollupResponse | nu
   return checks;
 }
 
+function summarizeGhArgs(args: string[]): string {
+  const visibleArgs = args.slice(0, 2);
+  const omittedCount = Math.max(args.length - visibleArgs.length, 0);
+  const summary = ["gh", ...visibleArgs].join(" ");
+  return omittedCount > 0 ? `${summary} +${omittedCount} arg${omittedCount === 1 ? "" : "s"}` : summary;
+}
+
+function sanitizeGhCommandMessage(message: string, args: string[]): string {
+  const commandSummary = summarizeGhArgs(args);
+  return message
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("Command failed: gh ")) {
+        return `Command failed: ${commandSummary}`;
+      }
+
+      if (line.startsWith("Command timed out: gh ")) {
+        return `Command timed out: ${commandSummary}`;
+      }
+
+      const timedOutAfterMarker = ": gh ";
+      if (line.startsWith("Command timed out after ") && line.includes(timedOutAfterMarker)) {
+        return `${line.slice(0, line.indexOf(timedOutAfterMarker) + 2)}${commandSummary}`;
+      }
+
+      return line;
+    })
+    .join("\n");
+}
+
 export class GitHubClient {
   private readonly copilotReviewLifecycleCache = new Map<string, Promise<CopilotReviewLifecycle>>();
 
@@ -337,6 +367,7 @@ export class GitHubClient {
 
   private async runGhCommand(args: string[], options: CommandOptions = {}): Promise<CommandResult> {
     let lastTransientMessage: string | null = null;
+    const commandSummary = summarizeGhArgs(args);
 
     for (let attempt = 0; attempt <= TRANSIENT_GITHUB_RETRY_LIMIT; attempt += 1) {
       try {
@@ -355,7 +386,7 @@ export class GitHubClient {
           throw error;
         }
 
-        lastTransientMessage = truncate(message, 500);
+        lastTransientMessage = truncate(sanitizeGhCommandMessage(message, args), 500);
       }
 
       const nextAttempt = attempt + 1;
@@ -363,15 +394,13 @@ export class GitHubClient {
         break;
       }
 
-      console.warn(
-        `Transient GitHub CLI failure for gh ${args.join(" ")}; retry ${nextAttempt}/${TRANSIENT_GITHUB_RETRY_LIMIT}.`,
-      );
+      console.warn(`Transient GitHub CLI failure for ${commandSummary}; retry ${nextAttempt}/${TRANSIENT_GITHUB_RETRY_LIMIT}.`);
       await this.delay(TRANSIENT_GITHUB_RETRY_BASE_DELAY_MS * nextAttempt);
     }
 
     throw new Error(
       [
-        `Transient GitHub CLI failure after ${TRANSIENT_GITHUB_RETRY_LIMIT + 1} attempts: gh ${args.join(" ")}`,
+        `Transient GitHub CLI failure after ${TRANSIENT_GITHUB_RETRY_LIMIT + 1} attempts: ${commandSummary}`,
         lastTransientMessage ?? "Unknown transient GitHub failure.",
       ]
         .filter(Boolean)


### PR DESCRIPTION
Closes #112
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the redaction fix in [`src/github.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-112/src/github.ts) and added focused regressions in [`src/github.test.ts`](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-112/src/github.test.ts). `runGhCommand()` now logs deterministic command summaries like `gh api graphql +8 args` instead of raw joined arguments, and it also sanitizes preserved transient command headers before surfacing the final error.

Focused verification passed with `./node_modules/.bin/tsx --test src/github.test.ts`, then `npm test` and `npm run build`. I updated the issue journal working notes and committed the change as `e0f67c9` (`Redact gh arguments in transient logs`).

Summary: Redacted raw `gh` arguments from transient retry warnings and terminal transient failures; added focused tests for both paths and committed the fix.
State hint: draft_pr
Blocked reason: none
Tests: ./node_modules/.bin/tsx --test src/github.test.ts; npm test; npm run build
Failure signature: none
Next action: Open a draft PR for branch `codex/issue-112` with the committed checkpoint.