### PR TITLE
Supervisor cleanup: extract remaining failure-context builders from src/supervisor.ts (#310)

### DIFF
--- a/src/pull-request-failure-context.ts
+++ b/src/pull-request-failure-context.ts
@@ -1,0 +1,31 @@
+import { FailureContext, GitHubPullRequest, PullRequestCheck } from "./types";
+import { nowIso } from "./utils";
+
+export function buildChecksFailureContext(pr: GitHubPullRequest, checks: PullRequestCheck[]): FailureContext | null {
+  const failingChecks = checks.filter((check) => check.bucket === "fail");
+  if (failingChecks.length === 0) {
+    return null;
+  }
+
+  return {
+    category: "checks",
+    summary: `PR #${pr.number} has failing checks.`,
+    signature: failingChecks.map((check) => `${check.name}:${check.bucket}`).join("|"),
+    command: "gh pr checks",
+    details: failingChecks.map((check) => `${check.name} (${check.bucket}/${check.state}) ${check.link ?? ""}`.trim()),
+    url: pr.url,
+    updated_at: nowIso(),
+  };
+}
+
+export function buildConflictFailureContext(pr: GitHubPullRequest): FailureContext {
+  return {
+    category: "conflict",
+    summary: `PR #${pr.number} has merge conflicts and needs a base-branch integration pass.`,
+    signature: `dirty:${pr.headRefOid}`,
+    command: "git fetch origin && git merge origin/<default-branch>",
+    details: [`mergeStateStatus=${pr.mergeStateStatus ?? "unknown"}`],
+    url: pr.url,
+    updated_at: nowIso(),
+  };
+}

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import {
   Supervisor,
   buildChecksFailureContext,
+  buildConflictFailureContext,
   formatDetailedStatus,
   inferStateFromPullRequest,
   localReviewHighSeverityNeedsRetry,
@@ -4042,6 +4043,75 @@ test("buildChecksFailureContext ignores cancelled runs", () => {
   ];
 
   assert.equal(buildChecksFailureContext(pr, checks), null);
+});
+
+test("buildChecksFailureContext preserves failing-check reporting fields", () => {
+  const pr: GitHubPullRequest = {
+    number: 42,
+    title: "Test PR",
+    url: "https://example.test/pr/42",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "UNSTABLE",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-42",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+  };
+
+  const checks: PullRequestCheck[] = [
+    {
+      name: "build (ubuntu-latest)",
+      state: "FAILURE",
+      bucket: "fail",
+      workflow: "CI",
+      link: "https://example.test/checks/ubuntu",
+    },
+    {
+      name: "test (macos-latest)",
+      state: "TIMED_OUT",
+      bucket: "fail",
+      workflow: "CI",
+    },
+  ];
+
+  const context = buildChecksFailureContext(pr, checks);
+  assert.equal(context?.category, "checks");
+  assert.equal(context?.summary, "PR #42 has failing checks.");
+  assert.equal(context?.signature, "build (ubuntu-latest):fail|test (macos-latest):fail");
+  assert.equal(context?.command, "gh pr checks");
+  assert.deepEqual(context?.details, [
+    "build (ubuntu-latest) (fail/FAILURE) https://example.test/checks/ubuntu",
+    "test (macos-latest) (fail/TIMED_OUT)",
+  ]);
+  assert.equal(context?.url, "https://example.test/pr/42");
+});
+
+test("buildConflictFailureContext preserves merge-conflict reporting fields", () => {
+  const pr: GitHubPullRequest = {
+    number: 42,
+    title: "Test PR",
+    url: "https://example.test/pr/42",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "DIRTY",
+    mergeable: "CONFLICTING",
+    headRefName: "codex/issue-42",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+  };
+
+  const context = buildConflictFailureContext(pr);
+  assert.equal(context.category, "conflict");
+  assert.equal(context.summary, "PR #42 has merge conflicts and needs a base-branch integration pass.");
+  assert.equal(context.signature, "dirty:deadbeef");
+  assert.equal(context.command, "git fetch origin && git merge origin/<default-branch>");
+  assert.deepEqual(context.details, ["mergeStateStatus=DIRTY"]);
+  assert.equal(context.url, "https://example.test/pr/42");
 });
 
 test("supervisor re-exports PR state inference from the dedicated pull-request-state module", () => {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -69,6 +69,7 @@ import {
   PostTurnPullRequestContext,
   PostTurnPullRequestResult,
 } from "./post-turn-pull-request";
+import { buildChecksFailureContext, buildConflictFailureContext } from "./pull-request-failure-context";
 import {
   resolveRunnableIssueContext as resolveIssueSelectionContext,
   RestartRunOnce as SelectionRestartRunOnce,
@@ -153,6 +154,7 @@ export {
   processedReviewThreadKey,
 } from "./review-handling";
 export { inferStateFromPullRequest } from "./pull-request-state";
+export { buildChecksFailureContext, buildConflictFailureContext } from "./pull-request-failure-context";
 export { reconcileRecoverableBlockedIssueStates } from "./recovery-reconciliation";
 export { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
 export { recoverUnexpectedCodexTurnFailure } from "./supervisor-failure-helpers";
@@ -196,36 +198,6 @@ function inferStateWithoutPullRequest(
 
   return "stabilizing";
 }
-
-export function buildChecksFailureContext(pr: GitHubPullRequest, checks: PullRequestCheck[]): FailureContext | null {
-  const failingChecks = checks.filter((check) => check.bucket === "fail");
-  if (failingChecks.length === 0) {
-    return null;
-  }
-
-  return {
-    category: "checks",
-    summary: `PR #${pr.number} has failing checks.`,
-    signature: failingChecks.map((check) => `${check.name}:${check.bucket}`).join("|"),
-    command: "gh pr checks",
-    details: failingChecks.map((check) => `${check.name} (${check.bucket}/${check.state}) ${check.link ?? ""}`.trim()),
-    url: pr.url,
-    updated_at: nowIso(),
-  };
-}
-
-function buildConflictFailureContext(pr: GitHubPullRequest): FailureContext {
-  return {
-    category: "conflict",
-    summary: `PR #${pr.number} has merge conflicts and needs a base-branch integration pass.`,
-    signature: `dirty:${pr.headRefOid}`,
-    command: "git fetch origin && git merge origin/<default-branch>",
-    details: [`mergeStateStatus=${pr.mergeStateStatus ?? "unknown"}`],
-    url: pr.url,
-    updated_at: nowIso(),
-  };
-}
-
 
 function shouldStopForRepeatedFailureSignature(record: IssueRunRecord, config: SupervisorConfig): boolean {
   return (


### PR DESCRIPTION
Closes #310
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the remaining PR failure-context builders into [pull-request-failure-context.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-310/src/pull-request-failure-context.ts) and re-exported them from [supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-310/src/supervisor.ts). I also tightened focused coverage in [supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-310/src/supervisor.test.ts) to lock the checks and merge-conflict payload shapes before and after the move.

Focused verification passed with `./node_modules/.bin/tsx --test src/supervisor.test.ts --test-name-pattern="build(Check|Conflict)FailureContext"` and `npm run build`. I committed the checkpoint as `2642767` (`Extract PR failure context helpers`).

Summary: Extracted checks/conflict failure-context builders from `src/supervisor.ts`, added focused payload-shape tests, and committed the change.
State hint: implementing
Blocked reason: none
Tests: `./node_modules/.bin/tsx --test src/supervisor.test.ts --test-name-pattern="build(Check|Conflict)FailureContext"`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-310` if supervisor flow requires it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured failure context generation for pull request check failures and merge conflicts.

* **Tests**
  * Added test coverage for new failure context generation capabilities.

* **Refactor**
  * Reorganized internal utilities to improve code modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->