### PR TITLE
Restrict durable promotion by external review source tier

### DIFF
--- a/src/external-review-durable-guardrail-candidates.test.ts
+++ b/src/external-review-durable-guardrail-candidates.test.ts
@@ -238,6 +238,49 @@ test("toDurableGuardrailCandidates allows unanchored actionable top-level review
   ]);
 });
 
+test("toDurableGuardrailCandidates restricts file-scoped top-level reviews to reviewer_rubric", () => {
+  const candidates = toDurableGuardrailCandidates({
+    issueNumber: 85,
+    prNumber: 144,
+    branch: "codex/issue-85",
+    headSha: "deadbeefcafebabe",
+    sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+    localReviewSummaryPath: "/tmp/head-deadbeef.md",
+    localReviewFindingsPath: "/tmp/head-deadbeef.json",
+    finding: createMissFinding({
+      sourceKind: "top_level_review",
+      sourceId: "review-7",
+      sourceUrl: "https://example.test/pr/1#pullrequestreview-7",
+      threadId: null,
+      severity: "high",
+      url: "https://example.test/pr/1#pullrequestreview-7",
+    }),
+  });
+
+  assert.deepEqual(candidates.map((candidate) => candidate.category), ["reviewer_rubric"]);
+});
+
+test("toDurableGuardrailCandidates does not durably promote issue comments by default", () => {
+  const candidates = toDurableGuardrailCandidates({
+    issueNumber: 85,
+    prNumber: 144,
+    branch: "codex/issue-85",
+    headSha: "deadbeefcafebabe",
+    sourceArtifactPath: "/tmp/external-review-misses-head-deadbeef.json",
+    localReviewSummaryPath: "/tmp/head-deadbeef.md",
+    localReviewFindingsPath: "/tmp/head-deadbeef.json",
+    finding: createMissFinding({
+      sourceKind: "issue_comment",
+      sourceId: "issue-comment-7",
+      sourceUrl: "https://example.test/pr/1#issuecomment-7",
+      threadId: null,
+      url: "https://example.test/pr/1#issuecomment-7",
+    }),
+  });
+
+  assert.deepEqual(candidates, []);
+});
+
 test("toDurableGuardrailCandidates keeps unanchored durable ids stable across PR-local source ids", () => {
   const findingA = createMissFinding({
     sourceKind: "top_level_review",

--- a/src/external-review-durable-guardrail-candidates.ts
+++ b/src/external-review-durable-guardrail-candidates.ts
@@ -4,6 +4,7 @@ import {
   type ExternalReviewDurableGuardrailCandidate,
   type ExternalReviewDurableGuardrailCandidateCategory,
 } from "./external-review-miss-artifact-types";
+import { type ExternalReviewSignalSourceKind } from "./external-review-normalization";
 
 interface CandidateQualificationRule {
   reason: string;
@@ -13,6 +14,7 @@ interface CandidateQualificationRule {
 interface CandidateSpec {
   category: ExternalReviewDurableGuardrailCandidateCategory;
   titlePrefix: string;
+  allowedSourceKinds: readonly ExternalReviewSignalSourceKind[];
   rules: CandidateQualificationRule[];
 }
 
@@ -31,6 +33,7 @@ const CANDIDATE_SPECS: CandidateSpec[] = [
   {
     category: "reviewer_rubric",
     titlePrefix: "Promote reviewer rubric guardrail for",
+    allowedSourceKinds: ["review_thread", "top_level_review"],
     rules: [
       ...COMMON_RULES,
       {
@@ -42,6 +45,7 @@ const CANDIDATE_SPECS: CandidateSpec[] = [
   {
     category: "verifier",
     titlePrefix: "Promote verifier guardrail for",
+    allowedSourceKinds: ["review_thread"],
     rules: [
       ...COMMON_RULES,
       {
@@ -61,6 +65,7 @@ const CANDIDATE_SPECS: CandidateSpec[] = [
   {
     category: "regression_test",
     titlePrefix: "Promote regression-test guardrail for",
+    allowedSourceKinds: ["review_thread"],
     rules: [
       ...COMMON_RULES,
       {
@@ -83,6 +88,13 @@ function qualifies(
   finding: ExternalReviewMissFinding,
   spec: CandidateSpec,
 ): { qualified: boolean; qualificationReasons: string[] } {
+  if (!spec.allowedSourceKinds.includes(finding.sourceKind)) {
+    return {
+      qualified: false,
+      qualificationReasons: [],
+    };
+  }
+
   const qualificationReasons: string[] = [];
 
   for (const rule of spec.rules) {

--- a/src/external-review-regression-candidates.test.ts
+++ b/src/external-review-regression-candidates.test.ts
@@ -68,4 +68,28 @@ test("toRegressionTestCandidate rejects misses that do not meet the durable regr
     ),
     null,
   );
+  assert.equal(
+    toRegressionTestCandidate(
+      createMissFinding({
+        sourceKind: "top_level_review",
+        sourceId: "review-1",
+        sourceUrl: "https://example.test/pr/1#pullrequestreview-1",
+        threadId: null,
+        url: "https://example.test/pr/1#pullrequestreview-1",
+      }),
+    ),
+    null,
+  );
+  assert.equal(
+    toRegressionTestCandidate(
+      createMissFinding({
+        sourceKind: "issue_comment",
+        sourceId: "issue-comment-1",
+        sourceUrl: "https://example.test/pr/1#issuecomment-1",
+        threadId: null,
+        url: "https://example.test/pr/1#issuecomment-1",
+      }),
+    ),
+    null,
+  );
 });

--- a/src/external-review-regression-candidates.ts
+++ b/src/external-review-regression-candidates.ts
@@ -9,7 +9,7 @@ export function createRegressionCandidateId(finding: ExternalReviewMissFinding):
 export function toRegressionTestCandidate(
   finding: ExternalReviewMissFinding,
 ): ExternalReviewRegressionCandidate | null {
-  if (finding.classification !== "missed_by_local_review") {
+  if (finding.classification !== "missed_by_local_review" || finding.sourceKind !== "review_thread") {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- gate durable external-review promotion by source kind
- keep review-thread findings eligible for stronger verifier and regression promotion
- restrict top-level reviews to reviewer-rubric promotion and block issue-comment durable promotion by default

## Testing
- npm test -- src/external-review-durable-guardrail-candidates.test.ts
- npm test -- src/external-review-regression-candidates.test.ts
- npm run build

Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restricted file-scoped top-level reviews to reviewer_rubric category only.
  * Issue comments are no longer automatically promoted as durable guardrail candidates.
  * Regression test candidates now only accept review thread sources with missed findings.

* **Tests**
  * Added coverage for review source type validation and default promotion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->