### PR TITLE
Codex refactor: extract CLI execution and result shaping from src/codex.ts (#327)

### DIFF
--- a/src/codex-runner.test.ts
+++ b/src/codex-runner.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { mock } from "node:test";
 import { runCodexTurn } from "./codex-runner";
 import { SupervisorConfig } from "./types";
 
@@ -175,4 +175,34 @@ exit 0
   assert.equal(args[8], "session-123");
   assert.equal(args[9], "resume prompt");
   assert.equal(args.includes("-C"), false);
+});
+
+test("runCodexTurn removes its temp dir when command execution fails", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "missing-codex");
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  const rmCalls: string[] = [];
+  const originalRm = fs.rm.bind(fs);
+  const rmMock = mock.method(
+    fs,
+    "rm",
+    async (target: Parameters<typeof fs.rm>[0], options?: Parameters<typeof fs.rm>[1]) => {
+      rmCalls.push(String(target));
+      return originalRm(target, options);
+    },
+  );
+
+  try {
+    await assert.rejects(
+      runCodexTurn(createConfig({ codexBinary }), workspacePath, "prompt body", "implementing"),
+      /ENOENT|spawn/i,
+    );
+  } finally {
+    rmMock.mock.restore();
+  }
+
+  assert.equal(rmCalls.length, 1);
+  assert.match(rmCalls[0] ?? "", /codex-supervisor-/);
 });

--- a/src/codex-runner.ts
+++ b/src/codex-runner.ts
@@ -44,55 +44,57 @@ export async function runCodexTurn(
 ): Promise<CodexTurnResult> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-"));
   const messageFile = path.join(tempDir, "last-message.txt");
-  const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(config, state, record));
-  const commandArgs = sessionId
-    ? [
-        "exec",
-        "resume",
-        ...overrideArgs,
-        "--json",
-        "--dangerously-bypass-approvals-and-sandbox",
-        "-o",
-        messageFile,
-        sessionId,
-        prompt,
-      ]
-    : [
-        "exec",
-        ...overrideArgs,
-        "--json",
-        "--dangerously-bypass-approvals-and-sandbox",
-        "-C",
-        workspacePath,
-        "-o",
-        messageFile,
-        prompt,
-      ];
-  const result = await runCommand(
-    config.codexBinary,
-    commandArgs,
-    {
-      cwd: workspacePath,
-      allowExitCodes: [0, 1],
-      env: {
-        ...process.env,
-        npm_config_yes: "true",
-        CI: "1",
+  try {
+    const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(config, state, record));
+    const commandArgs = sessionId
+      ? [
+          "exec",
+          "resume",
+          ...overrideArgs,
+          "--json",
+          "--dangerously-bypass-approvals-and-sandbox",
+          "-o",
+          messageFile,
+          sessionId,
+          prompt,
+        ]
+      : [
+          "exec",
+          ...overrideArgs,
+          "--json",
+          "--dangerously-bypass-approvals-and-sandbox",
+          "-C",
+          workspacePath,
+          "-o",
+          messageFile,
+          prompt,
+        ];
+    const result = await runCommand(
+      config.codexBinary,
+      commandArgs,
+      {
+        cwd: workspacePath,
+        allowExitCodes: [0, 1],
+        env: {
+          ...process.env,
+          npm_config_yes: "true",
+          CI: "1",
+        },
+        timeoutMs: config.codexExecTimeoutMinutes * 60_000,
       },
-      timeoutMs: config.codexExecTimeoutMinutes * 60_000,
-    },
-  );
+    );
 
-  const lastMessage = await readLastMessage(messageFile);
-  const resolvedSessionId = extractSessionId(result.stdout, sessionId);
+    const lastMessage = await readLastMessage(messageFile);
+    const resolvedSessionId = extractSessionId(result.stdout, sessionId);
 
-  await fs.rm(tempDir, { recursive: true, force: true });
-
-  return {
-    exitCode: result.exitCode,
-    sessionId: resolvedSessionId,
-    lastMessage: lastMessage.trim(),
-    stderr: result.stderr,
-    stdout: result.stdout,
-  };
+    return {
+      exitCode: result.exitCode,
+      sessionId: resolvedSessionId,
+      lastMessage: lastMessage.trim(),
+      stderr: result.stderr,
+      stdout: result.stdout,
+    };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 }

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -6,3 +6,4 @@ export {
   type LocalReviewRepairContext,
 } from "./codex-prompt";
 export { runCodexTurn } from "./codex-runner";
+export type { CodexTurnResult, IssueRunRecord, RunState, SupervisorConfig } from "./types";


### PR DESCRIPTION
Closes #327
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the Codex CLI boundary into [`src/codex-runner.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-327/src/codex-runner.ts) and left [`src/codex.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-327/src/codex.ts) as a compatibility export surface. The new focused coverage in [`src/codex-runner.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-327/src/codex-runner.test.ts) locks down new-session and resume-session CLI arg shaping, message-file reading, exit-code handling, and `thread.started` session parsing.

Verification passed with `npx tsx --test src/codex-runner.test.ts src/run-once-turn-execution.test.ts`, `npx tsx --test src/supervisor.test.ts --test-name-pattern "runOnce records timeout bookkeeping when Codex exits non-zero|executeCodexTurn does not consume attempts when the Codex session lock is already held"`, and `npm run build`. I also updated the local issue journal handoff and committed the code as `f5fa760` (`Extract Codex CLI runner`).

Summary: Extracted `runCodexTurn` into a dedicated runner module, added focused runner tests, and verified focused turn-execution/supervisor paths plus build.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/codex-runner.test.ts src/run-once-turn-execution.test.ts`; `npx tsx --test src/supervisor.test.ts --test-name-pattern "runOnce records timeout bookkeeping when Codex exits non-zero|executeCodexTurn does not consume attempts when the Codex session lock is alrea...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Codex execution workflow, including scenarios for new session initialization and session resumption.

* **Refactor**
  * Reorganized internal Codex runner implementation into a dedicated module for improved code maintainability and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->