### PR TITLE
Fix stale post-merge merging reconciliation

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,62 +1,37 @@
-# Issue #513: External-review misses: reuse follow-up action reasoning in explain diagnostics
+# Issue #514: Post-merge reconciliation: recover tracked issues left stuck in merging after PR merge
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/513
-- Branch: codex/issue-513
-- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-513
-- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-513/.codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: fcd29449abc8129dce74a30408432c982096fea4
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/514
+- Branch: codex/issue-514
+- Workspace: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-514
+- Journal: /home/tommy/Dev/codex-supervisor-self-worktrees/issue-514/.codex-supervisor/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 50f581c012a2c2f514bb11c24382020bbdc5993f
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ851Bh3U|PRRT_kwDORgvdZ851Bh3e
-- Repeated failure signature count: 1
-- Updated at: 2026-03-18T10:07:00+09:00
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-18T01:15:08.754Z
 
 ## Latest Codex Summary
-Pushed review-fix commit `a90c2db` to [PR #520](https://github.com/TommyKammy/codex-supervisor/pull/520). `explain` now builds `external_review_follow_up` directly from the tracked record plus a best-effort PR head lookup in [src/supervisor/supervisor-selection-status.ts](../src/supervisor/supervisor-selection-status.ts), so missing `getChecks` or unresolved-thread APIs no longer suppress the shared digest-backed summary. The explain regression in [src/supervisor/supervisor-diagnostics-explain.test.ts](../src/supervisor/supervisor-diagnostics-explain.test.ts) now omits those unrelated GitHub stubs to lock the behavior in.
-
-I also rewrote the live journal summary links to repo-relative paths in [.codex-supervisor/issue-journal.md](issue-journal.md), then resolved the two CodeRabbit review threads after the push. Focused verification passed with `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-external-review-follow-up.test.ts` and `npm run build`. The only remaining workspace noise is the pre-existing untracked `.codex-supervisor/replay/`.
-
-Summary: Pushed the explain follow-up review fix, tightened the focused regression, fixed the journal links, and resolved both bot review threads on PR #520.
-State hint: pr_open
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-external-review-follow-up.test.ts`; `npm run build`
-Failure signature: none
-Next action: Monitor PR #520 for any fresh review or CI follow-up after the `a90c2db` review-fix push.
+- Reproduced the stuck post-merge `merging` case with a focused reconciliation test, fixed the refresh path so later reconciliation re-fetches open issue snapshots for merged tracked PRs before applying the existing merge-time safety gate, and verified the focused reconciliation/lifecycle suites plus `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `explain` should not synthesize its own external-review miss narrative; when a tracked issue has a current-head follow-up digest, it should surface the same compact digest-backed summary that `status` already trusts.
-- What changed: `buildExplainExternalReviewFollowUpSummary()` now bypasses `loadActiveIssueStatusSnapshot()` and calls the shared digest renderer directly using the tracked record plus a best-effort PR head SHA, the explain regression no longer stubs `resolvePullRequestForBranch`/`getChecks`/`getUnresolvedReviewThreads`, the live latest-summary journal links are repo-relative, and the two CodeRabbit review threads were resolved after the `a90c2db` push.
+- Hypothesis: stale open issue snapshots in the preloaded issue list can strand a tracked `merging` record after its PR already merged because reconciliation never refreshes the issue before checking the merge-time close gate.
+- What changed: `reconcileTrackedMergedButOpenIssues()` now re-fetches the live issue only for open `merging` records whose tracked PR is already merged, then reuses the existing `updatedAt <= mergedAt` safety gate and normal close-to-done convergence path; added a focused regression covering the stale-open-snapshot recovery case.
 - Current blocker: none
-- Next exact step: monitor PR #520 for any new review or CI follow-up after the resolved-thread push.
-- Verification gap: none locally after rerunning the focused explain/follow-up suites and `npm run build`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/supervisor/supervisor-selection-status.ts`
-- Rollback concern: if `explain` stops reusing the shared follow-up summary, operators get divergent miss-to-prevention stories between `status` and `explain`, which is the regression this issue closes.
+- Next exact step: commit this focused reconciliation fix and, if no PR exists yet, open a draft PR from `codex/issue-514`.
+- Verification gap: none locally after rerunning the focused reconciliation/lifecycle suites and `npm run build`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`
+- Rollback concern: if the `merging`-only refresh is removed, later cycles can keep trusting stale open issue snapshots and leave merged tracked issues stranded instead of converging them to `done`.
 - Last focused command: `npm run build`
+
 ### Scratchpad (workspace-local date in Asia/Tokyo unless noted)
-- 2026-03-18 (JST): Pushed review-fix commit `a90c2db` to `origin/codex/issue-513` and resolved CodeRabbit threads `PRRT_kwDORgvdZ851Bh3U` and `PRRT_kwDORgvdZ851Bh3e` with `gh api graphql`.
-- 2026-03-18 (JST): Review repair: `buildExplainExternalReviewFollowUpSummary()` no longer depends on `loadActiveIssueStatusSnapshot()` or `getChecks`/`getUnresolvedReviewThreads`; the explain regression now omits those stubs, and focused explain/follow-up tests plus `npm run build` passed.
-- 2026-03-18 (JST): Focused reproducer first failed in `src/external-review/external-review-miss-artifact.test.ts` because missed findings in the artifact had `preventionTarget: undefined`; failure signature: `missing-prevention-target`.
-- 2026-03-18 (JST): Deterministic target precedence is `issue_comment -> issue_template`, `top_level_review -> review_prompt`, severe anchored `review_thread` misses -> `durable_guardrail`, regression-qualified `review_thread` misses -> `regression_test`, otherwise `review_prompt`.
-- 2026-03-18 (JST): `npm run build` initially failed with `sh: 1: tsc: not found`; `npm ci` restored the local toolchain and the rerun passed.
-- 2026-03-18 (JST): Added a focused reproducer in `src/external-review/external-review-miss-persistence.test.ts`; it first failed with `ENOENT` for `external-review-misses-head-deadbeefcafe.md`, yielding failure signature `missing-follow-up-digest`.
-- 2026-03-18 (JST): `external-review-miss-digest.ts` now persists an adjacent markdown digest with `current-head` vs `stale-head` metadata, prevention-target grouping, and one deterministic recommended next action per missed finding.
-- 2026-03-18 (JST): Review repair: `buildExternalReviewMissFollowUpDigest` now throws if any `missed_by_local_review` finding reaches the digest without a prevention target, and the new artifact test locks that invariant in place.
-- 2026-03-18 (JST): Pushed `codex/issue-511`, retried `gh pr create` after the initial race with branch publication, and opened draft PR #518. Current GitHub check state is `UNSTABLE` only because CI jobs are still queued.
-- 2026-03-18 (JST): Pushed review-fix commit `c7b7a45` and resolved CodeRabbit threads `PRRT_kwDORgvdZ851BC62` and `PRRT_kwDORgvdZ851BC67` after focused verification passed.
-- 2026-03-18 (JST): Added `src/supervisor/supervisor-diagnostics-external-review-follow-up.test.ts`; the first focused run failed because `status` emitted only `external_review_misses_path` and no compact follow-up summary, yielding failure signature `missing-status-follow-up-summary`.
-- 2026-03-18 (JST): `status` now parses the adjacent external-review follow-up digest, emits `external_review_follow_up unresolved=... actions=...` only for `current-head`, and ignores `stale-head` digests.
-- 2026-03-18 (JST): Focused external-review/status tests passed before build, then `npm run build` failed once with `sh: 1: tsc: not found`; `npm ci` restored the local toolchain and the rerun passed.
-- 2026-03-18 (JST): Reran `npx tsx --test src/external-review/external-review-miss-persistence.test.ts src/supervisor/supervisor-diagnostics-external-review-follow-up.test.ts src/supervisor/supervisor-status-rendering.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts` and `npm run build`; both passed on commit `dcb4c41`.
-- 2026-03-18 (JST): Pushed `codex/issue-512` and opened draft PR #519 (`https://github.com/TommyKammy/codex-supervisor/pull/519`).
-- 2026-03-18 (JST): Review repair: `buildExternalReviewFollowUpStatusLine()` now requires the live head SHA plus digest SHAs to match `external_review_head_sha` before surfacing follow-up debt, the stale-head reproducer now uses mismatched digest/live SHAs and asserts on the emitted token, and the issue journal paths were rewritten to repo-relative form.
-- 2026-03-18 (JST): Verified review repairs with `npx tsx --test src/external-review/external-review-miss-persistence.test.ts src/supervisor/supervisor-diagnostics-external-review-follow-up.test.ts src/supervisor/supervisor-status-rendering.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts` and `npm run build`.
-- 2026-03-18 (JST): Added `src/supervisor/supervisor-diagnostics-explain.test.ts` coverage for a current-head actionable follow-up digest; the first focused run failed because `explain` returned only selection fields and omitted `external_review_follow_up`, yielding failure signature `missing-explain-follow-up-summary`.
-- 2026-03-18 (JST): `buildIssueExplainSummary()` now reuses `loadActiveIssueStatusSnapshot()` to append the same digest-backed `external_review_follow_up unresolved=... actions=...` line that `status` emits when the GitHub client can resolve active review state.
-- 2026-03-18 (JST): `npm run build` first failed with `sh: 1: tsc: not found`; `npm ci` restored the local toolchain, the rerun passed, and the focused explain/follow-up suites stayed green after the typing fix.
-- 2026-03-18 (JST): Pushed `codex/issue-513` to `origin`, opened draft PR #520 (`https://github.com/TommyKammy/codex-supervisor/pull/520`), and confirmed the initial PR state is `UNSTABLE` only because the CI build jobs are still running.
+- 2026-03-18 (JST): Added `reconcileTrackedMergedButOpenIssues refreshes open issue snapshots for merging records before applying the merge-time gate`; the first focused run failed because `getIssue` was never called for an open preloaded issue, yielding failure signature `stale-merging-issue-snapshot`.
+- 2026-03-18 (JST): Narrow fix: when a tracked PR is already merged and the local record is still `merging`, reconciliation now refreshes the live issue snapshot before applying the existing merge-time close gate, allowing later cycles to close the GitHub issue and mark the record `done`.
+- 2026-03-18 (JST): Verified with `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`, `npx tsx --test src/supervisor/supervisor-execution-cleanup.test.ts`, and `npm run build`.
+- 2026-03-18 (JST): `npm run build` initially failed in this worktree with `sh: 1: tsc: not found`; `npm ci` restored the local toolchain and the rerun passed.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -334,7 +334,9 @@ export async function reconcileTrackedMergedButOpenIssues(
     }
 
     let issue = issueByNumber.get(record.issue_number);
-    if (!issue) {
+    if (issue?.state === "OPEN" && record.state === "merging") {
+      issue = await github.getIssue(record.issue_number);
+    } else if (!issue) {
       issue = await github.getIssue(record.issue_number);
     }
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -492,6 +492,99 @@ test("reconcileTrackedMergedButOpenIssues fetches missing issue snapshots for no
   ]);
 });
 
+test("reconcileTrackedMergedButOpenIssues refreshes open issue snapshots for merging records before applying the merge-time gate", async () => {
+  const record = createRecord({
+    issue_number: 366,
+    state: "merging",
+    pr_number: 191,
+    blocked_reason: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "366": record,
+    },
+  };
+  const mergedPr: GitHubPullRequest = {
+    number: 191,
+    title: "Merged implementation",
+    url: "https://example.test/pr/191",
+    state: "MERGED",
+    createdAt: "2026-03-13T00:10:00Z",
+    updatedAt: "2026-03-13T00:20:00Z",
+    isDraft: false,
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "merged-head-191",
+    mergeStateStatus: "CLEAN",
+    reviewDecision: "APPROVED",
+    mergedAt: "2026-03-13T00:20:00Z",
+    copilotReviewState: null,
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+  };
+  const staleOpenIssue: GitHubIssue = {
+    number: 366,
+    title: "Merged implementation issue",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:25:00Z",
+    url: "https://example.test/issues/366",
+    state: "OPEN",
+  };
+  const refreshedOpenIssue: GitHubIssue = {
+    ...staleOpenIssue,
+    updatedAt: "2026-03-13T00:19:00Z",
+  };
+
+  let getIssueCalls = 0;
+  let closeIssueCalls = 0;
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async () => mergedPr,
+      getIssue: async () => {
+        getIssueCalls += 1;
+        return refreshedOpenIssue;
+      },
+      closeIssue: async () => {
+        closeIssueCalls += 1;
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    [staleOpenIssue],
+  );
+
+  assert.equal(getIssueCalls, 1);
+  assert.equal(closeIssueCalls, 1);
+  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["366"]?.state, "done");
+  assert.equal(state.issues["366"]?.pr_number, 191);
+  assert.equal(state.issues["366"]?.last_head_sha, "merged-head-191");
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "merged_pr_convergence: tracked PR #191 merged; marked issue #366 done",
+  ]);
+});
+
 test("reconcileTrackedMergedButOpenIssues does not rewrite recovery metadata when the done state is already current", async () => {
   const original = createRecord({
     issue_number: 366,


### PR DESCRIPTION
## Summary
- refresh open issue snapshots for merged tracked PRs when the local record is still `merging`
- preserve the existing merge-time safety gate and let later reconciliation close the issue and mark the record `done`
- add focused regression coverage for the stale open snapshot recovery path

## Testing
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-execution-cleanup.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reconciliation logic to refresh GitHub issue snapshots when merged pull requests have stale local records, ensuring accurate status synchronization.

* **Tests**
  * Added comprehensive test coverage for recovery reconciliation of merged pull requests with open issue states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->