### PR TITLE
Local Review Swarm merge gate: promote block_merge as the recommended default (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ If you run the supervisor this way, keep the service model simple:
 
 ## Local review
 
-`codex-supervisor` can optionally run a local advisory review swarm before a draft PR is marked ready.
+`codex-supervisor` can optionally run a local review swarm as part of PR gating.
 
 This is designed to reduce dependence on GitHub-hosted auto review. The supervisor:
 
@@ -409,7 +409,7 @@ Historical local review artifacts are intentionally retained until explicit clea
 
 Use explicit `localReviewRoles` when you want full manual control.
 
-This review does not mutate code. By default, `localReviewPolicy` is `block_ready`, so actionable findings keep a draft PR from becoming ready until the branch is updated and re-reviewed.
+This review does not mutate code. The recommended starting policy is `block_merge`, so actionable findings can still block merge on the current ready PR head while the normal draft-to-ready handoff stays intact.
 
 When `localReviewHighSeverityAction` is `retry` and the verifier confirms at least one high-severity finding, the supervisor enters a dedicated `local_review_fix` repair mode. That prompt is narrowed to the compressed root-cause list from the local-review artifact and, when the artifact identifies affected files, it tells Codex to inspect those files first instead of treating the turn as general checkpoint maintenance while the PR or merge is blocked.
 
@@ -417,9 +417,9 @@ During `local_review_fix`, active local-review blockers take priority over stale
 
 If you want stronger enforcement without giving the review swarm destructive powers, use policy gates instead of auto-closing PRs:
 
-- `advisory`: save findings only
+- `block_merge`: recommended default path; allow the PR to become ready, but stop merge while actionable findings remain; the swarm can re-run after ready PR head updates
 - `block_ready`: keep draft PRs from becoming ready when actionable findings exist
-- `block_merge`: allow the PR to become ready, but stop merge while actionable findings remain; the swarm can re-run after ready PR head updates
+- `advisory`: save findings only
 
 For high-severity findings, `localReviewHighSeverityAction` can either:
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -128,7 +128,7 @@ flowchart TD
 - role ごとに別 Codex turn を実行
 - Markdown と JSON artifact を保存
 - confidence threshold 以上の finding を actionable として扱う
-- policy に応じて `block_ready` / `block_merge` ができる
+- 推奨パスは `block_merge` で、必要に応じて `block_ready` / `advisory` を選べる
 
 代表的な role:
 

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -39,7 +39,7 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
   "localReviewRoles": [],
   "localReviewArtifactDir": "/Users/yourname/Dev/codex-supervisor/.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
-  "localReviewPolicy": "block_ready",
+  "localReviewPolicy": "block_merge",
   "localReviewHighSeverityAction": "retry",
   "reviewBotLogins": ["copilot-pull-request-reviewer"],
   "humanReviewBlocksMerge": true,
@@ -71,9 +71,10 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - `atlaspm` uses `Part of #...`, `Depends on: ...`, and `## Execution order`, so the built-in sequencing logic is enough.
 - If you use GSD for upstream planning, enable `gsdEnabled` and point `gsdPlanningFiles` at `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, and `STATE.md`.
 - Copilot review is expected to start automatically after the PR is marked ready.
-- A local advisory review swarm can run before `gh pr ready`, with Markdown (`head-<sha>.md`) and JSON (`head-<sha>.json`) artifacts written under the supervisor's `.local/reviews` directory.
+- A local review swarm should usually run with `localReviewPolicy: "block_merge"` so it acts as a practical merge gate, with Markdown (`head-<sha>.md`) and JSON (`head-<sha>.json`) artifacts written under the supervisor's `.local/reviews` directory.
 - Leaving `localReviewRoles` empty while `localReviewAutoDetect` is `true` lets the supervisor add repo-specific specialists such as `prisma_postgres_reviewer`, `migration_invariant_reviewer`, `contract_consistency_reviewer`, and workflow-oriented roles like `github_actions_semantics_reviewer`, `workflow_test_reviewer`, and `portability_reviewer` when the repo shape suggests them.
-- `localReviewPolicy: "block_ready"` keeps actionable local-review findings from advancing a draft PR to ready. `block_merge` allows the PR to become ready but still stops merge until the findings are resolved.
+- `localReviewPolicy: "block_merge"` is the recommended starting point because it allows normal ready-for-review flow while still blocking merge until actionable findings are resolved.
+- Use `block_ready` when you want the swarm to stop draft PRs before `gh pr ready`, and `advisory` when you only want saved findings without merge gating.
 - `localReviewHighSeverityAction: "retry"` sends high-severity local-review findings back into another implementation pass instead of allowing the PR to progress.
 - Findings below the configured confidence threshold stay in the raw role reports but are not counted as actionable.
 - Even with multiple local review roles, the reviewer turn should still read the generated context index and issue journal first, then open durable memory files only on demand.

--- a/docs/examples/atlaspm.supervisor.config.example.json
+++ b/docs/examples/atlaspm.supervisor.config.example.json
@@ -42,7 +42,7 @@
   "localReviewRoles": [],
   "localReviewArtifactDir": "/Users/yourname/Dev/codex-supervisor/.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
-  "localReviewPolicy": "block_ready",
+  "localReviewPolicy": "block_merge",
   "localReviewHighSeverityAction": "retry",
   "reviewBotLogins": [
     "copilot-pull-request-reviewer"

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -192,13 +192,15 @@ supervisor は、まず compact context index を読み、その後必要な dur
 
 ## local review swarm
 
-`codex-supervisor` は、local review swarm を pull request に対して実行できます。デフォルトの `localReviewPolicy` は `block_ready` なので、通常は draft PR を ready にする前に実行されます。`localReviewPolicy` を `block_merge` にすると、ready PR の head 更新時にも再実行できます。
+`codex-supervisor` は、pull request に対して local review swarm を実行できます。推奨される開始ポリシーは `block_merge` で、通常の ready-for-review の流れを保ちながら、現在の PR head に対して実用的な merge gate として動かせます。
 
 重要な点は次の通りです。
 
 - 各 role は別々の Codex turn で実行される
 - 挙動は `localReviewPolicy` で決まる
-- `advisory` は non-blocking、`block_ready` は draft から ready への進行を止め、`block_merge` は ready PR の merge を止める
+- `block_merge` は推奨される標準パスで、ready PR の merge を止め、ready PR の head 更新時にも再実行できる
+- `block_ready` はより早い段階で厳しく、draft から ready への進行を止める
+- `advisory` は non-blocking で、artifact を残したいが自動 gate は不要な場合に向く
 - findings は Markdown と JSON artifact に保存される
 - ここでも context 節約方針は同じで、まず compact context index と issue journal を読み、その後必要な durable memory だけを on-demand で開く
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,13 +186,15 @@ The supervisor reads a compact context index first, then opens durable memory fi
 
 ## Local review swarm
 
-`codex-supervisor` can run a local review swarm on pull requests. By default, `localReviewPolicy` is `block_ready`, so the swarm runs before a draft PR is marked ready. If you set `localReviewPolicy` to `block_merge`, it can also re-run on ready PR head updates.
+`codex-supervisor` can run a local review swarm on pull requests. The recommended starting policy is `block_merge`, because it keeps the normal ready-for-review flow while still making the swarm a practical merge gate on the current PR head.
 
 The important points are:
 
 - each role runs in a separate Codex turn
 - behavior is controlled by `localReviewPolicy`
-- `advisory` is non-blocking, `block_ready` gates draft-to-ready, and `block_merge` gates merge on ready PRs
+- `block_merge` is the recommended default path: it gates merge on ready PRs and re-runs on ready PR head updates
+- `block_ready` is stricter earlier in the flow: it gates draft-to-ready instead of merge
+- `advisory` is non-blocking and best when you want saved findings without automation gates
 - verifier-confirmed high-severity findings can trigger a dedicated `local_review_fix` turn that focuses on compressed root causes and the most relevant files
 - findings are saved as Markdown and JSON artifacts
 - the same context-budget policy still applies: read the compact context index and issue journal first, then open durable memory only on demand

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -138,3 +138,16 @@ test("loadConfig accepts explicit copilotReviewTimeoutAction", async (t) => {
 
   assert.equal(config.copilotReviewTimeoutAction, "block");
 });
+
+test("shipped example configs recommend block_merge for local review gating", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const examplePaths = [
+    path.join(rootDir, "supervisor.config.example.json"),
+    path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
+  ];
+
+  for (const examplePath of examplePaths) {
+    const raw = JSON.parse(await fs.readFile(examplePath, "utf8")) as { localReviewPolicy?: unknown };
+    assert.equal(raw.localReviewPolicy, "block_merge", `${path.relative(rootDir, examplePath)} should recommend block_merge`);
+  }
+});

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -44,7 +44,7 @@
   "localReviewRoles": [],
   "localReviewArtifactDir": "./.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
-  "localReviewPolicy": "block_ready",
+  "localReviewPolicy": "block_merge",
   "localReviewHighSeverityAction": "retry",
   "reviewBotLogins": [
     "copilot-pull-request-reviewer"


### PR DESCRIPTION
Closes #164
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the docs and shipped example configs to recommend `localReviewPolicy: "block_merge"` as the standard Local Review Swarm path, while still explaining when `block_ready` or `advisory` make sense. I also added a focused regression in [src/config.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-164/src/config.test.ts) that asserts both shipped example JSON files use `block_merge`.

The changes are committed on `codex/issue-164` at `b8823df` (`Promote block_merge in local review guidance`). Verification passed with `npx tsx --test src/config.test.ts` and `npx tsx --test src/*.test.ts`. `npm test` was not usable in this worktree because `tsx` was not installed on `PATH`, but the equivalent `npx` invocation succeeded.

Summary: Promoted `block_merge` to the recommended Local Review Swarm policy in docs/examples, added a focused example-config regression test, and committed the verified change as `b8823df`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/config.test.ts`; `npx tsx --test src/*.test.ts` (passed); `npm test` failed locally because `tsx` was not on `PATH`
Failure signature: none
Next action: Open or update the branch PR so the docs/example guidance change can be reviewed and merged.