### PR TITLE
Handle weakly anchored CodeRabbit current-head comments

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,35 @@
-# Issue #455: CodeRabbit settled wait: evaluate and safely incorporate status-context activity
+# Issue #456: CodeRabbit settled wait: strengthen comment-led current-head activity handling
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/455
-- Branch: codex/issue-455
-- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-455
-- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-455/.codex-supervisor/issue-journal.md
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/456
+- Branch: codex/issue-456
+- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-456
+- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-456/.codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: ad9eb685ee9fe2986af3664c98215da8e7c6d460
+- Last head SHA: f306a4c97c8d498d8dcd8da951c6391070dcc632
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-17T06:51:11.897Z
+- Updated at: 2026-03-17T07:07:24.004Z
 
 ## Latest Codex Summary
-- Safely incorporated current-head CodeRabbit status-context activity into configured-bot settled-wait observation by hydrating only latest-commit `StatusContext` entries and filtering to CodeRabbit-owned/signaled contexts; stale-head observations remain excluded.
+- Added a focused reproducer for CodeRabbit review-thread comments without `originalCommitOid` that arrive after a safe current-head observation, then scoped the current-head extension rule to that CodeRabbit-only case and verified the settled-wait path with focused tests plus `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: CodeRabbit can emit current-head status-context activity before comments/reviews; if hydrated from the PR head commit only, it is safe to treat as settled-wait activity.
-- What changed: Added status-context support to configured-bot review summary and hydrator GraphQL, plus focused tests covering current-head inclusion and stale-head exclusion.
+- Hypothesis: CodeRabbit can emit later review-thread comments with missing `originalCommitOid`; those comments are still safe to treat as current-head activity only when a stronger CodeRabbit current-head observation already exists.
+- What changed: Added focused review-signal and hydrator tests for weakly anchored CodeRabbit review comments, including a stale-head negative case; updated `inferConfiguredBotCurrentHeadObservedAt` to extend `currentHeadObservedAt` only for later CodeRabbit comments lacking `originalCommitOid` after a prior strong current-head observation.
 - Current blocker: none
 - Next exact step: Commit the verified checkpoint and hand back to the supervisor for the next phase.
-- Verification gap: none for the focused hydration/review-signal, pull-request-state, and build checks requested by the issue.
-- Files touched: src/github/github-review-signals.ts; src/github/github-review-signals.test.ts; src/github/github-hydration.ts; src/github/github-pull-request-hydrator.ts; src/github/github-pull-request-hydrator.test.ts; .codex-supervisor/issue-journal.md
-- Rollback concern: The new signal intentionally trusts only latest-commit `StatusContext` data and CodeRabbit-owned/signaled contexts; widening beyond that would risk ambiguous provider activity.
+- Verification gap: none for the focused review-signal, pull-request-state, hydrator, and build checks requested by the issue.
+- Files touched: src/github/github-review-signals.ts; src/github/github-review-signals.test.ts; src/github/github-pull-request-hydrator.test.ts; .codex-supervisor/issue-journal.md
+- Rollback concern: The weak-anchor extension is intentionally limited to CodeRabbit-authored review-thread comments that happen after a strong current-head observation; broadening that rule to other bots or comments without the prior observation would risk promoting stale history.
 - Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- Reproducing signature before the fix: `currentHeadObservedAt` stayed at the earlier summary-only current-head review and did not advance to a later CodeRabbit review-thread comment with `originalCommitOid: null`.
+- Verification commands: `npx tsx --test src/github/github-review-signals.test.ts`; `npx tsx --test src/github/github-pull-request-hydrator.test.ts`; `npx tsx --test src/pull-request-state.test.ts`; `npm ci`; `npm run build`.

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -795,6 +795,75 @@ test("GitHubPullRequestHydrator extends current-head observation with later acti
   assert.equal(observedAt, "2026-03-13T02:04:00Z");
 });
 
+test("GitHubPullRequestHydrator extends current-head observation with later weakly anchored CodeRabbit review comments", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [
+                    {
+                      submittedAt: "2026-03-13T02:02:00Z",
+                      state: "COMMENTED",
+                      body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+                      commit: {
+                        oid: "head-44",
+                      },
+                      author: {
+                        login: "coderabbitai[bot]",
+                      },
+                    },
+                  ],
+                },
+                comments: {
+                  nodes: [],
+                },
+                reviewThreads: {
+                  nodes: [
+                    {
+                      comments: {
+                        nodes: [
+                          {
+                            createdAt: "2026-03-13T02:04:00Z",
+                            originalCommit: null,
+                            author: {
+                              login: "coderabbitai[bot]",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+  const observedAt = (pr as GitHubPullRequest & { configuredBotCurrentHeadObservedAt?: string | null })
+    ?.configuredBotCurrentHeadObservedAt;
+
+  assert.equal(observedAt, "2026-03-13T02:04:00Z");
+});
+
 test("GitHubPullRequestHydrator treats current-head CodeRabbit status contexts as observations and excludes stale-head statuses", async () => {
   const config = createConfig({ reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"] });
   let lifecycleQuery: string | null = null;

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -586,6 +586,82 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
   });
 });
 
+test("buildConfiguredBotReviewSummary extends current-head observation with later weakly anchored CodeRabbit review comments", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    comments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:04:00Z",
+        originalCommitOid: null,
+      },
+    ],
+    issueComments: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: null,
+      arrivedAt: "2026-03-13T02:04:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    rateLimitWarningAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary keeps weakly anchored CodeRabbit review comments from stale-head history out of current-head observation", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "stale-head",
+        state: "COMMENTED",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    comments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:04:00Z",
+        originalCommitOid: null,
+      },
+    ],
+    issueComments: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: null,
+      arrivedAt: "2026-03-13T02:04:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: null,
+    rateLimitWarningAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary ignores late configured-bot closed-PR follow-up comments after a current-head observation", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -72,6 +72,10 @@ function normalizeLogin(value: string | null | undefined): string | null {
   return trimmed ? trimmed : null;
 }
 
+function isCodeRabbitLogin(value: string | null | undefined): boolean {
+  return (normalizeLogin(value) ?? "").includes("coderabbit");
+}
+
 function isConfiguredBotStatusContextActivity(args: {
   creatorLogin: string | null | undefined;
   context: string | null | undefined;
@@ -316,27 +320,41 @@ function inferConfiguredBotCurrentHeadObservedAt(
       : [],
   );
 
-  const latestCurrentHeadObservedAt = latestTimestamp([
+  const latestStrongCurrentHeadObservedAt = latestTimestamp([
     ...currentHeadReviewTimes,
     ...currentHeadCommentTimes,
     ...currentHeadStatusContextTimes,
   ]);
-  if (!latestCurrentHeadObservedAt) {
+  if (!latestStrongCurrentHeadObservedAt) {
     return null;
   }
 
-  const latestCurrentHeadObservedAtMs = parseTimestamp(latestCurrentHeadObservedAt);
+  const latestStrongCurrentHeadObservedAtMs = parseTimestamp(latestStrongCurrentHeadObservedAt);
+  const weaklyAnchoredCodeRabbitCommentTimes = facts.comments.flatMap((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      isCodeRabbitLogin(authorLogin) &&
+      !comment.originalCommitOid &&
+      parseTimestamp(comment.createdAt) >= latestStrongCurrentHeadObservedAtMs
+      ? [comment.createdAt]
+      : [];
+  });
   const followUpIssueCommentTimes = facts.issueComments.flatMap((comment) => {
     const authorLogin = normalizeLogin(comment.authorLogin);
     return authorLogin &&
       configuredReviewBots.has(authorLogin) &&
       hasActionableReviewText(comment.body) &&
-      parseTimestamp(comment.createdAt) >= latestCurrentHeadObservedAtMs
+      parseTimestamp(comment.createdAt) >= latestStrongCurrentHeadObservedAtMs
       ? [comment.createdAt]
       : [];
   });
 
-  return latestTimestamp([latestCurrentHeadObservedAt, ...followUpIssueCommentTimes]);
+  return latestTimestamp([
+    latestStrongCurrentHeadObservedAt,
+    ...weaklyAnchoredCodeRabbitCommentTimes,
+    ...followUpIssueCommentTimes,
+  ]);
 }
 
 function inferConfiguredBotRateLimitWarningAt(


### PR DESCRIPTION
## Summary
- extend CodeRabbit current-head observation handling for later review-thread comments that lack `originalCommitOid`
- keep the fallback conservative by requiring an existing stronger current-head observation before advancing `currentHeadObservedAt`
- add focused review-signal and hydrator coverage for the safe path and stale/ambiguous negatives

## Testing
- npx tsx --test src/github/github-review-signals.test.ts
- npx tsx --test src/github/github-pull-request-hydrator.test.ts
- npx tsx --test src/pull-request-state.test.ts
- npm ci
- npm run build

Closes #456


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced handling of CodeRabbit review comments with improved timestamp tracking for review observations.

* **Tests**
  * Added comprehensive test coverage for CodeRabbit review comment scenarios and review summary edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->