### PR TITLE
Recover when PR creation succeeds but immediate branch lookup misses the new PR (#355)

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { GitHubClient } from "./github";
-import { SupervisorConfig } from "./types";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "./types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -58,6 +58,95 @@ function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConf
     cleanupDoneWorkspacesAfterHours: 24,
     mergeMethod: "squash",
     draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 355,
+    title: "Recover PR rediscovery after creation",
+    body: "",
+    createdAt: "2026-03-16T01:00:00Z",
+    updatedAt: "2026-03-16T01:00:00Z",
+    url: "https://example.test/issues/355",
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 355,
+    state: "reproducing",
+    branch: "codex/issue-355",
+    pr_number: null,
+    workspace: "/tmp/workspaces/issue-355",
+    journal_path: "/tmp/workspaces/issue-355/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: null,
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 1,
+    implementation_attempt_count: 0,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: null,
+    last_codex_summary: "Focused regression coverage for PR rediscovery.",
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-16T01:00:00Z",
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 354,
+    title: "Recover PR rediscovery after creation (#355)",
+    url: "https://example.test/pull/354",
+    state: "OPEN",
+    createdAt: "2026-03-16T01:00:09Z",
+    updatedAt: "2026-03-16T01:00:09Z",
+    isDraft: true,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-355",
+    headRefOid: "head-354",
     ...overrides,
   };
 }
@@ -196,4 +285,144 @@ test("GitHubClient falls back from gh pr checks to statusCheckRollup", async () 
       link: "https://example.test/checks/lint",
     },
   ]);
+});
+
+test("GitHubClient createPullRequest recovers when the first open-branch lookup misses the new PR", async () => {
+  const config = createConfig();
+  const createdPr = createPullRequest();
+  let openBranchLookups = 0;
+  const commands: string[][] = [];
+  const delays: number[] = [];
+  const client = new GitHubClient(
+    config,
+    async (_command, args) => {
+      commands.push(args);
+
+      if (args[0] === "pr" && args[1] === "create") {
+        return {
+          exitCode: 0,
+          stdout: "https://example.test/pull/354\n",
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("open")) {
+        openBranchLookups += 1;
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify(openBranchLookups === 1 ? [] : [createdPr]),
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "api" && args[1] === "graphql") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewRequests: { nodes: [] },
+                  reviews: { nodes: [] },
+                  comments: { nodes: [] },
+                  reviewThreads: { nodes: [] },
+                  timelineItems: { nodes: [] },
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+
+      throw new Error(`Unexpected args: ${args.join(" ")}`);
+    },
+    async (ms) => {
+      delays.push(ms);
+    },
+  );
+
+  const pr = await client.createPullRequest(createIssue(), createRecord(), { draft: true });
+
+  assert.equal(pr.number, 354);
+  assert.equal(openBranchLookups, 2);
+  assert.deepEqual(delays, [200]);
+  assert.equal(
+    commands.filter((args) => args[0] === "pr" && args[1] === "list" && args.includes("open")).length,
+    2,
+  );
+  assert.equal(
+    commands.filter((args) => args[0] === "pr" && args[1] === "list" && args.includes("all")).length,
+    0,
+  );
+});
+
+test("GitHubClient createPullRequest falls back to all-state branch lookup after open-state retries", async () => {
+  const config = createConfig();
+  const createdPr = createPullRequest({ state: "CLOSED", updatedAt: "2026-03-16T01:00:12Z" });
+  let openBranchLookups = 0;
+  let allBranchLookups = 0;
+  const delays: number[] = [];
+  const client = new GitHubClient(
+    config,
+    async (_command, args) => {
+      if (args[0] === "pr" && args[1] === "create") {
+        return {
+          exitCode: 0,
+          stdout: "https://example.test/pull/354\n",
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("open")) {
+        openBranchLookups += 1;
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([]),
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("all")) {
+        allBranchLookups += 1;
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([createdPr]),
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "api" && args[1] === "graphql") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewRequests: { nodes: [] },
+                  reviews: { nodes: [] },
+                  comments: { nodes: [] },
+                  reviewThreads: { nodes: [] },
+                  timelineItems: { nodes: [] },
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+
+      throw new Error(`Unexpected args: ${args.join(" ")}`);
+    },
+    async (ms) => {
+      delays.push(ms);
+    },
+  );
+
+  const pr = await client.createPullRequest(createIssue(), createRecord(), { draft: true });
+
+  assert.equal(pr.number, 354);
+  assert.equal(openBranchLookups, 3);
+  assert.equal(allBranchLookups, 1);
+  assert.deepEqual(delays, [200, 400]);
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -22,6 +22,9 @@ export { isTransientGitHubCommandFailure } from "./github-transport";
 export { inferCopilotReviewLifecycle } from "./github-review-signals";
 export type { GitHubCommandRunner } from "./github-transport";
 
+const POST_CREATE_PR_LOOKUP_RETRY_LIMIT = 2;
+const POST_CREATE_PR_LOOKUP_BASE_DELAY_MS = 200;
+
 export class GitHubClient {
   private readonly pullRequestHydrator: GitHubPullRequestHydrator;
   private readonly transport: GitHubTransport;
@@ -29,7 +32,7 @@ export class GitHubClient {
   constructor(
     private readonly config: SupervisorConfig,
     commandRunner = runCommand,
-    delay: (ms: number) => Promise<void> = async (ms) => {
+    private readonly delay: (ms: number) => Promise<void> = async (ms) => {
       await new Promise((resolve) => setTimeout(resolve, ms));
     },
     private readonly now: () => number = Date.now,
@@ -384,12 +387,27 @@ export class GitHubClient {
       ...(options?.draft ? ["--draft"] : []),
     ]);
 
-    const created = await this.findOpenPullRequest(record.branch);
+    const created = await this.findPullRequestAfterCreation(record.branch);
     if (!created) {
       throw new Error(`Failed to locate PR after creation for branch ${record.branch}`);
     }
 
     return created;
+  }
+
+  private async findPullRequestAfterCreation(branch: string): Promise<GitHubPullRequest | null> {
+    for (let attempt = 0; attempt <= POST_CREATE_PR_LOOKUP_RETRY_LIMIT; attempt += 1) {
+      const pullRequest = await this.findOpenPullRequest(branch);
+      if (pullRequest) {
+        return pullRequest;
+      }
+
+      if (attempt < POST_CREATE_PR_LOOKUP_RETRY_LIMIT) {
+        await this.delay(POST_CREATE_PR_LOOKUP_BASE_DELAY_MS * (attempt + 1));
+      }
+    }
+
+    return this.findLatestPullRequestForBranch(branch);
   }
 
   async enableAutoMerge(prNumber: number, headSha: string): Promise<void> {


### PR DESCRIPTION
Closes #355
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the recovery path in [src/github.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-355/src/github.ts) and added focused regression coverage in [src/github.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-355/src/github.test.ts). After `gh pr create`, the client now retries `--state open --head <branch>` three times total with short backoff, then falls back to `--state all --head <branch>` before failing.

I first reproduced the bug with a narrow failing test, then added a second test for the `state=all` fallback. Verification passed with `npx tsx --test src/github.test.ts src/run-once-turn-execution.test.ts` and `npm run build`. The work is committed as `3a74fbb` (`Recover PR rediscovery after creation`). I also updated the working notes in [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-355/.codex-supervisor/issue-journal.md).

Summary: Added post-PR-create rediscovery retries plus `state=all` fallback, with focused regression tests and a checkpoint commit.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/github.test.ts src/run-once-turn-execution.test.ts`; `npm install`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-355` with commit `3a74fbb` and let CI verify the recovery path end to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pull request creation reliability by implementing automatic retry attempts when newly created pull requests aren't immediately visible.

* **Tests**
  * Added test coverage validating pull request creation behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->