### PR TITLE
State invariants: cover PR lifecycle, merge gating, and stale-head safety

### DIFF
--- a/src/pull-request-state.test.ts
+++ b/src/pull-request-state.test.ts
@@ -104,7 +104,7 @@ function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
     blocked_verification_retry_count: 0,
     repeated_blocker_count: 0,
     repeated_failure_signature_count: 1,
-    last_head_sha: "abcdef1",
+    last_head_sha: "head123",
     last_codex_summary: null,
     last_recovery_reason: null,
     last_recovery_at: null,
@@ -220,6 +220,45 @@ test("inferStateFromPullRequest does not wait for Copilot when no lifecycle sign
     inferStateFromPullRequest(config, record, createPullRequest({ createdAt: now }), checks, []),
     "ready_to_merge",
   );
+});
+
+test("inferStateFromPullRequest does not report ready_to_merge when the tracked head is stale", () => {
+  const config = createConfig();
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head-old",
+  });
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, createPullRequest({ headRefOid: "head-new" }), checks, []),
+    "stabilizing",
+  );
+});
+
+test("inferStateFromPullRequest keeps review-required PRs out of ready_to_merge", () => {
+  const config = createConfig();
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head123",
+  });
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, createPullRequest({ reviewDecision: "REVIEW_REQUIRED" }), checks, []),
+    "pr_open",
+  );
+});
+
+test("inferStateFromPullRequest keeps pending checks from reaching ready_to_merge", () => {
+  const config = createConfig();
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head123",
+  });
+  const checks: PullRequestCheck[] = [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }];
+
+  assert.equal(inferStateFromPullRequest(config, record, createPullRequest(), checks, []), "waiting_ci");
 });
 
 test("inferStateFromPullRequest waits briefly after ready-for-review for Copilot request propagation", () => {
@@ -848,6 +887,7 @@ test("inferStateFromPullRequest covers local review policy gating combinations",
       config: { localReviewEnabled: true, localReviewPolicy: "block_merge", copilotReviewWaitMinutes: 0 },
       record: {
         state: "pr_open",
+        last_head_sha: "newhead",
         local_review_head_sha: "oldhead",
         local_review_findings_count: 2,
         local_review_recommendation: "changes_requested",

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -243,6 +243,10 @@ function mergeConditionsSatisfied(pr: GitHubPullRequest, checks: PullRequestChec
   );
 }
 
+function pullRequestHeadMatchesRecord(record: Pick<IssueRunRecord, "last_head_sha">, pr: GitHubPullRequest): boolean {
+  return record.last_head_sha === null || record.last_head_sha === pr.headRefOid;
+}
+
 export function blockedReasonFromReviewState(
   config: SupervisorConfig,
   record: IssueRunRecord,
@@ -471,6 +475,10 @@ export function inferStateFromPullRequest(
 
   if (copilotReviewPending(config, record, pr) && !copilotTimeout.timedOut) {
     return "waiting_ci";
+  }
+
+  if (!pullRequestHeadMatchesRecord(record, pr) && mergeConditionsSatisfied(pr, checks)) {
+    return "stabilizing";
   }
 
   if (mergeConditionsSatisfied(pr, checks)) {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -103,7 +103,7 @@ function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
     blocked_verification_retry_count: 0,
     repeated_blocker_count: 0,
     repeated_failure_signature_count: 0,
-    last_head_sha: "abcdef1",
+    last_head_sha: "head123",
     last_codex_summary: null,
     last_recovery_reason: null,
     last_recovery_at: null,
@@ -201,6 +201,16 @@ test("shouldRunCodex only returns true for actionable supervisor states", () => 
       createRecord({ state: "repairing_ci" }),
       createPullRequest({ mergeStateStatus: "CLEAN" }),
       [{ name: "build", state: "FAILURE", bucket: "fail", workflow: "CI" }],
+      reviewThreads,
+      config,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldRunCodex(
+      createRecord({ state: "ready_to_merge", last_head_sha: "head-old" }),
+      createPullRequest({ headRefOid: "head-new" }),
+      checks,
       reviewThreads,
       config,
     ),


### PR DESCRIPTION
## Summary
- add focused pull-request lifecycle invariants for stale-head merge prevention
- cover review-required and pending-check merge gating regressions
- keep stale tracked heads out of `ready_to_merge` by holding them in `stabilizing`

Closes #419

## Verification
- ./node_modules/.bin/tsx --test src/pull-request-state.test.ts src/supervisor/supervisor-lifecycle.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR state handling when the tracked PR head becomes stale; now correctly transitions to stabilizing state instead of ready_to_merge.
  * Enhanced validation to prevent PRs with pending reviews from being marked as ready to merge.
  * Fixed handling of in-progress checks to maintain waiting state.

* **Tests**
  * Added validation tests for PR head staleness detection and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->