### PR TITLE
Execution-ready gate: lint issue bodies for required metadata (#155)

### DIFF
--- a/src/issue-metadata.test.ts
+++ b/src/issue-metadata.test.ts
@@ -118,3 +118,24 @@ Add deterministic issue-body linting for execution-ready metadata.`,
     missingRecommended: ["depends on", "execution order"],
   });
 });
+
+test("lintExecutionReadyIssueBody treats ##Heading without a space as the next section", () => {
+  const issue = createIssue({
+    body: `## Summary
+
+##Scope
+- keep scope content out of summary
+
+## Acceptance criteria
+- summary is still missing
+
+## Verification
+- npx tsx --test src/issue-metadata.test.ts`,
+  });
+
+  assert.deepEqual(lintExecutionReadyIssueBody(issue), {
+    isExecutionReady: false,
+    missingRequired: ["summary"],
+    missingRecommended: ["depends on", "execution order"],
+  });
+});

--- a/src/issue-metadata.ts
+++ b/src/issue-metadata.ts
@@ -42,6 +42,10 @@ function parseList(input: string): string[] {
     .filter(Boolean);
 }
 
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function parseExecutionOrder(
   body: string,
 ): { executionOrderIndex: number; executionOrderTotal: number } | null {
@@ -68,7 +72,7 @@ function parseExecutionOrder(
 
 function findMarkdownSectionContent(body: string, title: string): string | null {
   const lines = body.split(/\r?\n/);
-  const headingPattern = new RegExp(`^\\s*##\\s*${title}\\s*$`, "i");
+  const headingPattern = new RegExp(`^\\s*##\\s*${escapeRegExp(title)}\\s*$`, "i");
 
   for (let index = 0; index < lines.length; index += 1) {
     if (!headingPattern.test(lines[index])) {
@@ -77,7 +81,7 @@ function findMarkdownSectionContent(body: string, title: string): string | null 
 
     const sectionLines: string[] = [];
     for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
-      if (/^\s*##\s+\S/.test(lines[cursor])) {
+      if (/^\s*##\s*\S/.test(lines[cursor])) {
         break;
       }
 


### PR DESCRIPTION
Closes #155
This PR was opened by codex-supervisor.
Latest Codex summary:

Added deterministic execution-ready issue-body linting in [`src/issue-metadata.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-155/src/issue-metadata.ts) and focused coverage in [`src/issue-metadata.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-155/src/issue-metadata.test.ts). The new lint reports missing required metadata (`Summary`, `Scope`, `Acceptance criteria`, `Verification`) separately from strongly recommended metadata (`Depends on`, `Execution order`), and `parseIssueMetadata` now accepts both the existing `## Execution order` block and the single-line `Execution order: N of M` form used in live issue bodies.

Focused verification passed with `npx tsx --test src/issue-metadata.test.ts` and `npm run build`. I also updated the local issue journal handoff in `.codex-supervisor/issue-journal.md`; that file is ignored, so it was not included in the commit. Checkpoint commit: `b92a465` (`Add execution-ready issue body lint`).

Summary: Added execution-ready issue-body linting and support for single-line execution-order metadata, with focused tests and a checkpoint commit.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/issue-metadata.test.ts`; `npm run build`
Failure signature: none
Next action: Run the full `npm test` suite, then open or update a draft PR for branch `codex/issue-155` if everything stays green.