### PR TITLE
CodeRabbit signal ingestion: accept issue comments and top-level reviews in addition to review threads (#223)

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -68,6 +68,7 @@ test("inferCopilotReviewLifecycle returns not_requested when no Copilot signal e
       reviewRequests: [],
       reviews: [],
       comments: [],
+      issueComments: [],
       timeline: [],
     },
     ["copilot-pull-request-reviewer"],
@@ -86,6 +87,7 @@ test("inferCopilotReviewLifecycle returns requested when Copilot was requested b
       reviewRequests: ["copilot-pull-request-reviewer"],
       reviews: [],
       comments: [],
+      issueComments: [],
       timeline: [
         {
           type: "requested",
@@ -115,6 +117,7 @@ test("inferCopilotReviewLifecycle returns arrived when Copilot review exists", (
         },
       ],
       comments: [],
+      issueComments: [],
       timeline: [
         {
           type: "requested",
@@ -144,6 +147,7 @@ test("inferCopilotReviewLifecycle returns arrived when Copilot comments on a rev
           createdAt: "2026-03-13T02:04:05Z",
         },
       ],
+      issueComments: [],
       timeline: [
         {
           type: "requested",
@@ -169,9 +173,12 @@ test("inferCopilotReviewLifecycle treats configured review bots generically for 
       {
         authorLogin: "chatgpt-codex-connector",
         submittedAt: "2026-03-13T02:03:04Z",
+        state: "COMMENTED",
+        body: "Nitpick: the fallback path still skips the auth guard.",
       },
     ],
     comments: [],
+    issueComments: [],
     timeline: [
       {
         type: "requested" as const,
@@ -193,6 +200,74 @@ test("inferCopilotReviewLifecycle treats configured review bots generically for 
   });
 
   assert.deepEqual(inferCopilotReviewLifecycle(facts, ["copilot-pull-request-reviewer", "chatgpt-codex-connector"]), {
+    state: "arrived",
+    requestedAt: "2026-03-13T01:02:03Z",
+    arrivedAt: "2026-03-13T02:03:04Z",
+  });
+});
+
+test("inferCopilotReviewLifecycle ignores summary-only and draft-skip issue comments from configured bots", () => {
+  const lifecycle = inferCopilotReviewLifecycle(
+    {
+      reviewRequests: ["coderabbitai[bot]"],
+      reviews: [],
+      comments: [],
+      issueComments: [
+        {
+          authorLogin: "coderabbitai[bot]",
+          createdAt: "2026-03-13T02:04:05Z",
+          body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+        },
+        {
+          authorLogin: "coderabbitai[bot]",
+          createdAt: "2026-03-13T02:05:05Z",
+          body: "Skipping review because this pull request is still in draft.",
+        },
+      ],
+      timeline: [
+        {
+          type: "requested",
+          createdAt: "2026-03-13T01:02:03Z",
+          reviewerLogin: "coderabbitai[bot]",
+        },
+      ],
+    },
+    ["coderabbitai[bot]"],
+  );
+
+  assert.deepEqual(lifecycle, {
+    state: "requested",
+    requestedAt: "2026-03-13T01:02:03Z",
+    arrivedAt: null,
+  });
+});
+
+test("inferCopilotReviewLifecycle treats actionable configured-bot top-level reviews as arrived", () => {
+  const lifecycle = inferCopilotReviewLifecycle(
+    {
+      reviewRequests: ["coderabbitai[bot]"],
+      reviews: [
+        {
+          authorLogin: "coderabbitai[bot]",
+          submittedAt: "2026-03-13T02:03:04Z",
+          state: "COMMENTED",
+          body: "Nitpick: this nil check is inverted and can mask the error path.",
+        },
+      ],
+      comments: [],
+      issueComments: [],
+      timeline: [
+        {
+          type: "requested",
+          createdAt: "2026-03-13T01:02:03Z",
+          reviewerLogin: "coderabbitai[bot]",
+        },
+      ],
+    },
+    ["coderabbitai[bot]"],
+  );
+
+  assert.deepEqual(lifecycle, {
     state: "arrived",
     requestedAt: "2026-03-13T01:02:03Z",
     arrivedAt: "2026-03-13T02:03:04Z",
@@ -410,6 +485,191 @@ test("GitHubClient refreshes same-head Copilot lifecycle transitions from not_re
   assert.equal(third.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
   assert.equal(third.copilotReviewArrivedAt, "2026-03-13T01:03:04Z");
   assert.equal(lifecycleCallCount, 3);
+});
+
+test("GitHubClient hydrates arrived lifecycle from actionable configured-bot issue comments", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  let lifecycleQuery: string | null = null;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          number: 44,
+          title: "Issue comment lifecycle transition",
+          url: "https://example.test/pr/44",
+          state: "OPEN",
+          createdAt: "2026-03-13T00:00:00Z",
+          updatedAt: "2026-03-13T00:00:00Z",
+          isDraft: false,
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          headRefName: "codex/issue-141",
+          headRefOid: "head-44",
+          mergedAt: null,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      lifecycleQuery = args.find((arg) => arg.startsWith("query=")) ?? null;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [
+                    {
+                      requestedReviewer: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                reviews: {
+                  nodes: [],
+                },
+                comments: {
+                  nodes: [
+                    {
+                      createdAt: "2026-03-13T02:24:00Z",
+                      body: "Nitpick: this guard should return early before mutating shared state.",
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [
+                    {
+                      __typename: "ReviewRequestedEvent",
+                      createdAt: "2026-03-13T01:02:03Z",
+                      requestedReviewer: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await client.getPullRequest(44);
+
+  assert.ok(lifecycleQuery);
+  assert.match(lifecycleQuery, /comments\(last:\s*100\)/);
+  assert.equal(pr.copilotReviewState, "arrived");
+  assert.equal(pr.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
+  assert.equal(pr.copilotReviewArrivedAt, "2026-03-13T02:24:00Z");
+});
+
+test("GitHubClient ignores summary-only and draft-skip configured-bot issue comments", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          number: 44,
+          title: "Summary-only issue comment lifecycle",
+          url: "https://example.test/pr/44",
+          state: "OPEN",
+          createdAt: "2026-03-13T00:00:00Z",
+          updatedAt: "2026-03-13T00:00:00Z",
+          isDraft: false,
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          headRefName: "codex/issue-141",
+          headRefOid: "head-44",
+          mergedAt: null,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [
+                    {
+                      requestedReviewer: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                reviews: {
+                  nodes: [],
+                },
+                comments: {
+                  nodes: [
+                    {
+                      createdAt: "2026-03-13T02:24:00Z",
+                      body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                    {
+                      createdAt: "2026-03-13T02:25:00Z",
+                      body: "Skipping review because this pull request is still in draft.",
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [
+                    {
+                      __typename: "ReviewRequestedEvent",
+                      createdAt: "2026-03-13T01:02:03Z",
+                      requestedReviewer: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await client.getPullRequest(44);
+
+  assert.equal(pr.copilotReviewState, "requested");
+  assert.equal(pr.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
+  assert.equal(pr.copilotReviewArrivedAt, null);
 });
 
 test("GitHubClient fetches the newest unresolved review thread comments", async () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -91,6 +91,17 @@ interface PullRequestCopilotReviewLifecycleResponse {
         login?: string | null;
       } | null;
       submittedAt?: string | null;
+      state?: string | null;
+      body?: string | null;
+    } | null>;
+  } | null;
+  comments?: {
+    nodes?: Array<{
+      createdAt?: string | null;
+      body?: string | null;
+      author?: {
+        login?: string | null;
+      } | null;
     } | null>;
   } | null;
   reviewThreads?: {
@@ -119,10 +130,17 @@ export interface CopilotReviewLifecycleFacts {
   reviews: Array<{
     authorLogin: string | null;
     submittedAt: string | null;
+    state?: string | null;
+    body?: string | null;
   }>;
   comments: Array<{
     authorLogin: string | null;
     createdAt: string | null;
+  }>;
+  issueComments: Array<{
+    authorLogin: string | null;
+    createdAt: string | null;
+    body: string | null;
   }>;
   timeline: Array<{
     type: "requested" | "removed";
@@ -210,6 +228,52 @@ function latestTimestamp(values: Array<string | null | undefined>): string | nul
   return latest;
 }
 
+function normalizeReviewText(value: string | null | undefined): string {
+  return value?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
+}
+
+function isInformationalReviewText(value: string | null | undefined): boolean {
+  const normalized = normalizeReviewText(value);
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    (normalized.includes("summary") && normalized.includes("no actionable")) ||
+    normalized.includes("no actionable issues") ||
+    normalized.includes("no actionable comments") ||
+    normalized.includes("skipping review") ||
+    normalized.includes("skip review") ||
+    normalized.includes("still in draft") ||
+    normalized.includes("pull request is in draft") ||
+    normalized.includes("pull request is still in draft")
+  );
+}
+
+function hasActionableReviewText(value: string | null | undefined): boolean {
+  const normalized = normalizeReviewText(value);
+  if (!normalized || isInformationalReviewText(normalized)) {
+    return false;
+  }
+
+  return /\b(nit|nitpick|suggestion|consider|should|could|bug|issue|error|warning|fix|missing|fails?|incorrect|unsafe|please)\b/.test(
+    normalized,
+  );
+}
+
+function isActionableTopLevelReview(review: CopilotReviewLifecycleFacts["reviews"][number]): boolean {
+  const state = normalizeReviewText(review.state);
+  if (state === "changes_requested") {
+    return true;
+  }
+
+  if (!review.body && !review.state) {
+    return true;
+  }
+
+  return hasActionableReviewText(review.body);
+}
+
 export function inferCopilotReviewLifecycle(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -221,13 +285,19 @@ export function inferCopilotReviewLifecycle(
 
   const matchingReviewTimes = facts.reviews.flatMap((review) => {
     const authorLogin = normalizeLogin(review.authorLogin);
-    return authorLogin && configuredReviewBots.has(authorLogin) ? [review.submittedAt] : [];
+    return authorLogin && configuredReviewBots.has(authorLogin) && isActionableTopLevelReview(review) ? [review.submittedAt] : [];
   });
   const matchingCommentTimes = facts.comments.flatMap((comment) => {
     const authorLogin = normalizeLogin(comment.authorLogin);
     return authorLogin && configuredReviewBots.has(authorLogin) ? [comment.createdAt] : [];
   });
-  const arrivedAt = latestTimestamp([...matchingReviewTimes, ...matchingCommentTimes]);
+  const matchingIssueCommentTimes = facts.issueComments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin && configuredReviewBots.has(authorLogin) && hasActionableReviewText(comment.body)
+      ? [comment.createdAt]
+      : [];
+  });
+  const arrivedAt = latestTimestamp([...matchingReviewTimes, ...matchingCommentTimes, ...matchingIssueCommentTimes]);
   if (arrivedAt) {
     return {
       state: "arrived",
@@ -1033,6 +1103,17 @@ export class GitHubClient {
             reviews(last: 100) {
               nodes {
                 submittedAt
+                state
+                body
+                author {
+                  login
+                }
+              }
+            }
+            comments(last: 100) {
+              nodes {
+                createdAt
+                body
                 author {
                   login
                 }
@@ -1125,6 +1206,8 @@ export class GitHubClient {
         lifecycle?.reviews?.nodes?.map((node) => ({
           authorLogin: normalizeLogin(node?.author?.login ?? null),
           submittedAt: node?.submittedAt ?? null,
+          state: node?.state ?? null,
+          body: node?.body ?? null,
         })) ?? [],
       comments:
         lifecycle?.reviewThreads?.nodes?.flatMap((thread) =>
@@ -1133,6 +1216,12 @@ export class GitHubClient {
             createdAt: comment?.createdAt ?? null,
           })),
         ) ?? [],
+      issueComments:
+        lifecycle?.comments?.nodes?.map((comment) => ({
+          authorLogin: normalizeLogin(comment?.author?.login ?? null),
+          createdAt: comment?.createdAt ?? null,
+          body: comment?.body ?? null,
+        })) ?? [],
       timeline:
         lifecycle?.timelineItems?.nodes
           ?.map((node) => {

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -3146,6 +3146,41 @@ test("inferStateFromPullRequest keeps waiting when Copilot review was explicitly
   });
 });
 
+test("inferStateFromPullRequest treats an arrived configured-bot top-level review as satisfying the wait state", () => {
+  withStubbedDateNow("2026-03-11T00:10:00Z", () => {
+    const config = createConfig({
+      copilotReviewWaitMinutes: 10,
+      reviewBotLogins: ["coderabbitai[bot]"],
+    });
+    const requestedAt = "2026-03-11T00:05:00Z";
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: requestedAt,
+      review_wait_head_sha: "head123",
+    });
+    const pr: GitHubPullRequest = {
+      number: 44,
+      title: "Test PR",
+      url: "https://example.test/pr/44",
+      state: "OPEN",
+      createdAt: "2026-03-11T00:00:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-38",
+      headRefOid: "head123",
+      mergedAt: null,
+      copilotReviewState: "arrived",
+      copilotReviewRequestedAt: requestedAt,
+      copilotReviewArrivedAt: "2026-03-11T00:07:00Z",
+    };
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
+  });
+});
+
 test("inferStateFromPullRequest keeps waiting when a Copilot request was observed on the current head but has not arrived", () => {
   withStubbedDateNow("2026-03-11T00:10:00Z", () => {
     const config = createConfig({


### PR DESCRIPTION
Closes #223
This PR was opened by codex-supervisor.
Latest Codex summary:

Added configured-bot PR issue-comment ingestion in [src/github.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-223/src/github.ts) by extending the lifecycle GraphQL query to fetch top-level PR comments and by classifying top-level bot review/comment text as actionable vs informational. Review-thread handling is unchanged, actionable top-level reviews still count as arrival, and summary-only or draft-skip comments stay non-actionable. I also added focused coverage in [src/github.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-223/src/github.test.ts) and [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-223/src/supervisor.test.ts).

Committed on `codex/issue-223` as `2d0025b` with message `Handle configured bot review comments`.

Summary: Added actionable configured-bot PR issue-comment ingestion, filtered summary/draft-skip bot comments, kept top-level review and review-thread behavior covered, and committed the verified fix.
State hint: implementing
Blocked reason: none
Tests: `npm test -- src/github.test.ts`; `npm test -- src/supervisor.test.ts`; `npm run build`
Failure signature: none
Next action: Advance supervisor state from reproducing to the next implementation/review phase and open or update the draft PR when appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Copilot review lifecycle tracking with improved distinction between actionable and informational review comments.
  * Expanded review state transitions to better capture when reviews are requested and arrive.

* **Tests**
  * Added comprehensive test coverage for review lifecycle behavior with bot-generated comments and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->