### PR TITLE
Supervisor finishing cleanup: extract final lifecycle and orchestration glue from src/supervisor.ts (#322)

### DIFF
--- a/src/supervisor-lifecycle.test.ts
+++ b/src/supervisor-lifecycle.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { derivePullRequestLifecycleSnapshot, shouldRunCodex } from "./supervisor-lifecycle";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: {
+        confidenceThreshold: 0.7,
+        minimumSeverity: "low",
+      },
+      specialist: {
+        confidenceThreshold: 0.7,
+        minimumSeverity: "low",
+      },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/reopen-issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 366,
+    state: "blocked",
+    branch: "codex/reopen-issue-366",
+    pr_number: 44,
+    workspace: "/tmp/workspaces/issue-366",
+    journal_path: "/tmp/workspaces/issue-366/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: "session-1",
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 2,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "abcdef1",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-11T01:50:41.997Z",
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 44,
+    title: "Test PR",
+    url: "https://example.test/pr/44",
+    state: "OPEN",
+    createdAt: "2026-03-11T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-38",
+    headRefOid: "head123",
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+function withStubbedDateNow<T>(nowIso: string, run: () => T): T {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse(nowIso);
+  try {
+    return run();
+  } finally {
+    Date.now = originalDateNow;
+  }
+}
+
+test("derivePullRequestLifecycleSnapshot applies review-bot lifecycle patches before inferring blocked timeout state", () => {
+  withStubbedDateNow("2026-03-13T00:20:00Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+      copilotReviewWaitMinutes: 10,
+      copilotReviewTimeoutAction: "block",
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const pr = createPullRequest({
+      copilotReviewState: "requested",
+      copilotReviewRequestedAt: "2026-03-13T00:00:00Z",
+      copilotReviewArrivedAt: null,
+    });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+    const reviewThreads: ReviewThread[] = [];
+
+    const snapshot = derivePullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads);
+
+    assert.equal(snapshot.nextState, "blocked");
+    assert.deepEqual(snapshot.copilotRequestObservationPatch, {
+      copilot_review_requested_observed_at: "2026-03-13T00:00:00Z",
+      copilot_review_requested_head_sha: "head123",
+    });
+    assert.deepEqual(snapshot.copilotTimeoutPatch, {
+      copilot_review_timed_out_at: "2026-03-13T00:10:00.000Z",
+      copilot_review_timeout_action: "block",
+      copilot_review_timeout_reason:
+        "Requested Copilot review never arrived within 10 minute(s) for head head123.",
+    });
+    assert.equal(snapshot.failureContext?.signature, "review-bot-timeout:head123:block");
+    assert.equal(snapshot.recordForState.copilot_review_timeout_action, "block");
+  });
+});
+
+test("shouldRunCodex only returns true for actionable supervisor states", () => {
+  const config = createConfig();
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads: ReviewThread[] = [];
+
+  assert.equal(shouldRunCodex(createRecord({ state: "queued", pr_number: null }), null, [], [], config), true);
+  assert.equal(
+    shouldRunCodex(createRecord({ state: "draft_pr" }), createPullRequest({ isDraft: true }), checks, reviewThreads, config),
+    true,
+  );
+  assert.equal(
+    shouldRunCodex(createRecord({ state: "waiting_ci" }), createPullRequest(), checks, reviewThreads, config),
+    false,
+  );
+  assert.equal(
+    shouldRunCodex(
+      createRecord({ state: "repairing_ci" }),
+      createPullRequest({ mergeStateStatus: "CLEAN" }),
+      [{ name: "build", state: "FAILURE", bucket: "fail", workflow: "CI" }],
+      reviewThreads,
+      config,
+    ),
+    true,
+  );
+});

--- a/src/supervisor-lifecycle.ts
+++ b/src/supervisor-lifecycle.ts
@@ -1,0 +1,145 @@
+import { shouldPreserveNoPrFailureTracking } from "./no-pull-request-state";
+import type { PullRequestLifecycleSnapshot } from "./post-turn-pull-request";
+import {
+  blockedReasonFromReviewState,
+  inferStateFromPullRequest,
+  syncCopilotReviewRequestObservation,
+  syncCopilotReviewTimeoutState,
+  syncReviewWaitWindow,
+} from "./pull-request-state";
+import {
+  localReviewHighSeverityNeedsBlock,
+  localReviewRetryLoopStalled,
+} from "./review-handling";
+import { inferFailureContext } from "./supervisor-failure-context";
+import { mergeConflictDetected, summarizeChecks } from "./supervisor-status-rendering";
+import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
+import {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  RunState,
+  SupervisorConfig,
+} from "./types";
+
+export function shouldStopForRepeatedFailureSignature(record: IssueRunRecord, config: SupervisorConfig): boolean {
+  return (
+    record.last_failure_signature !== null &&
+    record.repeated_failure_signature_count >= config.sameFailureSignatureRepeatLimit
+  );
+}
+
+export function blockedReasonForLifecycleState(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+): IssueRunRecord["blocked_reason"] {
+  return (
+    blockedReasonFromReviewState(config, record, pr, reviewThreads) ??
+    (localReviewRetryLoopStalled(
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    ) || localReviewHighSeverityNeedsBlock(config, record, pr)
+      ? "verification"
+      : null)
+  );
+}
+
+export function derivePullRequestLifecycleSnapshot(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+  recordPatch: Partial<IssueRunRecord> = {},
+): PullRequestLifecycleSnapshot {
+  const baseRecord = { ...record, ...recordPatch };
+  const reviewWaitPatch = syncReviewWaitWindow(baseRecord, pr);
+  const copilotRequestObservationPatch = syncCopilotReviewRequestObservation(config, baseRecord, pr);
+  const recordForState = {
+    ...baseRecord,
+    ...reviewWaitPatch,
+    ...copilotRequestObservationPatch,
+  };
+  const copilotTimeoutPatch = syncCopilotReviewTimeoutState(config, recordForState, pr);
+  const finalizedRecordForState = {
+    ...recordForState,
+    ...copilotTimeoutPatch,
+  };
+
+  return {
+    recordForState: finalizedRecordForState,
+    nextState: inferStateFromPullRequest(config, finalizedRecordForState, pr, checks, reviewThreads),
+    failureContext: inferFailureContext(config, finalizedRecordForState, pr, checks, reviewThreads),
+    reviewWaitPatch,
+    copilotRequestObservationPatch,
+    copilotTimeoutPatch,
+  };
+}
+
+export function shouldRunCodex(
+  record: IssueRunRecord,
+  pr: GitHubPullRequest | null,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+  config: SupervisorConfig,
+): boolean {
+  if (!pr) {
+    return true;
+  }
+
+  const inferred = inferStateFromPullRequest(config, record, pr, checks, reviewThreads);
+  return (
+    inferred === "draft_pr" ||
+    inferred === "repairing_ci" ||
+    inferred === "resolving_conflict" ||
+    inferred === "addressing_review" ||
+    inferred === "implementing" ||
+    inferred === "local_review_fix" ||
+    inferred === "reproducing" ||
+    inferred === "stabilizing"
+  );
+}
+
+export function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
+  return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
+}
+
+export function resetNoPrLifecycleFailureTracking(
+  record: IssueRunRecord,
+): Pick<
+  IssueRunRecord,
+  | "copilot_review_requested_observed_at"
+  | "copilot_review_requested_head_sha"
+  | "copilot_review_timed_out_at"
+  | "copilot_review_timeout_action"
+  | "copilot_review_timeout_reason"
+  | "last_failure_context"
+  | "last_failure_signature"
+  | "repeated_failure_signature_count"
+  | "blocked_reason"
+> {
+  const preserveFailureTracking = shouldPreserveNoPrFailureTracking(record);
+  return {
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    last_failure_context: preserveFailureTracking ? record.last_failure_context : null,
+    last_failure_signature: preserveFailureTracking ? record.last_failure_signature : null,
+    repeated_failure_signature_count: preserveFailureTracking ? record.repeated_failure_signature_count : 0,
+    blocked_reason: null,
+  };
+}

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -23,7 +23,7 @@ import {
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,
 } from "./pull-request-state";
-import { inferStateWithoutPullRequest, shouldPreserveNoPrFailureTracking } from "./no-pull-request-state";
+import { inferStateWithoutPullRequest } from "./no-pull-request-state";
 import {
   hasProcessedReviewThread,
   localReviewBlocksMerge,
@@ -91,6 +91,14 @@ import {
 import { inferFailureContext } from "./supervisor-failure-context";
 import { StateStore } from "./state-store";
 import {
+  blockedReasonForLifecycleState,
+  derivePullRequestLifecycleSnapshot,
+  isOpenPullRequest,
+  resetNoPrLifecycleFailureTracking,
+  shouldRunCodex,
+  shouldStopForRepeatedFailureSignature,
+} from "./supervisor-lifecycle";
+import {
   formatDetailedStatus,
   mergeConflictDetected,
   summarizeChecks,
@@ -125,112 +133,6 @@ import {
   getWorkspaceStatus,
   pushBranch,
 } from "./workspace";
-
-function shouldStopForRepeatedFailureSignature(record: IssueRunRecord, config: SupervisorConfig): boolean {
-  return (
-    record.last_failure_signature !== null &&
-    record.repeated_failure_signature_count >= config.sameFailureSignatureRepeatLimit
-  );
-}
-
-function blockedReasonForLifecycleState(
-  config: SupervisorConfig,
-  record: IssueRunRecord,
-  pr: GitHubPullRequest,
-  checks: PullRequestCheck[],
-  reviewThreads: ReviewThread[],
-): IssueRunRecord["blocked_reason"] {
-  return (
-    blockedReasonFromReviewState(config, record, pr, reviewThreads) ??
-    (localReviewRetryLoopStalled(
-      config,
-      record,
-      pr,
-      checks,
-      reviewThreads,
-      manualReviewThreads,
-      configuredBotReviewThreads,
-      summarizeChecks,
-      mergeConflictDetected,
-    ) || localReviewHighSeverityNeedsBlock(config, record, pr)
-      ? "verification"
-      : null)
-  );
-}
-
-interface PullRequestLifecycleSnapshot {
-  recordForState: IssueRunRecord;
-  nextState: RunState;
-  failureContext: FailureContext | null;
-  reviewWaitPatch: Partial<Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">>;
-  copilotRequestObservationPatch: Partial<
-    Pick<IssueRunRecord, "copilot_review_requested_observed_at" | "copilot_review_requested_head_sha">
-  >;
-  copilotTimeoutPatch: Pick<
-    IssueRunRecord,
-    "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
-  >;
-}
-
-function derivePullRequestLifecycleSnapshot(
-  config: SupervisorConfig,
-  record: IssueRunRecord,
-  pr: GitHubPullRequest,
-  checks: PullRequestCheck[],
-  reviewThreads: ReviewThread[],
-  recordPatch: Partial<IssueRunRecord> = {},
-): PullRequestLifecycleSnapshot {
-  const baseRecord = { ...record, ...recordPatch };
-  const reviewWaitPatch = syncReviewWaitWindow(baseRecord, pr);
-  const copilotRequestObservationPatch = syncCopilotReviewRequestObservation(config, baseRecord, pr);
-  const recordForState = {
-    ...baseRecord,
-    ...reviewWaitPatch,
-    ...copilotRequestObservationPatch,
-  };
-  const copilotTimeoutPatch = syncCopilotReviewTimeoutState(config, recordForState, pr);
-  const finalizedRecordForState = {
-    ...recordForState,
-    ...copilotTimeoutPatch,
-  };
-
-  return {
-    recordForState: finalizedRecordForState,
-    nextState: inferStateFromPullRequest(config, finalizedRecordForState, pr, checks, reviewThreads),
-    failureContext: inferFailureContext(config, finalizedRecordForState, pr, checks, reviewThreads),
-    reviewWaitPatch,
-    copilotRequestObservationPatch,
-    copilotTimeoutPatch,
-  };
-}
-
-function shouldRunCodex(
-  record: IssueRunRecord,
-  pr: GitHubPullRequest | null,
-  checks: PullRequestCheck[],
-  reviewThreads: ReviewThread[],
-  config: SupervisorConfig,
-): boolean {
-  if (!pr) {
-    return true;
-  }
-
-  const inferred = inferStateFromPullRequest(config, record, pr, checks, reviewThreads);
-  return (
-    inferred === "draft_pr" ||
-    inferred === "repairing_ci" ||
-    inferred === "resolving_conflict" ||
-    inferred === "addressing_review" ||
-    inferred === "implementing" ||
-    inferred === "local_review_fix" ||
-    inferred === "reproducing" ||
-    inferred === "stabilizing"
-  );
-}
-
-function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
-  return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
-}
 
 interface ReadyIssueContext {
   kind: "ready";
@@ -540,18 +442,9 @@ export class Supervisor {
         );
       }
     } else {
-      const preserveFailureTracking = shouldPreserveNoPrFailureTracking(record);
       record = this.stateStore.touch(record, {
         state: inferStateWithoutPullRequest(record, workspaceStatus),
-        copilot_review_requested_observed_at: null,
-        copilot_review_requested_head_sha: null,
-        copilot_review_timed_out_at: null,
-        copilot_review_timeout_action: null,
-        copilot_review_timeout_reason: null,
-        last_failure_context: preserveFailureTracking ? record.last_failure_context : null,
-        last_failure_signature: preserveFailureTracking ? record.last_failure_signature : null,
-        repeated_failure_signature_count: preserveFailureTracking ? record.repeated_failure_signature_count : 0,
-        blocked_reason: null,
+        ...resetNoPrLifecycleFailureTracking(record),
       });
     }
     state.issues[String(record.issue_number)] = record;


### PR DESCRIPTION
Closes #322
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the remaining lifecycle/orchestration glue out of [src/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-322/src/supervisor.ts) into [src/supervisor-lifecycle.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-322/src/supervisor-lifecycle.ts), covering PR lifecycle snapshot derivation, blocked-reason bridging, open-PR detection, repeated-failure stopping, Codex-run gating, and the no-PR lifecycle reset patch. `Supervisor.runOnce(...)` now reads more like wiring/sequencing, with behavior kept intact.

Added focused coverage in [src/supervisor-lifecycle.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-322/src/supervisor-lifecycle.test.ts) for the extracted snapshot logic and `shouldRunCodex(...)`. The branch is clean and checkpointed at commit `2ba5bca` (`Extract supervisor lifecycle glue`).

Tests run:
- `./node_modules/.bin/tsx --test src/supervisor-lifecycle.test.ts`
- `./node_modules/.bin/tsx --test src/supervisor-lifecycle.test.ts src/no-pull-request-state.test.ts src/supervisor-status-rendering.test.ts`
- `./node_modules/.bin/tsx --test src/supervisor.test.ts`
- `npm run build`

Summary: Extracted supervisor lifecycle/orchestration glue into a dedicated module, added focused lifecycle tests, ran targeted supervisor regressions, and committed the checkpoint.
State hint: implementing
Blocked reason: none
Tests: ./node_modules/.bin/tsx --test src/supervisor-lifecycle.test.ts; ./node_modules/.bin/tsx --test src/supervisor-l...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized pull request supervisor lifecycle logic into a dedicated module for improved code maintainability and separation of concerns.

* **Tests**
  * Added comprehensive unit tests for pull request lifecycle handling, including state transitions, failure tracking, and execution decision validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->