### PR TITLE
Turn execution finishing refactor: extract external-review artifact patching from src/run-once-turn-execution.ts (#290)

### DIFF
--- a/src/external-review-miss-state.test.ts
+++ b/src/external-review-miss-state.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { nextExternalReviewMissPatch, syncExternalReviewMissState } from "./external-review-miss-state";
+import { type ExternalReviewMissContext } from "./external-review-misses";
+import { type IssueRunRecord, type SupervisorStateFile } from "./types";
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 102,
+    state: "addressing_review",
+    branch: "codex/issue-102",
+    pr_number: 116,
+    workspace: "/tmp/workspaces/issue-102",
+    journal_path: "/tmp/workspaces/issue-102/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: null,
+    local_review_head_sha: "deadbeef",
+    local_review_blocker_summary: null,
+    local_review_summary_path: "/tmp/reviews/local-review.json",
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 1,
+    implementation_attempt_count: 1,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "deadbeef",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-15T10:15:47.932Z",
+    ...overrides,
+  };
+}
+
+function createState(record: IssueRunRecord): SupervisorStateFile {
+  return {
+    activeIssueNumber: record.issue_number,
+    issues: {
+      [String(record.issue_number)]: record,
+    },
+  };
+}
+
+function createContext(overrides: Partial<ExternalReviewMissContext> = {}): ExternalReviewMissContext {
+  return {
+    artifactPath: "/tmp/reviews/external-review-misses-head-deadbeef.json",
+    matchedCount: 1,
+    nearMatchCount: 2,
+    missedCount: 3,
+    missedFindings: [],
+    regressionTestCandidates: [],
+    ...overrides,
+  };
+}
+
+test("nextExternalReviewMissPatch preserves same-head artifacts when no new miss artifact was written", () => {
+  const patch = nextExternalReviewMissPatch(
+    createRecord({
+      external_review_head_sha: "deadbeef",
+      external_review_misses_path: "/tmp/reviews/external-review-misses-head-deadbeef.json",
+      external_review_matched_findings_count: 1,
+      external_review_near_match_findings_count: 1,
+      external_review_missed_findings_count: 2,
+    }),
+    {
+      headRefOid: "deadbeef",
+    },
+    null,
+  );
+
+  assert.deepEqual(patch, {});
+});
+
+test("nextExternalReviewMissPatch clears stale artifacts when the PR head changes", () => {
+  const patch = nextExternalReviewMissPatch(
+    createRecord({
+      external_review_head_sha: "oldhead",
+      external_review_misses_path: "/tmp/reviews/external-review-misses-head-oldhead.json",
+      external_review_matched_findings_count: 1,
+      external_review_near_match_findings_count: 1,
+      external_review_missed_findings_count: 2,
+    }),
+    {
+      headRefOid: "newhead",
+    },
+    null,
+  );
+
+  assert.deepEqual(patch, {
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+  });
+});
+
+test("syncExternalReviewMissState persists artifact counters and journal updates when a miss artifact is written", async () => {
+  const originalRecord = createRecord();
+  const state = createState(originalRecord);
+  const savedStates: SupervisorStateFile[] = [];
+  const journaledRecords: IssueRunRecord[] = [];
+
+  const record = await syncExternalReviewMissState({
+    stateStore: {
+      touch(currentRecord, patch) {
+        return { ...currentRecord, ...patch };
+      },
+      async save(nextState) {
+        savedStates.push(nextState);
+      },
+    },
+    state,
+    record: originalRecord,
+    pr: { headRefOid: "deadbeef" },
+    context: createContext(),
+    syncJournal: async (nextRecord) => {
+      journaledRecords.push(nextRecord);
+    },
+  });
+
+  assert.equal(record.external_review_head_sha, "deadbeef");
+  assert.equal(record.external_review_misses_path, "/tmp/reviews/external-review-misses-head-deadbeef.json");
+  assert.equal(record.external_review_matched_findings_count, 1);
+  assert.equal(record.external_review_near_match_findings_count, 2);
+  assert.equal(record.external_review_missed_findings_count, 3);
+  assert.equal(state.issues["102"], record);
+  assert.equal(savedStates.length, 1);
+  assert.deepEqual(journaledRecords, [record]);
+});

--- a/src/external-review-miss-state.ts
+++ b/src/external-review-miss-state.ts
@@ -1,0 +1,62 @@
+import { type ExternalReviewMissContext } from "./external-review-misses";
+import { type StateStore } from "./state-store";
+import {
+  type GitHubPullRequest,
+  type IssueRunRecord,
+  type SupervisorStateFile,
+} from "./types";
+
+export function nextExternalReviewMissPatch(
+  record: Pick<
+    IssueRunRecord,
+    | "external_review_head_sha"
+    | "external_review_misses_path"
+    | "external_review_matched_findings_count"
+    | "external_review_near_match_findings_count"
+    | "external_review_missed_findings_count"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid"> | null,
+  context: ExternalReviewMissContext | null,
+): Partial<IssueRunRecord> {
+  if (context && pr) {
+    return {
+      external_review_head_sha: pr.headRefOid,
+      external_review_misses_path: context.artifactPath,
+      external_review_matched_findings_count: context.matchedCount,
+      external_review_near_match_findings_count: context.nearMatchCount,
+      external_review_missed_findings_count: context.missedCount,
+    };
+  }
+
+  if (pr && record.external_review_head_sha && record.external_review_head_sha !== pr.headRefOid) {
+    return {
+      external_review_head_sha: null,
+      external_review_misses_path: null,
+      external_review_matched_findings_count: 0,
+      external_review_near_match_findings_count: 0,
+      external_review_missed_findings_count: 0,
+    };
+  }
+
+  return {};
+}
+
+export async function syncExternalReviewMissState(args: {
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: Pick<GitHubPullRequest, "headRefOid"> | null;
+  context: ExternalReviewMissContext | null;
+  syncJournal: (record: IssueRunRecord) => Promise<void>;
+}): Promise<IssueRunRecord> {
+  const patch = nextExternalReviewMissPatch(args.record, args.pr, args.context);
+  if (Object.keys(patch).length === 0) {
+    return args.record;
+  }
+
+  const record = args.stateStore.touch(args.record, patch);
+  args.state.issues[String(record.issue_number)] = record;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(record);
+  return record;
+}

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -508,6 +508,166 @@ test("executeCodexTurnPhase persists blocked reason and repeated blocker bookkee
   assert.equal(state.issues["102"]?.repeated_failure_signature_count, 1);
 });
 
+test("executeCodexTurnPhase clears stale external-review miss artifacts when the PR head changes", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = {
+    number: 102,
+    title: "Clear stale external review artifacts",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/102",
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "addressing_review",
+        external_review_head_sha: "oldhead",
+        external_review_misses_path: "/tmp/reviews/external-review-misses-head-oldhead.json",
+        external_review_matched_findings_count: 1,
+        external_review_near_match_findings_count: 2,
+        external_review_missed_findings_count: 3,
+      }),
+    },
+  };
+  let syncJournalCalls = 0;
+  let journalReads = 0;
+
+  const result = await executeCodexTurnPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => {
+        throw new Error("unexpected resolvePullRequestForBranch call");
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      previousCodexSummary: null,
+      previousError: null,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      journalPath: path.join("/tmp/workspaces", "issue-102/.codex-supervisor/issue-journal.md"),
+      syncJournal: async () => {
+        syncJournalCalls += 1;
+      },
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      workspaceStatus: {
+        branch: "codex/issue-102",
+        headSha: "head-116",
+        hasUncommittedChanges: false,
+        baseAhead: 0,
+        baseBehind: 0,
+        remoteBranchExists: true,
+        remoteAhead: 0,
+        remoteBehind: 0,
+      },
+      pr: {
+        number: 116,
+        title: "Clear stale external review artifacts",
+        url: "https://example.test/pr/116",
+        state: "OPEN",
+        createdAt: "2026-03-13T06:20:00Z",
+        isDraft: false,
+        reviewDecision: "CHANGES_REQUESTED",
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        headRefName: "codex/issue-102",
+        headRefOid: "newhead",
+        mergedAt: null,
+        copilotReviewState: "not_requested",
+        copilotReviewRequestedAt: null,
+        copilotReviewArrivedAt: null,
+      },
+      checks: [],
+      reviewThreads: [],
+      options: { dryRun: false },
+    },
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-13T06:20:00Z",
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: () => {
+      throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
+    },
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? "## Codex Working Notes\n### Current Handoff\n- Hypothesis: clear stale artifacts.\n"
+        : [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: clear stale artifacts.",
+            "- What changed: cleared stale external review artifact counters.",
+            "- Next exact step: handle the current review feedback.",
+          ].join("\n");
+    },
+    runCodexTurnImpl: async () => ({
+      exitCode: 0,
+      sessionId: "session-102",
+      lastMessage: [
+        "Waiting on manual review",
+        "State hint: blocked",
+        "Blocked reason: manual_review",
+      ].join("\n"),
+      stderr: "",
+      stdout: "",
+    }),
+  });
+
+  assert.deepEqual(result, {
+    kind: "returned",
+    message: "Codex reported blocked for issue #102.",
+  });
+  assert.equal(syncJournalCalls, 2);
+  assert.equal(state.issues["102"]?.external_review_head_sha, null);
+  assert.equal(state.issues["102"]?.external_review_misses_path, null);
+  assert.equal(state.issues["102"]?.external_review_matched_findings_count, 0);
+  assert.equal(state.issues["102"]?.external_review_near_match_findings_count, 0);
+  assert.equal(state.issues["102"]?.external_review_missed_findings_count, 0);
+});
+
 test("executeCodexTurnPhase loads local-review repair context before building the local_review_fix prompt", async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "turn-execution-local-review-fix-"));
   const reviewDir = path.join(workspaceDir, "reviews");

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -14,6 +14,7 @@ import {
   loadRelevantExternalReviewMissPatterns,
   writeExternalReviewMissArtifact,
 } from "./external-review-misses";
+import { syncExternalReviewMissState } from "./external-review-miss-state";
 import { GitHubClient } from "./github";
 import {
   hasMeaningfulJournalHandoff,
@@ -61,41 +62,6 @@ export {
 
 function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
-}
-
-export function nextExternalReviewMissPatch(
-  record: Pick<
-    IssueRunRecord,
-    | "external_review_head_sha"
-    | "external_review_misses_path"
-    | "external_review_matched_findings_count"
-    | "external_review_near_match_findings_count"
-    | "external_review_missed_findings_count"
-  >,
-  pr: Pick<GitHubPullRequest, "headRefOid"> | null,
-  context: ExternalReviewMissContext | null,
-): Partial<IssueRunRecord> {
-  if (context && pr) {
-    return {
-      external_review_head_sha: pr.headRefOid,
-      external_review_misses_path: context.artifactPath,
-      external_review_matched_findings_count: context.matchedCount,
-      external_review_near_match_findings_count: context.nearMatchCount,
-      external_review_missed_findings_count: context.missedCount,
-    };
-  }
-
-  if (pr && record.external_review_head_sha && record.external_review_head_sha !== pr.headRefOid) {
-    return {
-      external_review_head_sha: null,
-      external_review_misses_path: null,
-      external_review_matched_findings_count: 0,
-      external_review_near_match_findings_count: 0,
-      external_review_missed_findings_count: 0,
-    };
-  }
-
-  return {};
 }
 
 export { loadLocalReviewRepairContext } from "./local-review-repair-context";
@@ -330,13 +296,14 @@ export async function executeCodexTurnPhase(
             localReviewSummaryPath: record.local_review_summary_path,
           })
         : null;
-    const externalReviewMissPatch = nextExternalReviewMissPatch(record, pr, externalReviewMissContext);
-    if (Object.keys(externalReviewMissPatch).length > 0) {
-      record = stateStore.touch(record, externalReviewMissPatch);
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
-    }
+    record = await syncExternalReviewMissState({
+      stateStore,
+      state,
+      record,
+      pr,
+      context: externalReviewMissContext,
+      syncJournal,
+    });
 
     const prompt = record.codex_session_id && shouldUseCompactResumePrompt(record.state)
       ? buildCodexResumePrompt({

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -10,7 +10,6 @@ import {
   formatDetailedStatus,
   inferStateFromPullRequest,
   localReviewHighSeverityNeedsRetry,
-  nextExternalReviewMissPatch,
   recoverUnexpectedCodexTurnFailure,
   summarizeChecks,
 } from "./supervisor";
@@ -5160,47 +5159,6 @@ test("inferStateFromPullRequest blocks a repeatedly unresolved configured bot th
   );
 });
 
-test("nextExternalReviewMissPatch preserves same-head artifacts when no new miss artifact was written", () => {
-  const patch = nextExternalReviewMissPatch(
-    createRecord({
-      external_review_head_sha: "deadbeef",
-      external_review_misses_path: "/tmp/reviews/external-review-misses-head-deadbeef.json",
-      external_review_matched_findings_count: 1,
-      external_review_near_match_findings_count: 1,
-      external_review_missed_findings_count: 2,
-    }),
-    {
-      headRefOid: "deadbeef",
-    },
-    null,
-  );
-
-  assert.deepEqual(patch, {});
-});
-
-test("nextExternalReviewMissPatch clears stale artifacts when the PR head changes", () => {
-  const patch = nextExternalReviewMissPatch(
-    createRecord({
-      external_review_head_sha: "oldhead",
-      external_review_misses_path: "/tmp/reviews/external-review-misses-head-oldhead.json",
-      external_review_matched_findings_count: 1,
-      external_review_near_match_findings_count: 1,
-      external_review_missed_findings_count: 2,
-    }),
-    {
-      headRefOid: "newhead",
-    },
-    null,
-  );
-
-  assert.deepEqual(patch, {
-    external_review_head_sha: null,
-    external_review_misses_path: null,
-    external_review_matched_findings_count: 0,
-    external_review_near_match_findings_count: 0,
-    external_review_missed_findings_count: 0,
-  });
-});
 
 test("formatDetailedStatus shows blocking local review status for current PR head", () => {
   const config = createConfig({ localReviewPolicy: "block_ready" });

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -62,8 +62,8 @@ import {
   CodexTurnShortCircuit,
   executeCodexTurnPhase,
   loadLocalReviewRepairContext,
-  nextExternalReviewMissPatch,
 } from "./run-once-turn-execution";
+import { nextExternalReviewMissPatch } from "./external-review-miss-state";
 import {
   handlePostTurnPullRequestTransitionsPhase,
   PostTurnPullRequestContext,
@@ -131,8 +131,8 @@ import {
 
 export {
   loadLocalReviewRepairContext,
-  nextExternalReviewMissPatch,
 } from "./run-once-turn-execution";
+export { nextExternalReviewMissPatch } from "./external-review-miss-state";
 export {
   hasProcessedReviewThread,
   localReviewBlocksMerge,


### PR DESCRIPTION
Closes #290
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the external-review miss state logic out of [`src/run-once-turn-execution.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-290/src/run-once-turn-execution.ts) into [`src/external-review-miss-state.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-290/src/external-review-miss-state.ts). The new module owns both the pure patch computation and the state/journal sync step, and [`src/supervisor.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-290/src/supervisor.ts) now re-exports the helper from there.

I added focused coverage in [`src/external-review-miss-state.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-290/src/external-review-miss-state.test.ts) and tightened integration coverage in [`src/run-once-turn-execution.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-290/src/run-once-turn-execution.test.ts) for stale-head artifact resets. The old broad helper assertions were removed from [`src/supervisor.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-290/src/supervisor.test.ts). I also updated the local issue journal handoff and committed the code as `254bdcd` (`Extract external review miss state helpers`).

Verification ran with `npx tsx --test src/external-review-miss-state.test.ts src/run-once-turn-execution.test.ts` and `npm run build`. I had to run `npm install` first because `tsc` was not installed in this worktree.

Summary: Extracted external-review miss patch/state sync into a dedic...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed stale external review artifacts remaining when pull request head changes; artifacts are now properly cleared upon PR head updates.

* **Chores**
  * Reorganized external review miss-state handling logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->