### PR TITLE
Supervisor cleanup: prune orphaned worktrees that are no longer referenced by state (#231)

### DIFF
--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -970,6 +970,59 @@ test("runOnce ignores non-canonical orphan workspace names", async () => {
   assert.match(git(["-C", fixture.repoPath, "branch", "--list", orphanBranch]), new RegExp(orphanBranch));
 });
 
+test("runOnce skips orphan cleanup when workspaceRoot cannot be listed", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.maxDoneWorkspaces = 1;
+  fixture.config.cleanupDoneWorkspacesAfterHours = -1;
+
+  const workspaceRootFile = path.join(path.dirname(fixture.stateFile), "workspace-root-file");
+  await fs.writeFile(workspaceRootFile, "not a directory\n", "utf8");
+  fixture.config.workspaceRoot = workspaceRootFile;
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [],
+    listCandidateIssues: async () => [],
+    getIssue: async () => {
+      throw new Error("unexpected getIssue call");
+    },
+    resolvePullRequestForBranch: async () => {
+      throw new Error("unexpected resolvePullRequestForBranch call");
+    },
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (message?: unknown, ...args: unknown[]) => {
+    warnings.push([message, ...args].map((value) => String(value)).join(" "));
+  };
+  try {
+    const message = await supervisor.runOnce({ dryRun: true });
+    assert.equal(message, "No matching open issue found.");
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.match(warnings.join("\n"), /Skipped orphaned workspace cleanup: unable to read workspace root/);
+});
+
 test("runOnce moves a non-ready issue into blocked(requirements) with missing requirements", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 91;

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -570,15 +570,22 @@ async function cleanupOrphanedIssueWorkspaces(
   config: SupervisorConfig,
   state: SupervisorStateFile,
 ): Promise<RecoveryEvent[]> {
-  if (!fs.existsSync(config.workspaceRoot)) {
-    return [];
-  }
-
   const referencedWorkspaces = new Set(
     Object.values(state.issues).map((record) => path.resolve(record.workspace)),
   );
   const recoveryEvents: RecoveryEvent[] = [];
-  const workspaceEntries = fs.readdirSync(config.workspaceRoot, { withFileTypes: true });
+  let workspaceEntries: fs.Dirent[];
+  try {
+    workspaceEntries = fs.readdirSync(config.workspaceRoot, { withFileTypes: true });
+  } catch (error) {
+    const maybeErr = error as NodeJS.ErrnoException;
+    if (maybeErr.code !== "ENOENT") {
+      console.warn(
+        `Skipped orphaned workspace cleanup: unable to read workspace root ${config.workspaceRoot} (${maybeErr.message}).`,
+      );
+    }
+    return recoveryEvents;
+  }
 
   for (const entry of workspaceEntries) {
     if (!entry.isDirectory()) {


### PR DESCRIPTION
Closes #231
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented orphaned worktree pruning in the supervisor cleanup path. `runOnce` now scans `workspaceRoot` for unreferenced `issue-*` git worktrees, derives the expected branch safely, prunes only safe orphan targets, and adds recovery-log entries so the cleanup is visible in output ([supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-231/src/supervisor.ts#L560), [supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-231/src/supervisor.ts#L2359), [supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-231/src/supervisor.ts#L4117)). I also added a focused regression test that reproduces the drift case with one tracked done workspace plus one orphan and verifies the orphan is removed while the tracked workspace remains ([supervisor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-231/src/supervisor.test.ts#L862)).

Local journal notes were updated in the ignored issue journal, and I created checkpoint commit `0f110ea` with message `Prune orphaned done worktrees`.

Summary: Added orphaned `issue-*` worktree pruning with recovery logging and a focused regression test; committed as `0f110ea`.
State hint: stabilizing
Blocked reason: none
Tests: `npm test -- src/supervisor.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for `codex/issue-231`, then wait for CI or review feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically prunes orphaned workspaces no longer referenced by state and records recovery events in logs.
  * Pruning only targets workspaces with canonical issue-style names; non-canonical names are ignored.

* **Bug Fixes**
  * Cleanup now safely skips when the workspace root cannot be listed and emits a warning instead of failing.

* **Tests**
  * Added tests for pruning, non-canonical names, and unreadable workspace-root handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->