### PR TITLE
Post-refactor stabilization: normalize family-directory import and barrel conventions (#376)

### DIFF
--- a/src/codex/reorganization.test.ts
+++ b/src/codex/reorganization.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+test("non-codex modules use the codex family barrel for prompt helpers", async () => {
+  const sourceFiles = [
+    path.join(__dirname, "..", "turn-execution-orchestration.ts"),
+    path.join(__dirname, "..", "local-review", "repair-context.ts"),
+  ];
+
+  await Promise.all(sourceFiles.map(async (sourceFile) => {
+    const content = await readFile(sourceFile, "utf8");
+    assert.doesNotMatch(content, /from ["'][.]{1,2}\/codex\/codex-prompt["']/);
+  }));
+});

--- a/src/local-review/repair-context.ts
+++ b/src/local-review/repair-context.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { type LocalReviewRepairContext } from "../codex/codex-prompt";
+import { type LocalReviewRepairContext } from "../codex";
 import { loadRelevantExternalReviewMissPatterns } from "../external-review/external-review-misses";
 import { parseJson } from "../core/utils";
 import { loadRelevantVerifierGuardrails } from "../verifier-guardrails";

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -3,7 +3,7 @@ import {
   buildCodexPrompt,
   buildCodexResumePrompt,
   shouldUseCompactResumePrompt,
-} from "./codex/codex-prompt";
+} from "./codex";
 import {
   collectExternalReviewSignals,
   ExternalReviewMissContext,


### PR DESCRIPTION
Closes #376
This PR was opened by codex-supervisor.
Latest Codex summary:

Normalized the `codex` family import convention by switching external prompt-helper consumers to the existing barrel in [src/turn-execution-orchestration.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-376/src/turn-execution-orchestration.ts) and [src/local-review/repair-context.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-376/src/local-review/repair-context.ts). I added a focused regression test in [src/codex/reorganization.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-376/src/codex/reorganization.test.ts) so non-`codex` modules cannot deep-import `codex-prompt` again.

Verified with `npm test -- --test-name-pattern "non-codex modules use the codex family barrel for prompt helpers"` and `npm run build`, then committed the checkpoint as `dc443c3` (`Normalize codex family barrel imports`). I also updated the local issue journal at [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-376/.codex-supervisor/issue-journal.md); it remains untracked by design.

Summary: Normalized external `codex` prompt-helper imports to the family barrel, added a focused regression test, and committed the verified change as `dc443c3`.
State hint: stabilizing
Blocked reason: none
Tests: `npm test -- --test-name-pattern "non-codex modules use the codex family barrel for prompt helpers"`; `npm run build`
Failure signature: none
Next action: Decide whether to broaden the same barrel-vs-direct convention into other familie...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify and enforce proper module dependency separation.

* **Refactor**
  * Reorganized internal module architecture for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->