### PR TITLE
Clarify stale local review head drift

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -2716,6 +2716,7 @@ test("formatDetailedStatus shows blocking local review status for current PR hea
     status,
     /local_review gating=yes policy=block_ready findings=3 root_causes=0 max_severity=high verified_findings=0 verified_max_severity=none head=current reviewed_head_sha=deadbeef pr_head_sha=deadbeef ran_at=2026-03-11T14:05:00Z signature=none repeated=0 stalled=no/,
   );
+  assert.doesNotMatch(status, /needs_review_run=/);
   assert.match(status, /external_review head=none reviewed_head_sha=none matched=0 near_match=0 missed=0/);
 });
 
@@ -3034,7 +3035,7 @@ test("formatDetailedStatus marks stale local review as non-gating", () => {
 
   assert.match(
     status,
-    /local_review gating=no policy=block_merge findings=2 root_causes=0 max_severity=medium verified_findings=0 verified_max_severity=none head=stale reviewed_head_sha=oldhead pr_head_sha=newhead ran_at=2026-03-11T14:05:00Z/,
+    /local_review gating=no policy=block_merge findings=2 root_causes=0 max_severity=medium verified_findings=0 verified_max_severity=none head=stale reviewed_head_sha=oldhead pr_head_sha=newhead ran_at=2026-03-11T14:05:00Z needs_review_run=yes drift=oldhead->newhead/,
   );
 });
 

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1722,11 +1722,17 @@ function localReviewHeadDetails(
   status: "none" | "current" | "stale" | "unknown";
   reviewedHeadSha: string;
   prHeadSha: string;
+  driftSuffix: string;
 } {
+  const status = localReviewHeadStatus(record, pr);
+  const reviewedHeadSha = record.local_review_head_sha ?? "none";
+  const prHeadSha = pr?.headRefOid ?? "unknown";
+
   return {
-    status: localReviewHeadStatus(record, pr),
-    reviewedHeadSha: record.local_review_head_sha ?? "none",
-    prHeadSha: pr?.headRefOid ?? "unknown",
+    status,
+    reviewedHeadSha,
+    prHeadSha,
+    driftSuffix: status === "stale" ? ` needs_review_run=yes drift=${reviewedHeadSha}->${prHeadSha}` : "",
   };
 }
 
@@ -1808,7 +1814,7 @@ export function formatDetailedStatus(args: {
     `last_failure_kind=${activeRecord.last_failure_kind ?? "none"}`,
     `last_failure_signature=${activeRecord.last_failure_signature ?? "none"}`,
     `retries timeout=${activeRecord.timeout_retry_count} verification=${activeRecord.blocked_verification_retry_count} same_blocker=${activeRecord.repeated_blocker_count} same_failure_signature=${activeRecord.repeated_failure_signature_count}`,
-    `local_review gating=${localReviewGating} policy=${config.localReviewPolicy} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
+    `local_review gating=${localReviewGating} policy=${config.localReviewPolicy} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"}${localReviewHead.driftSuffix} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
     `external_review head=${externalReviewHeadStatus} reviewed_head_sha=${activeRecord.external_review_head_sha ?? "none"} matched=${activeRecord.external_review_matched_findings_count} near_match=${activeRecord.external_review_near_match_findings_count} missed=${activeRecord.external_review_missed_findings_count}`,
   ];
 


### PR DESCRIPTION
## Summary
- make stale local-review status explicitly show when a new review run is needed
- keep current-head local-review status concise
- add focused formatter coverage for stale vs current rendering

Closes #166

## Testing
- npx tsx --test src/supervisor.test.ts