### PR TITLE
GitHub client refactor: slim GitHubClient by extracting review-summary cache and hydration glue (#280)

### DIFF
--- a/src/github-pull-request-hydrator.ts
+++ b/src/github-pull-request-hydrator.ts
@@ -1,0 +1,265 @@
+import { CommandOptions, CommandResult } from "./command";
+import {
+  applyConfiguredBotReviewSummary,
+  buildConfiguredBotReviewSummary,
+  PullRequestCopilotReviewLifecycleResponse,
+} from "./github-hydration";
+import { ConfiguredBotReviewSummary } from "./github-review-signals";
+import { CopilotReviewState, GitHubPullRequest, SupervisorConfig } from "./types";
+import { parseJson, truncate } from "./utils";
+
+const COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS = 30_000;
+const COPILOT_REVIEW_CACHE_MAX_ENTRIES = 128;
+
+interface CachedCopilotReviewLifecycleEntry {
+  fetchedAtMs: number;
+  state: CopilotReviewState | null;
+  promise: Promise<ConfiguredBotReviewSummary>;
+}
+
+class ConfiguredBotReviewSummaryCache {
+  private readonly entries = new Map<string, CachedCopilotReviewLifecycleEntry>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  get(cacheKey: string): Promise<ConfiguredBotReviewSummary> | null {
+    const nowMs = this.now();
+    const cachedLifecycle = this.entries.get(cacheKey);
+    if (!cachedLifecycle) {
+      return null;
+    }
+
+    if (cachedLifecycle.state === null) {
+      this.touch(cacheKey, cachedLifecycle);
+      return cachedLifecycle.promise;
+    }
+
+    if (cachedLifecycle.state === "arrived") {
+      this.touch(cacheKey, cachedLifecycle);
+      return cachedLifecycle.promise;
+    }
+
+    if (nowMs - cachedLifecycle.fetchedAtMs < COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS) {
+      this.touch(cacheKey, cachedLifecycle);
+      return cachedLifecycle.promise;
+    }
+
+    this.entries.delete(cacheKey);
+    return null;
+  }
+
+  set(
+    cacheKey: string,
+    lifecyclePromiseFactory: () => Promise<ConfiguredBotReviewSummary>,
+  ): Promise<ConfiguredBotReviewSummary> {
+    const cacheEntry: CachedCopilotReviewLifecycleEntry = {
+      fetchedAtMs: this.now(),
+      state: null,
+      promise: Promise.resolve({
+        lifecycle: { state: "not_requested", requestedAt: null, arrivedAt: null },
+        topLevelReview: { strength: null, submittedAt: null },
+      }),
+    };
+    const lifecyclePromise = lifecyclePromiseFactory()
+      .then((summary) => {
+        cacheEntry.fetchedAtMs = this.now();
+        cacheEntry.state = summary.lifecycle.state;
+        return summary;
+      })
+      .catch((error) => {
+        this.entries.delete(cacheKey);
+        throw error;
+      });
+
+    cacheEntry.promise = lifecyclePromise;
+    this.touch(cacheKey, cacheEntry);
+
+    while (this.entries.size > COPILOT_REVIEW_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.entries.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.entries.delete(oldestKey);
+    }
+
+    return lifecyclePromise;
+  }
+
+  private touch(cacheKey: string, entry: CachedCopilotReviewLifecycleEntry): void {
+    this.entries.delete(cacheKey);
+    this.entries.set(cacheKey, entry);
+  }
+}
+
+type GitHubCommandExecutor = (args: string[], options?: CommandOptions) => Promise<CommandResult>;
+
+export class GitHubPullRequestHydrator {
+  private readonly reviewSummaryCache: ConfiguredBotReviewSummaryCache;
+
+  constructor(
+    private readonly config: SupervisorConfig,
+    private readonly runGhCommand: GitHubCommandExecutor,
+    now: () => number = Date.now,
+  ) {
+    this.reviewSummaryCache = new ConfiguredBotReviewSummaryCache(now);
+  }
+
+  async hydrate(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+    if (!pr) {
+      return null;
+    }
+
+    const cacheKey = `${pr.number}:${pr.headRefOid}`;
+    const cachedSummary = this.reviewSummaryCache.get(cacheKey);
+    if (cachedSummary) {
+      const summary = await cachedSummary;
+      return applyConfiguredBotReviewSummary(pr, summary);
+    }
+
+    const summaryPromise = this.reviewSummaryCache.set(
+      cacheKey,
+      () => this.fetchConfiguredBotReviewSummary(pr.number),
+    );
+
+    try {
+      const summary = await summaryPromise;
+      return applyConfiguredBotReviewSummary(pr, summary);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Failed to hydrate Copilot review lifecycle for PR #${pr.number}: ${truncate(message, 500) ?? "unknown error"}`);
+      return applyConfiguredBotReviewSummary(pr, null);
+    }
+  }
+
+  private async fetchConfiguredBotReviewSummary(prNumber: number): Promise<ConfiguredBotReviewSummary> {
+    const { owner, repo } = repoOwnerAndName(this.config.repoSlug);
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewRequests(first: 100) {
+              nodes {
+                requestedReviewer {
+                  ... on Bot {
+                    login
+                  }
+                  ... on User {
+                    login
+                  }
+                  ... on Mannequin {
+                    login
+                  }
+                  ... on Team {
+                    slug
+                  }
+                }
+              }
+            }
+            reviews(last: 100) {
+              nodes {
+                submittedAt
+                state
+                body
+                author {
+                  login
+                }
+              }
+            }
+            comments(last: 100) {
+              nodes {
+                createdAt
+                body
+                author {
+                  login
+                }
+              }
+            }
+            reviewThreads(first: 100) {
+              nodes {
+                comments(last: 100) {
+                  nodes {
+                    createdAt
+                    author {
+                      login
+                    }
+                  }
+                }
+              }
+            }
+            timelineItems(last: 100, itemTypes: [REVIEW_REQUESTED_EVENT, REVIEW_REQUEST_REMOVED_EVENT]) {
+              nodes {
+                __typename
+                ... on ReviewRequestedEvent {
+                  createdAt
+                  requestedReviewer {
+                    ... on Bot {
+                      login
+                    }
+                    ... on User {
+                      login
+                    }
+                    ... on Mannequin {
+                      login
+                    }
+                    ... on Team {
+                      slug
+                    }
+                  }
+                }
+                ... on ReviewRequestRemovedEvent {
+                  createdAt
+                  requestedReviewer {
+                    ... on Bot {
+                      login
+                    }
+                    ... on User {
+                      login
+                    }
+                    ... on Mannequin {
+                      login
+                    }
+                    ... on Team {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await this.runGhCommand([
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `repo=${repo}`,
+      "-F",
+      `number=${prNumber}`,
+    ]);
+
+    const payload = parseJson<{
+      data?: {
+        repository?: {
+          pullRequest?: PullRequestCopilotReviewLifecycleResponse | null;
+        };
+      };
+    }>(result.stdout, `gh api graphql copilot review lifecycle pr=${prNumber}`);
+
+    return buildConfiguredBotReviewSummary(payload.data?.repository?.pullRequest, this.config.reviewBotLogins);
+  }
+}
+
+function repoOwnerAndName(repoSlug: string): { owner: string; repo: string } {
+  const [owner, repo] = repoSlug.split("/", 2);
+  if (!owner || !repo) {
+    throw new Error(`Invalid repoSlug: ${repoSlug}`);
+  }
+
+  return { owner, repo };
+}

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -729,6 +729,87 @@ test("GitHubClient refreshes same-head Copilot lifecycle transitions from not_re
   assert.equal(lifecycleCallCount, 3);
 });
 
+test("GitHubClient reuses arrived configured-bot lifecycle for the same head without refetching", async () => {
+  const config = createConfig();
+  let lifecycleCallCount = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          number: 44,
+          title: "Same head arrived lifecycle cache",
+          url: "https://example.test/pr/44",
+          state: "OPEN",
+          createdAt: "2026-03-13T00:00:00Z",
+          updatedAt: "2026-03-13T00:00:00Z",
+          isDraft: false,
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          headRefName: "codex/issue-141",
+          headRefOid: "head-44",
+          mergedAt: null,
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      lifecycleCallCount += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: {
+                  nodes: [
+                    {
+                      submittedAt: "2026-03-13T01:03:04Z",
+                      author: {
+                        login: "copilot-pull-request-reviewer",
+                      },
+                    },
+                  ],
+                },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: {
+                  nodes: [
+                    {
+                      __typename: "ReviewRequestedEvent",
+                      createdAt: "2026-03-13T01:02:03Z",
+                      requestedReviewer: {
+                        login: "copilot-pull-request-reviewer",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const first = await client.getPullRequest(44);
+  const second = await client.getPullRequest(44);
+
+  assert.equal(first.copilotReviewState, "arrived");
+  assert.equal(first.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
+  assert.equal(first.copilotReviewArrivedAt, "2026-03-13T01:03:04Z");
+  assert.equal(second.copilotReviewState, "arrived");
+  assert.equal(second.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
+  assert.equal(second.copilotReviewArrivedAt, "2026-03-13T01:03:04Z");
+  assert.equal(lifecycleCallCount, 1);
+});
+
 test("GitHubClient hydrates arrived lifecycle from actionable configured-bot issue comments", async () => {
   const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
   let lifecycleQuery: string | null = null;

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,4 @@
 import {
-  CopilotReviewState,
   GitHubIssue,
   GitHubPullRequest,
   IssueComment,
@@ -11,13 +10,10 @@ import {
 } from "./types";
 import { CommandOptions, runCommand } from "./command";
 import {
-  applyConfiguredBotReviewSummary,
-  buildConfiguredBotReviewSummary,
   normalizeRollupChecks,
-  PullRequestCopilotReviewLifecycleResponse,
   PullRequestStatusCheckRollupResponse,
 } from "./github-hydration";
-import { ConfiguredBotReviewSummary } from "./github-review-signals";
+import { GitHubPullRequestHydrator } from "./github-pull-request-hydrator";
 import { GitHubTransport } from "./github-transport";
 import type { GitHubCommandRunner } from "./github-transport";
 import { parseJson, truncate } from "./utils";
@@ -26,17 +22,8 @@ export { isTransientGitHubCommandFailure } from "./github-transport";
 export { inferCopilotReviewLifecycle } from "./github-review-signals";
 export type { GitHubCommandRunner } from "./github-transport";
 
-const COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS = 30_000;
-const COPILOT_REVIEW_CACHE_MAX_ENTRIES = 128;
-
-interface CachedCopilotReviewLifecycleEntry {
-  fetchedAtMs: number;
-  state: CopilotReviewState | null;
-  promise: Promise<ConfiguredBotReviewSummary>;
-}
-
 export class GitHubClient {
-  private readonly copilotReviewLifecycleCache = new Map<string, CachedCopilotReviewLifecycleEntry>();
+  private readonly pullRequestHydrator: GitHubPullRequestHydrator;
   private readonly transport: GitHubTransport;
 
   constructor(
@@ -48,6 +35,11 @@ export class GitHubClient {
     private readonly now: () => number = Date.now,
   ) {
     this.transport = new GitHubTransport(commandRunner, delay);
+    this.pullRequestHydrator = new GitHubPullRequestHydrator(
+      this.config,
+      (args, options = {}) => this.runGhCommand(args, options),
+      this.now,
+    );
   }
 
   private repoOwnerAndName(): { owner: string; repo: string } {
@@ -249,74 +241,6 @@ export class GitHubClient {
     }
 
     return this.findLatestPullRequestForBranch(branch);
-  }
-
-  private getCachedCopilotReviewLifecycle(
-    cacheKey: string,
-    nowMs: number,
-  ): Promise<ConfiguredBotReviewSummary> | null {
-    const cachedLifecycle = this.copilotReviewLifecycleCache.get(cacheKey);
-    if (!cachedLifecycle) {
-      return null;
-    }
-
-    if (cachedLifecycle.state === null) {
-      this.copilotReviewLifecycleCache.delete(cacheKey);
-      this.copilotReviewLifecycleCache.set(cacheKey, cachedLifecycle);
-      return cachedLifecycle.promise;
-    }
-
-    if (cachedLifecycle.state === "arrived") {
-      this.copilotReviewLifecycleCache.delete(cacheKey);
-      this.copilotReviewLifecycleCache.set(cacheKey, cachedLifecycle);
-      return cachedLifecycle.promise;
-    }
-
-    if (nowMs - cachedLifecycle.fetchedAtMs < COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS) {
-      this.copilotReviewLifecycleCache.delete(cacheKey);
-      this.copilotReviewLifecycleCache.set(cacheKey, cachedLifecycle);
-      return cachedLifecycle.promise;
-    }
-
-    this.copilotReviewLifecycleCache.delete(cacheKey);
-    return null;
-  }
-
-  private setCachedCopilotReviewLifecycle(
-    cacheKey: string,
-    lifecyclePromiseFactory: () => Promise<ConfiguredBotReviewSummary>,
-  ): Promise<ConfiguredBotReviewSummary> {
-    const cacheEntry: CachedCopilotReviewLifecycleEntry = {
-      fetchedAtMs: this.now(),
-      state: null,
-      promise: Promise.resolve({
-        lifecycle: { state: "not_requested", requestedAt: null, arrivedAt: null },
-        topLevelReview: { strength: null, submittedAt: null },
-      }),
-    };
-    const lifecyclePromise = lifecyclePromiseFactory()
-      .then((summary) => {
-        cacheEntry.fetchedAtMs = this.now();
-        cacheEntry.state = summary.lifecycle.state;
-        return summary;
-      })
-      .catch((error) => {
-        this.copilotReviewLifecycleCache.delete(cacheKey);
-        throw error;
-      });
-    cacheEntry.promise = lifecyclePromise;
-    this.copilotReviewLifecycleCache.delete(cacheKey);
-    this.copilotReviewLifecycleCache.set(cacheKey, cacheEntry);
-
-    while (this.copilotReviewLifecycleCache.size > COPILOT_REVIEW_CACHE_MAX_ENTRIES) {
-      const oldestKey = this.copilotReviewLifecycleCache.keys().next().value;
-      if (!oldestKey) {
-        break;
-      }
-      this.copilotReviewLifecycleCache.delete(oldestKey);
-    }
-
-    return lifecyclePromise;
   }
 
   async getMergedPullRequestsClosingIssue(issueNumber: number): Promise<GitHubPullRequest[]> {
@@ -735,152 +659,6 @@ export class GitHubClient {
   }
 
   private async hydratePullRequest(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
-    if (!pr) {
-      return null;
-    }
-
-    const cacheKey = `${pr.number}:${pr.headRefOid}`;
-    const cachedLifecycle = this.getCachedCopilotReviewLifecycle(cacheKey, this.now());
-    if (cachedLifecycle) {
-      const summary = await cachedLifecycle;
-      return applyConfiguredBotReviewSummary(pr, summary);
-    }
-
-    const lifecyclePromise = this.setCachedCopilotReviewLifecycle(
-      cacheKey,
-      () => this.getConfiguredBotReviewSummary(pr.number),
-    );
-
-    try {
-      const summary = await lifecyclePromise;
-      return applyConfiguredBotReviewSummary(pr, summary);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`Failed to hydrate Copilot review lifecycle for PR #${pr.number}: ${truncate(message, 500) ?? "unknown error"}`);
-      return applyConfiguredBotReviewSummary(pr, null);
-    }
-  }
-
-  private async getConfiguredBotReviewSummary(prNumber: number): Promise<ConfiguredBotReviewSummary> {
-    const { owner, repo } = this.repoOwnerAndName();
-    const query = `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewRequests(first: 100) {
-              nodes {
-                requestedReviewer {
-                  ... on Bot {
-                    login
-                  }
-                  ... on User {
-                    login
-                  }
-                  ... on Mannequin {
-                    login
-                  }
-                  ... on Team {
-                    slug
-                  }
-                }
-              }
-            }
-            reviews(last: 100) {
-              nodes {
-                submittedAt
-                state
-                body
-                author {
-                  login
-                }
-              }
-            }
-            comments(last: 100) {
-              nodes {
-                createdAt
-                body
-                author {
-                  login
-                }
-              }
-            }
-            reviewThreads(first: 100) {
-              nodes {
-                comments(last: 100) {
-                  nodes {
-                    createdAt
-                    author {
-                      login
-                    }
-                  }
-                }
-              }
-            }
-            timelineItems(last: 100, itemTypes: [REVIEW_REQUESTED_EVENT, REVIEW_REQUEST_REMOVED_EVENT]) {
-              nodes {
-                __typename
-                ... on ReviewRequestedEvent {
-                  createdAt
-                  requestedReviewer {
-                    ... on Bot {
-                      login
-                    }
-                    ... on User {
-                      login
-                    }
-                    ... on Mannequin {
-                      login
-                    }
-                    ... on Team {
-                      slug
-                    }
-                  }
-                }
-                ... on ReviewRequestRemovedEvent {
-                  createdAt
-                  requestedReviewer {
-                    ... on Bot {
-                      login
-                    }
-                    ... on User {
-                      login
-                    }
-                    ... on Mannequin {
-                      login
-                    }
-                    ... on Team {
-                      slug
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-
-    const result = await this.runGhCommand([
-      "api",
-      "graphql",
-      "-f",
-      `query=${query}`,
-      "-F",
-      `owner=${owner}`,
-      "-F",
-      `repo=${repo}`,
-      "-F",
-      `number=${prNumber}`,
-    ]);
-
-    const payload = parseJson<{
-      data?: {
-        repository?: {
-          pullRequest?: PullRequestCopilotReviewLifecycleResponse | null;
-        };
-      };
-    }>(result.stdout, `gh api graphql copilot review lifecycle pr=${prNumber}`);
-
-    return buildConfiguredBotReviewSummary(payload.data?.repository?.pullRequest, this.config.reviewBotLogins);
+    return this.pullRequestHydrator.hydrate(pr);
   }
 }


### PR DESCRIPTION
Closes #280
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the configured-bot review-summary cache and PR hydration glue into [src/github-pull-request-hydrator.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-280/src/github-pull-request-hydrator.ts). `GitHubClient` in [src/github.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-280/src/github.ts) now delegates hydration instead of owning the cache/query logic directly, which materially shrinks the client while preserving behavior. I also added a focused regression in [src/github.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-280/src/github.test.ts) that locks same-head arrived-summary cache reuse.

Committed on `codex/issue-280` as `36a9c99` (`Refactor GitHub pull request hydration`). The local issue journal was updated as required; it remains untracked because `.codex-supervisor/issue-journal.md` is gitignored.

Summary: Extracted GitHub PR hydration/cache into a dedicated module, added an arrived-cache reuse test, and committed the refactor as `36a9c99`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/github.test.ts`; `npx tsx --test src/supervisor.test.ts --test-name-pattern='runOnce dry-run selects an issue and hydrates workspace and PR context before Codex|runOnce waits for Copilot propagation after marking a draft PR ready|runOnce records an observed Copilot request time when GitHub omits the request timestamp|inferStateFromPullRequest keeps waiting when a configured bot request was observed on the current ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal caching mechanism for pull request data retrieval to improve performance and reduce redundant API calls.

* **Tests**
  * Added test coverage to ensure caching behavior works correctly and prevents unnecessary data fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->