### PR TITLE
Verifier guardrail test: avoid snapshotting the full returned rule array (#138)

### DIFF
--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -14,12 +14,15 @@ function assertRelevantRuleIdsAndFiles(args: {
   assert.deepEqual(args.rules, [...args.rules].sort(compareVerifierGuardrails));
   assert.ok(args.rules.every((rule) => args.changedFiles.includes(rule.file)));
 
+  const byFileAndId = (left: { id: string; file: string }, right: { id: string; file: string }): number =>
+    `${left.file}:${left.id}`.localeCompare(`${right.file}:${right.id}`);
   const expectedIds = new Set(args.expected.map((rule) => rule.id));
   assert.deepEqual(
     args.rules
       .filter((rule) => expectedIds.has(rule.id))
-      .map(({ id, file }) => ({ id, file })),
-    args.expected,
+      .map(({ id, file }) => ({ id, file }))
+      .sort(byFileAndId),
+    [...args.expected].sort(byFileAndId),
   );
 }
 


### PR DESCRIPTION
Closes #138
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the repo-backed verifier guardrail tests in [src/verifier-guardrails.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-138/src/verifier-guardrails.test.ts). The brittle whole-array snapshots were replaced with a helper that still enforces deterministic sort order and changed-file relevance, but now only requires the expected `id`/`file` pairs to be present. That keeps the test stable if unrelated committed guardrails are later added for the same files.

Focused verification passed with `npx tsx --test src/verifier-guardrails.test.ts`, and I committed the change as `74e6eb5` (`Relax verifier guardrail subset assertions`). I also updated the ignored issue journal in the worktree as requested.

Summary: Relaxed verifier guardrail repo-backed tests to assert sorted subset membership by expected id/file pairs instead of exact full-array snapshots
State hint: local_review
Blocked reason: none
Tests: `npx tsx --test src/verifier-guardrails.test.ts`
Failure signature: none
Next action: Open or update the PR for `codex/issue-138` if the supervisor wants an early reviewable checkpoint