### PR TITLE
Add provider-specific supervisor config profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ If you need near-immediate reaction, lower `pollIntervalSeconds`. Do not treat i
 
 Create `supervisor.config.json` from [supervisor.config.example.json](./supervisor.config.example.json).
 
+Provider-specific starting points are also shipped:
+
+- [supervisor.config.copilot.json](./supervisor.config.copilot.json)
+- [supervisor.config.codex.json](./supervisor.config.codex.json)
+- [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
+
+`supervisor.config.json` remains the active file that the supervisor loads. The provider-specific files are explicit templates: copy the one you want into `supervisor.config.json` or diff against it when switching review bots. The base example and Copilot profile preserve the existing safe Copilot-oriented defaults. The CodeRabbit profile includes both the app slug and bot login so request lifecycle events and review comments match the same configured provider.
+
 Important fields:
 
 - `repoPath`: absolute path to the managed repository

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -251,6 +251,9 @@ test("shipped example configs recommend block_merge for local review gating", as
   const rootDir = path.resolve(__dirname, "..");
   const examplePaths = [
     path.join(rootDir, "supervisor.config.example.json"),
+    path.join(rootDir, "supervisor.config.copilot.json"),
+    path.join(rootDir, "supervisor.config.codex.json"),
+    path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -264,6 +267,9 @@ test("shipped example configs recommend blocked for high-severity local review f
   const rootDir = path.resolve(__dirname, "..");
   const examplePaths = [
     path.join(rootDir, "supervisor.config.example.json"),
+    path.join(rootDir, "supervisor.config.copilot.json"),
+    path.join(rootDir, "supervisor.config.codex.json"),
+    path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -273,6 +279,26 @@ test("shipped example configs recommend blocked for high-severity local review f
       raw.localReviewHighSeverityAction,
       "blocked",
       `${path.relative(rootDir, examplePath)} should recommend blocked for high-severity local review findings`,
+    );
+  }
+});
+
+test("shipped config profiles declare the intended review bot logins", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const expectedProfiles = new Map<string, string[]>([
+    ["supervisor.config.example.json", ["copilot-pull-request-reviewer"]],
+    ["supervisor.config.copilot.json", ["copilot-pull-request-reviewer"]],
+    ["supervisor.config.codex.json", ["chatgpt-codex-connector"]],
+    ["supervisor.config.coderabbit.json", ["coderabbitai", "coderabbitai[bot]"]],
+  ]);
+
+  for (const [relativePath, expectedReviewBotLogins] of expectedProfiles) {
+    const profilePath = path.join(rootDir, relativePath);
+    const raw = JSON.parse(await fs.readFile(profilePath, "utf8")) as { reviewBotLogins?: unknown };
+    assert.deepEqual(
+      raw.reviewBotLogins,
+      expectedReviewBotLogins,
+      `${relativePath} should declare the expected reviewBotLogins`,
     );
   }
 });

--- a/supervisor.config.coderabbit.json
+++ b/supervisor.config.coderabbit.json
@@ -1,0 +1,84 @@
+{
+  "repoPath": "/absolute/path/to/managed-repo",
+  "repoSlug": "OWNER/REPO",
+  "defaultBranch": "main",
+  "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
+  "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
+  "codexBinary": "/absolute/path/to/codex",
+  "codexModelStrategy": "inherit",
+  "codexModel": "",
+  "codexReasoningEffortByState": {
+    "planning": "low",
+    "reproducing": "medium",
+    "implementing": "high",
+    "local_review_fix": "medium",
+    "stabilizing": "medium",
+    "draft_pr": "low",
+    "local_review": "low",
+    "repairing_ci": "medium",
+    "resolving_conflict": "high",
+    "addressing_review": "medium"
+  },
+  "codexReasoningEscalateOnRepeatedFailure": true,
+  "sharedMemoryFiles": [
+    "README.md",
+    "docs/architecture.md",
+    "docs/constitution.md",
+    "docs/workflow.md",
+    "docs/decisions.md"
+  ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
+  "localReviewEnabled": false,
+  "localReviewAutoDetect": true,
+  "localReviewRoles": [],
+  "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
+  "localReviewPolicy": "block_merge",
+  "localReviewHighSeverityAction": "blocked",
+  "reviewBotLogins": [
+    "coderabbitai",
+    "coderabbitai[bot]"
+  ],
+  "humanReviewBlocksMerge": true,
+  "issueJournalRelativePath": ".codex-supervisor/issue-journal.md",
+  "issueJournalMaxChars": 6000,
+  "issueLabel": "codex",
+  "skipTitlePrefixes": [],
+  "branchPrefix": "codex/issue-",
+  "pollIntervalSeconds": 120,
+  "copilotReviewWaitMinutes": 10,
+  "copilotReviewTimeoutAction": "continue",
+  "codexExecTimeoutMinutes": 30,
+  "maxCodexAttemptsPerIssue": 30,
+  "maxImplementationAttemptsPerIssue": 30,
+  "maxRepairAttemptsPerIssue": 30,
+  "timeoutRetryLimit": 2,
+  "blockedVerificationRetryLimit": 3,
+  "sameBlockerRepeatLimit": 2,
+  "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
+  "cleanupDoneWorkspacesAfterHours": 24,
+  "mergeMethod": "squash",
+  "draftPrAfterAttempt": 1
+}

--- a/supervisor.config.codex.json
+++ b/supervisor.config.codex.json
@@ -1,0 +1,83 @@
+{
+  "repoPath": "/absolute/path/to/managed-repo",
+  "repoSlug": "OWNER/REPO",
+  "defaultBranch": "main",
+  "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
+  "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
+  "codexBinary": "/absolute/path/to/codex",
+  "codexModelStrategy": "inherit",
+  "codexModel": "",
+  "codexReasoningEffortByState": {
+    "planning": "low",
+    "reproducing": "medium",
+    "implementing": "high",
+    "local_review_fix": "medium",
+    "stabilizing": "medium",
+    "draft_pr": "low",
+    "local_review": "low",
+    "repairing_ci": "medium",
+    "resolving_conflict": "high",
+    "addressing_review": "medium"
+  },
+  "codexReasoningEscalateOnRepeatedFailure": true,
+  "sharedMemoryFiles": [
+    "README.md",
+    "docs/architecture.md",
+    "docs/constitution.md",
+    "docs/workflow.md",
+    "docs/decisions.md"
+  ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
+  "localReviewEnabled": false,
+  "localReviewAutoDetect": true,
+  "localReviewRoles": [],
+  "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
+  "localReviewPolicy": "block_merge",
+  "localReviewHighSeverityAction": "blocked",
+  "reviewBotLogins": [
+    "chatgpt-codex-connector"
+  ],
+  "humanReviewBlocksMerge": true,
+  "issueJournalRelativePath": ".codex-supervisor/issue-journal.md",
+  "issueJournalMaxChars": 6000,
+  "issueLabel": "codex",
+  "skipTitlePrefixes": [],
+  "branchPrefix": "codex/issue-",
+  "pollIntervalSeconds": 120,
+  "copilotReviewWaitMinutes": 10,
+  "copilotReviewTimeoutAction": "continue",
+  "codexExecTimeoutMinutes": 30,
+  "maxCodexAttemptsPerIssue": 30,
+  "maxImplementationAttemptsPerIssue": 30,
+  "maxRepairAttemptsPerIssue": 30,
+  "timeoutRetryLimit": 2,
+  "blockedVerificationRetryLimit": 3,
+  "sameBlockerRepeatLimit": 2,
+  "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
+  "cleanupDoneWorkspacesAfterHours": 24,
+  "mergeMethod": "squash",
+  "draftPrAfterAttempt": 1
+}

--- a/supervisor.config.copilot.json
+++ b/supervisor.config.copilot.json
@@ -1,0 +1,83 @@
+{
+  "repoPath": "/absolute/path/to/managed-repo",
+  "repoSlug": "OWNER/REPO",
+  "defaultBranch": "main",
+  "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
+  "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
+  "codexBinary": "/absolute/path/to/codex",
+  "codexModelStrategy": "inherit",
+  "codexModel": "",
+  "codexReasoningEffortByState": {
+    "planning": "low",
+    "reproducing": "medium",
+    "implementing": "high",
+    "local_review_fix": "medium",
+    "stabilizing": "medium",
+    "draft_pr": "low",
+    "local_review": "low",
+    "repairing_ci": "medium",
+    "resolving_conflict": "high",
+    "addressing_review": "medium"
+  },
+  "codexReasoningEscalateOnRepeatedFailure": true,
+  "sharedMemoryFiles": [
+    "README.md",
+    "docs/architecture.md",
+    "docs/constitution.md",
+    "docs/workflow.md",
+    "docs/decisions.md"
+  ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
+  "localReviewEnabled": false,
+  "localReviewAutoDetect": true,
+  "localReviewRoles": [],
+  "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
+  "localReviewPolicy": "block_merge",
+  "localReviewHighSeverityAction": "blocked",
+  "reviewBotLogins": [
+    "copilot-pull-request-reviewer"
+  ],
+  "humanReviewBlocksMerge": true,
+  "issueJournalRelativePath": ".codex-supervisor/issue-journal.md",
+  "issueJournalMaxChars": 6000,
+  "issueLabel": "codex",
+  "skipTitlePrefixes": [],
+  "branchPrefix": "codex/issue-",
+  "pollIntervalSeconds": 120,
+  "copilotReviewWaitMinutes": 10,
+  "copilotReviewTimeoutAction": "continue",
+  "codexExecTimeoutMinutes": 30,
+  "maxCodexAttemptsPerIssue": 30,
+  "maxImplementationAttemptsPerIssue": 30,
+  "maxRepairAttemptsPerIssue": 30,
+  "timeoutRetryLimit": 2,
+  "blockedVerificationRetryLimit": 3,
+  "sameBlockerRepeatLimit": 2,
+  "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
+  "cleanupDoneWorkspacesAfterHours": 24,
+  "mergeMethod": "squash",
+  "draftPrAfterAttempt": 1
+}


### PR DESCRIPTION
Closes #215

## Summary
- add shipped supervisor config templates for Copilot, Codex Connector, and CodeRabbit
- keep Copilot-safe defaults intact while making provider selection explicit
- cover the new profiles with focused config fixture tests and document how they relate to supervisor.config.json

## Verification
- npx tsx --test src/config.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific configuration templates for Copilot, Codex, and CodeRabbit with optimized defaults for each platform.

* **Documentation**
  * Updated configuration guide with new provider-specific starting points and usage instructions.

* **Tests**
  * Added test coverage to validate provider configuration files and profile declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->