### PR TITLE
Replay corpus promotion: print a compact reviewable summary after promotion (#558)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,48 +1,36 @@
-# Issue #557: Replay corpus promotion: suggest normalized case ids during promotion
+# Issue #558: Replay corpus promotion: print a compact reviewable summary after promotion
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/557
-- Branch: codex/issue-557
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/558
+- Branch: codex/issue-558
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 55b2ad0d629944c3db02cbd10979df204cdb5e50
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: e6ae5c1e2e3e6c2cd894fbf97f9878e90e2e8e23
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ851N_xt
-- Repeated failure signature count: 1
-- Updated at: 2026-03-18T16:23:32.718Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-18T16:42:16.441Z
 
 ## Latest Codex Summary
-Implemented deterministic replay corpus case-id suggestions and surfaced them in the CLI when `replay-corpus-promote` is run without an explicit `caseId`. The promotion write path still requires an explicit operator-chosen id; the new behavior prints normalized suggestions such as `issue-557-reproducing` and a title-based fallback instead of failing before showing any guidance.
-
-Focused coverage was added in [src/supervisor/replay-corpus.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-557/src/supervisor/replay-corpus.test.ts) and [src/index.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-557/src/index.test.ts), with implementation in [src/supervisor/replay-corpus.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-557/src/supervisor/replay-corpus.ts) and [src/index.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-557/src/index.ts). I updated the issue journal, committed the change as `55b2ad0` (`Suggest replay corpus case ids during promotion`), pushed `codex/issue-557`, and opened draft PR #580: https://github.com/TommyKammy/codex-supervisor/pull/580
-
-Summary: Added deterministic replay corpus case-id suggestions, exposed them through `replay-corpus-promote` when `caseId` is omitted, verified with focused tests and `npm run build`, and opened draft PR #580.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/index.test.ts src/supervisor/replay-corpus.test.ts`; `npm install`; `npm run build`
-Failure signature: none
-Next action: Monitor PR #580 CI/results and address any review or verification failures.
+- Added compact replay-corpus promotion summary output to the CLI: successful promotion now prints the created case path, compact normalized expected outcome, and volatile-field normalization notes when the promotion rewrites those fields.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/580#discussion_r2954659260
-- Details:
-  - src/index.ts:205 _⚠️ Potential issue_ | _🟡 Minor_ **Guard suggestion derivation for malformed snapshots.** This path assumes `issue.number` and `decision.nextState` exist. If a snapshot passes schema-version parsing but is structurally incomplete, `suggestReplayCorpusCaseIds` can throw and skip this friendly guidance path. <details> <summary>💡 Suggested defensive handling</summary> ```diff if (options.caseId === undefined) { const snapshot = await loadSupervisorCycleDecisionSnapshot(options.snapshotPath!); - const suggestions = suggestReplayCorpusCaseIds(snapshot); + let suggestions: string[] = []; + try { + suggestions = suggestReplayCorpusCaseIds(snapshot); + } catch { + console.error("Unable to derive case-id suggestions from the snapshot. Provide an explicit case id."); + } console.error("The replay-corpus-promote command requires an explicit case id to write a new case."); if (suggestions.length > 0) { console.error("Suggested case ids:"); for (const suggestion of suggestions) { console.error(`- ${suggestion}`); ``` </details> <!-- suggestion_start --> <details> <summary>📝 Committable suggestion</summary> > ‼️ **IMPORTANT** > Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements. ```suggestion if (options.caseId === undefined) { const snapshot = await loadSupervisorCycleDecisionSnapshot(options.snapshotPath!); let suggestions: string[] = []; try { suggestions = suggestReplayCorpusCaseIds(snapshot); } catch { console.error("Unable to derive case-id suggestions from the snapshot. Provide an explicit case id."); } console.error("The replay-corpus-promote command requires an explicit case id to write a new case."); if (suggestions.length > 0) { console.error("Suggested case ids:"); for (const suggestion of suggestions) { console.error(`- ${suggestion}`); } } process.exitCode = 1; return; } ``` </details> <!-- suggestion_end --> <details> <summary>🤖 Prompt for AI Agents</summary> ``` Verify each finding against the current code and only fix it if needed. In `@src/index.ts` around lines 193 - 205, The code currently assumes loadSupervisorCycleDecisionSnapshot(options.snapshotPath!) returns a well-formed snapshot and that suggestReplayCorpusCaseIds(snapshot) will not throw; wrap the suggestion derivation in a defensive block: call loadSupervisorCycleDecisionSnapshot and then guard the snapshot shape (or catch exceptions) before calling suggestReplayCorpusCaseIds, and if anything fails just log the main error message and skip printing suggestions (or log a single “could not derive suggestions” message) rather than allowing an exception to propagate; update the block around options.caseId, loadSupervisorCycleDecisionSnapshot, and suggestReplayCorpusCaseIds to use try/catch and null/shape checks so malformed snapshots don’t crash this friendly guidance path. ``` </details> <!-- fingerprinting:phantom:poseidon:hawk --> <!-- This is an auto-generated comment by CodeRabbit -->
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: CodeRabbit's malformed-snapshot review finding is valid because the missing-case-id CLI guidance path loaded a schema-version-valid snapshot and then called `suggestReplayCorpusCaseIds(...)` without guarding missing `issue`/`decision` fields.
-- What changed: wrapped `suggestReplayCorpusCaseIds(...)` in a defensive `try/catch` in `src/index.ts` so malformed snapshots still print the explicit-case-id guidance without crashing; added a focused CLI regression in `src/index.test.ts` that omits `decision` from the snapshot payload and verifies the fallback stderr path.
+- Hypothesis: The remaining gap for issue #558 was that `replay-corpus-promote` completed successfully but only printed a one-line success banner, so operators still had to open files manually to review the created case and normalized expected outcome.
+- What changed: tightened the existing CLI promotion regression in `src/index.test.ts` to require `Case path`, `Expected outcome`, and `Normalization` lines; added `summarizeReplayCorpusPromotion(...)` plus an exported compact outcome formatter in `src/supervisor/replay-corpus.ts`; updated `src/index.ts` to print the compact promotion summary after a successful promotion.
 - Current blocker: none
-- Next exact step: commit this review repair, push `codex/issue-557`, and resolve the CodeRabbit thread on PR #580.
-- Verification gap: broader full-suite verification has still not been run; this repair was checked with `npx tsx --test src/index.test.ts` and `npm run build`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/index.ts`, `src/index.test.ts`
-- Rollback concern: removing the defensive catch would reintroduce a crash in the operator-guidance-only path for snapshots that parse but omit required nested fields.
-- Last focused command: `npx tsx --test src/index.test.ts`; `npm run build`
+- Next exact step: commit this promotion-summary checkpoint on `codex/issue-558`, then decide whether to open/update the draft PR for the branch.
+- Verification gap: no broader full-suite run yet; this slice was verified with focused CLI and replay-corpus tests plus `npm run build`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/index.ts`, `src/index.test.ts`, `src/supervisor/replay-corpus.ts`
+- Rollback concern: removing the new summary logic would regress operators back to the prior one-line success message, and broadening the normalization notes beyond changed fields would add noise to the review output.
+- Last focused command: `npx tsx --test src/index.test.ts`; `npx tsx --test src/supervisor/replay-corpus.test.ts`; `npm run build`
 ### Scratchpad
+- 2026-03-19 (JST): Reproduced issue #558 with a tightened CLI promotion regression that failed because stdout only contained `Promoted replay corpus case ...`; fixed it by printing case path, compact expected outcome, and conditional volatile-field normalization notes after promotion. Focused verification passed with `npx tsx --test src/index.test.ts`, `npx tsx --test src/supervisor/replay-corpus.test.ts`, and `npm run build` after restoring local dev dependencies via `npm install`.
 - 2026-03-19 (JST): Addressed CodeRabbit thread `PRRT_kwDORgvdZ851N_xt` by guarding replay corpus case-id suggestion derivation in `src/index.ts`; focused verification passed with `npx tsx --test src/index.test.ts` and `npm run build`.
 - 2026-03-19 (JST): Added focused parser coverage for `replay-corpus-promote` plus an end-to-end CLI promotion regression in `src/index.test.ts`; the initial missing behavior was that the CLI had no dedicated promotion entry path at all.
 - 2026-03-19 (JST): Implemented `replay-corpus-promote` in `src/index.ts` and extended `CliOptions` in `src/core/types.ts` with explicit `caseId` support; the new CLI path uses the existing `promoteCapturedReplaySnapshot(...)` implementation and defaults `corpusPath` to checked-in `replay-corpus`.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -407,6 +407,18 @@ test("replay-corpus-promote promotes a captured snapshot through the dedicated C
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Promoted replay corpus case "issue-534-reproducing" for issue #534\./);
+  assert.match(
+    result.stdout,
+    new RegExp(`Case path: ${escapeRegExp(path.join(corpusPath, "cases", "issue-534-reproducing"))}`),
+  );
+  assert.match(
+    result.stdout,
+    /Expected outcome: nextState=reproducing, shouldRunCodex=true, blockedReason=none, failureSignature=none/,
+  );
+  assert.match(
+    result.stdout,
+    /Normalization: workspace=>\., journal_path=>\.codex-supervisor\/issue-journal\.md, local_review_summary_path=>none, hasUncommittedChanges=>false/,
+  );
 
   const promotedCase = JSON.parse(
     await fs.readFile(path.join(corpusPath, "cases", "issue-534-reproducing", "case.json"), "utf8"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "./supervisor/supervisor-cycle-replay";
 import {
   createCheckedInReplayCorpusConfig,
+  summarizeReplayCorpusPromotion,
   formatReplayCorpusRunSummary,
   promoteCapturedReplaySnapshot,
   runReplayCorpus,
@@ -208,13 +209,20 @@ async function main(): Promise<void> {
       process.exitCode = 1;
       return;
     }
+    const sourceSnapshot = await loadSupervisorCycleDecisionSnapshot(options.snapshotPath!);
     const promoted = await promoteCapturedReplaySnapshot({
       corpusRoot: options.corpusPath!,
       snapshotPath: options.snapshotPath!,
       caseId: options.caseId!,
       config,
     });
+    const summary = summarizeReplayCorpusPromotion(sourceSnapshot, promoted);
     console.log(`Promoted replay corpus case "${promoted.id}" for issue #${promoted.metadata.issueNumber}.`);
+    console.log(`Case path: ${summary.casePath}`);
+    console.log(`Expected outcome: ${summary.expectedOutcome}`);
+    if (summary.normalizationNotes.length > 0) {
+      console.log(`Normalization: ${summary.normalizationNotes.join(", ")}`);
+    }
     return;
   }
 

--- a/src/supervisor/replay-corpus.ts
+++ b/src/supervisor/replay-corpus.ts
@@ -140,6 +140,12 @@ export interface ReplayCorpusSummaryLine {
   actual: ReplayCorpusNormalizedOutcome;
 }
 
+export interface ReplayCorpusPromotionSummary {
+  casePath: string;
+  expectedOutcome: string;
+  normalizationNotes: string[];
+}
+
 export interface PromoteCapturedReplaySnapshotArgs {
   corpusRoot: string;
   snapshotPath: string;
@@ -940,6 +946,41 @@ function normalizeReplayResult(
   };
 }
 
+function formatPromotionNoteValue(value: string | boolean | null): string {
+  return value === null ? "none" : String(value);
+}
+
+export function summarizeReplayCorpusPromotion(
+  sourceSnapshot: ReplayCorpusInputSnapshot,
+  promotedCase: ReplayCorpusCaseBundle,
+): ReplayCorpusPromotionSummary {
+  const normalizationNotes: string[] = [];
+  const normalizedSnapshot = promotedCase.input.snapshot;
+
+  if (sourceSnapshot.local.record.workspace !== normalizedSnapshot.local.record.workspace) {
+    normalizationNotes.push(`workspace=>${formatPromotionNoteValue(normalizedSnapshot.local.record.workspace)}`);
+  }
+  if (sourceSnapshot.local.record.journal_path !== normalizedSnapshot.local.record.journal_path) {
+    normalizationNotes.push(`journal_path=>${formatPromotionNoteValue(normalizedSnapshot.local.record.journal_path)}`);
+  }
+  if (sourceSnapshot.local.record.local_review_summary_path !== normalizedSnapshot.local.record.local_review_summary_path) {
+    normalizationNotes.push(
+      `local_review_summary_path=>${formatPromotionNoteValue(normalizedSnapshot.local.record.local_review_summary_path)}`,
+    );
+  }
+  if (sourceSnapshot.local.workspaceStatus.hasUncommittedChanges !== normalizedSnapshot.local.workspaceStatus.hasUncommittedChanges) {
+    normalizationNotes.push(
+      `hasUncommittedChanges=>${formatPromotionNoteValue(normalizedSnapshot.local.workspaceStatus.hasUncommittedChanges)}`,
+    );
+  }
+
+  return {
+    casePath: promotedCase.bundlePath,
+    expectedOutcome: formatReplayCorpusCompactOutcome(promotedCase.expected),
+    normalizationNotes,
+  };
+}
+
 function replayCorpusMismatchDetailsArtifactPath(config: SupervisorConfig): string {
   return path.join(config.repoPath, ".codex-supervisor", "replay", "replay-corpus-mismatch-details.json");
 }
@@ -994,7 +1035,7 @@ export function formatReplayCorpusOutcomeMismatch(result: ReplayCorpusCaseResult
   ].join("\n");
 }
 
-function formatCompactOutcome(outcome: ReplayCorpusNormalizedOutcome): string {
+export function formatReplayCorpusCompactOutcome(outcome: ReplayCorpusNormalizedOutcome): string {
   return [
     `nextState=${formatOutcomeValue(outcome.nextState)}`,
     `shouldRunCodex=${formatOutcomeValue(outcome.shouldRunCodex)}`,
@@ -1004,7 +1045,7 @@ function formatCompactOutcome(outcome: ReplayCorpusNormalizedOutcome): string {
 }
 
 export function formatReplayCorpusMismatchSummaryLine(result: ReplayCorpusCaseResult): string {
-  return `Mismatch: ${result.caseId} (issue #${result.issueNumber}) expected(${formatCompactOutcome(result.expected)}) actual(${formatCompactOutcome(result.actual)})`;
+  return `Mismatch: ${result.caseId} (issue #${result.issueNumber}) expected(${formatReplayCorpusCompactOutcome(result.expected)}) actual(${formatReplayCorpusCompactOutcome(result.actual)})`;
 }
 
 export function formatReplayCorpusMismatchDetailsArtifact(


### PR DESCRIPTION
Closes #558
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed `04f9b84` on `codex/issue-558`.

`replay-corpus-promote` now prints a reviewable post-promotion summary instead of only a success banner: the created case path, the normalized expected outcome in compact form, and volatile-field normalization notes only when promotion actually rewrote those fields. The focused CLI regression in [src/index.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-558/src/index.test.ts) now reproduces and locks that output; the shared summary/formatting logic lives in [src/supervisor/replay-corpus.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-558/src/supervisor/replay-corpus.ts), and the CLI wiring is in [src/index.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-558/src/index.ts). I also updated the journal in [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-558/.codex-supervisor/issue-journal.md).

Verification passed with `npx tsx --test src/index.test.ts`, `npx tsx --test src/supervisor/replay-corpus.test.ts`, and `npm run build`. `npm run build` initially failed because local `tsc` was missing, so I ran `npm install` before rerunning the build.

Summary: Added compact replay corpus promotion summary output and committed it as `04f9b84`
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/index.test.ts`; `npx tsx --test src/supervisor/replay-corpus.test.ts`; `npm run build`
Failure signature: none
Next action: Push `codex/iss...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replay-corpus promotions now generate and display comprehensive summaries after successful completion. The summary includes the case path being promoted, the expected outcome in a compact format, and detailed notes about any normalizations applied to volatile fields. This structured output replaces the previous minimal confirmation message, enabling clearer post-promotion review and verification of results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->