### PR TITLE
Supervisor status-model refactor: extract review-bot profile and diagnostics helpers (#340)

### DIFF
--- a/src/supervisor-status-model.ts
+++ b/src/supervisor-status-model.ts
@@ -4,10 +4,16 @@ import {
   localReviewBlocksReady,
   localReviewRetryLoopStalled,
 } from "./review-handling";
+import {
+  configuredBotRateLimitWaitWindow,
+  configuredBotTopLevelReviewEffect,
+  configuredReviewBots,
+  configuredReviewStatusLabel,
+  inferReviewBotProfile,
+  reviewBotDiagnostics,
+} from "./supervisor-status-review-bot";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
 import { truncate } from "./utils";
-
-const COPILOT_REVIEWER_LOGIN = "copilot-pull-request-reviewer";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
 type PendingReviewThreadClassifier = (
@@ -48,205 +54,8 @@ export interface BuildDetailedStatusSummaryLinesArgs {
   durableGuardrailSummary?: string | null;
 }
 
-function configuredReviewBots(config: SupervisorConfig): string[] {
-  return config.reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
-}
-
-function configuredBotRateLimitWaitWindow(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-): { status: "inactive" | "active" | "expired"; observedAt: string | null; waitUntil: string | null } {
-  const waitMinutes = config.configuredBotRateLimitWaitMinutes ?? 0;
-  if (waitMinutes <= 0 || !pr.configuredBotRateLimitedAt) {
-    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt ?? null, waitUntil: null };
-  }
-
-  const observedAtMs = Date.parse(pr.configuredBotRateLimitedAt);
-  if (Number.isNaN(observedAtMs)) {
-    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt, waitUntil: null };
-  }
-
-  const waitUntil = new Date(observedAtMs + waitMinutes * 60_000).toISOString();
-  return {
-    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-    observedAt: pr.configuredBotRateLimitedAt,
-    waitUntil,
-  };
-}
-
-function repoExpectsConfiguredBotReview(config: SupervisorConfig): boolean {
-  return configuredReviewBots(config).length > 0;
-}
-
-function repoUsesCopilotOnlyReviewBot(config: SupervisorConfig): boolean {
-  const bots = configuredReviewBots(config);
-  return bots.length === 1 && bots[0].toLowerCase() === COPILOT_REVIEWER_LOGIN;
-}
-
-function configuredReviewStatusLabel(config: SupervisorConfig): string {
-  return !repoExpectsConfiguredBotReview(config) || repoUsesCopilotOnlyReviewBot(config)
-    ? "copilot_review"
-    : "configured_bot_review";
-}
-
-type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
-
-interface ReviewBotProfileSummary {
-  profile: ReviewBotProfileId;
-  provider: string;
-  reviewers: string[];
-  signalSource: string;
-}
-
-interface ReviewBotDiagnostics {
-  status: string;
-  observedReview: string;
-  nextCheck: string;
-}
-
 function unresolvedReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-}
-
-function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummary {
-  const reviewers = configuredReviewBots(config);
-  const normalized = reviewers.map((reviewer) => reviewer.toLowerCase());
-  const normalizedSet = new Set(normalized);
-
-  if (normalized.length === 0) {
-    return {
-      profile: "none",
-      provider: "none",
-      reviewers,
-      signalSource: "none",
-    };
-  }
-
-  if (normalized.length === 1 && normalized[0] === COPILOT_REVIEWER_LOGIN) {
-    return {
-      profile: "copilot",
-      provider: COPILOT_REVIEWER_LOGIN,
-      reviewers,
-      signalSource: "copilot_lifecycle",
-    };
-  }
-
-  if (normalized.length === 1 && normalized[0] === "chatgpt-codex-connector") {
-    return {
-      profile: "codex",
-      provider: "chatgpt-codex-connector",
-      reviewers,
-      signalSource: "review_threads",
-    };
-  }
-
-  if (
-    normalized.length === 2 &&
-    normalizedSet.has("coderabbitai") &&
-    normalizedSet.has("coderabbitai[bot]")
-  ) {
-    return {
-      profile: "coderabbit",
-      provider: "coderabbitai",
-      reviewers,
-      signalSource: "review_threads",
-    };
-  }
-
-  return {
-    profile: "custom",
-    provider: reviewers.join(",") || "custom",
-    reviewers,
-    signalSource: normalized.includes(COPILOT_REVIEWER_LOGIN) ? "copilot_lifecycle+review_threads" : "review_threads",
-  };
-}
-
-function summarizeObservedReviewSignal(
-  config: SupervisorConfig,
-  activeRecord: IssueRunRecord,
-  pr: GitHubPullRequest,
-  reviewThreads: ReviewThread[],
-  configuredBotReviewThreads: ReviewThreadClassifier,
-): { observedReview: string; hasSignal: boolean } {
-  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
-  if (configuredThreads.length > 0) {
-    return { observedReview: "review_thread", hasSignal: true };
-  }
-
-  if (activeRecord.external_review_head_sha === pr.headRefOid) {
-    return { observedReview: "external_review_record", hasSignal: true };
-  }
-
-  const lifecycleState = pr.copilotReviewState ?? "not_requested";
-  if (lifecycleState === "arrived") {
-    return { observedReview: "copilot_arrived", hasSignal: true };
-  }
-  if (lifecycleState === "requested") {
-    return { observedReview: "copilot_requested", hasSignal: false };
-  }
-  if (pr.copilotReviewState === null) {
-    return { observedReview: "unknown", hasSignal: false };
-  }
-
-  return { observedReview: "none", hasSignal: false };
-}
-
-function reviewBotDiagnostics(
-  config: SupervisorConfig,
-  activeRecord: IssueRunRecord,
-  pr: GitHubPullRequest,
-  reviewThreads: ReviewThread[],
-  configuredBotReviewThreads: ReviewThreadClassifier,
-): ReviewBotDiagnostics {
-  if (!repoExpectsConfiguredBotReview(config)) {
-    return {
-      status: "disabled",
-      observedReview: "none",
-      nextCheck: "none",
-    };
-  }
-
-  const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
-  if (observed.hasSignal) {
-    return {
-      status: "review_signal_observed",
-      observedReview: observed.observedReview,
-      nextCheck: "none",
-    };
-  }
-
-  if (observed.observedReview === "copilot_requested") {
-    return {
-      status: "waiting_for_provider_review",
-      observedReview: observed.observedReview,
-      nextCheck: "provider_delivery",
-    };
-  }
-
-  return {
-    status: "missing_provider_signal",
-    observedReview: observed.observedReview,
-    nextCheck: "provider_setup_or_delivery",
-  };
-}
-
-function configuredBotTopLevelReviewEffect(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-  reviewThreads: ReviewThread[],
-  configuredBotReviewThreads: ReviewThreadClassifier,
-): string {
-  if (!repoExpectsConfiguredBotReview(config) || !pr.configuredBotTopLevelReviewStrength) {
-    return "none";
-  }
-
-  if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
-    return unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads)).length === 0
-      ? "softened"
-      : "awaiting_thread_resolution";
-  }
-
-  return "blocking";
 }
 
 export function sanitizeStatusValue(value: string | null | undefined): string | null {

--- a/src/supervisor-status-review-bot.test.ts
+++ b/src/supervisor-status-review-bot.test.ts
@@ -1,0 +1,293 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  configuredBotRateLimitWaitWindow,
+  configuredBotTopLevelReviewEffect,
+  configuredReviewStatusLabel,
+  inferReviewBotProfile,
+  reviewBotDiagnostics,
+} from "./supervisor-status-review-bot";
+import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: {
+        confidenceThreshold: 0.7,
+        minimumSeverity: "low",
+      },
+      specialist: {
+        confidenceThreshold: 0.7,
+        minimumSeverity: "low",
+      },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/reopen-issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 340,
+    state: "reproducing",
+    branch: "codex/issue-340",
+    pr_number: 340,
+    workspace: "/tmp/workspaces/issue-340",
+    journal_path: "/tmp/workspaces/issue-340/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: "session-340",
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 1,
+    implementation_attempt_count: 0,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "head-sha",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createPr(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 340,
+    title: "Refactor status helpers",
+    url: "https://example.test/pr/340",
+    state: "OPEN",
+    createdAt: "2026-03-16T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-340",
+    headRefOid: "head-sha",
+    ...overrides,
+  };
+}
+
+function createThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 1,
+    comments: { nodes: [] },
+    ...overrides,
+  };
+}
+
+const configuredBotReviewThreads = (_config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] =>
+  reviewThreads;
+
+test("inferReviewBotProfile identifies configured provider patterns", () => {
+  assert.deepEqual(inferReviewBotProfile(createConfig()), {
+    profile: "none",
+    provider: "none",
+    reviewers: [],
+    signalSource: "none",
+  });
+
+  assert.deepEqual(inferReviewBotProfile(createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] })), {
+    profile: "copilot",
+    provider: "copilot-pull-request-reviewer",
+    reviewers: ["copilot-pull-request-reviewer"],
+    signalSource: "copilot_lifecycle",
+  });
+
+  assert.deepEqual(
+    inferReviewBotProfile(createConfig({ reviewBotLogins: ["CodeRabbitAI", "coderabbitai[bot]"] })),
+    {
+      profile: "coderabbit",
+      provider: "coderabbitai",
+      reviewers: ["CodeRabbitAI", "coderabbitai[bot]"],
+      signalSource: "review_threads",
+    },
+  );
+});
+
+test("reviewBotDiagnostics tracks observed review signal precedence", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const pr = createPr();
+
+  assert.deepEqual(
+    reviewBotDiagnostics(config, createRecord(), pr, [createThread()], configuredBotReviewThreads),
+    {
+      status: "review_signal_observed",
+      observedReview: "review_thread",
+      nextCheck: "none",
+    },
+  );
+
+  assert.deepEqual(
+    reviewBotDiagnostics(
+      config,
+      createRecord({ external_review_head_sha: pr.headRefOid }),
+      pr,
+      [],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "review_signal_observed",
+      observedReview: "external_review_record",
+      nextCheck: "none",
+    },
+  );
+
+  assert.deepEqual(
+    reviewBotDiagnostics(
+      createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
+      createRecord(),
+      createPr({ copilotReviewState: "requested" }),
+      [],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "waiting_for_provider_review",
+      observedReview: "copilot_requested",
+      nextCheck: "provider_delivery",
+    },
+  );
+
+  assert.deepEqual(reviewBotDiagnostics(config, createRecord(), pr, [], configuredBotReviewThreads), {
+    status: "missing_provider_signal",
+    observedReview: "none",
+    nextCheck: "provider_setup_or_delivery",
+  });
+});
+
+test("configured review helpers preserve top-level status semantics", () => {
+  const config = createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] });
+  assert.equal(configuredReviewStatusLabel(config), "copilot_review");
+  assert.equal(configuredReviewStatusLabel(createConfig({ reviewBotLogins: ["coderabbitai[bot]"] })), "configured_bot_review");
+
+  assert.equal(
+    configuredBotTopLevelReviewEffect(
+      createConfig({ reviewBotLogins: ["coderabbitai[bot]"] }),
+      createPr({ configuredBotTopLevelReviewStrength: "nitpick_only" }),
+      [],
+      configuredBotReviewThreads,
+    ),
+    "softened",
+  );
+  assert.equal(
+    configuredBotTopLevelReviewEffect(
+      createConfig({ reviewBotLogins: ["coderabbitai[bot]"] }),
+      createPr({ configuredBotTopLevelReviewStrength: "nitpick_only" }),
+      [createThread()],
+      configuredBotReviewThreads,
+    ),
+    "awaiting_thread_resolution",
+  );
+});
+
+test("configuredBotRateLimitWaitWindow reports active and expired windows", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:05:00.000Z");
+
+  try {
+    assert.deepEqual(
+      configuredBotRateLimitWaitWindow(
+        createConfig({ configuredBotRateLimitWaitMinutes: 10 }),
+        createPr({ configuredBotRateLimitedAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "active",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: "2026-03-16T00:10:00.000Z",
+      },
+    );
+
+    assert.deepEqual(
+      configuredBotRateLimitWaitWindow(
+        createConfig({ configuredBotRateLimitWaitMinutes: 3 }),
+        createPr({ configuredBotRateLimitedAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "expired",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: "2026-03-16T00:03:00.000Z",
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/src/supervisor-status-review-bot.ts
+++ b/src/supervisor-status-review-bot.ts
@@ -1,0 +1,206 @@
+import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./types";
+
+const COPILOT_REVIEWER_LOGIN = "copilot-pull-request-reviewer";
+
+type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+
+export type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
+
+export interface ReviewBotProfileSummary {
+  profile: ReviewBotProfileId;
+  provider: string;
+  reviewers: string[];
+  signalSource: string;
+}
+
+export interface ReviewBotDiagnostics {
+  status: string;
+  observedReview: string;
+  nextCheck: string;
+}
+
+export function configuredReviewBots(config: SupervisorConfig): string[] {
+  return config.reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
+}
+
+export function configuredBotRateLimitWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): { status: "inactive" | "active" | "expired"; observedAt: string | null; waitUntil: string | null } {
+  const waitMinutes = config.configuredBotRateLimitWaitMinutes ?? 0;
+  if (waitMinutes <= 0 || !pr.configuredBotRateLimitedAt) {
+    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt ?? null, waitUntil: null };
+  }
+
+  const observedAtMs = Date.parse(pr.configuredBotRateLimitedAt);
+  if (Number.isNaN(observedAtMs)) {
+    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt, waitUntil: null };
+  }
+
+  const waitUntil = new Date(observedAtMs + waitMinutes * 60_000).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    observedAt: pr.configuredBotRateLimitedAt,
+    waitUntil,
+  };
+}
+
+export function repoExpectsConfiguredBotReview(config: SupervisorConfig): boolean {
+  return configuredReviewBots(config).length > 0;
+}
+
+export function repoUsesCopilotOnlyReviewBot(config: SupervisorConfig): boolean {
+  const bots = configuredReviewBots(config);
+  return bots.length === 1 && bots[0].toLowerCase() === COPILOT_REVIEWER_LOGIN;
+}
+
+export function configuredReviewStatusLabel(config: SupervisorConfig): string {
+  return !repoExpectsConfiguredBotReview(config) || repoUsesCopilotOnlyReviewBot(config)
+    ? "copilot_review"
+    : "configured_bot_review";
+}
+
+function unresolvedReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+}
+
+export function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummary {
+  const reviewers = configuredReviewBots(config);
+  const normalized = reviewers.map((reviewer) => reviewer.toLowerCase());
+  const normalizedSet = new Set(normalized);
+
+  if (normalized.length === 0) {
+    return {
+      profile: "none",
+      provider: "none",
+      reviewers,
+      signalSource: "none",
+    };
+  }
+
+  if (normalized.length === 1 && normalized[0] === COPILOT_REVIEWER_LOGIN) {
+    return {
+      profile: "copilot",
+      provider: COPILOT_REVIEWER_LOGIN,
+      reviewers,
+      signalSource: "copilot_lifecycle",
+    };
+  }
+
+  if (normalized.length === 1 && normalized[0] === "chatgpt-codex-connector") {
+    return {
+      profile: "codex",
+      provider: "chatgpt-codex-connector",
+      reviewers,
+      signalSource: "review_threads",
+    };
+  }
+
+  if (
+    normalized.length === 2 &&
+    normalizedSet.has("coderabbitai") &&
+    normalizedSet.has("coderabbitai[bot]")
+  ) {
+    return {
+      profile: "coderabbit",
+      provider: "coderabbitai",
+      reviewers,
+      signalSource: "review_threads",
+    };
+  }
+
+  return {
+    profile: "custom",
+    provider: reviewers.join(",") || "custom",
+    reviewers,
+    signalSource: normalized.includes(COPILOT_REVIEWER_LOGIN) ? "copilot_lifecycle+review_threads" : "review_threads",
+  };
+}
+
+export function summarizeObservedReviewSignal(
+  config: SupervisorConfig,
+  activeRecord: IssueRunRecord,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+  configuredBotReviewThreads: ReviewThreadClassifier,
+): { observedReview: string; hasSignal: boolean } {
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  if (configuredThreads.length > 0) {
+    return { observedReview: "review_thread", hasSignal: true };
+  }
+
+  if (activeRecord.external_review_head_sha === pr.headRefOid) {
+    return { observedReview: "external_review_record", hasSignal: true };
+  }
+
+  const lifecycleState = pr.copilotReviewState ?? "not_requested";
+  if (lifecycleState === "arrived") {
+    return { observedReview: "copilot_arrived", hasSignal: true };
+  }
+  if (lifecycleState === "requested") {
+    return { observedReview: "copilot_requested", hasSignal: false };
+  }
+  if (pr.copilotReviewState === null) {
+    return { observedReview: "unknown", hasSignal: false };
+  }
+
+  return { observedReview: "none", hasSignal: false };
+}
+
+export function reviewBotDiagnostics(
+  config: SupervisorConfig,
+  activeRecord: IssueRunRecord,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+  configuredBotReviewThreads: ReviewThreadClassifier,
+): ReviewBotDiagnostics {
+  if (!repoExpectsConfiguredBotReview(config)) {
+    return {
+      status: "disabled",
+      observedReview: "none",
+      nextCheck: "none",
+    };
+  }
+
+  const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
+  if (observed.hasSignal) {
+    return {
+      status: "review_signal_observed",
+      observedReview: observed.observedReview,
+      nextCheck: "none",
+    };
+  }
+
+  if (observed.observedReview === "copilot_requested") {
+    return {
+      status: "waiting_for_provider_review",
+      observedReview: observed.observedReview,
+      nextCheck: "provider_delivery",
+    };
+  }
+
+  return {
+    status: "missing_provider_signal",
+    observedReview: observed.observedReview,
+    nextCheck: "provider_setup_or_delivery",
+  };
+}
+
+export function configuredBotTopLevelReviewEffect(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+  configuredBotReviewThreads: ReviewThreadClassifier,
+): string {
+  if (!repoExpectsConfiguredBotReview(config) || !pr.configuredBotTopLevelReviewStrength) {
+    return "none";
+  }
+
+  if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
+    return unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads)).length === 0
+      ? "softened"
+      : "awaiting_thread_resolution";
+  }
+
+  return "blocking";
+}


### PR DESCRIPTION
Closes #340
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the review-bot diagnostics logic into [src/supervisor-status-review-bot.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-340/src/supervisor-status-review-bot.ts) and rewired [src/supervisor-status-model.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-340/src/supervisor-status-model.ts) to import those helpers. The new focused coverage in [src/supervisor-status-review-bot.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-340/src/supervisor-status-review-bot.test.ts) pins profile inference, observed-review diagnostics, top-level review effect, and configured-bot rate-limit wait windows. Existing status rendering/model behavior stayed green.

The focused reproducing failure was the missing extraction point itself: `Cannot find module './supervisor-status-review-bot'` from the new test. That’s resolved, `npm run build` passes, and the work is committed as `4bd1ebe` (`Extract supervisor status review-bot helpers`).

Summary: Extracted review-bot profile/diagnostics helpers from the status model, added focused tests, verified status-model behavior, and committed the change as `4bd1ebe`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/supervisor-status-review-bot.test.ts`; `npx tsx --test src/supervisor-status-rendering.test.ts`; `npx tsx --test src/supervisor.test.ts --test-name-pattern='buildDetailedStatusModel|formatDetailedStatus'`; `npm run build`
Failure signature: none
Next action: Open or update the branch...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized review bot evaluation logic for improved code maintainability and modularity.

* **Tests**
  * Added comprehensive test coverage for review bot configuration and status analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->