### PR TITLE
Supervisor status-model refactor: extract reusable status summary helpers (#341)

### DIFF
--- a/src/supervisor-status-model.test.ts
+++ b/src/supervisor-status-model.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: true,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: {
+        confidenceThreshold: 0.7,
+        minimumSeverity: "low",
+      },
+      specialist: {
+        confidenceThreshold: 0.7,
+        minimumSeverity: "low",
+      },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 58,
+    state: "blocked",
+    branch: "codex/issue-58",
+    pr_number: 58,
+    workspace: "/tmp/workspaces/issue-58",
+    journal_path: "/tmp/workspaces/issue-58/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: "session-1",
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 2,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "cafebabe",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-11T01:50:41.997Z",
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 58,
+    title: "Status helpers",
+    url: "https://example.test/pr/58",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-58",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+const noReviewThreads = (_config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] => reviewThreads;
+const noPendingReviewThreads = (): ReviewThread[] => [];
+const summarizeChecks = (checks: PullRequestCheck[]) => ({
+  allPassing: checks.every((check) => check.bucket === "pass"),
+  hasPending: checks.some((check) => check.bucket === "pending" || check.bucket === "cancel"),
+  hasFailing: checks.some((check) => check.bucket === "fail"),
+});
+
+test("buildDetailedStatusModel preserves check summaries and local-review drift wording", () => {
+  const checks: PullRequestCheck[] = [
+    { name: "unit", state: "FAILURE", bucket: "fail", workflow: "CI" },
+    { name: "lint", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" },
+    { name: "docs", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "nightly", state: "NEUTRAL", bucket: "skipping", workflow: "CI" },
+    { name: "merge-queue", state: "CANCELLED", bucket: "cancel", workflow: "CI" },
+    { name: "mystery", state: "UNKNOWN", bucket: "other", workflow: "CI" },
+  ];
+  const lines = buildDetailedStatusModel({
+    config: createConfig(),
+    activeRecord: createRecord({
+      local_review_head_sha: "cafebabe",
+      local_review_run_at: "2026-03-11T15:00:00Z",
+      local_review_findings_count: 2,
+      local_review_root_cause_count: 1,
+      local_review_max_severity: "high",
+      local_review_verified_findings_count: 1,
+      local_review_verified_max_severity: "high",
+      local_review_recommendation: "changes_requested",
+      local_review_blocker_summary: "high src/status.ts:12 stale review head",
+      last_local_review_signature: "local-review:high:2",
+      repeated_local_review_signature_count: 2,
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr: createPullRequest(),
+    checks,
+    reviewThreads: [],
+    manualReviewThreads: noReviewThreads,
+    configuredBotReviewThreads: noReviewThreads,
+    pendingBotReviewThreads: noPendingReviewThreads,
+    summarizeChecks,
+    mergeConflictDetected: () => false,
+  });
+
+  assert.ok(lines.includes("checks=pass=1 fail=1 pending=1 skipping=1 cancel=1 other=1"));
+  assert.ok(lines.includes("failing_checks=unit"));
+  assert.ok(lines.includes("pending_checks=lint"));
+  assert.ok(
+    lines.some((line) =>
+      line.includes(
+        "local_review gating=no policy=block_ready findings=2 root_causes=1 max_severity=high verified_findings=1 verified_max_severity=high head=stale reviewed_head_sha=cafebabe pr_head_sha=deadbeef ran_at=2026-03-11T15:00:00Z needs_review_run=yes drift=cafebabe->deadbeef signature=local-review:high:2 repeated=2 stalled=no",
+      ),
+    ),
+  );
+});
+
+test("buildDetailedStatusModel formats the latest record for idle status", () => {
+  const lines = buildDetailedStatusModel({
+    config: createConfig(),
+    activeRecord: null,
+    latestRecord: createRecord({
+      issue_number: 92,
+      state: "done",
+      updated_at: "2026-03-13T01:20:00Z",
+    }),
+    trackedIssueCount: 2,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    manualReviewThreads: noReviewThreads,
+    configuredBotReviewThreads: noReviewThreads,
+    pendingBotReviewThreads: noPendingReviewThreads,
+    summarizeChecks,
+    mergeConflictDetected: () => false,
+  });
+
+  assert.deepEqual(lines, [
+    "No active issue.",
+    "tracked_issues=2",
+    "latest_record=#92 state=done updated_at=2026-03-13T01:20:00Z",
+  ]);
+});
+
+test("buildDetailedStatusSummaryLines keeps artifact paths relative and falls back to basenames", () => {
+  const lines = buildDetailedStatusSummaryLines({
+    config: createConfig({ localReviewArtifactDir: "/tmp/reviews" }),
+    activeRecord: createRecord({
+      local_review_summary_path: "/tmp/reviews/owner/repo/issue-58/local-review-summary.md",
+      external_review_misses_path: "/var/tmp/external-review-misses-head-deadbeef.json",
+    }),
+  });
+
+  assert.deepEqual(lines, [
+    "local_review_summary_path=owner/repo/issue-58/local-review-summary.md",
+    "external_review_misses_path=external-review-misses-head-deadbeef.json",
+  ]);
+});

--- a/src/supervisor-status-model.ts
+++ b/src/supervisor-status-model.ts
@@ -1,9 +1,14 @@
-import path from "node:path";
 import {
-  localReviewBlocksMerge,
-  localReviewBlocksReady,
   localReviewRetryLoopStalled,
 } from "./review-handling";
+import {
+  displayRelativeArtifactPath,
+  formatRecentRecord,
+  listChecksByBucket,
+  localReviewHeadDetails,
+  localReviewIsGating,
+  summarizeCheckBuckets,
+} from "./supervisor-status-summary-helpers";
 import {
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
@@ -64,113 +69,6 @@ export function sanitizeStatusValue(value: string | null | undefined): string | 
   }
 
   return value.replace(/\r?\n/g, "\\n");
-}
-
-function summarizeCheckBuckets(checks: PullRequestCheck[]): string {
-  if (checks.length === 0) {
-    return "none";
-  }
-
-  const counts = {
-    pass: 0,
-    fail: 0,
-    pending: 0,
-    skipping: 0,
-    cancel: 0,
-    other: 0,
-  };
-
-  for (const check of checks) {
-    if (check.bucket === "pass") {
-      counts.pass += 1;
-    } else if (check.bucket === "fail") {
-      counts.fail += 1;
-    } else if (check.bucket === "pending") {
-      counts.pending += 1;
-    } else if (check.bucket === "skipping") {
-      counts.skipping += 1;
-    } else if (check.bucket === "cancel") {
-      counts.cancel += 1;
-    } else {
-      counts.other += 1;
-    }
-  }
-
-  return Object.entries(counts)
-    .filter(([, count]) => count > 0)
-    .map(([bucket, count]) => `${bucket}=${count}`)
-    .join(" ");
-}
-
-function listChecksByBucket(checks: PullRequestCheck[], bucket: "fail" | "pending"): string | null {
-  const matches = checks.filter((check) => check.bucket === bucket).map((check) => check.name);
-  return matches.length > 0 ? matches.join(", ") : null;
-}
-
-function formatRecentRecord(record: IssueRunRecord | null): string {
-  if (!record) {
-    return "none";
-  }
-
-  return `#${record.issue_number} state=${record.state} updated_at=${record.updated_at}`;
-}
-
-function localReviewHeadStatus(
-  record: Pick<IssueRunRecord, "local_review_head_sha">,
-  pr: Pick<GitHubPullRequest, "headRefOid"> | null,
-): "none" | "current" | "stale" | "unknown" {
-  if (!record.local_review_head_sha) {
-    return "none";
-  }
-
-  if (!pr) {
-    return "unknown";
-  }
-
-  return record.local_review_head_sha === pr.headRefOid ? "current" : "stale";
-}
-
-function localReviewHeadDetails(
-  record: Pick<IssueRunRecord, "local_review_head_sha">,
-  pr: Pick<GitHubPullRequest, "headRefOid"> | null,
-): {
-  status: "none" | "current" | "stale" | "unknown";
-  reviewedHeadSha: string;
-  prHeadSha: string;
-  driftSuffix: string;
-} {
-  const status = localReviewHeadStatus(record, pr);
-  const reviewedHeadSha = record.local_review_head_sha ?? "none";
-  const prHeadSha = pr?.headRefOid ?? "unknown";
-
-  return {
-    status,
-    reviewedHeadSha,
-    prHeadSha,
-    driftSuffix: status === "stale" ? ` needs_review_run=yes drift=${reviewedHeadSha}->${prHeadSha}` : "",
-  };
-}
-
-function localReviewIsGating(
-  config: SupervisorConfig,
-  record: Pick<
-    IssueRunRecord,
-    "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation"
-  >,
-  pr: GitHubPullRequest | null,
-): boolean {
-  if (!pr) {
-    return false;
-  }
-
-  return localReviewBlocksReady(config, record, pr) || localReviewBlocksMerge(config, record, pr);
-}
-
-function displayRelativeArtifactPath(config: SupervisorConfig, filePath: string): string {
-  const relativePath = path.relative(config.localReviewArtifactDir, filePath);
-  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
-    ? relativePath
-    : path.basename(filePath);
 }
 
 export function buildDetailedStatusModel(args: BuildDetailedStatusModelArgs): string[] {

--- a/src/supervisor-status-rendering.ts
+++ b/src/supervisor-status-rendering.ts
@@ -19,6 +19,7 @@ import {
   buildDetailedStatusSummaryLines,
   sanitizeStatusValue,
 } from "./supervisor-status-model";
+import { displayRelativeArtifactPath } from "./supervisor-status-summary-helpers";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
 import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";
 
@@ -50,13 +51,6 @@ export function summarizeChecks(
 
 export function mergeConflictDetected(pr: GitHubPullRequest): boolean {
   return pr.mergeStateStatus === "DIRTY";
-}
-
-function displayStatusArtifactPath(config: SupervisorConfig, filePath: string): string {
-  const relativePath = path.relative(config.localReviewArtifactDir, filePath);
-  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
-    ? relativePath
-    : path.basename(filePath);
 }
 
 async function loadStatusChangedFiles(config: SupervisorConfig, workspacePath: string): Promise<string[]> {
@@ -148,7 +142,7 @@ export async function buildDurableGuardrailStatusLine(args: {
       continue;
     }
 
-    const sourcePath = displayStatusArtifactPath(args.config, winner.pattern.sourceArtifactPath);
+    const sourcePath = displayRelativeArtifactPath(args.config, winner.pattern.sourceArtifactPath);
     runtimeCounts.set(sourcePath, (runtimeCounts.get(sourcePath) ?? 0) + 1);
   }
   if (committedCount > 0) {

--- a/src/supervisor-status-summary-helpers.ts
+++ b/src/supervisor-status-summary-helpers.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+import { localReviewBlocksMerge, localReviewBlocksReady } from "./review-handling";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig } from "./types";
+
+export function summarizeCheckBuckets(checks: PullRequestCheck[]): string {
+  if (checks.length === 0) {
+    return "none";
+  }
+
+  const counts = {
+    pass: 0,
+    fail: 0,
+    pending: 0,
+    skipping: 0,
+    cancel: 0,
+    other: 0,
+  };
+
+  for (const check of checks) {
+    if (check.bucket === "pass") {
+      counts.pass += 1;
+    } else if (check.bucket === "fail") {
+      counts.fail += 1;
+    } else if (check.bucket === "pending") {
+      counts.pending += 1;
+    } else if (check.bucket === "skipping") {
+      counts.skipping += 1;
+    } else if (check.bucket === "cancel") {
+      counts.cancel += 1;
+    } else {
+      counts.other += 1;
+    }
+  }
+
+  return Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .map(([bucket, count]) => `${bucket}=${count}`)
+    .join(" ");
+}
+
+export function listChecksByBucket(checks: PullRequestCheck[], bucket: "fail" | "pending"): string | null {
+  const matches = checks.filter((check) => check.bucket === bucket).map((check) => check.name);
+  return matches.length > 0 ? matches.join(", ") : null;
+}
+
+export function formatRecentRecord(record: IssueRunRecord | null): string {
+  if (!record) {
+    return "none";
+  }
+
+  return `#${record.issue_number} state=${record.state} updated_at=${record.updated_at}`;
+}
+
+export function localReviewHeadStatus(
+  record: Pick<IssueRunRecord, "local_review_head_sha">,
+  pr: Pick<GitHubPullRequest, "headRefOid"> | null,
+): "none" | "current" | "stale" | "unknown" {
+  if (!record.local_review_head_sha) {
+    return "none";
+  }
+
+  if (!pr) {
+    return "unknown";
+  }
+
+  return record.local_review_head_sha === pr.headRefOid ? "current" : "stale";
+}
+
+export function localReviewHeadDetails(
+  record: Pick<IssueRunRecord, "local_review_head_sha">,
+  pr: Pick<GitHubPullRequest, "headRefOid"> | null,
+): {
+  status: "none" | "current" | "stale" | "unknown";
+  reviewedHeadSha: string;
+  prHeadSha: string;
+  driftSuffix: string;
+} {
+  const status = localReviewHeadStatus(record, pr);
+  const reviewedHeadSha = record.local_review_head_sha ?? "none";
+  const prHeadSha = pr?.headRefOid ?? "unknown";
+
+  return {
+    status,
+    reviewedHeadSha,
+    prHeadSha,
+    driftSuffix: status === "stale" ? ` needs_review_run=yes drift=${reviewedHeadSha}->${prHeadSha}` : "",
+  };
+}
+
+export function localReviewIsGating(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation"
+  >,
+  pr: GitHubPullRequest | null,
+): boolean {
+  if (!pr) {
+    return false;
+  }
+
+  return localReviewBlocksReady(config, record, pr) || localReviewBlocksMerge(config, record, pr);
+}
+
+export function displayRelativeArtifactPath(config: SupervisorConfig, filePath: string): string {
+  const relativePath = path.relative(config.localReviewArtifactDir, filePath);
+  return relativePath && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)
+    ? relativePath
+    : path.basename(filePath);
+}


### PR DESCRIPTION
Closes #341
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the reusable status summary layer out of [`src/supervisor-status-model.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-341/src/supervisor-status-model.ts) into [`src/supervisor-status-summary-helpers.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-341/src/supervisor-status-summary-helpers.ts), covering check bucket summaries/listing, local-review head and gating details, recent-record formatting, and artifact-path display. [`src/supervisor-status-rendering.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-341/src/supervisor-status-rendering.ts) now reuses the shared artifact-path helper too.

Added focused regression coverage in [`src/supervisor-status-model.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-341/src/supervisor-status-model.test.ts) to lock current wording around check summaries, stale local-review drift output, idle recent-record formatting, and relative/basename artifact paths. The result is committed on `codex/issue-341` as `415b9f3` (`Refactor supervisor status summary helpers`).

Summary: Extracted reusable supervisor status summary helpers, added focused status-model tests, and verified build plus focused status tests.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/supervisor-status-model.test.ts`; `npx tsx --test src/supervisor-status-rendering.test.ts`; `npm run build`
Failure signature: none
Next action: Hand off for supervisor local review / downstream PR handling on th...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for supervisor status model rendering, including validation of check summaries, status formatting, and artifact path normalization.

* **Refactor**
  * Reorganized internal helper utilities for improved code maintainability and reusability across status rendering components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->