### PR TITLE
Provider profile validation: surface the active review-bot profile and missing prerequisites (#217)

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -4111,6 +4111,59 @@ test("formatDetailedStatus surfaces configured bot review timeout outcome with g
   );
 });
 
+test("formatDetailedStatus surfaces active review-bot profile and missing external signal for Codex profile", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: "REVIEW_REQUIRED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    copilotReviewState: "not_requested",
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+  };
+
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "pr_open",
+      blocked_reason: null,
+      external_review_head_sha: null,
+      external_review_matched_findings_count: 0,
+      external_review_near_match_findings_count: 0,
+      external_review_missed_findings_count: 0,
+      copilot_review_timed_out_at: null,
+      copilot_review_timeout_action: null,
+      copilot_review_timeout_reason: null,
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+  });
+
+  assert.match(
+    status,
+    /review_bot_profile profile=codex provider=chatgpt-codex-connector reviewers=chatgpt-codex-connector signal_source=review_threads/,
+  );
+  assert.match(
+    status,
+    /review_bot_diagnostics status=missing_provider_signal observed_review=none expected_reviewers=chatgpt-codex-connector next_check=provider_setup_or_delivery/,
+  );
+});
+
 test("formatDetailedStatus preserves Copilot-specific timeout wording for Copilot-only repos", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1048,6 +1048,140 @@ function configuredReviewStatusLabel(config: SupervisorConfig): string {
     : "configured_bot_review";
 }
 
+type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
+
+interface ReviewBotProfileSummary {
+  profile: ReviewBotProfileId;
+  provider: string;
+  reviewers: string[];
+  signalSource: string;
+}
+
+interface ReviewBotDiagnostics {
+  status: string;
+  observedReview: string;
+  nextCheck: string;
+}
+
+function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummary {
+  const reviewers = configuredReviewBots(config);
+  const normalized = reviewers.map((reviewer) => reviewer.toLowerCase());
+
+  if (normalized.length === 0) {
+    return {
+      profile: "none",
+      provider: "none",
+      reviewers,
+      signalSource: "none",
+    };
+  }
+
+  if (normalized.length === 1 && normalized[0] === COPILOT_REVIEWER_LOGIN) {
+    return {
+      profile: "copilot",
+      provider: COPILOT_REVIEWER_LOGIN,
+      reviewers,
+      signalSource: "copilot_lifecycle",
+    };
+  }
+
+  if (normalized.length === 1 && normalized[0] === "chatgpt-codex-connector") {
+    return {
+      profile: "codex",
+      provider: "chatgpt-codex-connector",
+      reviewers,
+      signalSource: "review_threads",
+    };
+  }
+
+  if (
+    normalized.length === 2 &&
+    normalized[0] === "coderabbitai" &&
+    normalized[1] === "coderabbitai[bot]"
+  ) {
+    return {
+      profile: "coderabbit",
+      provider: "coderabbitai",
+      reviewers,
+      signalSource: "review_threads",
+    };
+  }
+
+  return {
+    profile: "custom",
+    provider: reviewers.join(",") || "custom",
+    reviewers,
+    signalSource: normalized.includes(COPILOT_REVIEWER_LOGIN) ? "copilot_lifecycle+review_threads" : "review_threads",
+  };
+}
+
+function summarizeObservedReviewSignal(
+  config: SupervisorConfig,
+  activeRecord: IssueRunRecord,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): { observedReview: string; hasSignal: boolean } {
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  if (configuredThreads.length > 0) {
+    return { observedReview: "review_thread", hasSignal: true };
+  }
+
+  if (activeRecord.external_review_head_sha === pr.headRefOid) {
+    return { observedReview: "external_review_record", hasSignal: true };
+  }
+
+  const lifecycleState = pr.copilotReviewState ?? "not_requested";
+  if (lifecycleState === "arrived") {
+    return { observedReview: "copilot_arrived", hasSignal: true };
+  }
+  if (lifecycleState === "requested") {
+    return { observedReview: "copilot_requested", hasSignal: false };
+  }
+  if (pr.copilotReviewState === null) {
+    return { observedReview: "unknown", hasSignal: false };
+  }
+
+  return { observedReview: "none", hasSignal: false };
+}
+
+function reviewBotDiagnostics(
+  config: SupervisorConfig,
+  activeRecord: IssueRunRecord,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): ReviewBotDiagnostics {
+  if (!repoExpectsConfiguredBotReview(config)) {
+    return {
+      status: "disabled",
+      observedReview: "none",
+      nextCheck: "none",
+    };
+  }
+
+  const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads);
+  if (observed.hasSignal) {
+    return {
+      status: "review_signal_observed",
+      observedReview: observed.observedReview,
+      nextCheck: "none",
+    };
+  }
+
+  if (observed.observedReview === "copilot_requested") {
+    return {
+      status: "waiting_for_provider_review",
+      observedReview: observed.observedReview,
+      nextCheck: "provider_delivery",
+    };
+  }
+
+  return {
+    status: "missing_provider_signal",
+    observedReview: observed.observedReview,
+    nextCheck: "provider_setup_or_delivery",
+  };
+}
+
 function copilotReviewArrived(pr: GitHubPullRequest): boolean {
   return (pr.copilotReviewState ?? "not_requested") === "arrived" || Boolean(pr.copilotReviewArrivedAt);
 }
@@ -2074,11 +2208,19 @@ export function formatDetailedStatus(args: {
   }
 
   if (pr) {
+    const reviewBotProfile = inferReviewBotProfile(config);
+    const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads);
     const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");
     const reviewStatusLabel = configuredReviewStatusLabel(config);
     const reviewers = configuredReviewBots(config);
     const reviewersSuffix =
       reviewStatusLabel === "configured_bot_review" && reviewers.length > 0 ? ` reviewers=${reviewers.join(",")}` : "";
+    lines.push(
+      `review_bot_profile profile=${reviewBotProfile.profile} provider=${reviewBotProfile.provider} reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} signal_source=${reviewBotProfile.signalSource}`,
+    );
+    lines.push(
+      `review_bot_diagnostics status=${reviewBotStatus.status} observed_review=${reviewBotStatus.observedReview} expected_reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} next_check=${reviewBotStatus.nextCheck}`,
+    );
     lines.push(
       `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
     );


### PR DESCRIPTION
Closes #217
This PR was opened by codex-supervisor.
Latest Codex summary:

Added deterministic review-bot status diagnostics in [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-217/src/supervisor.ts) and covered the new Codex missing-signal case in [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-217/src/supervisor.test.ts). Status output now includes `review_bot_profile` and `review_bot_diagnostics`, inferring shipped profiles (`copilot`, `codex`, `coderabbit`, or `custom`) from `reviewBotLogins` and only reporting observable states: review signal observed, waiting for provider delivery, or missing provider signal.

The focused reproducer failed first because status only showed `configured_bot_review ... reviewers=chatgpt-codex-connector` without saying which profile was active or whether the provider had produced any usable signal. After the formatter change, the affected tests pass and the package builds. I also updated the local issue journal handoff and committed the checkpoint as `01ac42c` (`Surface active review-bot profile in status`).

Tests: `npm test -- --test-name-pattern="active review-bot profile and missing external signal for Codex profile"`; `npx tsx --test src/supervisor.test.ts src/config.test.ts`; `npm run build`

Summary: Added active review-bot profile and missing-signal diagnostics to status output, with a focused Codex-profile reproducer and passing verification.
State hint: stabilizing
Blocked reason: none
Tests: npm test -- --test-name...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced status output to include review bot profile information and diagnostic signals when review bots are configured.

* **Tests**
  * Added test cases for review bot status reporting and external signal detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->