### PR TITLE
Supervisor status: show configured-bot manual-review blocker summaries with reviewer, file, line, and head context (#256)

### DIFF
--- a/src/supervisor-reporting.ts
+++ b/src/supervisor-reporting.ts
@@ -592,6 +592,11 @@ export function formatDetailedStatus(args: {
     lines.push(
       `failure_context category=${activeRecord.last_failure_context.category ?? "none"} summary=${truncate(activeRecord.last_failure_context.summary, 200) ?? "none"}`,
     );
+    if (activeRecord.last_failure_context.details.length > 0) {
+      lines.push(
+        `failure_details=${truncate(sanitizeStatusValue(activeRecord.last_failure_context.details.join(" | ")), 300) ?? "none"}`,
+      );
+    }
   }
 
   if (handoffSummary) {

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -3680,6 +3680,32 @@ test("runOnce reprocesses a configured bot review thread once after a new PR hea
   assert.equal(record.last_head_sha, runHeadSha);
   assert.equal(record.blocked_reason, "manual_review");
   assert.deepEqual(record.processed_review_thread_ids, ["thread-1@head-a", `thread-1@${runHeadSha}`]);
+  assert.equal(record.last_failure_context?.category, "manual");
+  assert.match(
+    record.last_failure_context?.summary ?? "",
+    /configured bot review thread\(s\) remain unresolved after processing on the current head/,
+  );
+  assert.deepEqual(record.last_failure_context?.details, [
+    "reviewer=copilot-pull-request-reviewer file=src/file.ts line=12 processed_on_current_head=yes",
+  ]);
+
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: record,
+    latestRecord: record,
+    trackedIssueCount: 1,
+    pr,
+    checks: [],
+    reviewThreads,
+  });
+  assert.match(
+    status,
+    /failure_context category=manual summary=1 configured bot review thread\(s\) remain unresolved after processing on the current head and now require manual attention\./,
+  );
+  assert.match(
+    status,
+    /failure_details=reviewer=copilot-pull-request-reviewer file=src\/file\.ts line=12 processed_on_current_head=yes/,
+  );
 });
 
 test("runOnce does not mark configured bot review threads as processed for a refreshed PR head it did not evaluate", async () => {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -255,12 +255,12 @@ function buildStalledBotReviewFailureContext(reviewThreads: ReviewThread[]): Fai
   const details = reviewThreads.slice(0, 5).map((thread) => {
     const latestComment = latestReviewComment(thread);
     const author = latestComment?.author?.login ?? "unknown";
-    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} reviewer=${author} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
+    return `reviewer=${author} file=${thread.path ?? "unknown"} line=${thread.line ?? "?"} processed_on_current_head=yes`;
   });
 
   return {
     category: "manual",
-    summary: `${reviewThreads.length} configured bot review thread(s) remain unresolved after processing and now require manual attention.`,
+    summary: `${reviewThreads.length} configured bot review thread(s) remain unresolved after processing on the current head and now require manual attention.`,
     signature: reviewThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
     command: null,
     details,


### PR DESCRIPTION
Closes #256
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed the focused fix in `fec773a` (`Improve configured bot blocker status summaries`).

The change makes same-head configured-bot manual-review blockers persist and report clearer context: the stalled-bot failure summary now says it was already processed on the current head, its detail includes `reviewer`, `file`, `line`, and `processed_on_current_head=yes`, and detailed status now emits a `failure_details=` line so the blocker is visible from CLI status output. The focused regression is covered in [src/supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-256/src/supervisor.test.ts), with implementation in [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-256/src/supervisor.ts) and [src/supervisor-reporting.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-256/src/supervisor-reporting.ts). I also updated the local issue journal handoff notes.

Verification passed with the focused test run and `npm run build`.

Summary: Enriched configured-bot same-head manual-review blocker summaries in failure context and status output, added focused regression coverage, and committed the change as `fec773a`.
State hint: stabilizing
Blocked reason: none
Tests: `npm test -- --test-name-pattern "runOnce reprocesses a configured bot review thread once after a new PR head commit and then blocks if it remains unresolved|formatDetailedStatus shows blocking local review status for current PR head|runOnce records manual rev...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed failure information display in status output with structured metadata including reviewer, file, line, and processing status.
  * Failure details are now sanitized and truncated for optimal readability.

* **Tests**
  * Added comprehensive test coverage validating failure context propagation and detailed status rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->