### PR TITLE
Docs: refocus getting-started.md on operational guidance (#263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use `codex-supervisor` when you want Codex to work through execution-ready GitHu
 - run each turn in a dedicated worktree with a persistent issue journal
 - keep moving through draft PR, CI repair, review fixes, and merge
 
-If you want the full operator model, scheduling flow, or state machine, start with [Getting started](./docs/getting-started.md).
+If you want the setup flow, first-run commands, and operator decisions, start with [Getting started](./docs/getting-started.md).
 
 ## Who It Is For
 
@@ -79,7 +79,7 @@ If the provider never posts a usable PR review signal, fix the provider-side set
 
 ## Docs Map
 
-- [Getting started](./docs/getting-started.md): operator model, readiness-driven scheduling, state machine, local review, and first-run workflow
+- [Getting started](./docs/getting-started.md): setup checklist, execution-ready issue flow, first-run commands, and common operator decisions
 - [Configuration reference](./docs/configuration.md): config setup, provider profiles, model/reasoning controls, durable memory, and execution policy
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
 - [Architecture](./docs/architecture.md): core loop, durable state, reconciliations, and safety boundaries

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,353 +1,188 @@
 # Getting Started with codex-supervisor
 
-This guide is for people who have just installed Codex CLI or started using the Codex desktop app.
+Use this guide when you are ready to operate `codex-supervisor` against a real repository.
 
-The goal is to explain:
+It focuses on the practical flow:
 
-- what `codex-supervisor` is
-- when to use `codex-supervisor` alone
-- when to use `get-shit-done` (GSD) before the supervisor
-- how to talk to Codex as your operator console
-- how the supervisor actually chooses the next issue
+- decide whether the work is ready for the supervisor
+- configure the supervisor for your repo and review provider
+- author issues the scheduler can execute safely
+- run a first pass, inspect the result, then switch to the loop
+- know which reference doc to open when you need deeper detail
 
-## Mental model
+For the product overview, fit, and docs map, start with the [README](../README.md).
 
-Treat Codex as your operator console.
+## Before you start
 
-- You talk to Codex.
-- Codex can help you use GSD when requirements are still ambiguous.
-- Codex can help you run `codex-supervisor` when issues are already execution-ready.
+Confirm these prerequisites before you run the supervisor:
 
-`codex-supervisor` is the execution engine.
+- `gh auth status` succeeds
+- `codex` CLI is installed and works from your shell
+- the managed repository is already cloned locally
+- branch protection and CI are already configured on the managed repository
+- you have a repo path where the supervisor can create per-issue worktrees
 
-- It keeps local state.
-- It creates issue worktrees.
-- It runs `codex exec`.
-- It tracks PRs, CI, reviews, and mergeability.
-- It advances only when the current issue is actually runnable.
-
-GSD is an optional planning layer.
-
-- It is useful before execution starts.
-- It is useful when a large issue needs to be split.
-- It is useful when a blocked issue needs to be reframed.
-
-## Full picture
-
-```mermaid
-flowchart LR
-  U["User"] --> C["Codex CLI / Codex App"]
-  C --> P["GSD planning flow (optional)"]
-  C --> S["codex-supervisor"]
-
-  P --> M["Repo memory\nPROJECT.md / REQUIREMENTS.md / ROADMAP.md / STATE.md"]
-  P --> I["GitHub Issues\nEpic / child issues / Depends on / Execution order"]
-
-  S --> M
-  S --> I
-  S --> W["Issue worktrees + local state"]
-  S --> G["GitHub PR / CI / Reviews / Merge"]
-
-  G --> S
-  I --> S
-```
-
-## What codex-supervisor does
-
-At a high level, the supervisor runs this loop:
-
-1. Re-read GitHub and local state.
-2. Select the first runnable issue.
-3. Create or resume the issue worktree.
-4. Run a Codex turn.
-5. Push a branch and open or update a PR.
-6. Wait for CI and reviews.
-7. Repair CI or address valid review findings.
-8. Merge when the gate conditions are satisfied.
-9. Move to the next runnable issue.
-
-## Best fit
-
-`codex-supervisor` works best when:
-
-- one person, or one execution lane, owns the repo automation
-- issues are execution-ready
-- dependencies are written down
-- execution order is explicit
-- CI and branch protection are already in place
-
-Typical example:
-
-- one epic
-- several child issues
-- `Depends on`
-- `Part of`
-- `Execution order`
-- clear acceptance criteria
-
-## Not a fit
-
-It is a weak fit when:
-
-- issue priority changes constantly
-- issue descriptions are mostly discussion, not execution
-- multiple people change the same code paths at once
-- the backlog has no explicit dependencies or ordering
-
-In those cases, use GSD first to improve the backlog before asking the supervisor to execute it.
-
-## Two operating modes
-
-### Mode A: Without GSD
-
-Use this when your GitHub issues are already clear and sequenced.
-
-Flow:
-
-```mermaid
-flowchart LR
-  A["Execution-ready issues"] --> B["codex-supervisor"]
-  B --> C["Implement"]
-  C --> D["Draft PR"]
-  D --> E["Local review / CI / PR review"]
-  E --> F["Merge"]
-```
-
-Typical prompts to Codex:
-
-- "Build the supervisor and start working on the next runnable issue."
-- "Show me the current supervisor status."
-- "Check the PR review comments and fix valid ones."
-- "Check the failing CI for the current PR and repair it."
-
-### Mode B: With GSD
-
-Use this when the work is still ambiguous.
-
-Flow:
-
-```mermaid
-flowchart LR
-  A["Ambiguous request"] --> B["Codex using GSD"]
-  B --> C["Repo memory docs"]
-  B --> D["Epic + child issues"]
-  C --> E["codex-supervisor"]
-  D --> E
-  E --> F["PR / CI / Review / Merge loop"]
-```
-
-Typical prompts to Codex:
-
-- "Use GSD to break this feature into an epic and child issues."
-- "Use GSD to turn this vague request into execution-ready issues."
-- "Update PROJECT.md, REQUIREMENTS.md, ROADMAP.md, and STATE.md, then show me the proposed issue breakdown."
-- "This issue is too large. Use GSD to split it into smaller dependent issues."
-
-## How GSD hands off to codex-supervisor
-
-GSD should not replace the supervisor's execution loop.
-
-Use GSD for:
-
-- feature framing
-- phase planning
-- dependency design
-- acceptance criteria
-- repo memory updates
-
-Do not use GSD for:
-
-- PR monitoring
-- CI repair loops
-- merge gating
-- issue-by-issue execution orchestration
-
-The hand-off boundary is:
-
-1. GSD updates planning docs.
-2. GSD output becomes GitHub epic and child issues.
-3. Those issues become the supervisor's queue.
-
-## Recommended repo memory when using GSD
-
-These files work well as durable shared memory:
-
-- `PROJECT.md`
-- `REQUIREMENTS.md`
-- `ROADMAP.md`
-- `STATE.md`
-- `README.md`
-- `docs/architecture.md`
-- `docs/constitution.md`
-- `docs/workflow.md`
-- `docs/decisions.md`
-
-The supervisor reads a compact context index first, then opens durable memory files only on demand.
-
-## Focused reference guides
-
-Use the high-level flow in this guide, then jump to the reference that matches the task:
-
-- [Configuration reference](./configuration.md) for config fields, provider profiles, model strategy, durable memory, and execution policy
-- [Local review reference](./local-review.md) for review policies, role selection, artifacts, thresholds, and committed guardrails
-- [Issue metadata reference](./issue-metadata.md) for the canonical field guide, sequencing rules, and execution-ready issue template
-
-## How issue scheduling actually works
-
-This is the most important concept.
-
-The supervisor is not primarily "issue-created driven".
-
-It is "readiness-driven".
-
-That means it does not simply pick the newest open issue. It looks for the next issue that is actually runnable.
-
-## Why open issue order is not enough
-
-Consider this backlog:
-
-```text
-#101 Epic
-#102 1 of 3
-#103 2 of 3 Depends on: #102
-#104 3 of 3 Depends on: #103
-```
-
-All three child issues may already be open. But only `#102` is runnable.
-
-So the supervisor should not use:
-
-- "latest open issue"
-- "first open issue"
-- "issue creation time only"
-
-It should use:
-
-- "first runnable issue"
-
-## How readiness-driven scheduling works
-
-```mermaid
-flowchart TD
-  A["Poll GitHub + local state"] --> B["List open candidate issues"]
-  B --> C["Skip non-work items\n(example: Epic:)"]
-  C --> D["Check Depends on / Execution order"]
-  D --> E["Check local terminal state\n(blocked / failed / retry budget)"]
-  E --> F["Select next runnable issue"]
-  F --> G["Create or resume worktree"]
-  G --> H["Run Codex turn"]
-```
-
-The scheduler considers:
-
-- issue is open
-- issue matches the configured label or search
-- issue title is not skipped
-- dependencies are satisfied
-- execution order is satisfied
-- local record is not terminal in a way that blocks retry
-- stale PR or stale failure state has been reconciled
-
-For the detailed issue format, examples, and field-by-field rules, use the [Issue metadata reference](./issue-metadata.md).
-
-## State machine
-
-The supervisor is built around explicit state transitions.
-
-```mermaid
-flowchart TD
-  Q["queued"] --> R["reproducing"]
-  R --> S["stabilizing"]
-  S --> D["draft_pr"]
-  D --> L["local_review"]
-  L --> F["local_review_fix"]
-  F --> D
-  L --> W["waiting_ci"]
-  W --> A["addressing_review"]
-  W --> C["repairing_ci"]
-  W --> X["resolving_conflict"]
-  W --> F
-  W --> M["ready_to_merge"]
-  A --> W
-  C --> W
-  X --> W
-  M --> G["merging"]
-  G --> O["done"]
-  R --> B["blocked"]
-  S --> Z["failed"]
-```
-
-Short interpretation:
-
-- `reproducing`: make the problem concrete
-- `stabilizing`: move toward a clean checkpoint
-- `draft_pr`: publish early when the checkpoint is coherent
-- `local_review`: run a local advisory review swarm
-- `local_review_fix`: apply the smallest repair that clears the active compressed local-review root causes
-- `waiting_ci`: checks or review grace window
-- `addressing_review`: fix valid bot review findings
-- `repairing_ci`: fix failing checks
-- `resolving_conflict`: fix a dirty merge state
-- `ready_to_merge`: all gates are satisfied
-- `blocked`: needs manual clarification
-- `failed`: retry budget exhausted or unrecoverable condition
-
-## What to ask Codex
-
-### To use the supervisor
-
-- "Build the supervisor and start the next runnable issue."
-- "Show me the current supervisor status."
-- "Resume the current issue and report the PR, CI, and review state."
-
-### To use GSD before the supervisor
-
-- "Use GSD to turn this feature into an epic and child issues."
-- "Use GSD to update the planning docs and propose a dependency order."
-- "Use GSD to split this blocked issue into smaller execution-ready issues."
-
-### To bridge GSD into the supervisor
-
-- "Use GSD to refine the plan, update repo memory, create the issues, then hand off to codex-supervisor."
-
-## Suggested first-run workflow
-
-1. Install Codex CLI.
-2. Clone your repo.
-3. Prepare `supervisor.config.json`.
-   Use the [Configuration reference](./configuration.md) for the full field guide, the [Local review reference](./local-review.md) when you want to enable or tune the local review swarm, and the [Issue metadata reference](./issue-metadata.md) when you need to author or review execution-ready issues.
-4. Create execution-ready issues.
-5. Run:
+Build the CLI once in the supervisor repo:
 
 ```bash
 npm install
 npm run build
+```
+
+## Choose the operating mode
+
+Use `codex-supervisor` only when the next issue is already execution-ready.
+
+Choose `codex-supervisor` directly when:
+
+- the issue body explains the change clearly
+- dependencies are written down
+- execution order is explicit when sibling issues must run in sequence
+- acceptance criteria and verification are concrete
+
+Use GSD before the supervisor when:
+
+- the request is still vague
+- one issue needs to be split into several dependent issues
+- repo memory or planning docs need to be updated before execution starts
+
+Rule of thumb:
+
+**GSD designs the backlog. `codex-supervisor` executes the backlog.**
+
+## Prepare the supervisor config
+
+Create an active config from the base example:
+
+```bash
+cp supervisor.config.example.json supervisor.config.json
+```
+
+Then choose the provider profile that matches your PR review flow:
+
+- [supervisor.config.copilot.json](../supervisor.config.copilot.json)
+- [supervisor.config.codex.json](../supervisor.config.codex.json)
+- [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
+
+Either copy one of those files over `supervisor.config.json` or copy only its `reviewBotLogins` into your active config.
+
+At minimum, set these fields before the first run:
+
+- `repoPath`
+- `repoSlug`
+- `workspaceRoot`
+- `codexBinary`
+- provider-specific review bot settings you expect the supervisor to watch
+
+If you need the full field-by-field setup, model policy, durable memory, or provider guidance, use the [Configuration reference](./configuration.md).
+
+## Write execution-ready issues
+
+The scheduler is readiness-driven. It does not just pick the newest open issue; it picks the first issue that is actually runnable.
+
+Before you run the supervisor, make sure each candidate issue includes:
+
+- a clear `## Summary`
+- a bounded `## Scope`
+- `Depends on` for prerequisites
+- `## Execution order` when sibling issues must run in sequence
+- observable `## Acceptance criteria`
+- concrete `## Verification`
+
+Minimal example:
+
+```md
+## Summary
+Refocus the getting-started guide on setup and operator flow.
+
+## Scope
+- keep the guide centered on setup and operation
+- remove duplicated deep-reference sections
+- keep links to the deeper docs accurate
+
+Part of: #259
+Depends on: #262
+Parallelizable: No
+
+## Execution order
+4 of 5
+
+## Acceptance criteria
+- the guide reads as an operational setup-and-usage document
+- duplicated reference content is removed or shortened
+- related doc links are correct
+
+## Verification
+- review the getting-started flow for clarity
+- run npm run build
+```
+
+Use the [Issue metadata reference](./issue-metadata.md) for the canonical field rules and more examples.
+
+## Run the first pass
+
+Start with a single supervised pass so you can inspect the repo selection, worktree setup, and resulting state before you hand over the loop:
+
+```bash
 node dist/index.js run-once --config /path/to/supervisor.config.json
 node dist/index.js status --config /path/to/supervisor.config.json
 ```
 
-6. When the behavior looks correct, switch to:
+What to check after `run-once`:
+
+- the selected issue is the one you expected
+- the issue worktree was created under `workspaceRoot`
+- the issue journal shows a sensible hypothesis, blocker, and next step
+- any opened PR or status transition matches the actual repo state
+
+If the first pass picks the wrong issue, fix the issue metadata before running again. Do not treat issue creation time as the source of truth.
+
+## Move from run-once to loop
+
+When one supervised pass behaves correctly, switch to the continuous loop:
 
 ```bash
 node dist/index.js loop --config /path/to/supervisor.config.json
 ```
 
+In normal operation, the supervisor will:
+
+1. re-read GitHub and local state
+2. resume or select the next runnable issue
+3. run a Codex turn in that issue's dedicated worktree
+4. open or update the PR when there is a coherent checkpoint
+5. wait for CI and reviews, then repair or merge as needed
+
+Use `status` whenever you want the current issue, PR, check, review, and mergeability summary without advancing the loop.
+
+## Common operator decisions
+
+When should I use GSD first?
+Use GSD when the next issue is still a planning problem. Use the supervisor when the next issue is already an execution problem.
+
+When should I open a PR?
+Open or update a draft PR as soon as the branch has a coherent checkpoint. The supervisor is designed to publish early rather than waiting for a perfect final state.
+
+When should I enable local review?
+Enable it when you want a committed pre-merge review gate or an additional local advisory pass before CI and external reviews. Use the [Local review reference](./local-review.md) for role selection, thresholds, artifacts, and policy choices.
+
+What if the backlog order looks wrong?
+Fix `Depends on` and `Execution order` in GitHub. The scheduler follows runnable order, not operator intuition or chat history.
+
+What if the loop keeps hitting blocked work?
+Stop treating the issue as execution-ready. Tighten the issue body, split the work, or use GSD to rebuild the backlog.
+
 ## Common mistakes
 
-- using the supervisor before the backlog is execution-ready
-- expecting issue creation time to define execution order
-- mixing GSD execution flows into the supervisor loop
-- relying on chat memory instead of repo memory
 - starting with `loop` before validating `run-once`
+- asking the supervisor to execute issues that still need planning
+- relying on issue creation time instead of explicit dependency metadata
+- treating README-level overview content as a substitute for issue metadata
+- expecting deep config or local-review details to live in this guide instead of the dedicated references
 
-## Rule of thumb
+## Related docs
 
-Use this simple rule:
-
-- if the issue is clear, use `codex-supervisor`
-- if the issue is vague, use GSD first
-- when GSD output becomes explicit issues, hand back to the supervisor
-
-In one sentence:
-
-**GSD designs the backlog. codex-supervisor executes the backlog.**
+- [README](../README.md) for the overview, fit, and docs map
+- [Configuration reference](./configuration.md) for config fields, provider setup, model policy, and durable memory
+- [Local review reference](./local-review.md) for review roles, artifacts, thresholds, and merge policy
+- [Issue metadata reference](./issue-metadata.md) for execution-ready issue structure and scheduling inputs

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+async function readGettingStarted(): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), "docs", "getting-started.md"), "utf8");
+}
+
+test("getting-started stays focused on operator setup and flow", async () => {
+  const content = await readGettingStarted();
+
+  const requiredHeadings = [
+    "# Getting Started with codex-supervisor",
+    "## Before you start",
+    "## Choose the operating mode",
+    "## Prepare the supervisor config",
+    "## Write execution-ready issues",
+    "## Run the first pass",
+    "## Move from run-once to loop",
+    "## Common operator decisions",
+    "## Common mistakes",
+    "## Related docs",
+  ];
+
+  let lastIndex = -1;
+  for (const heading of requiredHeadings) {
+    const index = content.indexOf(heading);
+    assert.notEqual(index, -1, `expected ${heading} in docs/getting-started.md`);
+    assert.ok(index > lastIndex, `expected ${heading} to appear after the previous section`);
+    lastIndex = index;
+  }
+
+  assert.match(content, /\[README\]\(\.\.\/README\.md\)/);
+  assert.match(content, /\[Configuration reference\]\(\.\/configuration\.md\)/);
+  assert.match(content, /\[Local review reference\]\(\.\/local-review\.md\)/);
+  assert.match(content, /\[Issue metadata reference\]\(\.\/issue-metadata\.md\)/);
+
+  assert.doesNotMatch(content, /^## Full picture$/m);
+  assert.doesNotMatch(content, /^## What codex-supervisor does$/m);
+  assert.doesNotMatch(content, /^## Best fit$/m);
+  assert.doesNotMatch(content, /^## Not a fit$/m);
+  assert.doesNotMatch(content, /^## How readiness-driven scheduling works$/m);
+  assert.doesNotMatch(content, /^## State machine$/m);
+});


### PR DESCRIPTION
Closes #263
This PR was opened by codex-supervisor.
Latest Codex summary:

Refocused [docs/getting-started.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-263/docs/getting-started.md) into an operator guide: prerequisites, when to use GSD vs supervisor, config prep, execution-ready issue authoring, first-run flow, loop handoff, and common operator decisions. I removed the prior landing-page/reference-heavy sections and replaced them with tighter links back to [README.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-263/README.md), configuration, local review, and issue metadata.

Added [src/getting-started-docs.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-263/src/getting-started-docs.test.ts) to lock that scope down, and adjusted README copy so it points at the new getting-started intent. Verification passed after installing local deps in the worktree. Commit: `cc093c7` (`docs: refocus getting started guide`).

Summary: Refocused `getting-started.md` on operational guidance, added a focused docs test, updated README wording, and committed the result.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/getting-started-docs.test.ts`; `npm test`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-263` with commit `cc093c7` and move into local review.