### PR TITLE
Issue #302: extract issue metadata parser helpers

### DIFF
--- a/src/issue-metadata-parser.test.ts
+++ b/src/issue-metadata-parser.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseIssueMetadata,
+  parseRiskyChangeApprovalList,
+} from "./issue-metadata-parser";
+import { GitHubIssue } from "./types";
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 1,
+    title: "Issue",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.com/issues/1",
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+test("parseIssueMetadata preserves dependency and normalization behavior", () => {
+  const issue = createIssue({
+    body: `Part of: #123
+Depends on: #45, #67, #45, ignored, #0
+Parallel group: parser-refactor
+Touches: src/issue-metadata.ts, src/supervisor.ts
+
+## Execution order
+2 of 3`,
+  });
+
+  assert.deepEqual(parseIssueMetadata(issue), {
+    parentIssueNumber: 123,
+    executionOrderIndex: 2,
+    executionOrderTotal: 3,
+    dependsOn: [45, 67],
+    parallelGroup: "parser-refactor",
+    touches: ["src/issue-metadata.ts", "src/supervisor.ts"],
+  });
+});
+
+test("parseRiskyChangeApprovalList preserves approval aliases and normalization", () => {
+  const body = `Risky changes approved: billing, unknown, Billing
+Risky change opt-in: ci
+
+This issue explicitly authorize auth changes.
+This issue explicitly approved for secrets changes.`;
+
+  assert.deepEqual(parseRiskyChangeApprovalList(body), [
+    "auth",
+    "billing",
+    "ci",
+    "secrets",
+  ]);
+});

--- a/src/issue-metadata-parser.ts
+++ b/src/issue-metadata-parser.ts
@@ -1,0 +1,104 @@
+import type { GitHubIssue } from "./types";
+import type { IssueMetadata, RiskyChangeClass } from "./issue-metadata";
+
+const RISKY_CHANGE_CLASSES = ["auth", "billing", "permissions", "ci", "migrations", "secrets"] as const;
+
+function parseIssueNumberList(input: string): number[] {
+  return Array.from(
+    new Set(
+      [...input.matchAll(/#(\d+)/g)]
+        .map((match) => Number(match[1]))
+        .filter((value) => Number.isInteger(value) && value > 0),
+    ),
+  );
+}
+
+function parseList(input: string): string[] {
+  return input
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function normalizeRiskyChangeClass(input: string): RiskyChangeClass | null {
+  const normalized = input.trim().toLowerCase();
+  if ((RISKY_CHANGE_CLASSES as readonly string[]).includes(normalized)) {
+    return normalized as RiskyChangeClass;
+  }
+
+  return null;
+}
+
+export function parseTouchesList(body: string): string[] {
+  const touchesMatch = body.match(/^\s*Touches:\s*(.+)\s*$/im);
+  return touchesMatch ? parseList(touchesMatch[1]) : [];
+}
+
+export function parseExecutionOrder(
+  body: string,
+): { executionOrderIndex: number; executionOrderTotal: number } | null {
+  const headingMatch = body.match(
+    /^\s*##\s*Execution order\s*$[\r\n]+^\s*(\d+)\s+of\s+(\d+)\s*$/im,
+  );
+  if (headingMatch) {
+    return {
+      executionOrderIndex: Number(headingMatch[1]),
+      executionOrderTotal: Number(headingMatch[2]),
+    };
+  }
+
+  const singleLineMatch = body.match(/^\s*Execution order:\s*(\d+)\s+of\s+(\d+)\s*$/im);
+  if (!singleLineMatch) {
+    return null;
+  }
+
+  return {
+    executionOrderIndex: Number(singleLineMatch[1]),
+    executionOrderTotal: Number(singleLineMatch[2]),
+  };
+}
+
+export function parseRiskyChangeApprovalList(body: string): RiskyChangeClass[] {
+  const approved = new Set<RiskyChangeClass>();
+  const metadataMatches = body.matchAll(
+    /^\s*(?:Risky change approval|Risky changes approved|Risky change opt-in):\s*(.+)\s*$/gim,
+  );
+  for (const match of metadataMatches) {
+    for (const value of parseList(match[1])) {
+      const riskyClass = normalizeRiskyChangeClass(value);
+      if (riskyClass) {
+        approved.add(riskyClass);
+      }
+    }
+  }
+
+  const lowerBody = body.toLowerCase();
+  for (const riskyClass of RISKY_CHANGE_CLASSES) {
+    const sentencePatterns = [
+      `explicitly approved for ${riskyClass} changes`,
+      `explicitly authorize ${riskyClass} changes`,
+      `explicitly opt in to ${riskyClass} changes`,
+    ];
+    if (sentencePatterns.some((pattern) => lowerBody.includes(pattern))) {
+      approved.add(riskyClass);
+    }
+  }
+
+  return [...approved].sort();
+}
+
+export function parseIssueMetadata(issue: GitHubIssue): IssueMetadata {
+  const parentMatch = issue.body.match(/^\s*Part of:?\s+#(\d+)\s*$/im);
+  const dependsOnMatch = issue.body.match(/^\s*Depends on:\s*(.+)\s*$/im);
+  const parallelGroupMatch = issue.body.match(/^\s*Parallel group:\s*(.+)\s*$/im);
+  const executionOrder = parseExecutionOrder(issue.body);
+
+  return {
+    parentIssueNumber: parentMatch ? Number(parentMatch[1]) : null,
+    executionOrderIndex: executionOrder?.executionOrderIndex ?? null,
+    executionOrderTotal: executionOrder?.executionOrderTotal ?? null,
+    dependsOn: dependsOnMatch ? parseIssueNumberList(dependsOnMatch[1]) : [],
+    parallelGroup: parallelGroupMatch ? parallelGroupMatch[1].trim() : null,
+    touches: parseTouchesList(issue.body),
+  };
+}

--- a/src/issue-metadata.ts
+++ b/src/issue-metadata.ts
@@ -1,4 +1,12 @@
 import { GitHubIssue, SupervisorStateFile } from "./types";
+import {
+  parseExecutionOrder,
+  parseIssueMetadata,
+  parseRiskyChangeApprovalList,
+  parseTouchesList,
+} from "./issue-metadata-parser";
+
+export { parseIssueMetadata } from "./issue-metadata-parser";
 
 export interface IssueMetadata {
   parentIssueNumber: number | null;
@@ -101,63 +109,8 @@ const HIGH_RISK_AMBIGUITY_SIGNALS: Record<HighRiskAmbiguityClass, RegExp[]> = {
   ],
 };
 
-function parseIssueNumberList(input: string): number[] {
-  return Array.from(
-    new Set(
-      [...input.matchAll(/#(\d+)/g)]
-        .map((match) => Number(match[1]))
-        .filter((value) => Number.isInteger(value) && value > 0),
-    ),
-  );
-}
-
-function parseList(input: string): string[] {
-  return input
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-}
-
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function normalizeRiskyChangeClass(input: string): RiskyChangeClass | null {
-  const normalized = input.trim().toLowerCase();
-  if ((RISKY_CHANGE_CLASSES as readonly string[]).includes(normalized)) {
-    return normalized as RiskyChangeClass;
-  }
-
-  return null;
-}
-
-function parseTouchesList(body: string): string[] {
-  const touchesMatch = body.match(/^\s*Touches:\s*(.+)\s*$/im);
-  return touchesMatch ? parseList(touchesMatch[1]) : [];
-}
-
-function parseExecutionOrder(
-  body: string,
-): { executionOrderIndex: number; executionOrderTotal: number } | null {
-  const headingMatch = body.match(
-    /^\s*##\s*Execution order\s*$[\r\n]+^\s*(\d+)\s+of\s+(\d+)\s*$/im,
-  );
-  if (headingMatch) {
-    return {
-      executionOrderIndex: Number(headingMatch[1]),
-      executionOrderTotal: Number(headingMatch[2]),
-    };
-  }
-
-  const singleLineMatch = body.match(/^\s*Execution order:\s*(\d+)\s+of\s+(\d+)\s*$/im);
-  if (!singleLineMatch) {
-    return null;
-  }
-
-  return {
-    executionOrderIndex: Number(singleLineMatch[1]),
-    executionOrderTotal: Number(singleLineMatch[2]),
-  };
 }
 
 function findMarkdownSectionContent(body: string, title: string): string | null {
@@ -238,35 +191,6 @@ function hasConcreteVerificationTarget(content: string): boolean {
   return listItems.some((item) => item.split(/\s+/).length >= 5);
 }
 
-function parseRiskyChangeApprovalList(body: string): RiskyChangeClass[] {
-  const approved = new Set<RiskyChangeClass>();
-  const metadataMatches = body.matchAll(
-    /^\s*(?:Risky change approval|Risky changes approved|Risky change opt-in):\s*(.+)\s*$/gim,
-  );
-  for (const match of metadataMatches) {
-    for (const value of parseList(match[1])) {
-      const riskyClass = normalizeRiskyChangeClass(value);
-      if (riskyClass) {
-        approved.add(riskyClass);
-      }
-    }
-  }
-
-  const lowerBody = body.toLowerCase();
-  for (const riskyClass of RISKY_CHANGE_CLASSES) {
-    const sentencePatterns = [
-      `explicitly approved for ${riskyClass} changes`,
-      `explicitly authorize ${riskyClass} changes`,
-      `explicitly opt in to ${riskyClass} changes`,
-    ];
-    if (sentencePatterns.some((pattern) => lowerBody.includes(pattern))) {
-      approved.add(riskyClass);
-    }
-  }
-
-  return [...approved].sort();
-}
-
 function detectRiskyChangeClasses(issue: Pick<GitHubIssue, "title" | "body">): RiskyChangeClass[] {
   const detectionInputs = [
     issue.title,
@@ -284,22 +208,6 @@ function detectRiskyChangeClasses(issue: Pick<GitHubIssue, "title" | "body">): R
   }
 
   return [...detected].sort();
-}
-
-export function parseIssueMetadata(issue: GitHubIssue): IssueMetadata {
-  const parentMatch = issue.body.match(/^\s*Part of:?\s+#(\d+)\s*$/im);
-  const dependsOnMatch = issue.body.match(/^\s*Depends on:\s*(.+)\s*$/im);
-  const parallelGroupMatch = issue.body.match(/^\s*Parallel group:\s*(.+)\s*$/im);
-  const executionOrder = parseExecutionOrder(issue.body);
-
-  return {
-    parentIssueNumber: parentMatch ? Number(parentMatch[1]) : null,
-    executionOrderIndex: executionOrder?.executionOrderIndex ?? null,
-    executionOrderTotal: executionOrder?.executionOrderTotal ?? null,
-    dependsOn: dependsOnMatch ? parseIssueNumberList(dependsOnMatch[1]) : [],
-    parallelGroup: parallelGroupMatch ? parallelGroupMatch[1].trim() : null,
-    touches: parseTouchesList(issue.body),
-  };
 }
 
 export function lintExecutionReadyIssueBody(


### PR DESCRIPTION
## Summary
- extract issue metadata parsing and normalization helpers into a dedicated parser module
- keep existing issue-metadata callers compatible by re-exporting parseIssueMetadata
- add focused parser tests for metadata parsing and risky-change approval normalization

## Verification
- npx tsx --test src/issue-metadata-parser.test.ts src/issue-metadata.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for metadata parsing and validation workflows.

* **Refactor**
  * Reorganized internal parsing utilities for improved maintainability and code reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->