### PR TITLE
Supervisor: finish configured review-bot generalization edge cases after PR #211 (#212)

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -3113,7 +3113,10 @@ test("inferStateFromPullRequest waits when mixed configured bots include Copilot
 
 test("inferStateFromPullRequest keeps waiting when Copilot review was explicitly requested", () => {
   withStubbedDateNow("2026-03-11T00:10:00Z", () => {
-    const config = createConfig({ copilotReviewWaitMinutes: 10 });
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
     const requestedAt = "2026-03-11T00:05:00Z";
     const record = createRecord({
       state: "waiting_ci",
@@ -3145,7 +3148,10 @@ test("inferStateFromPullRequest keeps waiting when Copilot review was explicitly
 
 test("inferStateFromPullRequest keeps waiting when a Copilot request was observed on the current head but has not arrived", () => {
   withStubbedDateNow("2026-03-11T00:10:00Z", () => {
-    const config = createConfig({ copilotReviewWaitMinutes: 10 });
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
     const record = createRecord({
       state: "waiting_ci",
       review_wait_started_at: "2026-03-11T00:00:00Z",
@@ -3178,7 +3184,11 @@ test("inferStateFromPullRequest keeps waiting when a Copilot request was observe
 
 test("inferStateFromPullRequest does not start Copilot timeout from the generic review wait window", () => {
   withStubbedDateNow("2026-03-11T00:30:00Z", () => {
-    const config = createConfig({ copilotReviewWaitMinutes: 10, copilotReviewTimeoutAction: "block" });
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      copilotReviewTimeoutAction: "block",
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
     const record = createRecord({
       state: "waiting_ci",
       review_wait_started_at: "2026-03-11T00:00:00Z",
@@ -3209,7 +3219,11 @@ test("inferStateFromPullRequest does not start Copilot timeout from the generic 
 
 test("inferStateFromPullRequest can time out from the observed Copilot request timestamp when GitHub omits one", () => {
   withStubbedDateNow("2026-03-11T00:30:00Z", () => {
-    const config = createConfig({ copilotReviewWaitMinutes: 10, copilotReviewTimeoutAction: "block" });
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      copilotReviewTimeoutAction: "block",
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
     const record = createRecord({
       state: "waiting_ci",
       review_wait_started_at: "2026-03-11T00:00:00Z",
@@ -3277,6 +3291,43 @@ test("inferStateFromPullRequest can block when a configured bot review times out
   });
 });
 
+test("inferStateFromPullRequest does not wait on stale configured bot request state when no review bots are configured", () => {
+  withStubbedDateNow("2026-03-11T00:30:00Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      copilotReviewTimeoutAction: "block",
+      reviewBotLogins: [],
+    });
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: "2026-03-11T00:00:00Z",
+      review_wait_head_sha: "head123",
+      copilot_review_requested_observed_at: "2026-03-11T00:05:00Z",
+      copilot_review_requested_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-11T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
+  });
+});
+
 test("inferStateFromPullRequest times out requested Copilot reviews and continues by default", () => {
   withStubbedDateNow("2026-03-11T00:30:00Z", () => {
     const config = createConfig({ copilotReviewWaitMinutes: 10, copilotReviewTimeoutAction: "continue" });
@@ -3310,7 +3361,11 @@ test("inferStateFromPullRequest times out requested Copilot reviews and continue
 
 test("inferStateFromPullRequest can block when a requested Copilot review times out", () => {
   withStubbedDateNow("2026-03-11T00:30:00Z", () => {
-    const config = createConfig({ copilotReviewWaitMinutes: 10, copilotReviewTimeoutAction: "block" });
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      copilotReviewTimeoutAction: "block",
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    });
     const record = createRecord({
       state: "waiting_ci",
       review_wait_started_at: "2026-03-11T00:00:00Z",
@@ -4053,6 +4108,96 @@ test("formatDetailedStatus surfaces configured bot review timeout outcome with g
   assert.match(
     status,
     /timeout_reason=Requested configured review bot \(chatgpt-codex-connector\) review never arrived within 10 minute\(s\) for head deadbeef\./,
+  );
+});
+
+test("formatDetailedStatus preserves Copilot-specific timeout wording for Copilot-only repos", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const pr: GitHubPullRequest = {
+    number: 22,
+    title: "Add review learning",
+    url: "https://example.test/pr/22",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    headRefName: "codex/issue-58",
+    headRefOid: "deadbeef",
+    copilotReviewState: "requested",
+    copilotReviewRequestedAt: "2026-03-11T14:05:00Z",
+    copilotReviewArrivedAt: null,
+  };
+
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: createRecord({
+      pr_number: 22,
+      state: "ready_to_merge",
+      copilot_review_timed_out_at: "2026-03-11T14:15:00Z",
+      copilot_review_timeout_action: "continue",
+      copilot_review_timeout_reason:
+        "Requested Copilot review never arrived within 10 minute(s) for head deadbeef.",
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [],
+    reviewThreads: [],
+  });
+
+  assert.match(status, /copilot_review state=requested requested_at=2026-03-11T14:05:00Z arrived_at=none timed_out_at=2026-03-11T14:15:00Z timeout_action=continue/);
+  assert.match(status, /timeout_reason=Requested Copilot review never arrived within 10 minute\(s\) for head deadbeef\./);
+});
+
+test("formatDetailedStatus keeps generic configured bot timeout wording for mixed bot repos", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer", "chatgpt-codex-connector"],
+  });
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    copilotReviewState: "requested",
+    copilotReviewRequestedAt: "2026-03-11T14:05:00Z",
+    copilotReviewArrivedAt: null,
+  };
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "blocked",
+      blocked_reason: "review_bot_timeout",
+      copilot_review_timed_out_at: "2026-03-11T14:15:00Z",
+      copilot_review_timeout_action: "continue",
+      copilot_review_timeout_reason:
+        "Requested configured review bots (copilot-pull-request-reviewer, chatgpt-codex-connector) review never arrived within 10 minute(s) for head deadbeef.",
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+  });
+
+  assert.match(
+    status,
+    /configured_bot_review state=requested reviewers=copilot-pull-request-reviewer,chatgpt-codex-connector requested_at=2026-03-11T14:05:00Z arrived_at=none timed_out_at=2026-03-11T14:15:00Z timeout_action=continue/,
+  );
+  assert.match(
+    status,
+    /timeout_reason=Requested configured review bots \(copilot-pull-request-reviewer, chatgpt-codex-connector\) review never arrived within 10 minute\(s\) for head deadbeef\./,
   );
 });
 

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1015,8 +1015,24 @@ interface CopilotReviewTimeoutStatus {
   reason: string | null;
 }
 
+function configuredReviewBots(config: SupervisorConfig): string[] {
+  return config.reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
+}
+
+function repoExpectsConfiguredBotReview(config: SupervisorConfig): boolean {
+  return configuredReviewBots(config).length > 0;
+}
+
+function repoUsesCopilotOnlyReviewBot(config: SupervisorConfig): boolean {
+  const bots = configuredReviewBots(config);
+  return bots.length === 1 && bots[0].toLowerCase() === COPILOT_REVIEWER_LOGIN;
+}
+
 function configuredReviewBotLabel(config: SupervisorConfig): string {
-  const bots = config.reviewBotLogins.filter((login) => login.trim() !== "");
+  const bots = configuredReviewBots(config);
+  if (repoUsesCopilotOnlyReviewBot(config)) {
+    return "Copilot";
+  }
   if (bots.length === 1) {
     return `configured review bot (${bots[0]})`;
   }
@@ -1027,8 +1043,7 @@ function configuredReviewBotLabel(config: SupervisorConfig): string {
 }
 
 function configuredReviewStatusLabel(config: SupervisorConfig): string {
-  return config.reviewBotLogins.length === 0 ||
-    (config.reviewBotLogins.length === 1 && config.reviewBotLogins[0] === COPILOT_REVIEWER_LOGIN)
+  return !repoExpectsConfiguredBotReview(config) || repoUsesCopilotOnlyReviewBot(config)
     ? "copilot_review"
     : "configured_bot_review";
 }
@@ -1037,20 +1052,28 @@ function copilotReviewArrived(pr: GitHubPullRequest): boolean {
   return (pr.copilotReviewState ?? "not_requested") === "arrived" || Boolean(pr.copilotReviewArrivedAt);
 }
 
-function hasObservedCopilotRequest(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
-  return Boolean(record.copilot_review_requested_observed_at && record.copilot_review_requested_head_sha === pr.headRefOid);
-}
-
-function copilotReviewPending(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
-  if (pr.isDraft || copilotReviewArrived(pr)) {
+function hasObservedCopilotRequest(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): boolean {
+  if (!repoExpectsConfiguredBotReview(config)) {
     return false;
   }
 
-  return (pr.copilotReviewState ?? "not_requested") === "requested" || hasObservedCopilotRequest(record, pr);
+  return Boolean(record.copilot_review_requested_observed_at && record.copilot_review_requested_head_sha === pr.headRefOid);
 }
 
-function copilotReviewTimeoutStart(record: IssueRunRecord, pr: GitHubPullRequest): string | null {
-  if (!copilotReviewPending(record, pr)) {
+function copilotReviewPending(config: SupervisorConfig, record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  if (!repoExpectsConfiguredBotReview(config) || pr.isDraft || copilotReviewArrived(pr)) {
+    return false;
+  }
+
+  return (pr.copilotReviewState ?? "not_requested") === "requested" || hasObservedCopilotRequest(config, record, pr);
+}
+
+function copilotReviewTimeoutStart(config: SupervisorConfig, record: IssueRunRecord, pr: GitHubPullRequest): string | null {
+  if (!copilotReviewPending(config, record, pr)) {
     return null;
   }
 
@@ -1070,7 +1093,7 @@ function determineCopilotReviewTimeout(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
 ): CopilotReviewTimeoutStatus {
-  const startedAt = copilotReviewTimeoutStart(record, pr);
+  const startedAt = copilotReviewTimeoutStart(config, record, pr);
   if (!startedAt) {
     return { timedOut: false, action: null, startedAt: null, timedOutAt: null, reason: null };
   }
@@ -1095,10 +1118,6 @@ function determineCopilotReviewTimeout(
       `Requested ${configuredReviewBotLabel(config)} review never arrived within ${config.copilotReviewWaitMinutes} minute(s) ` +
       `for head ${pr.headRefOid}.`,
   };
-}
-
-function repoExpectsConfiguredBotReview(config: SupervisorConfig): boolean {
-  return config.reviewBotLogins.length > 0;
 }
 
 function shouldWaitForCopilotReviewPropagation(
@@ -1212,8 +1231,12 @@ function syncReviewWaitWindow(record: IssueRunRecord, pr: GitHubPullRequest): Pa
   };
 }
 
-function syncCopilotReviewRequestObservation(record: IssueRunRecord, pr: GitHubPullRequest): Partial<IssueRunRecord> {
-  if (pr.isDraft || copilotReviewArrived(pr)) {
+function syncCopilotReviewRequestObservation(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): Partial<IssueRunRecord> {
+  if (!repoExpectsConfiguredBotReview(config) || pr.isDraft || copilotReviewArrived(pr)) {
     return {
       copilot_review_requested_observed_at: null,
       copilot_review_requested_head_sha: null,
@@ -1244,7 +1267,7 @@ function syncCopilotReviewRequestObservation(record: IssueRunRecord, pr: GitHubP
     };
   }
 
-  if (hasObservedCopilotRequest(record, pr)) {
+  if (hasObservedCopilotRequest(config, record, pr)) {
     return {
       copilot_review_requested_observed_at: record.copilot_review_requested_observed_at,
       copilot_review_requested_head_sha: record.copilot_review_requested_head_sha,
@@ -1360,7 +1383,7 @@ export function inferStateFromPullRequest(
     return "waiting_ci";
   }
 
-  if (copilotReviewPending(record, pr) && !copilotTimeout.timedOut) {
+  if (copilotReviewPending(config, record, pr) && !copilotTimeout.timedOut) {
     return "waiting_ci";
   }
 
@@ -1399,7 +1422,7 @@ function derivePullRequestLifecycleSnapshot(
 ): PullRequestLifecycleSnapshot {
   const baseRecord = { ...record, ...recordPatch };
   const reviewWaitPatch = syncReviewWaitWindow(baseRecord, pr);
-  const copilotRequestObservationPatch = syncCopilotReviewRequestObservation(baseRecord, pr);
+  const copilotRequestObservationPatch = syncCopilotReviewRequestObservation(config, baseRecord, pr);
   const recordForState = {
     ...baseRecord,
     ...reviewWaitPatch,
@@ -2053,7 +2076,9 @@ export function formatDetailedStatus(args: {
   if (pr) {
     const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");
     const reviewStatusLabel = configuredReviewStatusLabel(config);
-    const reviewersSuffix = config.reviewBotLogins.length > 0 ? ` reviewers=${config.reviewBotLogins.join(",")}` : "";
+    const reviewers = configuredReviewBots(config);
+    const reviewersSuffix =
+      reviewStatusLabel === "configured_bot_review" && reviewers.length > 0 ? ` reviewers=${reviewers.join(",")}` : "";
     lines.push(
       `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
     );
@@ -2404,7 +2429,7 @@ async function reconcileStaleFailedIssueStates(
       pr_number: pr.number,
       last_head_sha: pr.headRefOid,
       ...syncReviewWaitWindow(record, pr),
-      ...syncCopilotReviewRequestObservation(record, pr),
+      ...syncCopilotReviewRequestObservation(config, record, pr),
       ...syncCopilotReviewTimeoutState(config, record, pr),
     };
 


### PR DESCRIPTION
Closes #212
This PR was opened by codex-supervisor.
Latest Codex summary:

Adjusted supervisor review-bot lifecycle handling and added focused regression coverage. In [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-212/src/supervisor.ts#L1018), Copilot-only configs now keep `Copilot` wording while mixed/non-Copilot configs stay generic; stale observed request state is ignored and cleared when the repo no longer expects configured bot review; Copilot-only status lines also stop showing the generic `reviewers=` suffix. I also updated stale-failed-state reconciliation to use the same gating logic in [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-212/src/supervisor.ts#L2420).

Focused tests were added in [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-212/src/supervisor.test.ts#L3294) and [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-212/src/supervisor.test.ts#L4114) for the no-bot stale-state case, Copilot-only wording, and mixed-bot wording. I also made older Copilot lifecycle tests explicit about using a Copilot-only config. The checkpoint is committed as `9c486da` with message `Fix review bot edge cases`. The issue journal was updated locally at `.codex-supervisor/issue-journal.md`.

Summary: Fixed Copilot-only wording and empty-config stale review-bot wait/timeout behavior; added focused supervisor regression tests; committed as `9c486da`.
State hint: stabilizing
Bloc...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Expanded test coverage for review bot configuration scenarios, including Copilot-only and mixed bot configurations, with improved timeout and state transition validation.

* **Refactor**
  - Enhanced review bot configuration handling to distinguish between Copilot-only and mixed bot review modes, with improved status labeling and timeout messaging that reflects the actual bot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->