### PR TITLE
Guardrail promotion candidate: require Copilot review arrival, not only request creation (#133)

### DIFF
--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -1,4 +1,21 @@
 {
   "version": 1,
-  "rules": []
+  "rules": [
+    {
+      "id": "copilot-review-arrival-lifecycle",
+      "title": "Separate Copilot request and arrival states",
+      "file": "src/github.ts",
+      "line": 205,
+      "summary": "Verify configured-bot review lifecycle stays requested until an actual configured-bot review or review-thread comment arrives.",
+      "rationale": "Merge readiness depends on distinguishing review request creation from real arrival, including paginated review-thread comments and propagation delays."
+    },
+    {
+      "id": "copilot-merge-readiness-arrival-gate",
+      "title": "Block merge until expected Copilot review arrives",
+      "file": "src/supervisor.ts",
+      "line": 1242,
+      "summary": "Require merge gating to keep waiting while a configured-bot review is expected and has not arrived, even if the request was already observed.",
+      "rationale": "Verifier coverage must prove merge cannot proceed before configured-bot review arrival, with request timestamps, missing timestamps, and timeout policy handled separately."
+    }
+  ]
 }

--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -123,3 +123,34 @@ test("loadRelevantVerifierGuardrails rejects malformed committed rules", async (
 
   await fs.rm(workspaceDir, { recursive: true, force: true });
 });
+
+test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecycle and merge gating", async () => {
+  const rules = await loadRelevantVerifierGuardrails({
+    workspacePath: process.cwd(),
+    changedFiles: ["src/github.ts", "src/supervisor.ts"],
+    limit: 10,
+  });
+
+  assert.deepEqual(rules, [
+    {
+      id: "copilot-review-arrival-lifecycle",
+      title: "Separate Copilot request and arrival states",
+      file: "src/github.ts",
+      line: 205,
+      summary:
+        "Verify configured-bot review lifecycle stays requested until an actual configured-bot review or review-thread comment arrives.",
+      rationale:
+        "Merge readiness depends on distinguishing review request creation from real arrival, including paginated review-thread comments and propagation delays.",
+    },
+    {
+      id: "copilot-merge-readiness-arrival-gate",
+      title: "Block merge until expected Copilot review arrives",
+      file: "src/supervisor.ts",
+      line: 1242,
+      summary:
+        "Require merge gating to keep waiting while a configured-bot review is expected and has not arrived, even if the request was already observed.",
+      rationale:
+        "Verifier coverage must prove merge cannot proceed before configured-bot review arrival, with request timestamps, missing timestamps, and timeout policy handled separately.",
+    },
+  ]);
+});


### PR DESCRIPTION
Closes #133
This PR was opened by codex-supervisor.
Latest Codex summary:

Added committed verifier guardrails for the Copilot request-vs-arrival lesson and locked them with a repo-level test. The rule set now covers both lifecycle hydration in [src/github.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-133/src/github.ts#L205) and merge gating in [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-133/src/supervisor.ts#L1242), with the committed wording stored in [docs/shared-memory/verifier-guardrails.json](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-133/docs/shared-memory/verifier-guardrails.json). The new repo assertion is in [src/verifier-guardrails.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-133/src/verifier-guardrails.test.ts).

This resolves the ambiguity in favor of `verifier` guardrails, not a new reviewer-rubric surface: the repo already has deterministic committed verifier guidance, while reviewer-rubric guidance would require a broader new committed mechanism. I committed the checkpoint as `d73d5d2` with message `Add Copilot arrival verifier guardrails`.

Summary: Added focused committed verifier guardrails requiring Copilot review arrival semantics for both lifecycle inference and merge gating, with a narrow repo-level test.
State hint: implementing
Blocked reason: none
Tests: `npm test -- --test-name-pattern "repo-committed verifier guardrails cover Copilot request-vs-arrival lifecycle and merge gating|loadRel...