### PR TITLE
Add CodeRabbit merge quiet period

### DIFF
--- a/src/core/review-providers.test.ts
+++ b/src/core/review-providers.test.ts
@@ -172,6 +172,7 @@ test("reviewProviderWaitPolicyFromConfig normalizes wait and timeout behavior be
     shouldTrackRequestedState: false,
     shouldApplyRequestedReviewTimeout: false,
     shouldApplyRateLimitCooldown: false,
+    shouldApplyCurrentHeadQuietPeriod: false,
   });
 
   assert.deepEqual(
@@ -183,6 +184,7 @@ test("reviewProviderWaitPolicyFromConfig normalizes wait and timeout behavior be
       shouldTrackRequestedState: true,
       shouldApplyRequestedReviewTimeout: true,
       shouldApplyRateLimitCooldown: true,
+      shouldApplyCurrentHeadQuietPeriod: false,
     },
   );
 
@@ -195,6 +197,7 @@ test("reviewProviderWaitPolicyFromConfig normalizes wait and timeout behavior be
       shouldTrackRequestedState: false,
       shouldApplyRequestedReviewTimeout: false,
       shouldApplyRateLimitCooldown: true,
+      shouldApplyCurrentHeadQuietPeriod: true,
     },
   );
 
@@ -209,6 +212,7 @@ test("reviewProviderWaitPolicyFromConfig normalizes wait and timeout behavior be
       shouldTrackRequestedState: true,
       shouldApplyRequestedReviewTimeout: true,
       shouldApplyRateLimitCooldown: true,
+      shouldApplyCurrentHeadQuietPeriod: false,
     },
   );
 });

--- a/src/core/review-providers.ts
+++ b/src/core/review-providers.ts
@@ -24,6 +24,7 @@ export interface ReviewProviderWaitPolicy {
   shouldTrackRequestedState: boolean;
   shouldApplyRequestedReviewTimeout: boolean;
   shouldApplyRateLimitCooldown: boolean;
+  shouldApplyCurrentHeadQuietPeriod: boolean;
 }
 
 function trimReviewBotLogins(reviewBotLogins: string[]): string[] {
@@ -101,6 +102,7 @@ export function reviewProviderWaitPolicyFromConfig(
 ): ReviewProviderWaitPolicy {
   const reviewers = configuredReviewBotLogins(config);
   const usesLifecycleSignals = repoExpectsLifecycleBotReview(config);
+  const providerKinds = configuredReviewProviderKinds(config);
   return {
     botLabel: repoUsesCopilotOnlyReviewBot(config)
       ? "Copilot"
@@ -114,6 +116,7 @@ export function reviewProviderWaitPolicyFromConfig(
     shouldTrackRequestedState: usesLifecycleSignals,
     shouldApplyRequestedReviewTimeout: usesLifecycleSignals,
     shouldApplyRateLimitCooldown: reviewers.length > 0,
+    shouldApplyCurrentHeadQuietPeriod: providerKinds.includes("coderabbit"),
   };
 }
 

--- a/src/pull-request-state.test.ts
+++ b/src/pull-request-state.test.ts
@@ -607,6 +607,56 @@ test("inferStateFromPullRequest allows merge again after a configured-bot rate l
   });
 });
 
+test("inferStateFromPullRequest waits briefly after a recent CodeRabbit current-head observation", () => {
+  withStubbedDateNow("2026-03-13T02:04:03Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          copilotReviewState: "arrived",
+          copilotReviewArrivedAt: "2026-03-13T02:04:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+        }),
+        checks,
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
+test("inferStateFromPullRequest does not wait on stale CodeRabbit current-head observations", () => {
+  withStubbedDateNow("2026-03-13T02:04:06Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          copilotReviewState: "arrived",
+          copilotReviewArrivedAt: "2026-03-13T02:04:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+        }),
+        checks,
+        [],
+      ),
+      "ready_to_merge",
+    );
+  });
+});
+
 test("inferStateFromPullRequest softens nitpick-only configured-bot top-level changes requests when no configured-bot threads remain", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai[bot]"],

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -30,6 +30,7 @@ import {
 import { nowIso } from "./core/utils";
 
 const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
+const CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS = 5_000;
 
 interface CopilotReviewTimeoutStatus {
   timedOut: boolean;
@@ -204,6 +205,23 @@ function shouldWaitForCopilotReviewPropagation(
   }
 
   return Date.now() < startedAtMs + COPILOT_REVIEW_PROPAGATION_GRACE_MS;
+}
+
+function shouldWaitForConfiguredBotCurrentHeadQuietPeriod(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): boolean {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
+  if (!policy.shouldApplyCurrentHeadQuietPeriod || pr.isDraft || !pr.configuredBotCurrentHeadObservedAt) {
+    return false;
+  }
+
+  const observedAtMs = Date.parse(pr.configuredBotCurrentHeadObservedAt);
+  if (Number.isNaN(observedAtMs)) {
+    return false;
+  }
+
+  return Date.now() < observedAtMs + CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS;
 }
 
 export function buildCopilotReviewTimeoutFailureContext(
@@ -467,6 +485,10 @@ export function inferStateFromPullRequest(
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
   if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
     return "blocked";
+  }
+
+  if (shouldWaitForConfiguredBotCurrentHeadQuietPeriod(config, pr)) {
+    return "waiting_ci";
   }
 
   if (shouldWaitForCopilotReviewPropagation(config, record, pr)) {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -182,6 +182,26 @@ test("derivePullRequestLifecycleSnapshot applies review-bot lifecycle patches be
   });
 });
 
+test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci during the short current-head quiet period", () => {
+  withStubbedDateNow("2026-03-13T02:04:03Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const pr = createPullRequest({
+      copilotReviewState: "arrived",
+      copilotReviewArrivedAt: "2026-03-13T02:04:00Z",
+      configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+    });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+    const reviewThreads: ReviewThread[] = [];
+
+    const snapshot = derivePullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads);
+
+    assert.equal(snapshot.nextState, "waiting_ci");
+  });
+});
+
 test("shouldRunCodex only returns true for actionable supervisor states", () => {
   const config = createConfig();
   const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];


### PR DESCRIPTION
## Summary
- add a short CodeRabbit-only quiet period before merge progression after a fresh current-head observation
- keep stale-head observations from triggering the wait
- cover the new provider policy and lifecycle behavior with focused tests

## Testing
- npx tsx --test src/pull-request-state.test.ts src/supervisor/supervisor-lifecycle.test.ts src/core/review-providers.test.ts
- npm run build

Part of #433
Depends on #434
Closes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a brief quiet period for CodeRabbit-reviewed pull requests that pauses merge readiness evaluation immediately following reviewer observations.

* **Tests**
  * Added comprehensive test coverage for the new quiet period feature, including scenarios for recent and stale observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->