### PR TITLE
Diagnostics: implement `status --why` for current issue selection reasoning (#399)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -290,4 +290,5 @@ export interface CliOptions {
   command: "run-once" | "loop" | "status";
   configPath?: string;
   dryRun: boolean;
+  why: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,12 @@ import { Supervisor } from "./supervisor";
 import { CliOptions } from "./core/types";
 import { sleep } from "./core/utils";
 
-function parseArgs(argv: string[]): CliOptions {
+export function parseArgs(argv: string[]): CliOptions {
   const args = [...argv];
   let command: CliOptions["command"] = "run-once";
   let configPath: string | undefined;
   let dryRun = false;
+  let why = false;
 
   while (args.length > 0) {
     const token = args.shift();
@@ -30,10 +31,19 @@ function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (token === "--why") {
+      why = true;
+      continue;
+    }
+
     throw new Error(`Unknown argument: ${token}`);
   }
 
-  return { command, configPath, dryRun };
+  if (why && command !== "status") {
+    throw new Error("The --why flag is only supported with the status command.");
+  }
+
+  return { command, configPath, dryRun, why };
 }
 
 async function runOnceWithSupervisorLock(
@@ -77,7 +87,7 @@ async function main(): Promise<void> {
   }
 
   if (options.command === "status") {
-    console.log(await supervisor.status());
+    console.log(await supervisor.status({ why: options.why }));
     return;
   }
 

--- a/src/supervisor/supervisor-selection-status.ts
+++ b/src/supervisor/supervisor-selection-status.ts
@@ -9,8 +9,11 @@ import { readIssueJournal, summarizeIssueJournalHandoff } from "../core/journal"
 import {
   formatExecutionReadyMissingFields,
   isEligibleForSelection,
+  shouldAutoRetryBlockedVerification,
+  shouldAutoRetryHandoffMissing,
   shouldEnforceExecutionReady,
 } from "./supervisor-execution-policy";
+import { shouldAutoRetryTimeout } from "./supervisor-failure-helpers";
 import { buildDurableGuardrailStatusLine } from "./supervisor-status-rendering";
 import {
   GitHubIssue,
@@ -23,6 +26,7 @@ import {
 } from "../core/types";
 
 type ReadinessSummaryGitHub = Pick<GitHubClient, "listCandidateIssues">;
+type SelectionWhyGitHub = Pick<GitHubClient, "listAllIssues" | "listCandidateIssues">;
 type ActiveStatusGitHub = Pick<
   GitHubClient,
   "resolvePullRequestForBranch" | "getChecks" | "getUnresolvedReviewThreads"
@@ -171,6 +175,46 @@ export async function buildReadinessSummary(
   ];
 }
 
+export async function buildSelectionWhySummary(
+  github: SelectionWhyGitHub,
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+): Promise<string[]> {
+  const candidateIssues = await github.listCandidateIssues();
+  const issues = await github.listAllIssues();
+
+  for (const issue of candidateIssues) {
+    if (config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix))) {
+      continue;
+    }
+
+    const existing = state.issues[String(issue.number)];
+    const readiness = lintExecutionReadyIssueBody(issue);
+    if (shouldEnforceExecutionReady(existing) && !readiness.isExecutionReady) {
+      continue;
+    }
+
+    if (findHighRiskBlockingAmbiguity(issue)) {
+      continue;
+    }
+
+    if (findBlockingIssue(issue, issues, state)) {
+      continue;
+    }
+
+    if (!isEligibleForSelection(existing, config)) {
+      continue;
+    }
+
+    return [
+      `selected_issue=#${issue.number}`,
+      `selection_reason=${formatSelectionReason(issue, issues, state, existing, readiness.isExecutionReady, config)}`,
+    ];
+  }
+
+  return ["selected_issue=none", "selection_reason=no_runnable_issue"];
+}
+
 function formatRunnableReadinessReason(
   issue: GitHubIssue,
   issues: GitHubIssue[],
@@ -221,4 +265,80 @@ function formatRunnableReadinessReason(
   }
 
   return reasons.join("+");
+}
+
+function formatSelectionReason(
+  issue: GitHubIssue,
+  issues: GitHubIssue[],
+  state: SupervisorStateFile,
+  existing: IssueRunRecord | undefined,
+  isExecutionReady: boolean,
+  config: SupervisorConfig,
+): string {
+  const metadata = parseIssueMetadata(issue);
+  const dependencyStatus =
+    metadata.dependsOn.length === 0
+      ? "none"
+      : `${metadata.dependsOn.join("|")}:${metadata.dependsOn.every((dependencyNumber) => state.issues[String(dependencyNumber)]?.state === "done") ? "done" : "pending"}`;
+
+  let executionOrderStatus = "none";
+  let predecessorStatus = "none";
+  if (metadata.parentIssueNumber !== null && metadata.executionOrderIndex !== null) {
+    executionOrderStatus = `${metadata.parentIssueNumber}/${metadata.executionOrderIndex}`;
+    const predecessors = issues
+      .filter((candidate) => candidate.number !== issue.number)
+      .map((candidate) => ({
+        issue: candidate,
+        metadata: parseIssueMetadata(candidate),
+      }))
+      .filter(
+        ({ metadata: candidateMetadata }) =>
+          candidateMetadata.parentIssueNumber === metadata.parentIssueNumber &&
+          candidateMetadata.executionOrderIndex !== null &&
+          candidateMetadata.executionOrderIndex < metadata.executionOrderIndex!,
+      )
+      .sort(
+        (left, right) =>
+          (left.metadata.executionOrderIndex ?? Number.MAX_SAFE_INTEGER) -
+          (right.metadata.executionOrderIndex ?? Number.MAX_SAFE_INTEGER),
+      )
+      .map(({ issue: predecessorIssue }) => predecessorIssue.number);
+
+    if (predecessors.length > 0) {
+      predecessorStatus = `${predecessors.join("|")}:${
+        predecessors.every((predecessorNumber) => state.issues[String(predecessorNumber)]?.state === "done")
+          ? "done"
+          : "pending"
+      }`;
+    }
+  }
+
+  return [
+    "ready",
+    `execution_ready=${isExecutionReady ? "yes" : "skipped"}`,
+    `depends_on=${dependencyStatus}`,
+    `execution_order=${executionOrderStatus}`,
+    `predecessors=${predecessorStatus}`,
+    `retry_state=${formatRetryState(existing, config)}`,
+  ].join(" ");
+}
+
+function formatRetryState(record: IssueRunRecord | undefined, config: SupervisorConfig): string {
+  if (!record || record.attempt_count === 0) {
+    return "fresh";
+  }
+
+  if (shouldAutoRetryTimeout(record, config)) {
+    return `timeout_retry:${record.timeout_retry_count}/${config.timeoutRetryLimit}`;
+  }
+
+  if (shouldAutoRetryBlockedVerification(record, config)) {
+    return `blocked_verification_retry:${record.blocked_verification_retry_count}/${config.blockedVerificationRetryLimit}`;
+  }
+
+  if (shouldAutoRetryHandoffMissing(record, config)) {
+    return "handoff_missing_retry";
+  }
+
+  return `resume:${record.state}`;
 }

--- a/src/supervisor/supervisor.test.ts
+++ b/src/supervisor/supervisor.test.ts
@@ -2292,6 +2292,149 @@ Execution order: 3 of 3`,
   );
 });
 
+test("status --why explains why the current runnable issue was selected", async () => {
+  const fixture = await createSupervisorFixture();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "91": createRecord({
+        issue_number: 91,
+        state: "done",
+        branch: branchName(fixture.config, 91),
+        workspace: path.join(fixture.workspaceRoot, "issue-91"),
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+      }),
+      "92": createRecord({
+        issue_number: 92,
+        state: "done",
+        branch: branchName(fixture.config, 92),
+        workspace: path.join(fixture.workspaceRoot, "issue-92"),
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+      }),
+      "95": createRecord({
+        issue_number: 95,
+        state: "blocked",
+        branch: branchName(fixture.config, 95),
+        workspace: path.join(fixture.workspaceRoot, "issue-95"),
+        journal_path: null,
+        blocked_reason: "verification",
+        last_error: "verification still failing",
+        blocked_verification_retry_count: 1,
+        repeated_blocker_count: fixture.config.sameBlockerRepeatLimit,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const blockedIssue: GitHubIssue = {
+    number: 95,
+    title: "Blocked verification retry",
+    body: `## Summary
+Retry the failing verification.
+
+## Scope
+- rerun the failing check
+
+## Acceptance criteria
+- verification can pass
+
+## Verification
+- npm test -- src/supervisor.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/95",
+    state: "OPEN",
+  };
+  const predecessorIssueOne: GitHubIssue = {
+    number: 91,
+    title: "Step 1",
+    body: `## Summary
+Ship the first step.
+
+## Scope
+- start the execution order chain
+
+## Acceptance criteria
+- step one lands first
+
+## Verification
+- npm test -- src/supervisor.test.ts
+
+Part of: #150
+Execution order: 1 of 3`,
+    createdAt: "2026-03-12T23:55:00Z",
+    updatedAt: "2026-03-12T23:55:00Z",
+    url: "https://example.test/issues/91",
+    state: "CLOSED",
+  };
+  const predecessorIssueTwo: GitHubIssue = {
+    number: 92,
+    title: "Step 2",
+    body: `## Summary
+Ship the second step.
+
+## Scope
+- continue the execution order chain
+
+## Acceptance criteria
+- step two lands after step one
+
+## Verification
+- npm test -- src/supervisor.test.ts
+
+Part of: #150
+Execution order: 2 of 3`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/92",
+    state: "CLOSED",
+  };
+  const selectedIssue: GitHubIssue = {
+    number: 93,
+    title: "Step 3",
+    body: `## Summary
+Ship the third step.
+
+## Scope
+- build after the first two steps land
+
+## Acceptance criteria
+- status explains why this issue is selected
+
+## Verification
+- npm test -- src/supervisor.test.ts
+
+Depends on: #91
+Part of: #150
+Execution order: 3 of 3`,
+    createdAt: "2026-03-13T00:05:00Z",
+    updatedAt: "2026-03-13T00:05:00Z",
+    url: "https://example.test/issues/93",
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listAllIssues: async () => [predecessorIssueOne, predecessorIssueTwo, blockedIssue, selectedIssue],
+    listCandidateIssues: async () => [blockedIssue, selectedIssue],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(status, /selected_issue=#93/);
+  assert.match(
+    status,
+    /selection_reason=ready execution_ready=yes depends_on=91:done execution_order=150\/3 predecessors=91\|92:done retry_state=fresh/,
+  );
+});
+
 test("status includes a compact handoff summary for an active blocker", async () => {
   const fixture = await createSupervisorFixture();
   const journalPath = path.join(fixture.workspaceRoot, "issue-92", ".codex-supervisor", "issue-journal.md");

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -85,6 +85,7 @@ import {
 } from "./supervisor-execution-policy";
 import {
   buildReadinessSummary,
+  buildSelectionWhySummary,
   loadActiveIssueStatusSnapshot,
   summarizeSupervisorStatusRecords,
 } from "./supervisor-selection-status";
@@ -563,7 +564,7 @@ export class Supervisor {
     return acquireFileLock(this.lockPath("supervisor", "run"), `supervisor-${label}`);
   }
 
-  async status(): Promise<string> {
+  async status(options: Pick<CliOptions, "why"> = { why: false }): Promise<string> {
     const state = await this.stateStore.load();
     const gsdSummary = await describeGsdIntegration(this.config);
     const statusRecords = summarizeSupervisorStatusRecords(state);
@@ -581,7 +582,8 @@ export class Supervisor {
       });
       try {
         const readinessLines = await buildReadinessSummary(this.github, this.config, state);
-        return [gsdSummary, `${baseStatus}\n${readinessLines.join("\n")}`]
+        const whyLines = options.why ? await buildSelectionWhySummary(this.github, this.config, state) : [];
+        return [gsdSummary, `${baseStatus}\n${readinessLines.join("\n")}${whyLines.length > 0 ? `\n${whyLines.join("\n")}` : ""}`]
           .filter(Boolean)
           .join("\n");
       } catch (error) {


### PR DESCRIPTION
Closes #399
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented `status --why` on branch `codex/issue-399` in commit `cecf801`.

`status --why` now appends a deterministic selection explanation for the currently runnable issue, including readiness, dependency state, execution-order context, and retry state. The CLI parses `--why`, `Supervisor.status()` supports the mode, and the explanation uses current candidates for selection plus all issues for dependency/order context so closed predecessors can still be explained. I also added a focused runnable-selection test in [src/supervisor/supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-399/src/supervisor/supervisor.test.ts).

Verification passed with `./node_modules/.bin/tsx --test src/supervisor/supervisor.test.ts --test-name-pattern "status --why explains why the current runnable issue was selected"` and `npm run build`. The issue journal was updated in the workspace before finishing.

Summary: Added `status --why` selection diagnostics, covered by a focused runnable-selection test, and `npm run build` passes
State hint: implementing
Blocked reason: none
Tests: `./node_modules/.bin/tsx --test src/supervisor/supervisor.test.ts --test-name-pattern "status --why explains why the current runnable issue was selected"`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for commit `cecf801` if the supervisor wants an early checkpoint published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--why` flag to the status command that displays detailed reasoning for why the currently selected issue was chosen.

* **Tests**
  * Added test coverage for the new `--why` flag functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->