### PR TITLE
Add verifier guardrails for malformed guardrail inputs

### DIFF
--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -2,12 +2,28 @@
   "version": 1,
   "rules": [
     {
+      "id": "committed-guardrails-malformed-input",
+      "title": "Differentiate missing and malformed committed guardrails",
+      "file": "src/committed-guardrails.ts",
+      "line": 289,
+      "summary": "Verify optional committed guardrail files remain a no-op when absent or blank, but malformed JSON, schema violations, duplicates, and oversize payloads fail loudly with actionable errors.",
+      "rationale": "Silent fallback is only safe for genuinely missing optional inputs; malformed committed guardrails corrupt durable reviewer guidance and must stop the run instead of degrading quietly."
+    },
+    {
       "id": "copilot-review-arrival-lifecycle",
       "title": "Separate Copilot request and arrival states",
       "file": "src/github.ts",
       "line": 205,
       "summary": "Verify configured-bot review lifecycle stays requested until an actual configured-bot review or review-thread comment arrives.",
       "rationale": "Merge readiness depends on distinguishing review request creation from real arrival, including paginated review-thread comments and propagation delays."
+    },
+    {
+      "id": "local-review-repair-context-malformed-input",
+      "title": "Fail loudly on malformed local-review repair context",
+      "file": "src/supervisor.ts",
+      "line": 187,
+      "summary": "Verify local-review repair context returns null only when the summary or derived findings artifact is genuinely absent, while malformed findings JSON or malformed committed guardrails abort repair-context loading.",
+      "rationale": "Repair prompts can safely continue without optional history, but silently dropping malformed findings or committed guardrails hides correctness risks and breaks the learning loop."
     },
     {
       "id": "copilot-merge-readiness-arrival-gate",

--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -143,6 +143,16 @@ test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecy
         "Merge readiness depends on distinguishing review request creation from real arrival, including paginated review-thread comments and propagation delays.",
     },
     {
+      id: "local-review-repair-context-malformed-input",
+      title: "Fail loudly on malformed local-review repair context",
+      file: "src/supervisor.ts",
+      line: 187,
+      summary:
+        "Verify local-review repair context returns null only when the summary or derived findings artifact is genuinely absent, while malformed findings JSON or malformed committed guardrails abort repair-context loading.",
+      rationale:
+        "Repair prompts can safely continue without optional history, but silently dropping malformed findings or committed guardrails hides correctness risks and breaks the learning loop.",
+    },
+    {
       id: "copilot-merge-readiness-arrival-gate",
       title: "Block merge until expected Copilot review arrives",
       file: "src/supervisor.ts",
@@ -163,4 +173,40 @@ test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecy
         "GitHub merge truth and local state convergence are separate concerns; tests should prove they reconcile deterministically without requiring manual cleanup.",
     },
   ]);
+});
+
+test("repo-committed verifier guardrails cover malformed guardrails and repair-context failure boundaries", async () => {
+  const rules = await loadRelevantVerifierGuardrails({
+    workspacePath: process.cwd(),
+    changedFiles: ["src/committed-guardrails.ts", "src/supervisor.ts"],
+    limit: 10,
+  });
+
+  assert.deepEqual(
+    rules.filter((rule) =>
+      ["committed-guardrails-malformed-input", "local-review-repair-context-malformed-input"].includes(rule.id),
+    ),
+    [
+      {
+        id: "committed-guardrails-malformed-input",
+        title: "Differentiate missing and malformed committed guardrails",
+        file: "src/committed-guardrails.ts",
+        line: 289,
+        summary:
+          "Verify optional committed guardrail files remain a no-op when absent or blank, but malformed JSON, schema violations, duplicates, and oversize payloads fail loudly with actionable errors.",
+        rationale:
+          "Silent fallback is only safe for genuinely missing optional inputs; malformed committed guardrails corrupt durable reviewer guidance and must stop the run instead of degrading quietly.",
+      },
+      {
+        id: "local-review-repair-context-malformed-input",
+        title: "Fail loudly on malformed local-review repair context",
+        file: "src/supervisor.ts",
+        line: 187,
+        summary:
+          "Verify local-review repair context returns null only when the summary or derived findings artifact is genuinely absent, while malformed findings JSON or malformed committed guardrails abort repair-context loading.",
+        rationale:
+          "Repair prompts can safely continue without optional history, but silently dropping malformed findings or committed guardrails hides correctness risks and breaks the learning loop.",
+      },
+    ],
+  );
 });


### PR DESCRIPTION
## Summary
- add committed verifier rules for malformed committed guardrails and malformed local-review repair context
- add a focused verifier-guardrails coverage test that proves the durable guidance is committed
- keep the rule boundary explicit: absent optional inputs are a no-op, malformed inputs fail loudly

Closes #135
