### PR TITLE
Supervisor refactor: extract workspace and pull-request preparation flow (#240)

### DIFF
--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -1,0 +1,438 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isRestartRunOnce,
+  prepareIssueExecutionContext,
+} from "./run-once-issue-preparation";
+import {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  SupervisorConfig,
+  SupervisorStateFile,
+  WorkspaceStatus,
+} from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+      specialist: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/reopen-issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 240,
+    state: "reproducing",
+    branch: "codex/reopen-issue-240",
+    pr_number: null,
+    workspace: "/tmp/workspaces/issue-240",
+    journal_path: null,
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: null,
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 0,
+    implementation_attempt_count: 0,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: null,
+    last_codex_summary: "previous summary",
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: "previous error",
+    last_failure_kind: "command_error",
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: "handoff_missing",
+    processed_review_thread_ids: [],
+    updated_at: "2026-03-15T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 240,
+    title: "Extract preparation flow",
+    body: "",
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/240",
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+function createWorkspaceStatus(overrides: Partial<WorkspaceStatus> = {}): WorkspaceStatus {
+  return {
+    branch: "codex/reopen-issue-240",
+    headSha: "head-240",
+    hasUncommittedChanges: false,
+    baseAhead: 0,
+    baseBehind: 0,
+    remoteBranchExists: false,
+    remoteAhead: 0,
+    remoteBehind: 0,
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 240,
+    title: "Extract preparation flow",
+    url: "https://example.test/pr/240",
+    state: "OPEN",
+    createdAt: "2026-03-15T00:10:00Z",
+    isDraft: true,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/reopen-issue-240",
+    headRefOid: "pr-head-240",
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+function createState(record: IssueRunRecord): SupervisorStateFile {
+  return {
+    activeIssueNumber: record.issue_number,
+    issues: {
+      [String(record.issue_number)]: record,
+    },
+  };
+}
+
+test("prepareIssueExecutionContext prepares workspace, journal, memory, and head state", async () => {
+  const record = createRecord();
+  const state = createState(record);
+  const config = createConfig();
+  const issue = createIssue();
+  const workspaceStatus = createWorkspaceStatus({ headSha: "workspace-head-240" });
+  const saveSnapshots: SupervisorStateFile[] = [];
+  const touchedRecords: IssueRunRecord[] = [];
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config,
+    stateStore: {
+      touch(currentRecord, patch) {
+        const nextRecord = { ...currentRecord, ...patch };
+        touchedRecords.push(nextRecord);
+        return nextRecord;
+      },
+      async save(currentState) {
+        saveSnapshots.push(JSON.parse(JSON.stringify(currentState)));
+      },
+    },
+    state,
+    record,
+    issue,
+    options: { dryRun: true },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async ({ journalPath, record: currentRecord }) => {
+      assert.equal(journalPath, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
+      assert.equal(currentRecord.state, "planning");
+    },
+    syncMemoryArtifacts: async ({ workspacePath, journalPath }) => {
+      assert.equal(workspacePath, "/tmp/workspaces/issue-240");
+      assert.equal(journalPath, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
+      return {
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+        alwaysReadFiles: ["/tmp/AGENTS.generated.md", "/tmp/context-index.md", journalPath],
+        onDemandFiles: [],
+      };
+    },
+    getWorkspaceStatus: async () => workspaceStatus,
+  });
+
+  assert.equal(typeof result, "object");
+  assert.ok(result && !isRestartRunOnce(result) && typeof result !== "string");
+  assert.equal(result.record.state, "planning");
+  assert.equal(result.record.last_head_sha, "workspace-head-240");
+  assert.equal(result.previousCodexSummary, "previous summary");
+  assert.equal(result.previousError, "previous error");
+  assert.equal(result.workspacePath, "/tmp/workspaces/issue-240");
+  assert.equal(result.journalPath, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
+  assert.equal(result.pr, null);
+  assert.equal(saveSnapshots.length, 2);
+  assert.equal(saveSnapshots[0]?.issues["240"]?.journal_path, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
+  assert.equal(saveSnapshots[1]?.issues["240"]?.last_head_sha, "workspace-head-240");
+  assert.equal(touchedRecords.at(-1)?.last_head_sha, "workspace-head-240");
+});
+
+test("prepareIssueExecutionContext restarts when a tracked PR already merged", async () => {
+  const record = createRecord({
+    implementation_attempt_count: 2,
+    pr_number: 191,
+    state: "pr_open",
+  });
+  const state = createState(record);
+  const issue = createIssue();
+  const mergedPr = createPullRequest({
+    number: 191,
+    state: "MERGED",
+    isDraft: false,
+    headRefOid: "merged-head-191",
+    mergedAt: "2026-03-15T00:20:00Z",
+  });
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => mergedPr,
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: createConfig(),
+    stateStore: {
+      touch(currentRecord, patch) {
+        return { ...currentRecord, ...patch };
+      },
+      async save() {},
+    },
+    state,
+    record,
+    issue,
+    options: { dryRun: true },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async () => {},
+    syncMemoryArtifacts: async () => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => createWorkspaceStatus(),
+    now: () => "2026-03-15T00:30:00Z",
+  });
+
+  assert.ok(isRestartRunOnce(result));
+  assert.equal(result.recoveryEvents?.[0]?.reason, "merged_pr_convergence: tracked PR #191 merged; marked issue #240 done");
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["240"]?.state, "done");
+  assert.equal(state.issues["240"]?.pr_number, 191);
+  assert.equal(state.issues["240"]?.last_head_sha, "merged-head-191");
+});
+
+test("prepareIssueExecutionContext blocks and syncs the journal when a tracked PR was closed", async () => {
+  const record = createRecord({
+    implementation_attempt_count: 2,
+    pr_number: 44,
+    state: "pr_open",
+    last_failure_signature: "old",
+    repeated_failure_signature_count: 2,
+  });
+  const state = createState(record);
+  const issue = createIssue();
+  const closedPr = createPullRequest({
+    number: 44,
+    state: "CLOSED",
+    headRefOid: "closed-head-44",
+  });
+  const journalSyncs: string[] = [];
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => closedPr,
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: createConfig(),
+    stateStore: {
+      touch(currentRecord, patch) {
+        return { ...currentRecord, ...patch };
+      },
+      async save() {},
+    },
+    state,
+    record,
+    issue,
+    options: { dryRun: true },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async ({ record: currentRecord }) => {
+      journalSyncs.push(`${currentRecord.state}:${currentRecord.blocked_reason}`);
+    },
+    syncMemoryArtifacts: async () => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => createWorkspaceStatus(),
+    now: () => "2026-03-15T00:30:00Z",
+  });
+
+  assert.equal(result, "Issue #240 blocked because PR #44 was closed without merge.");
+  assert.deepEqual(journalSyncs, ["pr_open:null", "blocked:manual_pr_closed"]);
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["240"]?.state, "blocked");
+  assert.equal(state.issues["240"]?.blocked_reason, "manual_pr_closed");
+  assert.match(state.issues["240"]?.last_error ?? "", /PR #44 was closed without merge/);
+  assert.equal(state.issues["240"]?.repeated_failure_signature_count, 1);
+});
+
+test("prepareIssueExecutionContext creates a draft PR after checkpointed workspace hydration", async () => {
+  const record = createRecord({
+    implementation_attempt_count: 2,
+    state: "stabilizing",
+  });
+  const state = createState(record);
+  const issue = createIssue();
+  const workspaceStatus = createWorkspaceStatus({
+    baseAhead: 2,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+  });
+  const draftPr = createPullRequest({ number: 113, headRefOid: "draft-pr-head-113" });
+  const pushCalls: Array<{ workspacePath: string; branch: string; remoteBranchExists: boolean }> = [];
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      getChecks: async (prNumber: number) => {
+        assert.equal(prNumber, 113);
+        return [];
+      },
+      getUnresolvedReviewThreads: async (prNumber: number) => {
+        assert.equal(prNumber, 113);
+        return [];
+      },
+      createPullRequest: async (currentIssue, currentRecord, options) => {
+        assert.equal(currentIssue.number, 240);
+        assert.equal(currentRecord.issue_number, 240);
+        assert.deepEqual(options, { draft: true });
+        return draftPr;
+      },
+    },
+    config: createConfig({ draftPrAfterAttempt: 1 }),
+    stateStore: {
+      touch(currentRecord, patch) {
+        return { ...currentRecord, ...patch };
+      },
+      async save() {},
+    },
+    state,
+    record,
+    issue,
+    options: { dryRun: false },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async () => {},
+    syncMemoryArtifacts: async () => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => workspaceStatus,
+    pushBranch: async (workspacePath, branch, remoteBranchExists) => {
+      pushCalls.push({ workspacePath, branch, remoteBranchExists });
+    },
+  });
+
+  assert.equal(typeof result, "object");
+  assert.ok(result && !isRestartRunOnce(result) && typeof result !== "string");
+  assert.equal(result.pr?.number, 113);
+  assert.deepEqual(pushCalls, [
+    {
+      workspacePath: "/tmp/workspaces/issue-240",
+      branch: "codex/reopen-issue-240",
+      remoteBranchExists: true,
+    },
+  ]);
+});

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -1,0 +1,345 @@
+import { GitHubClient } from "./github";
+import { issueJournalPath, syncIssueJournal as syncIssueJournalImpl } from "./journal";
+import { syncMemoryArtifacts as syncMemoryArtifactsImpl } from "./memory";
+import { RecoveryEvent } from "./run-once-cycle-prelude";
+import { StateStore } from "./state-store";
+import {
+  CliOptions,
+  FailureContext,
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+  WorkspaceStatus,
+} from "./types";
+import { nowIso } from "./utils";
+import {
+  ensureWorkspace as ensureWorkspaceImpl,
+  getWorkspaceStatus as getWorkspaceStatusImpl,
+  pushBranch as pushBranchImpl,
+} from "./workspace";
+
+export type IssueJournalSync = (record: IssueRunRecord) => Promise<void>;
+export type MemoryArtifacts = Awaited<ReturnType<typeof syncMemoryArtifactsImpl>>;
+
+export interface PreparedWorkspaceContext {
+  record: IssueRunRecord;
+  issue: GitHubIssue;
+  previousCodexSummary: string | null;
+  previousError: string | null;
+  workspacePath: string;
+  journalPath: string;
+  syncJournal: IssueJournalSync;
+  memoryArtifacts: MemoryArtifacts;
+  workspaceStatus: WorkspaceStatus;
+}
+
+export interface HydratedPullRequestContext {
+  record: IssueRunRecord;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  workspaceStatus: WorkspaceStatus;
+}
+
+export interface PreparedIssueExecutionContext extends PreparedWorkspaceContext, HydratedPullRequestContext {}
+
+export interface RestartRunOnce {
+  kind: "restart";
+  recoveryEvents?: RecoveryEvent[];
+}
+
+type PreparationGitHub = Pick<
+  GitHubClient,
+  "resolvePullRequestForBranch" | "getChecks" | "getUnresolvedReviewThreads" | "createPullRequest"
+>;
+type PreparationStateStore = Pick<StateStore, "save" | "touch">;
+
+interface SyncIssueJournalArgs {
+  issue: GitHubIssue;
+  record: IssueRunRecord;
+  journalPath: string;
+  maxChars: number;
+}
+
+interface SyncMemoryArtifactsArgs {
+  config: SupervisorConfig;
+  issueNumber: number;
+  workspacePath: string;
+  journalPath: string;
+}
+
+interface PrepareIssueExecutionContextArgs {
+  github: PreparationGitHub;
+  config: SupervisorConfig;
+  stateStore: PreparationStateStore;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  issue: GitHubIssue;
+  options: Pick<CliOptions, "dryRun">;
+  ensureWorkspace?: (config: SupervisorConfig, issueNumber: number, branch: string) => Promise<string>;
+  syncIssueJournal?: (args: SyncIssueJournalArgs) => Promise<void>;
+  syncMemoryArtifacts?: (args: SyncMemoryArtifactsArgs) => Promise<MemoryArtifacts>;
+  getWorkspaceStatus?: (workspacePath: string, branch: string, defaultBranch: string) => Promise<WorkspaceStatus>;
+  pushBranch?: (workspacePath: string, branch: string, remoteBranchExists: boolean) => Promise<void>;
+  now?: () => string;
+}
+
+export function isRestartRunOnce(
+  result: unknown,
+): result is RestartRunOnce {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "kind" in result &&
+    (result as { kind?: string }).kind === "restart"
+  );
+}
+
+function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
+  return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
+}
+
+function normalizeBlockerSignature(message: string | null | undefined): string | null {
+  if (!message) {
+    return null;
+  }
+
+  return message
+    .toLowerCase()
+    .replace(/\d{4}-\d{2}-\d{2}t\d{2}:\d{2}:\d{2}(?:\.\d+)?z/g, "<ts>")
+    .replace(/#\d+/g, "#<n>")
+    .replace(/\b[0-9a-f]{7,40}\b/g, "<sha>")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1000);
+}
+
+function buildCodexFailureContext(
+  now: () => string,
+  category: FailureContext["category"],
+  summary: string,
+  details: string[],
+): FailureContext {
+  return {
+    category,
+    summary,
+    signature: normalizeBlockerSignature(`${summary}\n${details.join("\n")}`),
+    command: null,
+    details,
+    url: null,
+    updated_at: now(),
+  };
+}
+
+function applyFailureSignature(
+  record: IssueRunRecord,
+  failureContext: FailureContext | null,
+): Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count"> {
+  const signature = failureContext?.signature ?? null;
+  if (!signature) {
+    return {
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    };
+  }
+
+  return {
+    last_failure_signature: signature,
+    repeated_failure_signature_count:
+      record.last_failure_signature === signature ? record.repeated_failure_signature_count + 1 : 1,
+  };
+}
+
+function buildRecoveryEvent(issueNumber: number, reason: string, now: () => string): RecoveryEvent {
+  return {
+    issueNumber,
+    reason,
+    at: now(),
+  };
+}
+
+function applyRecoveryEvent(
+  patch: Partial<IssueRunRecord>,
+  recoveryEvent: RecoveryEvent,
+): Partial<IssueRunRecord> {
+  return {
+    ...patch,
+    last_recovery_reason: recoveryEvent.reason,
+    last_recovery_at: recoveryEvent.at,
+  };
+}
+
+async function prepareWorkspaceContext(
+  args: PrepareIssueExecutionContextArgs,
+): Promise<PreparedWorkspaceContext> {
+  const ensureWorkspace = args.ensureWorkspace ?? ensureWorkspaceImpl;
+  const syncIssueJournal = args.syncIssueJournal ?? syncIssueJournalImpl;
+  const syncMemoryArtifacts = args.syncMemoryArtifacts ?? syncMemoryArtifactsImpl;
+  const getWorkspaceStatus = args.getWorkspaceStatus ?? getWorkspaceStatusImpl;
+
+  const previousCodexSummary = args.record.last_codex_summary;
+  const previousError = args.record.last_error;
+  const workspacePath = await ensureWorkspace(args.config, args.record.issue_number, args.record.branch);
+  const journalPath = issueJournalPath(workspacePath, args.config.issueJournalRelativePath);
+  const syncJournal: IssueJournalSync = async (currentRecord: IssueRunRecord): Promise<void> => {
+    await syncIssueJournal({
+      issue: args.issue,
+      record: currentRecord,
+      journalPath,
+      maxChars: args.config.issueJournalMaxChars,
+    });
+  };
+
+  const preparedRecord = args.stateStore.touch(args.record, {
+    workspace: workspacePath,
+    journal_path: journalPath,
+    state: args.record.implementation_attempt_count === 0 ? "planning" : args.record.state,
+    last_error: null,
+    last_failure_kind: null,
+    blocked_reason: null,
+  });
+  args.state.issues[String(preparedRecord.issue_number)] = preparedRecord;
+  await args.stateStore.save(args.state);
+  await syncJournal(preparedRecord);
+
+  const memoryArtifacts = await syncMemoryArtifacts({
+    config: args.config,
+    issueNumber: preparedRecord.issue_number,
+    workspacePath,
+    journalPath,
+  });
+
+  const workspaceStatus = await getWorkspaceStatus(workspacePath, preparedRecord.branch, args.config.defaultBranch);
+  const hydratedRecord = args.stateStore.touch(preparedRecord, { last_head_sha: workspaceStatus.headSha });
+  args.state.issues[String(hydratedRecord.issue_number)] = hydratedRecord;
+  await args.stateStore.save(args.state);
+
+  return {
+    record: hydratedRecord,
+    issue: args.issue,
+    previousCodexSummary,
+    previousError,
+    workspacePath,
+    journalPath,
+    syncJournal,
+    memoryArtifacts,
+    workspaceStatus,
+  };
+}
+
+async function hydratePullRequestContext(
+  args: PrepareIssueExecutionContextArgs & {
+    record: IssueRunRecord;
+    workspacePath: string;
+    workspaceStatus: WorkspaceStatus;
+    syncJournal: IssueJournalSync;
+  },
+): Promise<HydratedPullRequestContext | RestartRunOnce | string> {
+  const pushBranch = args.pushBranch ?? pushBranchImpl;
+  const getWorkspaceStatus = args.getWorkspaceStatus ?? getWorkspaceStatusImpl;
+  const now = args.now ?? nowIso;
+
+  let nextWorkspaceStatus = args.workspaceStatus;
+  if (nextWorkspaceStatus.remoteBranchExists && nextWorkspaceStatus.remoteAhead > 0) {
+    await pushBranch(args.workspacePath, args.record.branch, true);
+    nextWorkspaceStatus = await getWorkspaceStatus(args.workspacePath, args.record.branch, args.config.defaultBranch);
+  }
+
+  const resolvedPr = await args.github.resolvePullRequestForBranch(args.record.branch, args.record.pr_number);
+  let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
+  let checks = pr ? await args.github.getChecks(pr.number) : [];
+  let reviewThreads = pr ? await args.github.getUnresolvedReviewThreads(pr.number) : [];
+
+  if (!pr) {
+    if (!resolvedPr) {
+      // No current or historical PR for this branch; continue with normal branch/PR flow.
+    } else if (resolvedPr.mergedAt || resolvedPr.state === "MERGED") {
+      const recoveryEvent = buildRecoveryEvent(
+        args.record.issue_number,
+        `merged_pr_convergence: tracked PR #${resolvedPr.number} merged; marked issue #${args.record.issue_number} done`,
+        now,
+      );
+      const doneRecord = args.stateStore.touch(args.record, {
+        pr_number: resolvedPr.number,
+        state: "done",
+        last_head_sha: resolvedPr.headRefOid,
+        ...applyRecoveryEvent({}, recoveryEvent),
+      });
+      args.state.issues[String(doneRecord.issue_number)] = doneRecord;
+      args.state.activeIssueNumber = null;
+      await args.stateStore.save(args.state);
+      return { kind: "restart", recoveryEvents: [recoveryEvent] };
+    } else if (resolvedPr.state === "CLOSED") {
+      const failureContext = buildCodexFailureContext(
+        now,
+        "manual",
+        `PR #${resolvedPr.number} was closed without merge.`,
+        ["Manual intervention is required before the supervisor can continue this issue."],
+      );
+      const blockedRecord = args.stateStore.touch(args.record, {
+        pr_number: resolvedPr.number,
+        state: "blocked",
+        last_error:
+          `PR #${resolvedPr.number} was closed without merge. ` +
+          `Manual intervention is required before issue #${args.record.issue_number} can continue.`,
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        ...applyFailureSignature(args.record, failureContext),
+        blocked_reason: "manual_pr_closed",
+      });
+      args.state.issues[String(blockedRecord.issue_number)] = blockedRecord;
+      args.state.activeIssueNumber = null;
+      await args.stateStore.save(args.state);
+      await args.syncJournal(blockedRecord);
+      return `Issue #${blockedRecord.issue_number} blocked because PR #${resolvedPr.number} was closed without merge.`;
+    }
+  }
+
+  if (
+    !pr &&
+    nextWorkspaceStatus.baseAhead > 0 &&
+    !nextWorkspaceStatus.hasUncommittedChanges &&
+    args.record.implementation_attempt_count >= args.config.draftPrAfterAttempt
+  ) {
+    await pushBranch(args.workspacePath, args.record.branch, nextWorkspaceStatus.remoteBranchExists);
+    pr = await args.github.createPullRequest(args.issue, args.record, { draft: true });
+    checks = await args.github.getChecks(pr.number);
+    reviewThreads = await args.github.getUnresolvedReviewThreads(pr.number);
+  }
+
+  return {
+    record: args.record,
+    pr,
+    checks,
+    reviewThreads,
+    workspaceStatus: nextWorkspaceStatus,
+  };
+}
+
+export async function prepareIssueExecutionContext(
+  args: PrepareIssueExecutionContextArgs,
+): Promise<PreparedIssueExecutionContext | RestartRunOnce | string> {
+  const preparedWorkspace = await prepareWorkspaceContext(args);
+  const hydratedPullRequest = await hydratePullRequestContext({
+    ...args,
+    record: preparedWorkspace.record,
+    workspacePath: preparedWorkspace.workspacePath,
+    workspaceStatus: preparedWorkspace.workspaceStatus,
+    syncJournal: preparedWorkspace.syncJournal,
+  });
+  if (typeof hydratedPullRequest === "string") {
+    return hydratedPullRequest;
+  }
+  if (isRestartRunOnce(hydratedPullRequest)) {
+    return hydratedPullRequest;
+  }
+
+  return {
+    ...preparedWorkspace,
+    ...hydratedPullRequest,
+  };
+}

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -37,13 +37,21 @@ import {
   issueJournalPath,
   readIssueJournal,
   summarizeIssueJournalHandoff,
-  syncIssueJournal,
 } from "./journal";
 import { acquireFileLock, inspectFileLock, LockHandle } from "./lock";
 import { localReviewHasActionableFindings, LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY, runLocalReview, shouldRunLocalReview } from "./local-review";
 import { reviewDir } from "./local-review-artifacts";
-import { syncMemoryArtifacts } from "./memory";
-import { resolveRunnableIssueContext as resolveIssueSelectionContext } from "./run-once-issue-selection";
+import {
+  isRestartRunOnce,
+  IssueJournalSync,
+  MemoryArtifacts,
+  prepareIssueExecutionContext,
+  PreparedIssueExecutionContext,
+} from "./run-once-issue-preparation";
+import {
+  resolveRunnableIssueContext as resolveIssueSelectionContext,
+  RestartRunOnce as SelectionRestartRunOnce,
+} from "./run-once-issue-selection";
 import { RecoveryEvent, runOnceCyclePrelude } from "./run-once-cycle-prelude";
 import { StateStore } from "./state-store";
 import {
@@ -1687,45 +1695,11 @@ function formatRunnableReadinessReason(
   return reasons.join("+");
 }
 
-type IssueJournalSync = (record: IssueRunRecord) => Promise<void>;
-type MemoryArtifacts = Awaited<ReturnType<typeof syncMemoryArtifacts>>;
-
-interface PreparedWorkspaceContext {
-  record: IssueRunRecord;
-  issue: GitHubIssue;
-  previousCodexSummary: string | null;
-  previousError: string | null;
-  workspacePath: string;
-  journalPath: string;
-  syncJournal: IssueJournalSync;
-  memoryArtifacts: MemoryArtifacts;
-  workspaceStatus: WorkspaceStatus;
-}
-
 interface ReadyIssueContext {
   kind: "ready";
   record: IssueRunRecord;
   issue: GitHubIssue;
   issueLock: LockHandle;
-}
-
-interface HydratedPullRequestContext {
-  record: IssueRunRecord;
-  pr: GitHubPullRequest | null;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  workspaceStatus: WorkspaceStatus;
-}
-
-interface PreparedIssueExecutionContext extends PreparedWorkspaceContext, HydratedPullRequestContext {}
-
-interface RestartRunOnce {
-  kind: "restart";
-  recoveryEvents?: RecoveryEvent[];
-}
-
-function isRestartRunOnce(result: HydratedPullRequestContext | PreparedIssueExecutionContext | RestartRunOnce): result is RestartRunOnce {
-  return "kind" in result && result.kind === "restart";
 }
 
 async function ensureRecordJournalContext(
@@ -2766,65 +2740,10 @@ export class Supervisor {
     return recoveryEvents;
   }
 
-  private async prepareWorkspaceContext(
-    state: SupervisorStateFile,
-    record: IssueRunRecord,
-    issue: GitHubIssue,
-  ): Promise<PreparedWorkspaceContext> {
-    const previousCodexSummary = record.last_codex_summary;
-    const previousError = record.last_error;
-    const workspacePath = await ensureWorkspace(this.config, record.issue_number, record.branch);
-    const journalPath = issueJournalPath(workspacePath, this.config.issueJournalRelativePath);
-    const syncJournal: IssueJournalSync = async (currentRecord: IssueRunRecord): Promise<void> => {
-      await syncIssueJournal({
-        issue,
-        record: currentRecord,
-        journalPath,
-        maxChars: this.config.issueJournalMaxChars,
-      });
-    };
-
-    const preparedRecord = this.stateStore.touch(record, {
-      workspace: workspacePath,
-      journal_path: journalPath,
-      state: record.implementation_attempt_count === 0 ? "planning" : record.state,
-      last_error: null,
-      last_failure_kind: null,
-      blocked_reason: null,
-    });
-    state.issues[String(preparedRecord.issue_number)] = preparedRecord;
-    await this.stateStore.save(state);
-    await syncJournal(preparedRecord);
-
-    const memoryArtifacts = await syncMemoryArtifacts({
-      config: this.config,
-      issueNumber: preparedRecord.issue_number,
-      workspacePath,
-      journalPath,
-    });
-
-    const workspaceStatus = await getWorkspaceStatus(workspacePath, preparedRecord.branch, this.config.defaultBranch);
-    const hydratedRecord = this.stateStore.touch(preparedRecord, { last_head_sha: workspaceStatus.headSha });
-    state.issues[String(hydratedRecord.issue_number)] = hydratedRecord;
-    await this.stateStore.save(state);
-
-    return {
-      record: hydratedRecord,
-      issue,
-      previousCodexSummary,
-      previousError,
-      workspacePath,
-      journalPath,
-      syncJournal,
-      memoryArtifacts,
-      workspaceStatus,
-    };
-  }
-
   private async resolveRunnableIssueContext(
     state: SupervisorStateFile,
     currentRecord: IssueRunRecord | null,
-  ): Promise<ReadyIssueContext | RestartRunOnce | string> {
+  ): Promise<ReadyIssueContext | SelectionRestartRunOnce | string> {
     const runnableIssue = await resolveIssueSelectionContext({
       github: this.github,
       config: this.config,
@@ -2885,119 +2804,6 @@ export class Supervisor {
       record,
       issue,
       issueLock,
-    };
-  }
-
-  private async hydratePullRequestContext(
-    state: SupervisorStateFile,
-    record: IssueRunRecord,
-    issue: GitHubIssue,
-    workspacePath: string,
-    workspaceStatus: WorkspaceStatus,
-    syncJournal: IssueJournalSync,
-    options: Pick<CliOptions, "dryRun">,
-  ): Promise<HydratedPullRequestContext | RestartRunOnce | string> {
-    let nextWorkspaceStatus = workspaceStatus;
-    if (nextWorkspaceStatus.remoteBranchExists && nextWorkspaceStatus.remoteAhead > 0) {
-      await pushBranch(workspacePath, record.branch, true);
-      nextWorkspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, this.config.defaultBranch);
-    }
-
-    const resolvedPr = await this.github.resolvePullRequestForBranch(record.branch, record.pr_number);
-    let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
-    let checks = pr ? await this.github.getChecks(pr.number) : [];
-    let reviewThreads = pr ? await this.github.getUnresolvedReviewThreads(pr.number) : [];
-
-    if (!pr) {
-      if (!resolvedPr) {
-        // No current or historical PR for this branch; continue with normal branch/PR flow.
-      } else if (resolvedPr.mergedAt || resolvedPr.state === "MERGED") {
-        const recoveryEvent = buildRecoveryEvent(
-          record.issue_number,
-          `merged_pr_convergence: tracked PR #${resolvedPr.number} merged; marked issue #${record.issue_number} done`,
-        );
-        const doneRecord = this.stateStore.touch(record, {
-          pr_number: resolvedPr.number,
-          state: "done",
-          last_head_sha: resolvedPr.headRefOid,
-          ...applyRecoveryEvent({}, recoveryEvent),
-        });
-        state.issues[String(doneRecord.issue_number)] = doneRecord;
-        state.activeIssueNumber = null;
-        await this.stateStore.save(state);
-        return { kind: "restart", recoveryEvents: [recoveryEvent] };
-      } else if (resolvedPr.state === "CLOSED") {
-        const failureContext = buildCodexFailureContext(
-          "manual",
-          `PR #${resolvedPr.number} was closed without merge.`,
-          ["Manual intervention is required before the supervisor can continue this issue."],
-        );
-        const blockedRecord = this.stateStore.touch(record, {
-          pr_number: resolvedPr.number,
-          state: "blocked",
-          last_error:
-            `PR #${resolvedPr.number} was closed without merge. ` +
-            `Manual intervention is required before issue #${record.issue_number} can continue.`,
-          last_failure_kind: null,
-          last_failure_context: failureContext,
-          ...applyFailureSignature(record, failureContext),
-          blocked_reason: "manual_pr_closed",
-        });
-        state.issues[String(blockedRecord.issue_number)] = blockedRecord;
-        state.activeIssueNumber = null;
-        await this.stateStore.save(state);
-        await syncJournal(blockedRecord);
-        return `Issue #${blockedRecord.issue_number} blocked because PR #${resolvedPr.number} was closed without merge.`;
-      }
-    }
-
-    if (
-      !pr &&
-      nextWorkspaceStatus.baseAhead > 0 &&
-      !nextWorkspaceStatus.hasUncommittedChanges &&
-      record.implementation_attempt_count >= this.config.draftPrAfterAttempt
-    ) {
-      await pushBranch(workspacePath, record.branch, nextWorkspaceStatus.remoteBranchExists);
-      pr = await this.github.createPullRequest(issue, record, { draft: true });
-      checks = await this.github.getChecks(pr.number);
-      reviewThreads = await this.github.getUnresolvedReviewThreads(pr.number);
-    }
-
-    return {
-      record,
-      pr,
-      checks,
-      reviewThreads,
-      workspaceStatus: nextWorkspaceStatus,
-    };
-  }
-
-  private async prepareIssueExecutionContext(
-    state: SupervisorStateFile,
-    record: IssueRunRecord,
-    issue: GitHubIssue,
-    options: Pick<CliOptions, "dryRun">,
-  ): Promise<PreparedIssueExecutionContext | RestartRunOnce | string> {
-    const preparedWorkspace = await this.prepareWorkspaceContext(state, record, issue);
-    const hydratedPullRequest = await this.hydratePullRequestContext(
-      state,
-      preparedWorkspace.record,
-      issue,
-      preparedWorkspace.workspacePath,
-      preparedWorkspace.workspaceStatus,
-      preparedWorkspace.syncJournal,
-      options,
-    );
-    if (typeof hydratedPullRequest === "string") {
-      return hydratedPullRequest;
-    }
-    if (isRestartRunOnce(hydratedPullRequest)) {
-      return hydratedPullRequest;
-    }
-
-    return {
-      ...preparedWorkspace,
-      ...hydratedPullRequest,
     };
   }
 
@@ -3960,13 +3766,21 @@ export class Supervisor {
     if (runnableIssue.kind === "restart") {
       return {
         kind: "restart",
-        carryoverRecoveryEvents: [...recoveryEvents, ...(runnableIssue.recoveryEvents ?? [])],
+        carryoverRecoveryEvents: recoveryEvents,
       };
     }
 
     try {
       const issue = runnableIssue.issue;
-      const preparedIssue = await this.prepareIssueExecutionContext(state, runnableIssue.record, issue, options);
+      const preparedIssue = await prepareIssueExecutionContext({
+        github: this.github,
+        config: this.config,
+        stateStore: this.stateStore,
+        state,
+        record: runnableIssue.record,
+        issue,
+        options,
+      });
       if (typeof preparedIssue === "string") {
         return {
           kind: "return",


### PR DESCRIPTION
Closes #240
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the workspace and PR preparation flow into [`src/run-once-issue-preparation.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-240/src/run-once-issue-preparation.ts), added focused seam coverage in [`src/run-once-issue-preparation.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-240/src/run-once-issue-preparation.test.ts), and rewired [`src/supervisor.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-240/src/supervisor.ts) to use the new module. The extracted module preserves workspace/journal/memory setup plus merged, closed, and draft-creation PR hydration paths.

Focused verification passed with `npm test -- src/run-once-issue-preparation.test.ts`, and `npm run build` passed. I also committed the code checkpoint as `ae5b996` (`Extract supervisor preparation phase`).

Summary: Extracted supervisor workspace/PR preparation into a dedicated phase module with focused tests and committed the checkpoint
State hint: implementing
Blocked reason: none
Tests: `npm test -- src/run-once-issue-preparation.test.ts`; `npm run build`
Failure signature: none
Next action: Rerun `npm test -- src/supervisor.test.ts` as a targeted regression check for the orchestrator after the extraction commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for issue execution context preparation across multiple execution paths and scenarios.

* **Refactor**
  * Extracted issue preparation logic into a dedicated module to improve code modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->