### PR TITLE
External-review cleanup: tighten signal heuristics boundary

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,37 +1,39 @@
-# Issue #489: Test cleanup: split supervisor PR lifecycle coverage by readiness and review-blocker boundaries
+# Issue #491: External-review cleanup: tighten the signal-heuristics and normalization boundary
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/489
-- Branch: codex/issue-489
-- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-489
-- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-489/.codex-supervisor/issue-journal.md
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/491
+- Branch: codex/issue-491
+- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-491
+- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-491/.codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 9704168f31e53da4a7139911a933b74613c5ca4c
+- Last head SHA: 18af0964675dd972a9db716197af125cf9b75cba
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-17T15:54:52.619Z
+- Updated at: 2026-03-17T16:15:30.271Z
 
 ## Latest Codex Summary
-- Split `src/supervisor/supervisor-pr-lifecycle.test.ts` into readiness and review-blocker suites, preserved the legacy file as a thin import facade, and re-verified the focused supervisor PR lifecycle tests plus `npm run build`.
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: #489 can stay behavior-neutral by splitting `supervisor-pr-lifecycle.test.ts` into one readiness/post-turn suite and one review-blocker/thread-reprocessing suite, with the legacy path preserved as a facade import for existing test entry points.
-- What changed: extracted readiness coverage into `src/supervisor/supervisor-pr-readiness.test.ts`, moved review-blocker and configured-bot thread reprocessing coverage into `src/supervisor/supervisor-pr-review-blockers.test.ts`, and reduced `src/supervisor/supervisor-pr-lifecycle.test.ts` to a thin facade import file.
+- Hypothesis: #491 can stay behavior-neutral by moving provider-specific external-review signal collection out of `external-review-normalization.ts`, leaving normalization focused on shaping preselected signal envelopes into findings.
+- What changed: added focused `external-review-signal-collection.test.ts` coverage for provider-activity filtering, extracted `collectExternalReviewSignals` and the thread/review/comment selection helpers into `src/external-review/external-review-signal-collection.ts`, moved shared signal types into `src/external-review/external-review-signals.ts`, and updated normalization/classifier/miss-persistence tests to use the explicit `signal -> normalized finding` boundary.
 - Current blocker: none
-- Next exact step: Commit the suite split on `codex/issue-489`, then push/open the draft PR if one still does not exist.
-- Verification gap: none for the split PR lifecycle suites or `npm run build`; `npm ci` was required first because `tsc` was initially unavailable locally.
-- Files touched: `src/supervisor/supervisor-pr-lifecycle.test.ts`, `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-pr-review-blockers.test.ts`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: reverting this cleanup would put readiness transitions, post-turn PR refresh, configured-bot thread reprocessing, and manual/local review blockers back into a single 915-line suite, making failures harder to localize.
+- Next exact step: Commit the external-review boundary cleanup on `codex/issue-491`, then check whether a draft PR already exists for the branch before opening or updating one.
+- Verification gap: none for the focused external-review suites or `npm run build`; `npm ci` was required first because `tsc` was initially unavailable locally in this worktree.
+- Files touched: `src/external-review/external-review-signal-collection.ts`, `src/external-review/external-review-signals.ts`, `src/external-review/external-review-normalization.ts`, `src/external-review/external-review-misses.ts`, `src/external-review/external-review-miss-persistence.ts`, `src/external-review/external-review-durable-guardrail-candidates.ts`, `src/external-review/external-review-miss-artifact-types.ts`, `src/external-review/external-review-signal-collection.test.ts`, `src/external-review/external-review-normalization.test.ts`, `src/external-review/external-review-classifier.test.ts`, `src/external-review/external-review-miss-persistence.test.ts`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: reverting this cleanup would put configured-bot selection and actionable filtering back into normalization, which makes future provider-signal changes span both collection and finding-shaping code paths again.
 - Last focused command: `npm run build`
 ### Scratchpad
-- 2026-03-18: Focused reproducer for #489 was `npx tsx --test src/supervisor/supervisor-pr-lifecycle.test.ts`, which passed before the split and confirmed the cleanup was behavior-neutral rather than a failing behavior fix.
-- 2026-03-18: Verification for #489 was `npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts`, `npx tsx --test src/supervisor/supervisor-pr-lifecycle.test.ts`, then `npm ci` and `npm run build`; `npm run build` first failed with `sh: 1: tsc: not found` before dependencies were restored.
+- 2026-03-18: Focused reproducer for #491 was a new `external-review-signal-collection.test.ts` suite that pins provider-activity behavior separately from `normalizeExternalReviewSignal`, including last-configured-bot thread comment selection, actionable state-only top-level reviews, and closed-PR issue-comment filtering.
+- 2026-03-18: #491 cleanup extracts provider signal collection into `external-review-signal-collection.ts` and shared signal types into `external-review-signals.ts`; `external-review-normalization.ts` now only shapes signal envelopes into normalized findings.
+- 2026-03-18: Focused verification for #491 was `npx tsx --test src/external-review/external-review-signal-collection.test.ts src/external-review/external-review-normalization.test.ts src/external-review/external-review-classifier.test.ts src/external-review/external-review-miss-persistence.test.ts`.
+- 2026-03-18: `npm run build` initially failed with `sh: 1: tsc: not found`; `npm ci` restored the local toolchain, then the rerun of the focused suites and `npm run build` passed.
 - 2026-03-18: `npm run build` initially failed with `sh: 1: tsc: not found`; `npm ci` restored the local toolchain and the rerun of `npm run build` passed.
 - 2026-03-17: Review repair for PR #497 updates the guardrail provenance fixtures so committed shared-memory files are added before `headSha` is captured; focused verification was `npx tsx --test src/supervisor/supervisor-diagnostics-guardrail-reporting.test.ts` and `npm run build`.
 - 2026-03-17: Added `draftSkipAt` to configured-bot summaries and hydrated PRs; focused verification was `npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts`, followed by `npm ci` and `npm run build`.

--- a/src/external-review/external-review-classifier.test.ts
+++ b/src/external-review/external-review-classifier.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { classifyExternalReviewFinding } from "./external-review-classifier";
-import { normalizeExternalReviewFinding } from "./external-review-normalization";
+import { normalizeExternalReviewSignal } from "./external-review-normalization";
+import { toExternalReviewThreadSignal } from "./external-review-signal-collection";
 import { ReviewThread } from "../core/types";
+
+function normalizeThreadFinding(thread: ReviewThread) {
+  const signal = toExternalReviewThreadSignal(thread, ["copilot-pull-request-reviewer"]);
+  return signal ? normalizeExternalReviewSignal(signal) : null;
+}
 
 function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
   return {
@@ -30,7 +36,7 @@ function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread
 }
 
 test("classifyExternalReviewFinding marks unmatched configured-bot feedback as missed_by_local_review", () => {
-  const normalized = normalizeExternalReviewFinding(createReviewThread(), ["copilot-pull-request-reviewer"]);
+  const normalized = normalizeThreadFinding(createReviewThread());
   assert.ok(normalized);
 
   const classified = classifyExternalReviewFinding(normalized, {
@@ -61,7 +67,7 @@ test("classifyExternalReviewFinding marks unmatched configured-bot feedback as m
 });
 
 test("classifyExternalReviewFinding marks same-hunk findings as matched even with low text overlap", () => {
-  const normalized = normalizeExternalReviewFinding(
+  const normalized = normalizeThreadFinding(
     createReviewThread({
       path: "src/auth.ts",
       line: 44,
@@ -80,7 +86,6 @@ test("classifyExternalReviewFinding marks same-hunk findings as matched even wit
         ],
       },
     }),
-    ["copilot-pull-request-reviewer"],
   );
   assert.ok(normalized);
 
@@ -113,7 +118,7 @@ test("classifyExternalReviewFinding marks same-hunk findings as matched even wit
 });
 
 test("classifyExternalReviewFinding keeps nearby same-file findings as near_match with stable match reasons", () => {
-  const normalized = normalizeExternalReviewFinding(
+  const normalized = normalizeThreadFinding(
     createReviewThread({
       path: "src/auth.ts",
       line: 42,
@@ -132,7 +137,6 @@ test("classifyExternalReviewFinding keeps nearby same-file findings as near_matc
         ],
       },
     }),
-    ["copilot-pull-request-reviewer"],
   );
   assert.ok(normalized);
 

--- a/src/external-review/external-review-durable-guardrail-candidates.ts
+++ b/src/external-review/external-review-durable-guardrail-candidates.ts
@@ -4,7 +4,7 @@ import {
   type ExternalReviewDurableGuardrailCandidate,
   type ExternalReviewDurableGuardrailCandidateCategory,
 } from "./external-review-miss-artifact-types";
-import { type ExternalReviewSignalSourceKind } from "./external-review-normalization";
+import { type ExternalReviewSignalSourceKind } from "./external-review-signals";
 
 interface CandidateQualificationRule {
   reason: string;

--- a/src/external-review/external-review-miss-artifact-types.ts
+++ b/src/external-review/external-review-miss-artifact-types.ts
@@ -1,5 +1,5 @@
 import { type ExternalReviewMissFinding } from "./external-review-classifier";
-import { type ExternalReviewSignalSourceKind } from "./external-review-normalization";
+import { type ExternalReviewSignalSourceKind } from "./external-review-signals";
 
 export type ExternalReviewPromptFinding = Pick<
   ExternalReviewMissFinding,

--- a/src/external-review/external-review-miss-persistence.test.ts
+++ b/src/external-review/external-review-miss-persistence.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { loadLocalReviewArtifact } from "./external-review-local-artifact-io";
 import { writeExternalReviewMissArtifact } from "./external-review-miss-persistence";
-import { collectExternalReviewSignals } from "./external-review-normalization";
+import { collectExternalReviewSignals } from "./external-review-signal-collection";
 import { IssueComment, PullRequestReview, ReviewThread } from "../core/types";
 
 function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {

--- a/src/external-review/external-review-miss-persistence.ts
+++ b/src/external-review/external-review-miss-persistence.ts
@@ -7,11 +7,11 @@ import {
   type LocalReviewArtifactLike,
 } from "./external-review-classifier";
 import {
-  collectExternalReviewSignals,
   normalizeExternalReviewSignal,
   type NormalizedExternalReviewFinding,
-  type ExternalReviewSignalEnvelope,
 } from "./external-review-normalization";
+import { collectExternalReviewSignals } from "./external-review-signal-collection";
+import { type ExternalReviewSignalEnvelope } from "./external-review-signals";
 import {
   type ExternalReviewMissArtifact,
   type ExternalReviewDurableGuardrailCandidate,

--- a/src/external-review/external-review-misses.ts
+++ b/src/external-review/external-review-misses.ts
@@ -1,11 +1,9 @@
 import {
-  collectExternalReviewSignals,
-  normalizeExternalReviewFinding,
   normalizeExternalReviewSignal,
   type NormalizedExternalReviewFinding,
-  type ExternalReviewSignalEnvelope,
-  type ExternalReviewSignalSourceKind,
 } from "./external-review-normalization";
+import { collectExternalReviewSignals } from "./external-review-signal-collection";
+import { type ExternalReviewSignalEnvelope, type ExternalReviewSignalSourceKind } from "./external-review-signals";
 import {
   classifyExternalReviewFinding,
   type ExternalReviewMatch,
@@ -26,7 +24,6 @@ export { writeExternalReviewMissArtifact } from "./external-review-miss-persiste
 export {
   classifyExternalReviewFinding,
   collectExternalReviewSignals,
-  normalizeExternalReviewFinding,
   normalizeExternalReviewSignal,
   type ExternalReviewMissArtifact,
   type ExternalReviewMatch,

--- a/src/external-review/external-review-normalization.test.ts
+++ b/src/external-review/external-review-normalization.test.ts
@@ -1,10 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  collectExternalReviewSignals,
-  normalizeExternalReviewFinding,
-} from "./external-review-normalization";
-import { IssueComment, PullRequestReview, ReviewThread } from "../core/types";
+import { normalizeExternalReviewSignal } from "./external-review-normalization";
+import { toExternalReviewThreadSignal } from "./external-review-signal-collection";
+import { ReviewThread } from "../core/types";
 
 function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
   return {
@@ -31,36 +29,7 @@ function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread
   };
 }
 
-function createTopLevelReview(overrides: Partial<PullRequestReview> = {}): PullRequestReview {
-  return {
-    id: "review-1",
-    body: "Nitpick: this nil check is inverted and can mask the error path.",
-    submittedAt: "2026-03-12T00:03:00Z",
-    url: "https://example.test/pr/1#pullrequestreview-1",
-    state: "COMMENTED",
-    author: {
-      login: "coderabbitai[bot]",
-      typeName: "Bot",
-    },
-    ...overrides,
-  };
-}
-
-function createIssueComment(overrides: Partial<IssueComment> = {}): IssueComment {
-  return {
-    id: "issue-comment-1",
-    body: "Suggestion: the fallback path should guard against unauthorized writes before persisting.",
-    createdAt: "2026-03-12T00:04:00Z",
-    url: "https://example.test/pr/1#issuecomment-1",
-    author: {
-      login: "coderabbitai[bot]",
-      typeName: "Bot",
-    },
-    ...overrides,
-  };
-}
-
-test("normalizeExternalReviewFinding uses the final configured-bot comment", () => {
+test("normalizeExternalReviewSignal shapes the selected configured-bot thread signal into a finding", () => {
   const thread = createReviewThread({
     comments: {
       nodes: [
@@ -98,93 +67,12 @@ test("normalizeExternalReviewFinding uses the final configured-bot comment", () 
     },
   });
 
-  const finding = normalizeExternalReviewFinding(thread, ["copilot-pull-request-reviewer"]);
+  const signal = toExternalReviewThreadSignal(thread, ["copilot-pull-request-reviewer"]);
+  const finding = signal ? normalizeExternalReviewSignal(signal) : null;
   assert.equal(finding?.reviewerLogin, "copilot-pull-request-reviewer");
   assert.equal(finding?.file, "src/auth.ts");
   assert.equal(finding?.line, 42);
   assert.match(finding?.summary ?? "", /permission guard/i);
   assert.equal(finding?.severity, "medium");
   assert.equal(finding?.confidence, 0.75);
-});
-
-test("collectExternalReviewSignals normalizes thread, top-level review, and issue comment sources through one shared model", () => {
-  const signals = collectExternalReviewSignals({
-    reviewThreads: [createReviewThread()],
-    reviews: [createTopLevelReview()],
-    issueComments: [createIssueComment()],
-    reviewBotLogins: ["copilot-pull-request-reviewer", "coderabbitai[bot]"],
-  });
-
-  assert.deepEqual(
-    signals.map((signal) => ({
-      sourceKind: signal.sourceKind,
-      sourceId: signal.sourceId,
-      file: signal.file,
-      line: signal.line,
-      threadId: signal.threadId,
-    })),
-    [
-      {
-        sourceKind: "review_thread",
-        sourceId: "thread-1",
-        file: "src/auth.ts",
-        line: 42,
-        threadId: "thread-1",
-      },
-      {
-        sourceKind: "top_level_review",
-        sourceId: "review-1",
-        file: null,
-        line: null,
-        threadId: null,
-      },
-      {
-        sourceKind: "issue_comment",
-        sourceId: "issue-comment-1",
-        file: null,
-        line: null,
-        threadId: null,
-      },
-    ],
-  );
-});
-
-test("collectExternalReviewSignals preserves actionable top-level reviews that only expose review state", () => {
-  const signals = collectExternalReviewSignals({
-    reviews: [
-      createTopLevelReview({
-        id: "review-state-only",
-        body: null,
-        state: "CHANGES_REQUESTED",
-        url: "https://example.test/pr/1#pullrequestreview-2",
-      }),
-    ],
-    reviewBotLogins: ["coderabbitai[bot]"],
-  });
-
-  assert.deepEqual(signals, [
-    {
-      sourceKind: "top_level_review",
-      sourceId: "review-state-only",
-      sourceUrl: "https://example.test/pr/1#pullrequestreview-2",
-      reviewerLogin: "coderabbitai[bot]",
-      body: "CHANGES_REQUESTED",
-      file: null,
-      line: null,
-      threadId: null,
-    },
-  ]);
-});
-
-test("collectExternalReviewSignals ignores late configured-bot closed-PR follow-up issue comments", () => {
-  const signals = collectExternalReviewSignals({
-    issueComments: [
-      createIssueComment({
-        body: "This pull request is already closed. Please ignore this follow-up review comment.",
-      }),
-    ],
-    reviewBotLogins: ["coderabbitai[bot]"],
-  });
-
-  assert.deepEqual(signals, []);
 });

--- a/src/external-review/external-review-normalization.ts
+++ b/src/external-review/external-review-normalization.ts
@@ -1,20 +1,6 @@
 import { truncate } from "../core/utils";
 import { type LocalReviewSeverity } from "../local-review/types";
-import { hasActionableReviewText, isActionableTopLevelReview } from "./external-review-signal-heuristics";
-import { type IssueComment, type PullRequestReview, type ReviewThread } from "../core/types";
-
-export type ExternalReviewSignalSourceKind = "review_thread" | "top_level_review" | "issue_comment";
-
-export interface ExternalReviewSignalEnvelope {
-  sourceKind: ExternalReviewSignalSourceKind;
-  sourceId: string;
-  sourceUrl: string | null;
-  reviewerLogin: string;
-  body: string;
-  file: string | null;
-  line: number | null;
-  threadId: string | null;
-}
+import { type ExternalReviewSignalEnvelope, type ExternalReviewSignalSourceKind } from "./external-review-signals";
 
 export interface NormalizedExternalReviewFinding {
   source: "external_bot";
@@ -72,112 +58,6 @@ function inferConfidence(body: string): number {
   return 0.75;
 }
 
-function normalizeBotLogins(reviewBotLogins: string[]): Set<string> {
-  return new Set(reviewBotLogins.map((login) => login.toLowerCase()));
-}
-
-function latestConfiguredBotComment(thread: ReviewThread, allowed: Set<string>) {
-  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
-    const comment = thread.comments.nodes[index];
-    const login = comment.author?.login?.toLowerCase();
-    if (login && allowed.has(login)) {
-      return comment;
-    }
-  }
-
-  return null;
-}
-
-export function toExternalReviewThreadSignal(
-  thread: ReviewThread,
-  reviewBotLogins: string[],
-): ExternalReviewSignalEnvelope | null {
-  const comment = latestConfiguredBotComment(thread, normalizeBotLogins(reviewBotLogins));
-  if (!comment) {
-    return null;
-  }
-
-  return {
-    sourceKind: "review_thread",
-    sourceId: thread.id,
-    sourceUrl: comment.url ?? null,
-    reviewerLogin: comment.author?.login ?? "unknown",
-    body: comment.body,
-    file: thread.path ?? null,
-    line: thread.line ?? null,
-    threadId: thread.id,
-  };
-}
-
-export function toExternalTopLevelReviewSignal(
-  review: PullRequestReview,
-  reviewBotLogins: string[],
-): ExternalReviewSignalEnvelope | null {
-  const login = review.author?.login?.toLowerCase();
-  if (!login || !normalizeBotLogins(reviewBotLogins).has(login) || !isActionableTopLevelReview(review)) {
-    return null;
-  }
-
-  const body = review.body?.trim() || review.state?.trim();
-  if (!body) {
-    return null;
-  }
-
-  return {
-    sourceKind: "top_level_review",
-    sourceId: review.id,
-    sourceUrl: review.url ?? null,
-    reviewerLogin: review.author?.login ?? "unknown",
-    body,
-    file: null,
-    line: null,
-    threadId: null,
-  };
-}
-
-export function toExternalIssueCommentSignal(
-  comment: IssueComment,
-  reviewBotLogins: string[],
-): ExternalReviewSignalEnvelope | null {
-  const login = comment.author?.login?.toLowerCase();
-  if (!login || !normalizeBotLogins(reviewBotLogins).has(login) || !hasActionableReviewText(comment.body)) {
-    return null;
-  }
-
-  return {
-    sourceKind: "issue_comment",
-    sourceId: comment.id,
-    sourceUrl: comment.url ?? null,
-    reviewerLogin: comment.author?.login ?? "unknown",
-    body: comment.body,
-    file: null,
-    line: null,
-    threadId: null,
-  };
-}
-
-export function collectExternalReviewSignals(args: {
-  reviewThreads?: ReviewThread[];
-  reviews?: PullRequestReview[];
-  issueComments?: IssueComment[];
-  reviewBotLogins: string[];
-}): ExternalReviewSignalEnvelope[] {
-  return [
-    ...(args.reviewThreads ?? []).flatMap((thread) => {
-      const signal = toExternalReviewThreadSignal(thread, args.reviewBotLogins);
-      return signal ? [signal] : [];
-    }),
-    ...(args.reviews ?? []).flatMap((review) => {
-      const signal = toExternalTopLevelReviewSignal(review, args.reviewBotLogins);
-      return signal ? [signal] : [];
-    }),
-    ...(args.issueComments ?? []).flatMap((comment) => {
-      const signal = toExternalIssueCommentSignal(comment, args.reviewBotLogins);
-      return signal ? [signal] : [];
-    }),
-  ];
-}
-
 export function normalizeExternalReviewSignal(
   signal: ExternalReviewSignalEnvelope,
 ): NormalizedExternalReviewFinding | null {
@@ -201,14 +81,6 @@ export function normalizeExternalReviewSignal(
     confidence: inferConfidence(signal.body),
     url: signal.sourceUrl,
   };
-}
-
-export function normalizeExternalReviewFinding(
-  thread: ReviewThread,
-  reviewBotLogins: string[],
-): NormalizedExternalReviewFinding | null {
-  const signal = toExternalReviewThreadSignal(thread, reviewBotLogins);
-  return signal ? normalizeExternalReviewSignal(signal) : null;
 }
 
 export function createExternalReviewMissPatternFingerprint(

--- a/src/external-review/external-review-signal-collection.test.ts
+++ b/src/external-review/external-review-signal-collection.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { collectExternalReviewSignals } from "./external-review-signal-collection";
+import { IssueComment, PullRequestReview, ReviewThread } from "../core/types";
+
+function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/auth.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "This fallback skips the permission guard and lets unauthorized callers update records.",
+          createdAt: "2026-03-12T00:00:00Z",
+          url: "https://example.test/thread-1#comment-1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function createTopLevelReview(overrides: Partial<PullRequestReview> = {}): PullRequestReview {
+  return {
+    id: "review-1",
+    body: "Nitpick: this nil check is inverted and can mask the error path.",
+    submittedAt: "2026-03-12T00:03:00Z",
+    url: "https://example.test/pr/1#pullrequestreview-1",
+    state: "COMMENTED",
+    author: {
+      login: "coderabbitai[bot]",
+      typeName: "Bot",
+    },
+    ...overrides,
+  };
+}
+
+function createIssueComment(overrides: Partial<IssueComment> = {}): IssueComment {
+  return {
+    id: "issue-comment-1",
+    body: "Suggestion: the fallback path should guard against unauthorized writes before persisting.",
+    createdAt: "2026-03-12T00:04:00Z",
+    url: "https://example.test/pr/1#issuecomment-1",
+    author: {
+      login: "coderabbitai[bot]",
+      typeName: "Bot",
+    },
+    ...overrides,
+  };
+}
+
+test("collectExternalReviewSignals uses the final configured-bot thread comment", () => {
+  const signals = collectExternalReviewSignals({
+    reviewThreads: [
+      createReviewThread({
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Initial note.",
+              createdAt: "2026-03-12T00:00:00Z",
+              url: "https://example.test/thread-1#comment-1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-2",
+              body: "Author reply",
+              createdAt: "2026-03-12T00:01:00Z",
+              url: "https://example.test/thread-1#comment-2",
+              author: {
+                login: "tommy",
+                typeName: "User",
+              },
+            },
+            {
+              id: "comment-3",
+              body: "This fallback skips the permission guard and lets unauthorized callers update records.",
+              createdAt: "2026-03-12T00:02:00Z",
+              url: "https://example.test/thread-1#comment-3",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+
+  assert.deepEqual(signals, [
+    {
+      sourceKind: "review_thread",
+      sourceId: "thread-1",
+      sourceUrl: "https://example.test/thread-1#comment-3",
+      reviewerLogin: "copilot-pull-request-reviewer",
+      body: "This fallback skips the permission guard and lets unauthorized callers update records.",
+      file: "src/auth.ts",
+      line: 42,
+      threadId: "thread-1",
+    },
+  ]);
+});
+
+test("collectExternalReviewSignals normalizes thread, top-level review, and issue comment sources through one shared model", () => {
+  const signals = collectExternalReviewSignals({
+    reviewThreads: [createReviewThread()],
+    reviews: [createTopLevelReview()],
+    issueComments: [createIssueComment()],
+    reviewBotLogins: ["copilot-pull-request-reviewer", "coderabbitai[bot]"],
+  });
+
+  assert.deepEqual(
+    signals.map((signal) => ({
+      sourceKind: signal.sourceKind,
+      sourceId: signal.sourceId,
+      file: signal.file,
+      line: signal.line,
+      threadId: signal.threadId,
+    })),
+    [
+      {
+        sourceKind: "review_thread",
+        sourceId: "thread-1",
+        file: "src/auth.ts",
+        line: 42,
+        threadId: "thread-1",
+      },
+      {
+        sourceKind: "top_level_review",
+        sourceId: "review-1",
+        file: null,
+        line: null,
+        threadId: null,
+      },
+      {
+        sourceKind: "issue_comment",
+        sourceId: "issue-comment-1",
+        file: null,
+        line: null,
+        threadId: null,
+      },
+    ],
+  );
+});
+
+test("collectExternalReviewSignals preserves actionable top-level reviews that only expose review state", () => {
+  const signals = collectExternalReviewSignals({
+    reviews: [
+      createTopLevelReview({
+        id: "review-state-only",
+        body: null,
+        state: "CHANGES_REQUESTED",
+        url: "https://example.test/pr/1#pullrequestreview-2",
+      }),
+    ],
+    reviewBotLogins: ["coderabbitai[bot]"],
+  });
+
+  assert.deepEqual(signals, [
+    {
+      sourceKind: "top_level_review",
+      sourceId: "review-state-only",
+      sourceUrl: "https://example.test/pr/1#pullrequestreview-2",
+      reviewerLogin: "coderabbitai[bot]",
+      body: "CHANGES_REQUESTED",
+      file: null,
+      line: null,
+      threadId: null,
+    },
+  ]);
+});
+
+test("collectExternalReviewSignals ignores late configured-bot closed-PR follow-up issue comments", () => {
+  const signals = collectExternalReviewSignals({
+    issueComments: [
+      createIssueComment({
+        body: "This pull request is already closed. Please ignore this follow-up review comment.",
+      }),
+    ],
+    reviewBotLogins: ["coderabbitai[bot]"],
+  });
+
+  assert.deepEqual(signals, []);
+});

--- a/src/external-review/external-review-signal-collection.ts
+++ b/src/external-review/external-review-signal-collection.ts
@@ -1,0 +1,109 @@
+import { type IssueComment, type PullRequestReview, type ReviewThread } from "../core/types";
+import { hasActionableReviewText, isActionableTopLevelReview } from "./external-review-signal-heuristics";
+import { type ExternalReviewSignalEnvelope } from "./external-review-signals";
+
+function normalizeBotLogins(reviewBotLogins: string[]): Set<string> {
+  return new Set(reviewBotLogins.map((login) => login.toLowerCase()));
+}
+
+function latestConfiguredBotComment(thread: ReviewThread, allowed: Set<string>) {
+  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
+    const comment = thread.comments.nodes[index];
+    const login = comment.author?.login?.toLowerCase();
+    if (login && allowed.has(login)) {
+      return comment;
+    }
+  }
+
+  return null;
+}
+
+export function toExternalReviewThreadSignal(
+  thread: ReviewThread,
+  reviewBotLogins: string[],
+): ExternalReviewSignalEnvelope | null {
+  const comment = latestConfiguredBotComment(thread, normalizeBotLogins(reviewBotLogins));
+  if (!comment) {
+    return null;
+  }
+
+  return {
+    sourceKind: "review_thread",
+    sourceId: thread.id,
+    sourceUrl: comment.url ?? null,
+    reviewerLogin: comment.author?.login ?? "unknown",
+    body: comment.body,
+    file: thread.path ?? null,
+    line: thread.line ?? null,
+    threadId: thread.id,
+  };
+}
+
+export function toExternalTopLevelReviewSignal(
+  review: PullRequestReview,
+  reviewBotLogins: string[],
+): ExternalReviewSignalEnvelope | null {
+  const login = review.author?.login?.toLowerCase();
+  if (!login || !normalizeBotLogins(reviewBotLogins).has(login) || !isActionableTopLevelReview(review)) {
+    return null;
+  }
+
+  const body = review.body?.trim() || review.state?.trim();
+  if (!body) {
+    return null;
+  }
+
+  return {
+    sourceKind: "top_level_review",
+    sourceId: review.id,
+    sourceUrl: review.url ?? null,
+    reviewerLogin: review.author?.login ?? "unknown",
+    body,
+    file: null,
+    line: null,
+    threadId: null,
+  };
+}
+
+export function toExternalIssueCommentSignal(
+  comment: IssueComment,
+  reviewBotLogins: string[],
+): ExternalReviewSignalEnvelope | null {
+  const login = comment.author?.login?.toLowerCase();
+  if (!login || !normalizeBotLogins(reviewBotLogins).has(login) || !hasActionableReviewText(comment.body)) {
+    return null;
+  }
+
+  return {
+    sourceKind: "issue_comment",
+    sourceId: comment.id,
+    sourceUrl: comment.url ?? null,
+    reviewerLogin: comment.author?.login ?? "unknown",
+    body: comment.body,
+    file: null,
+    line: null,
+    threadId: null,
+  };
+}
+
+export function collectExternalReviewSignals(args: {
+  reviewThreads?: ReviewThread[];
+  reviews?: PullRequestReview[];
+  issueComments?: IssueComment[];
+  reviewBotLogins: string[];
+}): ExternalReviewSignalEnvelope[] {
+  return [
+    ...(args.reviewThreads ?? []).flatMap((thread) => {
+      const signal = toExternalReviewThreadSignal(thread, args.reviewBotLogins);
+      return signal ? [signal] : [];
+    }),
+    ...(args.reviews ?? []).flatMap((review) => {
+      const signal = toExternalTopLevelReviewSignal(review, args.reviewBotLogins);
+      return signal ? [signal] : [];
+    }),
+    ...(args.issueComments ?? []).flatMap((comment) => {
+      const signal = toExternalIssueCommentSignal(comment, args.reviewBotLogins);
+      return signal ? [signal] : [];
+    }),
+  ];
+}

--- a/src/external-review/external-review-signals.ts
+++ b/src/external-review/external-review-signals.ts
@@ -1,0 +1,12 @@
+export type ExternalReviewSignalSourceKind = "review_thread" | "top_level_review" | "issue_comment";
+
+export interface ExternalReviewSignalEnvelope {
+  sourceKind: ExternalReviewSignalSourceKind;
+  sourceId: string;
+  sourceUrl: string | null;
+  reviewerLogin: string;
+  body: string;
+  file: string | null;
+  line: number | null;
+  threadId: string | null;
+}


### PR DESCRIPTION
## Summary
- move provider-specific external review signal collection into a dedicated module
- move shared external review signal envelope types into a small shared module
- keep normalization focused on shaping selected signals into findings and add focused collection coverage

Closes #491

## Testing
- npx tsx --test src/external-review/external-review-signal-collection.test.ts src/external-review/external-review-normalization.test.ts src/external-review/external-review-classifier.test.ts src/external-review/external-review-miss-persistence.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Reorganized external review signal processing to improve code structure and maintainability.
  
* **Tests**
  * Added comprehensive test coverage for signal collection and normalization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->