### PR TITLE
Track CodeRabbit status contexts in settled wait

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #455: CodeRabbit settled wait: evaluate and safely incorporate status-context activity
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/455
+- Branch: codex/issue-455
+- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-455
+- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-455/.codex-supervisor/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: ad9eb685ee9fe2986af3664c98215da8e7c6d460
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-17T06:51:11.897Z
+
+## Latest Codex Summary
+- Safely incorporated current-head CodeRabbit status-context activity into configured-bot settled-wait observation by hydrating only latest-commit `StatusContext` entries and filtering to CodeRabbit-owned/signaled contexts; stale-head observations remain excluded.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: CodeRabbit can emit current-head status-context activity before comments/reviews; if hydrated from the PR head commit only, it is safe to treat as settled-wait activity.
+- What changed: Added status-context support to configured-bot review summary and hydrator GraphQL, plus focused tests covering current-head inclusion and stale-head exclusion.
+- Current blocker: none
+- Next exact step: Commit the verified checkpoint and hand back to the supervisor for the next phase.
+- Verification gap: none for the focused hydration/review-signal, pull-request-state, and build checks requested by the issue.
+- Files touched: src/github/github-review-signals.ts; src/github/github-review-signals.test.ts; src/github/github-hydration.ts; src/github/github-pull-request-hydrator.ts; src/github/github-pull-request-hydrator.test.ts; .codex-supervisor/issue-journal.md
+- Rollback concern: The new signal intentionally trusts only latest-commit `StatusContext` data and CodeRabbit-owned/signaled contexts; widening beyond that would risk ambiguous provider activity.
+- Last focused command: npm run build
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -76,6 +76,26 @@ export interface PullRequestCopilotReviewLifecycleResponse {
       requestedReviewer?: ReviewActor | null;
     } | null>;
   } | null;
+  commits?: {
+    nodes?: Array<{
+      commit?: {
+        oid?: string | null;
+        statusCheckRollup?: {
+          contexts?: {
+            nodes?: Array<{
+              __typename?: string | null;
+              context?: string | null;
+              description?: string | null;
+              createdAt?: string | null;
+              creator?: {
+                login?: string | null;
+              } | null;
+            } | null>;
+          } | null;
+        } | null;
+      } | null;
+    } | null>;
+  } | null;
 }
 
 function mapCheckBucket(args: {
@@ -224,6 +244,25 @@ export function mapCopilotReviewLifecycleFacts(
         createdAt: comment?.createdAt ?? null,
         body: comment?.body ?? null,
       })) ?? [],
+    statusContexts:
+      lifecycle?.commits?.nodes?.flatMap((node) => {
+        const commitOid = node?.commit?.oid ?? null;
+        return (
+          node?.commit?.statusCheckRollup?.contexts?.nodes?.flatMap((contextNode) => {
+            if (contextNode?.__typename !== "StatusContext" && !contextNode?.context) {
+              return [];
+            }
+
+            return [{
+              creatorLogin: normalizeLogin(contextNode?.creator?.login ?? null),
+              context: contextNode?.context ?? null,
+              description: contextNode?.description ?? null,
+              createdAt: contextNode?.createdAt ?? null,
+              commitOid,
+            }];
+          }) ?? []
+        );
+      }) ?? [],
     timeline:
       lifecycle?.timelineItems?.nodes
         ?.map((node) => {

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -794,3 +794,95 @@ test("GitHubPullRequestHydrator extends current-head observation with later acti
 
   assert.equal(observedAt, "2026-03-13T02:04:00Z");
 });
+
+test("GitHubPullRequestHydrator treats current-head CodeRabbit status contexts as observations and excludes stale-head statuses", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"] });
+  let lifecycleQuery: string | null = null;
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      lifecycleQuery = args.find((arg) => arg.startsWith("query=")) ?? null;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [],
+                },
+                comments: {
+                  nodes: [],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+                commits: {
+                  nodes: [
+                    {
+                      commit: {
+                        oid: "head-44",
+                        statusCheckRollup: {
+                          contexts: {
+                            nodes: [
+                              {
+                                __typename: "StatusContext",
+                                context: "CodeRabbit",
+                                description: "CodeRabbit started reviewing the current head.",
+                                createdAt: "2026-03-13T02:04:00Z",
+                                creator: {
+                                  login: "coderabbitai",
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                    {
+                      commit: {
+                        oid: "stale-head-oid",
+                        statusCheckRollup: {
+                          contexts: {
+                            nodes: [
+                              {
+                                __typename: "StatusContext",
+                                context: "CodeRabbit",
+                                description: "Newer stale-head status should be ignored.",
+                                createdAt: "2026-03-13T02:06:00Z",
+                                creator: {
+                                  login: "coderabbitai",
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+  const observedAt = (pr as GitHubPullRequest & { configuredBotCurrentHeadObservedAt?: string | null })
+    ?.configuredBotCurrentHeadObservedAt;
+
+  assert.ok(lifecycleQuery);
+  assert.match(lifecycleQuery, /commits\(last:\s*1\)[\s\S]*statusCheckRollup[\s\S]*contexts\(last:\s*100\)/);
+  assert.match(lifecycleQuery, /StatusContext[\s\S]*createdAt[\s\S]*creator\s*\{\s*login\s*\}/);
+  assert.equal(observedAt, "2026-03-13T02:04:00Z");
+});

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -236,6 +236,28 @@ export class GitHubPullRequestHydrator {
                 }
               }
             }
+            commits(last: 1) {
+              nodes {
+                commit {
+                  oid
+                  statusCheckRollup {
+                    contexts(last: 100) {
+                      nodes {
+                        __typename
+                        ... on StatusContext {
+                          context
+                          description
+                          createdAt
+                          creator {
+                            login
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -661,3 +661,43 @@ test("buildConfiguredBotReviewSummary leaves current-head observation empty when
     rateLimitWarningAt: null,
   });
 });
+
+test("buildConfiguredBotReviewSummary treats current-head CodeRabbit status contexts as observations and excludes stale-head statuses", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [],
+    statusContexts: [
+      {
+        creatorLogin: "coderabbitai",
+        context: "CodeRabbit",
+        description: "CodeRabbit finished preparing its review.",
+        createdAt: "2026-03-13T02:06:00Z",
+        commitOid: "stale-head",
+      },
+      {
+        creatorLogin: "coderabbitai",
+        context: "CodeRabbit",
+        description: "CodeRabbit started reviewing the current head.",
+        createdAt: "2026-03-13T02:04:00Z",
+        commitOid: "head-44",
+      },
+    ],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai", "coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    rateLimitWarningAt: null,
+  });
+});

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -26,6 +26,13 @@ export interface CopilotReviewLifecycleFacts {
     createdAt: string | null;
     body: string | null;
   }>;
+  statusContexts?: Array<{
+    creatorLogin: string | null;
+    context: string | null;
+    description?: string | null;
+    createdAt: string | null;
+    commitOid?: string | null;
+  }>;
   timeline: Array<{
     type: "requested" | "removed";
     createdAt: string | null;
@@ -63,6 +70,22 @@ function parseTimestamp(value: string | null | undefined): number {
 function normalizeLogin(value: string | null | undefined): string | null {
   const trimmed = value?.trim().toLowerCase();
   return trimmed ? trimmed : null;
+}
+
+function isConfiguredBotStatusContextActivity(args: {
+  creatorLogin: string | null | undefined;
+  context: string | null | undefined;
+  description?: string | null | undefined;
+  configuredReviewBots: Set<string>;
+}): boolean {
+  const creatorLogin = normalizeLogin(args.creatorLogin);
+  if (creatorLogin && args.configuredReviewBots.has(creatorLogin)) {
+    return true;
+  }
+
+  const normalizedContext = (args.context ?? "").trim().toLowerCase();
+  const normalizedDescription = (args.description ?? "").trim().toLowerCase();
+  return normalizedContext.includes("coderabbit") || normalizedDescription.includes("coderabbit");
 }
 
 function latestTimestamp(values: Array<string | null | undefined>): string | null {
@@ -281,7 +304,23 @@ function inferConfiguredBotCurrentHeadObservedAt(
       : [];
   });
 
-  const latestCurrentHeadObservedAt = latestTimestamp([...currentHeadReviewTimes, ...currentHeadCommentTimes]);
+  const currentHeadStatusContextTimes = (facts.statusContexts ?? []).flatMap((statusContext) =>
+    statusContext.commitOid === normalizedCurrentHeadOid &&
+    isConfiguredBotStatusContextActivity({
+      creatorLogin: statusContext.creatorLogin,
+      context: statusContext.context,
+      description: statusContext.description,
+      configuredReviewBots,
+    })
+      ? [statusContext.createdAt]
+      : [],
+  );
+
+  const latestCurrentHeadObservedAt = latestTimestamp([
+    ...currentHeadReviewTimes,
+    ...currentHeadCommentTimes,
+    ...currentHeadStatusContextTimes,
+  ]);
   if (!latestCurrentHeadObservedAt) {
     return null;
   }


### PR DESCRIPTION
## Summary
- include current-head CodeRabbit status-context activity in settled-wait observation when it is safely tied to the latest PR head commit
- keep stale-head and ambiguous status activity excluded from the settled-wait signal
- add focused hydration and review-signal coverage for the supported path

## Testing
- npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts
- npx tsx --test src/pull-request-state.test.ts --test-name-pattern "CodeRabbit current-head observation|summary-only CodeRabbit current-head observation|later actionable CodeRabbit issue comments|stale CodeRabbit current-head observations|configuredBotSettledWaitSeconds"
- npm run build

Refs #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced code review status tracking to capture detailed reviewer status context information and timestamps from configured review bots.

* **Bug Fixes**
  * Improved accuracy of review observation timestamps by properly distinguishing between current and previous commit head statuses, ensuring only relevant data influences review lifecycle timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->