### PR TITLE
Supervisor refactor: extract issue selection, readiness gates, and reservation flow (#239)

### DIFF
--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -193,6 +193,91 @@ test("resolveRunnableIssueContext keeps the acquired lock attached to a ready is
   assert.equal(savedStates.length, 1);
 });
 
+test("resolveRunnableIssueContext does not persist a new active reservation when the issue lock is busy", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = {
+    number: 93,
+    title: "Ready issue",
+    body: executionReadyBody("Ship the ready issue."),
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/93",
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const savedStates: SupervisorStateFile[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+    },
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: false,
+      reason: "lock held by pid 123 for issue-93",
+      release: async () => {},
+    }),
+  });
+
+  assert.equal(result, "Skipped issue #93: lock held by pid 123 for issue-93.");
+  assert.equal(state.activeIssueNumber, null);
+  assert.deepEqual(state.issues, {});
+  assert.equal(savedStates.length, 0);
+});
+
+test("resolveRunnableIssueContext restarts closed issues instead of handing them off as ready", async () => {
+  const config = createConfig();
+  const selectedIssue: GitHubIssue = {
+    number: 94,
+    title: "Ready issue",
+    body: executionReadyBody("Ship the ready issue."),
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/94",
+    state: "OPEN",
+  };
+  const closedIssue: GitHubIssue = {
+    ...selectedIssue,
+    state: "CLOSED",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const savedStates: SupervisorStateFile[] = [];
+  let released = false;
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [selectedIssue],
+      getIssue: async () => closedIssue,
+    },
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {
+        released = true;
+      },
+    }),
+  });
+
+  assert.deepEqual(result, { kind: "restart" });
+  assert.equal(released, true);
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["94"]?.state, "done");
+  assert.equal(savedStates.length, 2);
+});
+
 test("resolveRunnableIssueContext skips dependency-blocked candidates and reserves the next ready issue", async () => {
   const config = createConfig();
   const dependencyIssue: GitHubIssue = {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -36,6 +36,11 @@ type IssueSelectionStateStore = Pick<StateStore, "save" | "touch">;
 
 type IssueJournalContext = Pick<IssueRunRecord, "workspace" | "journal_path">;
 
+interface SelectedIssueRecord {
+  record: IssueRunRecord;
+  persistReservation: boolean;
+}
+
 interface SyncIssueJournalArgs {
   issue: GitHubIssue;
   record: IssueRunRecord;
@@ -289,7 +294,7 @@ async function selectIssueRecord(
   stateStore: IssueSelectionStateStore,
   state: SupervisorStateFile,
   currentRecord: IssueRunRecord | null,
-): Promise<IssueRunRecord | string> {
+): Promise<SelectedIssueRecord | string> {
   let record = currentRecord;
 
   if (!record || !isEligibleForSelection(record, config)) {
@@ -319,12 +324,16 @@ async function selectIssueRecord(
       return "No matching open issue found.";
     }
 
-    state.activeIssueNumber = record.issue_number;
-    state.issues[String(record.issue_number)] = record;
-    await stateStore.save(state);
+    return {
+      record,
+      persistReservation: true,
+    };
   }
 
-  return record;
+  return {
+    record,
+    persistReservation: false,
+  };
 }
 
 export async function resolveRunnableIssueContext(
@@ -345,7 +354,7 @@ export async function resolveRunnableIssueContext(
     return selectedRecord;
   }
 
-  let record = selectedRecord;
+  let { record, persistReservation } = selectedRecord;
   const issueLock = await acquireIssueLock(record);
   if (!issueLock.acquired) {
     return `Skipped issue #${record.issue_number}: ${issueLock.reason}.`;
@@ -353,8 +362,15 @@ export async function resolveRunnableIssueContext(
 
   let shouldReleaseIssueLock = true;
   try {
+    if (persistReservation) {
+      state.activeIssueNumber = record.issue_number;
+      state.issues[String(record.issue_number)] = record;
+      await stateStore.save(state);
+      persistReservation = false;
+    }
+
     const issue = await github.getIssue(record.issue_number);
-    if (issue.state === "CLOSED" && record.pr_number !== null) {
+    if (issue.state === "CLOSED") {
       record = stateStore.touch(record, { state: "done" });
       state.issues[String(record.issue_number)] = record;
       state.activeIssueNumber = null;

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -16,6 +16,7 @@ import {
   shouldAutoRetryHandoffMissing,
   summarizeChecks,
 } from "./supervisor";
+import { StateStore } from "./state-store";
 import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, SupervisorStateFile } from "./types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -2151,6 +2152,72 @@ test("runOnce releases the current issue lock before restarting after a merged P
   assert.equal(persisted.issues[String(mergedIssueNumber)]?.last_head_sha, "merged-head-191");
   assert.equal(persisted.issues[String(nextIssueNumber)]?.branch, nextBranch);
   assert.equal(listAllIssuesCalls, 2);
+});
+
+test("runOnce releases the issue lock when budget failure persistence throws", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 91;
+  const issueLockPath = path.join(
+    path.dirname(fixture.stateFile),
+    "locks",
+    "issues",
+    `issue-${issueNumber}.lock`,
+  );
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Budget exhausted issue",
+    body: executionReadyBody("Budget exhausted issue."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(
+    createConfig({
+      ...fixture.config,
+      maxImplementationAttemptsPerIssue: 0,
+    }),
+  );
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const stateStore = (supervisor as unknown as { stateStore: StateStore }).stateStore;
+  const originalSave = stateStore.save.bind(stateStore);
+  stateStore.save = async (nextState: SupervisorStateFile) => {
+    const record = nextState.issues[String(issueNumber)];
+    if (record?.state === "failed") {
+      throw new Error("injected state save failure");
+    }
+    await originalSave(nextState);
+  };
+
+  await assert.rejects(
+    supervisor.runOnce({ dryRun: true }),
+    /injected state save failure/,
+  );
+  await assert.rejects(fs.access(issueLockPath));
 });
 
 test("runOnce clears a stale active issue reservation before selecting the next runnable issue", async () => {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -2848,33 +2848,36 @@ export class Supervisor {
     let { record, issue, issueLock } = runnableIssue;
     const budgetLaneBeforeWorkspace = attemptLane(record, null);
     if (!hasAttemptBudgetRemaining(record, this.config, budgetLaneBeforeWorkspace)) {
-      const used = attemptsUsedForLane(record, budgetLaneBeforeWorkspace);
-      const max = attemptBudgetForLane(this.config, budgetLaneBeforeWorkspace);
-      const failureContext = buildCodexFailureContext(
-        "manual",
-        `Issue #${record.issue_number} exhausted its ${budgetLaneBeforeWorkspace} Codex attempt budget.`,
-        [
-          `attempt_lane=${budgetLaneBeforeWorkspace}`,
-          `attempts=${used}`,
-          `max=${max}`,
-          `total_attempts=${record.attempt_count}`,
-        ],
-      );
-      record = this.stateStore.touch(record, {
-        state: "failed",
-        last_failure_kind: "command_error",
-        last_error:
-          `Reached max ${budgetLaneBeforeWorkspace} Codex attempts for issue #${record.issue_number} ` +
-          `(${used}/${max}).`,
-        last_failure_context: failureContext,
-        ...applyFailureSignature(record, failureContext),
-        blocked_reason: null,
-      });
-      state.issues[String(record.issue_number)] = record;
-      state.activeIssueNumber = null;
-      await this.stateStore.save(state);
-      await issueLock.release();
-      return `Issue #${record.issue_number} reached max ${budgetLaneBeforeWorkspace} Codex attempts.`;
+      try {
+        const used = attemptsUsedForLane(record, budgetLaneBeforeWorkspace);
+        const max = attemptBudgetForLane(this.config, budgetLaneBeforeWorkspace);
+        const failureContext = buildCodexFailureContext(
+          "manual",
+          `Issue #${record.issue_number} exhausted its ${budgetLaneBeforeWorkspace} Codex attempt budget.`,
+          [
+            `attempt_lane=${budgetLaneBeforeWorkspace}`,
+            `attempts=${used}`,
+            `max=${max}`,
+            `total_attempts=${record.attempt_count}`,
+          ],
+        );
+        record = this.stateStore.touch(record, {
+          state: "failed",
+          last_failure_kind: "command_error",
+          last_error:
+            `Reached max ${budgetLaneBeforeWorkspace} Codex attempts for issue #${record.issue_number} ` +
+            `(${used}/${max}).`,
+          last_failure_context: failureContext,
+          ...applyFailureSignature(record, failureContext),
+          blocked_reason: null,
+        });
+        state.issues[String(record.issue_number)] = record;
+        state.activeIssueNumber = null;
+        await this.stateStore.save(state);
+        return `Issue #${record.issue_number} reached max ${budgetLaneBeforeWorkspace} Codex attempts.`;
+      } finally {
+        await issueLock.release();
+      }
     }
 
     return {


### PR DESCRIPTION
Closes #239
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the selection/gating boundary into [run-once-issue-selection.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-239/src/run-once-issue-selection.ts) and delegated [Supervisor.resolveRunnableIssueContext]( /home/tommy/Dev/codex-supervisor-self-worktrees/issue-239/src/supervisor.ts ) to it, leaving attempt-budget handling in `supervisor.ts`. The new phase owns issue selection, execution-ready checks, clarification blocking, dependency blocking, and issue-lock reservation/restart handoff. I also added focused coverage in [run-once-issue-selection.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-239/src/run-once-issue-selection.test.ts) for requirements blocking with journal sync and lock release, ready lock handoff, and dependency-skipping selection.

Verification passed with `npx tsx --test src/run-once-issue-selection.test.ts`, `npm test -- src/supervisor.test.ts src/run-once-issue-selection.test.ts`, and `npm run build`. Checkpoint commit: `b66dbe1` (`Extract supervisor issue selection phase`).

Summary: Extracted supervisor issue selection/readiness gating into a dedicated phase module with focused tests and kept existing supervisor behavior green
State hint: implementing
Blocked reason: none
Tests: npx tsx --test src/run-once-issue-selection.test.ts; npm test -- src/supervisor.test.ts src/run-once-issue-selection.test.ts; npm run build
Failure signature: none
Next action: Open or update a draft PR for commit b66dbe1, then continue the remai...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated issue selection and preparation into a single, dedicated flow for more consistent selection, locking, and restart behavior.

* **Tests**
  * Added extensive tests covering ready handoffs, busy locks, restart paths, dependency-blocking, and ensuring locks are released when persistence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->