### PR TITLE
Supervisor reporting refactor: extract review-thread aggregation and blocker-summary helpers (#294)

### DIFF
--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -5,12 +5,14 @@ import {
   localReviewRetryLoopStalled,
 } from "./review-handling";
 import {
-  configuredBotReviewThreads,
-  manualReviewThreads,
   mergeConflictDetected,
-  pendingBotReviewThreads,
   summarizeChecks,
 } from "./supervisor-reporting";
+import {
+  configuredBotReviewThreads,
+  manualReviewThreads,
+  pendingBotReviewThreads,
+} from "./review-thread-reporting";
 import {
   BlockedReason,
   FailureContext,

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildManualReviewFailureContext,
+  buildRequestedChangesFailureContext,
+  buildStalledBotReviewFailureContext,
+  configuredBotReviewThreads,
+  pendingBotReviewThreads,
+} from "./review-thread-reporting";
+import { GitHubPullRequest, ReviewThread, SupervisorConfig } from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+      specialist: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/reopen-issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createProcessedThreadRecord(overrides: Partial<{
+  processed_review_thread_ids: string[];
+  processed_review_thread_fingerprints: string[];
+  last_head_sha: string | null;
+}> = {}) {
+  return {
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    last_head_sha: null,
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T00:00:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    headRefName: "codex/issue-44",
+    headRefOid: "head-a",
+    ...overrides,
+  };
+}
+
+function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test("configuredBotReviewThreads normalizes configured bot logins before classifying threads", () => {
+  const config = createConfig({
+    reviewBotLogins: [" Copilot-Pull-Request-Reviewer "],
+  });
+
+  const matchingThread = createReviewThread();
+  const manualThread = createReviewThread({
+    id: "thread-2",
+    comments: {
+      nodes: [
+        {
+          id: "comment-2",
+          body: "Human feedback.",
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "reviewer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(configuredBotReviewThreads(config, [matchingThread, manualThread]), [matchingThread]);
+});
+
+test("pendingBotReviewThreads leaves a same-head configured thread pending when the latest comment changed", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const record = createProcessedThreadRecord({
+    last_head_sha: "head-a",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+  });
+  const pr = createPullRequest();
+  const updatedThread = createReviewThread({
+    comments: {
+      nodes: [
+        createReviewThread().comments.nodes[0],
+        {
+          id: "comment-2",
+          body: "One more note on the same thread.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(pendingBotReviewThreads(config, record, pr, [updatedThread]), [updatedThread]);
+});
+
+test("buildManualReviewFailureContext includes reviewer details and normalized body text", () => {
+  const context = buildManualReviewFailureContext([
+    createReviewThread({
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Please\naddress this.",
+            createdAt: "2026-03-11T00:00:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "reviewer",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    }),
+  ]);
+
+  assert.equal(context?.category, "manual");
+  assert.equal(context?.summary, "1 unresolved manual or unconfigured review thread(s) require human attention.");
+  assert.deepEqual(context?.details, ["src/file.ts:12 reviewer=reviewer Please address this."]);
+});
+
+test("buildStalledBotReviewFailureContext carries processed-on-current-head details for configured bots", () => {
+  const context = buildStalledBotReviewFailureContext([createReviewThread()]);
+
+  assert.equal(context?.category, "manual");
+  assert.equal(
+    context?.summary,
+    "1 configured bot review thread(s) remain unresolved after processing on the current head and now require manual attention.",
+  );
+  assert.deepEqual(context?.details, [
+    "reviewer=copilot-pull-request-reviewer file=src/file.ts line=12 processed_on_current_head=yes",
+  ]);
+});
+
+test("buildRequestedChangesFailureContext keeps requested-changes blocker wording stable", () => {
+  const context = buildRequestedChangesFailureContext(createPullRequest());
+
+  assert.equal(context.category, "manual");
+  assert.equal(context.summary, "PR #44 has requested changes and requires manual review resolution before merge.");
+  assert.equal(context.signature, "changes-requested:head-a");
+  assert.deepEqual(context.details, ["reviewDecision=CHANGES_REQUESTED"]);
+});

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -1,0 +1,123 @@
+import { hasProcessedReviewThread } from "./review-handling";
+import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./types";
+import { nowIso } from "./utils";
+
+function configuredReviewBots(config: SupervisorConfig): string[] {
+  return config.reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
+}
+
+function isAllowedReviewBotThread(config: SupervisorConfig, thread: ReviewThread): boolean {
+  const configuredLogins = new Set(configuredReviewBots(config).map((login) => login.toLowerCase()));
+  return thread.comments.nodes.some((comment) => {
+    const login = comment.author?.login?.toLowerCase();
+    return Boolean(login && configuredLogins.has(login));
+  });
+}
+
+export function latestReviewComment(thread: ReviewThread) {
+  return thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
+}
+
+export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter((thread) => !isAllowedReviewBotThread(config, thread));
+}
+
+export function configuredBotReviewThreads(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  return reviewThreads.filter((thread) => isAllowedReviewBotThread(config, thread));
+}
+
+export function pendingBotReviewThreads(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "last_head_sha"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  return configuredBotReviewThreads(config, reviewThreads).filter(
+    (thread) => !hasProcessedReviewThread(record, pr, thread),
+  );
+}
+
+export function buildReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
+  if (reviewThreads.length === 0) {
+    return null;
+  }
+
+  const details = reviewThreads.slice(0, 5).map((thread) => {
+    const latestComment = latestReviewComment(thread);
+    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
+  });
+
+  return {
+    category: "review",
+    summary: `${reviewThreads.length} unresolved automated review thread(s) remain.`,
+    signature: reviewThreads.map((thread) => thread.id).join("|"),
+    command: null,
+    details,
+    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
+    updated_at: nowIso(),
+  };
+}
+
+export function buildManualReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
+  if (reviewThreads.length === 0) {
+    return null;
+  }
+
+  const details = reviewThreads.slice(0, 5).map((thread) => {
+    const latestComment = latestReviewComment(thread);
+    const author = latestComment?.author?.login ?? "unknown";
+    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} reviewer=${author} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
+  });
+
+  return {
+    category: "manual",
+    summary: `${reviewThreads.length} unresolved manual or unconfigured review thread(s) require human attention.`,
+    signature: reviewThreads.map((thread) => `manual:${thread.id}`).join("|"),
+    command: null,
+    details,
+    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
+    updated_at: nowIso(),
+  };
+}
+
+export function buildRequestedChangesFailureContext(
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "reviewDecision" | "url">,
+): FailureContext {
+  return {
+    category: "manual",
+    summary: `PR #${pr.number} has requested changes and requires manual review resolution before merge.`,
+    signature: `changes-requested:${pr.headRefOid}`,
+    command: null,
+    details: [`reviewDecision=${pr.reviewDecision ?? "none"}`],
+    url: pr.url,
+    updated_at: nowIso(),
+  };
+}
+
+export function buildStalledBotReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
+  if (reviewThreads.length === 0) {
+    return null;
+  }
+
+  const details = reviewThreads.slice(0, 5).map((thread) => {
+    const latestComment = latestReviewComment(thread);
+    const author = latestComment?.author?.login ?? "unknown";
+    return `reviewer=${author} file=${thread.path ?? "unknown"} line=${thread.line ?? "?"} processed_on_current_head=yes`;
+  });
+
+  return {
+    category: "manual",
+    summary: `${reviewThreads.length} configured bot review thread(s) remain unresolved after processing on the current head and now require manual attention.`,
+    signature: reviewThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
+    command: null,
+    details,
+    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
+    updated_at: nowIso(),
+  };
+}

--- a/src/supervisor-reporting.ts
+++ b/src/supervisor-reporting.ts
@@ -14,6 +14,12 @@ import {
   buildDetailedStatusSummaryLines,
   sanitizeStatusValue,
 } from "./supervisor-status-model";
+import {
+  configuredBotReviewThreads,
+  latestReviewComment,
+  manualReviewThreads,
+  pendingBotReviewThreads,
+} from "./review-thread-reporting";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
 import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";
 
@@ -43,58 +49,8 @@ export function summarizeChecks(
   return { allPassing, hasPending, hasFailing };
 }
 
-export function latestReviewComment(thread: ReviewThread) {
-  return thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
-}
-
-function isAllowedReviewBotThread(config: SupervisorConfig, thread: ReviewThread): boolean {
-  const configuredLogins = new Set(configuredReviewBots(config).map((login) => login.toLowerCase()));
-  return thread.comments.nodes.some((comment) => {
-    const login = comment.author?.login?.toLowerCase();
-    return Boolean(login && configuredLogins.has(login));
-  });
-}
-
-export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
-  return reviewThreads.filter((thread) => !isAllowedReviewBotThread(config, thread));
-}
-
-export function configuredBotReviewThreads(
-  config: SupervisorConfig,
-  reviewThreads: ReviewThread[],
-): ReviewThread[] {
-  return reviewThreads.filter((thread) => isAllowedReviewBotThread(config, thread));
-}
-
-export function pendingBotReviewThreads(
-  config: SupervisorConfig,
-  record: Pick<
-    IssueRunRecord,
-    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "last_head_sha"
-  >,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-  reviewThreads: ReviewThread[],
-): ReviewThread[] {
-  return configuredBotReviewThreads(config, reviewThreads).filter(
-    (thread) => !hasProcessedReviewThread(record, pr, thread),
-  );
-}
-
 export function mergeConflictDetected(pr: GitHubPullRequest): boolean {
   return pr.mergeStateStatus === "DIRTY";
-}
-
-function configuredReviewBots(config: SupervisorConfig): string[] {
-  return config.reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
-}
-
-function repoExpectsConfiguredBotReview(config: SupervisorConfig): boolean {
-  return configuredReviewBots(config).length > 0;
-}
-
-function repoUsesCopilotOnlyReviewBot(config: SupervisorConfig): boolean {
-  const bots = configuredReviewBots(config);
-  return bots.length === 1 && bots[0].toLowerCase() === "copilot-pull-request-reviewer";
 }
 
 function displayStatusArtifactPath(config: SupervisorConfig, filePath: string): string {
@@ -244,3 +200,9 @@ export function formatDetailedStatus(args: {
 }
 
 export { sanitizeStatusValue };
+export {
+  configuredBotReviewThreads,
+  latestReviewComment,
+  manualReviewThreads,
+  pendingBotReviewThreads,
+} from "./review-thread-reporting";

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -99,15 +99,20 @@ import {
 import { StateStore } from "./state-store";
 import {
   buildDurableGuardrailStatusLine,
-  configuredBotReviewThreads,
   formatDetailedStatus,
-  latestReviewComment,
-  manualReviewThreads,
   mergeConflictDetected,
-  pendingBotReviewThreads,
   sanitizeStatusValue,
   summarizeChecks,
 } from "./supervisor-reporting";
+import {
+  buildManualReviewFailureContext,
+  buildRequestedChangesFailureContext,
+  buildReviewFailureContext,
+  buildStalledBotReviewFailureContext,
+  configuredBotReviewThreads,
+  manualReviewThreads,
+  pendingBotReviewThreads,
+} from "./review-thread-reporting";
 import {
   BlockedReason,
   CliOptions,
@@ -205,83 +210,6 @@ export function buildChecksFailureContext(pr: GitHubPullRequest, checks: PullReq
     command: "gh pr checks",
     details: failingChecks.map((check) => `${check.name} (${check.bucket}/${check.state}) ${check.link ?? ""}`.trim()),
     url: pr.url,
-    updated_at: nowIso(),
-  };
-}
-
-function buildReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
-  if (reviewThreads.length === 0) {
-    return null;
-  }
-
-  const details = reviewThreads.slice(0, 5).map((thread) => {
-    const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1];
-    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
-  });
-
-  return {
-    category: "review",
-    summary: `${reviewThreads.length} unresolved automated review thread(s) remain.`,
-    signature: reviewThreads.map((thread) => thread.id).join("|"),
-    command: null,
-    details,
-    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
-    updated_at: nowIso(),
-  };
-}
-
-function buildManualReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
-  if (reviewThreads.length === 0) {
-    return null;
-  }
-
-  const details = reviewThreads.slice(0, 5).map((thread) => {
-    const latestComment = latestReviewComment(thread);
-    const author = latestComment?.author?.login ?? "unknown";
-    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} reviewer=${author} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
-  });
-
-  return {
-    category: "manual",
-    summary: `${reviewThreads.length} unresolved manual or unconfigured review thread(s) require human attention.`,
-    signature: reviewThreads.map((thread) => `manual:${thread.id}`).join("|"),
-    command: null,
-    details,
-    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
-    updated_at: nowIso(),
-  };
-}
-
-function buildRequestedChangesFailureContext(pr: GitHubPullRequest): FailureContext {
-  return {
-    category: "manual",
-    summary: `PR #${pr.number} has requested changes and requires manual review resolution before merge.`,
-    signature: `changes-requested:${pr.headRefOid}`,
-    command: null,
-    details: [`reviewDecision=${pr.reviewDecision ?? "none"}`],
-    url: pr.url,
-    updated_at: nowIso(),
-  };
-}
-
-function buildStalledBotReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
-  if (reviewThreads.length === 0) {
-    return null;
-  }
-
-  const details = reviewThreads.slice(0, 5).map((thread) => {
-    const latestComment = latestReviewComment(thread);
-    const author = latestComment?.author?.login ?? "unknown";
-    return `reviewer=${author} file=${thread.path ?? "unknown"} line=${thread.line ?? "?"} processed_on_current_head=yes`;
-  });
-
-  return {
-    category: "manual",
-    summary: `${reviewThreads.length} configured bot review thread(s) remain unresolved after processing on the current head and now require manual attention.`,
-    signature: reviewThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
-    command: null,
-    details,
-    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
     updated_at: nowIso(),
   };
 }


### PR DESCRIPTION
Closes #294
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the review-thread aggregation and blocker-summary logic into [src/review-thread-reporting.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-294/src/review-thread-reporting.ts), then rewired [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-294/src/supervisor.ts), [src/pull-request-state.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-294/src/pull-request-state.ts), and [src/supervisor-reporting.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-294/src/supervisor-reporting.ts) to use it. I also added direct extraction coverage in [src/review-thread-reporting.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-294/src/review-thread-reporting.test.ts) for configured/manual thread classification, same-head pending behavior, and blocker summaries.

Verification passed with `npx tsx --test src/review-thread-reporting.test.ts`, `npx tsx --test src/supervisor.test.ts src/review-handling.test.ts`, and `npm run build`. The code is committed on `codex/issue-294` as `18602cb` (`Extract review thread reporting helpers`). The issue journal was updated locally in `.codex-supervisor/issue-journal.md`; that file is gitignored, so it is not part of the commit.

Summary: Extracted review-thread reporting helpers into a focused module, added direct tests, and verified the refactor with focused tests plus build.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/review-thread-reporting.test.ts`; `npx ts...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized review thread classification and reporting utilities into a dedicated module.
  * Updated imports and exports across related modules to support the new code structure.

* **Tests**
  * Added comprehensive test coverage for review thread handling logic, including bot filtering and failure context generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->