### PR TITLE
Supervisor turn execution: route execution through the agent-runner abstraction (#385)

### DIFF
--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -2,8 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { executeCodexTurnPhase } from "./run-once-turn-execution";
-import { GitHubIssue, GitHubPullRequest, SupervisorStateFile } from "./core/types";
+import { FailureContextCategory, GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorStateFile } from "./core/types";
 import { createConfig, createIssue, createPullRequest, createRecord, createReviewThread } from "./turn-execution-test-helpers";
+import { AgentRunner, AgentTurnRequest } from "./supervisor/agent-runner";
+
+function createSuccessfulAgentRunner(
+  impl: (request: AgentTurnRequest) => ReturnType<AgentRunner["runTurn"]>,
+): AgentRunner {
+  return {
+    capabilities: {
+      supportsResume: true,
+      supportsStructuredResult: true,
+    },
+    runTurn: impl,
+  };
+}
 
 test("executeCodexTurnPhase does not mark review threads processed for a refreshed PR head it did not evaluate", async () => {
   const config = createConfig();
@@ -146,13 +159,16 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
             "- Next exact step: inspect the refreshed PR state.",
           ].join("\n");
     },
-    runCodexTurnImpl: async () => ({
+    agentRunner: createSuccessfulAgentRunner(async () => ({
       exitCode: 0,
       sessionId: "session-102",
-      lastMessage: "Reviewed the configured bot thread on the current head.",
+      supervisorMessage: "Reviewed the configured bot thread on the current head.",
       stderr: "",
       stdout: "",
-    }),
+      structuredResult: null,
+      failureKind: null,
+      failureContext: null,
+    })),
   });
 
   assert.equal(result.kind, "completed");
@@ -266,9 +282,9 @@ test("executeCodexTurnPhase skips prompt preparation side effects when the sessi
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
     readIssueJournal: async () => "## Codex Working Notes\n### Current Handoff\n- Hypothesis: wait for the lock.\n",
-    runCodexTurnImpl: async () => {
-      throw new Error("unexpected runCodexTurnImpl call");
-    },
+    agentRunner: createSuccessfulAgentRunner(async () => {
+      throw new Error("unexpected agentRunner.runTurn call");
+    }),
   });
 
   assert.deepEqual(result, {
@@ -278,4 +294,171 @@ test("executeCodexTurnPhase skips prompt preparation side effects when the sessi
   assert.equal(syncJournalCalls, 0);
   assert.equal(state.issues["102"]?.external_review_misses_path, null);
   assert.equal(state.issues["102"]?.external_review_head_sha, null);
+});
+
+test("executeCodexTurnPhase routes start and resume turns through the shared agent runner contract", async () => {
+  const requests: AgentTurnRequest[] = [];
+  const agentRunner = createSuccessfulAgentRunner(async (request) => {
+    requests.push(request);
+    return {
+      exitCode: 0,
+      sessionId: request.kind === "resume" ? request.sessionId : "session-started",
+      supervisorMessage: [
+        "Summary: completed via agent runner",
+        "State hint: stabilizing",
+        "Blocked reason: none",
+        "Tests: not run",
+        "Failure signature: none",
+        "Next action: continue",
+      ].join("\n"),
+      stderr: "",
+      stdout: "",
+      structuredResult: {
+        summary: "completed via agent runner",
+        stateHint: "stabilizing",
+        blockedReason: null,
+        failureSignature: null,
+        nextAction: "continue",
+        tests: "not run",
+      },
+      failureKind: null,
+      failureContext: null,
+    };
+  });
+  const issue: GitHubIssue = createIssue({ title: "Use the agent runner contract" });
+  const pr: GitHubPullRequest = createPullRequest({ title: "Agent runner turn execution" });
+
+  const createContext = (record = createRecord({ codex_session_id: null })) => {
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": record,
+      },
+    };
+
+    return {
+      state,
+      record,
+      issue,
+      previousCodexSummary: null,
+      previousError: null,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      workspaceStatus: {
+        branch: "codex/issue-102",
+        headSha: "head-a",
+        hasUncommittedChanges: false,
+        baseAhead: 0,
+        baseBehind: 0,
+        remoteBranchExists: true,
+        remoteAhead: 0,
+        remoteBehind: 0,
+      },
+      pr,
+      checks: [],
+      reviewThreads: [],
+      options: { dryRun: false },
+    };
+  };
+
+  const createArgs = (context: ReturnType<typeof createContext>) => ({
+    config: createConfig(),
+    stateStore: {
+      touch: (record: IssueRunRecord, patch: Partial<IssueRunRecord>) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => pr,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context,
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error" as const,
+    buildCodexFailureContext: (category: FailureContextCategory, summary: string, details: string[]) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-13T06:20:00Z",
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: (record: typeof context.record) => ({
+      recordForState: record,
+      nextState: "stabilizing" as const,
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    inferStateWithoutPullRequest: () => "stabilizing" as const,
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    getWorkspaceStatus: async () => context.workspaceStatus,
+    pushBranch: async () => {
+      throw new Error("unexpected pushBranch call");
+    },
+    readIssueJournal: (() => {
+      let readCount = 0;
+      return async () => {
+        readCount += 1;
+        return readCount === 1
+          ? [
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: use the agent runner contract.",
+            ].join("\n")
+          : [
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: use the agent runner contract.",
+              "- What changed: agent runner wrote a journal handoff.",
+            ].join("\n");
+      };
+    })(),
+    agentRunner,
+  });
+
+  const startContext = createContext();
+  const startResult = await executeCodexTurnPhase(createArgs(startContext));
+  assert.equal(startResult.kind, "completed");
+
+  const resumeContext = createContext(createRecord({ codex_session_id: "session-existing" }));
+  const resumeResult = await executeCodexTurnPhase(createArgs(resumeContext));
+  assert.equal(resumeResult.kind, "completed");
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0]?.kind, "start");
+  assert.equal(requests[1]?.kind, "resume");
+  assert.equal(requests[1]?.sessionId, "session-existing");
 });

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -1,9 +1,3 @@
-import {
-  extractBlockedReason,
-  extractFailureSignature,
-  extractStateHint,
-  runCodexTurn,
-} from "./codex";
 import { loadRelevantExternalReviewMissPatterns } from "./external-review/external-review-misses";
 import { GitHubClient } from "./github";
 import {
@@ -42,6 +36,7 @@ import {
 } from "./core/types";
 import { truncate } from "./core/utils";
 import { getWorkspaceStatus, pushBranch } from "./core/workspace";
+import { AgentRunner, createCodexAgentRunner } from "./supervisor/agent-runner";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -212,7 +207,7 @@ interface ExecuteCodexTurnPhaseArgs {
   getWorkspaceStatus?: typeof getWorkspaceStatus;
   pushBranch?: typeof pushBranch;
   readIssueJournal?: typeof readIssueJournal;
-  runCodexTurnImpl?: typeof runCodexTurn;
+  agentRunner?: AgentRunner;
 }
 
 export async function executeCodexTurnPhase(
@@ -221,7 +216,6 @@ export async function executeCodexTurnPhase(
   const getWorkspaceStatusImpl = args.getWorkspaceStatus ?? getWorkspaceStatus;
   const pushBranchImpl = args.pushBranch ?? pushBranch;
   const readIssueJournalImpl = args.readIssueJournal ?? readIssueJournal;
-  const runCodexTurnImpl = args.runCodexTurnImpl ?? runCodexTurn;
   const persistCodexTurnExecutionFailureImpl =
     args.persistCodexTurnExecutionFailure ?? persistCodexTurnExecutionFailure;
   const persistCodexTurnExitFailureImpl = args.persistCodexTurnExitFailure ?? persistCodexTurnExitFailure;
@@ -229,6 +223,12 @@ export async function executeCodexTurnPhase(
     args.persistMissingCodexJournalHandoff ?? persistMissingCodexJournalHandoff;
   const persistHintedCodexTurnStateImpl =
     args.persistHintedCodexTurnState ?? persistHintedCodexTurnState;
+  const agentRunner =
+    args.agentRunner ??
+    createCodexAgentRunner({
+      classifyFailureImpl: args.classifyFailure,
+      buildFailureContextImpl: args.buildCodexFailureContext,
+    });
   const { config, stateStore, github } = args;
   const { state, issue, previousCodexSummary, previousError, workspacePath, journalPath, syncJournal, memoryArtifacts, options } = args.context;
   let { record, workspaceStatus, pr, checks, reviewThreads } = args.context;
@@ -275,50 +275,42 @@ export async function executeCodexTurnPhase(
       record = preparedTurn.record;
       const { prompt, reviewThreadsToProcess } = preparedTurn;
 
-      let codexResult;
-      try {
-        codexResult = await runCodexTurnImpl(
-          config,
-          workspacePath,
-          prompt,
-          record.state,
-          record,
-          record.codex_session_id,
-        );
-      } catch (error) {
-        record = await persistCodexTurnExecutionFailureImpl({
-          stateStore,
-          state,
-          record,
-          syncJournal,
-          issueNumber: record.issue_number,
-          error,
-          classifyFailure: args.classifyFailure,
-          buildCodexFailureContext: args.buildCodexFailureContext,
-          applyFailureSignature: args.applyFailureSignature,
-        });
-        return {
-          kind: "returned",
-          message: `Codex turn failed for issue #${record.issue_number}.`,
-        };
-      }
-
-      const hintedState = extractStateHint(codexResult.lastMessage);
-      const hintedBlockedReason = extractBlockedReason(codexResult.lastMessage);
-      const hintedFailureSignature = extractFailureSignature(codexResult.lastMessage);
+      const turnRequest =
+        record.codex_session_id && agentRunner.capabilities.supportsResume
+          ? {
+              kind: "resume" as const,
+              sessionId: record.codex_session_id,
+              config,
+              workspacePath,
+              prompt,
+              state: record.state,
+              record,
+            }
+          : {
+              kind: "start" as const,
+              config,
+              workspacePath,
+              prompt,
+              state: record.state,
+              record,
+            };
+      const turnResult = await agentRunner.runTurn(turnRequest);
+      const hintedState = turnResult.structuredResult?.stateHint ?? null;
+      const hintedBlockedReason = turnResult.structuredResult?.blockedReason ?? null;
+      const hintedFailureSignature = turnResult.structuredResult?.failureSignature ?? null;
       const journalAfterRun = await readIssueJournalImpl(journalPath);
       record = stateStore.touch(record, {
-        codex_session_id: codexResult.sessionId,
-        last_codex_summary: truncate(codexResult.lastMessage),
-        last_failure_kind: null,
+        codex_session_id: turnResult.sessionId,
+        last_codex_summary: truncate(turnResult.supervisorMessage),
+        last_failure_kind: turnResult.failureKind,
         last_error:
-          codexResult.exitCode === 0
+          turnResult.exitCode === 0
             ? null
-            : truncate([codexResult.stderr.trim(), codexResult.stdout.trim()].filter(Boolean).join("\n")),
+            : truncate([turnResult.stderr.trim(), turnResult.stdout.trim()].filter(Boolean).join("\n")),
       });
 
       if (
-        codexResult.exitCode === 0 &&
+        turnResult.exitCode === 0 &&
         (!journalAfterRun ||
           journalAfterRun === journalContent ||
           !hasMeaningfulJournalHandoff(journalAfterRun))
@@ -338,14 +330,41 @@ export async function executeCodexTurnPhase(
         };
       }
 
-      if (codexResult.exitCode !== 0) {
+      if (turnResult.failureKind === "timeout" || turnResult.failureKind === "command_error") {
+        const message =
+          turnResult.stderr.trim() ||
+          turnResult.stdout.trim() ||
+          turnResult.supervisorMessage.trim() ||
+          "Unknown failure";
+        record = await persistCodexTurnExecutionFailureImpl({
+          stateStore,
+          state,
+          record,
+          syncJournal,
+          issueNumber: record.issue_number,
+          error: new Error(message),
+          classifyFailure: args.classifyFailure,
+          buildCodexFailureContext: args.buildCodexFailureContext,
+          applyFailureSignature: args.applyFailureSignature,
+        });
+        return {
+          kind: "returned",
+          message: `Codex turn failed for issue #${record.issue_number}.`,
+        };
+      }
+
+      if (turnResult.exitCode !== 0) {
         record = await persistCodexTurnExitFailureImpl({
           stateStore,
           state,
           record,
           syncJournal,
           issueNumber: record.issue_number,
-          codexResult,
+          codexResult: {
+            lastMessage: turnResult.supervisorMessage,
+            stderr: turnResult.stderr,
+            stdout: turnResult.stdout,
+          },
           classifyFailure: args.classifyFailure,
           buildCodexFailureContext: args.buildCodexFailureContext,
           applyFailureSignature: args.applyFailureSignature,
@@ -363,7 +382,7 @@ export async function executeCodexTurnPhase(
           record,
           syncJournal,
           issueNumber: record.issue_number,
-          lastMessage: codexResult.lastMessage,
+          lastMessage: turnResult.supervisorMessage,
           hintedState,
           hintedBlockedReason,
           hintedFailureSignature,

--- a/src/supervisor/supervisor.test.ts
+++ b/src/supervisor/supervisor.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import {
   Supervisor,
 } from "./supervisor";
+import { AgentRunner, AgentTurnRequest } from "./agent-runner";
 import { recoverUnexpectedCodexTurnFailure } from "./supervisor-failure-helpers";
 import { formatDetailedStatus } from "./supervisor-status-rendering";
 import { shouldAutoRetryHandoffMissing } from "./supervisor-execution-policy";
@@ -4097,6 +4098,95 @@ test("runOnce records manual review context when GitHub reports changes requeste
   assert.match(record.last_error ?? "", /requires manual review resolution before merge/);
   assert.equal(record.last_failure_context?.category, "manual");
   assert.match(record.last_failure_context?.summary ?? "", /requires manual review resolution before merge/);
+});
+
+test("runOnce routes supervisor turn execution through an injected agent runner", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 93;
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Use the shared agent runner for supervisor turns",
+    body: executionReadyBody("Use the shared agent runner for supervisor turns."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const requests: AgentTurnRequest[] = [];
+  const agentRunner: AgentRunner = {
+    capabilities: {
+      supportsResume: true,
+      supportsStructuredResult: true,
+    },
+    async runTurn(request) {
+      requests.push(request);
+      await fs.appendFile(
+        path.join(request.workspacePath, ".codex-supervisor", "issue-journal.md"),
+        "\n- What changed: the injected agent runner handled this turn.\n",
+        "utf8",
+      );
+      return {
+        exitCode: 0,
+        sessionId: "session-agent-runner",
+        supervisorMessage: [
+          "Summary: completed via injected agent runner",
+          "State hint: stabilizing",
+          "Blocked reason: none",
+          "Tests: not run",
+          "Failure signature: none",
+          "Next action: continue",
+        ].join("\n"),
+        stderr: "",
+        stdout: "",
+        structuredResult: {
+          summary: "completed via injected agent runner",
+          stateHint: "stabilizing",
+          blockedReason: null,
+          failureSignature: null,
+          nextAction: "continue",
+          tests: "not run",
+        },
+        failureKind: null,
+        failureContext: null,
+      };
+    },
+  };
+
+  const supervisor = new Supervisor(
+    createConfig({
+      ...fixture.config,
+      codexBinary: path.join(path.dirname(fixture.stateFile), "missing-codex"),
+    }),
+    { agentRunner },
+  );
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: false });
+  assert.match(message, /issue=#93/);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.kind, "start");
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.codex_session_id, "session-agent-runner");
+  assert.equal(record.last_failure_kind, null);
+  assert.match(record.last_codex_summary ?? "", /completed via injected agent runner/);
 });
 
 function branchName(config: SupervisorConfig, issueNumber: number): string {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -72,6 +72,7 @@ import {
   recoverUnexpectedCodexTurnFailure,
   shouldAutoRetryTimeout,
 } from "./supervisor-failure-helpers";
+import { AgentRunner, createCodexAgentRunner } from "./agent-runner";
 import {
   attemptBudgetForLane,
   attemptLane,
@@ -203,13 +204,15 @@ function formatStatus(record: IssueRunRecord | null): string {
 export class Supervisor {
   private readonly github: GitHubClient;
   private readonly stateStore: StateStore;
+  private readonly agentRunner: AgentRunner;
 
-  constructor(public readonly config: SupervisorConfig) {
+  constructor(public readonly config: SupervisorConfig, options: { agentRunner?: AgentRunner } = {}) {
     this.github = new GitHubClient(config);
     this.stateStore = new StateStore(config.stateFile, {
       backend: config.stateBackend,
       bootstrapFilePath: config.stateBootstrapFile,
     });
+    this.agentRunner = options.agentRunner ?? createCodexAgentRunner();
   }
 
   static fromConfig(configPath?: string): Supervisor {
@@ -370,6 +373,7 @@ export class Supervisor {
             ...args,
             stateStore: this.stateStore,
           }),
+        agentRunner: this.agentRunner,
       });
     } catch (error) {
       await sessionLock?.release();


### PR DESCRIPTION
Closes #385
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated supervisor turn execution to go through `AgentRunner` instead of calling Codex turn execution directly. `executeCodexTurnPhase` now accepts or resolves a runner, uses the shared start/resume contract, and preserves the existing failure, blocker, and journal-handoff behavior by consuming normalized runner results. `Supervisor` now resolves a default Codex-backed runner, so runtime behavior stays equivalent unless a test or caller injects a different runner.

I added focused coverage in [src/run-once-turn-execution.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-385/src/run-once-turn-execution.test.ts) for start/resume routing and in [src/supervisor/supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-385/src/supervisor/supervisor.test.ts) for supervisor-level injected-runner execution. The implementation changes are in [src/run-once-turn-execution.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-385/src/run-once-turn-execution.ts) and [src/supervisor/supervisor.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-385/src/supervisor/supervisor.ts). I also updated the local issue journal handoff and committed the code as `93253a0` (`Route supervisor turns through agent runner`).

Verification:
`npx tsx --test src/run-once-turn-execution.test.ts`
`npx tsx --test src/supervisor/supervisor.test.ts`
`npm run build`

Summary: Routed supervisor turn execution through the shared agent-runner contract, kept Codex as the defaul...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal turn execution architecture to support flexible agent integration patterns.

* **Tests**
  * Expanded test coverage to verify turn execution routing, session state management, and end-to-end request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->