### PR TITLE
Durable guardrails: expand fail-loud coverage for malformed rule inputs (#187)

### DIFF
--- a/src/codex.test.ts
+++ b/src/codex.test.ts
@@ -797,6 +797,57 @@ test("loadLocalReviewRepairContext surfaces malformed committed durable guardrai
   await fs.rm(workspaceDir, { recursive: true, force: true });
 });
 
+test("loadLocalReviewRepairContext surfaces malformed committed durable guardrails even without relevant files", async () => {
+  const workspaceDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "local-review-fix-invalid-durable-guardrails-no-files-test-"),
+  );
+  const reviewDir = path.join(workspaceDir, "reviews");
+  const summaryPath = path.join(reviewDir, "head-deadbeef.md");
+  const findingsPath = path.join(reviewDir, "head-deadbeef.json");
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.mkdir(reviewDir, { recursive: true });
+  await fs.writeFile(summaryPath, "# summary\n", "utf8");
+  await fs.writeFile(
+    findingsPath,
+    JSON.stringify({
+      branch: "codex/issue-46",
+      headSha: "deadbeef",
+      actionableFindings: [],
+      rootCauseSummaries: [{ severity: "high", summary: "Permission guard retry path is fragile", file: null }],
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    durableGuardrailPath,
+    JSON.stringify({
+      version: 1,
+      patterns: [
+        {
+          fingerprint: "",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Check the permission guard before the fallback write path.",
+          sourceArtifactPath: "/tmp/reviews/issue-46/external-review-misses-head-old.json",
+          sourceHeadSha: "oldhead123",
+          lastSeenAt: "2026-03-12T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    loadLocalReviewRepairContext(summaryPath, workspaceDir),
+    /Invalid durable external review guardrails in .*external-review-guardrails\.json: patterns\[0\]\.fingerprint must be a non-empty string\./,
+  );
+
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
 test("loadLocalReviewRepairContext surfaces malformed committed verifier guardrails", async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-fix-invalid-verifier-guardrails-test-"));
   const reviewDir = path.join(workspaceDir, "reviews");
@@ -840,6 +891,54 @@ test("loadLocalReviewRepairContext surfaces malformed committed verifier guardra
   await assert.rejects(
     loadLocalReviewRepairContext(summaryPath, workspaceDir),
     /Invalid verifier guardrails in .*verifier-guardrails\.json: rules\[0\]\.title must be a non-empty string\./,
+  );
+
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+test("loadLocalReviewRepairContext surfaces malformed committed verifier guardrails even without relevant files", async () => {
+  const workspaceDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "local-review-fix-invalid-verifier-guardrails-no-files-test-"),
+  );
+  const reviewDir = path.join(workspaceDir, "reviews");
+  const summaryPath = path.join(reviewDir, "head-deadbeef.md");
+  const findingsPath = path.join(reviewDir, "head-deadbeef.json");
+  const verifierGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "verifier-guardrails.json");
+
+  await fs.mkdir(path.dirname(verifierGuardrailPath), { recursive: true });
+  await fs.mkdir(reviewDir, { recursive: true });
+  await fs.writeFile(summaryPath, "# summary\n", "utf8");
+  await fs.writeFile(
+    findingsPath,
+    JSON.stringify({
+      branch: "codex/issue-46",
+      headSha: "deadbeef",
+      actionableFindings: [],
+      rootCauseSummaries: [{ severity: "high", summary: "Permission guard retry path is fragile", file: null }],
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    verifierGuardrailPath,
+    JSON.stringify({
+      version: 1,
+      rules: [
+        {
+          id: "permission-fallback",
+          title: "Re-check permission fallback invariants",
+          file: "",
+          line: 42,
+          summary: "Verify the permission guard path.",
+          rationale: "Read the guard path directly before dismissing the finding.",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    loadLocalReviewRepairContext(summaryPath, workspaceDir),
+    /Invalid verifier guardrails in .*verifier-guardrails\.json: rules\[0\]\.file must be a non-empty string\./,
   );
 
   await fs.rm(workspaceDir, { recursive: true, force: true });

--- a/src/external-review-miss-history.ts
+++ b/src/external-review-miss-history.ts
@@ -47,6 +47,9 @@ export async function loadRelevantExternalReviewMissPatterns(args: {
   workspacePath?: string;
 }): Promise<ExternalReviewMissPattern[]> {
   const changedFiles = [...new Set(args.changedFiles.filter((filePath) => filePath.trim() !== ""))].sort();
+  const committedPatterns = args.workspacePath
+    ? await loadCommittedExternalReviewGuardrails(args.workspacePath)
+    : [];
   if (changedFiles.length === 0) {
     return [];
   }
@@ -54,8 +57,8 @@ export async function loadRelevantExternalReviewMissPatterns(args: {
   const changedFileSet = new Set(changedFiles);
   const deduped = new Map<string, ExternalReviewMissPattern>();
 
-  if (args.workspacePath) {
-    mergeRelevantPatterns(deduped, await loadCommittedExternalReviewGuardrails(args.workspacePath), changedFileSet);
+  if (committedPatterns.length > 0) {
+    mergeRelevantPatterns(deduped, committedPatterns, changedFileSet);
   }
 
   let entries: string[];

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -782,6 +782,43 @@ test("loadRelevantExternalReviewMissPatterns rejects durable guardrails with an 
   );
 });
 
+test("loadRelevantExternalReviewMissPatterns rejects malformed committed durable guardrails even when no files changed", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-durable-guardrails-invalid-no-files-test-"));
+  const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");
+  await fs.mkdir(path.dirname(durableGuardrailPath), { recursive: true });
+  await fs.writeFile(
+    durableGuardrailPath,
+    JSON.stringify({
+      version: 1,
+      patterns: [
+        {
+          fingerprint: "",
+          reviewerLogin: "copilot-pull-request-reviewer",
+          file: "src/auth.ts",
+          line: 42,
+          summary: "Permission guard is bypassed.",
+          rationale: "Check the permission guard before the fallback write path.",
+          sourceArtifactPath: "external-review-misses-head-new.json",
+          sourceHeadSha: "newhead",
+          lastSeenAt: "2026-03-11T00:00:00Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => loadRelevantExternalReviewMissPatterns({
+      artifactDir: path.join(workspaceDir, ".local", "reviews"),
+      branch: "codex/issue-61",
+      currentHeadSha: "currenthead",
+      changedFiles: [],
+      workspacePath: workspaceDir,
+    }),
+    /Invalid durable external review guardrails in .*external-review-guardrails\.json: patterns\[0\]\.fingerprint must be a non-empty string\./,
+  );
+});
+
 test("loadRelevantExternalReviewMissPatterns rejects malformed durable guardrail fields and trims identifier-like strings", async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-review-durable-guardrails-strict-test-"));
   const durableGuardrailPath = path.join(workspaceDir, "docs", "shared-memory", "external-review-guardrails.json");

--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -205,6 +205,40 @@ test("loadRelevantVerifierGuardrails rejects malformed committed rules", async (
   await fs.rm(workspaceDir, { recursive: true, force: true });
 });
 
+test("loadRelevantVerifierGuardrails rejects malformed committed rules even when no files changed", async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "verifier-guardrails-invalid-no-files-test-"));
+  const guardrailPath = path.join(workspaceDir, "docs", "shared-memory", "verifier-guardrails.json");
+  await fs.mkdir(path.dirname(guardrailPath), { recursive: true });
+  await fs.writeFile(
+    guardrailPath,
+    JSON.stringify({
+      version: 1,
+      rules: [
+        {
+          id: "permission-fallback",
+          title: "Re-check permission fallback invariants",
+          file: "",
+          line: 42,
+          summary: "Verify that every fallback path still enforces the permission guard before returning privileged data.",
+          rationale: "A prior confirmed verifier miss cleared a similar fallback too early; require a direct read of the guard path before dismissing the finding.",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await assert.rejects(
+    loadRelevantVerifierGuardrails({
+      workspacePath: workspaceDir,
+      changedFiles: [],
+      limit: 3,
+    }),
+    /Invalid verifier guardrails in .*verifier-guardrails\.json: rules\[0\]\.file must be a non-empty string\./,
+  );
+
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
 test("repo-committed verifier guardrails cover Copilot request-vs-arrival lifecycle and merged-PR convergence", async () => {
   const changedFiles = ["src/github.ts", "src/supervisor.ts"];
   const rules = await loadRelevantVerifierGuardrails({

--- a/src/verifier-guardrails.ts
+++ b/src/verifier-guardrails.ts
@@ -17,6 +17,7 @@ export async function loadRelevantVerifierGuardrails(args: {
   changedFiles: string[];
   limit?: number;
 }): Promise<VerifierGuardrailRule[]> {
+  const committedRules = await loadCommittedVerifierGuardrails(args.workspacePath);
   const changedFiles = [...new Set(args.changedFiles.filter((filePath) => filePath.trim() !== ""))];
   if (changedFiles.length === 0) {
     return [];
@@ -24,7 +25,7 @@ export async function loadRelevantVerifierGuardrails(args: {
 
   const changedFileSet = new Set(changedFiles);
   const deduped = new Map<string, VerifierGuardrailRule>();
-  for (const rule of await loadCommittedVerifierGuardrails(args.workspacePath)) {
+  for (const rule of committedRules) {
     if (!changedFileSet.has(rule.file)) {
       continue;
     }


### PR DESCRIPTION
Closes #187
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the fail-loud fix for malformed committed guardrails when repair context has no file-scoped findings. The loaders now validate committed verifier and external-review guardrails before `changedFiles` filtering, and I added focused regressions in [src/codex.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-187/src/codex.test.ts), [src/verifier-guardrails.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-187/src/verifier-guardrails.test.ts), and [src/external-review-misses.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-187/src/external-review-misses.test.ts). The behavior change is in [src/verifier-guardrails.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-187/src/verifier-guardrails.ts) and [src/external-review-miss-history.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-187/src/external-review-miss-history.ts).

Checkpoint commit: `c4d670f` (`Fail loudly on malformed committed guardrails without file context`). I also updated the local issue journal handoff.

Summary: Fixed silent skipping of malformed committed guardrails when repair context had no relevant files, added focused verifier/external-review/repair-context regressions, and committed the checkpoint.
State hint: stabilizing
Blocked reason: none
Tests: `npm test -- --test-name-pattern "no files changed|without relevant files|surfaces malformed committed|rejects malformed committed|rejects malformed durable guardrail fields"`; `npm run build`
...