### PR TITLE
Local review refactor: extract reviewer execution and verifier wiring (#334)

### DIFF
--- a/src/local-review-execution.test.ts
+++ b/src/local-review-execution.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { runLocalReviewExecution, selectVerifierFindings } from "./local-review-execution";
 import { type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
+import { type LocalReviewRoleSelection } from "./review-role-detector";
 import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -105,6 +106,14 @@ function createRoleResult(overrides: Partial<LocalReviewRoleResult> = {}): Local
   };
 }
 
+function createDetectedRoles(overrides: Partial<LocalReviewRoleSelection> = {}): LocalReviewRoleSelection {
+  return {
+    role: "reviewer",
+    reasons: [{ kind: "baseline", signal: "default", paths: [] }],
+    ...overrides,
+  };
+}
+
 async function waitFor(condition: () => boolean): Promise<void> {
   while (!condition()) {
     await new Promise<void>((resolve) => setImmediate(resolve));
@@ -173,6 +182,11 @@ test("selectVerifierFindings keeps only deduped actionable high-severity finding
   const config = createConfig();
   const result = selectVerifierFindings({
     config,
+    detectedRoles: [
+      createDetectedRoles({
+        role: "security_reviewer",
+      }),
+    ],
     roleResults: [
       createRoleResult({
         role: "reviewer",
@@ -214,7 +228,7 @@ test("selectVerifierFindings keeps only deduped actionable high-severity finding
             start: 5,
             end: 6,
             severity: "high",
-            confidence: 0.75,
+            confidence: 0.65,
             category: "security",
             evidence: null,
           },
@@ -287,6 +301,52 @@ test("runLocalReviewExecution invokes verifier only when actionable high-severit
 
   assert.deepEqual(findingsPassed, ["Actionable high"]);
   assert.equal(withVerifier.verifierReport?.role, "verifier");
+
+  const baselineDetectedRole = await runLocalReviewExecution({
+    config: createConfig(),
+    issue: createIssue(),
+    branch: "codex/issue-334",
+    workspacePath: "/tmp/repo",
+    defaultBranch: "main",
+    pr: createPullRequest(),
+    roles: ["security_reviewer"],
+    detectedRoles: [
+      createDetectedRoles({
+        role: "security_reviewer",
+      }),
+    ],
+    alwaysReadFiles: [],
+    onDemandFiles: [],
+    priorMissPatterns: [],
+    runRoleReview: async () => createRoleResult({
+      role: "security_reviewer",
+      findings: [
+        {
+          role: "security_reviewer",
+          title: "Baseline generic high",
+          body: "Body",
+          file: "src/example.ts",
+          start: 5,
+          end: 6,
+          severity: "high",
+          confidence: 0.75,
+          category: "security",
+          evidence: null,
+        },
+      ],
+    }),
+    runVerifierReview: async ({ findings }) => ({
+      role: "verifier",
+      summary: findings[0]?.title ?? "verified",
+      recommendation: "changes_requested",
+      findings: [],
+      rawOutput: "raw",
+      exitCode: 0,
+      degraded: false,
+    }),
+  });
+
+  assert.equal(baselineDetectedRole.verifierReport?.summary, "Baseline generic high");
 
   const withoutVerifier = await runLocalReviewExecution({
     config: createConfig(),

--- a/src/local-review-execution.ts
+++ b/src/local-review-execution.ts
@@ -3,10 +3,12 @@ import { findingMeetsReviewerThreshold, reviewerTypeForRole } from "./local-revi
 import { runRoleReview as defaultRunRoleReview, runVerifierReview as defaultRunVerifierReview } from "./local-review-runner";
 import { type ExternalReviewMissPattern } from "./external-review-misses";
 import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
+import { type LocalReviewRoleSelection } from "./review-role-detector";
 import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
 
 export function selectVerifierFindings(args: {
   config: SupervisorConfig;
+  detectedRoles?: LocalReviewRoleSelection[];
   roleResults: LocalReviewRoleResult[];
 }): LocalReviewFinding[] {
   return dedupeFindings(
@@ -16,7 +18,7 @@ export function selectVerifierFindings(args: {
         finding.severity === "high" &&
         findingMeetsReviewerThreshold({
           finding,
-          reviewerType: reviewerTypeForRole({ role: finding.role }),
+          reviewerType: reviewerTypeForRole({ role: finding.role, detectedRoles: args.detectedRoles }),
           config: args.config,
         }),
       ),
@@ -31,6 +33,7 @@ export async function runLocalReviewExecution(args: {
   defaultBranch: string;
   pr: GitHubPullRequest;
   roles: string[];
+  detectedRoles?: LocalReviewRoleSelection[];
   alwaysReadFiles: string[];
   onDemandFiles: string[];
   priorMissPatterns: ExternalReviewMissPattern[];
@@ -72,6 +75,7 @@ export async function runLocalReviewExecution(args: {
 
   const findings = selectVerifierFindings({
     config: args.config,
+    detectedRoles: args.detectedRoles,
     roleResults,
   });
 

--- a/src/local-review.ts
+++ b/src/local-review.ts
@@ -171,6 +171,7 @@ export async function runLocalReview(args: {
   const { roleResults, verifierReport } = await runLocalReviewExecution({
     ...args,
     roles,
+    detectedRoles,
     priorMissPatterns,
   });
   const ranAt = nowIso();


### PR DESCRIPTION
Closes #334
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the reviewer execution and verifier wiring out of [`src/local-review.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-334/src/local-review.ts) into [`src/local-review-execution.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-334/src/local-review-execution.ts). `local-review.ts` now stays on preparation, finalization, and artifact output, while the new helper owns the concurrency-2 reviewer loop and the actionable high-severity verifier handoff. I also added focused coverage in [`src/local-review-execution.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-334/src/local-review-execution.test.ts) for reviewer ordering/concurrency and verifier gating.

Verification passed with `npx tsx --test src/local-review-execution.test.ts`, `npx tsx --test src/local-review.test.ts src/local-review-execution.test.ts`, and `npm run build`. I recorded the work in the local issue journal and committed the refactor as `222e86e` (`refactor local review execution wiring`).

Summary: Extracted local-review execution wiring into a dedicated helper with focused tests; build and local-review test slice pass.
State hint: implementing
Blocked reason: none
Tests: npx tsx --test src/local-review-execution.test.ts; npx tsx --test src/local-review.test.ts src/local-review-execution.test.ts; npm run build
Failure signature: none
Next action: Push or open/update the branch PR checkpoint, then continue the local-review refactor sequence if more issue #334 scope re...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized local review execution that runs role reviews in parallel and returns consolidated role results plus an optional verifier report.

* **Performance Improvements**
  * Parallelized role reviews with a two-worker cap for faster local reviews.

* **Quality Improvements**
  * Deduplication and threshold filtering of findings; verifier runs only when actionable high-severity findings exist.

* **Tests**
  * Added tests covering concurrency, ordering, deduplication, and conditional verifier invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->