### PR TITLE
Turn execution refactor: extract Codex turn failure, blocker, and retry helper logic (#284)

### DIFF
--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { hasProcessedReviewThread } from "./review-handling";
-import { handlePostTurnPullRequestTransitionsPhase } from "./run-once-turn-execution";
+import { executeCodexTurnPhase, handlePostTurnPullRequestTransitionsPhase } from "./run-once-turn-execution";
 import {
   FailureContext,
   GitHubIssue,
@@ -350,4 +350,157 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
   assert.equal(readyCalls, 1);
   assert.equal(snapshotLoads, 2);
   assert.equal(syncJournalCalls, 0);
+});
+
+test("executeCodexTurnPhase persists blocked reason and repeated blocker bookkeeping from Codex hints", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = {
+    number: 102,
+    title: "Persist blocked Codex hints",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/102",
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "reproducing",
+        repeated_blocker_count: 1,
+        last_blocker_signature: "waiting on verification evidence failure signature: prior-check",
+      }),
+    },
+  };
+  let journalReads = 0;
+  let syncJournalCalls = 0;
+  const result = await executeCodexTurnPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => {
+        throw new Error("unexpected resolvePullRequestForBranch call");
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      previousCodexSummary: null,
+      previousError: null,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      journalPath: path.join("/tmp/workspaces", "issue-102/.codex-supervisor/issue-journal.md"),
+      syncJournal: async () => {
+        syncJournalCalls += 1;
+      },
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      workspaceStatus: {
+        branch: "codex/issue-102",
+        headSha: "head-116",
+        hasUncommittedChanges: false,
+        baseAhead: 0,
+        baseBehind: 0,
+        remoteBranchExists: true,
+        remoteAhead: 0,
+        remoteBehind: 0,
+      },
+      pr: null,
+      checks: [],
+      reviewThreads: [],
+      options: { dryRun: false },
+    },
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-13T06:20:00Z",
+    }),
+    applyFailureSignature: (record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count:
+        failureContext?.signature && record.last_failure_signature === failureContext.signature
+          ? record.repeated_failure_signature_count + 1
+          : failureContext?.signature
+            ? 1
+            : 0,
+    }),
+    normalizeBlockerSignature: (message) =>
+      message
+        ?.toLowerCase()
+        .replace(/state hint:\s*[a-z_]+/i, "")
+        .replace(/blocked reason:\s*[a-z_]+/i, "")
+        .replace(/\s+/g, " ")
+        .trim() ?? null,
+    isVerificationBlockedMessage: (message) => (message ?? "").includes("verification"),
+    derivePullRequestLifecycleSnapshot: () => {
+      throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
+    },
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? "## Codex Working Notes\n### Current Handoff\n- Hypothesis: reproduce the failure.\n"
+        : [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: reproduce the failure.",
+            "- Current blocker: Waiting on verification evidence.",
+            "- Next exact step: capture the missing verification output.",
+          ].join("\n");
+    },
+    runCodexTurnImpl: async () => ({
+      exitCode: 0,
+      sessionId: "session-102",
+      lastMessage: [
+        "Waiting on verification evidence",
+        "State hint: blocked",
+        "Blocked reason: verification",
+        "Failure signature: prior-check",
+      ].join("\n"),
+      stderr: "",
+      stdout: "",
+    }),
+  });
+
+  assert.deepEqual(result, {
+    kind: "returned",
+    message: "Codex reported blocked for issue #102.",
+  });
+  assert.equal(syncJournalCalls, 1);
+  assert.equal(state.issues["102"]?.state, "blocked");
+  assert.equal(state.issues["102"]?.blocked_reason, "verification");
+  assert.equal(state.issues["102"]?.last_blocker_signature, "waiting on verification evidence failure signature: prior-check");
+  assert.equal(state.issues["102"]?.repeated_blocker_count, 2);
+  assert.equal(state.issues["102"]?.last_failure_signature, "prior-check");
+  assert.equal(state.issues["102"]?.repeated_failure_signature_count, 1);
 });

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -22,6 +22,12 @@ import {
 } from "./journal";
 import { LockHandle } from "./lock";
 import {
+  persistCodexTurnExecutionFailure,
+  persistCodexTurnExitFailure,
+  persistHintedCodexTurnState,
+  persistMissingCodexJournalHandoff,
+} from "./turn-execution-failure-helpers";
+import {
   LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
   runLocalReview,
   shouldRunLocalReview,
@@ -303,6 +309,80 @@ interface ExecuteCodexTurnPhaseArgs {
   recoverUnexpectedCodexTurnFailure: (
     args: RecoverUnexpectedCodexTurnFailureArgs,
   ) => Promise<IssueRunRecord>;
+  persistCodexTurnExecutionFailure?: (args: {
+    stateStore: Pick<StateStore, "touch" | "save">;
+    state: SupervisorStateFile;
+    record: IssueRunRecord;
+    syncJournal: (record: IssueRunRecord) => Promise<void>;
+    issueNumber: number;
+    error: unknown;
+    classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+    buildCodexFailureContext: (
+      category: FailureContext["category"],
+      summary: string,
+      details: string[],
+    ) => FailureContext;
+    applyFailureSignature: (
+      record: IssueRunRecord,
+      failureContext: FailureContext | null,
+    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  }) => Promise<IssueRunRecord>;
+  persistCodexTurnExitFailure?: (args: {
+    stateStore: Pick<StateStore, "touch" | "save">;
+    state: SupervisorStateFile;
+    record: IssueRunRecord;
+    syncJournal: (record: IssueRunRecord) => Promise<void>;
+    issueNumber: number;
+    codexResult: Pick<import("./types").CodexTurnResult, "lastMessage" | "stderr" | "stdout">;
+    classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+    buildCodexFailureContext: (
+      category: FailureContext["category"],
+      summary: string,
+      details: string[],
+    ) => FailureContext;
+    applyFailureSignature: (
+      record: IssueRunRecord,
+      failureContext: FailureContext | null,
+    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  }) => Promise<IssueRunRecord>;
+  persistMissingCodexJournalHandoff?: (args: {
+    stateStore: Pick<StateStore, "touch" | "save">;
+    state: SupervisorStateFile;
+    record: IssueRunRecord;
+    syncJournal: (record: IssueRunRecord) => Promise<void>;
+    issueNumber: number;
+    buildCodexFailureContext: (
+      category: FailureContext["category"],
+      summary: string,
+      details: string[],
+    ) => FailureContext;
+    applyFailureSignature: (
+      record: IssueRunRecord,
+      failureContext: FailureContext | null,
+    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  }) => Promise<IssueRunRecord>;
+  persistHintedCodexTurnState?: (args: {
+    stateStore: Pick<StateStore, "touch" | "save">;
+    state: SupervisorStateFile;
+    record: IssueRunRecord;
+    syncJournal: (record: IssueRunRecord) => Promise<void>;
+    issueNumber: number;
+    lastMessage: string;
+    hintedState: "blocked" | "failed";
+    hintedBlockedReason: IssueRunRecord["blocked_reason"];
+    hintedFailureSignature: string | null;
+    buildCodexFailureContext: (
+      category: FailureContext["category"],
+      summary: string,
+      details: string[],
+    ) => FailureContext;
+    applyFailureSignature: (
+      record: IssueRunRecord,
+      failureContext: FailureContext | null,
+    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    normalizeBlockerSignature: (message: string | null | undefined) => string | null;
+    isVerificationBlockedMessage: (message: string | null | undefined) => boolean;
+  }) => Promise<IssueRunRecord>;
   getWorkspaceStatus?: typeof getWorkspaceStatus;
   pushBranch?: typeof pushBranch;
   readIssueJournal?: typeof readIssueJournal;
@@ -363,6 +443,13 @@ export async function executeCodexTurnPhase(
   const pushBranchImpl = args.pushBranch ?? pushBranch;
   const readIssueJournalImpl = args.readIssueJournal ?? readIssueJournal;
   const runCodexTurnImpl = args.runCodexTurnImpl ?? runCodexTurn;
+  const persistCodexTurnExecutionFailureImpl =
+    args.persistCodexTurnExecutionFailure ?? persistCodexTurnExecutionFailure;
+  const persistCodexTurnExitFailureImpl = args.persistCodexTurnExitFailure ?? persistCodexTurnExitFailure;
+  const persistMissingCodexJournalHandoffImpl =
+    args.persistMissingCodexJournalHandoff ?? persistMissingCodexJournalHandoff;
+  const persistHintedCodexTurnStateImpl =
+    args.persistHintedCodexTurnState ?? persistHintedCodexTurnState;
   const { config, stateStore, github } = args;
   const { state, issue, previousCodexSummary, previousError, workspacePath, journalPath, syncJournal, memoryArtifacts, options } = args.context;
   let { record, workspaceStatus, pr, checks, reviewThreads } = args.context;
@@ -483,26 +570,17 @@ export async function executeCodexTurnPhase(
         record.codex_session_id,
       );
     } catch (error) {
-      const message = error instanceof Error ? error.stack ?? error.message : String(error);
-      const failureKind = args.classifyFailure(message);
-      const failureContext = args.buildCodexFailureContext(
-        "codex",
-        `Codex turn execution failed for issue #${record.issue_number}.`,
-        [truncate(message, 2000) ?? "Unknown failure"],
-      );
-      record = stateStore.touch(record, {
-        state: "failed",
-        last_error: truncate(message),
-        last_failure_kind: failureKind,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: null,
-        timeout_retry_count:
-          failureKind === "timeout" ? record.timeout_retry_count + 1 : record.timeout_retry_count,
+      record = await persistCodexTurnExecutionFailureImpl({
+        stateStore,
+        state,
+        record,
+        syncJournal,
+        issueNumber: record.issue_number,
+        error,
+        classifyFailure: args.classifyFailure,
+        buildCodexFailureContext: args.buildCodexFailureContext,
+        applyFailureSignature: args.applyFailureSignature,
       });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
       return {
         kind: "returned",
         message: `Codex turn failed for issue #${record.issue_number}.`,
@@ -531,22 +609,15 @@ export async function executeCodexTurnPhase(
         journalAfterRun === journalContent ||
         !hasMeaningfulJournalHandoff(journalAfterRun))
     ) {
-      const failureContext = args.buildCodexFailureContext(
-        "blocked",
-        `Codex completed without updating the issue journal for issue #${record.issue_number}.`,
-        ["Update the Codex Working Notes section before ending the turn."],
-      );
-      record = stateStore.touch(record, {
-        state: "blocked",
-        last_error: truncate(failureContext.summary),
-        last_failure_kind: null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: "handoff_missing",
+      record = await persistMissingCodexJournalHandoffImpl({
+        stateStore,
+        state,
+        record,
+        syncJournal,
+        issueNumber: record.issue_number,
+        buildCodexFailureContext: args.buildCodexFailureContext,
+        applyFailureSignature: args.applyFailureSignature,
       });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
       return {
         kind: "returned",
         message: `Codex turn for issue #${record.issue_number} was rejected because no journal handoff was written.`,
@@ -554,28 +625,17 @@ export async function executeCodexTurnPhase(
     }
 
     if (codexResult.exitCode !== 0) {
-      const failureOutput = [codexResult.lastMessage, codexResult.stderr, codexResult.stdout]
-        .filter(Boolean)
-        .join("\n");
-      const failureKind = args.classifyFailure(failureOutput) === "timeout" ? "timeout" : "codex_exit";
-      const failureContext = args.buildCodexFailureContext(
-        "codex",
-        `Codex exited non-zero for issue #${record.issue_number}.`,
-        [truncate(failureOutput, 2000) ?? "Unknown failure output"],
-      );
-      record = stateStore.touch(record, {
-        state: "failed",
-        last_error: truncate(failureOutput),
-        last_failure_kind: failureKind,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: null,
-        timeout_retry_count:
-          failureKind === "timeout" ? record.timeout_retry_count + 1 : record.timeout_retry_count,
+      record = await persistCodexTurnExitFailureImpl({
+        stateStore,
+        state,
+        record,
+        syncJournal,
+        issueNumber: record.issue_number,
+        codexResult,
+        classifyFailure: args.classifyFailure,
+        buildCodexFailureContext: args.buildCodexFailureContext,
+        applyFailureSignature: args.applyFailureSignature,
       });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
       return {
         kind: "returned",
         message: `Codex turn failed for issue #${record.issue_number}.`,
@@ -583,37 +643,21 @@ export async function executeCodexTurnPhase(
     }
 
     if (hintedState === "blocked" || hintedState === "failed") {
-      const blockerSignature = hintedState === "blocked" ? args.normalizeBlockerSignature(codexResult.lastMessage) : null;
-      const repeatedBlockerCount =
-        hintedState === "blocked" && blockerSignature && blockerSignature === record.last_blocker_signature
-          ? record.repeated_blocker_count + 1
-          : hintedState === "blocked"
-            ? 1
-            : 0;
-      const failureContext = args.buildCodexFailureContext(
-        hintedState === "failed" ? "codex" : "blocked",
-        `Codex reported ${hintedState} for issue #${record.issue_number}.`,
-        [truncate(codexResult.lastMessage, 2000) ?? "No additional summary."],
-      );
-      if (hintedFailureSignature) {
-        failureContext.signature = hintedFailureSignature;
-      }
-      record = stateStore.touch(record, {
-        state: hintedState,
-        last_error: truncate(codexResult.lastMessage),
-        last_failure_kind: hintedState === "failed" ? "codex_failed" : null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        repeated_blocker_count: repeatedBlockerCount,
-        last_blocker_signature: blockerSignature,
-        blocked_reason:
-          hintedState === "blocked"
-            ? hintedBlockedReason ?? (args.isVerificationBlockedMessage(codexResult.lastMessage) ? "verification" : "unknown")
-            : null,
+      record = await persistHintedCodexTurnStateImpl({
+        stateStore,
+        state,
+        record,
+        syncJournal,
+        issueNumber: record.issue_number,
+        lastMessage: codexResult.lastMessage,
+        hintedState,
+        hintedBlockedReason,
+        hintedFailureSignature,
+        buildCodexFailureContext: args.buildCodexFailureContext,
+        applyFailureSignature: args.applyFailureSignature,
+        normalizeBlockerSignature: args.normalizeBlockerSignature,
+        isVerificationBlockedMessage: args.isVerificationBlockedMessage,
       });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
       return {
         kind: "returned",
         message: `Codex reported ${hintedState} for issue #${record.issue_number}.`,

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -1,0 +1,235 @@
+import { StateStore } from "./state-store";
+import { CodexTurnResult, FailureContext, IssueRunRecord, SupervisorStateFile } from "./types";
+import { truncate } from "./utils";
+
+type TurnExecutionFailureStateStore = Pick<StateStore, "save" | "touch">;
+
+interface PersistTurnExecutionFailureArgs {
+  stateStore: TurnExecutionFailureStateStore;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: (record: IssueRunRecord) => Promise<void>;
+  issueNumber: number;
+  error: unknown;
+  classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+  buildCodexFailureContext: (
+    category: FailureContext["category"],
+    summary: string,
+    details: string[],
+  ) => FailureContext;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+}
+
+interface PersistCodexExitFailureArgs {
+  stateStore: TurnExecutionFailureStateStore;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: (record: IssueRunRecord) => Promise<void>;
+  issueNumber: number;
+  codexResult: Pick<CodexTurnResult, "lastMessage" | "stderr" | "stdout">;
+  classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+  buildCodexFailureContext: (
+    category: FailureContext["category"],
+    summary: string,
+    details: string[],
+  ) => FailureContext;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+}
+
+interface PersistMissingJournalHandoffArgs {
+  stateStore: TurnExecutionFailureStateStore;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: (record: IssueRunRecord) => Promise<void>;
+  issueNumber: number;
+  buildCodexFailureContext: (
+    category: FailureContext["category"],
+    summary: string,
+    details: string[],
+  ) => FailureContext;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+}
+
+interface PersistHintedCodexTurnStateArgs {
+  stateStore: TurnExecutionFailureStateStore;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: (record: IssueRunRecord) => Promise<void>;
+  issueNumber: number;
+  lastMessage: string;
+  hintedState: "blocked" | "failed";
+  hintedBlockedReason: IssueRunRecord["blocked_reason"];
+  hintedFailureSignature: string | null;
+  buildCodexFailureContext: (
+    category: FailureContext["category"],
+    summary: string,
+    details: string[],
+  ) => FailureContext;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  normalizeBlockerSignature: (message: string | null | undefined) => string | null;
+  isVerificationBlockedMessage: (message: string | null | undefined) => boolean;
+}
+
+function timeoutRetryPatch(
+  record: IssueRunRecord,
+  failureKind: "timeout" | "command_error" | "codex_exit",
+): Pick<IssueRunRecord, "timeout_retry_count"> {
+  return {
+    timeout_retry_count: failureKind === "timeout" ? record.timeout_retry_count + 1 : record.timeout_retry_count,
+  };
+}
+
+function nextBlockerTracking(
+  record: IssueRunRecord,
+  hintedState: "blocked" | "failed",
+  lastMessage: string,
+  normalizeBlockerSignature: (message: string | null | undefined) => string | null,
+): Pick<IssueRunRecord, "repeated_blocker_count" | "last_blocker_signature"> {
+  const blockerSignature = hintedState === "blocked" ? normalizeBlockerSignature(lastMessage) : null;
+  const repeatedBlockerCount =
+    hintedState === "blocked" && blockerSignature && blockerSignature === record.last_blocker_signature
+      ? record.repeated_blocker_count + 1
+      : hintedState === "blocked"
+        ? 1
+        : 0;
+  return {
+    repeated_blocker_count: repeatedBlockerCount,
+    last_blocker_signature: blockerSignature,
+  };
+}
+
+async function persistTurnFailurePatch(args: {
+  stateStore: TurnExecutionFailureStateStore;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: (record: IssueRunRecord) => Promise<void>;
+  patch: Partial<IssueRunRecord>;
+}): Promise<IssueRunRecord> {
+  const updated = args.stateStore.touch(args.record, args.patch);
+  args.state.issues[String(args.record.issue_number)] = updated;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updated);
+  return updated;
+}
+
+export async function persistCodexTurnExecutionFailure(args: PersistTurnExecutionFailureArgs): Promise<IssueRunRecord> {
+  const message = args.error instanceof Error ? args.error.stack ?? args.error.message : String(args.error);
+  const failureKind = args.classifyFailure(message);
+  const failureContext = args.buildCodexFailureContext(
+    "codex",
+    `Codex turn execution failed for issue #${args.issueNumber}.`,
+    [truncate(message, 2000) ?? "Unknown failure"],
+  );
+
+  return persistTurnFailurePatch({
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    syncJournal: args.syncJournal,
+    patch: {
+      state: "failed",
+      last_error: truncate(message),
+      last_failure_kind: failureKind,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason: null,
+      ...timeoutRetryPatch(args.record, failureKind),
+    },
+  });
+}
+
+export async function persistCodexTurnExitFailure(args: PersistCodexExitFailureArgs): Promise<IssueRunRecord> {
+  const failureOutput = [args.codexResult.lastMessage, args.codexResult.stderr, args.codexResult.stdout]
+    .filter(Boolean)
+    .join("\n");
+  const failureKind = args.classifyFailure(failureOutput) === "timeout" ? "timeout" : "codex_exit";
+  const failureContext = args.buildCodexFailureContext(
+    "codex",
+    `Codex exited non-zero for issue #${args.issueNumber}.`,
+    [truncate(failureOutput, 2000) ?? "Unknown failure output"],
+  );
+
+  return persistTurnFailurePatch({
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    syncJournal: args.syncJournal,
+    patch: {
+      state: "failed",
+      last_error: truncate(failureOutput),
+      last_failure_kind: failureKind,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason: null,
+      ...timeoutRetryPatch(args.record, failureKind),
+    },
+  });
+}
+
+export async function persistMissingCodexJournalHandoff(
+  args: PersistMissingJournalHandoffArgs,
+): Promise<IssueRunRecord> {
+  const failureContext = args.buildCodexFailureContext(
+    "blocked",
+    `Codex completed without updating the issue journal for issue #${args.issueNumber}.`,
+    ["Update the Codex Working Notes section before ending the turn."],
+  );
+
+  return persistTurnFailurePatch({
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    syncJournal: args.syncJournal,
+    patch: {
+      state: "blocked",
+      last_error: truncate(failureContext.summary),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason: "handoff_missing",
+    },
+  });
+}
+
+export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnStateArgs): Promise<IssueRunRecord> {
+  const failureContext = args.buildCodexFailureContext(
+    args.hintedState === "failed" ? "codex" : "blocked",
+    `Codex reported ${args.hintedState} for issue #${args.issueNumber}.`,
+    [truncate(args.lastMessage, 2000) ?? "No additional summary."],
+  );
+  if (args.hintedFailureSignature) {
+    failureContext.signature = args.hintedFailureSignature;
+  }
+
+  return persistTurnFailurePatch({
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    syncJournal: args.syncJournal,
+    patch: {
+      state: args.hintedState,
+      last_error: truncate(args.lastMessage),
+      last_failure_kind: args.hintedState === "failed" ? "codex_failed" : null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      ...nextBlockerTracking(args.record, args.hintedState, args.lastMessage, args.normalizeBlockerSignature),
+      blocked_reason:
+        args.hintedState === "blocked"
+          ? args.hintedBlockedReason ??
+            (args.isVerificationBlockedMessage(args.lastMessage) ? "verification" : "unknown")
+          : null,
+    },
+  });
+}


### PR DESCRIPTION
Closes #284
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the Codex turn failure/blocker persistence out of [`src/run-once-turn-execution.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-284/src/run-once-turn-execution.ts) into [`src/turn-execution-failure-helpers.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-284/src/turn-execution-failure-helpers.ts), leaving the execute phase to orchestrate calls instead of owning the state-patch details. I also added a focused regression in [`src/run-once-turn-execution.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-284/src/run-once-turn-execution.test.ts) that drives the blocked-hint path and locks down blocker reason, blocker signature, and repeated-count behavior before/after the extraction.

Verification passed locally after installing deps with `npm ci`: `npx tsx --test src/run-once-turn-execution.test.ts`, `npx tsx --test src/supervisor-execution-policy.test.ts src/supervisor.test.ts`, and `npm run build`. I updated the issue journal and committed the checkpoint as `ab2d244` (`Extract turn execution failure helpers`).

Summary: Extracted turn execution failure/blocker helper logic into a dedicated module, added focused regression coverage, and verified tests plus build locally.
State hint: draft_pr
Blocked reason: none
Tests: npm ci; npx tsx --test src/run-once-turn-execution.test.ts; npx tsx --test src/supervisor-execution-policy.test.ts src/supervisor.test.ts; npm run build
Failure signature: none
Next action: Open or update a draft PR ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling and recovery for Codex turn execution failures with improved failure classification
  * Improved tracking of blocked states, failure reasons, and retry counters
  * More structured approach to failure persistence and recovery workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->