### PR TITLE
Replay corpus promotion: add a dedicated CLI entry path (#556)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,40 +1,36 @@
-# Issue #554: Recovery visibility: reuse recorded recovery reasons in explain diagnostics
+# Issue #556: Replay corpus promotion: add a dedicated CLI entry path
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/554
-- Branch: codex/issue-554
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/556
+- Branch: codex/issue-556
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 2aee74ceb319c2dc23b4690a9d80d80073571dc8
+- Last head SHA: 31cf0220c064207a30787f287afc47150b89e77a
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-18T15:32:14.651Z
+- Updated at: 2026-03-18T15:51:26.098Z
 
 ## Latest Codex Summary
-- None yet.
+- Added a dedicated `replay-corpus-promote` CLI entry that promotes a captured replay snapshot into a canonical corpus case via the existing promotion path.
+- Added focused parser and end-to-end CLI coverage for the new entry path and verified the promoted case replays cleanly.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `explain` already knew when a tracked issue was in a resumed lifecycle state, but it only surfaced generic selection text like `retry_state=resume:reproducing` and never reused the persisted `last_recovery_reason` / `last_recovery_at` story that status already formats.
-- What changed: added a focused explain regression for a recovered tracked PR issue in `reproducing`, then updated `buildIssueExplainSummary(...)` to reuse `formatLatestRecoveryStatusLine(...)` so explain emits the same compact `latest_recovery ... reason=<code> detail=<stored explanation>` line as status.
+- Hypothesis: replay-corpus promotion was already implemented in `promoteCapturedReplaySnapshot(...)`, but there was no dedicated CLI command to invoke it directly, so operators had no supported entry path.
+- What changed: added a focused CLI repro in `src/index.test.ts` for a dedicated promotion command, then implemented `replay-corpus-promote <snapshotPath> <caseId> [corpusPath]` in `parseArgs(...)` and `main()` to call `promoteCapturedReplaySnapshot(...)`.
 - Current blocker: none
-- Next exact step: monitor draft PR #578 and respond to review or CI feedback.
-- Verification gap: broader full-suite verification has not been run.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/supervisor/supervisor-selection-status.ts`
-- Rollback concern: removing the shared recovery formatter from explain would drop the canonical persisted recovery story and regress resumed tracked-PR explanations back to generic lifecycle text.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm install`; `npm run build`
+- Next exact step: commit the verified CLI promotion change set, then open or update a draft PR for issue #556.
+- Verification gap: broader full-suite verification has not been run beyond the focused CLI/replay tests and `npm run build`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/core/types.ts`, `src/index.ts`, `src/index.test.ts`
+- Rollback concern: removing `replay-corpus-promote` from the CLI would restore the previous gap where captured replay snapshots could only be promoted through internal-only code paths.
+- Last focused command: `npx tsx --test src/index.test.ts src/supervisor/replay-corpus.test.ts`; `npm install`; `npm run build`
 ### Scratchpad
-- 2026-03-19 (JST): Pushed `codex/issue-554` and opened draft PR #578 for the explain recovery diagnostic reuse change.
-- 2026-03-19 (JST): Added a focused repro in `src/supervisor/supervisor-diagnostics-explain.test.ts` for a tracked PR issue resumed into `reproducing`; the initial failure was missing `latest_recovery ...` output and only showed `selection_reason=... retry_state=resume:reproducing`. Reused `formatLatestRecoveryStatusLine(...)` in `src/supervisor/supervisor-selection-status.ts`, reran the focused explain + recovery tests, restored local dependencies with `npm install`, and reran `npm run build` successfully.
-- 2026-03-19 (JST): Pushed `codex/issue-553` and opened draft PR #570 for the compact latest-recovery status rendering change.
-- 2026-03-19 (JST): Added a focused repro in `src/supervisor/supervisor-status-rendering.test.ts` for an active recovered record whose `last_recovery_reason` was rendered as a raw `tracked_pr_head_advanced: ...` string; implemented compact `reason=` / `detail=` status rendering via `formatLatestRecoveryStatusLine(...)`; reran focused status + recovery tests and `npm run build` after restoring local dependencies with `npm install`.
-- 2026-03-18 (JST): Reran the focused recovery/lifecycle tests and `npm run build`, pushed `codex/issue-552`, and opened draft PR #569.
-- 2026-03-18 (JST): Added a narrow repro in `src/supervisor/supervisor-recovery-reconciliation.test.ts` for a failed record with `repeated_failure_signature_count=3` that resumes after tracked PR `#191` advances from `head-old-191` to `head-new-191`; the initial focused failure was `last_recovery_reason === null`.
-- 2026-03-18 (JST): Implemented deterministic tracked-PR resume recovery reasons in `src/recovery-reconciliation.ts`, distinguishing head-advance resumptions from same-head fresh-facts resumptions, and persisted them with `applyRecoveryEvent(...)`.
-- 2026-03-18 (JST): `npm run build` initially failed with `sh: 1: tsc: not found`; ran `npm install` to restore the local toolchain, then reran focused tests and the build successfully.
+- 2026-03-19 (JST): Added focused parser coverage for `replay-corpus-promote` plus an end-to-end CLI promotion regression in `src/index.test.ts`; the initial missing behavior was that the CLI had no dedicated promotion entry path at all.
+- 2026-03-19 (JST): Implemented `replay-corpus-promote` in `src/index.ts` and extended `CliOptions` in `src/core/types.ts` with explicit `caseId` support; the new CLI path uses the existing `promoteCapturedReplaySnapshot(...)` implementation and defaults `corpusPath` to checked-in `replay-corpus`.
+- 2026-03-19 (JST): Focused verification passed with `npx tsx --test src/index.test.ts src/supervisor/replay-corpus.test.ts`; `npm run build` first failed because `tsc` was missing locally, so ran `npm install` and reran `npm run build` successfully.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -301,11 +301,12 @@ export interface CodexTurnResult {
 }
 
 export interface CliOptions {
-  command: "run-once" | "loop" | "status" | "explain" | "doctor" | "replay" | "replay-corpus";
+  command: "run-once" | "loop" | "status" | "explain" | "doctor" | "replay" | "replay-corpus" | "replay-corpus-promote";
   configPath?: string;
   dryRun: boolean;
   why: boolean;
   issueNumber?: number;
   snapshotPath?: string;
+  caseId?: string;
   corpusPath?: string;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,6 +38,7 @@ test("parseArgs accepts doctor as a command", () => {
     why: false,
     issueNumber: undefined,
     snapshotPath: undefined,
+    caseId: undefined,
     corpusPath: undefined,
   });
 });
@@ -50,6 +51,7 @@ test("parseArgs accepts replay with a snapshot path", () => {
     why: false,
     issueNumber: undefined,
     snapshotPath: "/tmp/decision-cycle-snapshot.json",
+    caseId: undefined,
     corpusPath: undefined,
   });
 });
@@ -62,6 +64,7 @@ test("parseArgs accepts replay-corpus with an explicit corpus root", () => {
     why: false,
     issueNumber: undefined,
     snapshotPath: undefined,
+    caseId: undefined,
     corpusPath: "/tmp/replay-corpus",
   });
 });
@@ -74,6 +77,42 @@ test("parseArgs defaults replay-corpus to the checked-in corpus path", () => {
     why: false,
     issueNumber: undefined,
     snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: "replay-corpus",
+  });
+});
+
+test("parseArgs accepts replay-corpus-promote with explicit snapshot, case id, and corpus root", () => {
+  assert.deepEqual(parseArgs([
+    "replay-corpus-promote",
+    "/tmp/decision-cycle-snapshot.json",
+    "issue-408-reproducing",
+    "/tmp/replay-corpus",
+  ]), {
+    command: "replay-corpus-promote",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    snapshotPath: "/tmp/decision-cycle-snapshot.json",
+    caseId: "issue-408-reproducing",
+    corpusPath: "/tmp/replay-corpus",
+  });
+});
+
+test("parseArgs defaults replay-corpus-promote to the checked-in corpus path", () => {
+  assert.deepEqual(parseArgs([
+    "replay-corpus-promote",
+    "/tmp/decision-cycle-snapshot.json",
+    "issue-408-reproducing",
+  ]), {
+    command: "replay-corpus-promote",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    snapshotPath: "/tmp/decision-cycle-snapshot.json",
+    caseId: "issue-408-reproducing",
     corpusPath: "replay-corpus",
   });
 });
@@ -186,6 +225,195 @@ test("replay re-runs a saved snapshot through the CLI entry path", async () => {
   assert.equal(result.status, 0);
   assert.match(result.stdout, /replayed_next_state=reproducing/);
   assert.match(result.stdout, /decision_match=yes/);
+});
+
+test("replay-corpus-promote promotes a captured snapshot through the dedicated CLI entry path", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "replay-corpus-cli-promote-"));
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  const corpusPath = path.join(tempDir, "replay-corpus");
+  const snapshotPath = path.join(tempDir, "captured-snapshot.json");
+
+  await fs.writeFile(configPath, JSON.stringify({
+    repoPath: tempDir,
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: path.join(tempDir, "workspaces"),
+    stateBackend: "json",
+    stateFile: path.join(tempDir, "state.json"),
+    codexBinary: "/usr/bin/codex",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    branchPrefix: "codex/issue-",
+  }));
+  await fs.mkdir(path.join(corpusPath, "cases", "review-blocked", "input"), { recursive: true });
+  await fs.mkdir(path.join(corpusPath, "cases", "review-blocked", "expected"), { recursive: true });
+  await fs.writeFile(path.join(corpusPath, "manifest.json"), JSON.stringify({
+    schemaVersion: 1,
+    cases: [{ id: "review-blocked", path: "cases/review-blocked" }],
+  }));
+
+  const existingSnapshot = {
+    schemaVersion: 1,
+    capturedAt: "2026-03-16T10:07:00Z",
+    issue: {
+      number: 408,
+      title: "Replay debugging snapshot",
+      url: "https://example.test/issues/408",
+      state: "OPEN",
+      updatedAt: "2026-03-16T10:05:00Z",
+    },
+    local: {
+      record: {
+        issue_number: 408,
+        state: "reproducing",
+        branch: "codex/issue-408",
+        pr_number: null,
+        workspace: path.join(tempDir, "workspaces", "issue-408"),
+        journal_path: path.join(tempDir, "workspaces", "issue-408", ".codex-supervisor", "issue-journal.md"),
+        attempt_count: 0,
+        implementation_attempt_count: 0,
+        repair_attempt_count: 0,
+        timeout_retry_count: 0,
+        blocked_verification_retry_count: 0,
+        repeated_blocker_count: 0,
+        repeated_failure_signature_count: 0,
+        blocked_reason: null,
+        last_error: null,
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        last_head_sha: "head-408",
+        review_wait_started_at: null,
+        review_wait_head_sha: null,
+        copilot_review_requested_observed_at: null,
+        copilot_review_requested_head_sha: null,
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+        local_review_head_sha: null,
+        local_review_blocker_summary: null,
+        local_review_summary_path: null,
+        local_review_run_at: null,
+        local_review_max_severity: null,
+        local_review_findings_count: 0,
+        local_review_root_cause_count: 0,
+        local_review_verified_max_severity: null,
+        local_review_verified_findings_count: 0,
+        local_review_recommendation: null,
+        local_review_degraded: false,
+        last_local_review_signature: null,
+        repeated_local_review_signature_count: 0,
+        processed_review_thread_ids: [],
+        processed_review_thread_fingerprints: [],
+        updated_at: "2026-03-16T10:05:00Z",
+      },
+      workspaceStatus: {
+        branch: "codex/issue-408",
+        headSha: "head-408",
+        hasUncommittedChanges: false,
+        baseAhead: 0,
+        baseBehind: 0,
+        remoteBranchExists: false,
+        remoteAhead: 0,
+        remoteBehind: 0,
+      },
+    },
+    github: {
+      pullRequest: null,
+      checks: [],
+      reviewThreads: [],
+    },
+    decision: {
+      nextState: "reproducing",
+      shouldRunCodex: true,
+      blockedReason: null,
+      failureContext: null,
+    },
+  };
+  const promotedSnapshot = {
+    ...existingSnapshot,
+    capturedAt: "2026-03-18T08:59:03.959Z",
+    issue: {
+      ...existingSnapshot.issue,
+      number: 534,
+      title: "Replay corpus promotion through the CLI entry path",
+      url: "https://example.test/issues/534",
+      updatedAt: "2026-03-18T07:27:52Z",
+    },
+    local: {
+      record: {
+        ...existingSnapshot.local.record,
+        issue_number: 534,
+        state: "planning",
+        branch: "codex/issue-534",
+        workspace: "/home/tommy/Dev/codex-supervisor-self-worktrees/issue-534",
+        journal_path: "/home/tommy/Dev/codex-supervisor-self-worktrees/issue-534/.codex-supervisor/issue-journal.md",
+        local_review_summary_path: "/tmp/reviews/promoted-summary.md",
+        last_head_sha: "head-534",
+        updated_at: "2026-03-18T08:59:03.090Z",
+      },
+      workspaceStatus: {
+        branch: "codex/issue-534",
+        headSha: "head-534",
+        hasUncommittedChanges: true,
+        baseAhead: 0,
+        baseBehind: 0,
+        remoteBranchExists: false,
+        remoteAhead: 0,
+        remoteBehind: 0,
+      },
+    },
+  };
+
+  await fs.writeFile(path.join(corpusPath, "cases", "review-blocked", "case.json"), JSON.stringify({
+    schemaVersion: 1,
+    id: "review-blocked",
+    issueNumber: existingSnapshot.issue.number,
+    title: existingSnapshot.issue.title,
+    capturedAt: existingSnapshot.capturedAt,
+  }));
+  await fs.writeFile(path.join(corpusPath, "cases", "review-blocked", "input", "snapshot.json"), JSON.stringify(existingSnapshot));
+  await fs.writeFile(path.join(corpusPath, "cases", "review-blocked", "expected", "replay-result.json"), JSON.stringify({
+    nextState: existingSnapshot.decision.nextState,
+    shouldRunCodex: existingSnapshot.decision.shouldRunCodex,
+    blockedReason: existingSnapshot.decision.blockedReason,
+    failureSignature: null,
+  }));
+  await fs.writeFile(snapshotPath, JSON.stringify(promotedSnapshot));
+
+  const result = runCli([
+    "replay-corpus-promote",
+    snapshotPath,
+    "issue-534-reproducing",
+    corpusPath,
+    "--config",
+    configPath,
+  ]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Promoted replay corpus case "issue-534-reproducing" for issue #534\./);
+
+  const promotedCase = JSON.parse(
+    await fs.readFile(path.join(corpusPath, "cases", "issue-534-reproducing", "case.json"), "utf8"),
+  );
+  assert.deepEqual(promotedCase, {
+    schemaVersion: 1,
+    id: "issue-534-reproducing",
+    issueNumber: 534,
+    title: "Replay corpus promotion through the CLI entry path",
+    capturedAt: "2026-03-18T08:59:03.959Z",
+  });
+
+  const promotedInput = JSON.parse(
+    await fs.readFile(path.join(corpusPath, "cases", "issue-534-reproducing", "input", "snapshot.json"), "utf8"),
+  );
+  assert.equal(promotedInput.local.record.workspace, ".");
+  assert.equal(promotedInput.local.record.journal_path, ".codex-supervisor/issue-journal.md");
+  assert.equal(promotedInput.local.record.local_review_summary_path, null);
+  assert.equal(promotedInput.local.workspaceStatus.hasUncommittedChanges, false);
+
+  const replayResult = runCli(["replay-corpus", corpusPath, "--config", configPath]);
+  assert.equal(replayResult.status, 0);
+  assert.match(replayResult.stdout, /Replay corpus summary: total=2 passed=2 failed=0/);
 });
 
 test("replay-corpus prints a compact all-pass summary", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   createCheckedInReplayCorpusConfig,
   formatReplayCorpusRunSummary,
+  promoteCapturedReplaySnapshot,
   runReplayCorpus,
   syncReplayCorpusMismatchDetailsArtifact,
 } from "./supervisor/replay-corpus";
@@ -24,6 +25,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let why = false;
   let issueNumber: number | undefined;
   let snapshotPath: string | undefined;
+  let caseId: string | undefined;
   let corpusPath: string | undefined;
 
   while (args.length > 0) {
@@ -39,7 +41,8 @@ export function parseArgs(argv: string[]): CliOptions {
       token === "explain" ||
       token === "doctor" ||
       token === "replay" ||
-      token === "replay-corpus"
+      token === "replay-corpus" ||
+      token === "replay-corpus-promote"
     ) {
       if (commandSeen) {
         throw new Error(`Unexpected second command: ${token}`);
@@ -76,6 +79,23 @@ export function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (command === "replay-corpus-promote") {
+      if (snapshotPath === undefined) {
+        snapshotPath = token;
+        continue;
+      }
+
+      if (caseId === undefined) {
+        caseId = token;
+        continue;
+      }
+
+      if (corpusPath === undefined) {
+        corpusPath = token;
+        continue;
+      }
+    }
+
     if (command === "replay-corpus" && corpusPath === undefined) {
       corpusPath = token;
       continue;
@@ -96,6 +116,14 @@ export function parseArgs(argv: string[]): CliOptions {
     throw new Error("The replay command requires one snapshot path.");
   }
 
+  if (command === "replay-corpus-promote" && snapshotPath === undefined) {
+    throw new Error("The replay-corpus-promote command requires one snapshot path.");
+  }
+
+  if (command === "replay-corpus-promote" && caseId === undefined) {
+    throw new Error("The replay-corpus-promote command requires one case id.");
+  }
+
   return {
     command,
     configPath,
@@ -103,7 +131,11 @@ export function parseArgs(argv: string[]): CliOptions {
     why,
     issueNumber,
     snapshotPath,
-    corpusPath: command === "replay-corpus" ? (corpusPath ?? "replay-corpus") : undefined,
+    caseId,
+    corpusPath:
+      command === "replay-corpus" || command === "replay-corpus-promote"
+        ? (corpusPath ?? "replay-corpus")
+        : undefined,
   };
 }
 
@@ -153,6 +185,21 @@ async function main(): Promise<void> {
     }
 
     console.log(summary);
+    return;
+  }
+
+  if (options.command === "replay-corpus-promote") {
+    const config =
+      options.configPath === undefined && options.corpusPath === "replay-corpus"
+        ? createCheckedInReplayCorpusConfig(process.cwd())
+        : loadConfig(options.configPath);
+    const promoted = await promoteCapturedReplaySnapshot({
+      corpusRoot: options.corpusPath!,
+      snapshotPath: options.snapshotPath!,
+      caseId: options.caseId!,
+      config,
+    });
+    console.log(`Promoted replay corpus case "${promoted.id}" for issue #${promoted.metadata.issueNumber}.`);
     return;
   }
 


### PR DESCRIPTION
Closes #556
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a dedicated `replay-corpus-promote` CLI command and wired it to the existing promotion path in [src/index.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-556/src/index.ts) with explicit `snapshotPath`, `caseId`, and optional `corpusPath` inputs. `CliOptions` now carries `caseId` in [src/core/types.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-556/src/core/types.ts), and focused parser plus end-to-end CLI promotion coverage is in [src/index.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-556/src/index.test.ts). The CLI test proves the promoted case is normalized and then replays cleanly through the existing corpus runner.

I updated the issue notes in [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-556/.codex-supervisor/issue-journal.md) and created checkpoint commit `bbf4f46` (`Add replay corpus promotion CLI entry`). Local verification passed after restoring missing toolchain deps with `npm install`.

Summary: Added `replay-corpus-promote` CLI entry, covered it with focused parser and end-to-end CLI tests, updated the journal, and committed the change as `bbf4f46`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/index.test.ts src/supervisor/replay-corpus.test.ts`; `npm install`; `npm run build`
Failure signature: none
Next action: open or update a draft PR for issue #556 and monitor for review/CI feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `replay-corpus-promote` CLI command to promote captured replay snapshots into the canonical corpus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->