### PR TITLE
Treat late CodeRabbit closed-PR follow-ups as informational

### DIFF
--- a/src/external-review/external-review-misses.test.ts
+++ b/src/external-review/external-review-misses.test.ts
@@ -183,6 +183,19 @@ test("collectExternalReviewSignals preserves actionable top-level reviews that o
   ]);
 });
 
+test("collectExternalReviewSignals ignores late configured-bot closed-PR follow-up issue comments", () => {
+  const signals = collectExternalReviewSignals({
+    issueComments: [
+      createIssueComment({
+        body: "This pull request is already closed. Please ignore this follow-up review comment.",
+      }),
+    ],
+    reviewBotLogins: ["coderabbitai[bot]"],
+  });
+
+  assert.deepEqual(signals, []);
+});
+
 test("classifyExternalReviewFinding marks unmatched configured-bot feedback as missed_by_local_review", () => {
   const normalized = normalizeExternalReviewFinding(createReviewThread(), ["copilot-pull-request-reviewer"]);
   assert.ok(normalized);

--- a/src/external-review/external-review-signal-heuristics.ts
+++ b/src/external-review/external-review-signal-heuristics.ts
@@ -3,6 +3,8 @@ function normalizeReviewText(value: string | null | undefined): string {
 }
 
 const RATE_LIMIT_REVIEW_TEXT_PATTERN = /\brate limit exceeded\b/;
+const CLOSED_PULL_REQUEST_REVIEW_TEXT_PATTERN =
+  /\b(?:pull request|pr)\b[^.!?\n\r]*\balready closed\b|\balready closed\b[^.!?\n\r]*\b(?:pull request|pr)\b/;
 
 const NITPICK_REVIEW_TEXT_PATTERN =
   /\b(nit|nitpick|nits|style|format|formatting|typo|wording|docs?|documentation|comment|comments|naming|rename|readability|consistency|prefer)\b/;
@@ -23,7 +25,8 @@ export function isInformationalReviewText(value: string | null | undefined): boo
     normalized.includes("skip review") ||
     normalized.includes("still in draft") ||
     normalized.includes("pull request is in draft") ||
-    normalized.includes("pull request is still in draft")
+    normalized.includes("pull request is still in draft") ||
+    CLOSED_PULL_REQUEST_REVIEW_TEXT_PATTERN.test(normalized)
   );
 }
 

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -586,6 +586,44 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
   });
 });
 
+test("buildConfiguredBotReviewSummary ignores late configured-bot closed-PR follow-up comments after a current-head observation", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:04:00Z",
+        body: "This pull request is already closed. Please ignore this follow-up review comment.",
+      },
+    ],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-03-13T02:02:00Z",
+    rateLimitWarningAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary leaves current-head observation empty when only stale-head evidence exists", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],


### PR DESCRIPTION
## Summary
- treat late configured-bot issue comments that only say the pull request is already closed as informational
- keep those comments from creating actionable external-review signals or extending current-head observation windows
- add focused regression tests for the late post-merge false-alarm path

## Verification
- npx tsx --test src/github/github-review-signals.test.ts src/external-review/external-review-misses.test.ts
- npm run build

Closes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of already-closed pull requests in review comments to better handle late follow-up feedback.

* **Tests**
  * Added test coverage for closed pull request scenarios in review signal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->