### PR TITLE
Execution-ready gate: show readiness reasons in status output (#157)

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -954,6 +954,119 @@ Missing execution-ready metadata.`,
   );
 });
 
+test("status marks skipped readiness checks explicitly and uses non-conflicting inner separators", async () => {
+  const fixture = await createSupervisorFixture();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "91": createRecord({
+        issue_number: 91,
+        state: "done",
+        branch: branchName(fixture.config, 91),
+        workspace: path.join(fixture.workspaceRoot, "issue-91"),
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+      }),
+      "92": createRecord({
+        issue_number: 92,
+        state: "done",
+        branch: branchName(fixture.config, 92),
+        workspace: path.join(fixture.workspaceRoot, "issue-92"),
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+      }),
+      "93": createRecord({
+        issue_number: 93,
+        state: "queued",
+        branch: branchName(fixture.config, 93),
+        workspace: path.join(fixture.workspaceRoot, "issue-93"),
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+        attempt_count: 1,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const predecessorOne: GitHubIssue = {
+    number: 91,
+    title: "Step 1",
+    body: `## Summary
+Finish step 1.
+
+## Scope
+- start the execution order chain
+
+## Acceptance criteria
+- step 1 completes first
+
+## Verification
+- npm test -- src/supervisor.test.ts
+
+Part of: #150
+Execution order: 1 of 3`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/91",
+    state: "CLOSED",
+  };
+  const predecessorTwo: GitHubIssue = {
+    number: 92,
+    title: "Step 2",
+    body: `## Summary
+Finish step 2.
+
+## Scope
+- land after step 1
+
+## Acceptance criteria
+- step 2 completes after step 1
+
+## Verification
+- npm test -- src/supervisor.test.ts
+
+Part of: #150
+Execution order: 2 of 3`,
+    createdAt: "2026-03-13T00:05:00Z",
+    updatedAt: "2026-03-13T00:05:00Z",
+    url: "https://example.test/issues/92",
+    state: "CLOSED",
+  };
+  const skippedRequirementsIssue: GitHubIssue = {
+    number: 93,
+    title: "Step 3",
+    body: `## Summary
+Existing in-flight issue with missing readiness metadata.
+
+Depends on: #91, #92
+Part of: #150
+Execution order: 3 of 3`,
+    createdAt: "2026-03-13T00:10:00Z",
+    updatedAt: "2026-03-13T00:10:00Z",
+    url: "https://example.test/issues/93",
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [predecessorOne, predecessorTwo, skippedRequirementsIssue],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status();
+
+  assert.match(
+    status,
+    /runnable_issues=#93 ready=requirements_skipped\+depends_on_satisfied:91\|92\+execution_order_satisfied:91\|92/,
+  );
+});
+
 test("runOnce still prefers a ready issue over dependency-blocked candidates", async () => {
   const fixture = await createSupervisorFixture();
   const dependencyIssueNumber = 91;

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1405,14 +1405,12 @@ async function buildReadinessSummary(
     }
 
     const existing = state.issues[String(issue.number)];
-    if (shouldEnforceExecutionReady(existing)) {
-      const readiness = lintExecutionReadyIssueBody(issue);
-      if (!readiness.isExecutionReady) {
-        blocked.push(
-          `#${issue.number} blocked_by=requirements:${formatExecutionReadyMissingFields(readiness.missingRequired)}`,
-        );
-        continue;
-      }
+    const readiness = lintExecutionReadyIssueBody(issue);
+    if (shouldEnforceExecutionReady(existing) && !readiness.isExecutionReady) {
+      blocked.push(
+        `#${issue.number} blocked_by=requirements:${formatExecutionReadyMissingFields(readiness.missingRequired)}`,
+      );
+      continue;
     }
 
     const blockingIssue = findBlockingIssue(issue, issues, state);
@@ -1428,7 +1426,7 @@ async function buildReadinessSummary(
       continue;
     }
 
-    runnable.push(`#${issue.number} ready=${formatRunnableReadinessReason(issue, issues, state)}`);
+    runnable.push(`#${issue.number} ready=${formatRunnableReadinessReason(issue, issues, state, readiness.isExecutionReady)}`);
   }
 
   return [
@@ -1441,9 +1439,10 @@ function formatRunnableReadinessReason(
   issue: GitHubIssue,
   issues: GitHubIssue[],
   state: SupervisorStateFile,
+  isExecutionReady: boolean,
 ): string {
   const metadata = parseIssueMetadata(issue);
-  const reasons = ["execution_ready"];
+  const reasons = [isExecutionReady ? "execution_ready" : "requirements_skipped"];
 
   if (metadata.dependsOn.length > 0) {
     const satisfiedDependencies = metadata.dependsOn.filter(
@@ -1451,7 +1450,7 @@ function formatRunnableReadinessReason(
     );
 
     if (satisfiedDependencies.length > 0) {
-      reasons.push(`depends_on_satisfied:${satisfiedDependencies.join(",")}`);
+      reasons.push(`depends_on_satisfied:${satisfiedDependencies.join("|")}`);
     }
   }
 
@@ -1481,7 +1480,7 @@ function formatRunnableReadinessReason(
       .filter((predecessorNumber) => state.issues[String(predecessorNumber)]?.state === "done");
 
     if (clearedPredecessors.length > 0) {
-      reasons.push(`execution_order_satisfied:${clearedPredecessors.join(",")}`);
+      reasons.push(`execution_order_satisfied:${clearedPredecessors.join("|")}`);
     }
   }
 


### PR DESCRIPTION
Closes #157
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated `status` so runnable entries now carry compact readiness reasons instead of just issue numbers. The change is in [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-157/src/supervisor.ts#L1393) and adds `ready=...` payloads such as `execution_ready+depends_on_satisfied:91`, while keeping blocked entries on the existing concise `blocked_by=...` format. I also added focused operator-visible coverage in [src/supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-157/src/supervisor.test.ts#L890).

Checkpoint commit: `2bfaa6b` (`Show readiness reasons in status output`). Focused verification passed with `npx tsx --test src/supervisor.test.ts`.

Summary: Added readiness reasons to `status` runnable output and covered it with a focused supervisor test; committed as `2bfaa6b`.
State hint: implementing
Blocked reason: none
Tests: `npm test -- --test-name-pattern "status shows readiness reasons for runnable and requirements-blocked issues"`; `npx tsx --test src/supervisor.test.ts`
Failure signature: none
Next action: Open or update the draft PR for branch `codex/issue-157` if one is needed for review.