### PR TITLE
Fix stale stabilizing recovery PR context leak

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,40 +1,39 @@
-# Issue #525: Local review abstraction: support fake-runner focused tests for reviewer and verifier orchestration
+# Issue #528: Supervisor bug: issue can stay locked in stabilizing with wrong PR context and no active Codex turn
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/525
-- Branch: codex/issue-525
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/528
+- Branch: codex/issue-528
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: c36827e84d1e2e964fce3b588bde0de8e4c3a27c
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: cc79a0a7cbd8f182d72f4909f1165af4a89c8031
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ851Du7Z|PRRT_kwDORgvdZ851Du7f
-- Repeated failure signature count: 1
-- Updated at: 2026-03-18T05:52:34Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-18T06:07:13.358Z
 
 ## Latest Codex Summary
-Summary: Committed `c36827e` (`Fix fake local-review runner review follow-ups`), pushed `codex/issue-525`, and resolved both CodeRabbit threads on PR #529 after sanitizing the journal links, fixing fake-runner empty-string handling, and adding a regression test.
-State hint: pr_open
-Blocked reason: none
-Tests: `npx tsx --test src/local-review/runner.test.ts src/local-review/execution.test.ts`; `npm run build`
-Failure signature: none
-Next action: Monitor PR #529 for refreshed CI and any additional review feedback.
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the missing leverage point was not product code but test support; focused reviewer/verifier orchestration coverage needed a reusable fake runner that still exercised the real local-review runner parsing path instead of stubbing entire role/verifier functions.
-- What changed: validated the two CodeRabbit review comments, updated `.codex-supervisor/issue-journal.md` to use repo-relative links instead of workstation-local paths, changed `createFakeLocalReviewRunner()` in `src/local-review/test-helpers.ts` to treat empty-string outputs as configured values, added a regression test in `src/local-review/runner.test.ts` that exercises `runRoleReview()` with `rawOutput: ""`, committed the repair as `c36827e` (`Fix fake local-review runner review follow-ups`), pushed `codex/issue-525`, and resolved both review threads on PR #529.
+- Hypothesis: the stabilizing recovery bug comes from two invariant breaks: stale-lock cleanup leaves a stranded `stabilizing` record half-active unless it already has `pr_number=null`, and PR rediscovery/reconciliation accepts a tracked PR number even when that PR belongs to a different issue branch.
+- What changed: added focused regressions in `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-execution-orchestration.test.ts`, and `src/github/github.test.ts`; changed stale active reservation cleanup to auth-check first and then requeue `stabilizing` records when no matching branch PR exists; enforced branch matching in `resolvePullRequestForBranch()` and tracked-merged reconciliation; and cleared stale `pr_number` during issue preparation when branch PR resolution returns null.
 - Current blocker: none
-- Next exact step: monitor PR #529 (`https://github.com/TommyKammy/codex-supervisor/pull/529`) for refreshed CI and any further review feedback.
-- Verification gap: none for the requested focused tests and build; broader suite was not rerun after the targeted verification.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/local-review/runner.test.ts`, `src/local-review/test-helpers.ts`
-- Rollback concern: removing the fake-runner helpers would push focused orchestration tests back toward live CLI dependence or coarse stubs, reducing confidence in reviewer/verifier wiring.
-- Last focused command: `gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId='PRRT_kwDORgvdZ851Du7f'`
+- Next exact step: commit the recovery fix on `codex/issue-528`, then open or update the draft PR with the focused verification results.
+- Verification gap: `npx tsx --test ...` and `npm run build` passed, but I did not rerun the repo-wide `npm test` script because it expands to the full suite and still includes unrelated pre-existing failures in layout/prompt tests outside this issue.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github.test.ts`, `src/github/github.ts`, `src/recovery-reconciliation.ts`, `src/run-once-cycle-prelude.ts`, `src/run-once-issue-preparation.ts`, `src/supervisor/supervisor-execution-orchestration.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor.ts`
+- Rollback concern: reverting the branch-matching guards would allow stale `pr_number` state from another issue branch to mark the current issue done or keep it stuck in `stabilizing` again.
+- Last focused command: `npm run build`
 ### Scratchpad
+- 2026-03-18 (JST): Added a narrow repro in `src/supervisor/supervisor-recovery-reconciliation.test.ts` showing `reconcileStaleActiveIssueReservation()` left stale `stabilizing` records in place instead of requeueing when the reservation locks were gone and no PR was tracked.
+- 2026-03-18 (JST): Added a supervisor dry-run regression in `src/supervisor/supervisor-execution-orchestration.test.ts` showing a stale `stabilizing` record with `pr_number=527` from another issue branch could be reclaimed with wrong PR context unless recovery cleared it first.
+- 2026-03-18 (JST): Added `src/github/github.test.ts` coverage proving `resolvePullRequestForBranch()` must ignore tracked PRs whose `headRefName` does not match the issue branch.
+- 2026-03-18 (JST): Implemented branch-matching guards in `src/github/github.ts` and `src/recovery-reconciliation.ts`, moved auth handling ahead of stale-lock cleanup in `src/run-once-cycle-prelude.ts`, and cleared stale `pr_number` state in `src/run-once-issue-preparation.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`, `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`, `npx tsx --test src/github/github.test.ts`, and `npm run build` passed.
 - 2026-03-18 (JST): Added two narrow repro tests in `src/local-review/execution.test.ts`; initial focused failure was `TypeError: (0 , import_test_helpers.createRoleTurnOutput) is not a function`.
 - 2026-03-18 (JST): Implemented `createFakeLocalReviewRunner()`, `createRoleTurnOutput()`, and `createVerifierTurnOutput()` in `src/local-review/test-helpers.ts`; first pass exposed a shape mismatch (`Cannot read properties of undefined (reading 'match')`) because the helper accepted raw strings but did not normalize them into `{ exitCode, rawOutput }`.
 - 2026-03-18 (JST): Normalized string outputs inside the fake runner helper; `npx tsx --test src/local-review/execution.test.ts`, `npx tsx --test src/local-review/runner.test.ts src/local-review/execution.test.ts`, and `npm run build` then passed.

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -426,3 +426,73 @@ test("GitHubClient createPullRequest falls back to all-state branch lookup after
   assert.equal(allBranchLookups, 1);
   assert.deepEqual(delays, [200, 400]);
 });
+
+test("GitHubClient resolvePullRequestForBranch ignores a tracked PR from another branch", async () => {
+  const config = createConfig();
+  const branch = "codex/issue-355";
+  const latestBranchPr = createPullRequest({
+    number: 360,
+    headRefName: branch,
+    headRefOid: "head-360",
+  });
+  const mismatchedTrackedPr = createPullRequest({
+    number: 527,
+    headRefName: "codex/issue-524",
+    headRefOid: "head-527",
+    state: "MERGED",
+    mergedAt: "2026-03-16T01:30:00Z",
+  });
+
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("open")) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([]),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "pr" && args[1] === "view" && args[2] === "527") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(mismatchedTrackedPr),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("all")) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([latestBranchPr]),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const resolved = await client.resolvePullRequestForBranch(branch, 527);
+
+  assert.equal(resolved?.number, 360);
+  assert.equal(resolved?.headRefName, branch);
+});

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -238,7 +238,7 @@ export class GitHubClient {
 
     if (trackedPrNumber !== null) {
       const trackedPullRequest = await this.getPullRequestIfExists(trackedPrNumber);
-      if (trackedPullRequest) {
+      if (trackedPullRequest && trackedPullRequest.headRefName === branch) {
         return trackedPullRequest;
       }
     }

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -40,6 +40,13 @@ function sanitizeRecoveryReason(reason: string): string {
   return reason.replace(/\r?\n/g, "\\n");
 }
 
+function matchesTrackedBranch(
+  record: Pick<IssueRunRecord, "branch">,
+  pr: Pick<import("./core/types").GitHubPullRequest, "headRefName">,
+): boolean {
+  return pr.headRefName === record.branch;
+}
+
 function doneResetPatch(
   patch: Partial<IssueRunRecord> = {},
 ): Partial<IssueRunRecord> {
@@ -329,6 +336,25 @@ export async function reconcileTrackedMergedButOpenIssues(
     }
 
     const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);
+    if (trackedPullRequest && !matchesTrackedBranch(record, trackedPullRequest)) {
+      if (state.activeIssueNumber === record.issue_number) {
+        continue;
+      }
+
+      const recoveryEvent = buildRecoveryEvent(
+        record.issue_number,
+        `stale_pr_context_cleanup: cleared tracked PR #${trackedPullRequest.number} because it belongs to branch ${trackedPullRequest.headRefName}`,
+      );
+      const updated = stateStore.touch(record, applyRecoveryEvent({
+        pr_number: null,
+        state: record.state === "stabilizing" ? "queued" : record.state,
+      }, recoveryEvent));
+      state.issues[String(record.issue_number)] = updated;
+      changed = true;
+      recoveryEvents.push(recoveryEvent);
+      continue;
+    }
+
     if (!trackedPullRequest || (!trackedPullRequest.mergedAt && trackedPullRequest.state !== "MERGED")) {
       continue;
     }
@@ -643,6 +669,7 @@ export async function reconcileStaleActiveIssueReservation(args: {
   state: SupervisorStateFile;
   issueLockPath: (issueNumber: number) => string;
   sessionLockPath: (sessionId: string) => string;
+  resolvePullRequestForBranch?: (branch: string, trackedPrNumber: number | null) => Promise<import("./core/types").GitHubPullRequest | null>;
 }): Promise<RecoveryEvent[]> {
   const recoveryEvents: RecoveryEvent[] = [];
   if (args.state.activeIssueNumber === null) {
@@ -674,11 +701,21 @@ export async function reconcileStaleActiveIssueReservation(args: {
     missingLockReason = "issue lock and session lock were missing";
   }
 
+  const matchedPullRequest =
+    record.state === "stabilizing" && args.resolvePullRequestForBranch
+      ? await args.resolvePullRequestForBranch(record.branch, record.pr_number)
+      : null;
+  const shouldRequeueStabilizing = record.state === "stabilizing" && matchedPullRequest === null;
+
   const recoveryEvent = buildRecoveryEvent(
     record.issue_number,
-    `stale_state_cleanup: cleared stale active reservation after ${missingLockReason}`,
+    shouldRequeueStabilizing
+      ? `stale_state_cleanup: requeued stabilizing issue #${record.issue_number} after ${missingLockReason}`
+      : `stale_state_cleanup: cleared stale active reservation after ${missingLockReason}`,
   );
   args.state.issues[String(record.issue_number)] = args.stateStore.touch(record, {
+    state: shouldRequeueStabilizing ? "queued" : record.state,
+    pr_number: shouldRequeueStabilizing ? null : record.pr_number,
     codex_session_id: null,
     ...applyRecoveryEvent({}, recoveryEvent),
   });

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -51,7 +51,6 @@ export async function runOnceCyclePrelude(
 ): Promise<RunOnceCyclePreludeResult | RunOnceCyclePreludeAuthFailure> {
   const state = await args.stateStore.load();
   const recoveryEvents: RecoveryEvent[] = [...args.carryoverRecoveryEvents];
-  recoveryEvents.push(...(await args.reconcileStaleActiveIssueReservation(state)));
 
   const authFailure = await args.handleAuthFailure(state);
   if (authFailure) {
@@ -61,6 +60,8 @@ export async function runOnceCyclePrelude(
       recoveryEvents,
     };
   }
+
+  recoveryEvents.push(...(await args.reconcileStaleActiveIssueReservation(state)));
 
   const issues = await args.listAllIssues();
   recoveryEvents.push(...(await args.reconcileTrackedMergedButOpenIssues(state, issues)));

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -219,6 +219,15 @@ async function hydratePullRequestContext(
   let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
   let checks = pr ? await args.github.getChecks(pr.number) : [];
   let reviewThreads = pr ? await args.github.getUnresolvedReviewThreads(pr.number) : [];
+  let record = args.record;
+
+  if (!resolvedPr && record.pr_number !== null) {
+    record = args.stateStore.touch(record, {
+      pr_number: null,
+    });
+    args.state.issues[String(record.issue_number)] = record;
+    await args.stateStore.save(args.state);
+  }
 
   if (!pr) {
     if (!resolvedPr) {
@@ -228,7 +237,7 @@ async function hydratePullRequestContext(
         config: args.config,
         capturedAt: now(),
         issue: args.issue,
-        record: args.record,
+        record,
         workspacePath: args.workspacePath,
         workspaceStatus: nextWorkspaceStatus,
         pr: resolvedPr,
@@ -236,11 +245,11 @@ async function hydratePullRequestContext(
         reviewThreads: [],
       });
       const recoveryEvent = buildRecoveryEvent(
-        args.record.issue_number,
-        `merged_pr_convergence: tracked PR #${resolvedPr.number} merged; marked issue #${args.record.issue_number} done`,
+        record.issue_number,
+        `merged_pr_convergence: tracked PR #${resolvedPr.number} merged; marked issue #${record.issue_number} done`,
         now,
       );
-      const doneRecord = args.stateStore.touch(args.record, {
+      const doneRecord = args.stateStore.touch(record, {
         pr_number: resolvedPr.number,
         state: "done",
         last_head_sha: resolvedPr.headRefOid,
@@ -255,7 +264,7 @@ async function hydratePullRequestContext(
         config: args.config,
         capturedAt: now(),
         issue: args.issue,
-        record: args.record,
+        record,
         workspacePath: args.workspacePath,
         workspaceStatus: nextWorkspaceStatus,
         pr: resolvedPr,
@@ -267,15 +276,15 @@ async function hydratePullRequestContext(
         `PR #${resolvedPr.number} was closed without merge.`,
         ["Manual intervention is required before the supervisor can continue this issue."],
       );
-      const blockedRecord = args.stateStore.touch(args.record, {
+      const blockedRecord = args.stateStore.touch(record, {
         pr_number: resolvedPr.number,
         state: "blocked",
         last_error:
           `PR #${resolvedPr.number} was closed without merge. ` +
-          `Manual intervention is required before issue #${args.record.issue_number} can continue.`,
+          `Manual intervention is required before issue #${record.issue_number} can continue.`,
         last_failure_kind: null,
         last_failure_context: failureContext,
-        ...applyFailureSignature(args.record, failureContext),
+        ...applyFailureSignature(record, failureContext),
         blocked_reason: "manual_pr_closed",
       });
       args.state.issues[String(blockedRecord.issue_number)] = blockedRecord;
@@ -293,7 +302,7 @@ async function hydratePullRequestContext(
     args.record.implementation_attempt_count >= args.config.draftPrAfterAttempt
   ) {
     await pushBranch(args.workspacePath, args.record.branch, nextWorkspaceStatus.remoteBranchExists);
-    pr = await args.github.createPullRequest(args.issue, args.record, { draft: true });
+    pr = await args.github.createPullRequest(args.issue, record, { draft: true });
     checks = await args.github.getChecks(pr.number);
     reviewThreads = await args.github.getUnresolvedReviewThreads(pr.number);
   }
@@ -302,7 +311,7 @@ async function hydratePullRequestContext(
     config: args.config,
     capturedAt: now(),
     issue: args.issue,
-    record: args.record,
+    record,
     workspacePath: args.workspacePath,
     workspaceStatus: nextWorkspaceStatus,
     pr,
@@ -311,7 +320,7 @@ async function hydratePullRequestContext(
   });
 
   return {
-    record: args.record,
+    record,
     pr,
     checks,
     reviewThreads,

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -258,6 +258,95 @@ test("runOnce dry-run selects an issue and hydrates workspace and PR context bef
   assert.equal(reviewThreadCalls, 1);
 });
 
+test("runOnce reclaims a stale stabilizing issue without carrying mismatched tracked PR context", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 91;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "stabilizing",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 527,
+        codex_session_id: "stale-session",
+        implementation_attempt_count: 0,
+        last_codex_summary: "Stale summary mentioning PR #527 from another issue.",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Recover stale stabilizing reservation",
+    body: executionReadyBody("Recover stale stabilizing reservation."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+
+  let resolveCalls = 0;
+  const resolvedPrNumbers: Array<number | null> = [];
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      resolveCalls += 1;
+      resolvedPrNumbers.push(prNumber);
+      assert.equal(branchName, branch);
+      return null;
+    },
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => ({
+      number: 527,
+      title: "Merged PR for another issue",
+      url: "https://example.test/pr/527",
+      state: "MERGED",
+      createdAt: "2026-03-13T00:10:00Z",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      headRefName: "codex/issue-524",
+      headRefOid: "wrong-head-527",
+      mergedAt: "2026-03-13T00:20:00Z",
+    }),
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(
+    message,
+    /recovery issue=#91 reason=stale_state_cleanup: requeued stabilizing issue #91 after issue lock and session lock were missing/,
+  );
+  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(persisted.activeIssueNumber, issueNumber);
+  assert.equal(record.state, "reproducing");
+  assert.equal(record.pr_number, null);
+  assert.equal(record.codex_session_id, null);
+  assert.equal(record.last_codex_summary, "Stale summary mentioning PR #527 from another issue.");
+  assert.equal(resolveCalls, 2);
+  assert.deepEqual(resolvedPrNumbers, [527, null]);
+});
+
 test("runOnce returns no matching issue when no runnable candidate is available", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -224,6 +224,54 @@ test("reconcileStaleActiveIssueReservation clears a stale reservation and emits 
   );
 });
 
+test("reconcileStaleActiveIssueReservation requeues a stale stabilizing issue without a tracked PR", async () => {
+  const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 366,
+    issues: {
+      "366": createRecord({
+        issue_number: 366,
+        state: "stabilizing",
+        pr_number: null,
+        codex_session_id: "session-366",
+        implementation_attempt_count: 0,
+      }),
+    },
+  };
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...record,
+        ...patch,
+        updated_at: "2026-03-11T06:33:08.821Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleActiveIssueReservation({
+    stateStore,
+    state,
+    issueLockPath: (issueNumber) => path.join(lockRoot, "locks", "issues", String(issueNumber)),
+    sessionLockPath: (sessionId) => path.join(lockRoot, "locks", "sessions", String(sessionId)),
+  });
+
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["366"]?.state, "queued");
+  assert.equal(state.issues["366"]?.pr_number, null);
+  assert.equal(state.issues["366"]?.codex_session_id, null);
+  assert.equal(saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+  assert.match(
+    formatRecoveryLog(recoveryEvents) ?? "",
+    /recovery issue=#366 reason=stale_state_cleanup: requeued stabilizing issue #366 after issue lock and session lock were missing/,
+  );
+});
+
 test("reconcileMergedIssueClosures clears a stale active issue pointer even when the record already matches the done patch", async () => {
   const original = createRecord({
     issue_number: 366,

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -674,6 +674,8 @@ export class Supervisor {
         state,
         issueLockPath: (issueNumber) => this.lockPath("issues", `issue-${issueNumber}`),
         sessionLockPath: (sessionId) => this.lockPath("sessions", `session-${sessionId}`),
+        resolvePullRequestForBranch: (branch, trackedPrNumber) =>
+          this.github.resolvePullRequestForBranch(branch, trackedPrNumber),
       }),
       handleAuthFailure: (state) => handleAuthFailure(this.github, this.stateStore, state),
       listAllIssues: () => this.github.listAllIssues(),


### PR DESCRIPTION
## Summary
- requeue stale stabilizing reservations when no branch-matching PR exists
- reject tracked PR context from other issue branches during recovery and PR resolution
- clear stale `pr_number` state during issue preparation and cover the regression paths

## Testing
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
- npx tsx --test src/github/github.test.ts
- npm run build

Closes #528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale pull request context handling when branch information becomes mismatched.
  * Improved state cleanup to clear outdated PR references during recovery.

* **Tests**
  * Added comprehensive test coverage for pull request resolution and recovery scenarios.
  * Added validation for branch-specific pull request matching and stale state requeuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->