### PR TITLE
Agent runner abstraction: clarify normalized result and failure semantics (#394)

### DIFF
--- a/src/supervisor/agent-runner.test.ts
+++ b/src/supervisor/agent-runner.test.ts
@@ -20,7 +20,7 @@ import type {
   ResumeAgentTurnContext,
   StartAgentTurnContext,
 } from "./agent-runner";
-import { createCodexAgentRunner, detectCodexCliCapabilities } from "./agent-runner";
+import { createCodexAgentRunner, detectCodexCliCapabilities, parseAgentTurnStructuredResult } from "./agent-runner";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -270,6 +270,42 @@ test("agent turn result supports both parsed and raw supervisor output", () => {
   assert.equal(parsedResult.structuredResult?.failureSignature, "missing-test");
 });
 
+test("parseAgentTurnStructuredResult only keeps canonical blocked and failure fields for blocked or failed hints", () => {
+  const implementing = parseAgentTurnStructuredResult([
+    "Summary: making progress",
+    "State hint: implementing",
+    "Blocked reason: verification",
+    "Failure signature: should-not-apply",
+    "Tests: not run",
+    "Next action: continue",
+  ].join("\n"));
+  const blocked = parseAgentTurnStructuredResult([
+    "Summary: waiting on verification",
+    "State hint: blocked",
+    "Blocked reason: verification",
+    "Failure signature: missing-test",
+  ].join("\n"));
+  const failed = parseAgentTurnStructuredResult([
+    "Summary: implementation failed",
+    "State hint: failed",
+    "Blocked reason: verification",
+    "Failure signature: compile-error",
+  ].join("\n"));
+
+  assert.deepEqual(implementing, {
+    summary: "making progress",
+    stateHint: "implementing",
+    blockedReason: null,
+    failureSignature: null,
+    nextAction: "continue",
+    tests: "not run",
+  });
+  assert.equal(blocked?.blockedReason, "verification");
+  assert.equal(blocked?.failureSignature, "missing-test");
+  assert.equal(failed?.blockedReason, null);
+  assert.equal(failed?.failureSignature, "compile-error");
+});
+
 test("createCodexAgentRunner adapts normalized start and resume turn contexts to Codex CLI turns", async () => {
   const config = createConfig();
   const issue: GitHubIssue = {
@@ -407,9 +443,7 @@ test("createCodexAgentRunner adapts normalized start and resume turn contexts to
   assert.equal(startResult.structuredResult?.tests, "npx tsx --test src/supervisor/agent-runner.test.ts");
   assert.equal(resumeResult.sessionId, "session-123");
   assert.equal(resumeResult.failureKind, "codex_exit");
-  assert.equal(resumeResult.structuredResult?.stateHint, "blocked");
-  assert.equal(resumeResult.structuredResult?.blockedReason, "verification");
-  assert.equal(resumeResult.structuredResult?.failureSignature, "reproduced-contract-gap");
+  assert.equal(resumeResult.structuredResult, null);
   assert.match(resumeResult.failureContext?.summary ?? "", /exited non-zero/i);
 });
 

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -82,6 +82,9 @@ export interface AgentTurnResult {
   supervisorMessage: string;
   stderr: string;
   stdout: string;
+  // Structured output is only the normalized machine-readable footer from a
+  // successful turn. Runner failures must be expressed via failureKind and
+  // failureContext instead of mixing both channels.
   structuredResult: AgentTurnStructuredResult | null;
   failureKind: FailureKind;
   failureContext: FailureContext | null;
@@ -129,8 +132,9 @@ function extractLabeledValue(message: string, label: string): string | null {
 export function parseAgentTurnStructuredResult(message: string): AgentTurnStructuredResult | null {
   const summary = extractLabeledValue(message, "Summary");
   const stateHint = extractStateHint(message);
-  const blockedReason = extractBlockedReason(message);
-  const failureSignature = extractFailureSignature(message);
+  const blockedReason = stateHint === "blocked" ? extractBlockedReason(message) : null;
+  const failureSignature =
+    stateHint === "blocked" || stateHint === "failed" ? extractFailureSignature(message) : null;
   const tests = extractLabeledValue(message, "Tests");
   const nextAction = extractLabeledValue(message, "Next action");
 
@@ -180,8 +184,8 @@ export function createCodexAgentRunner(options: CreateCodexAgentRunnerOptions = 
           context.record,
           context.kind === "resume" ? context.sessionId : undefined,
         );
-        const structuredResult = parseAgentTurnStructuredResult(result.lastMessage);
         const failureKind: FailureKind = result.exitCode === 0 ? null : "codex_exit";
+        const structuredResult = failureKind === null ? parseAgentTurnStructuredResult(result.lastMessage) : null;
 
         return {
           exitCode: result.exitCode,


### PR DESCRIPTION
Closes #394
This PR was opened by codex-supervisor.
Latest Codex summary:

Clarified the runner boundary in [agent-runner.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-394/src/supervisor/agent-runner.ts) and locked it down in [agent-runner.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-394/src/supervisor/agent-runner.test.ts). The key change is that `structuredResult` is now only emitted for successful turns, while non-zero runner exits are represented only through `failureKind` and `failureContext`. I also normalized parsed footer fields so `blockedReason` only survives for `State hint: blocked`, and `failureSignature` only survives for `blocked` or `failed`.

I reproduced the ambiguity first with a focused failing test, then fixed it conservatively and verified the adjacent surfaces. Commit: `4ad3405` (`Clarify agent runner failure semantics`).

Tests run: `npx tsx --test src/codex/codex-output-parser.test.ts src/codex/codex-runner.test.ts src/supervisor/agent-runner.test.ts src/run-once-turn-execution.test.ts src/turn-execution-failure-helpers.test.ts`; `npm run build`

Summary: Clarified agent-runner structured-result vs failure semantics, added focused coverage, and verified build.
State hint: stabilizing
Blocked reason: none
Tests: npx tsx --test src/codex/codex-output-parser.test.ts src/codex/codex-runner.test.ts src/supervisor/agent-runner.test.ts src/run-once-turn-execution.test.ts src/turn-execution-failure-helpers.test.ts; npm run build
Failure signature: none
Next action: Open or update the draft PR for iss...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured result field to agent turn responses to provide machine-readable summaries on successful turns.
  * Introduced parser function to extract and validate structured results from agent output.

* **Tests**
  * Added tests verifying proper filtering and preservation of fields based on agent turn outcomes.
  * Updated tests reflecting that failed turns now have null structured results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->