### PR TITLE
Make CodeRabbit settled wait configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ Each shipped profile only covers supervisor-side expectations. You still need th
 ### CodeRabbit profile
 
 - Supervisor-side: use `supervisor.config.coderabbit.json`, which tracks both `coderabbitai` and `coderabbitai[bot]`, waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing, and applies a short settled wait after a fresh CodeRabbit current-head observation.
+- Tuning: `configuredBotSettledWaitSeconds` controls that CodeRabbit quiet period. The default is `5`, which preserves current behavior.
 - Provider-side: install CodeRabbit. Add `.coderabbit.yaml` only when you intentionally want repo-specific CodeRabbit behavior; it is not required just to make the supervisor wait through temporary rate limits.
 - Operator note: while that short settled wait is active, `status` shows `configured_bot_settled_wait status=active provider=coderabbit ...`. That means the supervisor saw CodeRabbit on the current PR head and is deliberately pausing merge progression for a few seconds so late-arriving review signals can land first.
 - Verify: open a PR and confirm CodeRabbit posts review activity under one of the configured bot identities.
@@ -78,6 +79,7 @@ Review and merge policy:
 - `reviewBotLogins`
 - `humanReviewBlocksMerge`
 - `copilotReviewWaitMinutes`, `copilotReviewTimeoutAction`
+- `configuredBotRateLimitWaitMinutes`, `configuredBotSettledWaitSeconds`
 - `localReviewEnabled`, `localReviewAutoDetect`, `localReviewRoles`
 - `localReviewPolicy`, `localReviewHighSeverityAction`
 - `localReviewArtifactDir`, `localReviewConfidenceThreshold`, `localReviewReviewerThresholds`

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -206,6 +206,35 @@ test("loadConfig rejects non-finite configuredBotRateLimitWaitMinutes by falling
   assert.equal(config.configuredBotRateLimitWaitMinutes, 0);
 });
 
+test("loadConfig accepts an explicit configuredBotSettledWaitSeconds override", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      configuredBotSettledWaitSeconds: 3,
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath) as ReturnType<typeof loadConfig> & {
+    configuredBotSettledWaitSeconds?: number;
+  };
+
+  assert.equal(config.configuredBotSettledWaitSeconds, 3);
+});
+
 test("loadConfig defaults localReviewHighSeverityAction to blocked", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -286,6 +286,12 @@ export function loadConfig(configPath?: string): SupervisorConfig {
       raw.configuredBotRateLimitWaitMinutes >= 0
         ? raw.configuredBotRateLimitWaitMinutes
         : 0,
+    configuredBotSettledWaitSeconds:
+      typeof raw.configuredBotSettledWaitSeconds === "number" &&
+      Number.isFinite(raw.configuredBotSettledWaitSeconds) &&
+      raw.configuredBotSettledWaitSeconds >= 0
+        ? raw.configuredBotSettledWaitSeconds
+        : 5,
     codexExecTimeoutMinutes:
       typeof raw.codexExecTimeoutMinutes === "number" && raw.codexExecTimeoutMinutes > 0
         ? raw.codexExecTimeoutMinutes

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -78,6 +78,7 @@ export interface SupervisorConfig {
   copilotReviewWaitMinutes: number;
   copilotReviewTimeoutAction: CopilotReviewTimeoutAction;
   configuredBotRateLimitWaitMinutes?: number;
+  configuredBotSettledWaitSeconds?: number;
   codexExecTimeoutMinutes: number;
   maxCodexAttemptsPerIssue: number;
   maxImplementationAttemptsPerIssue: number;

--- a/src/pull-request-state.test.ts
+++ b/src/pull-request-state.test.ts
@@ -657,6 +657,32 @@ test("inferStateFromPullRequest does not wait on stale CodeRabbit current-head o
   });
 });
 
+test("inferStateFromPullRequest uses configuredBotSettledWaitSeconds for recent CodeRabbit current-head observations", () => {
+  withStubbedDateNow("2026-03-13T02:04:04Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    (config as SupervisorConfig & { configuredBotSettledWaitSeconds?: number }).configuredBotSettledWaitSeconds = 3;
+    const record = createRecord({ state: "waiting_ci" });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          copilotReviewState: "arrived",
+          copilotReviewArrivedAt: "2026-03-13T02:04:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+        }),
+        checks,
+        [],
+      ),
+      "ready_to_merge",
+    );
+  });
+});
+
 test("inferStateFromPullRequest softens nitpick-only configured-bot top-level changes requests when no configured-bot threads remain", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai[bot]"],

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -30,7 +30,7 @@ import {
 import { nowIso } from "./core/utils";
 
 const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
-const CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS = 5_000;
+const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
 
 interface CopilotReviewTimeoutStatus {
   timedOut: boolean;
@@ -221,7 +221,8 @@ function shouldWaitForConfiguredBotCurrentHeadQuietPeriod(
     return false;
   }
 
-  return Date.now() < observedAtMs + CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS;
+  const settledWaitMs = (config.configuredBotSettledWaitSeconds ?? DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS / 1_000) * 1_000;
+  return Date.now() < observedAtMs + settledWaitMs;
 }
 
 export function buildCopilotReviewTimeoutFailureContext(

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -327,3 +327,28 @@ test("configuredBotSettledWaitWindow reports the active CodeRabbit quiet period"
     Date.now = originalNow;
   }
 });
+
+test("configuredBotSettledWaitWindow uses configuredBotSettledWaitSeconds when provided", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:00:03.500Z");
+
+  try {
+    assert.deepEqual(
+      configuredBotSettledWaitWindow(
+        createConfig({
+          reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+          configuredBotSettledWaitSeconds: 3,
+        }),
+        createPr({ configuredBotCurrentHeadObservedAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "expired",
+        provider: "coderabbit",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: "2026-03-16T00:00:03.000Z",
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -8,7 +8,7 @@ import {
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
-const CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS = 5_000;
+const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
 
 export type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
 
@@ -79,7 +79,8 @@ export function configuredBotSettledWaitWindow(
     };
   }
 
-  const waitUntil = new Date(observedAtMs + CODERABBIT_CURRENT_HEAD_QUIET_PERIOD_MS).toISOString();
+  const settledWaitMs = (config.configuredBotSettledWaitSeconds ?? DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS / 1_000) * 1_000;
+  const waitUntil = new Date(observedAtMs + settledWaitMs).toISOString();
   return {
     status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
     provider: "coderabbit",

--- a/supervisor.config.coderabbit.json
+++ b/supervisor.config.coderabbit.json
@@ -70,6 +70,7 @@
   "copilotReviewWaitMinutes": 10,
   "copilotReviewTimeoutAction": "continue",
   "configuredBotRateLimitWaitMinutes": 30,
+  "configuredBotSettledWaitSeconds": 5,
   "codexExecTimeoutMinutes": 30,
   "maxCodexAttemptsPerIssue": 30,
   "maxImplementationAttemptsPerIssue": 30,

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -68,6 +68,7 @@
   "pollIntervalSeconds": 120,
   "copilotReviewWaitMinutes": 10,
   "copilotReviewTimeoutAction": "continue",
+  "configuredBotSettledWaitSeconds": 5,
   "codexExecTimeoutMinutes": 30,
   "maxCodexAttemptsPerIssue": 30,
   "maxImplementationAttemptsPerIssue": 30,


### PR DESCRIPTION
## Summary
- add a config-backed `configuredBotSettledWaitSeconds` for CodeRabbit settled waits
- preserve the existing 5-second default and thread it through settled-wait logic
- cover config parsing and settled-wait behavior with focused tests

## Verification
- npx tsx --test src/config.test.ts src/pull-request-state.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npm run build

Refs #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option to control bot settling wait duration (default: 5 seconds).

* **Documentation**
  * Updated configuration guide with new bot settling wait option under Review and merge policy section.

* **Tests**
  * Added test coverage for the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->