### PR TITLE
Supervisor cleanup: move remaining small glue helpers out of src/supervisor.ts (#319)

### DIFF
--- a/src/no-pull-request-state.test.ts
+++ b/src/no-pull-request-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { inferStateWithoutPullRequest } from "./no-pull-request-state";
+import { inferStateWithoutPullRequest, shouldPreserveNoPrFailureTracking } from "./no-pull-request-state";
 import { IssueRunRecord, WorkspaceStatus } from "./types";
 
 function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
@@ -118,4 +118,33 @@ test("inferStateWithoutPullRequest preserves no-PR state policy branches", () =>
       testCase.name,
     );
   }
+});
+
+test("shouldPreserveNoPrFailureTracking only keeps repeated blocked no-PR failures", () => {
+  assert.equal(shouldPreserveNoPrFailureTracking(createRecord()), true);
+  assert.equal(
+    shouldPreserveNoPrFailureTracking(createRecord({ repeated_failure_signature_count: 0 })),
+    false,
+  );
+  assert.equal(
+    shouldPreserveNoPrFailureTracking(createRecord({ last_failure_signature: null })),
+    false,
+  );
+  assert.equal(
+    shouldPreserveNoPrFailureTracking(
+      createRecord({
+        last_failure_context: {
+          category: "manual",
+          summary: "Needs manual follow-up.",
+          signature: "manual-follow-up",
+          command: null,
+          details: [],
+          url: null,
+          updated_at: "2026-03-11T01:50:41.997Z",
+        },
+      }),
+    ),
+    false,
+  );
+  assert.equal(shouldPreserveNoPrFailureTracking(createRecord({ pr_number: 123 })), false);
 });

--- a/src/no-pull-request-state.ts
+++ b/src/no-pull-request-state.ts
@@ -1,5 +1,19 @@
 import { IssueRunRecord, RunState, WorkspaceStatus } from "./types";
 
+export function shouldPreserveNoPrFailureTracking(
+  record: Pick<
+    IssueRunRecord,
+    "pr_number" | "last_failure_context" | "last_failure_signature" | "repeated_failure_signature_count"
+  >,
+): boolean {
+  return (
+    record.pr_number === null &&
+    record.last_failure_context?.category === "blocked" &&
+    record.last_failure_signature !== null &&
+    record.repeated_failure_signature_count > 0
+  );
+}
+
 export function inferStateWithoutPullRequest(
   record: IssueRunRecord,
   workspaceStatus: WorkspaceStatus,

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -23,7 +23,7 @@ import {
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,
 } from "./pull-request-state";
-import { inferStateWithoutPullRequest } from "./no-pull-request-state";
+import { inferStateWithoutPullRequest, shouldPreserveNoPrFailureTracking } from "./no-pull-request-state";
 import {
   hasProcessedReviewThread,
   localReviewBlocksMerge,
@@ -125,25 +125,6 @@ import {
   getWorkspaceStatus,
   pushBranch,
 } from "./workspace";
-
-const MAX_PROCESSED_REVIEW_THREAD_IDS = 200;
-
-function trimProcessedReviewThreadIds(ids: string[]): string[] {
-  if (ids.length <= MAX_PROCESSED_REVIEW_THREAD_IDS) {
-    return ids;
-  }
-
-  return ids.slice(ids.length - MAX_PROCESSED_REVIEW_THREAD_IDS);
-}
-
-function shouldPreserveNoPrFailureTracking(record: IssueRunRecord): boolean {
-  return (
-    record.pr_number === null &&
-    record.last_failure_context?.category === "blocked" &&
-    record.last_failure_signature !== null &&
-    record.repeated_failure_signature_count > 0
-  );
-}
 
 function shouldStopForRepeatedFailureSignature(record: IssueRunRecord, config: SupervisorConfig): boolean {
   return (


### PR DESCRIPTION
Closes #319
This PR was opened by codex-supervisor.
Latest Codex summary:

Moved the no-PR failure-tracking preservation rule out of [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-319/src/supervisor.ts) into [src/no-pull-request-state.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-319/src/no-pull-request-state.ts), added focused coverage in [src/no-pull-request-state.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-319/src/no-pull-request-state.test.ts), and removed the unused `trimProcessedReviewThreadIds(...)` helper from the supervisor facade. The code changes are committed as `5f606df` (`Refactor no-PR supervisor helpers`).

Verification passed with `npx tsx --test src/no-pull-request-state.test.ts src/run-once-turn-execution.test.ts`, `npx tsx --test src/supervisor.test.ts --test-name-pattern "reprocesses a configured bot review thread once after a new PR head commit and then blocks if it remains unresolved"`, and `npm run build`. I also updated the local issue journal at [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-319/.codex-supervisor/issue-journal.md); that file is gitignored, so it remains as an uncommitted local handoff note.

Summary: Moved the live no-PR helper into `no-pull-request-state`, removed an unused supervisor helper, added focused regression coverage, and committed the code changes.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/no-pull-request-state.test.ts src/run-once-turn-execution.test.ts`; `npx ts...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for failure tracking preservation logic.

* **Refactor**
  * Reorganized internal failure tracking system for improved code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->