### PR TITLE
Codex agent runner: adapt the current Codex CLI integration behind the new runner contract (#384)

### DIFF
--- a/src/supervisor/agent-runner.test.ts
+++ b/src/supervisor/agent-runner.test.ts
@@ -10,6 +10,7 @@ import type {
   ResumeAgentTurnRequest,
   StartAgentTurnRequest,
 } from "./agent-runner";
+import { createCodexAgentRunner } from "./agent-runner";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -176,6 +177,130 @@ test("agent turn result supports both parsed and raw supervisor output", () => {
   assert.equal(parsedResult.structuredResult?.stateHint, "blocked");
   assert.equal(parsedResult.structuredResult?.blockedReason, "verification");
   assert.equal(parsedResult.structuredResult?.failureSignature, "missing-test");
+});
+
+test("createCodexAgentRunner adapts start and resume requests to Codex CLI turns", async () => {
+  const config = createConfig();
+  const seenCalls: Array<{
+    workspacePath: string;
+    prompt: string;
+    state: RunState;
+    record:
+      | {
+          repeated_failure_signature_count: number;
+          blocked_verification_retry_count: number;
+          timeout_retry_count: number;
+        }
+      | null
+      | undefined;
+    sessionId: string | null | undefined;
+  }> = [];
+  const runner = createCodexAgentRunner({
+    runCodexTurnImpl: async (_config, workspacePath, prompt, state, record, sessionId) => {
+      seenCalls.push({
+        workspacePath,
+        prompt,
+        state,
+        record,
+        sessionId,
+      });
+      return {
+        exitCode: sessionId ? 1 : 0,
+        sessionId: sessionId ?? "session-new",
+        lastMessage: [
+          "Summary: Codex adapter result",
+          `State hint: ${sessionId ? "blocked" : "implementing"}`,
+          `Blocked reason: ${sessionId ? "verification" : "none"}`,
+          "Failure signature: reproduced-contract-gap",
+          "Tests: npx tsx --test src/supervisor/agent-runner.test.ts",
+          "Next action: continue with focused verification",
+        ].join("\n"),
+        stderr: sessionId ? "resume failed" : "",
+        stdout: sessionId ? "resume output" : "fresh output",
+      };
+    },
+  });
+
+  const startResult = await runner.runTurn({
+    kind: "start",
+    config,
+    workspacePath: "/tmp/workspace",
+    prompt: "Investigate the failing path.",
+    state: "reproducing",
+    record: {
+      repeated_failure_signature_count: 0,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+    },
+  });
+  const resumeResult = await runner.runTurn({
+    kind: "resume",
+    config,
+    workspacePath: "/tmp/workspace",
+    prompt: "Continue from the previous session.",
+    state: "implementing",
+    sessionId: "session-123",
+    record: null,
+  });
+
+  assert.equal(runner.capabilities.supportsResume, true);
+  assert.equal(runner.capabilities.supportsStructuredResult, true);
+  assert.deepEqual(seenCalls, [
+    {
+      workspacePath: "/tmp/workspace",
+      prompt: "Investigate the failing path.",
+      state: "reproducing",
+      record: {
+        repeated_failure_signature_count: 0,
+        blocked_verification_retry_count: 0,
+        timeout_retry_count: 0,
+      },
+      sessionId: undefined,
+    },
+    {
+      workspacePath: "/tmp/workspace",
+      prompt: "Continue from the previous session.",
+      state: "implementing",
+      record: null,
+      sessionId: "session-123",
+    },
+  ]);
+  assert.equal(startResult.sessionId, "session-new");
+  assert.equal(startResult.failureKind, null);
+  assert.equal(startResult.structuredResult?.summary, "Codex adapter result");
+  assert.equal(startResult.structuredResult?.stateHint, "implementing");
+  assert.equal(startResult.structuredResult?.blockedReason, null);
+  assert.equal(startResult.structuredResult?.tests, "npx tsx --test src/supervisor/agent-runner.test.ts");
+  assert.equal(resumeResult.sessionId, "session-123");
+  assert.equal(resumeResult.failureKind, "codex_exit");
+  assert.equal(resumeResult.structuredResult?.stateHint, "blocked");
+  assert.equal(resumeResult.structuredResult?.blockedReason, "verification");
+  assert.equal(resumeResult.structuredResult?.failureSignature, "reproduced-contract-gap");
+  assert.match(resumeResult.failureContext?.summary ?? "", /exited non-zero/i);
+});
+
+test("createCodexAgentRunner normalizes Codex execution errors into the shared failure shape", async () => {
+  const runner = createCodexAgentRunner({
+    runCodexTurnImpl: async () => {
+      throw new Error("Command timed out after 1800000ms");
+    },
+  });
+
+  const result = await runner.runTurn({
+    kind: "start",
+    config: createConfig(),
+    workspacePath: "/tmp/workspace",
+    prompt: "Retry the focused verification command.",
+    state: "repairing_ci",
+    record: null,
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.sessionId, null);
+  assert.equal(result.structuredResult, null);
+  assert.equal(result.failureKind, "timeout");
+  assert.equal(result.failureContext?.category, "codex");
+  assert.match(result.failureContext?.details[0] ?? "", /Command timed out after 1800000ms/);
 });
 
 void ([

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -1,4 +1,7 @@
+import { extractBlockedReason, extractFailureSignature, extractStateHint, runCodexTurn } from "../codex";
+import { truncate } from "../core/utils";
 import type { BlockedReason, FailureKind, FailureContext, IssueRunRecord, RunState, SupervisorConfig } from "../core/types";
+import { buildCodexFailureContext, classifyFailure } from "./supervisor-failure-helpers";
 
 export interface AgentRunnerCapabilities {
   supportsResume: boolean;
@@ -50,4 +53,119 @@ export interface AgentTurnResult {
 export interface AgentRunner {
   readonly capabilities: AgentRunnerCapabilities;
   runTurn(request: AgentTurnRequest): Promise<AgentTurnResult>;
+}
+
+export interface CreateCodexAgentRunnerOptions {
+  runCodexTurnImpl?: typeof runCodexTurn;
+  classifyFailureImpl?: typeof classifyFailure;
+  buildFailureContextImpl?: typeof buildCodexFailureContext;
+}
+
+function extractLabeledValue(message: string, label: string): string | null {
+  const match = message.match(new RegExp(`^${label}:\\s*(.+)$`, "im"));
+  if (!match) {
+    return null;
+  }
+
+  const value = match[1]?.trim();
+  if (!value || value.toLowerCase() === "none") {
+    return null;
+  }
+
+  return value;
+}
+
+export function parseAgentTurnStructuredResult(message: string): AgentTurnStructuredResult | null {
+  const summary = extractLabeledValue(message, "Summary");
+  const stateHint = extractStateHint(message);
+  const blockedReason = extractBlockedReason(message);
+  const failureSignature = extractFailureSignature(message);
+  const tests = extractLabeledValue(message, "Tests");
+  const nextAction = extractLabeledValue(message, "Next action");
+
+  if (!summary && !stateHint && !blockedReason && !failureSignature && !tests && !nextAction) {
+    return null;
+  }
+
+  return {
+    summary: summary ?? "",
+    stateHint,
+    blockedReason,
+    failureSignature,
+    nextAction,
+    tests,
+  };
+}
+
+function buildCodexExitFailureContext(
+  buildFailureContextImpl: typeof buildCodexFailureContext,
+  message: string,
+  stderr: string,
+  stdout: string,
+): FailureContext {
+  return buildFailureContextImpl(
+    "codex",
+    "Codex exited non-zero.",
+    [truncate([message, stderr, stdout].filter(Boolean).join("\n"), 2000) ?? "Unknown failure output"],
+  );
+}
+
+export function createCodexAgentRunner(options: CreateCodexAgentRunnerOptions = {}): AgentRunner {
+  const runCodexTurnImpl = options.runCodexTurnImpl ?? runCodexTurn;
+  const classifyFailureImpl = options.classifyFailureImpl ?? classifyFailure;
+  const buildFailureContextImpl = options.buildFailureContextImpl ?? buildCodexFailureContext;
+
+  return {
+    capabilities: {
+      supportsResume: true,
+      supportsStructuredResult: true,
+    },
+    async runTurn(request): Promise<AgentTurnResult> {
+      try {
+        const result = await runCodexTurnImpl(
+          request.config,
+          request.workspacePath,
+          request.prompt,
+          request.state,
+          request.record,
+          request.kind === "resume" ? request.sessionId : undefined,
+        );
+        const structuredResult = parseAgentTurnStructuredResult(result.lastMessage);
+        const failureKind: FailureKind = result.exitCode === 0 ? null : "codex_exit";
+
+        return {
+          exitCode: result.exitCode,
+          sessionId: result.sessionId,
+          supervisorMessage: result.lastMessage,
+          stderr: result.stderr,
+          stdout: result.stdout,
+          structuredResult,
+          failureKind,
+          failureContext:
+            failureKind === null
+              ? null
+              : buildCodexExitFailureContext(
+                  buildFailureContextImpl,
+                  result.lastMessage,
+                  result.stderr,
+                  result.stdout,
+                ),
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.stack ?? error.message : String(error);
+        return {
+          exitCode: 1,
+          sessionId: request.kind === "resume" ? request.sessionId : null,
+          supervisorMessage: "",
+          stderr: message,
+          stdout: "",
+          structuredResult: null,
+          failureKind: classifyFailureImpl(message),
+          failureContext: buildFailureContextImpl("codex", "Codex turn execution failed.", [
+            truncate(message, 2000) ?? "Unknown failure",
+          ]),
+        };
+      }
+    },
+  };
 }


### PR DESCRIPTION
Closes #384
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a Codex-backed `AgentRunner` in [src/supervisor/agent-runner.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-384/src/supervisor/agent-runner.ts) and added focused regression coverage in [src/supervisor/agent-runner.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-384/src/supervisor/agent-runner.test.ts). The adapter now maps start/resume requests onto the existing Codex CLI runner, parses the supervisor footer into the shared structured result, and normalizes non-zero exits and execution errors into the shared failure shape without changing the existing turn orchestration path.

Verification passed after reproducing the missing-adapter failure first. I ran `npx tsx --test src/supervisor/agent-runner.test.ts`, `npx tsx --test src/codex/codex-runner.test.ts src/supervisor/agent-runner.test.ts`, and `npm run build`. I also committed the code changes as `e3c1ad7` (`Add Codex agent runner adapter`).

Summary: Added a Codex-backed agent runner adapter and focused contract tests, preserving current Codex CLI semantics behind the new runner contract.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/supervisor/agent-runner.test.ts`; `npx tsx --test src/codex/codex-runner.test.ts src/supervisor/agent-runner.test.ts`; `npm ci`; `npm run build`
Failure signature: none
Next action: Integrate the new `createCodexAgentRunner` path into the next orchestration step that consumes the shared runner contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex agent runner with session management, structured result parsing, and error classification.
  * Enhanced error handling for timeout detection and failure context building.

* **Tests**
  * Comprehensive test coverage for Codex integration, validating session handling, result parsing, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->