### PR TITLE
Expose CodeRabbit settled wait in status

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Requirements: `gh auth status` must succeed, `codex` CLI must be installed, and 
 
 - Copilot profile: start from [supervisor.config.copilot.json](./supervisor.config.copilot.json), enable GitHub Copilot review for the target repo or org, and verify a ready PR receives review activity from `copilot-pull-request-reviewer`.
 - Codex Connector profile: start from [supervisor.config.codex.json](./supervisor.config.codex.json), connect the repo to Codex in ChatGPT/OpenAI, and verify PR review activity arrives from `chatgpt-codex-connector`.
-- CodeRabbit profile: start from [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json), install CodeRabbit, and verify review activity arrives from `coderabbitai` or `coderabbitai[bot]`. The shipped profile also waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing, so you can keep auto-incremental review enabled without adding repo-level throttling by default.
+- CodeRabbit profile: start from [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json), install CodeRabbit, and verify review activity arrives from `coderabbitai` or `coderabbitai[bot]`. The shipped profile also waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing, and it briefly holds merge progression after a fresh current-head CodeRabbit observation; `status` shows that short hold as `configured_bot_settled_wait status=active` so operators can see that the pause is intentional.
 
 If the provider never posts a usable PR review signal, fix the provider-side setup before treating the profile as working.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,8 +37,9 @@ Each shipped profile only covers supervisor-side expectations. You still need th
 
 ### CodeRabbit profile
 
-- Supervisor-side: use `supervisor.config.coderabbit.json`, which tracks both `coderabbitai` and `coderabbitai[bot]` and waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing.
+- Supervisor-side: use `supervisor.config.coderabbit.json`, which tracks both `coderabbitai` and `coderabbitai[bot]`, waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing, and applies a short settled wait after a fresh CodeRabbit current-head observation.
 - Provider-side: install CodeRabbit. Add `.coderabbit.yaml` only when you intentionally want repo-specific CodeRabbit behavior; it is not required just to make the supervisor wait through temporary rate limits.
+- Operator note: while that short settled wait is active, `status` shows `configured_bot_settled_wait status=active provider=coderabbit ...`. That means the supervisor saw CodeRabbit on the current PR head and is deliberately pausing merge progression for a few seconds so late-arriving review signals can land first.
 - Verify: open a PR and confirm CodeRabbit posts review activity under one of the configured bot identities.
 
 Only treat a profile as working after the provider produces a usable PR review signal that the supervisor can observe and react to.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,6 +155,8 @@ In normal operation, the supervisor will:
 
 Use `status` whenever you want the current issue, PR, check, review, and mergeability summary without advancing the loop.
 
+If you use the CodeRabbit profile, `status` can briefly show `configured_bot_settled_wait status=active provider=coderabbit ...` after CodeRabbit posts on the current PR head. That indicates a short intentional quiet period before merge progression resumes.
+
 ## Common operator decisions
 
 When should I use GSD first?

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -9,6 +9,7 @@ import {
   summarizeCheckBuckets,
 } from "./supervisor-status-summary-helpers";
 import {
+  configuredBotSettledWaitWindow,
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
   configuredReviewBots,
@@ -139,6 +140,12 @@ export function buildActiveDetailedStatusLines(
     if (configuredBotRateLimit.observedAt) {
       lines.push(
         `configured_bot_rate_limit status=${configuredBotRateLimit.status} observed_at=${configuredBotRateLimit.observedAt} wait_until=${configuredBotRateLimit.waitUntil ?? "none"}`,
+      );
+    }
+    const configuredBotSettledWait = configuredBotSettledWaitWindow(config, pr);
+    if (configuredBotSettledWait.status === "active") {
+      lines.push(
+        `configured_bot_settled_wait status=${configuredBotSettledWait.status} provider=${configuredBotSettledWait.provider} observed_at=${configuredBotSettledWait.observedAt ?? "none"} wait_until=${configuredBotSettledWait.waitUntil ?? "none"}`,
       );
     }
     if (activeRecord.copilot_review_timeout_reason) {

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -132,6 +132,16 @@ function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPu
   };
 }
 
+function withStubbedDateNow<T>(nowIso: string, run: () => T): T {
+  const realDateNow = Date.now;
+  Date.now = () => Date.parse(nowIso);
+  try {
+    return run();
+  } finally {
+    Date.now = realDateNow;
+  }
+}
+
 test("summarizeChecks treats cancelled runs as waiting, not failing", () => {
   const summary = summarizeChecks([{ name: "merge-queue", state: "CANCELLED", bucket: "cancel", workflow: "CI" }]);
 
@@ -477,6 +487,36 @@ test("formatDetailedStatus detects the CodeRabbit profile for canonical and reve
       /review_bot_profile profile=coderabbit provider=coderabbitai .* signal_source=review_threads/,
     );
   }
+});
+
+test("formatDetailedStatus surfaces an active CodeRabbit settled wait after a current-head observation", () => {
+  withStubbedDateNow("2026-03-13T02:04:03Z", () => {
+    const status = formatDetailedStatus({
+      config: createConfig({
+        reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+      }),
+      activeRecord: createRecord({
+        pr_number: 44,
+        state: "waiting_ci",
+      }),
+      latestRecord: null,
+      trackedIssueCount: 1,
+      pr: createPullRequest({
+        number: 44,
+        headRefName: "codex/issue-38",
+        copilotReviewState: "arrived",
+        copilotReviewArrivedAt: "2026-03-13T02:04:00Z",
+        configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+      }),
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [],
+    });
+
+    assert.match(
+      status,
+      /configured_bot_settled_wait status=active provider=coderabbit observed_at=2026-03-13T02:04:00Z wait_until=2026-03-13T02:04:05\.000Z/,
+    );
+  });
 });
 
 test("formatDetailedStatus preserves Copilot-specific timeout wording for Copilot-only repos", () => {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  configuredBotSettledWaitWindow,
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
   configuredReviewStatusLabel,
@@ -285,6 +286,41 @@ test("configuredBotRateLimitWaitWindow reports active and expired windows", () =
         status: "expired",
         observedAt: "2026-03-16T00:00:00.000Z",
         waitUntil: "2026-03-16T00:03:00.000Z",
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("configuredBotSettledWaitWindow reports the active CodeRabbit quiet period", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:00:03.000Z");
+
+  try {
+    assert.deepEqual(
+      configuredBotSettledWaitWindow(
+        createConfig({ reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"] }),
+        createPr({ configuredBotCurrentHeadObservedAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "active",
+        provider: "coderabbit",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: "2026-03-16T00:00:05.000Z",
+      },
+    );
+
+    assert.deepEqual(
+      configuredBotSettledWaitWindow(
+        createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+        createPr({ configuredBotCurrentHeadObservedAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "inactive",
+        provider: "none",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: null,
       },
     );
   } finally {

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -1,5 +1,6 @@
 import {
   configuredReviewBotLogins,
+  configuredReviewProviderKinds,
   repoExpectsConfiguredBotReview,
   repoUsesCopilotOnlyReviewBot,
   reviewProviderProfileFromConfig,
@@ -7,6 +8,7 @@ import {
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+const CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS = 5_000;
 
 export type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
 
@@ -45,6 +47,43 @@ export function configuredBotRateLimitWaitWindow(
   return {
     status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
     observedAt: pr.configuredBotRateLimitedAt,
+    waitUntil,
+  };
+}
+
+export function configuredBotSettledWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): {
+  status: "inactive" | "active" | "expired";
+  provider: "none" | "coderabbit";
+  observedAt: string | null;
+  waitUntil: string | null;
+} {
+  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || !pr.configuredBotCurrentHeadObservedAt) {
+    return {
+      status: "inactive",
+      provider: "none",
+      observedAt: pr.configuredBotCurrentHeadObservedAt ?? null,
+      waitUntil: null,
+    };
+  }
+
+  const observedAtMs = Date.parse(pr.configuredBotCurrentHeadObservedAt);
+  if (Number.isNaN(observedAtMs)) {
+    return {
+      status: "inactive",
+      provider: "coderabbit",
+      observedAt: pr.configuredBotCurrentHeadObservedAt,
+      waitUntil: null,
+    };
+  }
+
+  const waitUntil = new Date(observedAtMs + CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    provider: "coderabbit",
+    observedAt: pr.configuredBotCurrentHeadObservedAt,
     waitUntil,
   };
 }


### PR DESCRIPTION
## Summary
- surface the active CodeRabbit settled wait in detailed status output
- add focused tests for the settled-wait status rendering and helper logic
- document the short CodeRabbit-specific quiet period in operator docs

## Testing
- npx tsx --test src/supervisor/supervisor-status-rendering-supervisor.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/getting-started-docs.test.ts src/config.test.ts
- npm run build

Closes #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CodeRabbit provider configuration and getting-started guides to describe new settled wait behavior and status indicators.

* **New Features**
  * CodeRabbit integration now pauses merge progression with a brief quiet period after posting fresh observations on pull requests. During this settled wait period, an active status indicator is displayed, providing a short intentional pause to allow for additional review signals before merge progression resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->