### PR TITLE
Clean up supervisor module exports

### DIFF
--- a/src/codex.test.ts
+++ b/src/codex.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { buildCodexPrompt, buildCodexResumePrompt, extractStateHint, shouldUseCompactResumePrompt } from "./codex";
-import { loadLocalReviewRepairContext } from "./supervisor";
+import { loadLocalReviewRepairContext } from "./local-review-repair-context";
 import { FailureContext, GitHubIssue, RunState } from "./types";
 import { type VerifierGuardrailRule } from "./verifier-guardrails";
 

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -6,18 +6,15 @@ import os from "node:os";
 import path from "node:path";
 import {
   Supervisor,
-  buildChecksFailureContext,
-  buildConflictFailureContext,
-  formatDetailedStatus,
-  inferStateFromPullRequest,
-  localReviewHighSeverityNeedsRetry,
-  recoverUnexpectedCodexTurnFailure,
-  summarizeChecks,
 } from "./supervisor";
+import { buildChecksFailureContext, buildConflictFailureContext } from "./pull-request-failure-context";
+import { inferStateFromPullRequest } from "./pull-request-state";
+import { localReviewHighSeverityNeedsRetry } from "./review-handling";
+import { recoverUnexpectedCodexTurnFailure } from "./supervisor-failure-helpers";
+import { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
 import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
 import { shouldAutoRetryHandoffMissing } from "./supervisor-execution-policy";
 import { handleAuthFailure } from "./supervisor-failure-helpers";
-import { inferStateFromPullRequest as inferPullRequestStateFromModule } from "./pull-request-state";
 import {
   formatRecoveryLog,
   reconcileMergedIssueClosures,
@@ -4216,8 +4213,8 @@ test("buildConflictFailureContext preserves merge-conflict reporting fields", ()
   assert.equal(context.url, "https://example.test/pr/42");
 });
 
-test("supervisor re-exports PR state inference from the dedicated pull-request-state module", () => {
-  assert.equal(inferStateFromPullRequest, inferPullRequestStateFromModule);
+test("supervisor module continues to export the Supervisor class", () => {
+  assert.equal(typeof Supervisor, "function");
 });
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1,6 +1,4 @@
 import path from "node:path";
-import {
-} from "./codex";
 import { loadConfig } from "./config";
 import { GitHubClient } from "./github";
 import { describeGsdIntegration } from "./gsd";
@@ -126,32 +124,6 @@ import {
   getWorkspaceStatus,
   pushBranch,
 } from "./workspace";
-
-export {
-  loadLocalReviewRepairContext,
-} from "./run-once-turn-execution";
-export { nextExternalReviewMissPatch } from "./external-review-miss-state";
-export {
-  hasProcessedReviewThread,
-  localReviewBlocksMerge,
-  localReviewBlocksReady,
-  localReviewFailureContext,
-  localReviewFailureSummary,
-  localReviewHighSeverityNeedsBlock,
-  localReviewHighSeverityNeedsRetry,
-  localReviewRetryLoopCandidate,
-  localReviewRetryLoopStalled,
-  localReviewStallFailureContext,
-  nextLocalReviewSignatureTracking,
-  processedReviewThreadKey,
-} from "./review-handling";
-export { inferStateFromPullRequest } from "./pull-request-state";
-export { inferStateWithoutPullRequest } from "./no-pull-request-state";
-export { buildChecksFailureContext, buildConflictFailureContext } from "./pull-request-failure-context";
-export { reconcileRecoverableBlockedIssueStates } from "./recovery-reconciliation";
-export { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
-export { recoverUnexpectedCodexTurnFailure } from "./supervisor-failure-helpers";
-export { shouldAutoRetryHandoffMissing } from "./supervisor-execution-policy";
 
 const MAX_PROCESSED_REVIEW_THREAD_IDS = 200;
 


### PR DESCRIPTION
## Summary
- remove incidental helper re-exports from `src/supervisor.ts`
- update affected tests to import helpers from their dedicated modules
- keep the `Supervisor` export surface intact while reducing facade clutter

## Testing
- npx tsx --test src/codex.test.ts
- npx tsx --test src/supervisor.test.ts
- npm run build

Closes #313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized module structure to improve code organization and maintainability. Utility functions have been relocated to dedicated modules for better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->