### PR TITLE
Turn execution refactor: extract configured-bot review-thread handling and local-review gating helpers (#283)

### DIFF
--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -3,7 +3,7 @@ import {
   localReviewHighSeverityNeedsBlock,
   localReviewHighSeverityNeedsRetry,
   localReviewRetryLoopStalled,
-} from "./run-once-turn-execution";
+} from "./review-handling";
 import {
   configuredBotReviewThreads,
   manualReviewThreads,

--- a/src/review-handling.test.ts
+++ b/src/review-handling.test.ts
@@ -1,0 +1,300 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  hasProcessedReviewThread,
+  localReviewBlocksMerge,
+  localReviewBlocksReady,
+  localReviewHighSeverityNeedsBlock,
+  localReviewHighSeverityNeedsRetry,
+  localReviewRetryLoopCandidate,
+  localReviewRetryLoopStalled,
+  nextLocalReviewSignatureTracking,
+} from "./review-handling";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: true,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+      specialist: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 42,
+    title: "Test PR",
+    url: "https://example.test/pr/42",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: true,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-42",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 42,
+    state: "stabilizing",
+    branch: "codex/issue-42",
+    pr_number: 42,
+    workspace: "/tmp/workspaces/issue-42",
+    journal_path: "/tmp/workspaces/issue-42/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: null,
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 1,
+    implementation_attempt_count: 1,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "deadbeef",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-13T06:20:00Z",
+    ...overrides,
+  };
+}
+
+function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this.",
+          createdAt: "2026-03-13T06:20:00Z",
+          url: "https://example.test/pr/42#discussion_r1",
+          author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test("hasProcessedReviewThread reprocesses same-head threads when the latest bot comment changes", () => {
+  const processed = hasProcessedReviewThread(
+    createRecord({
+      processed_review_thread_ids: ["thread-1@deadbeef"],
+      processed_review_thread_fingerprints: ["thread-1@deadbeef#comment-1"],
+    }),
+    createPullRequest(),
+    createReviewThread({
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Please address this.",
+            createdAt: "2026-03-13T06:20:00Z",
+            url: "https://example.test/pr/42#discussion_r1",
+            author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+          },
+          {
+            id: "comment-2",
+            body: "Please also handle this update.",
+            createdAt: "2026-03-13T06:25:00Z",
+            url: "https://example.test/pr/42#discussion_r2",
+            author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  );
+
+  assert.equal(processed, false);
+});
+
+test("local review gating only blocks the intended transition for current actionable findings", () => {
+  const pr = createPullRequest({ isDraft: false });
+  const actionableRecord = createRecord({
+    local_review_head_sha: "deadbeef",
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+  });
+
+  assert.equal(localReviewBlocksReady(createConfig({ localReviewPolicy: "block_ready" }), actionableRecord, pr), true);
+  assert.equal(localReviewBlocksReady(createConfig({ localReviewPolicy: "block_merge" }), actionableRecord, pr), false);
+  assert.equal(localReviewBlocksMerge(createConfig({ localReviewPolicy: "block_merge" }), actionableRecord, pr), true);
+  assert.equal(localReviewBlocksMerge(createConfig({ localReviewPolicy: "block_ready" }), actionableRecord, pr), false);
+});
+
+test("local review high-severity actions distinguish retry from blocked", () => {
+  const pr = createPullRequest();
+  const record = createRecord({
+    local_review_head_sha: "deadbeef",
+    local_review_verified_max_severity: "high",
+  });
+
+  assert.equal(localReviewHighSeverityNeedsRetry(createConfig({ localReviewHighSeverityAction: "retry" }), record, pr), true);
+  assert.equal(localReviewHighSeverityNeedsRetry(createConfig({ localReviewHighSeverityAction: "blocked" }), record, pr), false);
+  assert.equal(localReviewHighSeverityNeedsBlock(createConfig({ localReviewHighSeverityAction: "blocked" }), record, pr), true);
+  assert.equal(localReviewHighSeverityNeedsBlock(createConfig({ localReviewHighSeverityAction: "retry" }), record, pr), false);
+});
+
+test("local review retry loop helpers require a clean path and stall after repeated identical signatures", () => {
+  const config = createConfig({
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    sameFailureSignatureRepeatLimit: 2,
+    humanReviewBlocksMerge: true,
+  });
+  const pr = createPullRequest({ isDraft: false });
+  const record = createRecord({
+    local_review_head_sha: "deadbeef",
+    local_review_verified_max_severity: "high",
+    repeated_local_review_signature_count: 2,
+  });
+  const checks: PullRequestCheck[] = [];
+  const reviewThreads: ReviewThread[] = [];
+
+  const manualReviewThreads = () => [];
+  const configuredBotReviewThreads = () => [];
+  const summarizeChecks = () => ({ hasFailing: false, hasPending: false });
+  const mergeConflictDetected = () => false;
+
+  assert.equal(
+    localReviewRetryLoopCandidate(
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    ),
+    true,
+  );
+  assert.equal(
+    localReviewRetryLoopStalled(
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    ),
+    true,
+  );
+});
+
+test("nextLocalReviewSignatureTracking only increments on identical signatures for the same reviewed head", () => {
+  assert.deepEqual(
+    nextLocalReviewSignatureTracking(
+      createRecord({
+        local_review_head_sha: "deadbeef",
+        last_local_review_signature: "local-review:high:1:clean",
+        repeated_local_review_signature_count: 2,
+      }),
+      "deadbeef",
+      "local-review:high:1:clean",
+    ),
+    {
+      last_local_review_signature: "local-review:high:1:clean",
+      repeated_local_review_signature_count: 3,
+    },
+  );
+
+  assert.deepEqual(
+    nextLocalReviewSignatureTracking(createRecord(), "deadbeef", null),
+    {
+      last_local_review_signature: null,
+      repeated_local_review_signature_count: 0,
+    },
+  );
+});

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -1,0 +1,271 @@
+import { localReviewHasActionableFindings } from "./local-review";
+import {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+} from "./types";
+import { nowIso } from "./utils";
+
+export function processedReviewThreadKey(threadId: string, headSha: string): string {
+  return `${threadId}@${headSha}`;
+}
+
+export function latestReviewThreadCommentFingerprint(
+  thread: Pick<ReviewThread, "comments">,
+): string | null {
+  const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
+  if (!latestComment) {
+    return null;
+  }
+
+  return latestComment.id || latestComment.createdAt || null;
+}
+
+export function processedReviewThreadFingerprintKey(
+  threadId: string,
+  headSha: string,
+  latestCommentFingerprint: string,
+): string {
+  return `${processedReviewThreadKey(threadId, headSha)}#${latestCommentFingerprint}`;
+}
+
+export function hasProcessedReviewThread(
+  record: Pick<
+    IssueRunRecord,
+    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "last_head_sha"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+): boolean {
+  const processedKeys = record.processed_review_thread_ids ?? [];
+  const processedFingerprints = record.processed_review_thread_fingerprints ?? [];
+  const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
+  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
+  if (
+    latestCommentFingerprint &&
+    processedFingerprints.includes(
+      processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestCommentFingerprint),
+    )
+  ) {
+    return true;
+  }
+
+  if (processedKeys.includes(headScopedKey)) {
+    if (latestCommentFingerprint === null) {
+      return true;
+    }
+
+    const threadFingerprintPrefix = `${headScopedKey}#`;
+    const hasStoredFingerprintForThreadOnHead = processedFingerprints.some((key) =>
+      key.startsWith(threadFingerprintPrefix),
+    );
+    return !hasStoredFingerprintForThreadOnHead;
+  }
+
+  return record.last_head_sha === pr.headRefOid && processedKeys.includes(thread.id);
+}
+
+export function localReviewBlocksReady(
+  config: SupervisorConfig,
+  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation">,
+  pr: GitHubPullRequest,
+): boolean {
+  return config.localReviewPolicy === "block_ready" && localReviewHasActionableFindings(record, pr);
+}
+
+export function localReviewBlocksMerge(
+  config: SupervisorConfig,
+  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation">,
+  pr: GitHubPullRequest,
+): boolean {
+  return !pr.isDraft && config.localReviewPolicy === "block_merge" && localReviewHasActionableFindings(record, pr);
+}
+
+export function localReviewHighSeverityNeedsRetry(
+  config: SupervisorConfig,
+  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_verified_max_severity">,
+  pr: GitHubPullRequest,
+): boolean {
+  return (
+    config.localReviewPolicy !== "advisory" &&
+    record.local_review_head_sha === pr.headRefOid &&
+    record.local_review_verified_max_severity === "high" &&
+    config.localReviewHighSeverityAction === "retry"
+  );
+}
+
+export function localReviewRetryLoopCandidate(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_head_sha"
+    | "local_review_verified_max_severity"
+    | "repeated_local_review_signature_count"
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+  >,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
+  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasFailing: boolean; hasPending: boolean },
+  mergeConflictDetected: (pr: GitHubPullRequest) => boolean,
+): boolean {
+  const checkSummary = summarizeChecks(checks);
+  const manualThreads = manualReviewThreads(config, reviewThreads);
+  const unresolvedBotThreads = configuredBotReviewThreads(config, reviewThreads);
+  return (
+    localReviewHighSeverityNeedsRetry(config, record, pr) &&
+    !checkSummary.hasFailing &&
+    !checkSummary.hasPending &&
+    unresolvedBotThreads.length === 0 &&
+    (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
+    !mergeConflictDetected(pr)
+  );
+}
+
+export function localReviewRetryLoopStalled(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_head_sha"
+    | "local_review_verified_max_severity"
+    | "repeated_local_review_signature_count"
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+  >,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
+  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasFailing: boolean; hasPending: boolean },
+  mergeConflictDetected: (pr: GitHubPullRequest) => boolean,
+): boolean {
+  return (
+    localReviewRetryLoopCandidate(
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    ) &&
+    record.repeated_local_review_signature_count >= config.sameFailureSignatureRepeatLimit
+  );
+}
+
+export function localReviewHighSeverityNeedsBlock(
+  config: SupervisorConfig,
+  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_verified_max_severity">,
+  pr: GitHubPullRequest,
+): boolean {
+  return (
+    config.localReviewPolicy !== "advisory" &&
+    record.local_review_head_sha === pr.headRefOid &&
+    record.local_review_verified_max_severity === "high" &&
+    config.localReviewHighSeverityAction === "blocked"
+  );
+}
+
+export function localReviewFailureSummary(
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_findings_count"
+    | "local_review_root_cause_count"
+    | "local_review_max_severity"
+    | "local_review_verified_findings_count"
+    | "local_review_verified_max_severity"
+    | "local_review_degraded"
+  >,
+): string {
+  if (record.local_review_degraded) {
+    return "Local review completed in a degraded state.";
+  }
+
+  return `Local review found ${record.local_review_findings_count} actionable finding(s) across ${record.local_review_root_cause_count} root cause(s); max severity=${record.local_review_max_severity ?? "unknown"}; verified high-severity findings=${record.local_review_verified_findings_count}; verified max severity=${record.local_review_verified_max_severity ?? "none"}.`;
+}
+
+export function localReviewFailureContext(
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_findings_count"
+    | "local_review_root_cause_count"
+    | "local_review_max_severity"
+    | "local_review_verified_findings_count"
+    | "local_review_verified_max_severity"
+    | "local_review_degraded"
+    | "local_review_summary_path"
+  >,
+): FailureContext {
+  return {
+    category: "blocked",
+    summary: localReviewFailureSummary(record),
+    signature: `local-review:${record.local_review_max_severity ?? "unknown"}:${record.local_review_verified_max_severity ?? "none"}:${record.local_review_root_cause_count}:${record.local_review_verified_findings_count}:${record.local_review_degraded ? "degraded" : "clean"}`,
+    command: null,
+    details: [
+      `findings=${record.local_review_findings_count}`,
+      `root_causes=${record.local_review_root_cause_count}`,
+      record.local_review_summary_path ? `summary=${record.local_review_summary_path}` : "summary=none",
+    ],
+    url: null,
+    updated_at: nowIso(),
+  };
+}
+
+export function localReviewStallFailureContext(
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_findings_count"
+    | "local_review_root_cause_count"
+    | "local_review_max_severity"
+    | "local_review_verified_findings_count"
+    | "local_review_verified_max_severity"
+    | "local_review_degraded"
+    | "local_review_summary_path"
+    | "repeated_local_review_signature_count"
+  >,
+): FailureContext {
+  return {
+    ...localReviewFailureContext(record),
+    summary:
+      `Local review findings repeated without code changes ${record.repeated_local_review_signature_count} times; manual intervention is required.`,
+    signature:
+      `local-review-stalled:${record.local_review_max_severity ?? "unknown"}:` +
+      `${record.local_review_root_cause_count}:${record.local_review_degraded ? "degraded" : "clean"}`,
+    details: [
+      `findings=${record.local_review_findings_count}`,
+      `root_causes=${record.local_review_root_cause_count}`,
+      `repeated_local_review_signature_count=${record.repeated_local_review_signature_count}`,
+      record.local_review_summary_path ? `summary=${record.local_review_summary_path}` : "summary=none",
+    ],
+  };
+}
+
+export function nextLocalReviewSignatureTracking(
+  record: Pick<IssueRunRecord, "local_review_head_sha" | "last_local_review_signature" | "repeated_local_review_signature_count">,
+  prHeadSha: string,
+  actionableSignature: string | null,
+): Pick<IssueRunRecord, "last_local_review_signature" | "repeated_local_review_signature_count"> {
+  if (!actionableSignature) {
+    return {
+      last_local_review_signature: null,
+      repeated_local_review_signature_count: 0,
+    };
+  }
+
+  const sameHead = record.local_review_head_sha === prHeadSha;
+  const sameSignature = record.last_local_review_signature === actionableSignature;
+  return {
+    last_local_review_signature: actionableSignature,
+    repeated_local_review_signature_count:
+      sameHead && sameSignature ? record.repeated_local_review_signature_count + 1 : 1,
+  };
+}

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -1,10 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import {
-  hasProcessedReviewThread,
-  handlePostTurnPullRequestTransitionsPhase,
-} from "./run-once-turn-execution";
+import { hasProcessedReviewThread } from "./review-handling";
+import { handlePostTurnPullRequestTransitionsPhase } from "./run-once-turn-execution";
 import {
   FailureContext,
   GitHubIssue,

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -22,11 +22,25 @@ import {
 } from "./journal";
 import { LockHandle } from "./lock";
 import {
-  localReviewHasActionableFindings,
   LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
   runLocalReview,
   shouldRunLocalReview,
 } from "./local-review";
+import {
+  hasProcessedReviewThread,
+  latestReviewThreadCommentFingerprint,
+  localReviewBlocksReady,
+  localReviewFailureContext,
+  localReviewFailureSummary,
+  localReviewHighSeverityNeedsBlock,
+  localReviewHighSeverityNeedsRetry,
+  localReviewRetryLoopCandidate,
+  localReviewRetryLoopStalled,
+  localReviewStallFailureContext,
+  nextLocalReviewSignatureTracking,
+  processedReviewThreadFingerprintKey,
+  processedReviewThreadKey,
+} from "./review-handling";
 import { IssueJournalSync, MemoryArtifacts } from "./run-once-issue-preparation";
 import { StateStore } from "./state-store";
 import {
@@ -47,81 +61,6 @@ import { getWorkspaceStatus, pushBranch } from "./workspace";
 
 function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
-}
-
-export function processedReviewThreadKey(threadId: string, headSha: string): string {
-  return `${threadId}@${headSha}`;
-}
-
-export function latestReviewThreadCommentFingerprint(
-  thread: Pick<ReviewThread, "comments">,
-): string | null {
-  const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
-  if (!latestComment) {
-    return null;
-  }
-
-  return latestComment.id || latestComment.createdAt || null;
-}
-
-export function processedReviewThreadFingerprintKey(
-  threadId: string,
-  headSha: string,
-  latestCommentFingerprint: string,
-): string {
-  return `${processedReviewThreadKey(threadId, headSha)}#${latestCommentFingerprint}`;
-}
-
-export function hasProcessedReviewThread(
-  record: Pick<
-    IssueRunRecord,
-    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "last_head_sha"
-  >,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-  thread: Pick<ReviewThread, "id" | "comments">,
-): boolean {
-  const processedKeys = record.processed_review_thread_ids ?? [];
-  const processedFingerprints = record.processed_review_thread_fingerprints ?? [];
-  const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
-  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
-  if (
-    latestCommentFingerprint &&
-    processedFingerprints.includes(
-      processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestCommentFingerprint),
-    )
-  ) {
-    return true;
-  }
-
-  if (processedKeys.includes(headScopedKey)) {
-    if (latestCommentFingerprint === null) {
-      return true;
-    }
-
-    const threadFingerprintPrefix = `${headScopedKey}#`;
-    const hasStoredFingerprintForThreadOnHead = processedFingerprints.some((key) =>
-      key.startsWith(threadFingerprintPrefix),
-    );
-    return !hasStoredFingerprintForThreadOnHead;
-  }
-
-  return record.last_head_sha === pr.headRefOid && processedKeys.includes(thread.id);
-}
-
-export function localReviewBlocksReady(
-  config: SupervisorConfig,
-  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation">,
-  pr: GitHubPullRequest,
-): boolean {
-  return config.localReviewPolicy === "block_ready" && localReviewHasActionableFindings(record, pr);
-}
-
-export function localReviewBlocksMerge(
-  config: SupervisorConfig,
-  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation">,
-  pr: GitHubPullRequest,
-): boolean {
-  return !pr.isDraft && config.localReviewPolicy === "block_merge" && localReviewHasActionableFindings(record, pr);
 }
 
 export function nextExternalReviewMissPatch(
@@ -157,19 +96,6 @@ export function nextExternalReviewMissPatch(
   }
 
   return {};
-}
-
-export function localReviewHighSeverityNeedsRetry(
-  config: SupervisorConfig,
-  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_verified_max_severity">,
-  pr: GitHubPullRequest,
-): boolean {
-  return (
-    config.localReviewPolicy !== "advisory" &&
-    record.local_review_head_sha === pr.headRefOid &&
-    record.local_review_verified_max_severity === "high" &&
-    config.localReviewHighSeverityAction === "retry"
-  );
 }
 
 interface LocalReviewRepairArtifact {
@@ -262,179 +188,6 @@ export async function loadLocalReviewRepairContext(summaryPath: string | null, w
     rootCauses,
     priorMissPatterns,
     verifierGuardrails,
-  };
-}
-
-export function localReviewRetryLoopCandidate(
-  config: SupervisorConfig,
-  record: Pick<
-    IssueRunRecord,
-    | "local_review_head_sha"
-    | "local_review_verified_max_severity"
-    | "repeated_local_review_signature_count"
-    | "processed_review_thread_ids"
-    | "processed_review_thread_fingerprints"
-  >,
-  pr: GitHubPullRequest,
-  checks: PullRequestCheck[],
-  reviewThreads: ReviewThread[],
-  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
-  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
-  summarizeChecks: (checks: PullRequestCheck[]) => { hasFailing: boolean; hasPending: boolean },
-  mergeConflictDetected: (pr: GitHubPullRequest) => boolean,
-): boolean {
-  const checkSummary = summarizeChecks(checks);
-  const manualThreads = manualReviewThreads(config, reviewThreads);
-  const unresolvedBotThreads = configuredBotReviewThreads(config, reviewThreads);
-  return (
-    localReviewHighSeverityNeedsRetry(config, record, pr) &&
-    !checkSummary.hasFailing &&
-    !checkSummary.hasPending &&
-    unresolvedBotThreads.length === 0 &&
-    (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
-    !mergeConflictDetected(pr)
-  );
-}
-
-export function localReviewRetryLoopStalled(
-  config: SupervisorConfig,
-  record: Pick<
-    IssueRunRecord,
-    | "local_review_head_sha"
-    | "local_review_verified_max_severity"
-    | "repeated_local_review_signature_count"
-    | "processed_review_thread_ids"
-    | "processed_review_thread_fingerprints"
-  >,
-  pr: GitHubPullRequest,
-  checks: PullRequestCheck[],
-  reviewThreads: ReviewThread[],
-  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
-  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[],
-  summarizeChecks: (checks: PullRequestCheck[]) => { hasFailing: boolean; hasPending: boolean },
-  mergeConflictDetected: (pr: GitHubPullRequest) => boolean,
-): boolean {
-  return (
-    localReviewRetryLoopCandidate(
-      config,
-      record,
-      pr,
-      checks,
-      reviewThreads,
-      manualReviewThreads,
-      configuredBotReviewThreads,
-      summarizeChecks,
-      mergeConflictDetected,
-    ) &&
-    record.repeated_local_review_signature_count >= config.sameFailureSignatureRepeatLimit
-  );
-}
-
-export function localReviewHighSeverityNeedsBlock(
-  config: SupervisorConfig,
-  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_verified_max_severity">,
-  pr: GitHubPullRequest,
-): boolean {
-  return (
-    config.localReviewPolicy !== "advisory" &&
-    record.local_review_head_sha === pr.headRefOid &&
-    record.local_review_verified_max_severity === "high" &&
-    config.localReviewHighSeverityAction === "blocked"
-  );
-}
-
-export function localReviewFailureSummary(
-  record: Pick<
-    IssueRunRecord,
-    | "local_review_findings_count"
-    | "local_review_root_cause_count"
-    | "local_review_max_severity"
-    | "local_review_verified_findings_count"
-    | "local_review_verified_max_severity"
-    | "local_review_degraded"
-  >,
-): string {
-  if (record.local_review_degraded) {
-    return "Local review completed in a degraded state.";
-  }
-
-  return `Local review found ${record.local_review_findings_count} actionable finding(s) across ${record.local_review_root_cause_count} root cause(s); max severity=${record.local_review_max_severity ?? "unknown"}; verified high-severity findings=${record.local_review_verified_findings_count}; verified max severity=${record.local_review_verified_max_severity ?? "none"}.`;
-}
-
-export function localReviewFailureContext(
-  record: Pick<
-    IssueRunRecord,
-    | "local_review_findings_count"
-    | "local_review_root_cause_count"
-    | "local_review_max_severity"
-    | "local_review_verified_findings_count"
-    | "local_review_verified_max_severity"
-    | "local_review_degraded"
-    | "local_review_summary_path"
-  >,
-): FailureContext {
-  return {
-    category: "blocked",
-    summary: localReviewFailureSummary(record),
-    signature: `local-review:${record.local_review_max_severity ?? "unknown"}:${record.local_review_verified_max_severity ?? "none"}:${record.local_review_root_cause_count}:${record.local_review_verified_findings_count}:${record.local_review_degraded ? "degraded" : "clean"}`,
-    command: null,
-    details: [
-      `findings=${record.local_review_findings_count}`,
-      `root_causes=${record.local_review_root_cause_count}`,
-      record.local_review_summary_path ? `summary=${record.local_review_summary_path}` : "summary=none",
-    ],
-    url: null,
-    updated_at: nowIso(),
-  };
-}
-
-export function localReviewStallFailureContext(
-  record: Pick<
-    IssueRunRecord,
-    | "local_review_findings_count"
-    | "local_review_root_cause_count"
-    | "local_review_max_severity"
-    | "local_review_verified_findings_count"
-    | "local_review_verified_max_severity"
-    | "local_review_degraded"
-    | "local_review_summary_path"
-    | "repeated_local_review_signature_count"
-  >,
-): FailureContext {
-  return {
-    ...localReviewFailureContext(record),
-    summary:
-      `Local review findings repeated without code changes ${record.repeated_local_review_signature_count} times; manual intervention is required.`,
-    signature:
-      `local-review-stalled:${record.local_review_max_severity ?? "unknown"}:` +
-      `${record.local_review_root_cause_count}:${record.local_review_degraded ? "degraded" : "clean"}`,
-    details: [
-      `findings=${record.local_review_findings_count}`,
-      `root_causes=${record.local_review_root_cause_count}`,
-      `repeated_local_review_signature_count=${record.repeated_local_review_signature_count}`,
-      record.local_review_summary_path ? `summary=${record.local_review_summary_path}` : "summary=none",
-    ],
-  };
-}
-
-export function nextLocalReviewSignatureTracking(
-  record: Pick<IssueRunRecord, "local_review_head_sha" | "last_local_review_signature" | "repeated_local_review_signature_count">,
-  prHeadSha: string,
-  actionableSignature: string | null,
-): Pick<IssueRunRecord, "last_local_review_signature" | "repeated_local_review_signature_count"> {
-  if (!actionableSignature) {
-    return {
-      last_local_review_signature: null,
-      repeated_local_review_signature_count: 0,
-    };
-  }
-
-  const sameHead = record.local_review_head_sha === prHeadSha;
-  const sameSignature = record.last_local_review_signature === actionableSignature;
-  return {
-    last_local_review_signature: actionableSignature,
-    repeated_local_review_signature_count:
-      sameHead && sameSignature ? record.repeated_local_review_signature_count + 1 : 1,
   };
 }
 

--- a/src/supervisor-reporting.ts
+++ b/src/supervisor-reporting.ts
@@ -13,7 +13,7 @@ import {
   localReviewBlocksMerge,
   localReviewBlocksReady,
   localReviewRetryLoopStalled,
-} from "./run-once-turn-execution";
+} from "./review-handling";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
 import { truncate } from "./utils";
 import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -36,6 +36,20 @@ import {
   syncReviewWaitWindow,
 } from "./pull-request-state";
 import {
+  hasProcessedReviewThread,
+  localReviewBlocksMerge,
+  localReviewBlocksReady,
+  localReviewFailureContext,
+  localReviewFailureSummary,
+  localReviewHighSeverityNeedsBlock,
+  localReviewHighSeverityNeedsRetry,
+  localReviewRetryLoopCandidate,
+  localReviewRetryLoopStalled,
+  localReviewStallFailureContext,
+  nextLocalReviewSignatureTracking,
+  processedReviewThreadKey,
+} from "./review-handling";
+import {
   isRestartRunOnce,
   IssueJournalSync,
   MemoryArtifacts,
@@ -48,22 +62,10 @@ import {
   CodexTurnShortCircuit,
   executeCodexTurnPhase,
   handlePostTurnPullRequestTransitionsPhase,
-  hasProcessedReviewThread,
   loadLocalReviewRepairContext,
-  localReviewBlocksMerge,
-  localReviewBlocksReady,
-  localReviewFailureContext,
-  localReviewFailureSummary,
-  localReviewHighSeverityNeedsBlock,
-  localReviewHighSeverityNeedsRetry,
-  localReviewRetryLoopCandidate,
-  localReviewRetryLoopStalled,
-  localReviewStallFailureContext,
   nextExternalReviewMissPatch,
-  nextLocalReviewSignatureTracking,
   PostTurnPullRequestContext,
   PostTurnPullRequestResult,
-  processedReviewThreadKey,
 } from "./run-once-turn-execution";
 import {
   resolveRunnableIssueContext as resolveIssueSelectionContext,
@@ -127,9 +129,22 @@ import {
 
 export {
   loadLocalReviewRepairContext,
-  localReviewHighSeverityNeedsRetry,
   nextExternalReviewMissPatch,
 } from "./run-once-turn-execution";
+export {
+  hasProcessedReviewThread,
+  localReviewBlocksMerge,
+  localReviewBlocksReady,
+  localReviewFailureContext,
+  localReviewFailureSummary,
+  localReviewHighSeverityNeedsBlock,
+  localReviewHighSeverityNeedsRetry,
+  localReviewRetryLoopCandidate,
+  localReviewRetryLoopStalled,
+  localReviewStallFailureContext,
+  nextLocalReviewSignatureTracking,
+  processedReviewThreadKey,
+} from "./review-handling";
 export { inferStateFromPullRequest } from "./pull-request-state";
 export { reconcileRecoverableBlockedIssueStates } from "./recovery-reconciliation";
 export { formatDetailedStatus, summarizeChecks } from "./supervisor-reporting";


### PR DESCRIPTION
Closes #283
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the configured-bot review-thread and review-coupled local-review helpers into [src/review-handling.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/review-handling.ts), and rewired callers in [src/run-once-turn-execution.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/run-once-turn-execution.ts), [src/pull-request-state.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/pull-request-state.ts), [src/supervisor-reporting.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/supervisor-reporting.ts), and [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/supervisor.ts). I added focused coverage in [src/review-handling.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/review-handling.test.ts) and updated [src/run-once-turn-execution.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-283/src/run-once-turn-execution.test.ts) to import the extracted thread helper from the new module.

Focused verification passed with:
`npx tsx --test src/review-handling.test.ts src/run-once-turn-execution.test.ts src/local-review.test.ts src/supervisor.test.ts --test-name-pattern='hasProcessedReviewThread|local review gating|local review high-severity actions|local review retry loop helpers|nextLocalReviewSignatureTracking|localReviewHighSeverityNeedsRetry only escalates verifier-confirmed high findings|refreshes PR state after marking ready'`
and `npm run build`...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced review handling with improved thread processing, actionability assessment, and local review gating logic.
  * Added retry loop coordination and stall detection for review management.
  * Signature tracking for managing repeated review scenarios.

* **Tests**
  * Added comprehensive test coverage for review handling workflows, including thread reprocessing, policy validation, and retry/stall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->