### PR TITLE
Broaden current-head CodeRabbit settled-wait observation

### DIFF
--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -666,6 +666,72 @@ test("GitHubPullRequestHydrator records the latest configured-bot observation sc
   assert.equal(observedAt, "2026-03-13T02:04:00Z");
 });
 
+test("GitHubPullRequestHydrator treats summary-only configured-bot reviews on the current head as observations", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [
+                    {
+                      submittedAt: "2026-03-13T02:03:04Z",
+                      state: "COMMENTED",
+                      body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+                      commit: {
+                        oid: "stale-head-oid",
+                      },
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                    {
+                      submittedAt: "2026-03-13T02:02:00Z",
+                      state: "COMMENTED",
+                      body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+                      commit: {
+                        oid: "head-44",
+                      },
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                comments: {
+                  nodes: [],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+  const observedAt = (pr as GitHubPullRequest & { configuredBotCurrentHeadObservedAt?: string | null })
+    ?.configuredBotCurrentHeadObservedAt;
+
+  assert.equal(observedAt, "2026-03-13T02:02:00Z");
+});
+
 test("GitHubPullRequestHydrator extends current-head observation with later actionable configured-bot issue comments", async () => {
   const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
   const hydrator = new GitHubPullRequestHydrator(config, async (args) => {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -504,6 +504,45 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
   });
 });
 
+test("buildConfiguredBotReviewSummary treats summary-only configured-bot reviews on the current head as observations", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:03:00Z",
+        commitOid: "stale-head",
+        state: "COMMENTED",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    comments: [],
+    issueComments: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-03-13T02:02:00Z",
+    rateLimitWarningAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary extends current-head observation with later actionable configured-bot issue comments", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -267,8 +267,7 @@ function inferConfiguredBotCurrentHeadObservedAt(
     const authorLogin = normalizeLogin(review.authorLogin);
     return authorLogin &&
       configuredReviewBots.has(authorLogin) &&
-      review.commitOid === normalizedCurrentHeadOid &&
-      isActionableTopLevelReview(review)
+      review.commitOid === normalizedCurrentHeadOid
       ? [review.submittedAt]
       : [];
   });


### PR DESCRIPTION
## Summary
- broaden configured-bot current-head observation to include summary-only top-level reviews tied to the current PR head via `commitOid`
- keep stale-head exclusion intact by only counting reviews scoped to the current head
- add focused review-signal and hydrator coverage for the new observation path

## Testing
- npx tsx --test src/github/github-review-signals.test.ts
- npx tsx --test src/github/github-pull-request-hydrator.test.ts
- npm run build

Closes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of summary-only automated bot reviews on pull requests to properly recognize them as observations and accurately record their timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->