### PR TITLE
Review provider abstraction: normalize review wait and timeout policy behind the provider-neutral model (#404)

### DIFF
--- a/src/core/review-providers.test.ts
+++ b/src/core/review-providers.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   configuredReviewProviderKinds,
   mapConfiguredReviewProviders,
+  reviewProviderWaitPolicyFromConfig,
   reviewProviderProfileFromConfig,
 } from "./review-providers";
 import { SupervisorConfig } from "./types";
@@ -160,5 +161,54 @@ test("configuredReviewProviderKinds reports the normalized kinds in config order
       createConfig({ reviewBotLogins: ["CodeRabbitAI", "coderabbitai[bot]", "chatgpt-codex-connector"] }),
     ),
     ["coderabbit", "codex"],
+  );
+});
+
+test("reviewProviderWaitPolicyFromConfig normalizes wait and timeout behavior behind the provider model", () => {
+  assert.deepEqual(reviewProviderWaitPolicyFromConfig(createConfig()), {
+    botLabel: "configured review bot",
+    shouldWaitForRequestedReviewSignal: false,
+    shouldWaitForRequestPropagation: false,
+    shouldTrackRequestedState: false,
+    shouldApplyRequestedReviewTimeout: false,
+    shouldApplyRateLimitCooldown: false,
+  });
+
+  assert.deepEqual(
+    reviewProviderWaitPolicyFromConfig(createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] })),
+    {
+      botLabel: "Copilot",
+      shouldWaitForRequestedReviewSignal: true,
+      shouldWaitForRequestPropagation: true,
+      shouldTrackRequestedState: true,
+      shouldApplyRequestedReviewTimeout: true,
+      shouldApplyRateLimitCooldown: true,
+    },
+  );
+
+  assert.deepEqual(
+    reviewProviderWaitPolicyFromConfig(createConfig({ reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"] })),
+    {
+      botLabel: "configured review bots (coderabbitai, coderabbitai[bot])",
+      shouldWaitForRequestedReviewSignal: true,
+      shouldWaitForRequestPropagation: false,
+      shouldTrackRequestedState: false,
+      shouldApplyRequestedReviewTimeout: false,
+      shouldApplyRateLimitCooldown: true,
+    },
+  );
+
+  assert.deepEqual(
+    reviewProviderWaitPolicyFromConfig(
+      createConfig({ reviewBotLogins: ["chatgpt-codex-connector", "copilot-pull-request-reviewer"] }),
+    ),
+    {
+      botLabel: "configured review bots (chatgpt-codex-connector, copilot-pull-request-reviewer)",
+      shouldWaitForRequestedReviewSignal: true,
+      shouldWaitForRequestPropagation: true,
+      shouldTrackRequestedState: true,
+      shouldApplyRequestedReviewTimeout: true,
+      shouldApplyRateLimitCooldown: true,
+    },
   );
 });

--- a/src/core/review-providers.ts
+++ b/src/core/review-providers.ts
@@ -17,6 +17,15 @@ export interface ReviewProviderProfileSummary {
   signalSource: string;
 }
 
+export interface ReviewProviderWaitPolicy {
+  botLabel: string;
+  shouldWaitForRequestedReviewSignal: boolean;
+  shouldWaitForRequestPropagation: boolean;
+  shouldTrackRequestedState: boolean;
+  shouldApplyRequestedReviewTimeout: boolean;
+  shouldApplyRateLimitCooldown: boolean;
+}
+
 function trimReviewBotLogins(reviewBotLogins: string[]): string[] {
   return reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
 }
@@ -85,6 +94,27 @@ export function repoExpectsLifecycleBotReview(config: Pick<SupervisorConfig, "re
 export function repoUsesCopilotOnlyReviewBot(config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">): boolean {
   const providers = configuredReviewProviders(config);
   return providers.length === 1 && providers[0]?.kind === "copilot" && providers[0].reviewerLogins.length === 1;
+}
+
+export function reviewProviderWaitPolicyFromConfig(
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
+): ReviewProviderWaitPolicy {
+  const reviewers = configuredReviewBotLogins(config);
+  const usesLifecycleSignals = repoExpectsLifecycleBotReview(config);
+  return {
+    botLabel: repoUsesCopilotOnlyReviewBot(config)
+      ? "Copilot"
+      : reviewers.length === 1
+        ? `configured review bot (${reviewers[0]})`
+        : reviewers.length > 1
+          ? `configured review bots (${reviewers.join(", ")})`
+          : "configured review bot",
+    shouldWaitForRequestedReviewSignal: reviewers.length > 0,
+    shouldWaitForRequestPropagation: usesLifecycleSignals,
+    shouldTrackRequestedState: usesLifecycleSignals,
+    shouldApplyRequestedReviewTimeout: usesLifecycleSignals,
+    shouldApplyRateLimitCooldown: reviewers.length > 0,
+  };
 }
 
 export function reviewProviderProfileFromConfig(

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -24,10 +24,8 @@ import {
   SupervisorConfig,
 } from "./core/types";
 import {
-  configuredReviewBotLogins,
   repoExpectsConfiguredBotReview,
-  repoExpectsLifecycleBotReview,
-  repoUsesCopilotOnlyReviewBot,
+  reviewProviderWaitPolicyFromConfig,
 } from "./core/review-providers";
 import { nowIso } from "./core/utils";
 
@@ -55,17 +53,7 @@ function reviewSatisfied(pr: GitHubPullRequest): boolean {
 }
 
 function configuredReviewBotLabel(config: SupervisorConfig): string {
-  const bots = configuredReviewBotLogins(config);
-  if (repoUsesCopilotOnlyReviewBot(config)) {
-    return "Copilot";
-  }
-  if (bots.length === 1) {
-    return `configured review bot (${bots[0]})`;
-  }
-  if (bots.length > 1) {
-    return `configured review bots (${bots.join(", ")})`;
-  }
-  return "configured review bot";
+  return reviewProviderWaitPolicyFromConfig(config).botLabel;
 }
 
 function copilotReviewArrived(pr: GitHubPullRequest): boolean {
@@ -76,8 +64,15 @@ function determineConfiguredBotRateLimitWait(
   config: SupervisorConfig,
   pr: GitHubPullRequest,
 ): ConfiguredBotRateLimitWaitStatus {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
   const waitMinutes = config.configuredBotRateLimitWaitMinutes ?? 0;
-  if (waitMinutes <= 0 || pr.isDraft || copilotReviewArrived(pr) || !pr.configuredBotRateLimitedAt) {
+  if (
+    !policy.shouldApplyRateLimitCooldown ||
+    waitMinutes <= 0 ||
+    pr.isDraft ||
+    copilotReviewArrived(pr) ||
+    !pr.configuredBotRateLimitedAt
+  ) {
     return { active: false, observedAt: null, waitUntil: null };
   }
 
@@ -99,7 +94,7 @@ function hasObservedCopilotRequest(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
 ): boolean {
-  if (!repoExpectsLifecycleBotReview(config)) {
+  if (!reviewProviderWaitPolicyFromConfig(config).shouldTrackRequestedState) {
     return false;
   }
 
@@ -107,7 +102,17 @@ function hasObservedCopilotRequest(
 }
 
 function copilotReviewPending(config: SupervisorConfig, record: IssueRunRecord, pr: GitHubPullRequest): boolean {
-  if (!repoExpectsConfiguredBotReview(config) || pr.isDraft || copilotReviewArrived(pr)) {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
+  if (
+    !repoExpectsConfiguredBotReview(config) ||
+    !policy.shouldWaitForRequestedReviewSignal ||
+    pr.isDraft ||
+    copilotReviewArrived(pr)
+  ) {
+    return false;
+  }
+
+  if (!policy.shouldApplyRequestedReviewTimeout && pr.configuredBotRateLimitedAt) {
     return false;
   }
 
@@ -115,6 +120,7 @@ function copilotReviewPending(config: SupervisorConfig, record: IssueRunRecord, 
 }
 
 function copilotReviewTimeoutStart(config: SupervisorConfig, record: IssueRunRecord, pr: GitHubPullRequest): string | null {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
   if (!copilotReviewPending(config, record, pr)) {
     return null;
   }
@@ -123,7 +129,7 @@ function copilotReviewTimeoutStart(config: SupervisorConfig, record: IssueRunRec
     return pr.copilotReviewRequestedAt;
   }
 
-  if (hasObservedCopilotRequest(config, record, pr)) {
+  if (policy.shouldTrackRequestedState && hasObservedCopilotRequest(config, record, pr)) {
     return record.copilot_review_requested_observed_at;
   }
 
@@ -135,7 +141,8 @@ function determineCopilotReviewTimeout(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
 ): CopilotReviewTimeoutStatus {
-  if (config.copilotReviewWaitMinutes <= 0) {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
+  if (!policy.shouldApplyRequestedReviewTimeout || config.copilotReviewWaitMinutes <= 0) {
     return { timedOut: false, action: null, startedAt: null, timedOutAt: null, reason: null };
   }
 
@@ -171,8 +178,9 @@ function shouldWaitForCopilotReviewPropagation(
   record: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">,
   pr: GitHubPullRequest,
 ): boolean {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
   if (
-    !repoExpectsLifecycleBotReview(config) ||
+    !policy.shouldWaitForRequestPropagation ||
     config.copilotReviewWaitMinutes <= 0 ||
     pr.isDraft ||
     pr.headRefOid !== record.review_wait_head_sha
@@ -293,7 +301,7 @@ export function syncCopilotReviewRequestObservation(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
 ): Partial<IssueRunRecord> {
-  if (!repoExpectsLifecycleBotReview(config) || pr.isDraft || copilotReviewArrived(pr)) {
+  if (!reviewProviderWaitPolicyFromConfig(config).shouldTrackRequestedState || pr.isDraft || copilotReviewArrived(pr)) {
     return {
       copilot_review_requested_observed_at: null,
       copilot_review_requested_head_sha: null,


### PR DESCRIPTION
Closes #404
This PR was opened by codex-supervisor.
Latest Codex summary:

Routed review wait/timeout behavior through a provider-neutral policy helper in [src/core/review-providers.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-404/src/core/review-providers.ts) and updated [src/pull-request-state.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-404/src/pull-request-state.ts) to use it for request propagation, observed-request fallback, requested-review timeout, configured-bot labeling, and rate-limit cooldown handling. I added focused coverage in [src/core/review-providers.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-404/src/core/review-providers.test.ts), starting with a failing reproducer, and preserved the existing Copilot/CodeRabbit behavior split.

Focused verification passed with `npx tsx --test src/core/review-providers.test.ts src/pull-request-state.test.ts src/review-handling.test.ts` and `npm run build`. Checkpoint committed on `codex/issue-404` as `fbd64b9` (`Normalize review provider wait policy`).

Summary: Added a provider-neutral review wait policy helper, refactored pull-request wait/timeout logic to use it, kept current provider behavior stable, and committed the verified change.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/core/review-providers.test.ts src/pull-request-state.test.ts src/review-handling.test.ts`; `npm run build`
Failure signature: none
Next action: continue with any broader local review or open/update a draft PR from commit `fbd64b9` if this checkp...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized review bot wait policy handling for more consistent behavior across pull request state management.

* **Tests**
  * Added comprehensive tests for review provider wait policy configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->