### PR TITLE
Review provider abstraction: update docs and terminology to provider-neutral wording (#405)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Not a fit:
    cp supervisor.config.example.json supervisor.config.json
    ```
 
-3. Choose the review-bot profile that matches your PR review flow, then either copy that file over `supervisor.config.json` or copy its `reviewBotLogins` into the `supervisor.config.json` you created in step 2.
+3. Choose the review provider profile that matches your PR review flow, then either copy that file over `supervisor.config.json` or copy its `reviewBotLogins` into the `supervisor.config.json` you created in step 2.
 
    - [supervisor.config.copilot.json](./supervisor.config.copilot.json)
    - [supervisor.config.codex.json](./supervisor.config.codex.json)
    - [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
 
-4. Edit `supervisor.config.json` and set `repoPath`, `repoSlug`, `workspaceRoot`, `codexBinary`, and any provider-specific values you want to keep.
+4. Edit `supervisor.config.json` and set `repoPath`, `repoSlug`, `workspaceRoot`, `codexBinary`, and any review-provider-specific values you want to keep.
 
 5. Run a single pass first, then switch to the loop when the config looks right.
 
@@ -69,7 +69,7 @@ Requirements: `gh auth status` must succeed, `codex` CLI must be installed, and 
 
 ## Provider Profiles
 
-`supervisor.config.json` is always the active file. The shipped provider profiles are starting points that set the expected review-bot identities.
+`supervisor.config.json` is always the active file. The shipped provider profiles are starting points that set the expected review signal identities for each provider.
 
 - Copilot profile: start from [supervisor.config.copilot.json](./supervisor.config.copilot.json), enable GitHub Copilot review for the target repo or org, and verify a ready PR receives review activity from `copilot-pull-request-reviewer`.
 - Codex Connector profile: start from [supervisor.config.codex.json](./supervisor.config.codex.json), connect the repo to Codex in ChatGPT/OpenAI, and verify PR review activity arrives from `chatgpt-codex-connector`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ This guide holds the setup and reference material that used to make the root `RE
 
 ## Base Setup
 
-Start from [supervisor.config.example.json](../supervisor.config.example.json), then choose the provider profile that matches your review flow:
+Start from [supervisor.config.example.json](../supervisor.config.example.json), then choose the review provider profile that matches your review flow:
 
 - [supervisor.config.copilot.json](../supervisor.config.copilot.json)
 - [supervisor.config.codex.json](../supervisor.config.codex.json)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ Create an active config from the base example:
 cp supervisor.config.example.json supervisor.config.json
 ```
 
-Then choose the provider profile that matches your PR review flow:
+Then choose the review provider profile that matches your PR review flow:
 
 - [supervisor.config.copilot.json](../supervisor.config.copilot.json)
 - [supervisor.config.codex.json](../supervisor.config.codex.json)
@@ -72,7 +72,7 @@ At minimum, set these fields before the first run:
 - `repoSlug`
 - `workspaceRoot`
 - `codexBinary`
-- provider-specific review bot settings you expect the supervisor to watch
+- provider-specific review settings you expect the supervisor to watch
 
 If you need the full field-by-field setup, model policy, durable memory, or provider guidance, use the [Configuration reference](./configuration.md).
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -426,9 +426,12 @@ test("README stays a lightweight landing page with provider profile guidance and
   assert.match(readme, /Copilot profile/i);
   assert.match(readme, /Codex Connector profile/i);
   assert.match(readme, /CodeRabbit profile/i);
+  assert.match(readme, /review provider profile/i);
+  assert.match(readme, /provider-side setup/i);
   assert.match(readme, /supervisor\.config\.copilot\.json/i);
   assert.match(readme, /supervisor\.config\.codex\.json/i);
   assert.match(readme, /supervisor\.config\.coderabbit\.json/i);
+  assert.doesNotMatch(readme, /review-bot profile/i);
   assert.doesNotMatch(readme, /^## Run states$/m);
   assert.doesNotMatch(readme, /^## State backends$/m);
   assert.doesNotMatch(readme, /^## Commands$/m);
@@ -443,6 +446,9 @@ test("getting started links to focused configuration and local review references
   assert.match(gettingStarted, /\[Configuration reference\]\(\.\/configuration\.md\)/i);
   assert.match(gettingStarted, /\[Local review reference\]\(\.\/local-review\.md\)/i);
   assert.match(gettingStarted, /\[Issue metadata reference\]\(\.\/issue-metadata\.md\)/i);
+  assert.match(gettingStarted, /review provider profile/i);
+  assert.match(gettingStarted, /provider-specific review settings/i);
+  assert.doesNotMatch(gettingStarted, /review-bot profile/i);
   assert.doesNotMatch(gettingStarted, /^### Option 1: Auto-detect roles$/m);
   assert.doesNotMatch(gettingStarted, /^### Option 2: Explicit roles$/m);
   assert.doesNotMatch(gettingStarted, /^### What specialist roles are for$/m);


### PR DESCRIPTION
Closes #405
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the doc guard and docs to use provider-neutral operator wording while keeping concrete provider examples. The focused regression was added in [src/config.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-405/src/config.test.ts), and the wording changes landed in [README.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-405/README.md), [docs/getting-started.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-405/docs/getting-started.md), and [docs/configuration.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-405/docs/configuration.md). I also updated the local issue journal notes.

Verification passed with `npx tsx --test src/config.test.ts` and `npm run build`. Commit: `f03ef39` (`docs: use provider-neutral review wording`).

Summary: Added a focused doc regression test, reproduced the old provider-specific wording, updated docs to provider-neutral terminology, and committed the checkpoint.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/config.test.ts`; `npm install`; `npm run build`
Failure signature: none
Next action: Push `codex/issue-405` and open or update the PR checkpoint if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology throughout guides to clarify "review provider profile" references.
  * Added detailed CodeRabbit provider profile documentation with integration details and rate limit handling.

* **Tests**
  * Added test assertions to verify documentation accuracy and terminology consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->