### PR TITLE
Verifier guardrail: align merged-PR convergence rule and test with the actual done-state transition boundary (#145)

### DIFF
--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -37,7 +37,7 @@
       "id": "merged-pr-state-convergence",
       "title": "Reconcile merged PR truth into done state",
       "file": "src/supervisor.ts",
-      "line": 1889,
+      "line": 1929,
       "summary": "Verify merged PR reconciliation drives local supervisor state to done, leaves not-yet-merged PRs untouched, and preserves stale-state recovery boundaries.",
       "rationale": "GitHub merge truth and local state convergence are separate concerns; tests should prove they reconcile deterministically without requiring manual cleanup."
     }

--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -9,7 +9,7 @@ import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";
 function assertRelevantRuleIdsAndFiles(args: {
   rules: Awaited<ReturnType<typeof loadRelevantVerifierGuardrails>>;
   changedFiles: string[];
-  expected: Array<{ id: string; file: string }>;
+  expected: Array<{ id: string; file: string; line?: number | null }>;
 }): void {
   assert.deepEqual(args.rules, [...args.rules].sort(compareVerifierGuardrails));
   assert.ok(args.rules.every((rule) => args.changedFiles.includes(rule.file)));
@@ -18,13 +18,19 @@ function assertRelevantRuleIdsAndFiles(args: {
     "repo-backed verifier guardrail line hints must stay optional or positive integers",
   );
 
-  const byFileAndId = (left: { id: string; file: string }, right: { id: string; file: string }): number =>
+  const byFileAndId = (
+    left: { id: string; file: string; line?: number | null },
+    right: { id: string; file: string; line?: number | null },
+  ): number =>
     `${left.file}:${left.id}`.localeCompare(`${right.file}:${right.id}`);
-  const expectedIds = new Set(args.expected.map((rule) => rule.id));
+  const expectedById = new Map(args.expected.map((rule) => [rule.id, rule]));
   assert.deepEqual(
     args.rules
-      .filter((rule) => expectedIds.has(rule.id))
-      .map(({ id, file }) => ({ id, file }))
+      .filter((rule) => expectedById.has(rule.id))
+      .map(({ id, file, line }) => {
+        const expectedRule = expectedById.get(id);
+        return { id, file, ...(expectedRule?.line !== undefined ? { line } : {}) };
+      })
       .sort(byFileAndId),
     [...args.expected].sort(byFileAndId),
   );
@@ -214,7 +220,7 @@ test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecy
       { id: "copilot-review-arrival-lifecycle", file: "src/github.ts" },
       { id: "local-review-repair-context-malformed-input", file: "src/supervisor.ts" },
       { id: "copilot-merge-readiness-arrival-gate", file: "src/supervisor.ts" },
-      { id: "merged-pr-state-convergence", file: "src/supervisor.ts" },
+      { id: "merged-pr-state-convergence", file: "src/supervisor.ts", line: 1929 },
     ],
   });
 });


### PR DESCRIPTION
Closes #145
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the committed verifier guardrail so `merged-pr-state-convergence` now points at the real stale-boundary logic in [verifier-guardrails.json](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-145/docs/shared-memory/verifier-guardrails.json#L37), aligning it with `issueUpdatedAtMs > mergedAtMs` in [supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-145/src/supervisor.ts#L1929). I also tightened [verifier-guardrails.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-145/src/verifier-guardrails.test.ts#L9) so this line hint is asserted without making the rest of the guardrail coverage brittle.

Focused verification passed with the narrowed guardrail tests and `npm run guardrails:check`. The change is committed on `codex/issue-145` as `55ec75b` (`Align merged PR guardrail boundary`). I updated the local issue journal as requested; that file is gitignored, so it remains a workspace-only state update.

Summary: Aligned the merged-PR verifier guardrail and its test with the actual done-state/stale-boundary logic and committed the fix as `55ec75b`.
State hint: local_review
Blocked reason: none
Tests: `npm test -- --test-name-pattern="repo-committed verifier guardrails cover Copilot request-vs-arrival lifecycle and merged-PR convergence|repo-committed verifier guardrails cover malformed guardrails and repair-context failure boundaries"`; `npm run guardrails:check`
Failure signature: none
Next ac...