### PR TITLE
Add CodeRabbit initial grace wait after CI green

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,32 +1,33 @@
-# Issue #469: CodeRabbit initial grace wait: record the current-head CI-green timestamp for provider-start waiting
+# Issue #468: CodeRabbit initial grace wait: pause briefly after CI turns green before merge progression
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/469
-- Branch: codex/issue-469
-- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-469
-- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-469/.codex-supervisor/issue-journal.md
-- Current phase: stabilizing
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/468
+- Branch: codex/issue-468
+- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-468
+- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-468/.codex-supervisor/issue-journal.md
+- Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 1c6bc037675a3da061798ece74d4ceca6fca84e1
+- Last head SHA: 36051b281154d7402f6c986f35ca2c8a67a9b227
 - Blocked reason: none
-- Last failure signature: missing-current-head-ci-green-at
+- Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-17T10:16:58Z
+- Updated at: 2026-03-17T10:38:30.734Z
 
 ## Latest Codex Summary
-- Added current-head CI-green timestamp derivation for required checks in configured-bot hydration/review-signal summaries and exposed it on hydrated pull requests without changing merge-state behavior.
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
-- Hypothesis: the initial provider-start grace window needs a stable current-head CI-ready timestamp derived from required current-head checks, and that data can be exposed via configured-bot hydration without affecting current merge decisions.
-- What changed: Added `currentHeadCiGreenAt` to configured-bot review summaries and hydrated PRs; extended the GraphQL hydration query to collect required `StatusContext` and `CheckRun` metadata on the current head; derived the timestamp as the latest completion among required current-head checks only when every required current-head check is already passing/skipping.
+### Current Handoff
+- Hypothesis: CodeRabbit needed a separate startup grace window keyed off `currentHeadCiGreenAt`; the existing settled wait only covered post-observation quiet time and could not pause merge progression while the provider was still silent.
+- What changed: Added `configuredBotInitialGraceWaitSeconds` with a default of 90 seconds, used it only for CodeRabbit when required checks are green and no current-head provider activity has been observed, kept the settled-wait handoff after activity begins, and surfaced the active initial-grace window in supervisor status/output.
 - Current blocker: none
-- Next exact step: review the diff, commit the checkpoint on `codex/issue-469`, and use it as the base for the later provider-start grace-window behavior.
-- Verification gap: none for the recorded timestamp slice; focused hydration/review-signal tests, pull-request-state compatibility coverage, and `npm run build` all pass locally after reinstalling dependencies.
-- Files touched: src/core/types.ts; src/github/github-hydration.ts; src/github/github-pull-request-hydrator.ts; src/github/github-review-signals.ts; src/github/github-pull-request-hydrator.test.ts; src/github/github-review-signals.test.ts; .codex-supervisor/issue-journal.md
-- Rollback concern: `currentHeadCiGreenAt` intentionally stays observational for now; later grace-window logic should use it only for the matching current head and avoid falling back to stale-head required checks or optional checks.
+- Next exact step: Stage the focused implementation and test updates, then create a checkpoint commit on `codex/issue-468`.
+- Verification gap: none for local focused verification; remote CI has not run yet.
+- Files touched: `src/pull-request-state.ts`, `src/supervisor/supervisor-status-review-bot.ts`, `src/supervisor/supervisor-detailed-status-assembly.ts`, focused tests, `src/core/config.ts`, `src/core/types.ts`, `supervisor.config.coderabbit.json`, `docs/configuration.md`
+- Rollback concern: defaulting the new CodeRabbit-only grace to 90 seconds changes merge timing for CodeRabbit-configured repos immediately; reverting means removing the config default and initial-grace branch together.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
@@ -34,3 +35,4 @@
 - Focused derivation rule: use the latest completion timestamp among required current-head checks, but only when every required current-head check on the tracked head is already passing/skipping; otherwise leave the field null.
 - Verification commands: `npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts`; `npx tsx --test src/pull-request-state-provider-waits.test.ts`; `npm ci`; `npm run build`.
 - Local failure resolved: `npm run build` initially failed with `sh: 1: tsc: not found` because this worktree was missing `node_modules`; `npm ci` restored the local toolchain and the acceptance build passed afterward.
+- 2026-03-17: Focused reproducer was `inferStateFromPullRequest` returning `ready_to_merge` instead of `waiting_ci` when `currentHeadCiGreenAt=2026-03-13T02:05:00Z`, CodeRabbit was configured, and no `configuredBotCurrentHeadObservedAt` existed. The new initial grace wait covers that silent-provider window and hands off to the existing settled wait once `configuredBotCurrentHeadObservedAt` appears.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,8 +37,8 @@ Each shipped profile only covers supervisor-side expectations. You still need th
 
 ### CodeRabbit profile
 
-- Supervisor-side: use `supervisor.config.coderabbit.json`, which tracks both `coderabbitai` and `coderabbitai[bot]`, waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing, and applies a short settled wait after a fresh CodeRabbit current-head observation.
-- Tuning: `configuredBotSettledWaitSeconds` controls that CodeRabbit quiet period. The default is `5`, which preserves current behavior.
+- Supervisor-side: use `supervisor.config.coderabbit.json`, which tracks both `coderabbitai` and `coderabbitai[bot]`, waits up to 30 minutes after a CodeRabbit `Rate limit exceeded` warning before continuing, applies an initial startup grace period after required checks turn green, and then applies a short settled wait after a fresh CodeRabbit current-head observation.
+- Tuning: `configuredBotInitialGraceWaitSeconds` controls the initial startup grace period. The default is `90`, and practical tuning can extend into the 60-120 second range. `configuredBotSettledWaitSeconds` controls the later post-activity quiet period. The default is `5`, which preserves current behavior after CodeRabbit begins reviewing the current head.
 - Provider-side: install CodeRabbit. Add `.coderabbit.yaml` only when you intentionally want repo-specific CodeRabbit behavior; it is not required just to make the supervisor wait through temporary rate limits.
 - Operator note: while that short settled wait is active, `status` shows `configured_bot_settled_wait status=active provider=coderabbit pause_reason=recent_current_head_observation recent_observation=current_head_activity ... wait_until=...`. That means the supervisor saw recent CodeRabbit activity on the current PR head, is deliberately pausing merge progression for a few seconds, and is telling you when progression will resume.
 - Verify: open a PR and confirm CodeRabbit posts review activity under one of the configured bot identities.
@@ -79,7 +79,7 @@ Review and merge policy:
 - `reviewBotLogins`
 - `humanReviewBlocksMerge`
 - `copilotReviewWaitMinutes`, `copilotReviewTimeoutAction`
-- `configuredBotRateLimitWaitMinutes`, `configuredBotSettledWaitSeconds`
+- `configuredBotRateLimitWaitMinutes`, `configuredBotInitialGraceWaitSeconds`, `configuredBotSettledWaitSeconds`
 - `localReviewEnabled`, `localReviewAutoDetect`, `localReviewRoles`
 - `localReviewPolicy`, `localReviewHighSeverityAction`
 - `localReviewArtifactDir`, `localReviewConfidenceThreshold`, `localReviewReviewerThresholds`

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { loadConfig } from "./core/config";
+import { SupervisorConfig } from "./core/types";
 
 test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
@@ -233,6 +234,35 @@ test("loadConfig accepts an explicit configuredBotSettledWaitSeconds override", 
   };
 
   assert.equal(config.configuredBotSettledWaitSeconds, 3);
+});
+
+test("loadConfig accepts an explicit configuredBotInitialGraceWaitSeconds override", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      configuredBotInitialGraceWaitSeconds: 120,
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath) as SupervisorConfig & {
+    configuredBotInitialGraceWaitSeconds?: number;
+  };
+
+  assert.equal(config.configuredBotInitialGraceWaitSeconds, 120);
 });
 
 test("loadConfig defaults localReviewHighSeverityAction to blocked", async (t) => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -286,6 +286,12 @@ export function loadConfig(configPath?: string): SupervisorConfig {
       raw.configuredBotRateLimitWaitMinutes >= 0
         ? raw.configuredBotRateLimitWaitMinutes
         : 0,
+    configuredBotInitialGraceWaitSeconds:
+      typeof raw.configuredBotInitialGraceWaitSeconds === "number" &&
+      Number.isFinite(raw.configuredBotInitialGraceWaitSeconds) &&
+      raw.configuredBotInitialGraceWaitSeconds >= 0
+        ? raw.configuredBotInitialGraceWaitSeconds
+        : 90,
     configuredBotSettledWaitSeconds:
       typeof raw.configuredBotSettledWaitSeconds === "number" &&
       Number.isFinite(raw.configuredBotSettledWaitSeconds) &&

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -78,6 +78,7 @@ export interface SupervisorConfig {
   copilotReviewWaitMinutes: number;
   copilotReviewTimeoutAction: CopilotReviewTimeoutAction;
   configuredBotRateLimitWaitMinutes?: number;
+  configuredBotInitialGraceWaitSeconds?: number;
   configuredBotSettledWaitSeconds?: number;
   codexExecTimeoutMinutes: number;
   maxCodexAttemptsPerIssue: number;

--- a/src/pull-request-state-provider-waits.test.ts
+++ b/src/pull-request-state-provider-waits.test.ts
@@ -380,6 +380,81 @@ test("inferStateFromPullRequest waits briefly after a recent CodeRabbit current-
   });
 });
 
+test("inferStateFromPullRequest waits briefly after required checks turn green for a silent CodeRabbit provider", () => {
+  withStubbedDateNow("2026-03-13T02:05:45Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    config.configuredBotInitialGraceWaitSeconds = 90;
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        createRecord({ state: "waiting_ci" }),
+        createPullRequest({
+          copilotReviewState: "not_requested",
+          copilotReviewArrivedAt: null,
+          currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+          configuredBotCurrentHeadObservedAt: null,
+        }),
+        passingChecks(),
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
+test("inferStateFromPullRequest hands off from the initial CodeRabbit grace wait to the settled wait after provider activity begins", () => {
+  withStubbedDateNow("2026-03-13T02:06:17Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    config.configuredBotInitialGraceWaitSeconds = 90;
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        createRecord({ state: "waiting_ci" }),
+        createPullRequest({
+          copilotReviewState: "arrived",
+          copilotReviewArrivedAt: "2026-03-13T02:06:16Z",
+          currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-03-13T02:06:15Z",
+        }),
+        passingChecks(),
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
+test("inferStateFromPullRequest does not wait after the initial CodeRabbit grace window expires without provider activity", () => {
+  withStubbedDateNow("2026-03-13T02:06:31Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    });
+    config.configuredBotInitialGraceWaitSeconds = 90;
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        createRecord({ state: "waiting_ci" }),
+        createPullRequest({
+          copilotReviewState: "not_requested",
+          copilotReviewArrivedAt: null,
+          currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+          configuredBotCurrentHeadObservedAt: null,
+        }),
+        passingChecks(),
+        [],
+      ),
+      "ready_to_merge",
+    );
+  });
+});
+
 test("inferStateFromPullRequest waits on a recent summary-only CodeRabbit current-head observation", () => {
   withStubbedDateNow("2026-03-13T02:04:03Z", () => {
     const config = createConfig({

--- a/src/pull-request-state-test-helpers.ts
+++ b/src/pull-request-state-test-helpers.ts
@@ -44,6 +44,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     copilotReviewWaitMinutes: 10,
     copilotReviewTimeoutAction: "continue",
     configuredBotRateLimitWaitMinutes: 0,
+    configuredBotInitialGraceWaitSeconds: 90,
     codexExecTimeoutMinutes: 30,
     maxCodexAttemptsPerIssue: 5,
     maxImplementationAttemptsPerIssue: 5,

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -31,6 +31,7 @@ import { nowIso } from "./core/utils";
 
 const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
+const DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS = 90_000;
 
 interface CopilotReviewTimeoutStatus {
   timedOut: boolean;
@@ -223,6 +224,30 @@ function shouldWaitForConfiguredBotCurrentHeadQuietPeriod(
 
   const settledWaitMs = (config.configuredBotSettledWaitSeconds ?? DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS / 1_000) * 1_000;
   return Date.now() < observedAtMs + settledWaitMs;
+}
+
+function shouldWaitForConfiguredBotInitialGracePeriod(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): boolean {
+  const policy = reviewProviderWaitPolicyFromConfig(config);
+  if (
+    !policy.shouldApplyCurrentHeadQuietPeriod ||
+    pr.isDraft ||
+    pr.configuredBotCurrentHeadObservedAt ||
+    !pr.currentHeadCiGreenAt
+  ) {
+    return false;
+  }
+
+  const ciGreenAtMs = Date.parse(pr.currentHeadCiGreenAt);
+  if (Number.isNaN(ciGreenAtMs)) {
+    return false;
+  }
+
+  const initialGraceWaitMs =
+    (config.configuredBotInitialGraceWaitSeconds ?? DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS / 1_000) * 1_000;
+  return Date.now() < ciGreenAtMs + initialGraceWaitMs;
 }
 
 export function buildCopilotReviewTimeoutFailureContext(
@@ -486,6 +511,10 @@ export function inferStateFromPullRequest(
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
   if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
     return "blocked";
+  }
+
+  if (shouldWaitForConfiguredBotInitialGracePeriod(config, pr)) {
+    return "waiting_ci";
   }
 
   if (shouldWaitForConfiguredBotCurrentHeadQuietPeriod(config, pr)) {

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -9,6 +9,7 @@ import {
   summarizeCheckBuckets,
 } from "./supervisor-status-summary-helpers";
 import {
+  configuredBotInitialGraceWaitWindow,
   configuredBotSettledWaitWindow,
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
@@ -140,6 +141,12 @@ export function buildActiveDetailedStatusLines(
     if (configuredBotRateLimit.observedAt) {
       lines.push(
         `configured_bot_rate_limit status=${configuredBotRateLimit.status} observed_at=${configuredBotRateLimit.observedAt} wait_until=${configuredBotRateLimit.waitUntil ?? "none"}`,
+      );
+    }
+    const configuredBotInitialGraceWait = configuredBotInitialGraceWaitWindow(config, pr);
+    if (configuredBotInitialGraceWait.status === "active") {
+      lines.push(
+        `configured_bot_initial_grace_wait status=${configuredBotInitialGraceWait.status} provider=${configuredBotInitialGraceWait.provider} pause_reason=${configuredBotInitialGraceWait.pauseReason} recent_observation=${configuredBotInitialGraceWait.recentObservation} observed_at=${configuredBotInitialGraceWait.observedAt ?? "none"} wait_until=${configuredBotInitialGraceWait.waitUntil ?? "none"}`,
       );
     }
     const configuredBotSettledWait = configuredBotSettledWaitWindow(config, pr);

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -202,6 +202,28 @@ test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci du
   });
 });
 
+test("derivePullRequestLifecycleSnapshot keeps silent CodeRabbit repos in waiting_ci during the initial grace window after checks turn green", () => {
+  withStubbedDateNow("2026-03-13T02:05:45Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+      configuredBotInitialGraceWaitSeconds: 90,
+    });
+    const record = createRecord({ state: "waiting_ci" });
+    const pr = createPullRequest({
+      copilotReviewState: "not_requested",
+      copilotReviewArrivedAt: null,
+      currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+      configuredBotCurrentHeadObservedAt: null,
+    });
+    const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+    const reviewThreads: ReviewThread[] = [];
+
+    const snapshot = derivePullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads);
+
+    assert.equal(snapshot.nextState, "waiting_ci");
+  });
+});
+
 test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci for summary-only current-head observations", () => {
   withStubbedDateNow("2026-03-13T02:04:03Z", () => {
     const config = createConfig({

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -249,6 +249,56 @@ test("buildDetailedStatusModel explains why an active CodeRabbit settled wait is
   }
 });
 
+test("buildDetailedStatusModel explains why an active CodeRabbit initial grace wait is pausing merge progression", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:01:00.000Z");
+
+  try {
+    const lines = buildDetailedStatusModel({
+      config: createConfig({
+        reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+        configuredBotInitialGraceWaitSeconds: 90,
+      }),
+      activeRecord: createRecord({
+        pr_number: 44,
+        state: "waiting_ci",
+        blocked_reason: null,
+        last_error: null,
+      }),
+      latestRecord: null,
+      trackedIssueCount: 1,
+      pr: createPullRequest({
+        currentHeadCiGreenAt: "2026-03-16T00:00:00.000Z",
+        configuredBotCurrentHeadObservedAt: null,
+      }),
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [],
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      pendingBotReviewThreads: (innerConfig, innerRecord, innerPr, innerReviewThreads) =>
+        configuredBotReviewThreads(innerConfig, innerReviewThreads).filter(
+          (thread) =>
+            !innerRecord.processed_review_thread_ids.includes(thread.id) &&
+            innerRecord.last_head_sha === innerPr.headRefOid,
+        ),
+      summarizeChecks: (checks) => ({
+        allPassing: checks.every((check) => check.bucket === "pass"),
+        hasPending: checks.some((check) => check.bucket === "pending" || check.bucket === "cancel"),
+        hasFailing: checks.some((check) => check.bucket === "fail"),
+      }),
+      mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
+    });
+
+    assert.ok(
+      lines.includes(
+        "configured_bot_initial_grace_wait status=active provider=coderabbit pause_reason=awaiting_initial_provider_activity recent_observation=required_checks_green observed_at=2026-03-16T00:00:00.000Z wait_until=2026-03-16T00:01:30.000Z",
+      ),
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("buildDetailedStatusSummaryLines shapes optional summaries and artifact paths", () => {
   const config = createConfig({
     localReviewArtifactDir: "/tmp/reviews",

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -519,6 +519,38 @@ test("formatDetailedStatus surfaces an active CodeRabbit settled wait after a cu
   });
 });
 
+test("formatDetailedStatus surfaces an active CodeRabbit initial grace wait after checks turn green", () => {
+  withStubbedDateNow("2026-03-13T02:05:45Z", () => {
+    const status = formatDetailedStatus({
+      config: createConfig({
+        reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+        configuredBotInitialGraceWaitSeconds: 90,
+      }),
+      activeRecord: createRecord({
+        pr_number: 44,
+        state: "waiting_ci",
+      }),
+      latestRecord: null,
+      trackedIssueCount: 1,
+      pr: createPullRequest({
+        number: 44,
+        headRefName: "codex/issue-38",
+        copilotReviewState: "not_requested",
+        copilotReviewArrivedAt: null,
+        currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+        configuredBotCurrentHeadObservedAt: null,
+      }),
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [],
+    });
+
+    assert.match(
+      status,
+      /configured_bot_initial_grace_wait status=active provider=coderabbit pause_reason=awaiting_initial_provider_activity recent_observation=required_checks_green observed_at=2026-03-13T02:05:00Z wait_until=2026-03-13T02:06:30\.000Z/,
+    );
+  });
+});
+
 test("formatDetailedStatus preserves Copilot-specific timeout wording for Copilot-only repos", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  configuredBotInitialGraceWaitWindow,
   configuredBotSettledWaitWindow,
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
@@ -53,6 +54,7 @@ function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConf
     pollIntervalSeconds: 60,
     copilotReviewWaitMinutes: 10,
     copilotReviewTimeoutAction: "continue",
+    configuredBotInitialGraceWaitSeconds: 90,
     codexExecTimeoutMinutes: 30,
     maxCodexAttemptsPerIssue: 5,
     maxImplementationAttemptsPerIssue: 5,
@@ -317,6 +319,51 @@ test("configuredBotSettledWaitWindow reports the active CodeRabbit quiet period"
       configuredBotSettledWaitWindow(
         createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
         createPr({ configuredBotCurrentHeadObservedAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "inactive",
+        provider: "none",
+        pauseReason: "none",
+        recentObservation: "none",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: null,
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("configuredBotInitialGraceWaitWindow reports the active CodeRabbit startup grace period after checks turn green", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:01:00.000Z");
+
+  try {
+    assert.deepEqual(
+      configuredBotInitialGraceWaitWindow(
+        createConfig({ reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"] }),
+        createPr({ currentHeadCiGreenAt: "2026-03-16T00:00:00.000Z" }),
+      ),
+      {
+        status: "active",
+        provider: "coderabbit",
+        pauseReason: "awaiting_initial_provider_activity",
+        recentObservation: "required_checks_green",
+        observedAt: "2026-03-16T00:00:00.000Z",
+        waitUntil: "2026-03-16T00:01:30.000Z",
+      },
+    );
+
+    assert.deepEqual(
+      configuredBotInitialGraceWaitWindow(
+        createConfig({
+          reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+          configuredBotInitialGraceWaitSeconds: 60,
+        }),
+        createPr({
+          currentHeadCiGreenAt: "2026-03-16T00:00:00.000Z",
+          configuredBotCurrentHeadObservedAt: "2026-03-16T00:00:30.000Z",
+        }),
       ),
       {
         status: "inactive",

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -9,6 +9,7 @@ import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } fro
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
+const DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS = 90_000;
 
 export type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
 
@@ -93,6 +94,53 @@ export function configuredBotSettledWaitWindow(
     pauseReason: "recent_current_head_observation",
     recentObservation: "current_head_activity",
     observedAt: pr.configuredBotCurrentHeadObservedAt,
+    waitUntil,
+  };
+}
+
+export function configuredBotInitialGraceWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): {
+  status: "inactive" | "active" | "expired";
+  provider: "none" | "coderabbit";
+  pauseReason: "none" | "awaiting_initial_provider_activity";
+  recentObservation: "none" | "required_checks_green";
+  observedAt: string | null;
+  waitUntil: string | null;
+} {
+  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || pr.configuredBotCurrentHeadObservedAt || !pr.currentHeadCiGreenAt) {
+    return {
+      status: "inactive",
+      provider: "none",
+      pauseReason: "none",
+      recentObservation: "none",
+      observedAt: pr.currentHeadCiGreenAt ?? null,
+      waitUntil: null,
+    };
+  }
+
+  const observedAtMs = Date.parse(pr.currentHeadCiGreenAt);
+  if (Number.isNaN(observedAtMs)) {
+    return {
+      status: "inactive",
+      provider: "coderabbit",
+      pauseReason: "awaiting_initial_provider_activity",
+      recentObservation: "required_checks_green",
+      observedAt: pr.currentHeadCiGreenAt,
+      waitUntil: null,
+    };
+  }
+
+  const initialGraceWaitMs =
+    (config.configuredBotInitialGraceWaitSeconds ?? DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS / 1_000) * 1_000;
+  const waitUntil = new Date(observedAtMs + initialGraceWaitMs).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    provider: "coderabbit",
+    pauseReason: "awaiting_initial_provider_activity",
+    recentObservation: "required_checks_green",
+    observedAt: pr.currentHeadCiGreenAt,
     waitUntil,
   };
 }

--- a/supervisor.config.coderabbit.json
+++ b/supervisor.config.coderabbit.json
@@ -70,6 +70,7 @@
   "copilotReviewWaitMinutes": 10,
   "copilotReviewTimeoutAction": "continue",
   "configuredBotRateLimitWaitMinutes": 30,
+  "configuredBotInitialGraceWaitSeconds": 90,
   "configuredBotSettledWaitSeconds": 5,
   "codexExecTimeoutMinutes": 30,
   "maxCodexAttemptsPerIssue": 30,


### PR DESCRIPTION
## Summary
- add a CodeRabbit-only initial grace wait after required checks turn green when no current-head provider activity has been observed
- hand off from the initial grace window into the existing settled wait once CodeRabbit activity starts
- surface the active initial-grace window in supervisor status and cover the behavior with focused tests

Closes #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an initial grace period that pauses merge progression for 90 seconds after CI checks turn green, allowing time for provider activity detection before proceeding to the settled wait phase.
  * New configuration option to customize the grace period duration.

* **Documentation**
  * Updated configuration guide to document the new initial grace period setting and its default value.

* **Tests**
  * Added test coverage for the new grace period behavior and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->