### PR TITLE
Src reorganization: move local-review modules into src/local-review/ (#364)

### DIFF
--- a/docs/shared-memory/external-review-guardrails.json
+++ b/docs/shared-memory/external-review-guardrails.json
@@ -2,9 +2,9 @@
   "version": 1,
   "patterns": [
     {
-      "fingerprint": "src/local-review-prompt.ts|anchor-findings-to-real-boundary",
+      "fingerprint": "src/local-review/prompt.ts|anchor-findings-to-real-boundary",
       "reviewerLogin": "copilot-pull-request-reviewer",
-      "file": "src/local-review-prompt.ts",
+      "file": "src/local-review/prompt.ts",
       "line": null,
       "summary": "Flag findings or promoted guardrails that anchor to an earlier or adjacent implementation step when the real behavioral boundary is a later transition or invariant.",
       "rationale": "Guardrails last longer when they point at the decisive boundary under protection instead of a nearby setup location that refactors can move without changing the behavior.",
@@ -13,9 +13,9 @@
       "lastSeenAt": "2026-03-14T00:00:00Z"
     },
     {
-      "fingerprint": "src/local-review.test.ts|avoid-drift-prone-line-coupling",
+      "fingerprint": "src/local-review/index.test.ts|avoid-drift-prone-line-coupling",
       "reviewerLogin": "copilot-pull-request-reviewer",
-      "file": "src/local-review.test.ts",
+      "file": "src/local-review/index.test.ts",
       "line": null,
       "summary": "Flag tests or promoted guardrails that hard-code exact source line numbers when a stable behavior, identifier, or nearby intent anchor would verify the same invariant.",
       "rationale": "Source lines drift during refactors. Keep exact line assertions only when the source location itself is the intended contract, such as user-visible diagnostics or mappings.",

--- a/src/external-review-classifier.ts
+++ b/src/external-review-classifier.ts
@@ -1,4 +1,4 @@
-import { type LocalReviewSeverity } from "./local-review-types";
+import { type LocalReviewSeverity } from "./local-review/types";
 import { type NormalizedExternalReviewFinding } from "./external-review-normalization";
 
 export type ExternalReviewMatch = "matched" | "near_match" | "missed_by_local_review";

--- a/src/external-review-misses.test.ts
+++ b/src/external-review-misses.test.ts
@@ -1217,18 +1217,18 @@ test("repo-committed durable external-review guardrails teach stable anchors for
     artifactDir: path.join(repoRoot, ".local", "reviews"),
     branch: "codex/issue-203",
     currentHeadSha: "currenthead",
-    changedFiles: ["src/local-review.test.ts"],
+    changedFiles: ["src/local-review/index.test.ts"],
     limit: 10,
     workspacePath: repoRoot,
   });
 
   assert.deepEqual(
-    patterns.filter((pattern) => pattern.fingerprint === "src/local-review.test.ts|avoid-drift-prone-line-coupling"),
+    patterns.filter((pattern) => pattern.fingerprint === "src/local-review/index.test.ts|avoid-drift-prone-line-coupling"),
     [
       {
-        fingerprint: "src/local-review.test.ts|avoid-drift-prone-line-coupling",
+        fingerprint: "src/local-review/index.test.ts|avoid-drift-prone-line-coupling",
         reviewerLogin: "copilot-pull-request-reviewer",
-        file: "src/local-review.test.ts",
+        file: "src/local-review/index.test.ts",
         line: null,
         summary:
           "Flag tests or promoted guardrails that hard-code exact source line numbers when a stable behavior, identifier, or nearby intent anchor would verify the same invariant.",
@@ -1248,18 +1248,18 @@ test("repo-committed durable external-review guardrails prefer the real behavior
     artifactDir: path.join(repoRoot, ".local", "reviews"),
     branch: "codex/issue-204",
     currentHeadSha: "currenthead",
-    changedFiles: ["src/local-review-prompt.ts"],
+    changedFiles: ["src/local-review/prompt.ts"],
     limit: 10,
     workspacePath: repoRoot,
   });
 
   assert.deepEqual(
-    patterns.filter((pattern) => pattern.fingerprint === "src/local-review-prompt.ts|anchor-findings-to-real-boundary"),
+    patterns.filter((pattern) => pattern.fingerprint === "src/local-review/prompt.ts|anchor-findings-to-real-boundary"),
     [
       {
-        fingerprint: "src/local-review-prompt.ts|anchor-findings-to-real-boundary",
+        fingerprint: "src/local-review/prompt.ts|anchor-findings-to-real-boundary",
         reviewerLogin: "copilot-pull-request-reviewer",
-        file: "src/local-review-prompt.ts",
+        file: "src/local-review/prompt.ts",
         line: null,
         summary:
           "Flag findings or promoted guardrails that anchor to an earlier or adjacent implementation step when the real behavioral boundary is a later transition or invariant.",

--- a/src/external-review-normalization.ts
+++ b/src/external-review-normalization.ts
@@ -1,5 +1,5 @@
 import { truncate } from "./utils";
-import { type LocalReviewSeverity } from "./local-review-types";
+import { type LocalReviewSeverity } from "./local-review/types";
 import { hasActionableReviewText, isActionableTopLevelReview } from "./external-review-signal-heuristics";
 import { type IssueComment, type PullRequestReview, type ReviewThread } from "./types";
 

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -3,9 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { writeLocalReviewArtifacts } from "./local-review-artifacts";
-import { finalizeLocalReview } from "./local-review-finalize";
-import { createConfig } from "./local-review-test-helpers";
+import { writeLocalReviewArtifacts } from "./artifacts";
+import { finalizeLocalReview } from "./finalize";
+import { createConfig } from "./test-helpers";
 
 test("writeLocalReviewArtifacts renders durable guardrail provenance compactly", async () => {
   const config = createConfig({

--- a/src/local-review/artifacts.ts
+++ b/src/local-review/artifacts.ts
@@ -1,8 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type SupervisorConfig } from "./types";
-import { type FinalizedLocalReview, type LocalReviewFinding, type LocalReviewResult, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type SupervisorConfig } from "../types";
+import {
+  type FinalizedLocalReview,
+  type LocalReviewFinding,
+  type LocalReviewResult,
+  type LocalReviewRoleResult,
+  type LocalReviewVerifierReport,
+} from "./types";
 
 function safeSlug(input: string): string {
   return input.replace(/[^a-zA-Z0-9._-]+/g, "-");

--- a/src/local-review/execution.test.ts
+++ b/src/local-review/execution.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { runLocalReviewExecution, selectVerifierFindings } from "./local-review-execution";
-import { type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
+import { runLocalReviewExecution, selectVerifierFindings } from "./execution";
+import { type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./types";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "../types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {

--- a/src/local-review/execution.ts
+++ b/src/local-review/execution.ts
@@ -1,10 +1,10 @@
-import { dedupeFindings } from "./local-review-finalize";
-import { findingMeetsReviewerThreshold, reviewerTypeForRole } from "./local-review-thresholds";
-import { runRoleReview as defaultRunRoleReview, runVerifierReview as defaultRunVerifierReview } from "./local-review-runner";
-import { type ExternalReviewMissPattern } from "./external-review-misses";
-import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
+import { dedupeFindings } from "./finalize";
+import { findingMeetsReviewerThreshold, reviewerTypeForRole } from "./thresholds";
+import { runRoleReview as defaultRunRoleReview, runVerifierReview as defaultRunVerifierReview } from "./runner";
+import { type ExternalReviewMissPattern } from "../external-review-misses";
+import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./types";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "../types";
 
 export function selectVerifierFindings(args: {
   config: SupervisorConfig;

--- a/src/local-review/finalize.test.ts
+++ b/src/local-review/finalize.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { finalizeLocalReview } from "./local-review-finalize";
-import { createConfig, createDetectedRoles } from "./local-review-test-helpers";
+import { finalizeLocalReview } from "./finalize";
+import { createConfig, createDetectedRoles } from "./test-helpers";
 
 test("finalizeLocalReview keeps raw high-severity findings separate from dismissed verifier results", () => {
   const result = finalizeLocalReview({
@@ -334,7 +334,7 @@ test("finalizeLocalReview merges root-cause groups connected by a bridging findi
             role: "reviewer",
             title: "Auth refresh misses invalid session guard",
             body: "The auth refresh path can continue after an invalid session token and retry stale work.",
-            file: "src/local-review.ts",
+            file: "src/local-review/index.ts",
             start: 10,
             end: 12,
             severity: "high",
@@ -346,7 +346,7 @@ test("finalizeLocalReview merges root-cause groups connected by a bridging findi
             role: "reviewer",
             title: "Bridge finding links the same stale session retry path",
             body: "The auth refresh retry path keeps using the same stale session token after invalidation.",
-            file: "src/local-review.ts",
+            file: "src/local-review/index.ts",
             start: 15,
             end: 17,
             severity: "high",
@@ -358,7 +358,7 @@ test("finalizeLocalReview merges root-cause groups connected by a bridging findi
             role: "explorer",
             title: "Retry loop keeps invalid session token alive",
             body: "The auth refresh retry loop can keep an invalid session token alive and repeat stale work.",
-            file: "src/local-review.ts",
+            file: "src/local-review/index.ts",
             start: 21,
             end: 23,
             severity: "high",

--- a/src/local-review/finalize.ts
+++ b/src/local-review/finalize.ts
@@ -1,7 +1,7 @@
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type SupervisorConfig } from "./types";
-import { truncate } from "./utils";
-import { findingMeetsReviewerThreshold, reviewerTypeForRole, thresholdsForReviewerType } from "./local-review-thresholds";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type SupervisorConfig } from "../types";
+import { truncate } from "../utils";
+import { findingMeetsReviewerThreshold, reviewerTypeForRole, thresholdsForReviewerType } from "./thresholds";
 import {
   type FinalizedLocalReview,
   type LocalReviewGuardrailProvenance,
@@ -12,7 +12,7 @@ import {
   type LocalReviewRoleResult,
   type LocalReviewSeverity,
   type LocalReviewVerifierReport,
-} from "./local-review-types";
+} from "./types";
 
 function severityWeight(severity: LocalReviewFinding["severity"]): number {
   switch (severity) {

--- a/src/local-review/index.test.ts
+++ b/src/local-review/index.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { localReviewHasActionableFindings, shouldRunLocalReview } from "./local-review";
-import { createConfig, createPullRequest } from "./local-review-test-helpers";
+import { localReviewHasActionableFindings, shouldRunLocalReview } from "./index";
+import { createConfig, createPullRequest } from "./test-helpers";
 
 test("shouldRunLocalReview covers draft and ready policy gating combinations", () => {
   const cases: Array<{

--- a/src/local-review/index.ts
+++ b/src/local-review/index.ts
@@ -1,18 +1,18 @@
 import {
   formatLocalReviewResult,
   prepareLocalReviewGuardrailProvenance,
-} from "./local-review-result";
-import { ensureDir, nowIso } from "./utils";
-import { finalizeLocalReview } from "./local-review-finalize";
-import { reviewDir, writeLocalReviewArtifacts } from "./local-review-artifacts";
-import { runLocalReviewExecution } from "./local-review-execution";
+} from "./result";
+import { ensureDir, nowIso } from "../utils";
+import { finalizeLocalReview } from "./finalize";
+import { reviewDir, writeLocalReviewArtifacts } from "./artifacts";
+import { runLocalReviewExecution } from "./execution";
 import {
   collectLocalReviewChangedFiles,
   loadLocalReviewExternalReviewContext,
   prepareLocalReviewRoleSelection,
-} from "./local-review-preparation";
-import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "./types";
-import { type LocalReviewResult } from "./local-review-types";
+} from "./preparation";
+import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "../types";
+import { type LocalReviewResult } from "./types";
 
 export type {
   ActionableSeverity,
@@ -28,11 +28,11 @@ export type {
   ParsedRoleFooter,
   ParsedVerifierFooter,
   VerificationVerdict,
-} from "./local-review-types";
+} from "./types";
 export {
   buildLocalReviewBlockerSummary,
   LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
-} from "./local-review-result";
+} from "./result";
 
 export function localReviewHasActionableFindings(
   record: Pick<IssueRunRecordLike, "local_review_head_sha" | "local_review_findings_count" | "local_review_recommendation">,

--- a/src/local-review/preparation.test.ts
+++ b/src/local-review/preparation.test.ts
@@ -6,9 +6,9 @@ import {
   loadLocalReviewExternalReviewContext,
   prepareLocalReviewRoleSelection,
   selectLocalReviewRoles,
-} from "./local-review-preparation";
-import { createConfig, createDetectedRoles, createMissPattern } from "./local-review-test-helpers";
-import { type LocalReviewRoleSelection } from "./review-role-detector";
+} from "./preparation";
+import { createConfig, createDetectedRoles, createMissPattern } from "./test-helpers";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
 
 test("selectLocalReviewRoles preserves configured roles before detected or default roles", () => {
   assert.deepEqual(

--- a/src/local-review/preparation.ts
+++ b/src/local-review/preparation.ts
@@ -1,13 +1,13 @@
 import {
   compareExternalReviewPatterns,
   loadCommittedExternalReviewGuardrails,
-} from "./committed-guardrails";
-import { runCommand } from "./command";
-import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "./external-review-misses";
-import { reviewDir } from "./local-review-artifacts";
-import { compareRef } from "./local-review-prompt";
-import { detectLocalReviewRoleSelections, type LocalReviewRoleSelection } from "./review-role-detector";
-import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
+} from "../committed-guardrails";
+import { runCommand } from "../command";
+import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "../external-review-misses";
+import { reviewDir } from "./artifacts";
+import { compareRef } from "./prompt";
+import { detectLocalReviewRoleSelections, type LocalReviewRoleSelection } from "../review-role-detector";
+import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "../types";
 
 export function selectLocalReviewRoles(args: {
   config: Pick<SupervisorConfig, "localReviewRoles">;

--- a/src/local-review/prompt.test.ts
+++ b/src/local-review/prompt.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildRolePrompt, buildVerifierPrompt } from "./local-review-prompt";
-import { createIssue, createPullRequest } from "./local-review-test-helpers";
-import { type VerifierGuardrailRule } from "./verifier-guardrails";
+import { buildRolePrompt, buildVerifierPrompt } from "./prompt";
+import { createIssue, createPullRequest } from "./test-helpers";
+import { type VerifierGuardrailRule } from "../verifier-guardrails";
 
 test("buildRolePrompt includes bounded relevant prior external misses", () => {
   const prompt = buildRolePrompt({
@@ -338,7 +338,7 @@ test("buildVerifierPrompt distinguishes drift-prone and legitimate line-sensitiv
         role: "reviewer",
         title: "Brittle line-number assertion",
         body: "The new test hard-codes a source line number even though it could anchor to the same guardrail id and behavior.",
-        file: "src/local-review.test.ts",
+        file: "src/local-review/index.test.ts",
         start: 1,
         end: 20,
         severity: "high",

--- a/src/local-review/prompt.ts
+++ b/src/local-review/prompt.ts
@@ -1,15 +1,15 @@
-import { type ExternalReviewMissPattern } from "./external-review-misses";
-import { type GitHubIssue, type GitHubPullRequest } from "./types";
-import { truncate } from "./utils";
-import { renderLines } from "./local-review-artifacts";
-import { findingKey } from "./local-review-finalize";
-import { type VerifierGuardrailRule } from "./verifier-guardrails";
+import { type ExternalReviewMissPattern } from "../external-review-misses";
+import { type GitHubIssue, type GitHubPullRequest } from "../types";
+import { truncate } from "../utils";
+import { renderLines } from "./artifacts";
+import { findingKey } from "./finalize";
+import { type VerifierGuardrailRule } from "../verifier-guardrails";
 import {
   type LocalReviewFinding,
   type LocalReviewVerificationFinding,
   type ParsedRoleFooter,
   type ParsedVerifierFooter,
-} from "./local-review-types";
+} from "./types";
 
 interface RolePromptArgs {
   repoSlug: string;

--- a/src/local-review/reorganization.test.ts
+++ b/src/local-review/reorganization.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
+import path from "node:path";
+
+const LOCAL_REVIEW_MODULES = [
+  "index.ts",
+  "artifacts.ts",
+  "execution.ts",
+  "finalize.ts",
+  "preparation.ts",
+  "prompt.ts",
+  "repair-context.ts",
+  "result.ts",
+  "runner.ts",
+  "test-helpers.ts",
+  "thresholds.ts",
+  "types.ts",
+] as const;
+
+test("local-review family lives under src/local-review", async () => {
+  await Promise.all(
+    LOCAL_REVIEW_MODULES.map(async (modulePath) => {
+      await assert.doesNotReject(() => access(path.join(__dirname, modulePath)));
+    }),
+  );
+});

--- a/src/local-review/repair-context.test.ts
+++ b/src/local-review/repair-context.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { loadLocalReviewRepairContext } from "./local-review-repair-context";
+import { loadLocalReviewRepairContext } from "./repair-context";
 
 test("loadLocalReviewRepairContext derives the findings path and trims prompt context", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-fix-test-"));

--- a/src/local-review/repair-context.ts
+++ b/src/local-review/repair-context.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { type LocalReviewRepairContext } from "./codex/codex-prompt";
-import { loadRelevantExternalReviewMissPatterns } from "./external-review-misses";
-import { parseJson } from "./utils";
-import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";
+import { type LocalReviewRepairContext } from "../codex/codex-prompt";
+import { loadRelevantExternalReviewMissPatterns } from "../external-review-misses";
+import { parseJson } from "../utils";
+import { loadRelevantVerifierGuardrails } from "../verifier-guardrails";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);

--- a/src/local-review/result.test.ts
+++ b/src/local-review/result.test.ts
@@ -5,9 +5,9 @@ import {
   formatLocalReviewResult,
   LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
   prepareLocalReviewGuardrailProvenance,
-} from "./local-review-result";
-import { finalizeLocalReview } from "./local-review-finalize";
-import { createConfig, createMissPattern } from "./local-review-test-helpers";
+} from "./result";
+import { finalizeLocalReview } from "./finalize";
+import { createConfig, createMissPattern } from "./test-helpers";
 
 test("prepareLocalReviewGuardrailProvenance groups runtime sources and keeps artifact-relative paths", () => {
   const config = createConfig({

--- a/src/local-review/result.ts
+++ b/src/local-review/result.ts
@@ -2,11 +2,11 @@ import path from "node:path";
 import {
   EXTERNAL_REVIEW_GUARDRAILS_PATH,
   VERIFIER_GUARDRAILS_PATH,
-} from "./committed-guardrails";
-import { type ExternalReviewMissPattern } from "./external-review-misses";
-import { type FinalizedLocalReview, type LocalReviewResult, type LocalReviewVerifierReport } from "./local-review-types";
-import { truncate } from "./utils";
-import { type SupervisorConfig } from "./types";
+} from "../committed-guardrails";
+import { type ExternalReviewMissPattern } from "../external-review-misses";
+import { type FinalizedLocalReview, type LocalReviewResult, type LocalReviewVerifierReport } from "./types";
+import { truncate } from "../utils";
+import { type SupervisorConfig } from "../types";
 
 export const LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY = "degraded local review; inspect the saved artifact";
 

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -1,14 +1,14 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { runCommand } from "./command";
-import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex/codex-policy";
-import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "./external-review-misses";
-import { reviewDir } from "./local-review-artifacts";
-import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./local-review-prompt";
-import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./local-review-types";
-import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
-import { loadRelevantVerifierGuardrails } from "./verifier-guardrails";
+import { runCommand } from "../command";
+import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "../codex/codex-policy";
+import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "../external-review-misses";
+import { reviewDir } from "./artifacts";
+import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./prompt";
+import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./types";
+import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "../types";
+import { loadRelevantVerifierGuardrails } from "../verifier-guardrails";
 
 function safeSlug(input: string): string {
   return input.replace(/[^a-zA-Z0-9._-]+/g, "-");

--- a/src/local-review/test-helpers.ts
+++ b/src/local-review/test-helpers.ts
@@ -1,6 +1,6 @@
-import { type ExternalReviewMissPattern } from "./external-review-misses";
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "./types";
+import { type ExternalReviewMissPattern } from "../external-review-misses";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "../types";
 
 export function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   const baseConfig: SupervisorConfig = {

--- a/src/local-review/thresholds.ts
+++ b/src/local-review/thresholds.ts
@@ -1,6 +1,6 @@
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type ActionableSeverity, type LocalReviewFinding, type LocalReviewReviewerThresholdConfig, type LocalReviewReviewerType } from "./local-review-types";
-import { type SupervisorConfig } from "./types";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type ActionableSeverity, type LocalReviewFinding, type LocalReviewReviewerThresholdConfig, type LocalReviewReviewerType } from "./types";
+import { type SupervisorConfig } from "../types";
 
 const SEVERITY_WEIGHT: Record<ActionableSeverity, number> = {
   low: 1,

--- a/src/local-review/types.ts
+++ b/src/local-review/types.ts
@@ -1,5 +1,5 @@
-import { type LocalReviewRoleSelection } from "./review-role-detector";
-import { type VerifierGuardrailRule } from "./verifier-guardrails";
+import { type LocalReviewRoleSelection } from "../review-role-detector";
+import { type VerifierGuardrailRule } from "../verifier-guardrails";
 
 export type LocalReviewSeverity = "none" | "low" | "medium" | "high";
 

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -53,7 +53,7 @@ function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullReques
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
 }
 
-export { loadLocalReviewRepairContext } from "./local-review-repair-context";
+export { loadLocalReviewRepairContext } from "./local-review/repair-context";
 
 export interface CodexTurnContext {
   state: SupervisorStateFile;

--- a/src/supervisor-status-rendering.ts
+++ b/src/supervisor-status-rendering.ts
@@ -7,7 +7,7 @@ import {
   VERIFIER_GUARDRAILS_PATH,
 } from "./committed-guardrails";
 import { loadRelevantExternalReviewMissPatterns } from "./external-review-misses";
-import { reviewDir } from "./local-review-artifacts";
+import { reviewDir } from "./local-review/artifacts";
 import {
   configuredBotReviewThreads,
   latestReviewComment,

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -11,7 +11,7 @@ import {
 } from "./external-review-misses";
 import { syncExternalReviewMissState } from "./external-review-miss-state";
 import { GitHubClient } from "./github";
-import { loadLocalReviewRepairContext } from "./local-review-repair-context";
+import { loadLocalReviewRepairContext } from "./local-review/repair-context";
 import {
   hasProcessedReviewThread,
   latestReviewThreadCommentFingerprint,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "./local-review-types";
+import type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "./local-review/types";
 
-export type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "./local-review-types";
+export type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "./local-review/types";
 
 export type RunState =
   | "queued"


### PR DESCRIPTION
Closes #364
This PR was opened by codex-supervisor.
Latest Codex summary:

Moved the local-review family into [`src/local-review/index.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/local-review/index.ts) and sibling modules/tests under [`src/local-review/`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/local-review). I added [`src/local-review/reorganization.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/local-review/reorganization.test.ts) first to reproduce the missing layout, then updated all affected imports and the committed durable guardrail/test fixtures that still referenced the old top-level filenames.

I also fixed downstream consumers in [`src/types.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/types.ts), [`src/turn-execution-orchestration.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/turn-execution-orchestration.ts), [`src/run-once-turn-execution.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/run-once-turn-execution.ts), [`src/supervisor-status-rendering.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/src/supervisor-status-rendering.ts), and [`docs/shared-memory/external-review-guardrails.json`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-364/docs/shared-memory/external-review-guardrails.json). The checkpoint is committed as `db86cce` with message `Move local-review family into src/local-review`.

Summary: Reorganized the full local-review family into `src/local-review/`, added a focused ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized module structure to consolidate related local-review files into a dedicated namespace for improved code organization.

* **Tests**
  * Added validation test suite to ensure accessibility of reorganized modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->