### PR TITLE
Reviewer and verifier guardrails: discourage unrelated edits and enforce surgical changes (#194)

### DIFF
--- a/src/local-review-prompt.ts
+++ b/src/local-review-prompt.ts
@@ -224,7 +224,7 @@ function roleGoal(role: string): string[] {
       return [
         "- Focus on correctness, regressions, edge cases, and missing tests in the changed code paths.",
         "- Prefer the smallest correct implementation when it satisfies the issue.",
-        "- Prefer narrowly scoped changes that stay inside the issue boundary.",
+        "- Prefer narrowly scoped changes that stay inside the issue scope.",
         "- Flag speculative abstraction, premature generalization, or unnecessary indirection only when it adds concrete maintenance or correctness risk.",
         "- Flag unrelated cleanup, opportunistic refactors, or incidental file churn when they are not required for correctness or tests.",
         "- Do not treat minimal supporting changes as scope drift when they are necessary to make the issue fix correct, testable, or buildable.",
@@ -383,7 +383,7 @@ export function buildVerifierPrompt(args: {
     "Goal:",
     "- Re-check only the listed high-severity findings.",
     "- Confirm a finding only when the diff and narrowly targeted reads support the original concern.",
-    "- Treat unrelated cleanup or opportunistic refactors outside the issue scope as potential confirmed findings when the diff does not need them for correctness.",
+    "- When a listed finding is about scope drift, confirm it only when unrelated cleanup or opportunistic refactors fall outside the issue scope and are not required to keep the issue fix correct, testable, or buildable.",
     "- Dismiss findings that appear to be false positives or overstated.",
     "- Do not treat narrow supporting edits as scope drift when they are required to keep the issue fix correct, testable, or buildable.",
     "- Use `unclear` when the evidence is inconclusive from the available local context.",

--- a/src/local-review.test.ts
+++ b/src/local-review.test.ts
@@ -912,7 +912,7 @@ test("buildRolePrompt teaches reviewer to flag unrelated cleanup but allow requi
     priorMissPatterns: [],
   });
 
-  assert.match(prompt, /Prefer narrowly scoped changes that stay inside the issue boundary\./);
+  assert.match(prompt, /Prefer narrowly scoped changes that stay inside the issue scope\./);
   assert.match(prompt, /Flag unrelated cleanup, opportunistic refactors, or incidental file churn when they are not required for correctness or tests\./);
   assert.match(prompt, /Do not treat minimal supporting changes as scope drift when they are necessary to make the issue fix correct, testable, or buildable\./);
 });
@@ -1085,7 +1085,7 @@ test("buildVerifierPrompt teaches verifier to detect scope drift without blockin
     verifierGuardrails: [],
   });
 
-  assert.match(prompt, /Treat unrelated cleanup or opportunistic refactors outside the issue scope as potential confirmed findings when the diff does not need them for correctness\./);
+  assert.match(prompt, /When a listed finding is about scope drift, confirm it only when unrelated cleanup or opportunistic refactors fall outside the issue scope and are not required to keep the issue fix correct, testable, or buildable\./);
   assert.match(prompt, /Do not treat narrow supporting edits as scope drift when they are required to keep the issue fix correct, testable, or buildable\./);
   assert.match(prompt, /Prefer the smallest explanation that distinguishes required support work from unrelated churn\./);
 });


### PR DESCRIPTION
Closes #194
This PR was opened by codex-supervisor.
Latest Codex summary:

Added prompt guardrails so both reviewer and verifier now explicitly prefer narrowly scoped issue fixes, surface unrelated cleanup/opportunistic refactors as findings when they are not needed, and avoid misclassifying minimal correctness/test/build support edits as scope drift. The implementation is in [src/local-review-prompt.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-194/src/local-review-prompt.ts) and the reproducing coverage is in [src/local-review.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-194/src/local-review.test.ts).

I first added two narrow failing prompt tests, confirmed the gap, then tightened only the prompt text and re-ran focused verification. I also updated the local issue journal handoff and created checkpoint commit `f126245` (`Tighten reviewer and verifier scope guardrails`).

Tests run: `npm test -- --test-name-pattern "build(Role|Verifier)Prompt.*(surgical|scope drift|support changes|simpler solutions|committed verifier guardrails|bounded relevant prior external misses)"`, `npx tsx --test src/local-review.test.ts`, `npm run build`.

Summary: Tightened reviewer/verifier prompt guidance to flag unrelated edits while allowing required support changes, with focused reproducing tests added and passing.
State hint: local_review
Blocked reason: none
Tests: `npm test -- --test-name-pattern "build(Role|Verifier)Prompt.*(surgical|scope drift|support changes|simpler solutions|committed verifier guardrails|bounded relevant prior ...