### PR TITLE
Docs: keep getting-started.ja.md as the fuller Japanese guide while reducing README duplication

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,196 +1,65 @@
 # codex-supervisor 日本語ガイド
 
-`codex-supervisor` は、`codex exec` と `gh` を使って GitHub Issues / PR / CI / review / merge のループを継続するための、**deterministic で durable な supervisor** です。
+`codex-supervisor` は、`codex exec` と `gh` を使って GitHub issue、PR、CI、review、merge の進行を継続監督するための deterministic な supervisor です。
 
-英語版の一次ソースは [README.md](/Users/tomoakikawada/Dev/codex-supervisor/README.md) です。この文書は、日本語で全体像と運用モデルを素早く把握するためのガイドです。
+英語版の一次ソースは [README.md](../README.md) です。この文書は、日本語で全体像と入口を把握するための軽い案内として使ってください。実際のセットアップと運用手順は [docs/getting-started.ja.md](./getting-started.ja.md) に寄せています。
 
-## 何を目指すか
+## 何をするツールか
 
-`codex-supervisor` の中心思想は次の 3 つです。
+`codex-supervisor` は、長い chat thread を覚え続ける代わりに、毎ターン GitHub とローカル state を読み直して次の行動を決めます。
 
-- GitHub を source of truth にする
-- chat thread の長期記憶に依存しない
-- 状態遷移とローカル state によって loop を継続する
-
-つまり、長い会話を維持して作業を続けるのではなく、毎ターン
-
-- issue
-- PR
-- checks
-- review threads
-- mergeability
-
-を GitHub から再取得し、次に取るべき行動を決めます。
-
-## 何が嬉しいか
-
-- issue 駆動で実装を進められる
-- PR 作成後の CI 待ち、review 待ち、修正、再 push を loop として扱える
-- local state があるので、会話コンテキスト圧縮で止まりにくい
-- readiness-driven に次の runnable issue を選べる
-
-## 何をしないか
-
-- GitHub 以外の曖昧な優先順位付けを勝手に発明しない
-- 長い設計議論を supervisor 自身が持ち続けない
-- repo 固有の workflow を自動で推測し切ることを期待しない
+- issue、PR、checks、review、mergeability を再取得する
+- runnable な issue を readiness-driven に選ぶ
+- issue ごとの worktree と issue journal を維持する
+- draft PR、CI 修復、review 対応、merge までの loop を継続する
 
 ## 向いているケース
 
-- 1 人開発、または小規模で ownership が明確な automation lane
-- `Depends on` や `Execution order` が issue に書かれている repo
-- branch protection と CI が整っている repo
-- execution-ready な issue を順番に回したい repo
+Best fit:
 
-## 向いていないケース
+- 1 人、または ownership が明確な automation lane
+- `Depends on` と `Execution order` が明示された backlog
+- branch protection と CI が整った repo
+- execution-ready issue を順に回したい運用
 
-- 多人数が同じ領域を頻繁に触る repo
-- issue の優先順位や依存関係が暗黙な backlog
-- issue が相談単位で、実装単位に分解されていない repo
+Not a fit:
 
-## 全体像
+- 優先順位や依存関係が暗黙な backlog
+- 相談単位の issue が多く、実装単位に分解されていない repo
+- 複数人が同じ領域を頻繁に触る repo
 
-```mermaid
-flowchart LR
-  U["User"] --> C["Codex CLI / Codex App"]
-  C --> P["GSD planning flow (optional)"]
-  C --> S["codex-supervisor"]
+## クイックスタート
 
-  P --> M["Repo memory"]
-  P --> I["GitHub Issues"]
+1. 依存関係を入れてビルドします。
 
-  S --> M
-  S --> I
-  S --> W["Worktrees + local state"]
-  S --> G["PR / CI / Reviews / Merge"]
+   ```bash
+   npm install
+   npm run build
+   ```
 
-  G --> S
-  I --> S
-```
+2. ベース設定から active config を作ります。
 
-ポイントは次です。
+   ```bash
+   cp supervisor.config.example.json supervisor.config.json
+   ```
 
-- 出発点は常に `User -> Codex`
-- GSD は optional な planning tool
-- `codex-supervisor` は execution engine
+3. review provider に合う profile を選び、`supervisor.config.json` に反映します。
 
-## readiness-driven scheduling
+   - [supervisor.config.copilot.json](../supervisor.config.copilot.json)
+   - [supervisor.config.codex.json](../supervisor.config.codex.json)
+   - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
 
-`codex-supervisor` は単純な「新しい issue が立ったら取る」仕組みではありません。
+4. `repoPath`、`repoSlug`、`workspaceRoot`、`codexBinary` などを設定します。
+5. まず `run-once` と `status` で挙動を確認し、その後 `loop` に切り替えます。
 
-本質は **今 runnable な issue を選ぶこと** です。
+より詳しい初回手順、issue の書き方、運用中の判断は [docs/getting-started.ja.md](./getting-started.ja.md) を参照してください。
 
-そのため、毎 poll で次を見ます。
+## ドキュメントマップ
 
-- issue が open か
-- label / search 条件に合うか
-- `Depends on` が解消されているか
-- `Execution order` 上、前段 issue が終わっているか
-- local state が `blocked` / `failed` のままではないか
-- 関連 PR / checks / review が stale ではないか
-
-これにより、Epic と複数の子 issue をまとめて open する運用でも、先に進めるべき issue だけを選べます。
-
-## 主な状態遷移
-
-```mermaid
-flowchart TD
-  Q["queued"] --> R["reproducing"]
-  R --> S["stabilizing"]
-  S --> D["draft_pr"]
-  D --> L["local_review"]
-  L --> W["waiting_ci"]
-  W --> A["addressing_review"]
-  W --> C["repairing_ci"]
-  W --> M["ready_to_merge"]
-  A --> W
-  C --> W
-  M --> G["merging"]
-  G --> O["done"]
-  R --> B["blocked"]
-  S --> F["failed"]
-```
-
-補足:
-
-- `reproducing`: 問題や要件を再現可能な形に寄せる
-- `stabilizing`: checkpoint を clean にして PR 可能な形へ寄せる
-- `local_review`: ローカル review swarm を回す
-- `repairing_ci`: CI failure 修正
-- `addressing_review`: bot review 対応
-
-## local review swarm
-
-`codex-supervisor` は、draft PR を ready にする前後でローカル review swarm を回せます。
-
-主な特徴:
-
-- role ごとに別 Codex turn を実行
-- Markdown と JSON artifact を保存
-- confidence threshold 以上の finding を actionable として扱う
-- 推奨パスは `block_merge` で、必要に応じて `block_ready` / `advisory` を選べる
-
-代表的な role:
-
-- `reviewer`
-- `explorer`
-- `docs_researcher`
-- `prisma_postgres_reviewer`
-- `migration_invariant_reviewer`
-- `contract_consistency_reviewer`
-- `ui_regression_reviewer`
-
-`localReviewRoles` を空にし、`localReviewAutoDetect: true` にすると、repo 構成から specialist role を自動選択できます。
-
-## model / reasoning の考え方
-
-現状の推奨は次です。
-
-- model は基本 `inherit`
-- Codex CLI / App 側の default model を `GPT-5.4` にする
-- 最適化は model 切り替えより reasoning effort の調整で行う
-
-`xhigh` は常用せず、例外的な repeated failure の escalation 用に残す方がよいです。
-
-## GSD との関係
-
-GSD は daily execution loop の中核ではありません。役割分担は次です。
-
-- GSD: 上流の planning
-- `codex-supervisor`: 下流の execution
-
-使い分け:
-
-- execution-ready な issue があるなら、そのまま supervisor に流す
-- wave / epic の設計、issue 分解、要求整理が必要なら GSD を使う
-- GSD の出力は `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `STATE.md` と GitHub issue に落としてから supervisor に渡す
-
-## 初回セットアップの流れ
-
-1. `gh auth status` が通ることを確認
-2. Codex CLI をインストール
-3. `supervisor.config.json` を作る
-4. `run-once` で 1 サイクル確認
-5. 問題なければ `loop` で常駐させる
-
-詳細な手順は以下を見てください。
-
-- [docs/getting-started.md](/Users/tomoakikawada/Dev/codex-supervisor/docs/getting-started.md)
-- [docs/getting-started.ja.md](/Users/tomoakikawada/Dev/codex-supervisor/docs/getting-started.ja.md)
-
-## 現時点での README コンセプト
-
-`codex-supervisor` は、もはや「最小限だけの supervisor」ではありません。現在の実態に近い表現は次です。
-
-- deterministic
-- durable
-- GitHub-driven
-- readiness-driven
-
-一方で、still true なこともあります。
-
-- orchestration の責務を明示的に保っている
-- GitHub と local state 以外を source of truth にしない
-- chat memory ではなく state machine を中心にしている
-
-その意味で、`codex-supervisor` は「軽量な toy」ではなく、**実用的な deterministic execution supervisor** と捉えるのが適切です。
+- [docs/getting-started.ja.md](./getting-started.ja.md): 日本語での詳しいセットアップ、issue readiness、初回実行、運用判断
+- [docs/getting-started.md](./getting-started.md): 英語版の getting started
+- [Configuration reference](./configuration.md): config 項目、provider profile、durable memory、実行ポリシー
+- [Local review reference](./local-review.md): local review の role、artifact、threshold、guardrail
+- [Architecture](./architecture.md): core loop、durable state、reconciliation、安全境界
+- [Issue metadata](./issue-metadata.md): issue body の canonical fields と scheduling inputs
+- [Validation checklist](./validation-checklist.md): 導入前後の確認項目

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -1,513 +1,198 @@
 # codex-supervisor 入門
 
-このガイドは、Codex CLI を入れたばかりの人、または Codex デスクトップアプリを使い始めた人向けです。
+このガイドは、`codex-supervisor` を実際の repo で運用し始める人向けの、日本語での詳しい getting started です。
 
-目的は次の 5 つです。
+主に次の流れを扱います。
 
-- `codex-supervisor` が何をするのか
-- `codex-supervisor` 単独で使う場面
-- `get-shit-done` (GSD) を先に使う場面
-- 窓口として Codex にどう指示するか
-- supervisor が次の issue をどう選ぶか
+- supervisor を使う準備が整っているかを判断する
+- review provider を含む config を用意する
+- scheduler が安全に実行できる issue を書く
+- 最初は `run-once` で確認し、その後 `loop` に移る
+- 迷った時にどの reference doc を開くかを判断する
 
-## 基本の考え方
+概要は [README](../README.md) と [README.ja](./README.ja.md) を参照してください。この文書は、README より踏み込んだ運用ガイドとして維持します。
 
-Codex を operator console だと考えてください。
+## 始める前に
 
-- あなたは Codex に話しかけます
-- 要件が曖昧なら、Codex に GSD を使わせて整理します
-- issue が実装可能な状態なら、Codex に `codex-supervisor` を使わせます
+まず次を確認してください。
 
-`codex-supervisor` は execution engine です。
+- `gh auth status` が成功する
+- `codex` CLI が shell から使える
+- 管理対象 repo がローカルに clone 済み
+- 対象 repo に branch protection と CI がある
+- supervisor が issue ごとの worktree を作れる場所がある
 
-- ローカル state を持つ
-- issue ごとに worktree を作る
-- `codex exec` を起動する
-- PR、CI、review、mergeability を追跡する
-- 本当に着手可能な issue だけを前に進める
-
-GSD は optional な planning layer です。
-
-- 実装前の整理に向いています
-- issue が大きすぎる時の再分割に向いています
-- blocked issue の再設計に向いています
-
-## 全体像
-
-```mermaid
-flowchart LR
-  U["User"] --> C["Codex CLI / Codex App"]
-  C --> P["GSD planning flow (optional)"]
-  C --> S["codex-supervisor"]
-
-  P --> M["Repo memory\nPROJECT.md / REQUIREMENTS.md / ROADMAP.md / STATE.md"]
-  P --> I["GitHub Issues\nEpic / child issues / Depends on / Execution order"]
-
-  S --> M
-  S --> I
-  S --> W["Issue worktrees + local state"]
-  S --> G["GitHub PR / CI / Reviews / Merge"]
-
-  G --> S
-  I --> S
-```
-
-この図で伝えたいことは 3 つです。
-
-- 出発点は常に `User -> Codex`
-- GSD は optional な planning tool
-- `codex-supervisor` は downstream の execution tool
-
-## codex-supervisor がやること
-
-大まかなループは次の通りです。
-
-1. GitHub と local state を再取得する
-2. 次に runnable な issue を選ぶ
-3. issue worktree を作成または再開する
-4. Codex ターンを 1 回実行する
-5. branch を push し、PR を作るか更新する
-6. CI と review を待つ
-7. failing check や妥当な review 指摘を修正する
-8. merge 条件が揃ったら merge する
-9. 次の runnable issue に進む
-
-## 向いているケース
-
-`codex-supervisor` は次のような repo に向いています。
-
-- 1 人、または 1 execution lane で運用する
-- issue が execution-ready である
-- 依存関係が明示されている
-- 実装順が明示されている
-- CI と branch protection が整っている
-
-典型例:
-
-- 1 つの epic
-- 複数の child issue
-- `Depends on`
-- `Part of`
-- `Execution order`
-- 明確な acceptance criteria
-
-## 向いていないケース
-
-次のような場合は弱いです。
-
-- issue の優先順位が頻繁に変わる
-- issue が相談単位で、実行単位ではない
-- 複数人が同じ領域を同時に触る
-- backlog に依存関係や順序の明示がない
-
-その場合は、まず GSD を使って backlog を整えてから supervisor に渡してください。
-
-## 2つの運用モード
-
-### モード A: GSD を使わない
-
-GitHub issue がすでに明確で、順序も依存関係も整っている場合です。
-
-フロー:
-
-```mermaid
-flowchart LR
-  A["Execution-ready issues"] --> B["codex-supervisor"]
-  B --> C["Implement"]
-  C --> D["Draft PR"]
-  D --> E["Local review / CI / PR review"]
-  E --> F["Merge"]
-```
-
-Codex への指示例:
-
-- 「Supervisor をビルドして、次の runnable issue を開始して」
-- 「現在の supervisor の状態を見せて」
-- 「PR の review コメントを確認して、妥当なら修正して」
-- 「現在の PR の failing CI を調べて直して」
-
-### モード B: GSD を使う
-
-要件がまだ曖昧な場合です。
-
-フロー:
-
-```mermaid
-flowchart LR
-  A["Ambiguous request"] --> B["Codex using GSD"]
-  B --> C["Repo memory docs"]
-  B --> D["Epic + child issues"]
-  C --> E["codex-supervisor"]
-  D --> E
-  E --> F["PR / CI / Review / Merge loop"]
-```
-
-Codex への指示例:
-
-- 「GSD を使って、この機能を epic と child issue に分解して」
-- 「この曖昧な要求を execution-ready issue 群にして」
-- 「PROJECT.md、REQUIREMENTS.md、ROADMAP.md、STATE.md を更新して、issue 分解案を見せて」
-- 「この issue は大きすぎるので、GSD で小さい依存付き issue に切り直して」
-
-## GSD から supervisor への hand-off
-
-GSD は supervisor の execution loop を置き換えるものではありません。
-
-GSD に向いていること:
-
-- feature framing
-- phase planning
-- dependency design
-- acceptance criteria の整理
-- repo memory の更新
-
-GSD に向いていないこと:
-
-- PR 監視
-- CI 修復ループ
-- merge 判定
-- issue 単位の実装オーケストレーション
-
-hand-off の境界はこうです。
-
-1. GSD が planning docs を更新する
-2. GSD の出力を GitHub の epic / child issue に落とす
-3. その issue 群を supervisor が実行する
-
-## GSD を使う時の repo memory
-
-次のファイルを durable memory にするのが自然です。
-
-- `PROJECT.md`
-- `REQUIREMENTS.md`
-- `ROADMAP.md`
-- `STATE.md`
-- `README.md`
-- `docs/architecture.md`
-- `docs/constitution.md`
-- `docs/workflow.md`
-- `docs/decisions.md`
-
-supervisor は、まず compact context index を読み、その後必要な durable memory だけを on-demand で開きます。
-
-## local review swarm
-
-`codex-supervisor` は、pull request に対して local review swarm を実行できます。推奨される開始ポリシーは `block_merge` で、通常の ready-for-review の流れを保ちながら、現在の PR head に対して実用的な merge gate として動かせます。
-
-重要な点は次の通りです。
-
-- 各 role は別々の Codex turn で実行される
-- 挙動は `localReviewPolicy` で決まる
-- `block_merge` は推奨される標準パスで、ready PR の merge を止め、ready PR の head 更新時にも再実行できる
-- `block_ready` はより早い段階で厳しく、draft から ready への進行を止める
-- `advisory` は non-blocking で、artifact を残したいが自動 gate は不要な場合に向く
-- findings は Markdown と JSON artifact に保存される
-- ここでも context 節約方針は同じで、まず compact context index と issue journal を読み、その後必要な durable memory だけを on-demand で開く
-
-review role の選び方は 2 通りあります。
-
-### 方法 1: role を自動検出する
-
-最初はこれが推奨です。
-
-`localReviewRoles` が空で、`localReviewAutoDetect` が `true` の場合、supervisor は managed repo の構成から role を推定します。
-
-例:
-
-```json
-{
-  "localReviewEnabled": true,
-  "localReviewAutoDetect": true,
-  "localReviewRoles": []
-}
-```
-
-baseline は次です。
-
-- `reviewer`
-- `explorer`
-
-そのうえで、repo の特徴に応じて specialist role を追加します。例えば:
-
-- docs や durable memory がある -> `docs_researcher`
-- Prisma schema と migrations がある -> `prisma_postgres_reviewer`, `migration_invariant_reviewer`, `contract_consistency_reviewer`
-- Playwright を使う repo -> `ui_regression_reviewer`
-- GitHub Actions workflow がある -> `github_actions_semantics_reviewer`
-- workflow 向け test がある -> `workflow_test_reviewer`
-- Node/script-heavy または workflow-heavy な repo -> `portability_reviewer`
-
-生成される local review artifact には、各 auto-detected role が選ばれた理由も入ります。
-
-- Markdown summary には `Auto-detected roles` セクションが追加され、signal を短く確認できます
-- JSON artifact には `autoDetectedRoles` が入り、role ごとに `kind`、`signal`、`paths` を machine-readable に保存します
-
-manual override に切り替えたいときは、まずこの理由データを見て必要な role だけを `localReviewRoles` にコピーし、`localReviewAutoDetect` を `false` にします。これで specialist を維持しつつ、role 選択を deterministic にできます。
-
-初回セットアップでは、最初から role 設計を細かくしなくてよいので、この方法が扱いやすいです。
-
-### 方法 2: role を明示指定する
-
-完全に手動で制御したい場合は、role を明示指定します。
-
-例:
-
-```json
-{
-  "localReviewEnabled": true,
-  "localReviewAutoDetect": false,
-  "localReviewRoles": [
-    "reviewer",
-    "explorer",
-    "docs_researcher",
-    "prisma_postgres_reviewer",
-    "migration_invariant_reviewer",
-    "contract_consistency_reviewer"
-  ]
-}
-```
-
-この方法が向いているのは次のケースです。
-
-- その repo に specialist reviewer が必要だと既に分かっている
-- マシンごとの差を減らしたい
-- swarm の比較検証を継続したい
-
-### specialist role の役割
-
-汎用 role は broad な bug hunt には役立ちますが、repo 固有の欠陥は取りこぼします。
-
-例:
-
-- `prisma_postgres_reviewer`
-  - PostgreSQL の unique 制約 semantics、nullable unique の罠、partial index、Prisma/schema の不整合を見る
-- `migration_invariant_reviewer`
-  - app code では禁止しているのに DB では入ってしまう invalid state を見る
-- `contract_consistency_reviewer`
-  - contract、schema、docs、tests のズレを見る
-- `ui_regression_reviewer`
-  - browser flow や E2E regression の可能性を見る
-- `github_actions_semantics_reviewer`
-  - GitHub Actions の event/context ミス、concurrency の落とし穴、stale な cancelled check の扱いを見る
-- `workflow_test_reviewer`
-  - brittle な workflow test、regex 依存の assertion、path/cwd 前提の崩れやすさを見る
-- `portability_reviewer`
-  - shell glob、path、改行コード、OS 差異に起因する portability risk を見る
-
-`atlaspm` のような repo では、generic role を増やすより、こうした specialist role を入れる方が効くことが多いです。
-
-## issue 検知ではなく issue scheduling
-
-ここが最重要です。
-
-`codex-supervisor` は単純な `issue created` 監視ではありません。
-
-本質は **readiness-driven** です。
-
-つまり「新しく open された issue」を取るのではなく、**今着手可能な issue** を選びます。
-
-## なぜ open 順ではいけないのか
-
-例えば次の backlog を考えます。
-
-```text
-#101 Epic
-#102 1 of 3
-#103 2 of 3 Depends on: #102
-#104 3 of 3 Depends on: #103
-```
-
-3 つの child issue はすべて open かもしれません。  
-ですが runnable なのは `#102` だけです。
-
-なので supervisor は、
-
-- 最新 issue
-- 最初に open された issue
-- 作成順だけ
-
-では選びません。
-
-選ぶのは、
-
-- **最初に runnable になっている issue**
-
-です。
-
-## readiness-driven scheduling の流れ
-
-```mermaid
-flowchart TD
-  A["Poll GitHub + local state"] --> B["List open candidate issues"]
-  B --> C["Skip non-work items\n(example: Epic:)"]
-  C --> D["Check Depends on / Execution order"]
-  D --> E["Check local terminal state\n(blocked / failed / retry budget)"]
-  E --> F["Select next runnable issue"]
-  F --> G["Create or resume worktree"]
-  G --> H["Run Codex turn"]
-```
-
-scheduler が見るもの:
-
-- issue が open か
-- label / search 条件に合うか
-- skip 対象タイトルでないか
-- dependency が解消されているか
-- execution order が満たされているか
-- local record が terminal state で止まっていないか
-- stale な PR / failure state が reconciliation されているか
-
-## issue 本文の書き方
-
-よい issue には通常これが入ります。
-
-- `Part of: #...`
-- `Depends on: #...`
-- `Parallelizable: Yes/No`
-- `Execution order`
-- `Acceptance criteria`
-
-例:
-
-```md
-## Summary
-Add a persisted recommendation severity model for wait stats findings.
-
-Part of: #42
-Depends on: #41
-Parallelizable: No
-
-## Execution order
-2 of 4
-
-## Acceptance criteria
-- severity levels are defined in the domain model
-- recommendation ranking uses the new severity model
-- focused tests cover the ranking behavior
-```
-
-## 状態遷移
-
-supervisor の中核は明示的な state machine です。
-
-```mermaid
-flowchart TD
-  Q["queued"] --> R["reproducing"]
-  R --> S["stabilizing"]
-  S --> D["draft_pr"]
-  D --> L["local_review"]
-  L --> W["waiting_ci"]
-  W --> A["addressing_review"]
-  W --> C["repairing_ci"]
-  W --> X["resolving_conflict"]
-  W --> M["ready_to_merge"]
-  A --> W
-  C --> W
-  X --> W
-  M --> G["merging"]
-  G --> O["done"]
-  R --> B["blocked"]
-  S --> F["failed"]
-```
-
-短い意味:
-
-- `reproducing`: 問題を再現可能にする
-- `stabilizing`: clean checkpoint に寄せる
-- `draft_pr`: checkpoint を早めに公開する
-- `local_review`: local advisory review swarm
-- `waiting_ci`: checks または review grace 待ち
-- `addressing_review`: bot review の妥当な指摘を直す
-- `repairing_ci`: failing checks を直す
-- `resolving_conflict`: dirty merge state を直す
-- `ready_to_merge`: merge 条件が揃った
-- `blocked`: 人手 clarification が必要
-- `failed`: retry budget 枯渇か unrecoverable
-
-## Local Review Swarm
-
-local review swarm は、`gh pr ready` の前に走る optional review phase です。
-
-典型的な role:
-
-- `reviewer`
-- `explorer`
-- `docs_researcher`
-
-やること:
-
-- role ごとに独立した review turn を走らせる
-- 実装ターンと同じ context budget policy を守る
-- Markdown summary を書く
-- structured JSON artifact を書く
-- actionable な high severity findings については、より強い gate の前に verifier pass を走らせる
-- findings を dedupe する
-- confidence threshold 以上の findings だけ actionable として扱う
-
-やらないこと:
-
-- コード編集
-- 単独で merge を止める
-- GitHub branch protection の代替
-
-artifact では、review role が出した raw actionable findings と verifier pass が確認した findings を分けて保存します。`block_ready` と `block_merge` は引き続き raw actionable findings に反応しますが、`localReviewHighSeverityAction` による強いエスカレーションは verifier が確認した high severity findings にだけ反応します。これにより、false positive の影響を減らせます。
-
-solo operator を前提にするなら、`localReviewHighSeverityAction: "blocked"` を基本にするのが安全です。verifier-confirmed な high severity findings が出たら merge を止めて、人が次の一手を明示的に決めてください。自動で repair pass をもう一度回したいチームだけ、明示的に `retry` を選びます。
-
-## Codex への指示例
-
-### supervisor を使う時
-
-- 「Supervisor をビルドして、次の runnable issue を開始して」
-- 「現在の supervisor status を報告して」
-- 「現在の issue を再開して、PR、CI、review の状態を報告して」
-
-### GSD を使う時
-
-- 「GSD を使って、この feature を epic と child issue に分解して」
-- 「GSD で planning docs を更新して、依存順を提案して」
-- 「この blocked issue を、もっと小さい execution-ready issue に分けて」
-
-### GSD から supervisor へ渡す時
-
-- 「GSD で plan を整理し、repo memory と issue を更新したら、その後 supervisor に hand-off して」
-
-## 最初の実行手順
-
-1. Codex CLI を入れる
-2. repo を clone する
-3. `supervisor.config.json` を用意する
-4. execution-ready issue を作る
-5. 次を実行する
+supervisor repo では一度ビルドしておきます。
 
 ```bash
 npm install
 npm run build
+```
+
+## どの運用モードを使うか
+
+`codex-supervisor` は execution-ready な issue を前に進めるツールです。まだ planning が必要なら、先に GSD を使って backlog を整えます。
+
+そのまま supervisor に流してよい条件:
+
+- issue body に変更内容が明確に書かれている
+- 依存関係が `Depends on` で明示されている
+- sibling issue の順番が `Execution order` で書かれている
+- acceptance criteria と verification が観測可能な形になっている
+
+先に GSD を使うべき条件:
+
+- 依頼がまだ曖昧
+- 1 issue が大きすぎて複数 issue に分ける必要がある
+- repo memory や planning docs を先に更新したい
+
+覚え方:
+
+**GSD は backlog を設計し、`codex-supervisor` は backlog を実行します。**
+
+## supervisor config を準備する
+
+ベース設定から active config を作ります。
+
+```bash
+cp supervisor.config.example.json supervisor.config.json
+```
+
+次に、PR review の運用に合う provider profile を選びます。
+
+- [supervisor.config.copilot.json](../supervisor.config.copilot.json)
+- [supervisor.config.codex.json](../supervisor.config.codex.json)
+- [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
+
+選んだ profile を `supervisor.config.json` に丸ごとコピーしてもよいですし、`reviewBotLogins` だけを手元の active config に移しても構いません。
+
+初回起動前に最低限設定する値:
+
+- `repoPath`
+- `repoSlug`
+- `workspaceRoot`
+- `codexBinary`
+- 利用する review provider に応じた設定
+
+config の全項目、model policy、durable memory、provider guidance は [Configuration reference](./configuration.md) を参照してください。
+
+## execution-ready issue を書く
+
+scheduler は「新しく open された issue」ではなく「今 runnable な issue」を選びます。したがって、issue 側の metadata を explicit にしておく必要があります。
+
+最低限そろえたい項目:
+
+- `## Summary`
+- `## Scope`
+- `Depends on`
+- `## Execution order`
+- `## Acceptance criteria`
+- `## Verification`
+
+最小例:
+
+```md
+## Summary
+Refocus the Japanese docs so README is lighter and getting-started stays the fuller guide.
+
+## Scope
+- keep the Japanese getting-started guide as the detailed operator doc
+- reduce duplicated detail in docs/README.ja.md
+- keep README/docs cross-links coherent
+
+Part of: #259
+Depends on: #263
+Parallelizable: No
+
+## Execution order
+5 of 5
+
+## Acceptance criteria
+- docs/getting-started.ja.md remains useful as the fuller guide
+- docs/README.ja.md is lighter and links to the deeper docs
+- Japanese and English doc links stay coherent
+
+## Verification
+- review Japanese doc links and structure
+- run npm run build
+```
+
+metadata の canonical な書式と scheduling への効き方は [Issue metadata reference](./issue-metadata.md) を参照してください。
+
+## 最初の 1 パスを実行する
+
+いきなり常駐 loop にせず、まずは単発の supervised pass で挙動を確認します。
+
+```bash
 node dist/index.js run-once --config /path/to/supervisor.config.json
 node dist/index.js status --config /path/to/supervisor.config.json
 ```
 
-6. 挙動が正しいことを確認したら次に進む
+`run-once` 後に確認する点:
+
+- 選ばれた issue が想定どおりか
+- issue worktree が `workspaceRoot` 配下に作られたか
+- issue journal に仮説、blocker、次の一手が残っているか
+- PR や state hint の変化が実際の GitHub 状態と一致しているか
+
+もし違う issue を拾うなら、コードではなく issue metadata を先に直してください。
+
+## run-once から loop に移る
+
+1 回の supervised pass が正しく動いたら、連続 loop に切り替えます。
 
 ```bash
 node dist/index.js loop --config /path/to/supervisor.config.json
 ```
 
+通常運用では、supervisor は次を繰り返します。
+
+1. GitHub とローカル state を再取得する
+2. 次の runnable issue を選ぶか再開する
+3. issue 専用 worktree で Codex turn を実行する
+4. coherent checkpoint があれば draft PR を開くか更新する
+5. CI、review、mergeability に応じて repair または merge に進む
+
+状態ヒントの意味を短く覚えるなら次です。
+
+- `reproducing`: 問題や要件を再現可能に寄せる段階
+- `stabilizing`: clean checkpoint を作って draft PR に近づける段階
+- `draft_pr`: 途中でも coherent checkpoint を公開した段階
+- `local_review`: ローカル review swarm を実行中の段階
+- `waiting_ci`: CI や review の結果待ち
+- `addressing_review`: bot review の妥当な指摘を修正中
+- `repairing_ci`: failing checks の修正中
+- `resolving_conflict`: dirty merge state を解消中
+
+## よくある運用判断
+
+GSD を先に使うべき時は?
+まだ planning 問題である時です。execution 問題に落ちてから supervisor に渡します。
+
+PR はいつ開くべきか?
+branch に coherent checkpoint ができた時点です。完璧な最終形まで待たず、draft PR を早めに出します。
+
+local review はいつ有効にすべきか?
+merge 前の追加 gate を入れたい時、または外部 review の前にローカル advisory pass を入れたい時です。role、threshold、artifact、guardrail は [Local review reference](./local-review.md) を参照してください。
+
+backlog の順番がおかしい時は?
+GitHub issue の `Depends on` と `Execution order` を直してください。scheduler は chat history ではなく metadata に従います。
+
+loop が blocked issue に当たり続ける時は?
+その issue は execution-ready ではありません。issue body を締めるか、分割するか、GSD で backlog を作り直してください。
+
 ## よくある失敗
 
-- execution-ready でない backlog をそのまま supervisor に流す
-- issue の作成順がそのまま実装順だと思い込む
-- GSD の execution flow を supervisor loop に混ぜる
-- chat memory に依存する
-- `run-once` を見ずにいきなり `loop` を常駐させる
+- `run-once` を見ずに最初から `loop` を常駐させる
+- planning が残った issue をそのまま supervisor に渡す
+- issue の作成順を実行順だと思い込む
+- README レベルの概要で十分だと考え、issue metadata を薄くする
+- config や local review の詳細をこのガイドだけに持たせようとする
 
-## 最後の指針
+## 関連ドキュメント
 
-このルールだけ覚えておけば十分です。
-
-- issue が明確なら `codex-supervisor`
-- issue が曖昧なら先に GSD
-- GSD の出力が explicit issue になったら supervisor に戻す
-
-一言で言うと、
-
-**GSD は backlog design、codex-supervisor は backlog execution です。**
+- [README](../README.md): 英語版の概要、適用範囲、docs map
+- [README.ja](./README.ja.md): 日本語の軽い overview と導線
+- [Configuration reference](./configuration.md): config 項目、provider setup、durable memory、実行ポリシー
+- [Local review reference](./local-review.md): review role、artifact、threshold、merge policy
+- [Issue metadata reference](./issue-metadata.md): execution-ready issue の構造と scheduling inputs

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -7,6 +7,14 @@ async function readGettingStarted(): Promise<string> {
   return fs.readFile(path.join(process.cwd(), "docs", "getting-started.md"), "utf8");
 }
 
+async function readJapaneseOverview(): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), "docs", "README.ja.md"), "utf8");
+}
+
+async function readJapaneseGettingStarted(): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), "docs", "getting-started.ja.md"), "utf8");
+}
+
 test("getting-started stays focused on operator setup and flow", async () => {
   const content = await readGettingStarted();
 
@@ -42,4 +50,29 @@ test("getting-started stays focused on operator setup and flow", async () => {
   assert.doesNotMatch(content, /^## Not a fit$/m);
   assert.doesNotMatch(content, /^## How readiness-driven scheduling works$/m);
   assert.doesNotMatch(content, /^## State machine$/m);
+});
+
+test("japanese docs keep overview and getting-started responsibilities separate", async () => {
+  const [overview, gettingStarted] = await Promise.all([
+    readJapaneseOverview(),
+    readJapaneseGettingStarted(),
+  ]);
+
+  assert.match(overview, /\[README\.md\]\(\.\.\/README\.md\)/);
+  assert.match(overview, /\[docs\/getting-started\.md\]\(\.\/getting-started\.md\)/);
+  assert.match(overview, /\[docs\/getting-started\.ja\.md\]\(\.\/getting-started\.ja\.md\)/);
+
+  assert.doesNotMatch(overview, /\/Users\//);
+  assert.doesNotMatch(gettingStarted, /\/Users\//);
+
+  assert.doesNotMatch(overview, /^## 初回セットアップの流れ$/m);
+  assert.doesNotMatch(overview, /^## Local Review Swarm$/m);
+  assert.doesNotMatch(overview, /^## Codex への指示例$/m);
+  assert.doesNotMatch(overview, /^## 最初の実行手順$/m);
+
+  assert.match(gettingStarted, /\[README\]\(\.\.\/README\.md\)/);
+  assert.match(gettingStarted, /\[README\.ja\]\(\.\/README\.ja\.md\)/);
+  assert.match(gettingStarted, /\[Configuration reference\]\(\.\/configuration\.md\)/);
+  assert.match(gettingStarted, /\[Local review reference\]\(\.\/local-review\.md\)/);
+  assert.match(gettingStarted, /\[Issue metadata reference\]\(\.\/issue-metadata\.md\)/);
 });


### PR DESCRIPTION
## Summary
- reduce duplicated detail in 
- keep  as the fuller Japanese operator guide
- add a focused doc test for Japanese README/getting-started link and responsibility split

## Testing
- npm test
- npm run build

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Japanese README and Getting Started guide for improved clarity and navigation.
  * Reorganized content from conceptual to practical, with explicit setup commands and configuration examples.
  * Simplified prerequisites and streamlined operation flow guidance.

* **Tests**
  * Added validation tests for Japanese documentation structure and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->