### PR TITLE
Record current-head CodeRabbit observation timestamps

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -218,6 +218,7 @@ export interface GitHubPullRequest {
   copilotReviewState?: CopilotReviewState | null;
   copilotReviewRequestedAt?: string | null;
   copilotReviewArrivedAt?: string | null;
+  configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotRateLimitedAt?: string | null;
   configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
   configuredBotTopLevelReviewSubmittedAt?: string | null;

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -37,6 +37,9 @@ export interface PullRequestCopilotReviewLifecycleResponse {
       author?: {
         login?: string | null;
       } | null;
+      commit?: {
+        oid?: string | null;
+      } | null;
       submittedAt?: string | null;
       state?: string | null;
       body?: string | null;
@@ -56,6 +59,9 @@ export interface PullRequestCopilotReviewLifecycleResponse {
       comments?: {
         nodes?: Array<{
           createdAt?: string | null;
+          originalCommit?: {
+            oid?: string | null;
+          } | null;
           author?: {
             login?: string | null;
           } | null;
@@ -199,6 +205,7 @@ export function mapCopilotReviewLifecycleFacts(
     reviews:
       lifecycle?.reviews?.nodes?.map((node) => ({
         authorLogin: normalizeLogin(node?.author?.login ?? null),
+        commitOid: node?.commit?.oid ?? null,
         submittedAt: node?.submittedAt ?? null,
         state: node?.state ?? null,
         body: node?.body ?? null,
@@ -208,6 +215,7 @@ export function mapCopilotReviewLifecycleFacts(
         (thread?.comments?.nodes ?? []).map((comment) => ({
           authorLogin: normalizeLogin(comment?.author?.login ?? null),
           createdAt: comment?.createdAt ?? null,
+          originalCommitOid: comment?.originalCommit?.oid ?? null,
         })),
       ) ?? [],
     issueComments:
@@ -244,8 +252,9 @@ export function mapCopilotReviewLifecycleFacts(
 export function buildConfiguredBotReviewSummary(
   lifecycle: PullRequestCopilotReviewLifecycleResponse | null | undefined,
   reviewBotLogins: string[],
+  currentHeadOid?: string | null,
 ): ConfiguredBotReviewSummary {
-  return summarizeConfiguredBotReviewSignals(mapCopilotReviewLifecycleFacts(lifecycle), reviewBotLogins);
+  return summarizeConfiguredBotReviewSignals(mapCopilotReviewLifecycleFacts(lifecycle), reviewBotLogins, currentHeadOid);
 }
 
 export function applyConfiguredBotReviewSummary(
@@ -257,6 +266,7 @@ export function applyConfiguredBotReviewSummary(
     copilotReviewState: summary?.lifecycle.state ?? null,
     copilotReviewRequestedAt: summary?.lifecycle.requestedAt ?? null,
     copilotReviewArrivedAt: summary?.lifecycle.arrivedAt ?? null,
+    configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotRateLimitedAt: summary?.rateLimitWarningAt ?? null,
     configuredBotTopLevelReviewStrength: summary?.topLevelReview.strength ?? null,
     configuredBotTopLevelReviewSubmittedAt: summary?.topLevelReview.submittedAt ?? null,

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -561,3 +561,107 @@ test("GitHubPullRequestHydrator ignores summary-only and draft-skip configured-b
   assert.equal(pr?.copilotReviewRequestedAt, "2026-03-13T01:02:03Z");
   assert.equal(pr?.copilotReviewArrivedAt, null);
 });
+
+test("GitHubPullRequestHydrator records the latest configured-bot observation scoped to the current head", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  let lifecycleQuery: string | null = null;
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      lifecycleQuery = args.find((arg) => arg.startsWith("query=")) ?? null;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [
+                    {
+                      submittedAt: "2026-03-13T02:03:04Z",
+                      state: "COMMENTED",
+                      body: "Stale review from the previous head.",
+                      commit: {
+                        oid: "stale-head-oid",
+                      },
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                    {
+                      submittedAt: "2026-03-13T02:02:00Z",
+                      state: "COMMENTED",
+                      body: "Current head review should win over newer stale observations.",
+                      commit: {
+                        oid: "head-44",
+                      },
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                comments: {
+                  nodes: [],
+                },
+                reviewThreads: {
+                  nodes: [
+                    {
+                      comments: {
+                        nodes: [
+                          {
+                            createdAt: "2026-03-13T02:05:00Z",
+                            originalCommit: {
+                              oid: "stale-head-oid",
+                            },
+                            author: {
+                              login: "coderabbitai[bot]",
+                            },
+                          },
+                          {
+                            createdAt: "2026-03-13T02:04:00Z",
+                            originalCommit: {
+                              oid: "head-44",
+                            },
+                            author: {
+                              login: "coderabbitai[bot]",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                timelineItems: {
+                  nodes: [
+                    {
+                      __typename: "ReviewRequestedEvent",
+                      createdAt: "2026-03-13T01:02:03Z",
+                      requestedReviewer: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+  const observedAt = (pr as GitHubPullRequest & { configuredBotCurrentHeadObservedAt?: string | null })
+    ?.configuredBotCurrentHeadObservedAt;
+
+  assert.ok(lifecycleQuery);
+  assert.match(lifecycleQuery, /reviews\(last:\s*100\)[\s\S]*commit\s*\{\s*oid\s*\}/);
+  assert.match(lifecycleQuery, /reviewThreads\(first:\s*100\)[\s\S]*originalCommit\s*\{\s*oid\s*\}/);
+  assert.equal(observedAt, "2026-03-13T02:04:00Z");
+});

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -58,6 +58,7 @@ class ConfiguredBotReviewSummaryCache {
       promise: Promise.resolve({
         lifecycle: { state: "not_requested", requestedAt: null, arrivedAt: null },
         topLevelReview: { strength: null, submittedAt: null },
+        currentHeadObservedAt: null,
         rateLimitWarningAt: null,
       }),
     };
@@ -119,7 +120,7 @@ export class GitHubPullRequestHydrator {
 
     const summaryPromise = this.reviewSummaryCache.set(
       cacheKey,
-      () => this.fetchConfiguredBotReviewSummary(pr.number),
+      () => this.fetchConfiguredBotReviewSummary(pr.number, pr.headRefOid),
     );
 
     try {
@@ -132,7 +133,10 @@ export class GitHubPullRequestHydrator {
     }
   }
 
-  private async fetchConfiguredBotReviewSummary(prNumber: number): Promise<ConfiguredBotReviewSummary> {
+  private async fetchConfiguredBotReviewSummary(
+    prNumber: number,
+    currentHeadOid: string,
+  ): Promise<ConfiguredBotReviewSummary> {
     const { owner, repo } = repoOwnerAndName(this.config.repoSlug);
     const query = `
       query($owner: String!, $repo: String!, $number: Int!) {
@@ -161,6 +165,9 @@ export class GitHubPullRequestHydrator {
                 submittedAt
                 state
                 body
+                commit {
+                  oid
+                }
                 author {
                   login
                 }
@@ -180,6 +187,9 @@ export class GitHubPullRequestHydrator {
                 comments(last: 100) {
                   nodes {
                     createdAt
+                    originalCommit {
+                      oid
+                    }
                     author {
                       login
                     }
@@ -252,7 +262,7 @@ export class GitHubPullRequestHydrator {
       };
     }>(result.stdout, `gh api graphql copilot review lifecycle pr=${prNumber}`);
 
-    return buildConfiguredBotReviewSummary(payload.data?.repository?.pullRequest, this.config.reviewBotLogins);
+    return buildConfiguredBotReviewSummary(payload.data?.repository?.pullRequest, this.config.reviewBotLogins, currentHeadOid);
   }
 }
 

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -341,6 +341,7 @@ test("buildConfiguredBotReviewSummary treats actionable configured-bot issue com
       strength: null,
       submittedAt: null,
     },
+    currentHeadObservedAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -377,6 +378,7 @@ test("buildConfiguredBotReviewSummary keeps top-level review strength scoped to 
       strength: "nitpick_only",
       submittedAt: "2026-03-13T02:03:04Z",
     },
+    currentHeadObservedAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -406,6 +408,7 @@ test("buildConfiguredBotReviewSummary treats configured-bot rate limit issue com
       strength: null,
       submittedAt: null,
     },
+    currentHeadObservedAt: null,
     rateLimitWarningAt: "2026-03-13T03:15:00Z",
   });
 });
@@ -446,6 +449,95 @@ test("buildConfiguredBotReviewSummary ignores configured-bot rate limit warnings
       strength: null,
       submittedAt: null,
     },
+    currentHeadObservedAt: null,
+    rateLimitWarningAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary records the latest configured-bot observation on the current head", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "Current head top-level review.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:03:00Z",
+        commitOid: "stale-head",
+        state: "COMMENTED",
+        body: "Newer stale-head top-level review.",
+      },
+    ],
+    comments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:04:00Z",
+        originalCommitOid: "head-44",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:05:00Z",
+        originalCommitOid: "stale-head",
+      },
+    ],
+    issueComments: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: null,
+      arrivedAt: "2026-03-13T02:05:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    rateLimitWarningAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary leaves current-head observation empty when only stale-head evidence exists", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:03:00Z",
+        commitOid: "stale-head",
+        state: "COMMENTED",
+        body: "Stale-head top-level review.",
+      },
+    ],
+    comments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:05:00Z",
+        originalCommitOid: "stale-head",
+      },
+    ],
+    issueComments: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: null,
+      arrivedAt: "2026-03-13T02:05:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: null,
     rateLimitWarningAt: null,
   });
 });

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -12,12 +12,14 @@ export interface CopilotReviewLifecycleFacts {
   reviews: Array<{
     authorLogin: string | null;
     submittedAt: string | null;
+    commitOid?: string | null;
     state?: string | null;
     body?: string | null;
   }>;
   comments: Array<{
     authorLogin: string | null;
     createdAt: string | null;
+    originalCommitOid?: string | null;
   }>;
   issueComments: Array<{
     authorLogin: string | null;
@@ -45,6 +47,7 @@ export interface ConfiguredBotTopLevelReviewSummary {
 export interface ConfiguredBotReviewSummary {
   lifecycle: CopilotReviewLifecycle;
   topLevelReview: ConfiguredBotTopLevelReviewSummary;
+  currentHeadObservedAt: string | null;
   rateLimitWarningAt: string | null;
 }
 
@@ -245,6 +248,43 @@ function inferConfiguredBotTopLevelReviewSummary(
   return latestConfiguredReview;
 }
 
+function inferConfiguredBotCurrentHeadObservedAt(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+  currentHeadOid: string | null | undefined,
+): string | null {
+  const normalizedCurrentHeadOid = currentHeadOid?.trim();
+  if (!normalizedCurrentHeadOid) {
+    return null;
+  }
+
+  const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
+  if (configuredReviewBots.size === 0) {
+    return null;
+  }
+
+  const currentHeadReviewTimes = facts.reviews.flatMap((review) => {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    return authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      review.commitOid === normalizedCurrentHeadOid &&
+      isActionableTopLevelReview(review)
+      ? [review.submittedAt]
+      : [];
+  });
+
+  const currentHeadCommentTimes = facts.comments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      comment.originalCommitOid === normalizedCurrentHeadOid
+      ? [comment.createdAt]
+      : [];
+  });
+
+  return latestTimestamp([...currentHeadReviewTimes, ...currentHeadCommentTimes]);
+}
+
 function inferConfiguredBotRateLimitWarningAt(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -279,10 +319,12 @@ function inferConfiguredBotRateLimitWarningAt(
 export function buildConfiguredBotReviewSummary(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
+  currentHeadOid?: string | null,
 ): ConfiguredBotReviewSummary {
   return {
     lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
     topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
+    currentHeadObservedAt: inferConfiguredBotCurrentHeadObservedAt(facts, reviewBotLogins, currentHeadOid),
     rateLimitWarningAt: inferConfiguredBotRateLimitWarningAt(facts, reviewBotLogins),
   };
 }


### PR DESCRIPTION
## Summary
- add a conservative `configuredBotCurrentHeadObservedAt` field to hydrated PR state
- scope CodeRabbit observation timestamps to the current PR head using review and review-thread commit OIDs
- cover current-head and stale-head cases in focused hydrator and review-signal tests

## Testing
- npx tsx --test src/github/github-review-signals.test.ts --test-name-pattern='current-head observation|stale-head evidence'
- npx tsx --test src/github/github-pull-request-hydrator.test.ts --test-name-pattern='GitHubPullRequestHydrator records the latest configured-bot observation scoped to the current head'
- npm run build

Closes #434.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking of when the current pull request head was last observed by configured review bots, with the observation timestamp now available in pull request data.
  * Enhanced review observations to include associated commit information for better traceability.

* **Tests**
  * Added test coverage for current head observation tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->