### PR TITLE
Review-bot profile detection: make CodeRabbit login matching order-insensitive (#225)

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -4199,6 +4199,58 @@ test("formatDetailedStatus surfaces active review-bot profile and missing extern
   );
 });
 
+test("formatDetailedStatus detects the CodeRabbit profile for canonical and reversed review bot login orderings", () => {
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: "REVIEW_REQUIRED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    copilotReviewState: "not_requested",
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+  };
+
+  for (const reviewBotLogins of [
+    ["coderabbitai", "coderabbitai[bot]"],
+    ["coderabbitai[bot]", "coderabbitai"],
+  ]) {
+    const config = createConfig({ reviewBotLogins });
+    const status = formatDetailedStatus({
+      config,
+      activeRecord: createRecord({
+        pr_number: 44,
+        state: "pr_open",
+        blocked_reason: null,
+        external_review_head_sha: null,
+        external_review_matched_findings_count: 0,
+        external_review_near_match_findings_count: 0,
+        external_review_missed_findings_count: 0,
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      }),
+      latestRecord: null,
+      trackedIssueCount: 1,
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [],
+    });
+
+    assert.match(
+      status,
+      /review_bot_profile profile=coderabbit provider=coderabbitai .* signal_source=review_threads/,
+    );
+  }
+});
+
 test("formatDetailedStatus preserves Copilot-specific timeout wording for Copilot-only repos", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1066,6 +1066,7 @@ interface ReviewBotDiagnostics {
 function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummary {
   const reviewers = configuredReviewBots(config);
   const normalized = reviewers.map((reviewer) => reviewer.toLowerCase());
+  const normalizedSet = new Set(normalized);
 
   if (normalized.length === 0) {
     return {
@@ -1096,8 +1097,8 @@ function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummar
 
   if (
     normalized.length === 2 &&
-    normalized[0] === "coderabbitai" &&
-    normalized[1] === "coderabbitai[bot]"
+    normalizedSet.has("coderabbitai") &&
+    normalizedSet.has("coderabbitai[bot]")
   ) {
     return {
       profile: "coderabbit",


### PR DESCRIPTION
Closes #225
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated CodeRabbit profile detection to ignore `reviewBotLogins` ordering by checking the expected two-login set instead of positional array indexes in [src/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-225/src/supervisor.ts#L1066). I also added a focused supervisor-status test that covers both canonical and reversed CodeRabbit login orderings in [src/supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-225/src/supervisor.test.ts#L4202).

Verification passed: focused profile-detection tests and `npm run build`. Checkpoint commit is `5c122b6` (`Make CodeRabbit profile detection order-insensitive`). The local issue journal was updated as requested.

Summary: Made CodeRabbit profile detection order-insensitive, added focused coverage for both login orders, and committed the fix as `5c122b6`.
State hint: implementing
Blocked reason: none
Tests: `npm test -- --test-name-pattern="formatDetailedStatus detects the CodeRabbit profile for canonical and reversed review bot login orderings"`; `npm test -- --test-name-pattern="review-bot profile|CodeRabbit profile"`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-225` with commit `5c122b6` and proceed to review/local verification flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CodeRabbit profile detection to work correctly regardless of the order in which reviewer logins are configured, ensuring consistent detection across different setup configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->