### PR TITLE
Issue #423: Surface change classes in supervisor status output

### DIFF
--- a/src/supervisor/supervisor-selection-status.ts
+++ b/src/supervisor/supervisor-selection-status.ts
@@ -16,7 +16,11 @@ import {
   shouldEnforceExecutionReady,
 } from "./supervisor-execution-policy";
 import { shouldAutoRetryTimeout } from "./supervisor-failure-helpers";
-import { buildDurableGuardrailStatusLine } from "./supervisor-status-rendering";
+import {
+  buildChangeClassesStatusLine,
+  buildDurableGuardrailStatusLine,
+  loadStatusChangedFiles,
+} from "./supervisor-status-rendering";
 import {
   GitHubIssue,
   GitHubPullRequest,
@@ -47,6 +51,7 @@ export interface ActiveIssueStatusSnapshot {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
   handoffSummary: string | null;
+  changeClassesSummary: string | null;
   durableGuardrailSummary: string | null;
   warningMessage: string | null;
 }
@@ -92,6 +97,7 @@ export async function loadActiveIssueStatusSnapshot(args: {
   let pr: GitHubPullRequest | null = null;
   let checks: PullRequestCheck[] = [];
   let reviewThreads: ReviewThread[] = [];
+  let changeClassesSummary: string | null = null;
   let durableGuardrailSummary: string | null = null;
   let warningMessage: string | null = null;
 
@@ -107,10 +113,13 @@ export async function loadActiveIssueStatusSnapshot(args: {
     pr = await args.github.resolvePullRequestForBranch(args.activeRecord.branch, args.activeRecord.pr_number);
     checks = isOpenPullRequest(pr) ? await args.github.getChecks(pr.number) : [];
     reviewThreads = isOpenPullRequest(pr) ? await args.github.getUnresolvedReviewThreads(pr.number) : [];
+    const changedFiles = await loadStatusChangedFiles(args.config, args.activeRecord.workspace);
+    changeClassesSummary = buildChangeClassesStatusLine(changedFiles);
     durableGuardrailSummary = await buildDurableGuardrailStatusLine({
       config: args.config,
       activeRecord: args.activeRecord,
       pr,
+      changedFiles,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -122,6 +131,7 @@ export async function loadActiveIssueStatusSnapshot(args: {
     checks,
     reviewThreads,
     handoffSummary,
+    changeClassesSummary,
     durableGuardrailSummary,
     warningMessage,
   };

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -226,10 +226,12 @@ test("buildDetailedStatusSummaryLines shapes optional summaries and artifact pat
       activeRecord,
       latestRecoveryRecord,
       handoffSummary: "blocked\nneeds reproduction",
+      changeClassesSummary: "change_classes=backend, docs, tests",
       durableGuardrailSummary: "durable_guardrails verifier=committed:.codex/verifier-guardrails.json#1 external_review=none",
     }),
     [
       "handoff_summary=blocked\\nneeds reproduction",
+      "change_classes=backend, docs, tests",
       "durable_guardrails verifier=committed:.codex/verifier-guardrails.json#1 external_review=none",
       "latest_recovery issue=#91 at=2026-03-13T00:20:00Z reason=merged_pr_convergence: tracked PR #191 merged; marked issue #91 done",
       "local_review_summary_path=owner-repo/issue-58/local-review-summary.md",

--- a/src/supervisor/supervisor-status-model.ts
+++ b/src/supervisor/supervisor-status-model.ts
@@ -45,6 +45,7 @@ export interface BuildDetailedStatusSummaryLinesArgs {
   activeRecord: IssueRunRecord | null;
   latestRecoveryRecord?: IssueRunRecord | null;
   handoffSummary?: string | null;
+  changeClassesSummary?: string | null;
   durableGuardrailSummary?: string | null;
 }
 
@@ -64,12 +65,17 @@ export function buildDetailedStatusSummaryLines(args: BuildDetailedStatusSummary
     activeRecord,
     latestRecoveryRecord = null,
     handoffSummary = null,
+    changeClassesSummary = null,
     durableGuardrailSummary = null,
   } = args;
   const lines: string[] = [];
 
   if (handoffSummary) {
     lines.push(`handoff_summary=${truncate(sanitizeStatusValue(handoffSummary), 200)}`);
+  }
+
+  if (changeClassesSummary) {
+    lines.push(truncate(sanitizeStatusValue(changeClassesSummary), 200) ?? "");
   }
 
   if (durableGuardrailSummary) {

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { formatDetailedStatus } from "./supervisor-status-rendering";
+import { buildChangeClassesStatusLine, formatDetailedStatus } from "./supervisor-status-rendering";
 import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -165,6 +165,7 @@ test("formatDetailedStatus renders core lines before appended summaries", () => 
     checks: [],
     reviewThreads: [],
     handoffSummary: "blocked\nneeds reproduction",
+    changeClassesSummary: "change_classes=backend, docs, tests",
     durableGuardrailSummary:
       "durable_guardrails verifier=committed:.codex/verifier-guardrails.json#1 external_review=runtime:owner-repo/issue-58/external-review-misses-head-deadbeef.json#2",
   });
@@ -195,11 +196,24 @@ test("formatDetailedStatus renders core lines before appended summaries", () => 
       "checks=none",
       "review_threads bot_pending=0 bot_unresolved=0 manual=0",
       "handoff_summary=blocked\\nneeds reproduction",
+      "change_classes=backend, docs, tests",
       "durable_guardrails verifier=committed:.codex/verifier-guardrails.json#1 external_review=runtime:owner-repo/issue-58/external-review-misses-head-deadbeef.json#2",
       "latest_recovery issue=#57 at=2026-03-13T00:20:00Z reason=merged_pr_convergence: tracked PR #157 merged; marked issue #57 done",
       "local_review_summary_path=owner-repo/issue-58/local-review-summary.md",
       "external_review_misses_path=owner-repo/issue-58/external-review-misses-head-deadbeef.json",
     ].join("\n"),
+  );
+});
+
+test("buildChangeClassesStatusLine reports a sorted multi-class summary", () => {
+  assert.equal(
+    buildChangeClassesStatusLine([
+      "src/supervisor.ts",
+      "docs/getting-started.md",
+      "src/supervisor/supervisor-status-rendering.test.ts",
+      "src/supervisor.ts",
+    ]),
+    "change_classes=backend, docs, tests",
   );
 });
 

--- a/src/supervisor/supervisor-status-rendering.ts
+++ b/src/supervisor/supervisor-status-rendering.ts
@@ -14,6 +14,7 @@ import {
   manualReviewThreads,
   pendingBotReviewThreads,
 } from "../review-thread-reporting";
+import { detectDeterministicChangeClasses } from "../issue-metadata";
 import {
   buildDetailedStatusModel,
   buildDetailedStatusSummaryLines,
@@ -53,7 +54,10 @@ export function mergeConflictDetected(pr: GitHubPullRequest): boolean {
   return pr.mergeStateStatus === "DIRTY";
 }
 
-async function loadStatusChangedFiles(config: SupervisorConfig, workspacePath: string): Promise<string[]> {
+export async function loadStatusChangedFiles(
+  config: SupervisorConfig,
+  workspacePath: string,
+): Promise<string[]> {
   let result;
   try {
     result = await runCommand(
@@ -76,12 +80,23 @@ async function loadStatusChangedFiles(config: SupervisorConfig, workspacePath: s
   )].sort();
 }
 
+export function buildChangeClassesStatusLine(changedFiles: string[]): string | null {
+  const changeClasses = detectDeterministicChangeClasses(changedFiles);
+  if (changeClasses.length === 0) {
+    return null;
+  }
+
+  return `change_classes=${changeClasses.join(", ")}`;
+}
+
 export async function buildDurableGuardrailStatusLine(args: {
   config: SupervisorConfig;
   activeRecord: Pick<IssueRunRecord, "branch" | "issue_number" | "last_head_sha" | "workspace">;
   pr: Pick<GitHubPullRequest, "headRefOid"> | null;
+  changedFiles?: string[];
 }): Promise<string | null> {
-  const changedFiles = await loadStatusChangedFiles(args.config, args.activeRecord.workspace);
+  const changedFiles =
+    args.changedFiles ?? (await loadStatusChangedFiles(args.config, args.activeRecord.workspace));
   if (changedFiles.length === 0) {
     return null;
   }
@@ -165,6 +180,7 @@ export function formatDetailedStatus(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
   handoffSummary?: string | null;
+  changeClassesSummary?: string | null;
   durableGuardrailSummary?: string | null;
 }): string {
   const lines = buildDetailedStatusModel({
@@ -187,6 +203,7 @@ export function formatDetailedStatus(args: {
     activeRecord: args.activeRecord,
     latestRecoveryRecord: args.latestRecoveryRecord,
     handoffSummary: args.handoffSummary,
+    changeClassesSummary: args.changeClassesSummary,
     durableGuardrailSummary: args.durableGuardrailSummary,
   });
   return [...lines, ...summaryLines].join("\n");

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -613,6 +613,7 @@ export class Supervisor {
       checks: activeStatus.checks,
       reviewThreads: activeStatus.reviewThreads,
       handoffSummary: activeStatus.handoffSummary,
+      changeClassesSummary: activeStatus.changeClassesSummary,
       durableGuardrailSummary: activeStatus.durableGuardrailSummary,
     });
 


### PR DESCRIPTION
## Summary
- surface computed change classes in supervisor status output
- reuse the existing status summary/rendering pipeline
- cover a multi-class example in focused tests

## Testing
- npx tsx --test src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-status-rendering.test.ts
- npm run build

Closes #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change classes summary to detailed status output, displaying categorized information about modified files (e.g., backend, docs, tests).
  * New capability to automatically detect and format change class information from modified files.

* **Enhancement**
  * Extended status rendering to propagate change class summaries throughout the status system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->