### PR TITLE
Broaden current-head CodeRabbit settled wait observation

### DIFF
--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -665,3 +665,66 @@ test("GitHubPullRequestHydrator records the latest configured-bot observation sc
   assert.match(lifecycleQuery, /reviewThreads\(first:\s*100\)[\s\S]*originalCommit\s*\{\s*oid\s*\}/);
   assert.equal(observedAt, "2026-03-13T02:04:00Z");
 });
+
+test("GitHubPullRequestHydrator extends current-head observation with later actionable configured-bot issue comments", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [
+                    {
+                      submittedAt: "2026-03-13T02:02:00Z",
+                      state: "COMMENTED",
+                      body: "Nitpick: prefer the simpler branch here.",
+                      commit: {
+                        oid: "head-44",
+                      },
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                comments: {
+                  nodes: [
+                    {
+                      createdAt: "2026-03-13T02:04:00Z",
+                      body: "Nitpick: return early before mutating shared state.",
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+  const observedAt = (pr as GitHubPullRequest & { configuredBotCurrentHeadObservedAt?: string | null })
+    ?.configuredBotCurrentHeadObservedAt;
+
+  assert.equal(observedAt, "2026-03-13T02:04:00Z");
+});

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -504,6 +504,49 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
   });
 });
 
+test("buildConfiguredBotReviewSummary extends current-head observation with later actionable configured-bot issue comments", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "Nitpick: prefer the simpler branch here.",
+      },
+    ],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:04:00Z",
+        body: "Nitpick: return early before mutating shared state.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:05:00Z",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: null,
+      arrivedAt: "2026-03-13T02:04:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    rateLimitWarningAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary leaves current-head observation empty when only stale-head evidence exists", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -282,7 +282,23 @@ function inferConfiguredBotCurrentHeadObservedAt(
       : [];
   });
 
-  return latestTimestamp([...currentHeadReviewTimes, ...currentHeadCommentTimes]);
+  const latestCurrentHeadObservedAt = latestTimestamp([...currentHeadReviewTimes, ...currentHeadCommentTimes]);
+  if (!latestCurrentHeadObservedAt) {
+    return null;
+  }
+
+  const latestCurrentHeadObservedAtMs = parseTimestamp(latestCurrentHeadObservedAt);
+  const followUpIssueCommentTimes = facts.issueComments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      hasActionableReviewText(comment.body) &&
+      parseTimestamp(comment.createdAt) >= latestCurrentHeadObservedAtMs
+      ? [comment.createdAt]
+      : [];
+  });
+
+  return latestTimestamp([latestCurrentHeadObservedAt, ...followUpIssueCommentTimes]);
 }
 
 function inferConfiguredBotRateLimitWarningAt(

--- a/src/pull-request-state.test.ts
+++ b/src/pull-request-state.test.ts
@@ -632,6 +632,31 @@ test("inferStateFromPullRequest waits briefly after a recent CodeRabbit current-
   });
 });
 
+test("inferStateFromPullRequest waits on later actionable CodeRabbit issue comments after a current-head observation", () => {
+  withStubbedDateNow("2026-03-13T02:04:03Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          copilotReviewState: "arrived",
+          copilotReviewArrivedAt: "2026-03-13T02:02:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+        }),
+        checks,
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
 test("inferStateFromPullRequest does not wait on stale CodeRabbit current-head observations", () => {
   withStubbedDateNow("2026-03-13T02:04:06Z", () => {
     const config = createConfig({


### PR DESCRIPTION
## Summary
- broaden current-head CodeRabbit settled-wait observation once it is anchored by head-scoped activity
- refresh the observation timestamp with later actionable CodeRabbit issue comments without allowing stale-head-only activity to trigger the wait
- add focused review-signal, hydrator, and pull-request-state coverage for the new observation source

Closes #442

## Verification
- npx tsx --test src/github/github-review-signals.test.ts
- npx tsx --test src/github/github-pull-request-hydrator.test.ts
- npx tsx --test src/pull-request-state.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed PR state tracking to properly consider bot activity that occurs after code changes, ensuring the system correctly waits for all relevant feedback before marking PRs complete.

* **Tests**
  * Added test coverage for handling actionable bot comments following code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->