### PR TITLE
Generalize configured review bot waiting

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -162,6 +162,43 @@ test("inferCopilotReviewLifecycle returns arrived when Copilot comments on a rev
   });
 });
 
+test("inferCopilotReviewLifecycle treats configured review bots generically for Codex-only and mixed configurations", () => {
+  const facts = {
+    reviewRequests: ["chatgpt-codex-connector"],
+    reviews: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        submittedAt: "2026-03-13T02:03:04Z",
+      },
+    ],
+    comments: [],
+    timeline: [
+      {
+        type: "requested" as const,
+        createdAt: "2026-03-13T01:02:03Z",
+        reviewerLogin: "chatgpt-codex-connector",
+      },
+      {
+        type: "requested" as const,
+        createdAt: "2026-03-13T01:00:00Z",
+        reviewerLogin: "copilot-pull-request-reviewer",
+      },
+    ],
+  };
+
+  assert.deepEqual(inferCopilotReviewLifecycle(facts, ["chatgpt-codex-connector"]), {
+    state: "arrived",
+    requestedAt: "2026-03-13T01:02:03Z",
+    arrivedAt: "2026-03-13T02:03:04Z",
+  });
+
+  assert.deepEqual(inferCopilotReviewLifecycle(facts, ["copilot-pull-request-reviewer", "chatgpt-codex-connector"]), {
+    state: "arrived",
+    requestedAt: "2026-03-13T01:02:03Z",
+    arrivedAt: "2026-03-13T02:03:04Z",
+  });
+});
+
 test("GitHubClient hydrates Copilot arrival from long review threads without truncating comments to 20", async () => {
   const config = createConfig();
   let lifecycleQuery: string | null = null;

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -2972,6 +2972,40 @@ test("inferStateFromPullRequest waits briefly after ready-for-review for Copilot
   });
 });
 
+test("inferStateFromPullRequest waits briefly after ready-for-review for configured bot request propagation", () => {
+  withStubbedDateNow("2026-03-13T05:42:40Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    });
+    const record = createRecord({
+      state: "pr_open",
+      review_wait_started_at: "2026-03-13T05:42:36Z",
+      review_wait_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-13T05:40:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "waiting_ci");
+  });
+});
+
 test("inferStateFromPullRequest allows merge after the Copilot propagation grace window expires", () => {
   withStubbedDateNow("2026-03-13T05:42:42Z", () => {
     const config = createConfig({
@@ -3003,6 +3037,77 @@ test("inferStateFromPullRequest allows merge after the Copilot propagation grace
     const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
 
     assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
+  });
+});
+
+test("inferStateFromPullRequest keeps waiting when a configured bot request was observed on the current head but has not arrived", () => {
+  withStubbedDateNow("2026-03-11T00:10:00Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    });
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: "2026-03-11T00:00:00Z",
+      review_wait_head_sha: "head123",
+      copilot_review_requested_observed_at: "2026-03-11T00:05:00Z",
+      copilot_review_requested_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-11T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "waiting_ci");
+  });
+});
+
+test("inferStateFromPullRequest waits when mixed configured bots include Copilot lifecycle state", () => {
+  withStubbedDateNow("2026-03-11T00:10:00Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["chatgpt-codex-connector", "copilot-pull-request-reviewer"],
+    });
+    const requestedAt = "2026-03-11T00:05:00Z";
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: requestedAt,
+      review_wait_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-11T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "requested",
+      copilotReviewRequestedAt: requestedAt,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "waiting_ci");
   });
 });
 
@@ -3105,6 +3210,43 @@ test("inferStateFromPullRequest does not start Copilot timeout from the generic 
 test("inferStateFromPullRequest can time out from the observed Copilot request timestamp when GitHub omits one", () => {
   withStubbedDateNow("2026-03-11T00:30:00Z", () => {
     const config = createConfig({ copilotReviewWaitMinutes: 10, copilotReviewTimeoutAction: "block" });
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: "2026-03-11T00:00:00Z",
+      review_wait_head_sha: "head123",
+      copilot_review_requested_observed_at: "2026-03-11T00:15:00Z",
+      copilot_review_requested_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-11T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "blocked");
+  });
+});
+
+test("inferStateFromPullRequest can block when a configured bot review times out from the observed request timestamp", () => {
+  withStubbedDateNow("2026-03-11T00:30:00Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      copilotReviewTimeoutAction: "block",
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    });
     const record = createRecord({
       state: "waiting_ci",
       review_wait_started_at: "2026-03-11T00:00:00Z",
@@ -3863,6 +4005,55 @@ test("formatDetailedStatus surfaces Copilot review timeout outcome", () => {
 
   assert.match(status, /copilot_review state=requested requested_at=2026-03-11T14:05:00Z arrived_at=none timed_out_at=2026-03-11T14:15:00Z timeout_action=continue/);
   assert.match(status, /timeout_reason=Requested Copilot review never arrived within 10 minute\(s\) for head deadbeef\./);
+});
+
+test("formatDetailedStatus surfaces configured bot review timeout outcome with generic wording", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    copilotReviewState: "requested",
+    copilotReviewRequestedAt: "2026-03-11T14:05:00Z",
+    copilotReviewArrivedAt: null,
+  };
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "blocked",
+      blocked_reason: "review_bot_timeout",
+      copilot_review_timed_out_at: "2026-03-11T14:15:00Z",
+      copilot_review_timeout_action: "continue",
+      copilot_review_timeout_reason:
+        "Requested configured review bot (chatgpt-codex-connector) review never arrived within 10 minute(s) for head deadbeef.",
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+  });
+
+  assert.match(
+    status,
+    /configured_bot_review state=requested reviewers=chatgpt-codex-connector requested_at=2026-03-11T14:05:00Z arrived_at=none timed_out_at=2026-03-11T14:15:00Z timeout_action=continue/,
+  );
+  assert.match(
+    status,
+    /timeout_reason=Requested configured review bot \(chatgpt-codex-connector\) review never arrived within 10 minute\(s\) for head deadbeef\./,
+  );
 });
 
 test("formatDetailedStatus surfaces the latest recovery reason separately from the active issue", () => {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1015,6 +1015,24 @@ interface CopilotReviewTimeoutStatus {
   reason: string | null;
 }
 
+function configuredReviewBotLabel(config: SupervisorConfig): string {
+  const bots = config.reviewBotLogins.filter((login) => login.trim() !== "");
+  if (bots.length === 1) {
+    return `configured review bot (${bots[0]})`;
+  }
+  if (bots.length > 1) {
+    return `configured review bots (${bots.join(", ")})`;
+  }
+  return "configured review bot";
+}
+
+function configuredReviewStatusLabel(config: SupervisorConfig): string {
+  return config.reviewBotLogins.length === 0 ||
+    (config.reviewBotLogins.length === 1 && config.reviewBotLogins[0] === COPILOT_REVIEWER_LOGIN)
+    ? "copilot_review"
+    : "configured_bot_review";
+}
+
 function copilotReviewArrived(pr: GitHubPullRequest): boolean {
   return (pr.copilotReviewState ?? "not_requested") === "arrived" || Boolean(pr.copilotReviewArrivedAt);
 }
@@ -1074,13 +1092,13 @@ function determineCopilotReviewTimeout(
     startedAt,
     timedOutAt,
     reason:
-      `Requested Copilot review never arrived within ${config.copilotReviewWaitMinutes} minute(s) ` +
+      `Requested ${configuredReviewBotLabel(config)} review never arrived within ${config.copilotReviewWaitMinutes} minute(s) ` +
       `for head ${pr.headRefOid}.`,
   };
 }
 
-function repoExpectsCopilotReview(config: SupervisorConfig): boolean {
-  return config.reviewBotLogins.includes(COPILOT_REVIEWER_LOGIN);
+function repoExpectsConfiguredBotReview(config: SupervisorConfig): boolean {
+  return config.reviewBotLogins.length > 0;
 }
 
 function shouldWaitForCopilotReviewPropagation(
@@ -1089,7 +1107,7 @@ function shouldWaitForCopilotReviewPropagation(
   pr: GitHubPullRequest,
 ): boolean {
   if (
-    !repoExpectsCopilotReview(config) ||
+    !repoExpectsConfiguredBotReview(config) ||
     config.copilotReviewWaitMinutes <= 0 ||
     pr.isDraft ||
     pr.headRefOid !== record.review_wait_head_sha
@@ -1127,14 +1145,14 @@ function buildCopilotReviewTimeoutFailureContext(
 
   return {
     category: "blocked",
-    summary: `PR #${pr.number} is blocked after a requested Copilot review timed out.`,
-    signature: `copilot-timeout:${pr.headRefOid}:${timeout.action}`,
+    summary: `PR #${pr.number} is blocked after a requested ${configuredReviewBotLabel(config)} review timed out.`,
+    signature: `review-bot-timeout:${pr.headRefOid}:${timeout.action}`,
     command: null,
     details: [
       `requested_at=${timeout.startedAt ?? "none"}`,
       `timed_out_at=${timeout.timedOutAt ?? "none"}`,
       `timeout_minutes=${config.copilotReviewWaitMinutes}`,
-      timeout.reason ?? "Requested Copilot review timed out.",
+      timeout.reason ?? `Requested ${configuredReviewBotLabel(config)} review timed out.`,
     ],
     url: pr.url,
     updated_at: nowIso(),
@@ -1160,7 +1178,7 @@ function blockedReasonFromReviewState(
 ): Exclude<BlockedReason, null> | null {
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
   if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
-    return "copilot_timeout";
+    return "review_bot_timeout";
   }
 
   if (
@@ -2034,8 +2052,10 @@ export function formatDetailedStatus(args: {
 
   if (pr) {
     const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");
+    const reviewStatusLabel = configuredReviewStatusLabel(config);
+    const reviewersSuffix = config.reviewBotLogins.length > 0 ? ` reviewers=${config.reviewBotLogins.join(",")}` : "";
     lines.push(
-      `copilot_review state=${copilotReviewState} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
+      `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
     );
     if (activeRecord.copilot_review_timeout_reason) {
       lines.push(`timeout_reason=${sanitizeStatusValue(activeRecord.copilot_review_timeout_reason)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export type BlockedReason =
   | "permissions"
   | "secrets"
   | "verification"
+  | "review_bot_timeout"
   | "copilot_timeout"
   | "manual_review"
   | "manual_pr_closed"


### PR DESCRIPTION
## Summary
- generalize supervisor review-wait propagation from Copilot-only semantics to configured review bots
- update timeout/status wording so Codex Connector can be treated as a first-class configured bot reviewer
- add focused tests for Copilot-only, Codex-Connector-only, and mixed configured-bot flows

## Verification
- npm test -- --grep "inferCopilotReviewLifecycle|inferStateFromPullRequest|formatDetailedStatus surfaces configured bot review timeout outcome"
- npm run build

Closes #210