### PR TITLE
Codex refactor: extract state, blocked-reason, and failure-signature parsing helpers (#325)

### DIFF
--- a/src/codex-output-parser.test.ts
+++ b/src/codex-output-parser.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { extractBlockedReason, extractFailureSignature, extractStateHint } from "./codex-output-parser";
+
+test("extractStateHint accepts supported states", () => {
+  assert.equal(extractStateHint("State hint: local_review_fix"), "local_review_fix");
+  assert.equal(extractStateHint("State hint: blocked"), "blocked");
+});
+
+test("extractStateHint rejects unsupported states", () => {
+  assert.equal(extractStateHint("State hint: clarification"), null);
+  assert.equal(extractStateHint("No state footer"), null);
+});
+
+test("extractBlockedReason accepts supported blocked reasons", () => {
+  assert.equal(extractBlockedReason("Blocked reason: verification"), "verification");
+  assert.equal(extractBlockedReason("Blocked reason: manual_pr_closed"), "manual_pr_closed");
+});
+
+test("extractBlockedReason rejects unsupported blocked reasons", () => {
+  assert.equal(extractBlockedReason("Blocked reason: clarification"), null);
+  assert.equal(extractBlockedReason("No blocked reason footer"), null);
+});
+
+test("extractFailureSignature normalizes empty and none values", () => {
+  assert.equal(extractFailureSignature("Failure signature: none"), null);
+  assert.equal(extractFailureSignature("Failure signature:    "), null);
+  assert.equal(extractFailureSignature("No failure signature footer"), null);
+});
+
+test("extractFailureSignature trims and truncates values", () => {
+  const longSignature = `Failure signature: ${"x".repeat(600)}`;
+  assert.equal(extractFailureSignature("Failure signature:  prior-check  "), "prior-check");
+  assert.equal(extractFailureSignature(longSignature), "x".repeat(500));
+});

--- a/src/codex-output-parser.ts
+++ b/src/codex-output-parser.ts
@@ -1,0 +1,68 @@
+import { type BlockedReason, type RunState } from "./types";
+
+const SUPPORTED_RUN_STATES: RunState[] = [
+  "queued",
+  "planning",
+  "reproducing",
+  "implementing",
+  "local_review_fix",
+  "stabilizing",
+  "draft_pr",
+  "local_review",
+  "pr_open",
+  "repairing_ci",
+  "resolving_conflict",
+  "waiting_ci",
+  "addressing_review",
+  "ready_to_merge",
+  "merging",
+  "done",
+  "blocked",
+  "failed",
+];
+
+const SUPPORTED_BLOCKED_REASONS: BlockedReason[] = [
+  "requirements",
+  "permissions",
+  "secrets",
+  "verification",
+  "manual_review",
+  "manual_pr_closed",
+  "handoff_missing",
+  "unknown",
+  null,
+];
+
+export function extractStateHint(message: string): RunState | null {
+  const match = message.match(/State hint:\s*([a-z_]+)/i);
+  if (!match) {
+    return null;
+  }
+
+  const value = match[1].toLowerCase() as RunState;
+  return SUPPORTED_RUN_STATES.includes(value) ? value : null;
+}
+
+export function extractBlockedReason(message: string): BlockedReason {
+  const match = message.match(/Blocked reason:\s*([a-z_]+)/i);
+  if (!match) {
+    return null;
+  }
+
+  const value = match[1].toLowerCase() as BlockedReason;
+  return SUPPORTED_BLOCKED_REASONS.includes(value) ? value : null;
+}
+
+export function extractFailureSignature(message: string): string | null {
+  const match = message.match(/Failure signature:\s*(.+)/i);
+  if (!match) {
+    return null;
+  }
+
+  const value = match[1].trim();
+  if (!value || value.toLowerCase() === "none") {
+    return null;
+  }
+
+  return value.slice(0, 500);
+}

--- a/src/codex.test.ts
+++ b/src/codex.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildCodexPrompt, buildCodexResumePrompt, extractStateHint, shouldUseCompactResumePrompt } from "./codex";
+import { buildCodexPrompt, buildCodexResumePrompt, shouldUseCompactResumePrompt } from "./codex";
 import { loadLocalReviewRepairContext } from "./local-review-repair-context";
 import { FailureContext, GitHubIssue, RunState } from "./types";
 import { type VerifierGuardrailRule } from "./verifier-guardrails";
@@ -16,10 +16,6 @@ const issue: GitHubIssue = {
   updatedAt: "2026-03-12T00:00:00Z",
   url: "https://example.test/issues/46",
 };
-
-test("extractStateHint accepts local_review_fix", () => {
-  assert.equal(extractStateHint("State hint: local_review_fix"), "local_review_fix");
-});
 
 test("shouldUseCompactResumePrompt only enables compact resume guidance for handoff-driven states", () => {
   assert.equal(shouldUseCompactResumePrompt("planning"), true);

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { extractIssueJournalHandoff } from "./journal";
 import { runCommand } from "./command";
 import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
+export { extractBlockedReason, extractFailureSignature, extractStateHint } from "./codex-output-parser";
 import { ExternalReviewMissContext, type ExternalReviewMissPattern } from "./external-review-misses";
 import {
   BlockedReason,
@@ -41,72 +42,6 @@ const LIVE_BLOCKER_HANDOFF_SUPPRESSION_STATES = new Set<RunState>([
 ]);
 
 const COMPACT_RESUME_PROMPT_STATES = new Set<RunState>(["planning", "reproducing", "implementing", "stabilizing", "draft_pr"]);
-
-export function extractStateHint(message: string): RunState | null {
-  const match = message.match(/State hint:\s*([a-z_]+)/i);
-  if (!match) {
-    return null;
-  }
-
-  const value = match[1].toLowerCase() as RunState;
-  const supported: RunState[] = [
-    "queued",
-    "planning",
-    "reproducing",
-    "implementing",
-    "local_review_fix",
-    "stabilizing",
-    "draft_pr",
-    "local_review",
-    "pr_open",
-    "repairing_ci",
-    "resolving_conflict",
-    "waiting_ci",
-    "addressing_review",
-    "ready_to_merge",
-    "merging",
-    "done",
-    "blocked",
-    "failed",
-  ];
-
-  return supported.includes(value) ? value : null;
-}
-
-export function extractBlockedReason(message: string): BlockedReason {
-  const match = message.match(/Blocked reason:\s*([a-z_]+)/i);
-  if (!match) {
-    return null;
-  }
-
-  const value = match[1].toLowerCase() as BlockedReason;
-  const supported: BlockedReason[] = [
-    "requirements",
-    "permissions",
-    "secrets",
-    "verification",
-    "manual_review",
-    "manual_pr_closed",
-    "handoff_missing",
-    "unknown",
-    null,
-  ];
-  return supported.includes(value) ? value : null;
-}
-
-export function extractFailureSignature(message: string): string | null {
-  const match = message.match(/Failure signature:\s*(.+)/i);
-  if (!match) {
-    return null;
-  }
-
-  const value = match[1].trim();
-  if (!value || value.toLowerCase() === "none") {
-    return null;
-  }
-
-  return value.slice(0, 500);
-}
 
 export function shouldUseCompactResumePrompt(state: RunState): boolean {
   return COMPACT_RESUME_PROMPT_STATES.has(state);


### PR DESCRIPTION
Closes #325
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the Codex footer parsers into [src/codex-output-parser.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-325/src/codex-output-parser.ts) and kept the existing `./codex` API compatible by re-exporting from [src/codex.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-325/src/codex.ts#L7). I added focused parser coverage in [src/codex-output-parser.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-325/src/codex-output-parser.test.ts) for supported/unsupported state hints, blocked reasons, and failure-signature normalization/truncation, and removed the parser-specific test from [src/codex.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-325/src/codex.test.ts).

Verification passed locally with `npx tsx --test src/codex-output-parser.test.ts src/codex.test.ts` and `npm run build`. I also updated the local issue journal handoff and created checkpoint commit `25c7a0a` (`refactor codex output parsers`).

Summary: Extracted Codex output parsing helpers into a dedicated module, added focused parser tests, preserved `./codex` compatibility, and committed the refactor as `25c7a0a`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/codex-output-parser.test.ts src/codex.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for branch `codex/issue-325` with commit `25c7a0a` if that branch checkpoint should be published now.