### PR TITLE
GitHub review-signal refactor: extract configured review-bot lifecycle and top-level review handling (#276)

### DIFF
--- a/src/github-hydration.ts
+++ b/src/github-hydration.ts
@@ -1,9 +1,9 @@
 import {
-  classifyConfiguredBotTopLevelReviewStrength,
-  hasActionableReviewText,
-  isActionableTopLevelReview,
-} from "./external-review-signal-heuristics";
-import { CopilotReviewState, GitHubPullRequest, PullRequestCheck } from "./types";
+  buildConfiguredBotReviewSummary as summarizeConfiguredBotReviewSignals,
+  ConfiguredBotReviewSummary,
+  CopilotReviewLifecycleFacts,
+} from "./github-review-signals";
+import { GitHubPullRequest, PullRequestCheck } from "./types";
 
 export interface PullRequestStatusCheckRollupResponse {
   statusCheckRollup?: Array<{
@@ -72,46 +72,6 @@ export interface PullRequestCopilotReviewLifecycleResponse {
   } | null;
 }
 
-export interface CopilotReviewLifecycleFacts {
-  reviewRequests: string[];
-  reviews: Array<{
-    authorLogin: string | null;
-    submittedAt: string | null;
-    state?: string | null;
-    body?: string | null;
-  }>;
-  comments: Array<{
-    authorLogin: string | null;
-    createdAt: string | null;
-  }>;
-  issueComments: Array<{
-    authorLogin: string | null;
-    createdAt: string | null;
-    body: string | null;
-  }>;
-  timeline: Array<{
-    type: "requested" | "removed";
-    createdAt: string | null;
-    reviewerLogin: string | null;
-  }>;
-}
-
-export interface CopilotReviewLifecycle {
-  state: CopilotReviewState;
-  requestedAt: string | null;
-  arrivedAt: string | null;
-}
-
-export interface ConfiguredBotTopLevelReviewSummary {
-  strength: "nitpick_only" | "blocking" | null;
-  submittedAt: string | null;
-}
-
-export interface ConfiguredBotReviewSummary {
-  lifecycle: CopilotReviewLifecycle;
-  topLevelReview: ConfiguredBotTopLevelReviewSummary;
-}
-
 function mapCheckBucket(args: {
   bucket?: string | null;
   state?: string | null;
@@ -158,164 +118,6 @@ function normalizeLogin(value: string | null | undefined): string | null {
 
 function extractReviewerLogin(actor: ReviewActor | null | undefined): string | null {
   return normalizeLogin(actor?.login ?? actor?.slug ?? null);
-}
-
-function latestTimestamp(values: Array<string | null | undefined>): string | null {
-  let latest: string | null = null;
-  let latestMs = 0;
-
-  for (const value of values) {
-    const parsed = parseTimestamp(value);
-    if (parsed === 0) {
-      continue;
-    }
-
-    if (!latest || parsed >= latestMs) {
-      latest = value ?? null;
-      latestMs = parsed;
-    }
-  }
-
-  return latest;
-}
-
-function summarizeConfiguredBotRequestWindow(
-  timeline: CopilotReviewLifecycleFacts["timeline"],
-  configuredReviewBots: Set<string>,
-): {
-  latestRequestedAt: string | null;
-  activeRequestStartedAt: string | null;
-} {
-  const requestedTimes = timeline
-    .filter((event) => event.type === "requested" && event.reviewerLogin && configuredReviewBots.has(event.reviewerLogin))
-    .map((event) => event.createdAt);
-  const latestRequestedAt = latestTimestamp(requestedTimes);
-
-  const activeRequestStarts = Array.from(configuredReviewBots).flatMap((botLogin) => {
-    const botLatestRequestedAt = latestTimestamp(
-      timeline
-        .filter((event) => event.type === "requested" && event.reviewerLogin === botLogin)
-        .map((event) => event.createdAt),
-    );
-    const botLatestRemovedAt = latestTimestamp(
-      timeline
-        .filter((event) => event.type === "removed" && event.reviewerLogin === botLogin)
-        .map((event) => event.createdAt),
-    );
-
-    return botLatestRequestedAt !== null &&
-      (botLatestRemovedAt === null || parseTimestamp(botLatestRequestedAt) > parseTimestamp(botLatestRemovedAt))
-      ? [botLatestRequestedAt]
-      : [];
-  });
-
-  return {
-    latestRequestedAt,
-    activeRequestStartedAt: latestTimestamp(activeRequestStarts),
-  };
-}
-
-export function inferCopilotReviewLifecycle(
-  facts: CopilotReviewLifecycleFacts,
-  reviewBotLogins: string[],
-): CopilotReviewLifecycle {
-  const configuredReviewBots = new Set(reviewBotLogins.map((login) => normalizeLogin(login)).filter((login): login is string => Boolean(login)));
-  if (configuredReviewBots.size === 0) {
-    return { state: "not_requested", requestedAt: null, arrivedAt: null };
-  }
-
-  const { latestRequestedAt, activeRequestStartedAt } = summarizeConfiguredBotRequestWindow(
-    facts.timeline,
-    configuredReviewBots,
-  );
-  const activeRequestStartedAtMs = parseTimestamp(activeRequestStartedAt);
-  const scopedToActiveRequest = (value: string | null | undefined): value is string =>
-    value !== null &&
-    value !== undefined &&
-    (activeRequestStartedAt === null || parseTimestamp(value) >= activeRequestStartedAtMs);
-
-  const matchingReviewTimes = facts.reviews.flatMap((review) => {
-    const authorLogin = normalizeLogin(review.authorLogin);
-    return authorLogin && configuredReviewBots.has(authorLogin) && isActionableTopLevelReview(review) && scopedToActiveRequest(review.submittedAt)
-      ? [review.submittedAt]
-      : [];
-  });
-  const matchingCommentTimes = facts.comments.flatMap((comment) => {
-    const authorLogin = normalizeLogin(comment.authorLogin);
-    return authorLogin && configuredReviewBots.has(authorLogin) && scopedToActiveRequest(comment.createdAt) ? [comment.createdAt] : [];
-  });
-  const matchingIssueCommentTimes = facts.issueComments.flatMap((comment) => {
-    const authorLogin = normalizeLogin(comment.authorLogin);
-    return authorLogin && configuredReviewBots.has(authorLogin) && hasActionableReviewText(comment.body) && scopedToActiveRequest(comment.createdAt)
-      ? [comment.createdAt]
-      : [];
-  });
-  const arrivedAt = latestTimestamp([...matchingReviewTimes, ...matchingCommentTimes, ...matchingIssueCommentTimes]);
-  if (arrivedAt) {
-    return {
-      state: "arrived",
-      requestedAt: activeRequestStartedAt ?? latestRequestedAt,
-      arrivedAt,
-    };
-  }
-
-  const matchingRequests = facts.reviewRequests.filter((login) => configuredReviewBots.has(normalizeLogin(login) ?? ""));
-
-  if (
-    matchingRequests.length > 0 ||
-    activeRequestStartedAt !== null
-  ) {
-    return {
-      state: "requested",
-      requestedAt: activeRequestStartedAt ?? latestRequestedAt,
-      arrivedAt: null,
-    };
-  }
-
-  return { state: "not_requested", requestedAt: null, arrivedAt: null };
-}
-
-function inferConfiguredBotTopLevelReviewSummary(
-  facts: CopilotReviewLifecycleFacts,
-  reviewBotLogins: string[],
-): ConfiguredBotTopLevelReviewSummary {
-  const configuredReviewBots = new Set(
-    reviewBotLogins.map((login) => normalizeLogin(login)).filter((login): login is string => Boolean(login)),
-  );
-  if (configuredReviewBots.size === 0) {
-    return { strength: null, submittedAt: null };
-  }
-
-  let latestConfiguredReview: ConfiguredBotTopLevelReviewSummary = { strength: null, submittedAt: null };
-  let latestConfiguredReviewMs = 0;
-
-  for (const review of facts.reviews) {
-    const authorLogin = normalizeLogin(review.authorLogin);
-    if (!authorLogin || normalizeLogin(review.state)?.replace(/\s+/g, "_") !== "changes_requested") {
-      continue;
-    }
-
-    if (!configuredReviewBots.has(authorLogin)) {
-      continue;
-    }
-
-    const submittedAtMs = parseTimestamp(review.submittedAt);
-    if (latestConfiguredReview.submittedAt && submittedAtMs < latestConfiguredReviewMs) {
-      continue;
-    }
-
-    latestConfiguredReview = {
-      strength: classifyConfiguredBotTopLevelReviewStrength(review),
-      submittedAt: review.submittedAt,
-    };
-    latestConfiguredReviewMs = submittedAtMs;
-  }
-
-  if (!latestConfiguredReview.strength) {
-    return { strength: null, submittedAt: null };
-  }
-
-  return latestConfiguredReview;
 }
 
 export function normalizeRollupChecks(rollup: PullRequestStatusCheckRollupResponse | null | undefined): PullRequestCheck[] {
@@ -443,11 +245,7 @@ export function buildConfiguredBotReviewSummary(
   lifecycle: PullRequestCopilotReviewLifecycleResponse | null | undefined,
   reviewBotLogins: string[],
 ): ConfiguredBotReviewSummary {
-  const facts = mapCopilotReviewLifecycleFacts(lifecycle);
-  return {
-    lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
-    topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
-  };
+  return summarizeConfiguredBotReviewSignals(mapCopilotReviewLifecycleFacts(lifecycle), reviewBotLogins);
 }
 
 export function applyConfiguredBotReviewSummary(

--- a/src/github-review-signals.test.ts
+++ b/src/github-review-signals.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildConfiguredBotReviewSummary, CopilotReviewLifecycleFacts } from "./github-review-signals";
+
+test("buildConfiguredBotReviewSummary treats actionable configured-bot issue comments as arrival signals", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: ["coderabbitai[bot]"],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:24:00Z",
+        body: "Nitpick: return early before mutating shared state.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:25:00Z",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    timeline: [
+      {
+        type: "requested",
+        createdAt: "2026-03-13T01:02:03Z",
+        reviewerLogin: "coderabbitai[bot]",
+      },
+    ],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: "2026-03-13T01:02:03Z",
+      arrivedAt: "2026-03-13T02:24:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+  });
+});
+
+test("buildConfiguredBotReviewSummary keeps top-level review strength scoped to the latest configured bot changes request", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "octocat",
+        submittedAt: "2026-03-13T02:02:00Z",
+        state: "CHANGES_REQUESTED",
+        body: "Please address these blocking concerns.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:03:04Z",
+        state: "CHANGES_REQUESTED",
+        body: "Nitpick: rename this helper for consistency.",
+      },
+    ],
+    comments: [],
+    issueComments: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: null,
+      arrivedAt: "2026-03-13T02:03:04Z",
+    },
+    topLevelReview: {
+      strength: "nitpick_only",
+      submittedAt: "2026-03-13T02:03:04Z",
+    },
+  });
+});

--- a/src/github-review-signals.ts
+++ b/src/github-review-signals.ts
@@ -1,0 +1,224 @@
+import {
+  classifyConfiguredBotTopLevelReviewStrength,
+  hasActionableReviewText,
+  isActionableTopLevelReview,
+} from "./external-review-signal-heuristics";
+import { CopilotReviewState } from "./types";
+
+export interface CopilotReviewLifecycleFacts {
+  reviewRequests: string[];
+  reviews: Array<{
+    authorLogin: string | null;
+    submittedAt: string | null;
+    state?: string | null;
+    body?: string | null;
+  }>;
+  comments: Array<{
+    authorLogin: string | null;
+    createdAt: string | null;
+  }>;
+  issueComments: Array<{
+    authorLogin: string | null;
+    createdAt: string | null;
+    body: string | null;
+  }>;
+  timeline: Array<{
+    type: "requested" | "removed";
+    createdAt: string | null;
+    reviewerLogin: string | null;
+  }>;
+}
+
+export interface CopilotReviewLifecycle {
+  state: CopilotReviewState;
+  requestedAt: string | null;
+  arrivedAt: string | null;
+}
+
+export interface ConfiguredBotTopLevelReviewSummary {
+  strength: "nitpick_only" | "blocking" | null;
+  submittedAt: string | null;
+}
+
+export interface ConfiguredBotReviewSummary {
+  lifecycle: CopilotReviewLifecycle;
+  topLevelReview: ConfiguredBotTopLevelReviewSummary;
+}
+
+function parseTimestamp(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeLogin(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : null;
+}
+
+function latestTimestamp(values: Array<string | null | undefined>): string | null {
+  let latest: string | null = null;
+  let latestMs = 0;
+
+  for (const value of values) {
+    const parsed = parseTimestamp(value);
+    if (parsed === 0) {
+      continue;
+    }
+
+    if (!latest || parsed >= latestMs) {
+      latest = value ?? null;
+      latestMs = parsed;
+    }
+  }
+
+  return latest;
+}
+
+function summarizeConfiguredBotRequestWindow(
+  timeline: CopilotReviewLifecycleFacts["timeline"],
+  configuredReviewBots: Set<string>,
+): {
+  latestRequestedAt: string | null;
+  activeRequestStartedAt: string | null;
+} {
+  const requestedTimes = timeline
+    .filter((event) => event.type === "requested" && event.reviewerLogin && configuredReviewBots.has(event.reviewerLogin))
+    .map((event) => event.createdAt);
+  const latestRequestedAt = latestTimestamp(requestedTimes);
+
+  const activeRequestStarts = Array.from(configuredReviewBots).flatMap((botLogin) => {
+    const botLatestRequestedAt = latestTimestamp(
+      timeline
+        .filter((event) => event.type === "requested" && event.reviewerLogin === botLogin)
+        .map((event) => event.createdAt),
+    );
+    const botLatestRemovedAt = latestTimestamp(
+      timeline
+        .filter((event) => event.type === "removed" && event.reviewerLogin === botLogin)
+        .map((event) => event.createdAt),
+    );
+
+    return botLatestRequestedAt !== null &&
+      (botLatestRemovedAt === null || parseTimestamp(botLatestRequestedAt) > parseTimestamp(botLatestRemovedAt))
+      ? [botLatestRequestedAt]
+      : [];
+  });
+
+  return {
+    latestRequestedAt,
+    activeRequestStartedAt: latestTimestamp(activeRequestStarts),
+  };
+}
+
+export function inferCopilotReviewLifecycle(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+): CopilotReviewLifecycle {
+  const configuredReviewBots = new Set(reviewBotLogins.map((login) => normalizeLogin(login)).filter((login): login is string => Boolean(login)));
+  if (configuredReviewBots.size === 0) {
+    return { state: "not_requested", requestedAt: null, arrivedAt: null };
+  }
+
+  const { latestRequestedAt, activeRequestStartedAt } = summarizeConfiguredBotRequestWindow(
+    facts.timeline,
+    configuredReviewBots,
+  );
+  const activeRequestStartedAtMs = parseTimestamp(activeRequestStartedAt);
+  const scopedToActiveRequest = (value: string | null | undefined): value is string =>
+    value !== null &&
+    value !== undefined &&
+    (activeRequestStartedAt === null || parseTimestamp(value) >= activeRequestStartedAtMs);
+
+  const matchingReviewTimes = facts.reviews.flatMap((review) => {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    return authorLogin && configuredReviewBots.has(authorLogin) && isActionableTopLevelReview(review) && scopedToActiveRequest(review.submittedAt)
+      ? [review.submittedAt]
+      : [];
+  });
+  const matchingCommentTimes = facts.comments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin && configuredReviewBots.has(authorLogin) && scopedToActiveRequest(comment.createdAt) ? [comment.createdAt] : [];
+  });
+  const matchingIssueCommentTimes = facts.issueComments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin && configuredReviewBots.has(authorLogin) && hasActionableReviewText(comment.body) && scopedToActiveRequest(comment.createdAt)
+      ? [comment.createdAt]
+      : [];
+  });
+  const arrivedAt = latestTimestamp([...matchingReviewTimes, ...matchingCommentTimes, ...matchingIssueCommentTimes]);
+  if (arrivedAt) {
+    return {
+      state: "arrived",
+      requestedAt: activeRequestStartedAt ?? latestRequestedAt,
+      arrivedAt,
+    };
+  }
+
+  const matchingRequests = facts.reviewRequests.filter((login) => configuredReviewBots.has(normalizeLogin(login) ?? ""));
+  if (matchingRequests.length > 0 || activeRequestStartedAt !== null) {
+    return {
+      state: "requested",
+      requestedAt: activeRequestStartedAt ?? latestRequestedAt,
+      arrivedAt: null,
+    };
+  }
+
+  return { state: "not_requested", requestedAt: null, arrivedAt: null };
+}
+
+function inferConfiguredBotTopLevelReviewSummary(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+): ConfiguredBotTopLevelReviewSummary {
+  const configuredReviewBots = new Set(
+    reviewBotLogins.map((login) => normalizeLogin(login)).filter((login): login is string => Boolean(login)),
+  );
+  if (configuredReviewBots.size === 0) {
+    return { strength: null, submittedAt: null };
+  }
+
+  let latestConfiguredReview: ConfiguredBotTopLevelReviewSummary = { strength: null, submittedAt: null };
+  let latestConfiguredReviewMs = 0;
+
+  for (const review of facts.reviews) {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    if (!authorLogin || normalizeLogin(review.state)?.replace(/\s+/g, "_") !== "changes_requested") {
+      continue;
+    }
+
+    if (!configuredReviewBots.has(authorLogin)) {
+      continue;
+    }
+
+    const submittedAtMs = parseTimestamp(review.submittedAt);
+    if (latestConfiguredReview.submittedAt && submittedAtMs < latestConfiguredReviewMs) {
+      continue;
+    }
+
+    latestConfiguredReview = {
+      strength: classifyConfiguredBotTopLevelReviewStrength(review),
+      submittedAt: review.submittedAt,
+    };
+    latestConfiguredReviewMs = submittedAtMs;
+  }
+
+  if (!latestConfiguredReview.strength) {
+    return { strength: null, submittedAt: null };
+  }
+
+  return latestConfiguredReview;
+}
+
+export function buildConfiguredBotReviewSummary(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+): ConfiguredBotReviewSummary {
+  return {
+    lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
+    topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
+  };
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -13,17 +13,17 @@ import { CommandOptions, runCommand } from "./command";
 import {
   applyConfiguredBotReviewSummary,
   buildConfiguredBotReviewSummary,
-  ConfiguredBotReviewSummary,
   normalizeRollupChecks,
   PullRequestCopilotReviewLifecycleResponse,
   PullRequestStatusCheckRollupResponse,
 } from "./github-hydration";
+import { ConfiguredBotReviewSummary } from "./github-review-signals";
 import { GitHubTransport } from "./github-transport";
 import type { GitHubCommandRunner } from "./github-transport";
 import { parseJson, truncate } from "./utils";
 
 export { isTransientGitHubCommandFailure } from "./github-transport";
-export { inferCopilotReviewLifecycle } from "./github-hydration";
+export { inferCopilotReviewLifecycle } from "./github-review-signals";
 export type { GitHubCommandRunner } from "./github-transport";
 
 const COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS = 30_000;


### PR DESCRIPTION
Closes #276
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the configured review-bot signal logic into [src/github-review-signals.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-276/src/github-review-signals.ts) and left [src/github-hydration.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-276/src/github-hydration.ts) responsible for GraphQL-to-facts mapping plus PR field application. [src/github.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-276/src/github.ts) now re-exports lifecycle inference from the new module.

Added focused characterization coverage in [src/github-review-signals.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-276/src/github-review-signals.test.ts) for actionable configured-bot issue comments and configured-bot top-level review strength, while keeping the existing GitHub and supervisor lifecycle tests green. Checkpoint commit: `8462b7e` (`Extract GitHub review signal module`).

Summary: Extracted GitHub review-signal lifecycle/top-level review logic into a dedicated module, added focused tests, and verified existing configured-bot behavior remains unchanged.
State hint: implementing
Blocked reason: none
Tests: `PATH=/home/tommy/Dev/codex-supervisor-self/node_modules/.bin:$PATH npm test -- --test-name-pattern "buildConfiguredBotReviewSummary|inferCopilotReviewLifecycle|configured-bot top-level review strength scoped|actionable configured-bot issue comments|summary-only and draft-skip configured-bot issue comments|arrived configured-bot top-level review|n...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of bot review signal processing logic for improved modularity and maintainability.

* **Tests**
  * Added comprehensive unit tests for bot review summary functionality, ensuring lifecycle states and review strength calculations are correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->