### PR TITLE
Post-refactor stabilization: reduce recurring local workspace noise (#378)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.DS_Store
 .local/
 .codex-supervisor/issue-journal.md
 supervisor.config.json

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -328,6 +329,43 @@ test("shipped config profiles declare the intended review bot logins", async () 
       `${relativePath} should declare the expected reviewBotLogins`,
     );
   }
+});
+
+test("repo gitignore ignores .DS_Store without hiding host-specific coderabbit config", async (t) => {
+  const rootDir = path.resolve(__dirname, "..");
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-gitignore-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  await fs.copyFile(path.join(rootDir, ".gitignore"), path.join(tempDir, ".gitignore"));
+  await fs.writeFile(path.join(tempDir, ".DS_Store"), "", "utf8");
+  await fs.writeFile(path.join(tempDir, "supervisor.config.coderabbit.json"), "{}", "utf8");
+
+  execFileSync("git", ["init"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+
+  const ignoredPath = execFileSync("git", ["check-ignore", ".DS_Store"], {
+    cwd: tempDir,
+    encoding: "utf8",
+  }).trim();
+  assert.equal(ignoredPath, ".DS_Store");
+
+  const coderabbitExitCode = (() => {
+    try {
+      execFileSync("git", ["check-ignore", "supervisor.config.coderabbit.json"], {
+        cwd: tempDir,
+        stdio: "ignore",
+      });
+      return 0;
+    } catch (error) {
+      const exitCode = (error as NodeJS.ErrnoException & { status?: number }).status;
+      return typeof exitCode === "number" ? exitCode : -1;
+    }
+  })();
+  assert.equal(coderabbitExitCode, 1);
 });
 
 test("README stays a lightweight landing page with provider profile guidance and a docs map", async () => {


### PR DESCRIPTION
Closes #378
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a narrow repo hygiene fix and committed it as `e8b6ded` (`Ignore .DS_Store workspace noise`). The change adds `.DS_Store` to [`/.gitignore`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-378/.gitignore) and adds a git-backed regression test in [`src/config.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-378/src/config.test.ts) proving `.DS_Store` is ignored while `supervisor.config.coderabbit.json` remains intentionally unignored.

Verification covered the focused regression with `npx tsx --test src/config.test.ts --test-name-pattern "repo gitignore ignores \\.DS_Store without hiding host-specific coderabbit config"` and `npm run build`. Working tree is clean aside from ignored local artifacts (`.codex-supervisor/`, `dist/`, `node_modules/`). The issue journal was updated with the reproduction, fix, and verification details.

Summary: Ignored recurring `.DS_Store` workspace noise without affecting the host-specific `supervisor.config.coderabbit.json` workflow, added a regression test, and committed the fix.
State hint: stabilizing
Blocked reason: none
Tests: Focused config test via `npx tsx --test src/config.test.ts --test-name-pattern "repo gitignore ignores \\.DS_Store without hiding host-specific coderabbit config"`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for branch `codex/issue-378` with commit `e8b6ded` if supervisor flow wants a PR at this checkpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude macOS Finder metadata files from version control tracking.

* **Tests**
  * Added test coverage to ensure system files are properly excluded from version control while preserving necessary configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->