### PR TITLE
Reviewer guardrails: prefer simpler solutions and flag speculative abstraction (#193)

### DIFF
--- a/src/local-review-prompt.ts
+++ b/src/local-review-prompt.ts
@@ -223,6 +223,8 @@ function roleGoal(role: string): string[] {
     case "reviewer":
       return [
         "- Focus on correctness, regressions, edge cases, and missing tests in the changed code paths.",
+        "- Prefer the smallest correct implementation when it satisfies the issue.",
+        "- Flag speculative abstraction, premature generalization, or unnecessary indirection only when it adds concrete maintenance or correctness risk.",
         "- Prefer precise findings tied to a specific file and line whenever possible.",
         "- Ignore style nits unless they could hide a bug or maintenance trap.",
       ];

--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -854,6 +854,37 @@ test("buildRolePrompt includes bounded relevant prior external misses", () => {
   assert.match(prompt, /Response omits a required field\./);
 });
 
+test("buildRolePrompt teaches reviewer to prefer simpler solutions and flag speculative abstraction narrowly", () => {
+  const prompt = buildRolePrompt({
+    repoSlug: "owner/repo",
+    issue: {
+      number: 193,
+      title: "Prefer simpler reviewer guardrails",
+      body: "",
+      url: "https://example.test/issues/193",
+      createdAt: "2026-03-14T00:00:00Z",
+      updatedAt: "2026-03-14T00:00:00Z",
+      labels: [],
+    },
+    branch: "codex/issue-193",
+    workspacePath: "/tmp/workspaces/issue-193",
+    defaultBranch: "main",
+    pr: createPullRequest({
+      number: 193,
+      url: "https://example.test/pr/193",
+      headRefOid: "head193",
+    }),
+    role: "reviewer",
+    alwaysReadFiles: [],
+    onDemandFiles: [],
+    confidenceThreshold: 0.7,
+    priorMissPatterns: [],
+  });
+
+  assert.match(prompt, /Prefer the smallest correct implementation when it satisfies the issue\./);
+  assert.match(prompt, /Flag speculative abstraction, premature generalization, or unnecessary indirection only when it adds concrete maintenance or correctness risk\./);
+});
+
 test("buildVerifierPrompt includes bounded relevant prior external misses", () => {
   const prompt = buildVerifierPrompt({
     repoSlug: "owner/repo",


### PR DESCRIPTION
Closes #193
This PR was opened by codex-supervisor.
Latest Codex summary:

Added bounded simplicity guidance to the local-review `reviewer` prompt in [src/local-review-prompt.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-193/src/local-review-prompt.ts) so reviewers now explicitly prefer the smallest correct implementation and only flag speculative abstraction, premature generalization, or unnecessary indirection when it creates concrete maintenance or correctness risk. I covered that with a focused prompt test in [src/local-review.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-193/src/local-review.test.ts).

Verification passed with `npm ci`, `npm test -- src/local-review.test.ts`, `npm test -- src/codex.test.ts`, and `npm run build`. Checkpoint commit: `3f45d3f` (`Tighten reviewer simplicity guardrails`).

Summary: Added reviewer prompt guardrails that favor simpler solutions and narrowly flag speculative abstraction, with focused test coverage and passing local verification.
State hint: implementing
Blocked reason: none
Tests: `npm ci`; `npm test -- src/local-review.test.ts`; `npm test -- src/codex.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the branch PR with commit `3f45d3f` if the supervisor wants an early draft checkpoint.