### PR TITLE
Structured handoff: define a clearer issue journal schema (#177)

### DIFF
--- a/src/codex.test.ts
+++ b/src/codex.test.ts
@@ -242,6 +242,51 @@ test("buildCodexPrompt keeps explicit operator overrides during local_review_fix
   assert.doesNotMatch(prompt, /Leave the PR as a stable checkpoint for handoff\./);
 });
 
+test("buildCodexPrompt suppresses structured next exact step guidance during local_review_fix without dropping later fields", () => {
+  const prompt = buildCodexPrompt({
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "local_review_fix" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+    journalExcerpt: `# Issue #46: Add a dedicated local_review_fix repair mode
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The repair path still carries forward stale checkpoint guidance.
+- Next exact step: Leave the PR as a stable checkpoint for handoff.
+- Verification gap: Full npm test was not rerun yet.
+
+### Scratchpad
+- Keep this section short.`,
+    localReviewRepairContext: {
+      summaryPath: "/tmp/reviews/issue-46/head-deadbeef.md",
+      findingsPath: "/tmp/reviews/issue-46/head-deadbeef.json",
+      relevantFiles: ["src/codex.ts"],
+      rootCauses: [
+        {
+          severity: "high",
+          summary: "Prompt guidance should ignore stale checkpoint-maintenance handoff text during repair.",
+          file: "src/codex.ts",
+          lines: "1-200",
+        },
+      ],
+      priorMissPatterns: [],
+      verifierGuardrails: [],
+    },
+  });
+
+  assert.doesNotMatch(prompt, /Leave the PR as a stable checkpoint for handoff\./);
+  assert.match(prompt, /- Next exact step: suppressed during active local-review repair/);
+  assert.match(prompt, /- Verification gap: Full npm test was not rerun yet\./);
+});
+
 test("buildCodexPrompt surfaces saved external review misses during addressing_review", () => {
   const prompt = buildCodexPrompt({
     repoSlug: "owner/repo",

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -169,15 +169,17 @@ function suppressStaleRepairHandoff(journalExcerpt: string | null | undefined, s
     return journalExcerpt;
   }
 
+  const nextActionLabels = ["Next 1-3 actions", "Next exact step"] as const;
   const lines = journalExcerpt.split("\n");
   const sanitized: string[] = [];
   let inNextActions = false;
-  let removedNextActions = false;
+  let removedNextActionsLabel: (typeof nextActionLabels)[number] | null = null;
 
   for (const line of lines) {
-    if (line.startsWith("- Next 1-3 actions:")) {
+    const matchedNextActionLabel = nextActionLabels.find((label) => line.startsWith(`- ${label}:`));
+    if (matchedNextActionLabel) {
       inNextActions = true;
-      removedNextActions = true;
+      removedNextActionsLabel = matchedNextActionLabel;
       continue;
     }
 
@@ -195,6 +197,12 @@ function suppressStaleRepairHandoff(journalExcerpt: string | null | undefined, s
         continue;
       }
 
+      if (/^- [^:]+:/.test(line)) {
+        inNextActions = false;
+        sanitized.push(line);
+        continue;
+      }
+
       const isBulletItem = /^[-*]\s+/.test(trimmed);
       const isContinuation = /^\s/.test(line);
       if (isBulletItem || isContinuation) {
@@ -207,7 +215,7 @@ function suppressStaleRepairHandoff(journalExcerpt: string | null | undefined, s
     sanitized.push(line);
   }
 
-  if (!removedNextActions) {
+  if (!removedNextActionsLabel) {
     return journalExcerpt;
   }
 
@@ -217,7 +225,7 @@ function suppressStaleRepairHandoff(journalExcerpt: string | null | undefined, s
     output.push(line);
     if (!insertedNotice && line.startsWith("### Current Handoff")) {
       output.push(
-        "- Next 1-3 actions: suppressed during active local-review repair; use the local-review blocker context unless an operator override note says otherwise.",
+        `- ${removedNextActionsLabel}: suppressed during active local-review repair; use the local-review blocker context unless an operator override note says otherwise.`,
       );
       insertedNotice = true;
     }

--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -132,3 +132,78 @@ test("syncIssueJournal preserves legacy handoff content by normalizing old field
   assert.match(content, /- Last focused command: npm test -- src\/journal\.test\.ts/);
   assert.match(content, /### Scratchpad\n- Existing note\./);
 });
+
+test("syncIssueJournal keeps wrapped next steps and preserves extra legacy actions", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-next-step-"));
+  const journalPath = path.join(tempDir, ".codex-supervisor", "issue-journal.md");
+
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    `# Issue #177: Structured handoff: define a clearer issue journal schema
+
+## Codex Working Notes
+### Current Handoff
+- Next 1-3 actions:
+  - Implement the handoff normalization
+    without dropping wrapped text.
+  - Update the downstream sanitizer for the new label.
+
+### Scratchpad
+- Existing note.
+`,
+    "utf8",
+  );
+
+  await syncIssueJournal({
+    issue,
+    record: createRecord({ workspace: tempDir, journal_path: journalPath }),
+    journalPath,
+  });
+
+  const content = await fs.readFile(journalPath, "utf8");
+  assert.match(content, /- Next exact step: Implement the handoff normalization without dropping wrapped text\./);
+  assert.match(content, /Update the downstream sanitizer for the new label\./);
+  assert.match(content, /### Scratchpad\n- Existing note\./);
+});
+
+test("syncIssueJournal compaction preserves populated current handoff values", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-compact-"));
+  const journalPath = path.join(tempDir, ".codex-supervisor", "issue-journal.md");
+
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    `# Issue #177: Structured handoff: define a clearer issue journal schema
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Structured handoff fields speed operator recovery.
+- What changed: Added explicit journal labels and normalization.
+- Current blocker: None.
+- Next exact step: Update the remaining prompt sanitizer.
+- Verification gap: Full npm test was not rerun.
+- Files touched: src/journal.ts, src/codex.ts
+- Rollback concern: Low.
+- Last focused command: npx tsx --test src/journal.test.ts
+
+### Scratchpad
+${Array.from({ length: 30 }, (_, index) => `- Scratch line ${index + 1}: ${"detail ".repeat(8).trim()}`).join("\n")}
+`,
+    "utf8",
+  );
+
+  await syncIssueJournal({
+    issue,
+    record: createRecord({ workspace: tempDir, journal_path: journalPath }),
+    journalPath,
+    maxChars: 650,
+  });
+
+  const content = await fs.readFile(journalPath, "utf8");
+  assert.match(content, /- What changed: Added explicit journal labels and normalization\./);
+  assert.match(content, /- Next exact step: Update the remaining prompt sanitizer\./);
+  assert.match(content, /- Verification gap: Full npm test was not rerun\./);
+  assert.doesNotMatch(content, /Scratch line 1:/);
+  assert.match(content, /Scratch line 30:/);
+});

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -69,6 +69,7 @@ function normalizeCurrentHandoff(lines: string[]): string[] {
   const values = new Map<HandoffField, string>();
   const extras: string[] = [];
   let activeField: HandoffField | null = null;
+  let preservingNextStepExtras = false;
 
   for (const line of lines) {
     const fieldMatch = line.match(/^- ([^:]+):(.*)$/);
@@ -78,6 +79,7 @@ function normalizeCurrentHandoff(lines: string[]): string[] {
       const rawValue = fieldMatch[2].trim();
 
       activeField = mappedField ?? null;
+      preservingNextStepExtras = false;
       if (!mappedField) {
         extras.push(line);
         continue;
@@ -95,13 +97,22 @@ function normalizeCurrentHandoff(lines: string[]): string[] {
       const trimmed = line.trim();
       if (trimmed.length === 0) {
         activeField = null;
+        preservingNextStepExtras = false;
         continue;
       }
 
+      if (preservingNextStepExtras) {
+        extras.push(line);
+        continue;
+      }
+
+      const isBulletItem = /^[-*]\s+/.test(trimmed);
       const continuation = trimmed.replace(/^[-*]\s+/, "").trim();
       if (continuation.length > 0) {
         const previous = values.get(activeField)?.trim() ?? "";
-        if (activeField === "Next exact step" && previous.length > 0) {
+        if (activeField === "Next exact step" && previous.length > 0 && isBulletItem) {
+          extras.push(line);
+          preservingNextStepExtras = true;
           continue;
         }
 
@@ -197,20 +208,29 @@ function preserveCodexNotes(existing: string): string | null {
 }
 
 function compactCodexNotes(notes: string, maxChars: number): string {
-  if (notes.length <= maxChars) {
-    return notes;
+  const normalizedNotes = normalizeCodexNotes(notes);
+
+  if (normalizedNotes.length <= maxChars) {
+    return normalizedNotes;
   }
 
-  const headerLines = normalizeCodexNotes(NOTES_TEMPLATE).trimEnd().split("\n");
-  const header = headerLines.join("\n");
-  const tailBudget = Math.max(0, maxChars - header.length - 1);
+  const normalizedLines = normalizedNotes.trimEnd().split("\n");
+  const scratchpadIndex = normalizedLines.findIndex((line) => line.trim() === "### Scratchpad");
+  const headerLines =
+    scratchpadIndex >= 0 ? normalizedLines.slice(0, scratchpadIndex + 1) : normalizedLines;
+  const tailSourceLines = scratchpadIndex >= 0 ? normalizedLines.slice(scratchpadIndex + 1) : [];
 
-  const lines = notes.split("\n");
+  const header = headerLines.join("\n");
+  if (header.length >= maxChars) {
+    return header.slice(0, maxChars);
+  }
+
+  const tailBudget = Math.max(0, maxChars - header.length - 1);
   const preservedTail: string[] = [];
   let currentLength = 0;
 
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const line = lines[index];
+  for (let index = tailSourceLines.length - 1; index >= 0; index -= 1) {
+    const line = tailSourceLines[index];
     const nextLength = currentLength + line.length + 1;
     if (preservedTail.length > 0 && nextLength > tailBudget) {
       break;
@@ -220,10 +240,7 @@ function compactCodexNotes(notes: string, maxChars: number): string {
     currentLength = nextLength;
   }
 
-  const compacted = [
-    ...headerLines,
-    ...preservedTail.filter((line) => line.trim() !== NOTES_MARKER),
-  ].join("\n");
+  const compacted = [...headerLines, ...preservedTail].join("\n");
 
   return compacted.length <= maxChars ? compacted : compacted.slice(0, maxChars);
 }
@@ -270,6 +287,6 @@ export async function syncIssueJournal(args: {
   const existing = await readIssueJournal(journalPath);
   const notes = existing ? preserveCodexNotes(existing) : null;
   const snapshot = buildSupervisorSnapshot({ issue, record, journalPath });
-  const nextContent = `${snapshot}\n${notes ? compactCodexNotes(normalizeCodexNotes(notes), maxChars) : NOTES_TEMPLATE}`;
+  const nextContent = `${snapshot}\n${notes ? compactCodexNotes(notes, maxChars) : NOTES_TEMPLATE}`;
   await fs.writeFile(journalPath, nextContent, "utf8");
 }


### PR DESCRIPTION
Closes #177
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the journal schema in [src/journal.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-177/src/journal.ts) and added focused coverage in [src/journal.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-177/src/journal.test.ts). New journals now emit explicit handoff fields for `What changed`, `Current blocker`, `Next exact step`, `Verification gap`, `Files touched`, and `Rollback concern`, while legacy handoff labels are normalized into the new layout on sync so older journals remain usable. I also kept unknown handoff lines as extras instead of dropping them.

Verification passed with `npx tsx --test src/journal.test.ts src/codex.test.ts` and `npm run build`. Checkpoint commit: `d08becd` (`Define a structured issue journal handoff schema`).

Summary: Added an explicit structured issue-journal handoff schema with legacy-field normalization and focused tests, then committed the checkpoint.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/journal.test.ts src/codex.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for the committed journal-schema checkpoint and continue with any broader review requested.