### PR TITLE
Supervisor hardening: detect and self-heal stale active-issue and stale-lock state (#128)

### DIFF
--- a/src/lock.test.ts
+++ b/src/lock.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { acquireFileLock } from "./lock";
+
+test("acquireFileLock self-heals malformed lock payloads", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-lock-"));
+  const lockPath = path.join(root, "issues", "issue-91.lock");
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(lockPath, "{not json\n", "utf8");
+
+  const lock = await acquireFileLock(lockPath, "issue-91");
+
+  assert.equal(lock.acquired, true);
+  await lock.release();
+  await assert.rejects(fs.access(lockPath));
+});

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -8,6 +8,11 @@ interface LockPayload {
   acquired_at: string;
 }
 
+export interface ExistingLockState {
+  status: "missing" | "live";
+  payload: LockPayload | null;
+}
+
 export interface LockHandle {
   acquired: boolean;
   reason?: string;
@@ -28,13 +33,35 @@ function isPidAlive(pid: number): boolean {
 }
 
 async function removeIfStale(lockPath: string): Promise<LockPayload | null> {
-  const payload = await readJsonIfExists<LockPayload>(lockPath);
+  let payload: LockPayload | null = null;
+  try {
+    payload = await readJsonIfExists<LockPayload>(lockPath);
+  } catch {
+    await fs.rm(lockPath, { force: true });
+    return null;
+  }
+
   if (!payload || isPidAlive(payload.pid)) {
     return payload;
   }
 
   await fs.rm(lockPath, { force: true });
   return null;
+}
+
+export async function inspectFileLock(lockPath: string): Promise<ExistingLockState> {
+  const payload = await removeIfStale(lockPath);
+  if (!payload) {
+    return {
+      status: "missing",
+      payload: null,
+    };
+  }
+
+  return {
+    status: "live",
+    payload,
+  };
 }
 
 export async function acquireFileLock(lockPath: string, label: string): Promise<LockHandle> {
@@ -66,14 +93,14 @@ export async function acquireFileLock(lockPath: string, label: string): Promise<
         throw error;
       }
 
-      const existing = await removeIfStale(lockPath);
-      if (!existing) {
+      const existing = await inspectFileLock(lockPath);
+      if (existing.status !== "live" || !existing.payload) {
         continue;
       }
 
       return {
         acquired: false,
-        reason: `lock held by pid ${existing.pid} for ${existing.label}`,
+        reason: `lock held by pid ${existing.payload.pid} for ${existing.payload.label}`,
         release: async () => {},
       };
     }

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -709,6 +709,148 @@ test("runOnce releases the current issue lock before restarting after a merged P
   assert.equal(listAllIssuesCalls, 2);
 });
 
+test("runOnce clears a stale active issue reservation before selecting the next runnable issue", async () => {
+  const fixture = await createSupervisorFixture();
+  const staleIssueNumber = 91;
+  const nextIssueNumber = 92;
+  const staleBranch = branchName(fixture.config, staleIssueNumber);
+  const nextBranch = branchName(fixture.config, nextIssueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: staleIssueNumber,
+    issues: {
+      [String(staleIssueNumber)]: createRecord({
+        issue_number: staleIssueNumber,
+        state: "implementing",
+        branch: staleBranch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${staleIssueNumber}`),
+        journal_path: null,
+        pr_number: null,
+        codex_session_id: "stale-session",
+        blocked_reason: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const staleIssue: GitHubIssue = {
+    number: staleIssueNumber,
+    title: "Previously active issue",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${staleIssueNumber}`,
+    state: "OPEN",
+  };
+  const nextIssue: GitHubIssue = {
+    number: nextIssueNumber,
+    title: "Higher-priority runnable issue",
+    body: "",
+    createdAt: "2026-03-13T00:05:00Z",
+    updatedAt: "2026-03-13T00:05:00Z",
+    url: `https://example.test/issues/${nextIssueNumber}`,
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [nextIssue, staleIssue],
+    listCandidateIssues: async () => [nextIssue, staleIssue],
+    getIssue: async (issueNumber: number) => (issueNumber === nextIssueNumber ? nextIssue : staleIssue),
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      assert.equal(branchName, nextBranch);
+      assert.equal(prNumber, null);
+      return null;
+    },
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /Dry run: would invoke Codex for issue #92\./);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  assert.equal(persisted.activeIssueNumber, nextIssueNumber);
+  assert.equal(persisted.issues[String(staleIssueNumber)]?.state, "implementing");
+  assert.equal(persisted.issues[String(staleIssueNumber)]?.codex_session_id, null);
+  assert.equal(persisted.issues[String(nextIssueNumber)]?.branch, nextBranch);
+});
+
+test("runOnce preserves a live active issue reservation when its issue lock is still owned", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 91;
+  const branch = branchName(fixture.config, issueNumber);
+  const lockPath = path.join(path.dirname(fixture.stateFile), "locks", "issues", `issue-${issueNumber}.lock`);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "implementing",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: null,
+        codex_session_id: null,
+        blocked_reason: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(
+    lockPath,
+    `${JSON.stringify({ pid: process.pid, label: `issue-${issueNumber}`, acquired_at: "2026-03-13T00:00:00.000Z" }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Still-active issue",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => {
+      throw new Error("unexpected resolvePullRequestForBranch call");
+    },
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /Skipped issue #91: lock held by pid /);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  assert.equal(persisted.activeIssueNumber, issueNumber);
+  assert.equal(persisted.issues[String(issueNumber)]?.codex_session_id, null);
+});
+
 test("runOnce reconciles inactive merging records whose tracked PR already merged", async () => {
   const fixture = await createSupervisorFixture();
   const mergedIssueNumber = 91;

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -7,7 +7,7 @@ import { GitHubClient } from "./github";
 import { findBlockingIssue, findParentIssuesReadyToClose } from "./issue-metadata";
 import { describeGsdIntegration } from "./gsd";
 import { hasMeaningfulJournalHandoff, issueJournalPath, readIssueJournal, syncIssueJournal } from "./journal";
-import { acquireFileLock, LockHandle } from "./lock";
+import { acquireFileLock, inspectFileLock, LockHandle } from "./lock";
 import { localReviewHasActionableFindings, runLocalReview, shouldRunLocalReview } from "./local-review";
 import { syncMemoryArtifacts } from "./memory";
 import { StateStore } from "./state-store";
@@ -94,6 +94,16 @@ function createIssueRecord(config: SupervisorConfig, issueNumber: number): Issue
 const MAX_PROCESSED_REVIEW_THREAD_IDS = 200;
 const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
 const COPILOT_REVIEWER_LOGIN = "copilot-pull-request-reviewer";
+const OWNER_GUARDED_ACTIVE_STATES = new Set<RunState>([
+  "planning",
+  "reproducing",
+  "implementing",
+  "local_review_fix",
+  "stabilizing",
+  "repairing_ci",
+  "resolving_conflict",
+  "addressing_review",
+]);
 
 function trimProcessedReviewThreadIds(ids: string[]): string[] {
   if (ids.length <= MAX_PROCESSED_REVIEW_THREAD_IDS) {
@@ -2035,6 +2045,41 @@ export class Supervisor {
     return path.resolve(path.dirname(this.config.stateFile), "locks", kind, `${safeKey}.lock`);
   }
 
+  private async reconcileStaleActiveIssueReservation(state: SupervisorStateFile): Promise<void> {
+    if (state.activeIssueNumber === null) {
+      return;
+    }
+
+    const record = state.issues[String(state.activeIssueNumber)] ?? null;
+    if (!record) {
+      state.activeIssueNumber = null;
+      await this.stateStore.save(state);
+      return;
+    }
+
+    if (!OWNER_GUARDED_ACTIVE_STATES.has(record.state)) {
+      return;
+    }
+
+    const issueLock = await inspectFileLock(this.lockPath("issues", `issue-${record.issue_number}`));
+    if (issueLock.status === "live") {
+      return;
+    }
+
+    if (record.codex_session_id) {
+      const sessionLock = await inspectFileLock(this.lockPath("sessions", `session-${record.codex_session_id}`));
+      if (sessionLock.status === "live") {
+        return;
+      }
+    }
+
+    state.issues[String(record.issue_number)] = this.stateStore.touch(record, {
+      codex_session_id: null,
+    });
+    state.activeIssueNumber = null;
+    await this.stateStore.save(state);
+  }
+
   private async selectIssueRecord(
     state: SupervisorStateFile,
     currentRecord: IssueRunRecord | null,
@@ -2874,6 +2919,7 @@ export class Supervisor {
   async runOnce(options: Pick<CliOptions, "dryRun">): Promise<string> {
     for (;;) {
       const state = await this.stateStore.load();
+      await this.reconcileStaleActiveIssueReservation(state);
       const authFailure = await handleAuthFailure(this.github, this.stateStore, state);
       if (authFailure) {
         return authFailure;


### PR DESCRIPTION
Closes #128
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented stale-state self-healing in [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-128/src/supervisor.ts) and [src/lock.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-128/src/lock.ts). The supervisor now clears an ownership-dependent active reservation when neither the issue lock nor the session lock has a live owner, and lock acquisition now removes malformed lock payloads instead of failing the cycle.

Focused coverage was added in [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-128/src/supervisor.test.ts) and [src/lock.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-128/src/lock.test.ts) for:
- stale active reservation gets released and the next runnable issue is selected
- malformed lock files are self-healed
- live lock ownership is preserved as a guard case

The issue journal was updated locally at [.codex-supervisor/issue-journal.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-128/.codex-supervisor/issue-journal.md). Checkpoint commit: `d6cff6f` (`Self-heal stale active issue and lock state`).

Summary: Added conservative self-healing for stale active-issue reservations and malformed stale lock files, with focused regression tests and a checkpoint commit.
State hint: draft_pr
Blocked reason: none
Tests: `npm test -- --test-name-pattern "stale active issue reservation|live active issue reserv...