### PR TITLE
Refactor supervisor detailed status assembly facade

### DIFF
--- a/src/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor-detailed-status-assembly.ts
@@ -1,0 +1,177 @@
+import {
+  localReviewRetryLoopStalled,
+} from "./review-handling";
+import {
+  formatRecentRecord,
+  listChecksByBucket,
+  localReviewHeadDetails,
+  localReviewIsGating,
+  summarizeCheckBuckets,
+} from "./supervisor-status-summary-helpers";
+import {
+  configuredBotRateLimitWaitWindow,
+  configuredBotTopLevelReviewEffect,
+  configuredReviewBots,
+  configuredReviewStatusLabel,
+  inferReviewBotProfile,
+  reviewBotDiagnostics,
+} from "./supervisor-status-review-bot";
+import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
+import { truncate } from "./utils";
+
+function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
+  return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+}
+
+export function sanitizeStatusValue(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value.replace(/\r?\n/g, "\\n");
+}
+
+export function buildInactiveDetailedStatusLines(
+  args: Pick<BuildDetailedStatusModelArgs, "latestRecord" | "latestRecoveryRecord" | "trackedIssueCount">,
+): string[] {
+  const { latestRecord, latestRecoveryRecord = null, trackedIssueCount } = args;
+  const lines = [
+    "No active issue.",
+    `tracked_issues=${trackedIssueCount}`,
+    `latest_record=${formatRecentRecord(latestRecord)}`,
+  ];
+
+  if (latestRecoveryRecord?.last_recovery_reason && latestRecoveryRecord.last_recovery_at) {
+    lines.push(
+      `latest_recovery issue=#${latestRecoveryRecord.issue_number} at=${latestRecoveryRecord.last_recovery_at} reason=${sanitizeStatusValue(latestRecoveryRecord.last_recovery_reason)}`,
+    );
+  }
+
+  return lines;
+}
+
+export function buildActiveDetailedStatusLines(
+  args: Omit<BuildDetailedStatusModelArgs, "latestRecord" | "trackedIssueCount"> & {
+    activeRecord: NonNullable<BuildDetailedStatusModelArgs["activeRecord"]>;
+  },
+): string[] {
+  const {
+    config,
+    activeRecord,
+    pr,
+    checks,
+    reviewThreads,
+    manualReviewThreads,
+    configuredBotReviewThreads,
+    pendingBotReviewThreads,
+    summarizeChecks,
+    mergeConflictDetected,
+  } = args;
+
+  const localReviewHead = localReviewHeadDetails(activeRecord, pr);
+  const localReviewGating = localReviewIsGating(config, activeRecord, pr) ? "yes" : "no";
+  const localReviewStalled =
+    pr &&
+    localReviewRetryLoopStalled(
+      config,
+      activeRecord,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    )
+      ? "yes"
+      : "no";
+  const externalReviewHeadStatus =
+    !activeRecord.external_review_head_sha
+      ? "none"
+      : pr
+        ? activeRecord.external_review_head_sha === pr.headRefOid
+          ? "current"
+          : "stale"
+        : "unknown";
+  const lines = [
+    `issue=#${activeRecord.issue_number}`,
+    `state=${activeRecord.state}`,
+    `branch=${activeRecord.branch}`,
+    `pr=${activeRecord.pr_number ?? "none"}`,
+    `attempts=${activeRecord.attempt_count}`,
+    `implementation_attempts=${activeRecord.implementation_attempt_count}`,
+    `repair_attempts=${activeRecord.repair_attempt_count}`,
+    `updated_at=${activeRecord.updated_at}`,
+    `workspace=${activeRecord.workspace}`,
+    `blocked_reason=${activeRecord.blocked_reason ?? "none"}`,
+    `last_failure_kind=${activeRecord.last_failure_kind ?? "none"}`,
+    `last_failure_signature=${activeRecord.last_failure_signature ?? "none"}`,
+    `retries timeout=${activeRecord.timeout_retry_count} verification=${activeRecord.blocked_verification_retry_count} same_blocker=${activeRecord.repeated_blocker_count} same_failure_signature=${activeRecord.repeated_failure_signature_count}`,
+    `local_review gating=${localReviewGating} policy=${config.localReviewPolicy} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"}${localReviewGating === "yes" && activeRecord.local_review_blocker_summary ? ` blocker_summary=${truncate(sanitizeStatusValue(activeRecord.local_review_blocker_summary), 160)}` : ""}${localReviewHead.driftSuffix} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
+    `external_review head=${externalReviewHeadStatus} reviewed_head_sha=${activeRecord.external_review_head_sha ?? "none"} matched=${activeRecord.external_review_matched_findings_count} near_match=${activeRecord.external_review_near_match_findings_count} missed=${activeRecord.external_review_missed_findings_count}`,
+  ];
+
+  if (activeRecord.last_error) {
+    lines.push(`last_error=${truncate(sanitizeStatusValue(activeRecord.last_error), 300)}`);
+  }
+
+  if (pr) {
+    const reviewBotProfile = inferReviewBotProfile(config);
+    const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
+    const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");
+    const reviewStatusLabel = configuredReviewStatusLabel(config);
+    const reviewers = configuredReviewBots(config);
+    const reviewersSuffix =
+      reviewStatusLabel === "configured_bot_review" && reviewers.length > 0 ? ` reviewers=${reviewers.join(",")}` : "";
+    lines.push(
+      `review_bot_profile profile=${reviewBotProfile.profile} provider=${reviewBotProfile.provider} reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} signal_source=${reviewBotProfile.signalSource}`,
+    );
+    lines.push(
+      `review_bot_diagnostics status=${reviewBotStatus.status} observed_review=${reviewBotStatus.observedReview} expected_reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} next_check=${reviewBotStatus.nextCheck}`,
+    );
+    lines.push(
+      `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
+    );
+    lines.push(
+      `configured_bot_top_level_review strength=${pr.configuredBotTopLevelReviewStrength ?? "none"} submitted_at=${pr.configuredBotTopLevelReviewSubmittedAt ?? "none"} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads)}`,
+    );
+    const configuredBotRateLimit = configuredBotRateLimitWaitWindow(config, pr);
+    if (configuredBotRateLimit.observedAt) {
+      lines.push(
+        `configured_bot_rate_limit status=${configuredBotRateLimit.status} observed_at=${configuredBotRateLimit.observedAt} wait_until=${configuredBotRateLimit.waitUntil ?? "none"}`,
+      );
+    }
+    if (activeRecord.copilot_review_timeout_reason) {
+      lines.push(`timeout_reason=${sanitizeStatusValue(activeRecord.copilot_review_timeout_reason)}`);
+    }
+    lines.push(
+      `pr_state=${pr.state} draft=${pr.isDraft ? "yes" : "no"} merge_state=${pr.mergeStateStatus ?? "unknown"} review_decision=${pr.reviewDecision ?? "none"} head_sha=${pr.headRefOid}`,
+    );
+    lines.push(`checks=${summarizeCheckBuckets(checks)}`);
+    const failingChecks = listChecksByBucket(checks, "fail");
+    if (failingChecks) {
+      lines.push(`failing_checks=${failingChecks}`);
+    }
+    const pendingChecks = listChecksByBucket(checks, "pending");
+    if (pendingChecks) {
+      lines.push(`pending_checks=${pendingChecks}`);
+    }
+    const unresolvedConfiguredBotThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
+    lines.push(
+      `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
+    );
+  }
+
+  if (activeRecord.last_failure_context) {
+    lines.push(
+      `failure_context category=${activeRecord.last_failure_context.category ?? "none"} summary=${truncate(sanitizeStatusValue(activeRecord.last_failure_context.summary), 200) ?? "none"}`,
+    );
+    if (activeRecord.last_failure_context.details.length > 0) {
+      lines.push(
+        `failure_details=${truncate(sanitizeStatusValue(activeRecord.last_failure_context.details.join(" | ")), 300) ?? "none"}`,
+      );
+    }
+  }
+
+  return lines;
+}

--- a/src/supervisor-status-model.test.ts
+++ b/src/supervisor-status-model.test.ts
@@ -221,6 +221,75 @@ test("buildDetailedStatusModel formats the latest record for idle status", () =>
   ]);
 });
 
+test("buildDetailedStatusModel preserves active-line ordering across PR and failure sections", () => {
+  const lines = buildDetailedStatusModel({
+    config: createConfig({ reviewBotLogins: ["coderabbitai[bot]"] }),
+    activeRecord: createRecord({
+      state: "pr_open",
+      blocked_reason: "verification",
+      last_failure_kind: "command_error",
+      last_failure_signature: "build:red",
+      last_error: "build failed\nsee logs",
+      copilot_review_timeout_reason: "provider timeout\nwaiting",
+      last_failure_context: {
+        category: "checks",
+        summary: "build failed\nsee logs",
+        signature: "build:red",
+        command: "npm run build",
+        details: ["step one", "step two"],
+        url: null,
+        updated_at: "2026-03-11T16:00:00Z",
+      },
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr: createPullRequest({
+      copilotReviewState: "arrived",
+      copilotReviewRequestedAt: "2026-03-11T15:00:00Z",
+      copilotReviewArrivedAt: "2026-03-11T15:05:00Z",
+      configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewSubmittedAt: "2026-03-11T15:05:00Z",
+    }),
+    checks: [
+      { name: "unit", state: "FAILURE", bucket: "fail", workflow: "CI" },
+      { name: "lint", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" },
+    ],
+    reviewThreads: [],
+    manualReviewThreads: noReviewThreads,
+    configuredBotReviewThreads: noReviewThreads,
+    pendingBotReviewThreads: noPendingReviewThreads,
+    summarizeChecks,
+    mergeConflictDetected: () => false,
+  });
+
+  const prefixesInOrder = [
+    "issue=#58",
+    "local_review gating=",
+    "external_review head=",
+    "last_error=build failed\\nsee logs",
+    "review_bot_profile profile=",
+    "review_bot_diagnostics status=",
+    "configured_bot_review state=arrived",
+    "configured_bot_top_level_review strength=blocking",
+    "timeout_reason=provider timeout\\nwaiting",
+    "pr_state=OPEN draft=no merge_state=CLEAN review_decision=none head_sha=deadbeef",
+    "checks=fail=1 pending=1",
+    "failing_checks=unit",
+    "pending_checks=lint",
+    "review_threads bot_pending=0 bot_unresolved=0 manual=0",
+    "failure_context category=checks summary=build failed\\nsee logs",
+    "failure_details=step one | step two",
+  ];
+
+  let lastIndex = -1;
+  for (const prefix of prefixesInOrder) {
+    const index = lines.findIndex((line) => line.startsWith(prefix));
+    assert.notEqual(index, -1, `expected line starting with ${prefix}`);
+    assert.ok(index > lastIndex, `expected ${prefix} after prior status sections`);
+    lastIndex = index;
+  }
+});
+
 test("buildDetailedStatusSummaryLines keeps artifact paths relative and falls back to basenames", () => {
   const lines = buildDetailedStatusSummaryLines({
     config: createConfig({ localReviewArtifactDir: "/tmp/reviews" }),

--- a/src/supervisor-status-model.ts
+++ b/src/supervisor-status-model.ts
@@ -1,22 +1,11 @@
 import {
-  localReviewRetryLoopStalled,
-} from "./review-handling";
+  buildActiveDetailedStatusLines,
+  buildInactiveDetailedStatusLines,
+  sanitizeStatusValue,
+} from "./supervisor-detailed-status-assembly";
 import {
   displayRelativeArtifactPath,
-  formatRecentRecord,
-  listChecksByBucket,
-  localReviewHeadDetails,
-  localReviewIsGating,
-  summarizeCheckBuckets,
 } from "./supervisor-status-summary-helpers";
-import {
-  configuredBotRateLimitWaitWindow,
-  configuredBotTopLevelReviewEffect,
-  configuredReviewBots,
-  configuredReviewStatusLabel,
-  inferReviewBotProfile,
-  reviewBotDiagnostics,
-} from "./supervisor-status-review-bot";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./types";
 import { truncate } from "./utils";
 
@@ -59,157 +48,14 @@ export interface BuildDetailedStatusSummaryLinesArgs {
   durableGuardrailSummary?: string | null;
 }
 
-function unresolvedReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
-  return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-}
-
-export function sanitizeStatusValue(value: string | null | undefined): string | null {
-  if (!value) {
-    return null;
-  }
-
-  return value.replace(/\r?\n/g, "\\n");
-}
-
 export function buildDetailedStatusModel(args: BuildDetailedStatusModelArgs): string[] {
-  const {
-    config,
-    activeRecord,
-    latestRecord,
-    latestRecoveryRecord = null,
-    trackedIssueCount,
-    pr,
-    checks,
-    reviewThreads,
-    manualReviewThreads,
-    configuredBotReviewThreads,
-    pendingBotReviewThreads,
-    summarizeChecks,
-    mergeConflictDetected,
-  } = args;
+  const { activeRecord } = args;
 
   if (!activeRecord) {
-    const lines = [
-      "No active issue.",
-      `tracked_issues=${trackedIssueCount}`,
-      `latest_record=${formatRecentRecord(latestRecord)}`,
-    ];
-
-    if (latestRecoveryRecord?.last_recovery_reason && latestRecoveryRecord.last_recovery_at) {
-      lines.push(
-        `latest_recovery issue=#${latestRecoveryRecord.issue_number} at=${latestRecoveryRecord.last_recovery_at} reason=${sanitizeStatusValue(latestRecoveryRecord.last_recovery_reason)}`,
-      );
-    }
-
-    return lines;
+    return buildInactiveDetailedStatusLines(args);
   }
 
-  const localReviewHead = localReviewHeadDetails(activeRecord, pr);
-  const localReviewGating = localReviewIsGating(config, activeRecord, pr) ? "yes" : "no";
-  const localReviewStalled =
-    pr &&
-    localReviewRetryLoopStalled(
-      config,
-      activeRecord,
-      pr,
-      checks,
-      reviewThreads,
-      manualReviewThreads,
-      configuredBotReviewThreads,
-      summarizeChecks,
-      mergeConflictDetected,
-    )
-      ? "yes"
-      : "no";
-  const externalReviewHeadStatus =
-    !activeRecord.external_review_head_sha
-      ? "none"
-      : pr
-        ? activeRecord.external_review_head_sha === pr.headRefOid
-          ? "current"
-          : "stale"
-        : "unknown";
-  const lines = [
-    `issue=#${activeRecord.issue_number}`,
-    `state=${activeRecord.state}`,
-    `branch=${activeRecord.branch}`,
-    `pr=${activeRecord.pr_number ?? "none"}`,
-    `attempts=${activeRecord.attempt_count}`,
-    `implementation_attempts=${activeRecord.implementation_attempt_count}`,
-    `repair_attempts=${activeRecord.repair_attempt_count}`,
-    `updated_at=${activeRecord.updated_at}`,
-    `workspace=${activeRecord.workspace}`,
-    `blocked_reason=${activeRecord.blocked_reason ?? "none"}`,
-    `last_failure_kind=${activeRecord.last_failure_kind ?? "none"}`,
-    `last_failure_signature=${activeRecord.last_failure_signature ?? "none"}`,
-    `retries timeout=${activeRecord.timeout_retry_count} verification=${activeRecord.blocked_verification_retry_count} same_blocker=${activeRecord.repeated_blocker_count} same_failure_signature=${activeRecord.repeated_failure_signature_count}`,
-    `local_review gating=${localReviewGating} policy=${config.localReviewPolicy} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"}${localReviewGating === "yes" && activeRecord.local_review_blocker_summary ? ` blocker_summary=${truncate(sanitizeStatusValue(activeRecord.local_review_blocker_summary), 160)}` : ""}${localReviewHead.driftSuffix} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
-    `external_review head=${externalReviewHeadStatus} reviewed_head_sha=${activeRecord.external_review_head_sha ?? "none"} matched=${activeRecord.external_review_matched_findings_count} near_match=${activeRecord.external_review_near_match_findings_count} missed=${activeRecord.external_review_missed_findings_count}`,
-  ];
-
-  if (activeRecord.last_error) {
-    lines.push(`last_error=${truncate(sanitizeStatusValue(activeRecord.last_error), 300)}`);
-  }
-
-  if (pr) {
-    const reviewBotProfile = inferReviewBotProfile(config);
-    const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
-    const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");
-    const reviewStatusLabel = configuredReviewStatusLabel(config);
-    const reviewers = configuredReviewBots(config);
-    const reviewersSuffix =
-      reviewStatusLabel === "configured_bot_review" && reviewers.length > 0 ? ` reviewers=${reviewers.join(",")}` : "";
-    lines.push(
-      `review_bot_profile profile=${reviewBotProfile.profile} provider=${reviewBotProfile.provider} reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} signal_source=${reviewBotProfile.signalSource}`,
-    );
-    lines.push(
-      `review_bot_diagnostics status=${reviewBotStatus.status} observed_review=${reviewBotStatus.observedReview} expected_reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} next_check=${reviewBotStatus.nextCheck}`,
-    );
-    lines.push(
-      `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
-    );
-    lines.push(
-      `configured_bot_top_level_review strength=${pr.configuredBotTopLevelReviewStrength ?? "none"} submitted_at=${pr.configuredBotTopLevelReviewSubmittedAt ?? "none"} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads)}`,
-    );
-    const configuredBotRateLimit = configuredBotRateLimitWaitWindow(config, pr);
-    if (configuredBotRateLimit.observedAt) {
-      lines.push(
-        `configured_bot_rate_limit status=${configuredBotRateLimit.status} observed_at=${configuredBotRateLimit.observedAt} wait_until=${configuredBotRateLimit.waitUntil ?? "none"}`,
-      );
-    }
-    if (activeRecord.copilot_review_timeout_reason) {
-      lines.push(`timeout_reason=${sanitizeStatusValue(activeRecord.copilot_review_timeout_reason)}`);
-    }
-    lines.push(
-      `pr_state=${pr.state} draft=${pr.isDraft ? "yes" : "no"} merge_state=${pr.mergeStateStatus ?? "unknown"} review_decision=${pr.reviewDecision ?? "none"} head_sha=${pr.headRefOid}`,
-    );
-    lines.push(`checks=${summarizeCheckBuckets(checks)}`);
-    const failingChecks = listChecksByBucket(checks, "fail");
-    if (failingChecks) {
-      lines.push(`failing_checks=${failingChecks}`);
-    }
-    const pendingChecks = listChecksByBucket(checks, "pending");
-    if (pendingChecks) {
-      lines.push(`pending_checks=${pendingChecks}`);
-    }
-    const unresolvedConfiguredBotThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-    lines.push(
-      `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
-    );
-  }
-
-  if (activeRecord.last_failure_context) {
-    lines.push(
-      `failure_context category=${activeRecord.last_failure_context.category ?? "none"} summary=${truncate(sanitizeStatusValue(activeRecord.last_failure_context.summary), 200) ?? "none"}`,
-    );
-    if (activeRecord.last_failure_context.details.length > 0) {
-      lines.push(
-        `failure_details=${truncate(sanitizeStatusValue(activeRecord.last_failure_context.details.join(" | ")), 300) ?? "none"}`,
-      );
-    }
-  }
-
-  return lines;
+  return buildActiveDetailedStatusLines({ ...args, activeRecord });
 }
 
 export function buildDetailedStatusSummaryLines(args: BuildDetailedStatusSummaryLinesArgs): string[] {
@@ -248,3 +94,5 @@ export function buildDetailedStatusSummaryLines(args: BuildDetailedStatusSummary
 
   return lines;
 }
+
+export { sanitizeStatusValue };


### PR DESCRIPTION
## Summary
- extract active and inactive detailed status assembly into a dedicated helper module
- keep supervisor-status-model as a thin facade around detailed status assembly and summary line wrappers
- add focused status-model coverage for active status line ordering

Closes #342

## Verification
- npx tsx --test src/supervisor-status-model.test.ts
- npx tsx --test --test-name-pattern "buildDetailedStatusModel|buildDetailedStatusSummaryLines" src/supervisor.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured supervisor status formatting into a dedicated module to improve code organization and ensure consistent aggregation of status information across multiple subsystems.

* **Tests**
  * Added tests to validate status section ordering in detailed status output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->