### PR TITLE
Supervisor: refresh cached Copilot lifecycle after request/arrival changes on the same PR head (#141)

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -237,6 +237,134 @@ test("GitHubClient hydrates Copilot arrival from long review threads without tru
   assert.equal(pr.copilotReviewArrivedAt, "2026-03-13T02:24:00Z");
 });
 
+test("GitHubClient refreshes same-head Copilot lifecycle transitions from not_requested to requested to arrived", async () => {
+  const config = createConfig();
+  let nowMs = Date.parse("2026-03-13T01:00:00Z");
+  const lifecycleResponses = [
+    {
+      reviewRequests: { nodes: [] },
+      reviews: { nodes: [] },
+      reviewThreads: { nodes: [] },
+      timelineItems: { nodes: [] },
+    },
+    {
+      reviewRequests: {
+        nodes: [
+          {
+            requestedReviewer: {
+              login: "copilot-pull-request-reviewer",
+            },
+          },
+        ],
+      },
+      reviews: { nodes: [] },
+      reviewThreads: { nodes: [] },
+      timelineItems: {
+        nodes: [
+          {
+            __typename: "ReviewRequestedEvent",
+            createdAt: "2026-03-13T01:02:03Z",
+            requestedReviewer: {
+              login: "copilot-pull-request-reviewer",
+            },
+          },
+        ],
+      },
+    },
+    {
+      reviewRequests: { nodes: [] },
+      reviews: {
+        nodes: [
+          {
+            submittedAt: "2026-03-13T01:03:04Z",
+            author: {
+              login: "copilot-pull-request-reviewer",
+            },
+          },
+        ],
+      },
+      reviewThreads: { nodes: [] },
+      timelineItems: {
+        nodes: [
+          {
+            __typename: "ReviewRequestedEvent",
+            createdAt: "2026-03-13T01:02:03Z",
+            requestedReviewer: {
+              login: "copilot-pull-request-reviewer",
+            },
+          },
+        ],
+      },
+    },
+  ];
+  let lifecycleCallCount = 0;
+  const client = new GitHubClient(
+    config,
+    async (_command, args) => {
+      if (args[0] === "pr" && args[1] === "view") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            number: 44,
+            title: "Same head lifecycle transition",
+            url: "https://example.test/pr/44",
+            state: "OPEN",
+            createdAt: "2026-03-13T00:00:00Z",
+            updatedAt: "2026-03-13T00:00:00Z",
+            isDraft: false,
+            reviewDecision: null,
+            mergeStateStatus: "CLEAN",
+            mergeable: "MERGEABLE",
+            headRefName: "codex/issue-141",
+            headRefOid: "head-44",
+            mergedAt: null,
+          }),
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "api" && args[1] === "graphql") {
+        const lifecycle = lifecycleResponses[lifecycleCallCount] ?? lifecycleResponses.at(-1);
+        lifecycleCallCount += 1;
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: lifecycle,
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+
+      throw new Error(`Unexpected args: ${args.join(" ")}`);
+    },
+    async () => {},
+    () => nowMs,
+  );
+
+  const first = await client.getPullRequest(44);
+  nowMs += 31_000;
+  const second = await client.getPullRequest(44);
+  nowMs += 31_000;
+  const third = await client.getPullRequest(44);
+
+  assert.equal(first.copilotReviewState, "not_requested");
+  assert.equal(first.copilotReviewRequestedAt, null);
+  assert.equal(first.copilotReviewArrivedAt, null);
+
+  assert.equal(second.copilotReviewState, "requested");
+  assert.equal(second.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
+  assert.equal(second.copilotReviewArrivedAt, null);
+
+  assert.equal(third.copilotReviewState, "arrived");
+  assert.equal(third.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
+  assert.equal(third.copilotReviewArrivedAt, "2026-03-13T01:03:04Z");
+  assert.equal(lifecycleCallCount, 3);
+});
+
 test("GitHubClient fetches the newest unresolved review thread comments", async () => {
   const config = createConfig();
   let reviewThreadQuery: string | null = null;

--- a/src/github.ts
+++ b/src/github.ts
@@ -12,6 +12,8 @@ import { parseJson, truncate } from "./utils";
 
 const TRANSIENT_GITHUB_RETRY_LIMIT = 2;
 const TRANSIENT_GITHUB_RETRY_BASE_DELAY_MS = 200;
+const COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS = 30_000;
+const COPILOT_REVIEW_CACHE_MAX_ENTRIES = 128;
 
 export type GitHubCommandRunner = (
   command: string,
@@ -133,6 +135,12 @@ export interface CopilotReviewLifecycle {
   state: CopilotReviewState;
   requestedAt: string | null;
   arrivedAt: string | null;
+}
+
+interface CachedCopilotReviewLifecycleEntry {
+  fetchedAtMs: number;
+  state: CopilotReviewState | null;
+  promise: Promise<CopilotReviewLifecycle>;
 }
 
 function mapCheckBucket(args: {
@@ -357,12 +365,13 @@ function sanitizeGhCommandMessage(message: string, args: string[]): string {
 }
 
 export class GitHubClient {
-  private readonly copilotReviewLifecycleCache = new Map<string, Promise<CopilotReviewLifecycle>>();
+  private readonly copilotReviewLifecycleCache = new Map<string, CachedCopilotReviewLifecycleEntry>();
 
   constructor(
     private readonly config: SupervisorConfig,
     private readonly commandRunner: GitHubCommandRunner = runCommand,
     private readonly delay: (ms: number) => Promise<void> = sleep,
+    private readonly now: () => number = Date.now,
   ) {}
 
   private async runGhCommand(args: string[], options: CommandOptions = {}): Promise<CommandResult> {
@@ -603,6 +612,71 @@ export class GitHubClient {
     }
 
     return this.findLatestPullRequestForBranch(branch);
+  }
+
+  private getCachedCopilotReviewLifecycle(
+    cacheKey: string,
+    nowMs: number,
+  ): Promise<CopilotReviewLifecycle> | null {
+    const cachedLifecycle = this.copilotReviewLifecycleCache.get(cacheKey);
+    if (!cachedLifecycle) {
+      return null;
+    }
+
+    if (cachedLifecycle.state === null) {
+      this.copilotReviewLifecycleCache.delete(cacheKey);
+      this.copilotReviewLifecycleCache.set(cacheKey, cachedLifecycle);
+      return cachedLifecycle.promise;
+    }
+
+    if (cachedLifecycle.state === "arrived") {
+      this.copilotReviewLifecycleCache.delete(cacheKey);
+      this.copilotReviewLifecycleCache.set(cacheKey, cachedLifecycle);
+      return cachedLifecycle.promise;
+    }
+
+    if (nowMs - cachedLifecycle.fetchedAtMs < COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS) {
+      this.copilotReviewLifecycleCache.delete(cacheKey);
+      this.copilotReviewLifecycleCache.set(cacheKey, cachedLifecycle);
+      return cachedLifecycle.promise;
+    }
+
+    this.copilotReviewLifecycleCache.delete(cacheKey);
+    return null;
+  }
+
+  private setCachedCopilotReviewLifecycle(
+    cacheKey: string,
+    lifecyclePromiseFactory: () => Promise<CopilotReviewLifecycle>,
+  ): Promise<CopilotReviewLifecycle> {
+    const cacheEntry: CachedCopilotReviewLifecycleEntry = {
+      fetchedAtMs: this.now(),
+      state: null,
+      promise: Promise.resolve({ state: "not_requested", requestedAt: null, arrivedAt: null }),
+    };
+    const lifecyclePromise = lifecyclePromiseFactory()
+      .then((lifecycle) => {
+        cacheEntry.fetchedAtMs = this.now();
+        cacheEntry.state = lifecycle.state;
+        return lifecycle;
+      })
+      .catch((error) => {
+        this.copilotReviewLifecycleCache.delete(cacheKey);
+        throw error;
+      });
+    cacheEntry.promise = lifecyclePromise;
+    this.copilotReviewLifecycleCache.delete(cacheKey);
+    this.copilotReviewLifecycleCache.set(cacheKey, cacheEntry);
+
+    while (this.copilotReviewLifecycleCache.size > COPILOT_REVIEW_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.copilotReviewLifecycleCache.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.copilotReviewLifecycleCache.delete(oldestKey);
+    }
+
+    return lifecyclePromise;
   }
 
   async getMergedPullRequestsClosingIssue(issueNumber: number): Promise<GitHubPullRequest[]> {
@@ -896,7 +970,7 @@ export class GitHubClient {
     }
 
     const cacheKey = `${pr.number}:${pr.headRefOid}`;
-    const cachedLifecycle = this.copilotReviewLifecycleCache.get(cacheKey);
+    const cachedLifecycle = this.getCachedCopilotReviewLifecycle(cacheKey, this.now());
     if (cachedLifecycle) {
       const lifecycle = await cachedLifecycle;
       return {
@@ -907,8 +981,10 @@ export class GitHubClient {
       };
     }
 
-    const lifecyclePromise = this.getCopilotReviewLifecycle(pr.number);
-    this.copilotReviewLifecycleCache.set(cacheKey, lifecyclePromise);
+    const lifecyclePromise = this.setCachedCopilotReviewLifecycle(
+      cacheKey,
+      () => this.getCopilotReviewLifecycle(pr.number),
+    );
 
     try {
       const lifecycle = await lifecyclePromise;
@@ -919,7 +995,6 @@ export class GitHubClient {
         copilotReviewArrivedAt: lifecycle.arrivedAt,
       };
     } catch (error) {
-      this.copilotReviewLifecycleCache.delete(cacheKey);
       const message = error instanceof Error ? error.message : String(error);
       console.warn(`Failed to hydrate Copilot review lifecycle for PR #${pr.number}: ${truncate(message, 500) ?? "unknown error"}`);
       return {


### PR DESCRIPTION
Closes #141
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the same-head Copilot lifecycle refresh fix in [src/github.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-141/src/github.ts) and added a focused regression in [src/github.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-141/src/github.test.ts). The cache now keeps in-flight dedupe, refreshes transitional `not_requested` and `requested` states after 30 seconds, keeps `arrived` cached for the same head, and caps the cache at 128 entries.

I also updated the local issue journal at [.codex-supervisor/issue-journal.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-141/.codex-supervisor/issue-journal.md) and created checkpoint commit `587c99d` (`Refresh cached Copilot lifecycle on same head`).

Verification ran with `npx tsx --test src/github.test.ts` and `npm run build`.

Summary: Added a focused same-head lifecycle regression test and replaced the forever-per-head Copilot lifecycle cache with a bounded, state-aware refresh policy.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/github.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-141` with commit `587c99d` and continue broader verification if needed