### PR TITLE
Turn execution refactor: extract post-turn PR refresh and transition handling (#285)

### DIFF
--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -1,0 +1,339 @@
+import { GitHubClient } from "./github";
+import {
+  LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
+  runLocalReview,
+  shouldRunLocalReview,
+} from "./local-review";
+import {
+  localReviewBlocksReady,
+  localReviewFailureContext,
+  localReviewFailureSummary,
+  localReviewHighSeverityNeedsBlock,
+  localReviewHighSeverityNeedsRetry,
+  localReviewRetryLoopCandidate,
+  localReviewRetryLoopStalled,
+  localReviewStallFailureContext,
+  nextLocalReviewSignatureTracking,
+} from "./review-handling";
+import { IssueJournalSync, MemoryArtifacts } from "./run-once-issue-preparation";
+import { StateStore } from "./state-store";
+import {
+  FailureContext,
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  RunState,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "./types";
+import { nowIso, truncate } from "./utils";
+
+export interface PostTurnPullRequestContext {
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  issue: GitHubIssue;
+  workspacePath: string;
+  syncJournal: IssueJournalSync;
+  memoryArtifacts: MemoryArtifacts;
+  pr: GitHubPullRequest;
+  options: { dryRun: boolean };
+}
+
+export interface PostTurnPullRequestResult {
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}
+
+export interface PullRequestLifecycleSnapshot {
+  recordForState: IssueRunRecord;
+  nextState: RunState;
+  failureContext: FailureContext | null;
+  reviewWaitPatch: Partial<Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">>;
+  copilotRequestObservationPatch: Partial<
+    Pick<IssueRunRecord, "copilot_review_requested_observed_at" | "copilot_review_requested_head_sha">
+  >;
+  copilotTimeoutPatch: Pick<
+    IssueRunRecord,
+    "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
+  >;
+}
+
+export interface HandlePostTurnPullRequestTransitionsArgs {
+  config: SupervisorConfig;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  github: Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads" | "markPullRequestReady">;
+  context: PostTurnPullRequestContext;
+  derivePullRequestLifecycleSnapshot: (
+    record: IssueRunRecord,
+    pr: GitHubPullRequest,
+    checks: PullRequestCheck[],
+    reviewThreads: ReviewThread[],
+    recordPatch?: Partial<IssueRunRecord>,
+  ) => PullRequestLifecycleSnapshot;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  blockedReasonFromReviewState: (
+    record: IssueRunRecord,
+    pr: GitHubPullRequest,
+    reviewThreads: ReviewThread[],
+  ) => IssueRunRecord["blocked_reason"];
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+  mergeConflictDetected: (pr: GitHubPullRequest) => boolean;
+  runLocalReviewImpl?: typeof runLocalReview;
+  loadOpenPullRequestSnapshot?: (prNumber: number) => Promise<{
+    pr: GitHubPullRequest;
+    checks: PullRequestCheck[];
+    reviewThreads: ReviewThread[];
+  }>;
+}
+
+async function loadOpenPullRequestSnapshot(
+  github: Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads">,
+  prNumber: number,
+): Promise<{
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}> {
+  const pr = await github.getPullRequest(prNumber);
+  const checks = await github.getChecks(prNumber);
+  const reviewThreads = await github.getUnresolvedReviewThreads(prNumber);
+  return { pr, checks, reviewThreads };
+}
+
+export async function handlePostTurnPullRequestTransitionsPhase(
+  args: HandlePostTurnPullRequestTransitionsArgs,
+): Promise<PostTurnPullRequestResult> {
+  const runLocalReviewImpl = args.runLocalReviewImpl ?? runLocalReview;
+  const loadOpenPullRequestSnapshotImpl =
+    args.loadOpenPullRequestSnapshot ?? ((prNumber: number) => loadOpenPullRequestSnapshot(args.github, prNumber));
+  const { config, stateStore, github } = args;
+  const { state, issue, workspacePath, syncJournal, memoryArtifacts, options } = args.context;
+  let { record, pr } = args.context;
+
+  let ranLocalReviewThisCycle = false;
+  const refreshed = await loadOpenPullRequestSnapshotImpl(pr.number);
+  const refreshedCheckSummary = args.summarizeChecks(refreshed.checks);
+
+  if (
+    shouldRunLocalReview(config, record, refreshed.pr) &&
+    !refreshedCheckSummary.hasPending &&
+    !refreshedCheckSummary.hasFailing &&
+    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
+    (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
+    !args.mergeConflictDetected(refreshed.pr) &&
+    !options.dryRun
+  ) {
+    ranLocalReviewThisCycle = true;
+    record = stateStore.touch(record, { state: "local_review" });
+    state.issues[String(record.issue_number)] = record;
+    await stateStore.save(state);
+    await syncJournal(record);
+
+    try {
+      const localReview = await runLocalReviewImpl({
+        config,
+        issue,
+        branch: record.branch,
+        workspacePath,
+        defaultBranch: config.defaultBranch,
+        pr: refreshed.pr,
+        alwaysReadFiles: memoryArtifacts.alwaysReadFiles,
+        onDemandFiles: memoryArtifacts.onDemandFiles,
+      });
+      const actionableSignature =
+        localReview.recommendation !== "ready"
+          ? `local-review:${localReview.maxSeverity ?? "unknown"}:${localReview.rootCauseCount}:${localReview.degraded ? "degraded" : "clean"}`
+          : null;
+      const signatureTracking = nextLocalReviewSignatureTracking(record, refreshed.pr.headRefOid, actionableSignature);
+
+      record = stateStore.touch(record, {
+        state: "draft_pr",
+        local_review_head_sha: refreshed.pr.headRefOid,
+        local_review_blocker_summary: localReview.blockerSummary,
+        local_review_summary_path: localReview.summaryPath,
+        local_review_run_at: localReview.ranAt,
+        local_review_max_severity: localReview.maxSeverity,
+        local_review_findings_count: localReview.findingsCount,
+        local_review_root_cause_count: localReview.rootCauseCount,
+        local_review_verified_max_severity: localReview.verifiedMaxSeverity,
+        local_review_verified_findings_count: localReview.verifiedFindingsCount,
+        local_review_recommendation: localReview.recommendation,
+        local_review_degraded: localReview.degraded,
+        ...signatureTracking,
+        external_review_head_sha: null,
+        external_review_misses_path: null,
+        external_review_matched_findings_count: 0,
+        external_review_near_match_findings_count: 0,
+        external_review_missed_findings_count: 0,
+        blocked_reason:
+          localReview.recommendation !== "ready" && config.localReviewHighSeverityAction === "blocked" && localReview.verifiedMaxSeverity === "high"
+            ? "verification"
+            : null,
+        last_error:
+          localReview.recommendation !== "ready"
+            ? truncate(
+                localReview.degraded
+                  ? "Local review completed in a degraded state."
+                  : localReview.verifiedMaxSeverity === "high" && config.localReviewHighSeverityAction === "retry"
+                    ? `Local review found high-severity issues (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). Codex will continue with a repair pass before the PR can proceed.`
+                    : localReview.verifiedMaxSeverity === "high" && config.localReviewHighSeverityAction === "blocked"
+                      ? `Local review found high-severity issues (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). Manual attention is required before the PR can proceed.`
+                      : `Local review requested changes (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)).`,
+                500,
+              )
+            : null,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      record = stateStore.touch(record, {
+        state: "draft_pr",
+        local_review_head_sha: refreshed.pr.headRefOid,
+        local_review_blocker_summary: LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
+        local_review_summary_path: null,
+        local_review_run_at: nowIso(),
+        local_review_max_severity: null,
+        local_review_findings_count: 0,
+        local_review_root_cause_count: 0,
+        local_review_verified_max_severity: null,
+        local_review_verified_findings_count: 0,
+        local_review_recommendation: "unknown",
+        local_review_degraded: true,
+        last_local_review_signature: null,
+        repeated_local_review_signature_count: 0,
+        external_review_head_sha: null,
+        external_review_misses_path: null,
+        external_review_matched_findings_count: 0,
+        external_review_near_match_findings_count: 0,
+        external_review_missed_findings_count: 0,
+        blocked_reason: "verification",
+        last_error: `Local review failed: ${truncate(message, 500) ?? "unknown error"}`,
+      });
+    }
+
+    state.issues[String(record.issue_number)] = record;
+    await stateStore.save(state);
+    await syncJournal(record);
+  }
+
+  if (
+    refreshed.pr.isDraft &&
+    !refreshedCheckSummary.hasPending &&
+    !refreshedCheckSummary.hasFailing &&
+    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
+    (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
+    !args.mergeConflictDetected(refreshed.pr) &&
+    !localReviewBlocksReady(config, record, refreshed.pr) &&
+    !options.dryRun
+  ) {
+    await github.markPullRequestReady(refreshed.pr.number);
+  }
+
+  const postReady = await loadOpenPullRequestSnapshotImpl(pr.number);
+  const repeatedLocalReviewSignatureCount =
+    !ranLocalReviewThisCycle &&
+    localReviewRetryLoopCandidate(
+      config,
+      record,
+      postReady.pr,
+      postReady.checks,
+      postReady.reviewThreads,
+      args.manualReviewThreads,
+      args.configuredBotReviewThreads,
+      args.summarizeChecks,
+      args.mergeConflictDetected,
+    ) &&
+    record.last_head_sha === postReady.pr.headRefOid &&
+    record.local_review_head_sha === postReady.pr.headRefOid
+      ? record.repeated_local_review_signature_count + 1
+      : localReviewHighSeverityNeedsRetry(config, record, postReady.pr) &&
+          record.local_review_head_sha === postReady.pr.headRefOid
+        ? 0
+        : record.repeated_local_review_signature_count;
+  const refreshedLifecycle = args.derivePullRequestLifecycleSnapshot(
+    record,
+    postReady.pr,
+    postReady.checks,
+    postReady.reviewThreads,
+    { repeated_local_review_signature_count: repeatedLocalReviewSignatureCount },
+  );
+  const postReadyLocalReviewFailureContext =
+    refreshedLifecycle.nextState === "blocked" &&
+    localReviewRetryLoopStalled(
+      config,
+      refreshedLifecycle.recordForState,
+      postReady.pr,
+      postReady.checks,
+      postReady.reviewThreads,
+      args.manualReviewThreads,
+      args.configuredBotReviewThreads,
+      args.summarizeChecks,
+      args.mergeConflictDetected,
+    )
+      ? localReviewStallFailureContext(refreshedLifecycle.recordForState)
+      : refreshedLifecycle.nextState === "blocked" &&
+          localReviewHighSeverityNeedsBlock(config, refreshedLifecycle.recordForState, postReady.pr)
+        ? localReviewFailureContext(refreshedLifecycle.recordForState)
+        : refreshedLifecycle.nextState === "local_review_fix" &&
+            localReviewHighSeverityNeedsRetry(config, refreshedLifecycle.recordForState, postReady.pr)
+          ? localReviewFailureContext(refreshedLifecycle.recordForState)
+          : null;
+  const effectiveFailureContext = refreshedLifecycle.failureContext ?? postReadyLocalReviewFailureContext;
+  record = stateStore.touch(record, {
+    pr_number: postReady.pr.number,
+    ...refreshedLifecycle.reviewWaitPatch,
+    ...refreshedLifecycle.copilotRequestObservationPatch,
+    ...refreshedLifecycle.copilotTimeoutPatch,
+    state: refreshedLifecycle.nextState,
+    last_head_sha: postReady.pr.headRefOid,
+    repeated_local_review_signature_count: repeatedLocalReviewSignatureCount,
+    last_error:
+      refreshedLifecycle.nextState === "blocked" && effectiveFailureContext
+        ? truncate(effectiveFailureContext.summary, 1000)
+        : refreshedLifecycle.nextState === "local_review_fix" &&
+            localReviewHighSeverityNeedsRetry(config, refreshedLifecycle.recordForState, postReady.pr)
+          ? truncate(localReviewFailureSummary(refreshedLifecycle.recordForState), 1000)
+          : record.last_error,
+    last_failure_context: effectiveFailureContext,
+    ...args.applyFailureSignature(record, effectiveFailureContext),
+    blocked_reason:
+      refreshedLifecycle.nextState === "blocked"
+        ? args.blockedReasonFromReviewState(
+            refreshedLifecycle.recordForState,
+            postReady.pr,
+            postReady.reviewThreads,
+          ) ??
+          ((localReviewRetryLoopStalled(
+            config,
+            refreshedLifecycle.recordForState,
+            postReady.pr,
+            postReady.checks,
+            postReady.reviewThreads,
+            args.manualReviewThreads,
+            args.configuredBotReviewThreads,
+            args.summarizeChecks,
+            args.mergeConflictDetected,
+          ) ||
+            localReviewHighSeverityNeedsBlock(config, refreshedLifecycle.recordForState, postReady.pr))
+            ? "verification"
+            : null)
+        : null,
+  });
+  state.issues[String(record.issue_number)] = record;
+  await stateStore.save(state);
+
+  return {
+    record,
+    pr: postReady.pr,
+    checks: postReady.checks,
+    reviewThreads: postReady.reviewThreads,
+  };
+}

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -2,7 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { hasProcessedReviewThread } from "./review-handling";
-import { executeCodexTurnPhase, handlePostTurnPullRequestTransitionsPhase } from "./run-once-turn-execution";
+import { executeCodexTurnPhase } from "./run-once-turn-execution";
+import { handlePostTurnPullRequestTransitionsPhase } from "./post-turn-pull-request";
 import {
   FailureContext,
   GitHubIssue,

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -28,25 +28,14 @@ import {
   persistMissingCodexJournalHandoff,
 } from "./turn-execution-failure-helpers";
 import {
-  LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
-  runLocalReview,
-  shouldRunLocalReview,
-} from "./local-review";
-import {
   hasProcessedReviewThread,
   latestReviewThreadCommentFingerprint,
-  localReviewBlocksReady,
-  localReviewFailureContext,
-  localReviewFailureSummary,
-  localReviewHighSeverityNeedsBlock,
-  localReviewHighSeverityNeedsRetry,
-  localReviewRetryLoopCandidate,
-  localReviewRetryLoopStalled,
-  localReviewStallFailureContext,
-  nextLocalReviewSignatureTracking,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
 } from "./review-handling";
+import {
+  PullRequestLifecycleSnapshot,
+} from "./post-turn-pull-request";
 import { IssueJournalSync, MemoryArtifacts } from "./run-once-issue-preparation";
 import { StateStore } from "./state-store";
 import {
@@ -61,9 +50,15 @@ import {
   SupervisorStateFile,
   WorkspaceStatus,
 } from "./types";
-import { nowIso, parseJson, truncate } from "./utils";
+import { parseJson, truncate } from "./utils";
 import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";
 import { getWorkspaceStatus, pushBranch } from "./workspace";
+
+export {
+  handlePostTurnPullRequestTransitionsPhase,
+  PostTurnPullRequestContext,
+  PostTurnPullRequestResult,
+} from "./post-turn-pull-request";
 
 function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
@@ -228,38 +223,6 @@ export interface CodexTurnShortCircuit {
   message: string;
 }
 
-export interface PostTurnPullRequestContext {
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  issue: GitHubIssue;
-  workspacePath: string;
-  syncJournal: IssueJournalSync;
-  memoryArtifacts: MemoryArtifacts;
-  pr: GitHubPullRequest;
-  options: { dryRun: boolean };
-}
-
-export interface PostTurnPullRequestResult {
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-}
-
-interface PullRequestLifecycleSnapshot {
-  recordForState: IssueRunRecord;
-  nextState: RunState;
-  failureContext: FailureContext | null;
-  reviewWaitPatch: Partial<Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">>;
-  copilotRequestObservationPatch: Partial<
-    Pick<IssueRunRecord, "copilot_review_requested_observed_at" | "copilot_review_requested_head_sha">
-  >;
-  copilotTimeoutPatch: Pick<
-    IssueRunRecord,
-    "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
-  >;
-}
-
 interface RecoverUnexpectedCodexTurnFailureArgs {
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
@@ -387,53 +350,6 @@ interface ExecuteCodexTurnPhaseArgs {
   pushBranch?: typeof pushBranch;
   readIssueJournal?: typeof readIssueJournal;
   runCodexTurnImpl?: typeof runCodexTurn;
-}
-
-interface HandlePostTurnPullRequestTransitionsArgs {
-  config: SupervisorConfig;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  github: Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads" | "markPullRequestReady">;
-  context: PostTurnPullRequestContext;
-  derivePullRequestLifecycleSnapshot: (
-    record: IssueRunRecord,
-    pr: GitHubPullRequest,
-    checks: PullRequestCheck[],
-    reviewThreads: ReviewThread[],
-    recordPatch?: Partial<IssueRunRecord>,
-  ) => PullRequestLifecycleSnapshot;
-  applyFailureSignature: (
-    record: IssueRunRecord,
-    failureContext: FailureContext | null,
-  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
-  blockedReasonFromReviewState: (
-    record: IssueRunRecord,
-    pr: GitHubPullRequest,
-    reviewThreads: ReviewThread[],
-  ) => IssueRunRecord["blocked_reason"];
-  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
-  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
-  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
-  mergeConflictDetected: (pr: GitHubPullRequest) => boolean;
-  runLocalReviewImpl?: typeof runLocalReview;
-  loadOpenPullRequestSnapshot?: (prNumber: number) => Promise<{
-    pr: GitHubPullRequest;
-    checks: PullRequestCheck[];
-    reviewThreads: ReviewThread[];
-  }>;
-}
-
-async function loadOpenPullRequestSnapshot(
-  github: Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads">,
-  prNumber: number,
-): Promise<{
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-}> {
-  const pr = await github.getPullRequest(prNumber);
-  const checks = await github.getChecks(prNumber);
-  const reviewThreads = await github.getUnresolvedReviewThreads(prNumber);
-  return { pr, checks, reviewThreads };
 }
 
 export async function executeCodexTurnPhase(
@@ -789,233 +705,4 @@ export async function executeCodexTurnPhase(
       message: `Recovered from unexpected Codex turn failure for issue #${record.issue_number}.`,
     };
   }
-}
-
-export async function handlePostTurnPullRequestTransitionsPhase(
-  args: HandlePostTurnPullRequestTransitionsArgs,
-): Promise<PostTurnPullRequestResult> {
-  const runLocalReviewImpl = args.runLocalReviewImpl ?? runLocalReview;
-  const loadOpenPullRequestSnapshotImpl =
-    args.loadOpenPullRequestSnapshot ?? ((prNumber: number) => loadOpenPullRequestSnapshot(args.github, prNumber));
-  const { config, stateStore, github } = args;
-  const { state, issue, workspacePath, syncJournal, memoryArtifacts, options } = args.context;
-  let { record, pr } = args.context;
-
-  let ranLocalReviewThisCycle = false;
-  const refreshed = await loadOpenPullRequestSnapshotImpl(pr.number);
-  const refreshedCheckSummary = args.summarizeChecks(refreshed.checks);
-
-  if (
-    shouldRunLocalReview(config, record, refreshed.pr) &&
-    !refreshedCheckSummary.hasPending &&
-    !refreshedCheckSummary.hasFailing &&
-    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
-    (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
-    !args.mergeConflictDetected(refreshed.pr) &&
-    !options.dryRun
-  ) {
-    ranLocalReviewThisCycle = true;
-    record = stateStore.touch(record, { state: "local_review" });
-    state.issues[String(record.issue_number)] = record;
-    await stateStore.save(state);
-    await syncJournal(record);
-
-    try {
-      const localReview = await runLocalReviewImpl({
-        config,
-        issue,
-        branch: record.branch,
-        workspacePath,
-        defaultBranch: config.defaultBranch,
-        pr: refreshed.pr,
-        alwaysReadFiles: memoryArtifacts.alwaysReadFiles,
-        onDemandFiles: memoryArtifacts.onDemandFiles,
-      });
-      const actionableSignature =
-        localReview.recommendation !== "ready"
-          ? `local-review:${localReview.maxSeverity ?? "unknown"}:${localReview.rootCauseCount}:${localReview.degraded ? "degraded" : "clean"}`
-          : null;
-      const signatureTracking = nextLocalReviewSignatureTracking(record, refreshed.pr.headRefOid, actionableSignature);
-
-      record = stateStore.touch(record, {
-        state: "draft_pr",
-        local_review_head_sha: refreshed.pr.headRefOid,
-        local_review_blocker_summary: localReview.blockerSummary,
-        local_review_summary_path: localReview.summaryPath,
-        local_review_run_at: localReview.ranAt,
-        local_review_max_severity: localReview.maxSeverity,
-        local_review_findings_count: localReview.findingsCount,
-        local_review_root_cause_count: localReview.rootCauseCount,
-        local_review_verified_max_severity: localReview.verifiedMaxSeverity,
-        local_review_verified_findings_count: localReview.verifiedFindingsCount,
-        local_review_recommendation: localReview.recommendation,
-        local_review_degraded: localReview.degraded,
-        ...signatureTracking,
-        external_review_head_sha: null,
-        external_review_misses_path: null,
-        external_review_matched_findings_count: 0,
-        external_review_near_match_findings_count: 0,
-        external_review_missed_findings_count: 0,
-        blocked_reason:
-          localReview.recommendation !== "ready" && config.localReviewHighSeverityAction === "blocked" && localReview.verifiedMaxSeverity === "high"
-            ? "verification"
-            : null,
-        last_error:
-          localReview.recommendation !== "ready"
-            ? truncate(
-                localReview.degraded
-                  ? "Local review completed in a degraded state."
-                  : localReview.verifiedMaxSeverity === "high" && config.localReviewHighSeverityAction === "retry"
-                    ? `Local review found high-severity issues (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). Codex will continue with a repair pass before the PR can proceed.`
-                    : localReview.verifiedMaxSeverity === "high" && config.localReviewHighSeverityAction === "blocked"
-                      ? `Local review found high-severity issues (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). Manual attention is required before the PR can proceed.`
-                      : `Local review requested changes (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)).`,
-                500,
-              )
-            : null,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      record = stateStore.touch(record, {
-        state: "draft_pr",
-        local_review_head_sha: refreshed.pr.headRefOid,
-        local_review_blocker_summary: LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
-        local_review_summary_path: null,
-        local_review_run_at: nowIso(),
-        local_review_max_severity: null,
-        local_review_findings_count: 0,
-        local_review_root_cause_count: 0,
-        local_review_verified_max_severity: null,
-        local_review_verified_findings_count: 0,
-        local_review_recommendation: "unknown",
-        local_review_degraded: true,
-        last_local_review_signature: null,
-        repeated_local_review_signature_count: 0,
-        external_review_head_sha: null,
-        external_review_misses_path: null,
-        external_review_matched_findings_count: 0,
-        external_review_near_match_findings_count: 0,
-        external_review_missed_findings_count: 0,
-        blocked_reason: "verification",
-        last_error: `Local review failed: ${truncate(message, 500) ?? "unknown error"}`,
-      });
-    }
-
-    state.issues[String(record.issue_number)] = record;
-    await stateStore.save(state);
-    await syncJournal(record);
-  }
-
-  if (
-    refreshed.pr.isDraft &&
-    !refreshedCheckSummary.hasPending &&
-    !refreshedCheckSummary.hasFailing &&
-    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
-    (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
-    !args.mergeConflictDetected(refreshed.pr) &&
-    !localReviewBlocksReady(config, record, refreshed.pr) &&
-    !options.dryRun
-  ) {
-    await github.markPullRequestReady(refreshed.pr.number);
-  }
-
-  const postReady = await loadOpenPullRequestSnapshotImpl(pr.number);
-  const repeatedLocalReviewSignatureCount =
-    !ranLocalReviewThisCycle &&
-    localReviewRetryLoopCandidate(
-      config,
-      record,
-      postReady.pr,
-      postReady.checks,
-      postReady.reviewThreads,
-      args.manualReviewThreads,
-      args.configuredBotReviewThreads,
-      args.summarizeChecks,
-      args.mergeConflictDetected,
-    ) &&
-    record.last_head_sha === postReady.pr.headRefOid &&
-    record.local_review_head_sha === postReady.pr.headRefOid
-      ? record.repeated_local_review_signature_count + 1
-      : localReviewHighSeverityNeedsRetry(config, record, postReady.pr) &&
-          record.local_review_head_sha === postReady.pr.headRefOid
-        ? 0
-        : record.repeated_local_review_signature_count;
-  const refreshedLifecycle = args.derivePullRequestLifecycleSnapshot(
-    record,
-    postReady.pr,
-    postReady.checks,
-    postReady.reviewThreads,
-    { repeated_local_review_signature_count: repeatedLocalReviewSignatureCount },
-  );
-  const postReadyLocalReviewFailureContext =
-    refreshedLifecycle.nextState === "blocked" &&
-    localReviewRetryLoopStalled(
-      config,
-      refreshedLifecycle.recordForState,
-      postReady.pr,
-      postReady.checks,
-      postReady.reviewThreads,
-      args.manualReviewThreads,
-      args.configuredBotReviewThreads,
-      args.summarizeChecks,
-      args.mergeConflictDetected,
-    )
-      ? localReviewStallFailureContext(refreshedLifecycle.recordForState)
-      : refreshedLifecycle.nextState === "blocked" &&
-          localReviewHighSeverityNeedsBlock(config, refreshedLifecycle.recordForState, postReady.pr)
-        ? localReviewFailureContext(refreshedLifecycle.recordForState)
-        : refreshedLifecycle.nextState === "local_review_fix" &&
-            localReviewHighSeverityNeedsRetry(config, refreshedLifecycle.recordForState, postReady.pr)
-          ? localReviewFailureContext(refreshedLifecycle.recordForState)
-          : null;
-  const effectiveFailureContext = refreshedLifecycle.failureContext ?? postReadyLocalReviewFailureContext;
-  record = stateStore.touch(record, {
-    pr_number: postReady.pr.number,
-    ...refreshedLifecycle.reviewWaitPatch,
-    ...refreshedLifecycle.copilotRequestObservationPatch,
-    ...refreshedLifecycle.copilotTimeoutPatch,
-    state: refreshedLifecycle.nextState,
-    last_head_sha: postReady.pr.headRefOid,
-    repeated_local_review_signature_count: repeatedLocalReviewSignatureCount,
-    last_error:
-      refreshedLifecycle.nextState === "blocked" && effectiveFailureContext
-        ? truncate(effectiveFailureContext.summary, 1000)
-        : refreshedLifecycle.nextState === "local_review_fix" &&
-            localReviewHighSeverityNeedsRetry(config, refreshedLifecycle.recordForState, postReady.pr)
-          ? truncate(localReviewFailureSummary(refreshedLifecycle.recordForState), 1000)
-          : record.last_error,
-    last_failure_context: effectiveFailureContext,
-    ...args.applyFailureSignature(record, effectiveFailureContext),
-    blocked_reason:
-      refreshedLifecycle.nextState === "blocked"
-        ? args.blockedReasonFromReviewState(
-            refreshedLifecycle.recordForState,
-            postReady.pr,
-            postReady.reviewThreads,
-          ) ??
-          ((localReviewRetryLoopStalled(
-            config,
-            refreshedLifecycle.recordForState,
-            postReady.pr,
-            postReady.checks,
-            postReady.reviewThreads,
-            args.manualReviewThreads,
-            args.configuredBotReviewThreads,
-            args.summarizeChecks,
-            args.mergeConflictDetected,
-          ) ||
-            localReviewHighSeverityNeedsBlock(config, refreshedLifecycle.recordForState, postReady.pr))
-            ? "verification"
-            : null)
-        : null,
-  });
-  state.issues[String(record.issue_number)] = record;
-  await stateStore.save(state);
-
-  return {
-    record,
-    pr: postReady.pr,
-    checks: postReady.checks,
-    reviewThreads: postReady.reviewThreads,
-  };
 }

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -61,12 +61,14 @@ import {
   CodexTurnResult,
   CodexTurnShortCircuit,
   executeCodexTurnPhase,
-  handlePostTurnPullRequestTransitionsPhase,
   loadLocalReviewRepairContext,
   nextExternalReviewMissPatch,
+} from "./run-once-turn-execution";
+import {
+  handlePostTurnPullRequestTransitionsPhase,
   PostTurnPullRequestContext,
   PostTurnPullRequestResult,
-} from "./run-once-turn-execution";
+} from "./post-turn-pull-request";
 import {
   resolveRunnableIssueContext as resolveIssueSelectionContext,
   RestartRunOnce as SelectionRestartRunOnce,


### PR DESCRIPTION
Closes #285
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the post-turn PR refresh/transition path into [src/post-turn-pull-request.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-285/src/post-turn-pull-request.ts), leaving [src/run-once-turn-execution.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-285/src/run-once-turn-execution.ts) focused on Codex turn execution plus re-exports for compatibility. [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-285/src/supervisor.ts) and the direct phase test in [src/run-once-turn-execution.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-285/src/run-once-turn-execution.test.ts) now point at the extracted module, with the existing ready-refresh behavior preserved.

Verification passed with `npx tsx --test src/run-once-turn-execution.test.ts src/supervisor.test.ts` and `npm run build`. I also recorded the turn in the local issue journal and created checkpoint commit `575bd87` (`Extract post-turn PR transition handling`).

Summary: Extracted post-turn PR refresh and transition handling into a dedicated module, kept behavior stable, and committed the refactor as `575bd87`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/run-once-turn-execution.test.ts src/supervisor.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR / continue with any follow-up review on the extracted module boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code architecture by reorganizing pull request lifecycle management. Extracted transition handling and state management logic into a dedicated, focused module to enhance modularity and separation of concerns throughout the system. All related modules have been updated to reference the new location, resulting in a cleaner codebase structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->