### PR TITLE
Guardrail promotion candidate: converge merged PR state to done without manual cleanup (#134)

### DIFF
--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -16,6 +16,14 @@
       "line": 1242,
       "summary": "Require merge gating to keep waiting while a configured-bot review is expected and has not arrived, even if the request was already observed.",
       "rationale": "Verifier coverage must prove merge cannot proceed before configured-bot review arrival, with request timestamps, missing timestamps, and timeout policy handled separately."
+    },
+    {
+      "id": "merged-pr-state-convergence",
+      "title": "Reconcile merged PR truth into done state",
+      "file": "src/supervisor.ts",
+      "line": 1889,
+      "summary": "Verify merged PR reconciliation drives local supervisor state to done, leaves not-yet-merged PRs untouched, and preserves stale-state recovery boundaries.",
+      "rationale": "GitHub merge truth and local state convergence are separate concerns; tests should prove they reconcile deterministically without requiring manual cleanup."
     }
   ]
 }

--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -124,7 +124,7 @@ test("loadRelevantVerifierGuardrails rejects malformed committed rules", async (
   await fs.rm(workspaceDir, { recursive: true, force: true });
 });
 
-test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecycle and merge gating", async () => {
+test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecycle and merged-PR convergence", async () => {
   const rules = await loadRelevantVerifierGuardrails({
     workspacePath: process.cwd(),
     changedFiles: ["src/github.ts", "src/supervisor.ts"],
@@ -151,6 +151,16 @@ test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecy
         "Require merge gating to keep waiting while a configured-bot review is expected and has not arrived, even if the request was already observed.",
       rationale:
         "Verifier coverage must prove merge cannot proceed before configured-bot review arrival, with request timestamps, missing timestamps, and timeout policy handled separately.",
+    },
+    {
+      id: "merged-pr-state-convergence",
+      title: "Reconcile merged PR truth into done state",
+      file: "src/supervisor.ts",
+      line: 1889,
+      summary:
+        "Verify merged PR reconciliation drives local supervisor state to done, leaves not-yet-merged PRs untouched, and preserves stale-state recovery boundaries.",
+      rationale:
+        "GitHub merge truth and local state convergence are separate concerns; tests should prove they reconcile deterministically without requiring manual cleanup.",
     },
   ]);
 });


### PR DESCRIPTION
Closes #134
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a committed verifier guardrail in [docs/shared-memory/verifier-guardrails.json](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-134/docs/shared-memory/verifier-guardrails.json) that makes merged-PR convergence explicit: a merged PR must drive local supervisor state to `done`, not-yet-merged PRs must stay untouched, and stale-state recovery boundaries must remain intact. I also tightened [src/verifier-guardrails.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-134/src/verifier-guardrails.test.ts) so the repo-committed guardrail set now directly exercises that rule.

This keeps the existing code invariant and tests in `src/supervisor.test.ts` as the implementation proof, while promoting the lesson into durable verifier guidance. Checkpoint commit: `a9e0b8b` (`Add merged PR convergence verifier guardrail`).

Summary: Added a committed verifier guardrail for merged PR to `done` convergence and covered it with a focused guardrail-loading test; committed as `a9e0b8b`.
State hint: implementing
Blocked reason: none
Tests: `npm test -- src/verifier-guardrails.test.ts`; `npm run guardrails:check`
Failure signature: none
Next action: Decide whether reviewer-side wording needs a separate committed mechanism or should remain covered by the existing supervisor reconciliation tests and verifier guardrail