### PR TITLE
Record current-head CI-green timestamp

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,38 +1,36 @@
-# Issue #464: Test refactor: finish splitting supervisor.test.ts by execution and PR lifecycle boundaries
+# Issue #469: CodeRabbit initial grace wait: record the current-head CI-green timestamp for provider-start waiting
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/464
-- Branch: codex/issue-464
-- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-464
-- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-464/.codex-supervisor/issue-journal.md
-- Current phase: reproducing
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/469
+- Branch: codex/issue-469
+- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-469
+- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-469/.codex-supervisor/issue-journal.md
+- Current phase: stabilizing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 23c2337fa46bf8e4d4e95751c70d7cfbd96eb9ca
+- Last head SHA: 1c6bc037675a3da061798ece74d4ceca6fca84e1
 - Blocked reason: none
-- Last failure signature: none
+- Last failure signature: missing-current-head-ci-green-at
 - Repeated failure signature count: 0
-- Updated at: 2026-03-17T18:57:00+09:00
+- Updated at: 2026-03-17T10:16:58Z
 
 ## Latest Codex Summary
-- Extracted the remaining execution-path, PR lifecycle, and injected agent-runner coverage from `src/supervisor/supervisor.test.ts` into focused suites, leaving only a minimal facade export smoke test behind.
+- Added current-head CI-green timestamp derivation for required checks in configured-bot hydration/review-signal summaries and exposed it on hydrated pull requests without changing merge-state behavior.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
-### Current Handoff
-- Hypothesis: the remaining run-once execution, PR lifecycle, and agent-runner wiring coverage can live in dedicated suites without changing supervisor semantics, leaving `supervisor.test.ts` as a thin facade.
-- What changed: Added `src/supervisor/supervisor-execution.test.ts`, `src/supervisor/supervisor-pr-lifecycle.test.ts`, and `src/supervisor/supervisor-agent-runner.test.ts`; moved the remaining execution-path, PR transition/review-blocker, and injected runner coverage out of `src/supervisor/supervisor.test.ts`; reduced `src/supervisor/supervisor.test.ts` to a single export smoke test.
+- Hypothesis: the initial provider-start grace window needs a stable current-head CI-ready timestamp derived from required current-head checks, and that data can be exposed via configured-bot hydration without affecting current merge decisions.
+- What changed: Added `currentHeadCiGreenAt` to configured-bot review summaries and hydrated PRs; extended the GraphQL hydration query to collect required `StatusContext` and `CheckRun` metadata on the current head; derived the timestamp as the latest completion among required current-head checks only when every required current-head check is already passing/skipping.
 - Current blocker: none
-- Next exact step: Review the final diff and commit the focused suite split on `codex/issue-464`.
-- Verification gap: none; the focused execution, PR lifecycle, and agent-runner suites plus `npm run build` pass locally after reinstalling dependencies.
-- Files touched: src/supervisor/supervisor.test.ts; src/supervisor/supervisor-execution.test.ts; src/supervisor/supervisor-pr-lifecycle.test.ts; src/supervisor/supervisor-agent-runner.test.ts; .codex-supervisor/issue-journal.md
-- Rollback concern: keep the new suites aligned to supervisor module boundaries; if future cases start mixing execution and lifecycle concerns back together, the split will regress into the same monolith under different filenames.
+- Next exact step: review the diff, commit the checkpoint on `codex/issue-469`, and use it as the base for the later provider-start grace-window behavior.
+- Verification gap: none for the recorded timestamp slice; focused hydration/review-signal tests, pull-request-state compatibility coverage, and `npm run build` all pass locally after reinstalling dependencies.
+- Files touched: src/core/types.ts; src/github/github-hydration.ts; src/github/github-pull-request-hydrator.ts; src/github/github-review-signals.ts; src/github/github-pull-request-hydrator.test.ts; src/github/github-review-signals.test.ts; .codex-supervisor/issue-journal.md
+- Rollback concern: `currentHeadCiGreenAt` intentionally stays observational for now; later grace-window logic should use it only for the matching current head and avoid falling back to stale-head required checks or optional checks.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
-- Reproducing signature before the fix: `src/supervisor/supervisor.test.ts` still held 2671 lines of execution-path, PR lifecycle, and agent-runner coverage after the diagnostics/recovery split.
-- Focused extraction result: `src/supervisor/supervisor.test.ts` is now 7 lines; extracted suites are 1671 lines (`supervisor-execution.test.ts`), 915 lines (`supervisor-pr-lifecycle.test.ts`), and 97 lines (`supervisor-agent-runner.test.ts`).
-- Focused failure during extraction: the first PR lifecycle split used a synchronous `withStubbedDateNow`, which restored `Date.now` before async `runOnce` calls completed and left Copilot-wait tests in `stabilizing`; converting the helper to `async` fixed the focused failures.
-- Verification commands: `npx tsx --test src/supervisor/supervisor-execution.test.ts`; `npx tsx --test src/supervisor/supervisor-pr-lifecycle.test.ts`; `npx tsx --test src/supervisor/supervisor-agent-runner.test.ts src/supervisor/supervisor.test.ts`; `npx tsx --test src/supervisor/supervisor-execution.test.ts src/supervisor/supervisor-pr-lifecycle.test.ts src/supervisor/supervisor-agent-runner.test.ts src/supervisor/supervisor.test.ts`; `npm ci`; `npm run build`.
-- Local failure resolved: `npm run build` initially failed with `sh: 1: tsc: not found` because `node_modules` was absent in this worktree; `npm ci` restored the local toolchain for the acceptance build.
+- Reproducing signature before the fix: required current-head CI completion metadata was absent from configured-bot hydration, so no stable `currentHeadCiGreenAt` value existed for later CodeRabbit provider-start wait logic.
+- Focused derivation rule: use the latest completion timestamp among required current-head checks, but only when every required current-head check on the tracked head is already passing/skipping; otherwise leave the field null.
+- Verification commands: `npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts`; `npx tsx --test src/pull-request-state-provider-waits.test.ts`; `npm ci`; `npm run build`.
+- Local failure resolved: `npm run build` initially failed with `sh: 1: tsc: not found` because this worktree was missing `node_modules`; `npm ci` restored the local toolchain and the acceptance build passed afterward.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -220,6 +220,7 @@ export interface GitHubPullRequest {
   copilotReviewRequestedAt?: string | null;
   copilotReviewArrivedAt?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
+  currentHeadCiGreenAt?: string | null;
   configuredBotRateLimitedAt?: string | null;
   configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
   configuredBotTopLevelReviewSubmittedAt?: string | null;

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -85,8 +85,15 @@ export interface PullRequestCopilotReviewLifecycleResponse {
             nodes?: Array<{
               __typename?: string | null;
               context?: string | null;
+              name?: string | null;
               description?: string | null;
+              state?: string | null;
+              status?: string | null;
+              conclusion?: string | null;
               createdAt?: string | null;
+              startedAt?: string | null;
+              completedAt?: string | null;
+              isRequired?: boolean | null;
               creator?: {
                 login?: string | null;
               } | null;
@@ -257,7 +264,30 @@ export function mapCopilotReviewLifecycleFacts(
               creatorLogin: normalizeLogin(contextNode?.creator?.login ?? null),
               context: contextNode?.context ?? null,
               description: contextNode?.description ?? null,
+              state: contextNode?.state ?? null,
               createdAt: contextNode?.createdAt ?? null,
+              isRequired: contextNode?.isRequired ?? null,
+              commitOid,
+            }];
+          }) ?? []
+        );
+      }) ?? [],
+    checkRuns:
+      lifecycle?.commits?.nodes?.flatMap((node) => {
+        const commitOid = node?.commit?.oid ?? null;
+        return (
+          node?.commit?.statusCheckRollup?.contexts?.nodes?.flatMap((contextNode) => {
+            if (contextNode?.__typename !== "CheckRun" && !contextNode?.name) {
+              return [];
+            }
+
+            return [{
+              name: contextNode?.name ?? null,
+              status: contextNode?.status ?? null,
+              conclusion: contextNode?.conclusion ?? null,
+              startedAt: contextNode?.startedAt ?? null,
+              completedAt: contextNode?.completedAt ?? null,
+              isRequired: contextNode?.isRequired ?? null,
               commitOid,
             }];
           }) ?? []
@@ -306,6 +336,7 @@ export function applyConfiguredBotReviewSummary(
     copilotReviewRequestedAt: summary?.lifecycle.requestedAt ?? null,
     copilotReviewArrivedAt: summary?.lifecycle.arrivedAt ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
+    currentHeadCiGreenAt: summary?.currentHeadCiGreenAt ?? null,
     configuredBotRateLimitedAt: summary?.rateLimitWarningAt ?? null,
     configuredBotTopLevelReviewStrength: summary?.topLevelReview.strength ?? null,
     configuredBotTopLevelReviewSubmittedAt: summary?.topLevelReview.submittedAt ?? null,

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -955,3 +955,93 @@ test("GitHubPullRequestHydrator treats current-head CodeRabbit status contexts a
   assert.match(lifecycleQuery, /StatusContext[\s\S]*createdAt[\s\S]*creator\s*\{\s*login\s*\}/);
   assert.equal(observedAt, "2026-03-13T02:04:00Z");
 });
+
+test("GitHubPullRequestHydrator records the current-head CI-green timestamp from required current-head checks", async () => {
+  const config = createConfig({ reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"] });
+  let lifecycleQuery: string | null = null;
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      lifecycleQuery = args.find((arg) => arg.startsWith("query=")) ?? null;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [],
+                },
+                comments: {
+                  nodes: [],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+                commits: {
+                  nodes: [
+                    {
+                      commit: {
+                        oid: "head-44",
+                        statusCheckRollup: {
+                          contexts: {
+                            nodes: [
+                              {
+                                __typename: "StatusContext",
+                                context: "lint",
+                                state: "SUCCESS",
+                                createdAt: "2026-03-13T02:01:00Z",
+                                isRequired: true,
+                                creator: {
+                                  login: "github-actions",
+                                },
+                              },
+                              {
+                                __typename: "CheckRun",
+                                name: "build",
+                                status: "COMPLETED",
+                                conclusion: "SUCCESS",
+                                startedAt: "2026-03-13T02:02:00Z",
+                                completedAt: "2026-03-13T02:05:00Z",
+                                isRequired: true,
+                              },
+                              {
+                                __typename: "CheckRun",
+                                name: "docs",
+                                status: "COMPLETED",
+                                conclusion: "SUCCESS",
+                                startedAt: "2026-03-13T02:03:00Z",
+                                completedAt: "2026-03-13T02:06:00Z",
+                                isRequired: false,
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+  const ciGreenAt = (pr as GitHubPullRequest & { currentHeadCiGreenAt?: string | null }).currentHeadCiGreenAt;
+
+  assert.ok(lifecycleQuery);
+  assert.match(lifecycleQuery, /isRequired\s*\(pullRequestNumber:\s*\$number\)/);
+  assert.match(lifecycleQuery, /CheckRun[\s\S]*completedAt/);
+  assert.equal(ciGreenAt, "2026-03-13T02:05:00Z");
+});

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -59,6 +59,7 @@ class ConfiguredBotReviewSummaryCache {
         lifecycle: { state: "not_requested", requestedAt: null, arrivedAt: null },
         topLevelReview: { strength: null, submittedAt: null },
         currentHeadObservedAt: null,
+        currentHeadCiGreenAt: null,
         rateLimitWarningAt: null,
       }),
     };
@@ -247,10 +248,20 @@ export class GitHubPullRequestHydrator {
                         ... on StatusContext {
                           context
                           description
+                          state
                           createdAt
+                          isRequired(pullRequestNumber: $number)
                           creator {
                             login
                           }
+                        }
+                        ... on CheckRun {
+                          name
+                          status
+                          conclusion
+                          startedAt
+                          completedAt
+                          isRequired(pullRequestNumber: $number)
                         }
                       }
                     }

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -342,6 +342,7 @@ test("buildConfiguredBotReviewSummary treats actionable configured-bot issue com
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -379,6 +380,7 @@ test("buildConfiguredBotReviewSummary keeps top-level review strength scoped to 
       submittedAt: "2026-03-13T02:03:04Z",
     },
     currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -409,6 +411,7 @@ test("buildConfiguredBotReviewSummary treats configured-bot rate limit issue com
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: "2026-03-13T03:15:00Z",
   });
 });
@@ -450,6 +453,7 @@ test("buildConfiguredBotReviewSummary ignores configured-bot rate limit warnings
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -500,6 +504,7 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -539,6 +544,7 @@ test("buildConfiguredBotReviewSummary treats summary-only configured-bot reviews
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:02:00Z",
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -582,6 +588,7 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -620,6 +627,7 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -658,6 +666,7 @@ test("buildConfiguredBotReviewSummary keeps weakly anchored CodeRabbit review co
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -696,6 +705,7 @@ test("buildConfiguredBotReviewSummary ignores late configured-bot closed-PR foll
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:02:00Z",
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -734,6 +744,7 @@ test("buildConfiguredBotReviewSummary leaves current-head observation empty when
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });
@@ -774,6 +785,129 @@ test("buildConfiguredBotReviewSummary treats current-head CodeRabbit status cont
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadCiGreenAt: null,
+    rateLimitWarningAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary records the current-head CI-green timestamp from required passing checks only", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [],
+    statusContexts: [
+      {
+        creatorLogin: "github-actions",
+        context: "lint",
+        createdAt: "2026-03-13T02:01:00Z",
+        state: "SUCCESS",
+        isRequired: true,
+        commitOid: "head-44",
+      },
+      {
+        creatorLogin: "github-actions",
+        context: "optional-docs",
+        createdAt: "2026-03-13T02:07:00Z",
+        state: "SUCCESS",
+        isRequired: false,
+        commitOid: "head-44",
+      },
+      {
+        creatorLogin: "github-actions",
+        context: "stale-required",
+        createdAt: "2026-03-13T02:09:00Z",
+        state: "SUCCESS",
+        isRequired: true,
+        commitOid: "stale-head",
+      },
+    ],
+    checkRuns: [
+      {
+        name: "build",
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        completedAt: "2026-03-13T02:05:00Z",
+        isRequired: true,
+        commitOid: "head-44",
+      },
+      {
+        name: "test",
+        status: "COMPLETED",
+        conclusion: "FAILURE",
+        completedAt: "2026-03-13T02:06:00Z",
+        isRequired: false,
+        commitOid: "head-44",
+      },
+    ],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: null,
+    currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+    rateLimitWarningAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary leaves current-head CI-green timestamp empty until all required current-head checks pass", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [],
+    statusContexts: [
+      {
+        creatorLogin: "github-actions",
+        context: "lint",
+        createdAt: "2026-03-13T02:01:00Z",
+        state: "SUCCESS",
+        isRequired: true,
+        commitOid: "head-44",
+      },
+    ],
+    checkRuns: [
+      {
+        name: "build",
+        status: "IN_PROGRESS",
+        conclusion: null,
+        completedAt: null,
+        isRequired: true,
+        commitOid: "head-44",
+      },
+      {
+        name: "stale-build",
+        status: "COMPLETED",
+        conclusion: "SUCCESS",
+        completedAt: "2026-03-13T02:05:00Z",
+        isRequired: true,
+        commitOid: "stale-head",
+      },
+    ],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: null,
+    currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
   });
 });

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -30,7 +30,18 @@ export interface CopilotReviewLifecycleFacts {
     creatorLogin: string | null;
     context: string | null;
     description?: string | null;
+    state?: string | null;
     createdAt: string | null;
+    isRequired?: boolean | null;
+    commitOid?: string | null;
+  }>;
+  checkRuns?: Array<{
+    name: string | null;
+    status: string | null;
+    conclusion?: string | null;
+    startedAt?: string | null;
+    completedAt: string | null;
+    isRequired?: boolean | null;
     commitOid?: string | null;
   }>;
   timeline: Array<{
@@ -55,6 +66,7 @@ export interface ConfiguredBotReviewSummary {
   lifecycle: CopilotReviewLifecycle;
   topLevelReview: ConfiguredBotTopLevelReviewSummary;
   currentHeadObservedAt: string | null;
+  currentHeadCiGreenAt: string | null;
   rateLimitWarningAt: string | null;
 }
 
@@ -90,6 +102,30 @@ function isConfiguredBotStatusContextActivity(args: {
   const normalizedContext = (args.context ?? "").trim().toLowerCase();
   const normalizedDescription = (args.description ?? "").trim().toLowerCase();
   return normalizedContext.includes("coderabbit") || normalizedDescription.includes("coderabbit");
+}
+
+function mapCheckBucket(args: {
+  state?: string | null;
+  conclusion?: string | null;
+}): "pass" | "fail" | "pending" | "skipping" | "cancel" | string {
+  const outcome = (args.conclusion ?? args.state ?? "").toLowerCase();
+  if (["success", "successful", "pass", "passed"].includes(outcome)) {
+    return "pass";
+  }
+  if (["pending", "queued", "in_progress", "expected", "waiting", "requested"].includes(outcome)) {
+    return "pending";
+  }
+  if (["failure", "failed", "error", "timed_out", "action_required", "startup_failure"].includes(outcome)) {
+    return "fail";
+  }
+  if (["cancelled", "canceled", "cancel"].includes(outcome)) {
+    return "cancel";
+  }
+  if (["neutral", "skipped", "stale", "skipping"].includes(outcome)) {
+    return "skipping";
+  }
+
+  return outcome || "unknown";
 }
 
 function latestTimestamp(values: Array<string | null | undefined>): string | null {
@@ -357,6 +393,55 @@ function inferConfiguredBotCurrentHeadObservedAt(
   ]);
 }
 
+function inferCurrentHeadCiGreenAt(
+  facts: CopilotReviewLifecycleFacts,
+  currentHeadOid: string | null | undefined,
+): string | null {
+  const normalizedCurrentHeadOid = currentHeadOid?.trim();
+  if (!normalizedCurrentHeadOid) {
+    return null;
+  }
+
+  const requiredChecks = [
+    ...(facts.statusContexts ?? [])
+      .filter((statusContext) => statusContext.isRequired && statusContext.commitOid === normalizedCurrentHeadOid)
+      .map((statusContext) => ({
+        bucket: mapCheckBucket({ state: statusContext.state }),
+        completedAt: statusContext.createdAt,
+      })),
+    ...(facts.checkRuns ?? [])
+      .filter((checkRun) => checkRun.isRequired && checkRun.commitOid === normalizedCurrentHeadOid)
+      .map((checkRun) => ({
+        bucket: mapCheckBucket({ state: checkRun.status, conclusion: checkRun.conclusion }),
+        completedAt: checkRun.completedAt ?? checkRun.startedAt ?? null,
+      })),
+  ];
+
+  if (requiredChecks.length === 0) {
+    return null;
+  }
+
+  let ciGreenAt: string | null = null;
+  let ciGreenAtMs = 0;
+  for (const check of requiredChecks) {
+    if (check.bucket !== "pass" && check.bucket !== "skipping") {
+      return null;
+    }
+
+    const completedAtMs = parseTimestamp(check.completedAt);
+    if (!check.completedAt || completedAtMs === 0) {
+      return null;
+    }
+
+    if (!ciGreenAt || completedAtMs >= ciGreenAtMs) {
+      ciGreenAt = check.completedAt;
+      ciGreenAtMs = completedAtMs;
+    }
+  }
+
+  return ciGreenAt;
+}
+
 function inferConfiguredBotRateLimitWarningAt(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -397,6 +482,7 @@ export function buildConfiguredBotReviewSummary(
     lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
     topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
     currentHeadObservedAt: inferConfiguredBotCurrentHeadObservedAt(facts, reviewBotLogins, currentHeadOid),
+    currentHeadCiGreenAt: inferCurrentHeadCiGreenAt(facts, currentHeadOid),
     rateLimitWarningAt: inferConfiguredBotRateLimitWarningAt(facts, reviewBotLogins),
   };
 }


### PR DESCRIPTION
## Summary
- record currentHeadCiGreenAt from required current-head checks only when the tracked head is fully CI-green
- expose the timestamp through hydrated pull request state for later provider-start grace logic
- add focused review-signal and hydrator coverage for the new timestamp derivation

## Verification
- npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts
- npx tsx --test src/pull-request-state-provider-waits.test.ts
- npm run build

Closes #469


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `currentHeadCiGreenAt` timestamp metric that tracks when all required CI checks for the current PR head have passed or been skipped. This timestamp is now available in pull request review summaries and hydration data, allowing visibility into CI completion status.

* **Tests**
  * Added comprehensive test coverage for the new CI-green timestamp tracking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->