### PR TITLE
Supervisor cleanup: extract no-PR state inference helper from src/supervisor.ts (#311)

### DIFF
--- a/src/no-pull-request-state.test.ts
+++ b/src/no-pull-request-state.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inferStateWithoutPullRequest } from "./no-pull-request-state";
+import { IssueRunRecord, WorkspaceStatus } from "./types";
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 366,
+    state: "blocked",
+    branch: "codex/reopen-issue-366",
+    pr_number: null,
+    workspace: "/tmp/workspaces/issue-366",
+    journal_path: "/tmp/workspaces/issue-366/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: "session-1",
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 2,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 1,
+    last_head_sha: "abcdef1",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: "Codex completed without updating the issue journal for issue #366.",
+    last_failure_kind: null,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Codex completed without updating the issue journal for issue #366.",
+      signature: "handoff-missing",
+      command: null,
+      details: ["Update the Codex Working Notes section before ending the turn."],
+      url: null,
+      updated_at: "2026-03-11T01:50:41.997Z",
+    },
+    last_blocker_signature: null,
+    last_failure_signature: "handoff-missing",
+    blocked_reason: "handoff_missing",
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-11T01:50:41.997Z",
+    ...overrides,
+  };
+}
+
+function createWorkspaceStatus(overrides: Partial<WorkspaceStatus> = {}): WorkspaceStatus {
+  return {
+    branch: "codex/reopen-issue-366",
+    headSha: "abcdef1",
+    hasUncommittedChanges: false,
+    baseAhead: 0,
+    baseBehind: 0,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+    remoteBehind: 0,
+    ...overrides,
+  };
+}
+
+test("inferStateWithoutPullRequest preserves no-PR state policy branches", () => {
+  const cases = [
+    {
+      name: "keeps zero-attempt runs in reproducing",
+      record: createRecord({ implementation_attempt_count: 0, state: "stabilizing" }),
+      workspaceStatus: createWorkspaceStatus({ baseAhead: 1 }),
+      expected: "reproducing",
+    },
+    {
+      name: "promotes a clean checkpoint branch to draft_pr",
+      record: createRecord({ state: "implementing" }),
+      workspaceStatus: createWorkspaceStatus({ baseAhead: 1 }),
+      expected: "draft_pr",
+    },
+    {
+      name: "keeps planning and reproducing states in reproducing without a clean checkpoint",
+      record: createRecord({ state: "planning" }),
+      workspaceStatus: createWorkspaceStatus({ hasUncommittedChanges: true, baseAhead: 1 }),
+      expected: "reproducing",
+    },
+    {
+      name: "falls back to stabilizing after implementation without a clean checkpoint",
+      record: createRecord({ state: "implementing" }),
+      workspaceStatus: createWorkspaceStatus({ hasUncommittedChanges: true, remoteAhead: 1 }),
+      expected: "stabilizing",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    assert.equal(
+      inferStateWithoutPullRequest(testCase.record, testCase.workspaceStatus),
+      testCase.expected,
+      testCase.name,
+    );
+  }
+});

--- a/src/no-pull-request-state.ts
+++ b/src/no-pull-request-state.ts
@@ -1,0 +1,21 @@
+import { IssueRunRecord, RunState, WorkspaceStatus } from "./types";
+
+export function inferStateWithoutPullRequest(
+  record: IssueRunRecord,
+  workspaceStatus: WorkspaceStatus,
+): RunState {
+  const branchHasCheckpoint = workspaceStatus.baseAhead > 0 || workspaceStatus.remoteAhead > 0;
+  if (record.implementation_attempt_count === 0) {
+    return "reproducing";
+  }
+
+  if (branchHasCheckpoint && !workspaceStatus.hasUncommittedChanges) {
+    return "draft_pr";
+  }
+
+  if (record.state === "planning" || record.state === "reproducing") {
+    return "reproducing";
+  }
+
+  return "stabilizing";
+}

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -35,6 +35,7 @@ import {
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,
 } from "./pull-request-state";
+import { inferStateWithoutPullRequest } from "./no-pull-request-state";
 import {
   hasProcessedReviewThread,
   localReviewBlocksMerge,
@@ -154,6 +155,7 @@ export {
   processedReviewThreadKey,
 } from "./review-handling";
 export { inferStateFromPullRequest } from "./pull-request-state";
+export { inferStateWithoutPullRequest } from "./no-pull-request-state";
 export { buildChecksFailureContext, buildConflictFailureContext } from "./pull-request-failure-context";
 export { reconcileRecoverableBlockedIssueStates } from "./recovery-reconciliation";
 export { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
@@ -177,26 +179,6 @@ function shouldPreserveNoPrFailureTracking(record: IssueRunRecord): boolean {
     record.last_failure_signature !== null &&
     record.repeated_failure_signature_count > 0
   );
-}
-
-function inferStateWithoutPullRequest(
-  record: IssueRunRecord,
-  workspaceStatus: WorkspaceStatus,
-): RunState {
-  const branchHasCheckpoint = workspaceStatus.baseAhead > 0 || workspaceStatus.remoteAhead > 0;
-  if (record.implementation_attempt_count === 0) {
-    return "reproducing";
-  }
-
-  if (branchHasCheckpoint && !workspaceStatus.hasUncommittedChanges) {
-    return "draft_pr";
-  }
-
-  if (record.state === "planning" || record.state === "reproducing") {
-    return "reproducing";
-  }
-
-  return "stabilizing";
 }
 
 function shouldStopForRepeatedFailureSignature(record: IssueRunRecord, config: SupervisorConfig): boolean {


### PR DESCRIPTION
Closes #311
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the no-PR inference helper into [`src/no-pull-request-state.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-311/src/no-pull-request-state.ts#L1) and updated [`src/supervisor.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-311/src/supervisor.ts#L30) to import and re-export it so existing callers stay compatible. I added focused direct coverage in [`src/no-pull-request-state.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-311/src/no-pull-request-state.test.ts#L1) for the preserved `reproducing`, `draft_pr`, and `stabilizing` branches.

Verification passed with `npm test -- src/no-pull-request-state.test.ts` and `npm run build`. The branch has a coherent checkpoint commit: `33d57d3` (`Extract no-PR supervisor state helper`). I also updated the local issue journal handoff notes.

Summary: Extracted no-PR supervisor state inference into a dedicated helper module, added focused policy tests, and verified build/test locally
State hint: stabilizing
Blocked reason: none
Tests: `npm test -- src/no-pull-request-state.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for branch `codex/issue-311` with commit `33d57d3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for state management across multiple scenarios, including branch checkpoint detection and uncommitted changes handling.

* **Refactor**
  * Reorganized implementation into separate modules for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->