### PR TITLE
test: cover CodeRabbit settled wait current-head signals

### DIFF
--- a/src/pull-request-state.test.ts
+++ b/src/pull-request-state.test.ts
@@ -632,6 +632,31 @@ test("inferStateFromPullRequest waits briefly after a recent CodeRabbit current-
   });
 });
 
+test("inferStateFromPullRequest waits on a recent summary-only CodeRabbit current-head observation", () => {
+  withStubbedDateNow("2026-03-13T02:04:03Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          copilotReviewState: "not_requested",
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+        }),
+        checks,
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
 test("inferStateFromPullRequest waits on later actionable CodeRabbit issue comments after a current-head observation", () => {
   withStubbedDateNow("2026-03-13T02:04:03Z", () => {
     const config = createConfig({

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -202,6 +202,26 @@ test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci du
   });
 });
 
+test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci for summary-only current-head observations", () => {
+  withStubbedDateNow("2026-03-13T02:04:03Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const pr = createPullRequest({
+      copilotReviewState: "not_requested",
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+    });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+    const reviewThreads: ReviewThread[] = [];
+
+    const snapshot = derivePullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads);
+
+    assert.equal(snapshot.nextState, "waiting_ci");
+  });
+});
+
 test("shouldRunCodex only returns true for actionable supervisor states", () => {
   const config = createConfig();
   const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];


### PR DESCRIPTION
## Summary
- add pull-request-state coverage for recent `configuredBotCurrentHeadObservedAt` activity without lifecycle arrival state
- add supervisor lifecycle coverage for the same summary-only current-head observation path
- keep the issue focused on proving the broader current-head activity model already gates merge progression conservatively

## Testing
- npx tsx --test src/pull-request-state.test.ts
- npx tsx --test src/supervisor/supervisor-lifecycle.test.ts
- npm run build

Closes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for pull request state inference and lifecycle snapshot derivation, including scenarios involving summary-only observations and current-head observation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->