### PR TITLE
Clean dist before build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Minimal GitHub issue/PR/CI supervisor using codex exec and gh.",
   "scripts": {
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.json",
     "guardrails:check": "tsx src/committed-guardrails-cli.ts check",
     "guardrails:fix": "tsx src/committed-guardrails-cli.ts fix",

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+function npmCommand(): string {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function runBuild(repoRoot: string): void {
+  const result = spawnSync(npmCommand(), ["run", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `npm run build failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
+function resolveModule(modulePath: string, repoRoot: string): string {
+  const result = spawnSync(process.execPath, ["-p", `require.resolve(${JSON.stringify(modulePath)})`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `module resolution failed for ${modulePath}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+
+  return result.stdout.trim();
+}
+
+test("npm run build removes stale root-level dist artifacts that can shadow family directories", { concurrency: false }, async (t) => {
+  const repoRoot = path.join(__dirname, "..");
+  const distDir = path.join(repoRoot, "dist");
+  const backupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-dist-backup-"));
+  const backupDistDir = path.join(backupRoot, "dist");
+
+  try {
+    await fs.rename(distDir, backupDistDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  t.after(async () => {
+    await fs.rm(distDir, { recursive: true, force: true });
+    try {
+      await fs.rename(backupDistDir, distDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+    await fs.rm(backupRoot, { recursive: true, force: true });
+  });
+
+  runBuild(repoRoot);
+  await fs.writeFile(path.join(distDir, "codex.js"), "module.exports = { stale: true };\n", "utf8");
+
+  assert.equal(resolveModule(path.join(distDir, "codex"), repoRoot), path.join(distDir, "codex.js"));
+
+  runBuild(repoRoot);
+
+  await assert.rejects(fs.access(path.join(distDir, "codex.js")));
+  assert.equal(resolveModule(path.join(distDir, "codex"), repoRoot), path.join(distDir, "codex", "index.js"));
+});


### PR DESCRIPTION
## Summary
- remove `dist/` on the normal `npm run build` path before TypeScript emits files
- add a focused regression that reproduces stale `dist/codex.js` shadowing and verifies rebuild resolution switches back to `dist/codex/index.js`

Closes #430

## Testing
- `npx tsx --test src/build.test.ts`
- `npm run build && printf 'module.exports = { stale: true };\\n' > dist/codex.js && node -p "require.resolve('./dist/codex', { paths: ['.'] })" && npm run build && node -p "require.resolve('./dist/codex', { paths: ['.'] })" && (test -f dist/codex.js && echo stale-present || echo stale-removed)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build workflow to automatically clean up stale artifacts before each build.

* **Tests**
  * Added tests to validate proper cleanup of build artifacts during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->