### PR TITLE
Local Review Swarm: generate reviewer rubric candidates from confirmed misses (#120)

### DIFF
--- a/src/external-review-durable-guardrail-candidates.test.ts
+++ b/src/external-review-durable-guardrail-candidates.test.ts
@@ -36,9 +36,9 @@ test("toDurableGuardrailCandidates emits explicit categories with deterministic 
 
   assert.deepEqual(candidates, [
     {
-      id: "prompt_rubric|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
-      category: "prompt_rubric",
-      title: "Promote prompt/rubric guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      id: "reviewer_rubric|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "reviewer_rubric",
+      title: "Promote reviewer rubric guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
       reviewerLogin: "copilot-pull-request-reviewer",
       file: "src/auth.ts",
       line: 42,
@@ -140,7 +140,7 @@ test("toDurableGuardrailCandidates rejects weak or ambiguous misses deterministi
         severity: "medium",
       }),
     }).map((candidate) => candidate.category),
-    ["prompt_rubric", "regression_test"],
+    ["reviewer_rubric", "regression_test"],
   );
 
   assert.deepEqual(
@@ -172,6 +172,6 @@ test("toDurableGuardrailCandidates rejects weak or ambiguous misses deterministi
         line: null,
       }),
     }).map((candidate) => candidate.category),
-    ["prompt_rubric"],
+    ["reviewer_rubric"],
   );
 });

--- a/src/external-review-durable-guardrail-candidates.ts
+++ b/src/external-review-durable-guardrail-candidates.ts
@@ -33,8 +33,8 @@ const COMMON_RULES: CandidateQualificationRule[] = [
 
 const CANDIDATE_SPECS: CandidateSpec[] = [
   {
-    category: "prompt_rubric",
-    titlePrefix: "Promote prompt/rubric guardrail for",
+    category: "reviewer_rubric",
+    titlePrefix: "Promote reviewer rubric guardrail for",
     rules: [
       ...COMMON_RULES,
       {

--- a/src/external-review-miss-artifact-types.ts
+++ b/src/external-review-miss-artifact-types.ts
@@ -31,7 +31,7 @@ export interface ExternalReviewRegressionCandidate {
 }
 
 export type ExternalReviewDurableGuardrailCandidateCategory =
-  | "prompt_rubric"
+  | "reviewer_rubric"
   | "verifier"
   | "regression_test";
 

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -407,9 +407,9 @@ test("writeExternalReviewMissArtifact derives deterministic regression-test cand
 
   assert.deepEqual(artifact.durableGuardrailCandidates, [
     {
-      id: "prompt_rubric|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
-      category: "prompt_rubric",
-      title: "Promote prompt/rubric guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
+      id: "reviewer_rubric|src/auth.ts|42|this fallback skips the permission guard and lets unauthorized callers update records.",
+      category: "reviewer_rubric",
+      title: "Promote reviewer rubric guardrail for This fallback skips the permission guard and lets unauthorized callers update records",
       reviewerLogin: "copilot-pull-request-reviewer",
       file: "src/auth.ts",
       line: 42,


### PR DESCRIPTION
Closes #120
This PR was opened by codex-supervisor.
Latest Codex summary:

Renamed the confirmed-miss durable candidate category from `prompt_rubric` to `reviewer_rubric` so the artifact now exposes an explicitly reviewer-facing rubric candidate, while keeping the existing deterministic qualification rules and provenance intact. The change is in [src/external-review-miss-artifact-types.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-120/src/external-review-miss-artifact-types.ts), [src/external-review-durable-guardrail-candidates.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-120/src/external-review-durable-guardrail-candidates.ts), and the focused expectations in [src/external-review-durable-guardrail-candidates.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-120/src/external-review-durable-guardrail-candidates.test.ts) and [src/external-review-misses.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-120/src/external-review-misses.test.ts).

I reproduced the gap first with the narrowed tests, then fixed it and committed the slice as `f66f232` (`Add reviewer rubric miss candidates`). I also updated the local issue journal working notes in the ignored supervisor state file.

Summary: Confirmed misses now generate deterministic `reviewer_rubric` candidates instead of the stale `prompt_rubric` label, with focused tests and build passing.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/external-review-durable-guard...