### PR TITLE
Replay debugging: snapshot GitHub and local decision inputs for one supervisor cycle (#407)

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -104,6 +104,7 @@ const EXPECTED_FAMILY_FILES = {
   supervisor: [
     "agent-runner.ts",
     "index.ts",
+    "supervisor-cycle-snapshot.ts",
     "supervisor-detailed-status-assembly.ts",
     "supervisor-execution-policy.ts",
     "supervisor-failure-context.ts",

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -186,6 +186,12 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
   const workspaceStatus = createWorkspaceStatus({ headSha: "workspace-head-240" });
   const saveSnapshots: SupervisorStateFile[] = [];
   const touchedRecords: IssueRunRecord[] = [];
+  const replaySnapshots: Array<{
+    pr: GitHubPullRequest | null;
+    checks: { name: string; state: string; bucket: string }[];
+    recordState: IssueRunRecord["state"];
+    workspaceHead: string;
+  }> = [];
 
   const result = await prepareIssueExecutionContext({
     github: {
@@ -227,6 +233,15 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
       };
     },
     getWorkspaceStatus: async () => workspaceStatus,
+    writeSupervisorCycleDecisionSnapshot: async ({ pr, checks, record: snapshotRecord, workspaceStatus: snapshotWorkspaceStatus }) => {
+      replaySnapshots.push({
+        pr,
+        checks,
+        recordState: snapshotRecord.state,
+        workspaceHead: snapshotWorkspaceStatus.headSha,
+      });
+      return "/tmp/workspaces/issue-240/.codex-supervisor/replay/decision-cycle-snapshot.json";
+    },
   });
 
   assert.equal(typeof result, "object");
@@ -242,6 +257,14 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
   assert.equal(saveSnapshots[0]?.issues["240"]?.journal_path, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
   assert.equal(saveSnapshots[1]?.issues["240"]?.last_head_sha, "workspace-head-240");
   assert.equal(touchedRecords.at(-1)?.last_head_sha, "workspace-head-240");
+  assert.deepEqual(replaySnapshots, [
+    {
+      pr: null,
+      checks: [],
+      recordState: "planning",
+      workspaceHead: "workspace-head-240",
+    },
+  ]);
 });
 
 test("prepareIssueExecutionContext restarts when a tracked PR already merged", async () => {

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -24,6 +24,7 @@ import {
   getWorkspaceStatus as getWorkspaceStatusImpl,
   pushBranch as pushBranchImpl,
 } from "./core/workspace";
+import { writeSupervisorCycleDecisionSnapshot as writeSupervisorCycleDecisionSnapshotImpl } from "./supervisor/supervisor-cycle-snapshot";
 
 export type IssueJournalSync = (record: IssueRunRecord) => Promise<void>;
 export type MemoryArtifacts = Awaited<ReturnType<typeof syncMemoryArtifactsImpl>>;
@@ -88,6 +89,17 @@ interface PrepareIssueExecutionContextArgs {
   syncMemoryArtifacts?: (args: SyncMemoryArtifactsArgs) => Promise<MemoryArtifacts>;
   getWorkspaceStatus?: (workspacePath: string, branch: string, defaultBranch: string) => Promise<WorkspaceStatus>;
   pushBranch?: (workspacePath: string, branch: string, remoteBranchExists: boolean) => Promise<void>;
+  writeSupervisorCycleDecisionSnapshot?: (args: {
+    config: SupervisorConfig;
+    capturedAt: string;
+    issue: GitHubIssue;
+    record: IssueRunRecord;
+    workspacePath: string;
+    workspaceStatus: WorkspaceStatus;
+    pr: GitHubPullRequest | null;
+    checks: PullRequestCheck[];
+    reviewThreads: ReviewThread[];
+  }) => Promise<string>;
   now?: () => string;
 }
 
@@ -193,6 +205,8 @@ async function hydratePullRequestContext(
 ): Promise<HydratedPullRequestContext | RestartRunOnce | string> {
   const pushBranch = args.pushBranch ?? pushBranchImpl;
   const getWorkspaceStatus = args.getWorkspaceStatus ?? getWorkspaceStatusImpl;
+  const writeSupervisorCycleDecisionSnapshot =
+    args.writeSupervisorCycleDecisionSnapshot ?? writeSupervisorCycleDecisionSnapshotImpl;
   const now = args.now ?? nowIso;
 
   let nextWorkspaceStatus = args.workspaceStatus;
@@ -210,6 +224,17 @@ async function hydratePullRequestContext(
     if (!resolvedPr) {
       // No current or historical PR for this branch; continue with normal branch/PR flow.
     } else if (resolvedPr.mergedAt || resolvedPr.state === "MERGED") {
+      await writeSupervisorCycleDecisionSnapshot({
+        config: args.config,
+        capturedAt: now(),
+        issue: args.issue,
+        record: args.record,
+        workspacePath: args.workspacePath,
+        workspaceStatus: nextWorkspaceStatus,
+        pr: resolvedPr,
+        checks: [],
+        reviewThreads: [],
+      });
       const recoveryEvent = buildRecoveryEvent(
         args.record.issue_number,
         `merged_pr_convergence: tracked PR #${resolvedPr.number} merged; marked issue #${args.record.issue_number} done`,
@@ -226,6 +251,17 @@ async function hydratePullRequestContext(
       await args.stateStore.save(args.state);
       return { kind: "restart", recoveryEvents: [recoveryEvent] };
     } else if (resolvedPr.state === "CLOSED") {
+      await writeSupervisorCycleDecisionSnapshot({
+        config: args.config,
+        capturedAt: now(),
+        issue: args.issue,
+        record: args.record,
+        workspacePath: args.workspacePath,
+        workspaceStatus: nextWorkspaceStatus,
+        pr: resolvedPr,
+        checks: [],
+        reviewThreads: [],
+      });
       const failureContext = buildCodexFailureContext(
         "manual",
         `PR #${resolvedPr.number} was closed without merge.`,
@@ -261,6 +297,18 @@ async function hydratePullRequestContext(
     checks = await args.github.getChecks(pr.number);
     reviewThreads = await args.github.getUnresolvedReviewThreads(pr.number);
   }
+
+  await writeSupervisorCycleDecisionSnapshot({
+    config: args.config,
+    capturedAt: now(),
+    issue: args.issue,
+    record: args.record,
+    workspacePath: args.workspacePath,
+    workspaceStatus: nextWorkspaceStatus,
+    pr,
+    checks,
+    reviewThreads,
+  });
 
   return {
     record: args.record,

--- a/src/supervisor/supervisor-cycle-snapshot.test.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig, WorkspaceStatus } from "../core/types";
+import {
+  buildSupervisorCycleDecisionSnapshot,
+  supervisorCycleSnapshotPath,
+  writeSupervisorCycleDecisionSnapshot,
+} from "./supervisor-cycle-snapshot";
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: true,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+      specialist: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/reopen-issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 407,
+    state: "addressing_review",
+    branch: "codex/reopen-issue-407",
+    pr_number: 88,
+    workspace: "/tmp/workspaces/issue-407",
+    journal_path: "/tmp/workspaces/issue-407/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: "2026-03-16T10:00:00Z",
+    review_wait_head_sha: "head-407",
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: null,
+    local_review_head_sha: "head-407",
+    local_review_blocker_summary: "High severity finding still open.",
+    local_review_summary_path: "/tmp/reviews/summary.md",
+    local_review_run_at: "2026-03-16T10:03:00Z",
+    local_review_max_severity: "high",
+    local_review_findings_count: 1,
+    local_review_root_cause_count: 1,
+    local_review_verified_max_severity: "high",
+    local_review_verified_findings_count: 1,
+    local_review_recommendation: "changes_requested",
+    local_review_degraded: false,
+    last_local_review_signature: "local-review:high",
+    repeated_local_review_signature_count: 1,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 3,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 1,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "head-407",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: "Review still pending.",
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: "review-pending",
+    blocked_reason: null,
+    processed_review_thread_ids: ["thread-1@head-407"],
+    processed_review_thread_fingerprints: ["thread-1@head-407#comment-1"],
+    updated_at: "2026-03-16T10:05:00Z",
+    ...overrides,
+  };
+}
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 407,
+    title: "Replay debugging snapshot",
+    body: "",
+    createdAt: "2026-03-16T09:00:00Z",
+    updatedAt: "2026-03-16T10:05:00Z",
+    url: "https://example.test/issues/407",
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+function createPr(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 88,
+    title: "Replay debugging snapshot",
+    url: "https://example.test/pull/88",
+    state: "OPEN",
+    createdAt: "2026-03-16T09:15:00Z",
+    updatedAt: "2026-03-16T10:06:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/reopen-issue-407",
+    headRefOid: "head-407",
+    mergedAt: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+    ...overrides,
+  };
+}
+
+function createWorkspaceStatus(overrides: Partial<WorkspaceStatus> = {}): WorkspaceStatus {
+  return {
+    branch: "codex/reopen-issue-407",
+    headSha: "head-407",
+    hasUncommittedChanges: false,
+    baseAhead: 1,
+    baseBehind: 0,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+    remoteBehind: 0,
+    ...overrides,
+  };
+}
+
+function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-2",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-2",
+          body: "Please address this blocking issue.",
+          createdAt: "2026-03-16T10:04:00Z",
+          url: "https://example.test/pull/88#discussion_r2",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test("buildSupervisorCycleDecisionSnapshot keeps the decision inputs narrow and replay-oriented", () => {
+  const snapshot = buildSupervisorCycleDecisionSnapshot({
+    config: createConfig(),
+    capturedAt: "2026-03-16T10:07:00Z",
+    issue: createIssue(),
+    record: createRecord(),
+    workspaceStatus: createWorkspaceStatus(),
+    pr: createPr(),
+    checks: [{ name: "build", state: "completed", bucket: "pass" }],
+    reviewThreads: [createReviewThread()],
+  });
+
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.issue.title, "Replay debugging snapshot");
+  assert.equal(snapshot.local.record.local_review_findings_count, 1);
+  assert.equal(snapshot.local.workspaceStatus.headSha, "head-407");
+  assert.equal(snapshot.github.pullRequest?.headRefOid, "head-407");
+  assert.equal(snapshot.github.checks.length, 1);
+  assert.equal(snapshot.github.reviewThreads[0]?.comments.nodes[0]?.body, "Please address this blocking issue.");
+  assert.equal(snapshot.decision.nextState, "addressing_review");
+  assert.equal(snapshot.decision.shouldRunCodex, true);
+  assert.equal(snapshot.decision.blockedReason, "manual_review");
+  assert.match(snapshot.decision.failureContext?.summary ?? "", /review/i);
+});
+
+test("writeSupervisorCycleDecisionSnapshot serializes one cycle into the workspace replay artifact", async () => {
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "cycle-snapshot-"));
+
+  const snapshotPath = await writeSupervisorCycleDecisionSnapshot({
+    config: createConfig(),
+    capturedAt: "2026-03-16T10:07:00Z",
+    issue: createIssue(),
+    record: createRecord(),
+    workspacePath,
+    workspaceStatus: createWorkspaceStatus(),
+    pr: createPr(),
+    checks: [{ name: "build", state: "completed", bucket: "pass" }],
+    reviewThreads: [createReviewThread()],
+  });
+
+  assert.equal(snapshotPath, supervisorCycleSnapshotPath(workspacePath));
+  const persisted = JSON.parse(await fs.readFile(snapshotPath, "utf8")) as ReturnType<typeof buildSupervisorCycleDecisionSnapshot>;
+  assert.equal(persisted.capturedAt, "2026-03-16T10:07:00Z");
+  assert.equal(persisted.local.record.issue_number, 407);
+  assert.equal(persisted.github.pullRequest?.number, 88);
+  assert.equal(persisted.decision.nextState, "addressing_review");
+});

--- a/src/supervisor/supervisor-cycle-snapshot.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ensureDir } from "../core/utils";
+import {
+  FailureContext,
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  WorkspaceStatus,
+} from "../core/types";
+import { inferStateFromPullRequest } from "../pull-request-state";
+import { blockedReasonForLifecycleState, shouldRunCodex } from "./supervisor-lifecycle";
+import { inferFailureContext } from "./supervisor-failure-context";
+
+export interface SupervisorCycleDecisionSnapshot {
+  schemaVersion: 1;
+  capturedAt: string;
+  issue: Pick<GitHubIssue, "number" | "title" | "url" | "state" | "updatedAt">;
+  local: {
+    record: Pick<
+      IssueRunRecord,
+      | "issue_number"
+      | "state"
+      | "branch"
+      | "pr_number"
+      | "workspace"
+      | "journal_path"
+      | "attempt_count"
+      | "implementation_attempt_count"
+      | "repair_attempt_count"
+      | "blocked_reason"
+      | "last_error"
+      | "last_failure_signature"
+      | "last_head_sha"
+      | "review_wait_started_at"
+      | "review_wait_head_sha"
+      | "copilot_review_requested_observed_at"
+      | "copilot_review_requested_head_sha"
+      | "copilot_review_timed_out_at"
+      | "copilot_review_timeout_action"
+      | "copilot_review_timeout_reason"
+      | "local_review_head_sha"
+      | "local_review_blocker_summary"
+      | "local_review_summary_path"
+      | "local_review_run_at"
+      | "local_review_max_severity"
+      | "local_review_findings_count"
+      | "local_review_root_cause_count"
+      | "local_review_verified_max_severity"
+      | "local_review_verified_findings_count"
+      | "local_review_recommendation"
+      | "local_review_degraded"
+      | "last_local_review_signature"
+      | "repeated_local_review_signature_count"
+      | "processed_review_thread_ids"
+      | "processed_review_thread_fingerprints"
+      | "updated_at"
+    >;
+    workspaceStatus: WorkspaceStatus;
+  };
+  github: {
+    pullRequest: GitHubPullRequest | null;
+    checks: PullRequestCheck[];
+    reviewThreads: ReviewThread[];
+  };
+  decision: {
+    nextState: IssueRunRecord["state"];
+    shouldRunCodex: boolean;
+    blockedReason: IssueRunRecord["blocked_reason"];
+    failureContext: FailureContext | null;
+  };
+}
+
+export function supervisorCycleSnapshotPath(workspacePath: string): string {
+  return path.join(workspacePath, ".codex-supervisor", "replay", "decision-cycle-snapshot.json");
+}
+
+export function buildSupervisorCycleDecisionSnapshot(args: {
+  config: SupervisorConfig;
+  capturedAt: string;
+  issue: GitHubIssue;
+  record: IssueRunRecord;
+  workspaceStatus: WorkspaceStatus;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): SupervisorCycleDecisionSnapshot {
+  const { config, capturedAt, issue, record, workspaceStatus, pr, checks, reviewThreads } = args;
+  const nextState = pr ? inferStateFromPullRequest(config, record, pr, checks, reviewThreads) : record.state;
+
+  return {
+    schemaVersion: 1,
+    capturedAt,
+    issue: {
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      state: issue.state,
+      updatedAt: issue.updatedAt,
+    },
+    local: {
+      record: {
+        issue_number: record.issue_number,
+        state: record.state,
+        branch: record.branch,
+        pr_number: record.pr_number,
+        workspace: record.workspace,
+        journal_path: record.journal_path,
+        attempt_count: record.attempt_count,
+        implementation_attempt_count: record.implementation_attempt_count,
+        repair_attempt_count: record.repair_attempt_count,
+        blocked_reason: record.blocked_reason,
+        last_error: record.last_error,
+        last_failure_signature: record.last_failure_signature,
+        last_head_sha: record.last_head_sha,
+        review_wait_started_at: record.review_wait_started_at,
+        review_wait_head_sha: record.review_wait_head_sha,
+        copilot_review_requested_observed_at: record.copilot_review_requested_observed_at,
+        copilot_review_requested_head_sha: record.copilot_review_requested_head_sha,
+        copilot_review_timed_out_at: record.copilot_review_timed_out_at,
+        copilot_review_timeout_action: record.copilot_review_timeout_action,
+        copilot_review_timeout_reason: record.copilot_review_timeout_reason,
+        local_review_head_sha: record.local_review_head_sha,
+        local_review_blocker_summary: record.local_review_blocker_summary,
+        local_review_summary_path: record.local_review_summary_path,
+        local_review_run_at: record.local_review_run_at,
+        local_review_max_severity: record.local_review_max_severity,
+        local_review_findings_count: record.local_review_findings_count,
+        local_review_root_cause_count: record.local_review_root_cause_count,
+        local_review_verified_max_severity: record.local_review_verified_max_severity,
+        local_review_verified_findings_count: record.local_review_verified_findings_count,
+        local_review_recommendation: record.local_review_recommendation,
+        local_review_degraded: record.local_review_degraded,
+        last_local_review_signature: record.last_local_review_signature,
+        repeated_local_review_signature_count: record.repeated_local_review_signature_count,
+        processed_review_thread_ids: [...record.processed_review_thread_ids],
+        processed_review_thread_fingerprints: [...record.processed_review_thread_fingerprints],
+        updated_at: record.updated_at,
+      },
+      workspaceStatus,
+    },
+    github: {
+      pullRequest: pr,
+      checks,
+      reviewThreads,
+    },
+    decision: {
+      nextState,
+      shouldRunCodex: shouldRunCodex(record, pr, checks, reviewThreads, config),
+      blockedReason: pr ? blockedReasonForLifecycleState(config, record, pr, checks, reviewThreads) : null,
+      failureContext: inferFailureContext(config, record, pr, checks, reviewThreads),
+    },
+  };
+}
+
+export async function writeSupervisorCycleDecisionSnapshot(args: {
+  config: SupervisorConfig;
+  capturedAt: string;
+  issue: GitHubIssue;
+  record: IssueRunRecord;
+  workspacePath: string;
+  workspaceStatus: WorkspaceStatus;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): Promise<string> {
+  const snapshotPath = supervisorCycleSnapshotPath(args.workspacePath);
+  await ensureDir(path.dirname(snapshotPath));
+  const snapshot = buildSupervisorCycleDecisionSnapshot(args);
+  await fs.writeFile(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+  return snapshotPath;
+}


### PR DESCRIPTION
Closes #407
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a narrow replay artifact for one prepared supervisor cycle. The new helper in [src/supervisor/supervisor-cycle-snapshot.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-407/src/supervisor/supervisor-cycle-snapshot.ts) writes `.codex-supervisor/replay/decision-cycle-snapshot.json` with the local record/workspace status, refreshed PR/check/review-thread facts, and derived decision outputs. I wired that into [src/run-once-issue-preparation.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-407/src/run-once-issue-preparation.ts) so the snapshot is captured during issue preparation, including merged/closed PR branches.

Focused coverage is in [src/supervisor/supervisor-cycle-snapshot.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-407/src/supervisor/supervisor-cycle-snapshot.test.ts) and [src/run-once-issue-preparation.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-407/src/run-once-issue-preparation.test.ts). I also updated the supervisor family layout guard in [src/family-directory-layout.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-407/src/family-directory-layout.test.ts). Checkpoint commit: `433ea52` (`Add replay snapshot for supervisor cycle inputs`).

Summary: Added a replay-oriented supervisor cycle snapshot artifact and covered it with focused tests; build passes.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/supervisor/supervisor-cycle-snapshot.test.ts`; `npx tsx --test src/run...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added supervisor decision-cycle snapshot functionality to record and persist supervisor decision points, improving observability and enabling replay analysis of supervisor operations.

* **Tests**
  * Added comprehensive test coverage for snapshot generation and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->