### PR TITLE
Supervisor: soften blocking for configured-bot nitpick-only top-level reviews (#258)

### DIFF
--- a/src/external-review-signal-heuristics.ts
+++ b/src/external-review-signal-heuristics.ts
@@ -2,6 +2,11 @@ function normalizeReviewText(value: string | null | undefined): string {
   return value?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
 }
 
+const NITPICK_REVIEW_TEXT_PATTERN =
+  /\b(nit|nitpick|nits|style|format|formatting|typo|wording|docs?|documentation|comment|comments|naming|rename|readability|consistency|prefer)\b/;
+const STRONG_REVIEW_TEXT_PATTERN =
+  /\b(bug|issue|error|warning|fix|fixed|missing|fails?|failure|broken|incorrect|unsafe|security|panic|crash|deadlock|regression|data loss|leak)\b/;
+
 export function isInformationalReviewText(value: string | null | undefined): boolean {
   const normalized = normalizeReviewText(value);
   if (!normalized) {
@@ -29,6 +34,27 @@ export function hasActionableReviewText(value: string | null | undefined): boole
   return /\b(nit|nitpick|suggestion|consider|should|could|bug|issue|error|warning|fix|missing|fails?|incorrect|unsafe|please)\b/.test(
     normalized,
   );
+}
+
+export function classifyConfiguredBotTopLevelReviewStrength(args: {
+  body?: string | null | undefined;
+  state?: string | null | undefined;
+}): "nitpick_only" | "blocking" | null {
+  const state = normalizeReviewText(args.state);
+  if (state !== "changes_requested") {
+    return null;
+  }
+
+  const normalized = normalizeReviewText(args.body ?? args.state);
+  if (!normalized || isInformationalReviewText(normalized)) {
+    return "blocking";
+  }
+
+  if (NITPICK_REVIEW_TEXT_PATTERN.test(normalized) && !STRONG_REVIEW_TEXT_PATTERN.test(normalized)) {
+    return "nitpick_only";
+  }
+
+  return "blocking";
 }
 
 export function isActionableTopLevelReview(args: {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -274,6 +274,80 @@ test("inferCopilotReviewLifecycle treats actionable configured-bot top-level rev
   });
 });
 
+test("GitHubClient classifies nitpick-only configured-bot top-level changes requests conservatively", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          number: 44,
+          title: "Nitpick-only top-level review",
+          url: "https://example.test/pr/44",
+          state: "OPEN",
+          createdAt: "2026-03-13T00:00:00Z",
+          updatedAt: "2026-03-13T00:00:00Z",
+          isDraft: false,
+          reviewDecision: "CHANGES_REQUESTED",
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          headRefName: "codex/issue-141",
+          headRefOid: "head-44",
+          mergedAt: null,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [
+                    {
+                      submittedAt: "2026-03-13T02:03:04Z",
+                      state: "CHANGES_REQUESTED",
+                      body: "Nitpick: rename this helper for consistency with the rest of the file.",
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                comments: {
+                  nodes: [],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await client.getPullRequest(44);
+
+  assert.equal(pr.copilotReviewState, "arrived");
+  assert.equal(pr.configuredBotTopLevelReviewStrength, "nitpick_only");
+  assert.equal(pr.configuredBotTopLevelReviewSubmittedAt, "2026-03-13T02:03:04Z");
+});
+
 test("GitHubClient hydrates Copilot arrival from long review threads without truncating comments to 20", async () => {
   const config = createConfig();
   let lifecycleQuery: string | null = null;

--- a/src/github.ts
+++ b/src/github.ts
@@ -10,7 +10,11 @@ import {
   SupervisorConfig,
 } from "./types";
 import { CommandOptions, CommandResult, runCommand } from "./command";
-import { hasActionableReviewText, isActionableTopLevelReview } from "./external-review-signal-heuristics";
+import {
+  classifyConfiguredBotTopLevelReviewStrength,
+  hasActionableReviewText,
+  isActionableTopLevelReview,
+} from "./external-review-signal-heuristics";
 import { parseJson, truncate } from "./utils";
 
 const TRANSIENT_GITHUB_RETRY_LIMIT = 2;
@@ -161,7 +165,17 @@ export interface CopilotReviewLifecycle {
 interface CachedCopilotReviewLifecycleEntry {
   fetchedAtMs: number;
   state: CopilotReviewState | null;
-  promise: Promise<CopilotReviewLifecycle>;
+  promise: Promise<ConfiguredBotReviewSummary>;
+}
+
+interface ConfiguredBotTopLevelReviewSummary {
+  strength: "nitpick_only" | "blocking" | null;
+  submittedAt: string | null;
+}
+
+interface ConfiguredBotReviewSummary {
+  lifecycle: CopilotReviewLifecycle;
+  topLevelReview: ConfiguredBotTopLevelReviewSummary;
 }
 
 function mapCheckBucket(args: {
@@ -291,6 +305,58 @@ export function inferCopilotReviewLifecycle(
   }
 
   return { state: "not_requested", requestedAt: null, arrivedAt: null };
+}
+
+function inferConfiguredBotTopLevelReviewSummary(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+): ConfiguredBotTopLevelReviewSummary {
+  const configuredReviewBots = new Set(
+    reviewBotLogins.map((login) => normalizeLogin(login)).filter((login): login is string => Boolean(login)),
+  );
+  if (configuredReviewBots.size === 0) {
+    return { strength: null, submittedAt: null };
+  }
+
+  let latestConfiguredReview: ConfiguredBotTopLevelReviewSummary = { strength: null, submittedAt: null };
+  let latestConfiguredReviewMs = 0;
+  let sawNonConfiguredChangesRequestedReview = false;
+
+  for (const review of facts.reviews) {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    if (!authorLogin || normalizeLogin(review.state)?.replace(/\s+/g, "_") !== "changes_requested") {
+      continue;
+    }
+
+    if (!configuredReviewBots.has(authorLogin)) {
+      sawNonConfiguredChangesRequestedReview = true;
+      continue;
+    }
+
+    const submittedAtMs = parseTimestamp(review.submittedAt);
+    if (latestConfiguredReview.submittedAt && submittedAtMs < latestConfiguredReviewMs) {
+      continue;
+    }
+
+    latestConfiguredReview = {
+      strength: classifyConfiguredBotTopLevelReviewStrength(review),
+      submittedAt: review.submittedAt,
+    };
+    latestConfiguredReviewMs = submittedAtMs;
+  }
+
+  if (!latestConfiguredReview.strength) {
+    return { strength: null, submittedAt: null };
+  }
+
+  if (sawNonConfiguredChangesRequestedReview) {
+    return {
+      strength: "blocking",
+      submittedAt: latestConfiguredReview.submittedAt,
+    };
+  }
+
+  return latestConfiguredReview;
 }
 
 function normalizeRollupChecks(rollup: PullRequestStatusCheckRollupResponse | null | undefined): PullRequestCheck[] {
@@ -644,7 +710,7 @@ export class GitHubClient {
   private getCachedCopilotReviewLifecycle(
     cacheKey: string,
     nowMs: number,
-  ): Promise<CopilotReviewLifecycle> | null {
+  ): Promise<ConfiguredBotReviewSummary> | null {
     const cachedLifecycle = this.copilotReviewLifecycleCache.get(cacheKey);
     if (!cachedLifecycle) {
       return null;
@@ -674,18 +740,21 @@ export class GitHubClient {
 
   private setCachedCopilotReviewLifecycle(
     cacheKey: string,
-    lifecyclePromiseFactory: () => Promise<CopilotReviewLifecycle>,
-  ): Promise<CopilotReviewLifecycle> {
+    lifecyclePromiseFactory: () => Promise<ConfiguredBotReviewSummary>,
+  ): Promise<ConfiguredBotReviewSummary> {
     const cacheEntry: CachedCopilotReviewLifecycleEntry = {
       fetchedAtMs: this.now(),
       state: null,
-      promise: Promise.resolve({ state: "not_requested", requestedAt: null, arrivedAt: null }),
+      promise: Promise.resolve({
+        lifecycle: { state: "not_requested", requestedAt: null, arrivedAt: null },
+        topLevelReview: { strength: null, submittedAt: null },
+      }),
     };
     const lifecyclePromise = lifecyclePromiseFactory()
-      .then((lifecycle) => {
+      .then((summary) => {
         cacheEntry.fetchedAtMs = this.now();
-        cacheEntry.state = lifecycle.state;
-        return lifecycle;
+        cacheEntry.state = summary.lifecycle.state;
+        return summary;
       })
       .catch((error) => {
         this.copilotReviewLifecycleCache.delete(cacheKey);
@@ -1129,27 +1198,31 @@ export class GitHubClient {
     const cacheKey = `${pr.number}:${pr.headRefOid}`;
     const cachedLifecycle = this.getCachedCopilotReviewLifecycle(cacheKey, this.now());
     if (cachedLifecycle) {
-      const lifecycle = await cachedLifecycle;
+      const summary = await cachedLifecycle;
       return {
         ...pr,
-        copilotReviewState: lifecycle.state,
-        copilotReviewRequestedAt: lifecycle.requestedAt,
-        copilotReviewArrivedAt: lifecycle.arrivedAt,
+        copilotReviewState: summary.lifecycle.state,
+        copilotReviewRequestedAt: summary.lifecycle.requestedAt,
+        copilotReviewArrivedAt: summary.lifecycle.arrivedAt,
+        configuredBotTopLevelReviewStrength: summary.topLevelReview.strength,
+        configuredBotTopLevelReviewSubmittedAt: summary.topLevelReview.submittedAt,
       };
     }
 
     const lifecyclePromise = this.setCachedCopilotReviewLifecycle(
       cacheKey,
-      () => this.getCopilotReviewLifecycle(pr.number),
+      () => this.getConfiguredBotReviewSummary(pr.number),
     );
 
     try {
-      const lifecycle = await lifecyclePromise;
+      const summary = await lifecyclePromise;
       return {
         ...pr,
-        copilotReviewState: lifecycle.state,
-        copilotReviewRequestedAt: lifecycle.requestedAt,
-        copilotReviewArrivedAt: lifecycle.arrivedAt,
+        copilotReviewState: summary.lifecycle.state,
+        copilotReviewRequestedAt: summary.lifecycle.requestedAt,
+        copilotReviewArrivedAt: summary.lifecycle.arrivedAt,
+        configuredBotTopLevelReviewStrength: summary.topLevelReview.strength,
+        configuredBotTopLevelReviewSubmittedAt: summary.topLevelReview.submittedAt,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -1159,11 +1232,13 @@ export class GitHubClient {
         copilotReviewState: null,
         copilotReviewRequestedAt: null,
         copilotReviewArrivedAt: null,
+        configuredBotTopLevelReviewStrength: null,
+        configuredBotTopLevelReviewSubmittedAt: null,
       };
     }
   }
 
-  private async getCopilotReviewLifecycle(prNumber: number): Promise<CopilotReviewLifecycle> {
+  private async getConfiguredBotReviewSummary(prNumber: number): Promise<ConfiguredBotReviewSummary> {
     const { owner, repo } = this.repoOwnerAndName();
     const query = `
       query($owner: String!, $repo: String!, $number: Int!) {
@@ -1333,6 +1408,9 @@ export class GitHubClient {
           .filter((event): event is CopilotReviewLifecycleFacts["timeline"][number] => event !== null) ?? [],
     };
 
-    return inferCopilotReviewLifecycle(facts, this.config.reviewBotLogins);
+    return {
+      lifecycle: inferCopilotReviewLifecycle(facts, this.config.reviewBotLogins),
+      topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, this.config.reviewBotLogins),
+    };
   }
 }

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -35,7 +35,10 @@ interface CopilotReviewTimeoutStatus {
 }
 
 function reviewSatisfied(pr: GitHubPullRequest): boolean {
-  return pr.reviewDecision !== "CHANGES_REQUESTED" && pr.reviewDecision !== "REVIEW_REQUIRED";
+  return (
+    (pr.reviewDecision !== "CHANGES_REQUESTED" || pr.configuredBotTopLevelReviewStrength === "nitpick_only") &&
+    pr.reviewDecision !== "REVIEW_REQUIRED"
+  );
 }
 
 function configuredReviewBots(config: SupervisorConfig): string[] {
@@ -216,19 +219,22 @@ export function blockedReasonFromReviewState(
   pr: GitHubPullRequest,
   reviewThreads: ReviewThread[],
 ): Exclude<BlockedReason, null> | null {
+  const manualThreads = manualReviewThreads(config, reviewThreads);
+  const unresolvedBotThreads = configuredBotReviewThreads(config, reviewThreads);
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
   if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
     return "review_bot_timeout";
   }
 
-  if (
-    manualReviewThreads(config, reviewThreads).length > 0 ||
-    configuredBotReviewThreads(config, reviewThreads).length > 0
-  ) {
+  if (manualThreads.length > 0 || unresolvedBotThreads.length > 0) {
     return "manual_review";
   }
 
-  if (pr.reviewDecision === "CHANGES_REQUESTED" && config.humanReviewBlocksMerge) {
+  if (
+    pr.reviewDecision === "CHANGES_REQUESTED" &&
+    (pr.configuredBotTopLevelReviewStrength === "blocking" ||
+      (config.humanReviewBlocksMerge && pr.configuredBotTopLevelReviewStrength !== "nitpick_only"))
+  ) {
     return "manual_review";
   }
 
@@ -348,11 +354,22 @@ export function inferStateFromPullRequest(
       return "addressing_review";
     }
 
-    if (unresolvedBotThreads.length > 0 || config.humanReviewBlocksMerge) {
+    const nitpickOnlyConfiguredBotReview =
+      pr.configuredBotTopLevelReviewStrength === "nitpick_only" &&
+      unresolvedBotThreads.length === 0 &&
+      manualThreads.length === 0;
+
+    if (unresolvedBotThreads.length > 0 || pr.configuredBotTopLevelReviewStrength === "blocking") {
       return "blocked";
     }
 
-    return "pr_open";
+    if (config.humanReviewBlocksMerge && !nitpickOnlyConfiguredBotReview) {
+      return "blocked";
+    }
+
+    if (!nitpickOnlyConfiguredBotReview) {
+      return "pr_open";
+    }
   }
 
   if (

--- a/src/supervisor-reporting.ts
+++ b/src/supervisor-reporting.ts
@@ -241,6 +241,22 @@ function reviewBotDiagnostics(
   };
 }
 
+function configuredBotTopLevelReviewEffect(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): string {
+  if (!repoExpectsConfiguredBotReview(config) || !pr.configuredBotTopLevelReviewStrength) {
+    return "none";
+  }
+
+  if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
+    return configuredBotReviewThreads(config, reviewThreads).length === 0 ? "softened" : "awaiting_thread_resolution";
+  }
+
+  return "blocking";
+}
+
 export function sanitizeStatusValue(value: string | null | undefined): string | null {
   if (!value) {
     return null;
@@ -570,6 +586,9 @@ export function formatDetailedStatus(args: {
     );
     lines.push(
       `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
+    );
+    lines.push(
+      `configured_bot_top_level_review strength=${pr.configuredBotTopLevelReviewStrength ?? "none"} submitted_at=${pr.configuredBotTopLevelReviewSubmittedAt ?? "none"} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads)}`,
     );
     if (activeRecord.copilot_review_timeout_reason) {
       lines.push(`timeout_reason=${sanitizeStatusValue(activeRecord.copilot_review_timeout_reason)}`);

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -4384,6 +4384,65 @@ test("inferStateFromPullRequest treats an arrived configured-bot top-level revie
   });
 });
 
+test("inferStateFromPullRequest softens nitpick-only configured-bot top-level changes requests when no configured-bot threads remain", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai[bot]"],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({ state: "pr_open" });
+  const pr = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T00:00:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "head123",
+    mergedAt: null,
+    copilotReviewState: "arrived",
+    copilotReviewRequestedAt: "2026-03-11T00:05:00Z",
+    copilotReviewArrivedAt: "2026-03-11T00:07:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+  } as GitHubPullRequest;
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "ready_to_merge");
+});
+
+test("inferStateFromPullRequest still blocks stronger configured-bot top-level changes requests without review threads", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai[bot]"],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({ state: "pr_open" });
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T00:00:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "head123",
+    mergedAt: null,
+    copilotReviewState: "arrived",
+    copilotReviewRequestedAt: "2026-03-11T00:05:00Z",
+    copilotReviewArrivedAt: "2026-03-11T00:07:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-11T00:07:00Z",
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, []), "blocked");
+});
+
 test("inferStateFromPullRequest keeps waiting when a Copilot request was observed on the current head but has not arrived", () => {
   withStubbedDateNow("2026-03-11T00:10:00Z", () => {
     const config = createConfig({
@@ -5463,6 +5522,49 @@ test("formatDetailedStatus surfaces configured bot review timeout outcome with g
   assert.match(
     status,
     /timeout_reason=Requested configured review bot \(chatgpt-codex-connector\) review never arrived within 10 minute\(s\) for head deadbeef\./,
+  );
+});
+
+test("formatDetailedStatus explains softened nitpick-only configured-bot top-level reviews", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai[bot]"],
+  });
+  const pr: GitHubPullRequest = {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    copilotReviewState: "arrived",
+    copilotReviewRequestedAt: "2026-03-11T14:05:00Z",
+    copilotReviewArrivedAt: "2026-03-11T14:06:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-11T14:06:00Z",
+  };
+
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "ready_to_merge",
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+  });
+
+  assert.match(
+    status,
+    /configured_bot_top_level_review strength=nitpick_only submitted_at=2026-03-11T14:06:00Z effect=softened/,
   );
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,8 @@ export interface GitHubPullRequest {
   copilotReviewState?: CopilotReviewState | null;
   copilotReviewRequestedAt?: string | null;
   copilotReviewArrivedAt?: string | null;
+  configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
+  configuredBotTopLevelReviewSubmittedAt?: string | null;
   mergedAt?: string | null;
 }
 


### PR DESCRIPTION
Closes #258
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a conservative softening path for configured-bot top-level `CHANGES_REQUESTED` reviews. The supervisor now classifies configured-bot top-level reviews as `nitpick_only` vs `blocking`, only softens the former when no configured-bot review threads remain, and shows that decision in detailed status output. The checkpoint is committed as `e04e95e` on `codex/issue-258`.

Key code paths changed in [src/github.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-258/src/github.ts), [src/pull-request-state.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-258/src/pull-request-state.ts), [src/supervisor-reporting.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-258/src/supervisor-reporting.ts), and [src/external-review-signal-heuristics.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-258/src/external-review-signal-heuristics.ts). Focused coverage was added in [src/github.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-258/src/github.test.ts) and [src/supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-258/src/supervisor.test.ts).

Summary: Softened nitpick-only configured-bot top-level review blocking, added focused lifecycle/blocking/status tests, and committed the checkpoint.
State hint: draft_pr
Blocked reason: none
Tests: `npm test -- --test-name-pattern "nitpick-only|configured-bot top-level|stronger configured-bot|explains softened"`; `npm run build`
Failure signature: none
Next action: Open or u...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for classifying configured bot reviews as "nitpick_only" or "blocking," allowing PRs with nitpick-only reviews to proceed to merge without additional changes.
  * PRs now track bot review strength and submission timestamp for improved review status visibility.

* **Tests**
  * Added test coverage for nitpick-only review behavior and merge readiness logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->