### PR TITLE
Docs bootstrap: add an English agent bootstrap protocol (#561)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,35 +1,36 @@
-# Issue #559: Replay corpus promotion: surface conservative promotion-worthiness hints
+# Issue #561: Docs bootstrap: add an English agent bootstrap protocol
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/559
-- Branch: codex/issue-559
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/561
+- Branch: codex/issue-561
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: f6ba8686c9cb92b35b921c2db7db88a51091511a
+- Last head SHA: 6fb209fb912329a3f97d33bb4102c64c957181b2
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-18T17:01:53.227Z
+- Updated at: 2026-03-18T17:22:40.614Z
 
 ## Latest Codex Summary
-- Reproduced the missing replay promotion-worthiness guidance with a focused `replay-corpus-promote` CLI regression, then added deterministic advisory hints for stale-head safety, provider waits, and retry escalation. The CLI now surfaces those hints both when operators ask for case-id suggestions and after a successful promotion summary. Focused CLI and replay-corpus tests passed, and `npm run build` passed after restoring local dev dependencies with `npm install`.
+- Added `docs/agent-instructions.md` as an English bootstrap hub for AI agents, backed by a focused docs regression and local build verification.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Replay corpus promotion still lacked operator-facing guidance about which captured snapshots are especially valuable to preserve, even though promotion invocation and review output already existed.
-- What changed: tightened the CLI guidance path in `src/index.test.ts` to require advisory promotion hints for a high-value stale-head snapshot and no hints for a routine required-check snapshot; added `deriveReplayCorpusPromotionWorthinessHints(...)` in `src/supervisor/replay-corpus.ts` with conservative deterministic signals for stale-head safety, provider waits, and retry escalation; extended `summarizeReplayCorpusPromotion(...)` and `src/index.ts` so hints surface both in missing-case-id guidance and after successful promotions; added focused helper coverage in `src/supervisor/replay-corpus.test.ts`.
+- Hypothesis: The missing English bootstrap hub can be fixed safely by adding one focused doc and a narrow regression that proves the file exists, stays ordered as a bootstrap protocol, and delegates detailed rules to the existing canonical references.
+- What changed: added `src/agent-instructions-docs.test.ts` to require `docs/agent-instructions.md` with bootstrap-specific headings plus links to `getting-started.md`, `configuration.md`, `issue-metadata.md`, and `local-review.md`; reproduced the issue with an `ENOENT` failure because the doc did not exist; added `docs/agent-instructions.md` with prerequisites, read order, first-run sequence, escalation rules, and canonical-reference links while keeping detailed policy delegated to the existing docs.
 - Current blocker: none
-- Next exact step: monitor CI and respond to any review or verification feedback on draft PR #582.
-- Verification gap: no broader full-suite run yet; this slice was verified with focused CLI and replay-corpus tests plus `npm run build`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/index.ts`, `src/index.test.ts`, `src/supervisor/replay-corpus.ts`, `src/supervisor/replay-corpus.test.ts`
-- Rollback concern: removing the new hint helper or CLI output would put operators back to manually inferring promotion-worthiness from raw snapshots, while making the helper less conservative would risk noisy or unstable hinting.
-- Last focused command: `npx tsx --test src/index.test.ts --test-name-pattern "replay-corpus-promote"`; `npx tsx --test src/supervisor/replay-corpus.test.ts --test-name-pattern "PromotionWorthinessHints|promoteCapturedReplaySnapshot|checked-in safety case bundles|runReplayCorpus replays the checked-in PR lifecycle safety cases without mismatches"`; `npm run build`
+- Next exact step: review the generated doc text once more for wording drift, then commit this docs-only checkpoint and open or update the draft PR if needed.
+- Verification gap: no full test suite run; this slice was verified with focused docs tests and `npm run build`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `docs/agent-instructions.md`, `src/agent-instructions-docs.test.ts`
+- Rollback concern: removing the new hub or its regression would reintroduce a missing first-read protocol for AI agents and make the docs bootstrap requirement easy to regress.
+- Last focused command: `npx tsx --test src/agent-instructions-docs.test.ts`; `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts`; `npm install`; `npm run build`
 ### Scratchpad
+- 2026-03-19 (JST): Reproduced issue #561 with a focused docs regression in `src/agent-instructions-docs.test.ts`; it failed with `ENOENT` because `docs/agent-instructions.md` did not exist. Added the new bootstrap hub doc with prerequisites, read order, first-run sequence, escalation rules, and canonical links. Focused verification passed with `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts` and `npm run build` after restoring local dev dependencies via `npm install`.
 - 2026-03-19 (JST): Pushed `codex/issue-559` and opened draft PR #582 (`https://github.com/TommyKammy/codex-supervisor/pull/582`) after the focused hinting slice passed local verification.
 - 2026-03-19 (JST): Reproduced issue #559 with a focused `replay-corpus-promote` regression that expected advisory hints for `stale-head-prevents-merge` but only saw the existing explicit-case-id guidance and suggestions. Fixed it by adding deterministic `deriveReplayCorpusPromotionWorthinessHints(...)` coverage for stale-head safety, provider waits, and retry escalation, then surfacing those hints in both CLI suggestion mode and successful promotion summaries. Focused verification passed with `npx tsx --test src/index.test.ts --test-name-pattern "replay-corpus-promote"`, `npx tsx --test src/supervisor/replay-corpus.test.ts --test-name-pattern "PromotionWorthinessHints|promoteCapturedReplaySnapshot|checked-in safety case bundles|runReplayCorpus replays the checked-in PR lifecycle safety cases without mismatches"`, and `npm run build` after restoring local dev dependencies via `npm install`.
 - 2026-03-19 (JST): Reproduced issue #558 with a tightened CLI promotion regression that failed because stdout only contained `Promoted replay corpus case ...`; fixed it by printing case path, compact expected outcome, and conditional volatile-field normalization notes after promotion. Focused verification passed with `npx tsx --test src/index.test.ts`, `npx tsx --test src/supervisor/replay-corpus.test.ts`, and `npm run build` after restoring local dev dependencies via `npm install`.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -1,0 +1,76 @@
+# Agent Bootstrap Protocol
+
+Use this document as the English bootstrap hub for AI agents that are about to operate `codex-supervisor`.
+
+It is not a second canonical ruleset. Its job is to tell an agent what to validate first, what to read next, and when to stop and escalate instead of improvising.
+
+## Purpose
+
+Start here when an agent is entering the repo for a first run or after a long gap.
+
+Use the linked reference docs for detailed policy:
+
+- [Getting started](./getting-started.md) for the operator flow and first-run commands
+- [Configuration reference](./configuration.md) for config fields, provider setup, durable memory, and execution policy
+- [Issue metadata reference](./issue-metadata.md) for execution-ready issue structure and scheduling inputs
+- [Local review reference](./local-review.md) for local review roles, artifacts, thresholds, and merge policy
+
+Treat this file as a bootstrap hub that points to those canonical references.
+
+## Prerequisites
+
+Before taking action, confirm:
+
+- `gh auth status` succeeds
+- `codex` CLI is installed and usable from the shell
+- the target repository is already cloned locally
+- branch protection and CI already exist on the managed repository
+- the supervisor config points at a writable `workspaceRoot` for per-issue worktrees
+
+Do not guess around missing auth, missing binaries, or missing repository setup. Escalate those conditions.
+
+## Read this first
+
+Read in this order:
+
+1. This file, so the execution order is explicit.
+2. [Getting started](./getting-started.md), so the first-run flow and operator checkpoints are clear.
+3. [Configuration reference](./configuration.md), only for the fields and provider behavior the current run depends on.
+4. [Issue metadata reference](./issue-metadata.md), before trusting an issue as execution-ready.
+5. [Local review reference](./local-review.md), only when local review is enabled or the issue is in a local-review state.
+
+Keep the reference-reading selective. Open the detailed doc that answers the current question instead of treating every doc as required upfront.
+
+## First-run sequence
+
+When operating the supervisor for the first time in a repo:
+
+1. Validate prerequisites and confirm the correct `supervisor.config.json` is in use.
+2. Read [Getting started](./getting-started.md) and confirm the repo is actually ready for supervisor execution rather than backlog planning.
+3. Check the active config against the [Configuration reference](./configuration.md), especially `repoPath`, `repoSlug`, `workspaceRoot`, `codexBinary`, and review-provider settings.
+4. Validate the candidate issue against the [Issue metadata reference](./issue-metadata.md): dependencies, execution order, acceptance criteria, and verification must be concrete.
+5. Build once with `npm run build`.
+6. Start with `node dist/index.js run-once --config /path/to/supervisor.config.json`.
+7. Inspect the result with `node dist/index.js status --config /path/to/supervisor.config.json` before switching to `loop`.
+
+Do not start with `loop` until `run-once` selects the expected issue, creates the expected worktree, and leaves a sensible journal state.
+
+## Escalate instead of guessing
+
+Stop and ask for operator help when:
+
+- auth, binaries, or provider setup are missing
+- the config does not clearly identify the target repo or workspace
+- issue dependencies or execution order are ambiguous
+- acceptance criteria or verification are too vague to prove completion
+- local review or external review policy is unclear for the current state
+- the observed repo state disagrees with the issue, PR, or journal narrative
+
+When escalating, name the exact blocker, the command or file that exposed it, and which canonical reference was insufficient.
+
+## Canonical references
+
+- [Getting started](./getting-started.md)
+- [Configuration reference](./configuration.md)
+- [Issue metadata reference](./issue-metadata.md)
+- [Local review reference](./local-review.md)

--- a/src/agent-instructions-docs.test.ts
+++ b/src/agent-instructions-docs.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+async function readAgentInstructions(): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), "docs", "agent-instructions.md"), "utf8");
+}
+
+test("agent bootstrap doc exists as a hub that delegates detailed rules", async () => {
+  const content = await readAgentInstructions();
+
+  const requiredHeadings = [
+    "# Agent Bootstrap Protocol",
+    "## Purpose",
+    "## Prerequisites",
+    "## Read this first",
+    "## First-run sequence",
+    "## Escalate instead of guessing",
+    "## Canonical references",
+  ];
+
+  let lastIndex = -1;
+  for (const heading of requiredHeadings) {
+    const index = content.indexOf(heading);
+    assert.notEqual(index, -1, `expected ${heading} in docs/agent-instructions.md`);
+    assert.ok(index > lastIndex, `expected ${heading} to appear after the previous section`);
+    lastIndex = index;
+  }
+
+  assert.match(content, /\[Getting started\]\(\.\/getting-started\.md\)/);
+  assert.match(content, /\[Configuration reference\]\(\.\/configuration\.md\)/);
+  assert.match(content, /\[Issue metadata reference\]\(\.\/issue-metadata\.md\)/);
+  assert.match(content, /\[Local review reference\]\(\.\/local-review\.md\)/);
+  assert.match(content, /bootstrap hub/i);
+
+  assert.doesNotMatch(content, /^## Full configuration reference$/m);
+  assert.doesNotMatch(content, /^## Complete issue metadata specification$/m);
+});


### PR DESCRIPTION
Closes #561
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the English bootstrap hub at [docs/agent-instructions.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-561/docs/agent-instructions.md) and backed it with a focused regression in [src/agent-instructions-docs.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-561/src/agent-instructions-docs.test.ts). The doc stays a bootstrap protocol, not a second ruleset: it covers prerequisites, read order, first-run sequence, escalation rules, and links back to the canonical references.

I reproduced the issue first with a failing `ENOENT` docs test, then fixed it and updated the journal in [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-561/.codex-supervisor/issue-journal.md). Local verification passed with `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts` and `npm run build`. I had to run `npm install` once because `tsc` was missing locally. Commit: `b39ec1a` (`Add agent bootstrap protocol doc`).

Summary: Added the AI-facing bootstrap hub doc, proved the missing-file failure with a focused regression, and verified the fix with focused docs tests plus `npm run build`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/agent-instructions-docs.test.ts` (initially failed with ENOENT), `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts`, `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agent Bootstrap Protocol guide providing AI agents with operational rules, prerequisites, validation flows, and escalation triggers.

* **Tests**
  * Added validation tests ensuring documentation structure, required sections, and internal references are properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->