### PR TITLE
Promote blocked local review default

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,8 @@ If you want stronger enforcement without giving the review swarm destructive pow
 
 For high-severity findings, `localReviewHighSeverityAction` can either:
 
-- `retry`: send the issue back into another repair pass, but only when the verifier confirms at least one high-severity finding
-- `blocked`: require explicit human intervention, but only when the verifier confirms at least one high-severity finding
+- `blocked`: safer default for solo operators; stop the merge and require explicit human intervention, but only when the verifier confirms at least one high-severity finding
+- `retry`: deterministic override for teams that want another repair pass automatically after the verifier confirms at least one high-severity finding
 
 The review artifacts distinguish between raw actionable findings from the review roles and verified findings confirmed by the verifier pass. `block_ready` and `block_merge` still react to raw actionable findings. The stronger high-severity actions above react only to verifier-confirmed high-severity findings, which reduces false positives without hiding the original review signal.
 

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -40,7 +40,7 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
   "localReviewArtifactDir": "/Users/yourname/Dev/codex-supervisor/.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
   "localReviewPolicy": "block_merge",
-  "localReviewHighSeverityAction": "retry",
+  "localReviewHighSeverityAction": "blocked",
   "reviewBotLogins": ["copilot-pull-request-reviewer"],
   "humanReviewBlocksMerge": true,
   "issueJournalRelativePath": ".codex-supervisor/issue-journal.md",
@@ -75,7 +75,8 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - Leaving `localReviewRoles` empty while `localReviewAutoDetect` is `true` lets the supervisor add repo-specific specialists such as `prisma_postgres_reviewer`, `migration_invariant_reviewer`, `contract_consistency_reviewer`, and workflow-oriented roles like `github_actions_semantics_reviewer`, `workflow_test_reviewer`, and `portability_reviewer` when the repo shape suggests them.
 - `localReviewPolicy: "block_merge"` is the recommended starting point because it allows normal ready-for-review flow while still blocking merge until actionable findings are resolved.
 - Use `block_ready` when you want the swarm to stop draft PRs before `gh pr ready`, and `advisory` when you only want saved findings without merge gating.
-- `localReviewHighSeverityAction: "retry"` sends high-severity local-review findings back into another implementation pass instead of allowing the PR to progress.
+- `localReviewHighSeverityAction: "blocked"` is the safer default for solo operators because verifier-confirmed high-severity findings stop the merge until a human decides the next step.
+- Switch to `localReviewHighSeverityAction: "retry"` when your team explicitly wants the supervisor to start another repair pass automatically after verifier-confirmed high-severity findings.
 - Findings below the configured confidence threshold stay in the raw role reports but are not counted as actionable.
 - Even with multiple local review roles, the reviewer turn should still read the generated context index and issue journal first, then open durable memory files only on demand.
 - `codexModelStrategy: "inherit"` means the supervisor follows the Codex CLI/App default model automatically. In practice, set the Codex default model to `GPT-5.4` and let the supervisor inherit it.

--- a/docs/examples/atlaspm.supervisor.config.example.json
+++ b/docs/examples/atlaspm.supervisor.config.example.json
@@ -43,7 +43,7 @@
   "localReviewArtifactDir": "/Users/yourname/Dev/codex-supervisor/.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
   "localReviewPolicy": "block_merge",
-  "localReviewHighSeverityAction": "retry",
+  "localReviewHighSeverityAction": "blocked",
   "reviewBotLogins": [
     "copilot-pull-request-reviewer"
   ],

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -451,6 +451,8 @@ local review swarm は、`gh pr ready` の前に走る optional review phase で
 
 artifact では、review role が出した raw actionable findings と verifier pass が確認した findings を分けて保存します。`block_ready` と `block_merge` は引き続き raw actionable findings に反応しますが、`localReviewHighSeverityAction` による強いエスカレーションは verifier が確認した high severity findings にだけ反応します。これにより、false positive の影響を減らせます。
 
+solo operator を前提にするなら、`localReviewHighSeverityAction: "blocked"` を基本にするのが安全です。verifier-confirmed な high severity findings が出たら merge を止めて、人が次の一手を明示的に決めてください。自動で repair pass をもう一度回したいチームだけ、明示的に `retry` を選びます。
+
 ## Codex への指示例
 
 ### supervisor を使う時

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -448,6 +448,8 @@ What it does not do by default:
 
 The artifacts keep raw actionable findings separate from verifier-confirmed findings. `block_ready` and `block_merge` still respond to raw actionable findings. `localReviewHighSeverityAction` only escalates on verifier-confirmed high-severity findings, which reduces false positives before the supervisor triggers a repair retry or manual block.
 
+For most solo-operator setups, prefer `localReviewHighSeverityAction: "blocked"` so verifier-confirmed high-severity findings stop the merge and force an explicit decision. Switch to `retry` only when you intentionally want the supervisor to launch another repair pass automatically.
+
 Older local review artifacts remain on disk unless you clean them up explicitly. For live triage, trust the `status` output first: `head=current` means the artifact for `reviewed_head_sha` matches `pr_head_sha`, while `head=stale` means the artifact is historical and a newer PR head needs another review run.
 
 If the supervisor sends the issue into `local_review_fix`, treat the active local-review blocker as the top priority. The repair prompt suppresses stale issue-journal `Next 1-3 actions` bullets so older checkpoint advice does not compete with the current blocker. If you need to force a temporary repair instruction anyway, write it explicitly in the journal as `- Operator override: ...`; that override remains visible in repair prompts.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -139,6 +139,32 @@ test("loadConfig accepts explicit copilotReviewTimeoutAction", async (t) => {
   assert.equal(config.copilotReviewTimeoutAction, "block");
 });
 
+test("loadConfig defaults localReviewHighSeverityAction to blocked", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+
+  assert.equal(config.localReviewHighSeverityAction, "blocked");
+});
+
 test("shipped example configs recommend block_merge for local review gating", async () => {
   const rootDir = path.resolve(__dirname, "..");
   const examplePaths = [
@@ -149,5 +175,22 @@ test("shipped example configs recommend block_merge for local review gating", as
   for (const examplePath of examplePaths) {
     const raw = JSON.parse(await fs.readFile(examplePath, "utf8")) as { localReviewPolicy?: unknown };
     assert.equal(raw.localReviewPolicy, "block_merge", `${path.relative(rootDir, examplePath)} should recommend block_merge`);
+  }
+});
+
+test("shipped example configs recommend blocked for high-severity local review findings", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const examplePaths = [
+    path.join(rootDir, "supervisor.config.example.json"),
+    path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
+  ];
+
+  for (const examplePath of examplePaths) {
+    const raw = JSON.parse(await fs.readFile(examplePath, "utf8")) as { localReviewHighSeverityAction?: unknown };
+    assert.equal(
+      raw.localReviewHighSeverityAction,
+      "blocked",
+      `${path.relative(rootDir, examplePath)} should recommend blocked for high-severity local review findings`,
+    );
   }
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -183,7 +183,7 @@ export function loadConfig(configPath?: string): SupervisorConfig {
       typeof raw.localReviewHighSeverityAction === "string" &&
       VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS.has(raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
         ? (raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
-        : "retry",
+        : "blocked",
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)
       ? raw.reviewBotLogins
           .filter((value): value is string => typeof value === "string" && value.trim() !== "")

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -45,7 +45,7 @@
   "localReviewArtifactDir": "./.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
   "localReviewPolicy": "block_merge",
-  "localReviewHighSeverityAction": "retry",
+  "localReviewHighSeverityAction": "blocked",
   "reviewBotLogins": [
     "copilot-pull-request-reviewer"
   ],


### PR DESCRIPTION
## Summary
- default `localReviewHighSeverityAction` to `blocked`
- update shipped example configs to recommend `blocked`
- clarify docs for when to prefer `blocked` versus `retry`

## Testing
- npx tsx --test src/config.test.ts
- npm run build

Closes #165