### PR TITLE
Issue #424: apply conservative change-risk verification policy

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -203,6 +203,56 @@ test("buildCodexPrompt accepts a normalized resume AgentTurnContext", () => {
   assert.doesNotMatch(prompt, /Issue body:/);
 });
 
+test("buildCodexPrompt applies focused verification guidance for lower-risk change classes", () => {
+  const prompt = buildCodexPrompt({
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "implementing" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+    changeClasses: ["docs", "tests"],
+  });
+
+  assert.match(prompt, /Verification policy:/);
+  assert.match(prompt, /Computed change classes: docs, tests/);
+  assert.match(prompt, /Verification intensity: focused/);
+  assert.match(
+    prompt,
+    /Keep verification focused on the directly affected documentation or tests unless another signal justifies broader coverage\./,
+  );
+});
+
+test("buildCodexPrompt keeps stronger verification guidance for workflow-like change classes", () => {
+  const prompt = buildCodexPrompt({
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "implementing" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+    changeClasses: ["backend", "workflow"],
+  });
+
+  assert.match(prompt, /Verification policy:/);
+  assert.match(prompt, /Computed change classes: backend, workflow/);
+  assert.match(prompt, /Verification intensity: strong/);
+  assert.match(
+    prompt,
+    /Keep stronger verification for workflow, schema, or infrastructure changes, including the most relevant higher-signal checks before concluding the work is done\./,
+  );
+});
+
 test("buildCodexPrompt requires config before treating input as an AgentTurnContext", () => {
   assert.throws(
     () =>

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -10,6 +10,7 @@ import {
 } from "../core/types";
 import { truncate } from "../core/utils";
 import { type VerifierGuardrailRule } from "../verifier-guardrails";
+import type { DeterministicChangeClass } from "../issue-metadata";
 import type {
   AgentTurnContext,
   ResumeAgentTurnContext,
@@ -192,6 +193,7 @@ export interface BuildCodexStartPromptInput {
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  changeClasses?: DeterministicChangeClass[];
   alwaysReadFiles: string[];
   onDemandMemoryFiles: string[];
   gsdEnabled?: boolean;
@@ -216,6 +218,37 @@ export interface BuildCodexResumePromptInput {
   failureContext?: FailureContext | null;
   previousSummary?: string | null;
   previousError?: string | null;
+}
+
+type VerificationIntensity = "focused" | "standard" | "strong";
+
+function describeVerificationPolicy(
+  changeClasses: DeterministicChangeClass[] | undefined,
+): { changeClasses: string; intensity: VerificationIntensity; guidance: string } | null {
+  if (!changeClasses || changeClasses.length === 0) {
+    return null;
+  }
+
+  const normalizedChangeClasses = [...new Set(changeClasses)].sort();
+  const hasStrongClass = normalizedChangeClasses.some((changeClass) =>
+    ["infrastructure", "schema", "workflow"].includes(changeClass),
+  );
+  const onlyFocusedClasses = normalizedChangeClasses.every((changeClass) =>
+    ["docs", "tests"].includes(changeClass),
+  );
+  const intensity: VerificationIntensity = hasStrongClass ? "strong" : onlyFocusedClasses ? "focused" : "standard";
+  const guidance =
+    intensity === "strong"
+      ? "Keep stronger verification for workflow, schema, or infrastructure changes, including the most relevant higher-signal checks before concluding the work is done."
+      : intensity === "focused"
+        ? "Keep verification focused on the directly affected documentation or tests unless another signal justifies broader coverage."
+        : "Use focused verification for the changed behavior, but keep at least the normal implementation safety bar for code changes.";
+
+  return {
+    changeClasses: normalizedChangeClasses.join(", "),
+    intensity,
+    guidance,
+  };
 }
 
 function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
@@ -365,6 +398,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
             : ["- No saved external review miss artifact is available for the current PR head."]),
         ]
       : [];
+  const verificationPolicy = describeVerificationPolicy(input.changeClasses);
 
   return [
     `You are operating inside a dedicated worktree for ${input.repoSlug}.`,
@@ -376,6 +410,15 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     "",
     "Current phase guidance:",
     ...phaseGuidance(input.state),
+    ...(verificationPolicy
+      ? [
+          "",
+          "Verification policy:",
+          `- Computed change classes: ${verificationPolicy.changeClasses}`,
+          `- Verification intensity: ${verificationPolicy.intensity}`,
+          `- Guidance: ${verificationPolicy.guidance}`,
+        ]
+      : []),
     "",
     "Issue body:",
     input.issue.body || "(empty)",
@@ -560,6 +603,7 @@ function toStartPromptInput(input: StartAgentTurnContext): BuildCodexStartPrompt
     pr: input.pr,
     checks: input.checks,
     reviewThreads: input.reviewThreads,
+    changeClasses: input.changeClasses,
     alwaysReadFiles: input.alwaysReadFiles,
     onDemandMemoryFiles: input.onDemandMemoryFiles,
     gsdEnabled: input.gsdEnabled,

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -22,6 +22,7 @@ import type {
 import { buildCodexFailureContext, classifyFailure } from "./supervisor-failure-helpers";
 import { basename } from "node:path";
 import type { ExternalReviewMissContext } from "../external-review/external-review-misses";
+import type { DeterministicChangeClass } from "../issue-metadata";
 
 export interface AgentRunnerCapabilities {
   supportsResume: boolean;
@@ -51,6 +52,7 @@ export interface StartAgentTurnContext extends AgentRunnerBaseRequest {
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  changeClasses?: DeterministicChangeClass[];
   alwaysReadFiles: string[];
   onDemandMemoryFiles: string[];
   gsdEnabled?: boolean;

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -297,3 +297,60 @@ test("prepareCodexTurnPrompt falls back to the full start prompt when the runner
   assert.match(prompt, /## Summary/);
   assert.match(prompt, /The fresh session still needs the issue body\./);
 });
+
+test("prepareCodexTurnPrompt computes change classes for start prompts", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "implementing",
+        codex_session_id: null,
+      }),
+    },
+  };
+
+  const prepared = await prepareCodexTurnPrompt({
+    config: createConfig(),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue: createIssue({
+      title: "Compute change classes for prompt verification guidance",
+      body: "Issue body",
+    }),
+    previousCodexSummary: null,
+    previousError: null,
+    workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    journalPath: path.join("/tmp/workspaces", "issue-102/.codex-supervisor/issue-journal.md"),
+    journalContent: "## Codex Working Notes\n### Current Handoff\n- Hypothesis: derive change classes.\n",
+    syncJournal: async () => undefined,
+    memoryArtifacts: {
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+    },
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    github: {
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    loadChangedFiles: async () => ["docs/getting-started.md", "src/codex/codex-prompt.test.ts"],
+  });
+
+  assert.equal(prepared.turnContext.kind, "start");
+  if (prepared.turnContext.kind !== "start") {
+    throw new Error("expected a start turn context");
+  }
+
+  assert.deepEqual(prepared.turnContext.changeClasses, ["docs", "tests"]);
+  const prompt = buildCodexPrompt(prepared.turnContext);
+  assert.match(prompt, /Computed change classes: docs, tests/);
+  assert.match(prompt, /Verification intensity: focused/);
+});

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -26,9 +26,11 @@ import {
   SupervisorConfig,
   SupervisorStateFile,
 } from "./core/types";
+import { detectDeterministicChangeClasses } from "./issue-metadata";
 import type { AgentRunnerCapabilities } from "./supervisor/agent-runner";
 import type { AgentTurnContext } from "./supervisor/agent-runner";
 import { truncate } from "./core/utils";
+import { loadStatusChangedFiles } from "./supervisor/supervisor-status-rendering";
 
 function shouldLoadExternalReviewContext(args: {
   preRunState: IssueRunRecord["state"];
@@ -96,6 +98,7 @@ export async function prepareCodexTurnPrompt(args: {
   reviewThreads: ReviewThread[];
   github: Pick<GitHubClient, "getExternalReviewSurface">;
   agentRunnerCapabilities?: Pick<AgentRunnerCapabilities, "supportsResume">;
+  loadChangedFiles?: (config: SupervisorConfig, workspacePath: string) => Promise<string[]>;
 }): Promise<{
   record: IssueRunRecord;
   turnContext: AgentTurnContext;
@@ -168,6 +171,12 @@ export async function prepareCodexTurnPrompt(args: {
     record,
     agentRunnerCapabilities: args.agentRunnerCapabilities,
   });
+  const changeClasses =
+    shouldResumeTurn
+      ? []
+      : detectDeterministicChangeClasses(
+          await (args.loadChangedFiles ?? loadStatusChangedFiles)(args.config, args.workspacePath),
+        );
   const turnContext =
     shouldResumeTurn
       ? {
@@ -181,6 +190,7 @@ export async function prepareCodexTurnPrompt(args: {
           pr: args.pr,
           checks: args.checks,
           reviewThreads: reviewThreadsToProcess,
+          changeClasses,
           alwaysReadFiles: args.memoryArtifacts.alwaysReadFiles,
           onDemandMemoryFiles: args.memoryArtifacts.onDemandFiles,
           gsdEnabled: args.config.gsdEnabled,


### PR DESCRIPTION
## Summary
- add a conservative verification-intensity mapping from deterministic change classes
- keep strong guidance for workflow, schema, and infrastructure-like changes
- cover both lower-risk and higher-risk prompt/orchestration cases

## Testing
- ./node_modules/.bin/tsx --test src/codex/codex-prompt.test.ts src/turn-execution-orchestration.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now detects code change classifications and automatically adjusts verification guidance accordingly.
  * Prompts include computed change classifications and corresponding verification intensity levels tailored to change types.

* **Tests**
  * Added tests validating change classification detection and verification policy generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->