### PR TITLE
Replay-corpus refactor: extract reporting and mismatch-formatting helpers (#597)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,45 +1,36 @@
-# Issue #596: Replay-corpus refactor: extract promotion helpers
+# Issue #597: Replay-corpus refactor: extract reporting and mismatch-formatting helpers
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/596
-- Branch: codex/issue-596
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/597
+- Branch: codex/issue-597
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 687355fa2e9658f02243d1fbfa8a00b997e095b2
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 2f8a2a265c96a414657af2a0d8c09472eb4ce7e6
 - Blocked reason: none
 - Last failure signature: none
-- Repeated failure signature count: 1
-- Updated at: 2026-03-18T23:45:06.000Z
+- Repeated failure signature count: 0
+- Updated at: 2026-03-19T00:01:22.869Z
 
 ## Latest Codex Summary
-Validated CodeRabbit thread `PRRT_kwDORgvdZ851UWEj` against the current branch and confirmed the provider-wait hint could be emitted when `configuredBotCurrentHeadObservedAt` was omitted entirely. Fixed [`replay-corpus-promotion-summary.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-596/src/supervisor/replay-corpus-promotion-summary.ts) to require a non-nullish observation timestamp before it counts as a provider-wait signal, unless `copilotReviewState` is explicitly present, and added a focused regression in [`replay-corpus-promotion.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-596/src/supervisor/replay-corpus-promotion.test.ts) for the missing-field case.
-
-The first new test assertion failed because the shared fixture still carried `timeout_retry_count=1`; I tightened the fixture overrides so the regression isolates only the provider-wait branch. The existing prebuild/build pipeline and the focused promotion suite passed locally. I committed the fix as `687355f`, pushed `codex/issue-596`, and resolved the CodeRabbit thread on PR #606. The only remaining worktree noise is the pre-existing untracked `.codex-supervisor/replay/` directory, which I left untouched.
-
-Summary: Fixed the provider-wait promotion hint false positive, added a focused regression, pushed `687355f`, and resolved the CodeRabbit thread on PR #606
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/replay-corpus-promotion.test.ts` (failed once due to fixture retry defaults, then passed after isolating the provider-wait branch); `npm run build`
-Failure signature: none
-Next action: Watch PR #606 for any follow-up review feedback or CI regressions after commit `687355f`
+- Reproduced the helper-extraction gap with focused module-level replay-corpus tests that failed on missing `replay-corpus-mismatch-formatting` and `replay-corpus-mismatch-artifact` modules, then extracted the mismatch/reporting and artifact helpers out of `src/supervisor/replay-corpus.ts` while preserving output and artifact semantics. Focused replay-corpus verification and `npm run build` now pass.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the only remaining risk in this PR slice was the provider-wait hint overcounting missing configured-bot observations; the local fix should fully cover that path because the helper now treats `configuredBotCurrentHeadObservedAt` as present only when it is non-nullish, and the focused regression exercises the previously false-positive combination.
-- What changed: updated `src/supervisor/replay-corpus-promotion-summary.ts` so the provider-wait hint only considers `configuredBotCurrentHeadObservedAt` when it is neither `null` nor `undefined`, and added a focused missing-observation regression to `src/supervisor/replay-corpus-promotion.test.ts` while preserving the earlier extracted promotion-helper split.
+- Hypothesis: the replay-corpus reporting refactor is complete for this slice because mismatch formatting, run-summary formatting, and mismatch artifact shaping now live in dedicated modules with direct tests that pin the existing CI-facing strings and artifact payloads.
+- What changed: added `src/supervisor/replay-corpus-mismatch-formatting.ts` and `src/supervisor/replay-corpus-mismatch-artifact.ts`, added focused tests for each new module, and trimmed `src/supervisor/replay-corpus.ts` down to orchestration plus re-exports.
 - Current blocker: none
-- Next exact step: watch PR #606 for any new review comments or CI noise after the `687355f` push.
-- Verification gap: none for the review fix; `npm run build` passed, and `npx tsx --test src/supervisor/replay-corpus-promotion.test.ts` passed after one initial regression-authoring failure caused by fixture retry defaults.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/replay-corpus-promotion-summary.ts`, `src/supervisor/replay-corpus-promotion.test.ts`
-- Rollback concern: reverting this narrow fix would reintroduce a false-positive promotion hint path for snapshots that omit `configuredBotCurrentHeadObservedAt`, which would make replay corpus promotions noisier without reflecting real supervisor state.
-- Last focused command: `npx tsx --test src/supervisor/replay-corpus-promotion.test.ts`; `npm run build`; `git push origin codex/issue-596`; `gh api graphql -f query='mutation($threadId:ID!){ resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } } }' -F threadId=PRRT_kwDORgvdZ851UWEj`
+- Next exact step: commit the replay-corpus reporting/artifact split on `codex/issue-597`, then open or update the draft PR if one is not already present.
+- Verification gap: none for the local refactor slice; focused replay-corpus tests and `npm run build` both passed after restoring local dev dependencies with `npm install`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/replay-corpus.ts`, `src/supervisor/replay-corpus-mismatch-formatting.ts`, `src/supervisor/replay-corpus-mismatch-formatting.test.ts`, `src/supervisor/replay-corpus-mismatch-artifact.ts`, `src/supervisor/replay-corpus-mismatch-artifact.test.ts`
+- Rollback concern: reverting this split would push CI-facing replay mismatch formatting and artifact shaping back into `replay-corpus.ts`, increasing coupling again without changing semantics.
+- Last focused command: `npx tsx --test src/supervisor/replay-corpus.test.ts src/supervisor/replay-corpus-mismatch-formatting.test.ts src/supervisor/replay-corpus-mismatch-artifact.test.ts`; `npm install`; `npm run build`
 ### Scratchpad
-- 2026-03-19 (JST): Pushed review-fix commit `687355f` to `origin/codex/issue-596` and resolved CodeRabbit thread `PRRT_kwDORgvdZ851UWEj` via `gh api graphql` after the focused promotion test file and `npm run build` passed locally.
+- 2026-03-19 (JST): Reproduced issue #597 by adding focused module-level tests for `replay-corpus-mismatch-formatting` and `replay-corpus-mismatch-artifact`; the first run failed with `MODULE_NOT_FOUND` for both new modules. Implemented the split by moving mismatch detail/summary/run-summary formatting into `src/supervisor/replay-corpus-mismatch-formatting.ts` and mismatch artifact shaping/sync into `src/supervisor/replay-corpus-mismatch-artifact.ts`, then re-exported them from `src/supervisor/replay-corpus.ts`. Verification passed with `npx tsx --test src/supervisor/replay-corpus.test.ts src/supervisor/replay-corpus-mismatch-formatting.test.ts src/supervisor/replay-corpus-mismatch-artifact.test.ts` and `npm run build` after a local `npm install` because `tsc` was initially unavailable.
 - 2026-03-19 (JST): Addressed CodeRabbit thread `PRRT_kwDORgvdZ851UWEj` by changing the provider-wait promotion hint guard to use a non-nullish check for `configuredBotCurrentHeadObservedAt` and adding a focused regression for the missing-field case. The first new assertion failed because the shared snapshot fixture still emitted `retry-escalation` via `timeout_retry_count=1`; after zeroing the retry counters in the test setup, `npx tsx --test src/supervisor/replay-corpus-promotion.test.ts` passed and `npm run build` remained green.
 - 2026-03-19 (JST): Reproduced issue #561 with a focused docs regression in `src/agent-instructions-docs.test.ts`; it failed with `ENOENT` because `docs/agent-instructions.md` did not exist. Added the new bootstrap hub doc with prerequisites, read order, first-run sequence, escalation rules, and canonical links. Focused verification passed with `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts` and `npm run build` after restoring local dev dependencies via `npm install`.
 - 2026-03-19 (JST): Pushed `codex/issue-559` and opened draft PR #582 (`https://github.com/TommyKammy/codex-supervisor/pull/582`) after the focused hinting slice passed local verification.

--- a/src/supervisor/replay-corpus-mismatch-artifact.test.ts
+++ b/src/supervisor/replay-corpus-mismatch-artifact.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createCheckedInReplayCorpusConfig } from "./replay-corpus";
+import type { ReplayCorpusRunResult } from "./replay-corpus-model";
+import {
+  formatReplayCorpusMismatchDetailsArtifact,
+  syncReplayCorpusMismatchDetailsArtifact,
+} from "./replay-corpus-mismatch-artifact";
+
+function createRunResult(tempDir: string): ReplayCorpusRunResult {
+  return {
+    rootPath: path.join(tempDir, "replay-corpus"),
+    manifestPath: path.join(tempDir, "replay-corpus", "manifest.json"),
+    totalCases: 2,
+    mismatchCount: 1,
+    results: [
+      {
+        caseId: "review-blocked",
+        issueNumber: 532,
+        bundlePath: path.join(tempDir, "replay-corpus", "cases", "review-blocked"),
+        expected: {
+          nextState: "ready_to_merge",
+          shouldRunCodex: true,
+          blockedReason: null,
+          failureSignature: null,
+        },
+        actual: {
+          nextState: "blocked",
+          shouldRunCodex: false,
+          blockedReason: "manual_review",
+          failureSignature: "stalled-bot:thread-1",
+        },
+        matchesExpected: false,
+      },
+      {
+        caseId: "review-pass",
+        issueNumber: 533,
+        bundlePath: path.join(tempDir, "replay-corpus", "cases", "review-pass"),
+        expected: {
+          nextState: "reproducing",
+          shouldRunCodex: true,
+          blockedReason: null,
+          failureSignature: null,
+        },
+        actual: {
+          nextState: "reproducing",
+          shouldRunCodex: true,
+          blockedReason: null,
+          failureSignature: null,
+        },
+        matchesExpected: true,
+      },
+    ],
+  };
+}
+
+test("mismatch artifact helpers shape deterministic details and remove stale success artifacts", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "replay-corpus-mismatch-details-"));
+  const config = createCheckedInReplayCorpusConfig(tempDir);
+  const artifactPath = path.join(tempDir, ".codex-supervisor", "replay", "replay-corpus-mismatch-details.json");
+  const result = createRunResult(tempDir);
+
+  const firstContext = await syncReplayCorpusMismatchDetailsArtifact(result, config);
+  assert.equal(firstContext?.artifactPath, artifactPath);
+  assert.deepEqual(
+    JSON.parse(await fs.readFile(artifactPath, "utf8")),
+    formatReplayCorpusMismatchDetailsArtifact(result, config),
+  );
+
+  const beforeRepeat = await fs.readFile(artifactPath, "utf8");
+  const secondContext = await syncReplayCorpusMismatchDetailsArtifact(result, config);
+  assert.equal(secondContext?.artifactPath, artifactPath);
+  assert.equal(await fs.readFile(artifactPath, "utf8"), beforeRepeat);
+
+  const successContext = await syncReplayCorpusMismatchDetailsArtifact(
+    {
+      ...result,
+      mismatchCount: 0,
+      results: result.results.map((entry) => ({
+        ...entry,
+        actual: entry.expected,
+        matchesExpected: true,
+      })),
+    },
+    config,
+  );
+  assert.equal(successContext, null);
+  await assert.rejects(() => fs.readFile(artifactPath, "utf8"), { code: "ENOENT" });
+});

--- a/src/supervisor/replay-corpus-mismatch-artifact.ts
+++ b/src/supervisor/replay-corpus-mismatch-artifact.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { writeJsonAtomic } from "../core/utils";
+import type {
+  ReplayCorpusMismatchDetailsArtifact,
+  ReplayCorpusMismatchDetailsArtifactContext,
+  ReplayCorpusRunResult,
+} from "./replay-corpus-model";
+import type { SupervisorConfig } from "../core/types";
+import {
+  formatReplayCorpusMismatchSummaryLine,
+  formatReplayCorpusOutcomeMismatch,
+} from "./replay-corpus-mismatch-formatting";
+
+function replayCorpusMismatchDetailsArtifactPath(config: SupervisorConfig): string {
+  return path.join(config.repoPath, ".codex-supervisor", "replay", "replay-corpus-mismatch-details.json");
+}
+
+function relativeReplayPath(config: SupervisorConfig, targetPath: string): string {
+  return path.relative(config.repoPath, targetPath) || ".";
+}
+
+export function formatReplayCorpusMismatchDetailsArtifact(
+  result: ReplayCorpusRunResult,
+  config: SupervisorConfig,
+): ReplayCorpusMismatchDetailsArtifact {
+  const mismatches = result.results
+    .filter((entry) => !entry.matchesExpected)
+    .map((entry) => ({
+      caseId: entry.caseId,
+      issueNumber: entry.issueNumber,
+      casePath: relativeReplayPath(config, entry.bundlePath),
+      expected: entry.expected,
+      actual: entry.actual,
+      compactSummary: formatReplayCorpusMismatchSummaryLine(entry),
+      detail: formatReplayCorpusOutcomeMismatch(entry),
+    }));
+
+  return {
+    schemaVersion: 1,
+    corpusPath: relativeReplayPath(config, result.rootPath),
+    manifestPath: relativeReplayPath(config, result.manifestPath),
+    totalCases: result.totalCases,
+    mismatchCount: result.mismatchCount,
+    mismatches,
+  };
+}
+
+export async function syncReplayCorpusMismatchDetailsArtifact(
+  result: ReplayCorpusRunResult,
+  config: SupervisorConfig,
+): Promise<ReplayCorpusMismatchDetailsArtifactContext | null> {
+  const artifactPath = replayCorpusMismatchDetailsArtifactPath(config);
+  if (result.mismatchCount === 0) {
+    await fs.rm(artifactPath, { force: true });
+    return null;
+  }
+
+  await writeJsonAtomic(artifactPath, formatReplayCorpusMismatchDetailsArtifact(result, config));
+  return { artifactPath };
+}

--- a/src/supervisor/replay-corpus-mismatch-formatting.test.ts
+++ b/src/supervisor/replay-corpus-mismatch-formatting.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ReplayCorpusCaseResult, ReplayCorpusRunResult } from "./replay-corpus-model";
+import {
+  formatReplayCorpusMismatchSummaryLine,
+  formatReplayCorpusOutcomeMismatch,
+  formatReplayCorpusRunSummary,
+} from "./replay-corpus-mismatch-formatting";
+
+function createMismatchResult(): ReplayCorpusCaseResult {
+  return {
+    caseId: "review-blocked",
+    issueNumber: 532,
+    bundlePath: "/tmp/replay-corpus/cases/review-blocked",
+    expected: {
+      nextState: "ready_to_merge",
+      shouldRunCodex: true,
+      blockedReason: null,
+      failureSignature: null,
+    },
+    actual: {
+      nextState: "blocked",
+      shouldRunCodex: false,
+      blockedReason: "manual_review",
+      failureSignature: "stalled-bot:thread-1",
+    },
+    matchesExpected: false,
+  };
+}
+
+test("mismatch formatting helpers render deterministic detail and compact summary output", () => {
+  const result = createMismatchResult();
+
+  assert.equal(
+    formatReplayCorpusOutcomeMismatch(result),
+    [
+      'Replay corpus mismatch for case "review-blocked" (issue #532)',
+      "  expected.nextState=ready_to_merge",
+      "  actual.nextState=blocked",
+      "  expected.shouldRunCodex=true",
+      "  actual.shouldRunCodex=false",
+      "  expected.blockedReason=none",
+      "  actual.blockedReason=manual_review",
+      "  expected.failureSignature=none",
+      "  actual.failureSignature=stalled-bot:thread-1",
+    ].join("\n"),
+  );
+
+  assert.equal(
+    formatReplayCorpusMismatchSummaryLine(result),
+    "Mismatch: review-blocked (issue #532) expected(nextState=ready_to_merge, shouldRunCodex=true, blockedReason=none, failureSignature=none) actual(nextState=blocked, shouldRunCodex=false, blockedReason=manual_review, failureSignature=stalled-bot:thread-1)",
+  );
+});
+
+test("run summary formatting reports pass and fail counts compactly", () => {
+  const mismatch = createMismatchResult();
+  const pass = {
+    caseId: "all-pass",
+    issueNumber: 540,
+    bundlePath: "/tmp/replay-corpus/cases/all-pass",
+    expected: {
+      nextState: "planning",
+      shouldRunCodex: false,
+      blockedReason: null,
+      failureSignature: null,
+    },
+    actual: {
+      nextState: "planning",
+      shouldRunCodex: false,
+      blockedReason: null,
+      failureSignature: null,
+    },
+    matchesExpected: true,
+  } satisfies ReplayCorpusCaseResult;
+
+  const result: ReplayCorpusRunResult = {
+    rootPath: "/tmp/replay-corpus",
+    manifestPath: "/tmp/replay-corpus/manifest.json",
+    totalCases: 2,
+    mismatchCount: 1,
+    results: [pass, mismatch],
+  };
+
+  assert.equal(
+    formatReplayCorpusRunSummary(result),
+    [
+      "Replay corpus summary: total=2 passed=1 failed=1",
+      "Mismatch: review-blocked (issue #532) expected(nextState=ready_to_merge, shouldRunCodex=true, blockedReason=none, failureSignature=none) actual(nextState=blocked, shouldRunCodex=false, blockedReason=manual_review, failureSignature=stalled-bot:thread-1)",
+    ].join("\n"),
+  );
+});

--- a/src/supervisor/replay-corpus-mismatch-formatting.ts
+++ b/src/supervisor/replay-corpus-mismatch-formatting.ts
@@ -1,0 +1,32 @@
+import type { ReplayCorpusCaseResult, ReplayCorpusRunResult } from "./replay-corpus-model";
+import { formatReplayCorpusCompactOutcome } from "./replay-corpus-outcome";
+
+export function formatReplayCorpusOutcomeMismatch(result: ReplayCorpusCaseResult): string {
+  return [
+    `Replay corpus mismatch for case "${result.caseId}" (issue #${result.issueNumber})`,
+    `  expected.nextState=${result.expected.nextState ?? "none"}`,
+    `  actual.nextState=${result.actual.nextState ?? "none"}`,
+    `  expected.shouldRunCodex=${String(result.expected.shouldRunCodex)}`,
+    `  actual.shouldRunCodex=${String(result.actual.shouldRunCodex)}`,
+    `  expected.blockedReason=${result.expected.blockedReason ?? "none"}`,
+    `  actual.blockedReason=${result.actual.blockedReason ?? "none"}`,
+    `  expected.failureSignature=${result.expected.failureSignature ?? "none"}`,
+    `  actual.failureSignature=${result.actual.failureSignature ?? "none"}`,
+  ].join("\n");
+}
+
+export function formatReplayCorpusMismatchSummaryLine(result: ReplayCorpusCaseResult): string {
+  return `Mismatch: ${result.caseId} (issue #${result.issueNumber}) expected(${formatReplayCorpusCompactOutcome(result.expected)}) actual(${formatReplayCorpusCompactOutcome(result.actual)})`;
+}
+
+export function formatReplayCorpusRunSummary(result: ReplayCorpusRunResult): string {
+  const passedCount = result.totalCases - result.mismatchCount;
+  const lines = [`Replay corpus summary: total=${result.totalCases} passed=${passedCount} failed=${result.mismatchCount}`];
+  for (const entry of result.results) {
+    if (!entry.matchesExpected) {
+      lines.push(formatReplayCorpusMismatchSummaryLine(entry));
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/supervisor/replay-corpus.ts
+++ b/src/supervisor/replay-corpus.ts
@@ -1,6 +1,4 @@
-import fs from "node:fs/promises";
 import path from "node:path";
-import { writeJsonAtomic } from "../core/utils";
 import { mapConfiguredReviewProviders } from "../core/review-providers";
 import type { SupervisorConfig } from "../core/types";
 import { replaySupervisorCycleDecisionSnapshot } from "./supervisor-cycle-replay";
@@ -11,12 +9,9 @@ import type {
   ReplayCorpus,
   ReplayCorpusCaseBundle,
   ReplayCorpusCaseMetadata,
-  ReplayCorpusCaseResult,
   ReplayCorpusExpectedReplayResult,
   ReplayCorpusInputSnapshot,
   ReplayCorpusManifest,
-  ReplayCorpusMismatchDetailsArtifact,
-  ReplayCorpusMismatchDetailsArtifactContext,
   ReplayCorpusNormalizedOutcome,
   ReplayCorpusPromotionHint,
   ReplayCorpusPromotionSummary,
@@ -24,7 +19,16 @@ import type {
 } from "./replay-corpus-model";
 import { loadReplayCorpusCaseBundle, loadReplayCorpusManifest, loadReplayCorpusManifestOrDefault } from "./replay-corpus-loading";
 import { validationError } from "./replay-corpus-validation";
-import { formatReplayCorpusCompactOutcome, normalizeExpectedReplayResult, normalizeReplayResult } from "./replay-corpus-outcome";
+import { normalizeExpectedReplayResult, normalizeReplayResult } from "./replay-corpus-outcome";
+import {
+  formatReplayCorpusMismatchDetailsArtifact,
+  syncReplayCorpusMismatchDetailsArtifact,
+} from "./replay-corpus-mismatch-artifact";
+import {
+  formatReplayCorpusMismatchSummaryLine,
+  formatReplayCorpusOutcomeMismatch,
+  formatReplayCorpusRunSummary,
+} from "./replay-corpus-mismatch-formatting";
 import { suggestReplayCorpusCaseIds } from "./replay-corpus-promotion-case-id";
 import {
   promoteCapturedReplaySnapshot,
@@ -36,6 +40,15 @@ import {
 } from "./replay-corpus-promotion-summary";
 
 export { formatReplayCorpusCompactOutcome } from "./replay-corpus-outcome";
+export {
+  formatReplayCorpusMismatchDetailsArtifact,
+  syncReplayCorpusMismatchDetailsArtifact,
+} from "./replay-corpus-mismatch-artifact";
+export {
+  formatReplayCorpusMismatchSummaryLine,
+  formatReplayCorpusOutcomeMismatch,
+  formatReplayCorpusRunSummary,
+} from "./replay-corpus-mismatch-formatting";
 export { suggestReplayCorpusCaseIds } from "./replay-corpus-promotion-case-id";
 export { promoteCapturedReplaySnapshot } from "./replay-corpus-promotion";
 export type { PromoteCapturedReplaySnapshotArgs } from "./replay-corpus-promotion";
@@ -131,14 +144,6 @@ export async function loadReplayCorpus(rootPath: string): Promise<ReplayCorpus> 
   };
 }
 
-function replayCorpusMismatchDetailsArtifactPath(config: SupervisorConfig): string {
-  return path.join(config.repoPath, ".codex-supervisor", "replay", "replay-corpus-mismatch-details.json");
-}
-
-function relativeReplayPath(config: SupervisorConfig, targetPath: string): string {
-  return path.relative(config.repoPath, targetPath) || ".";
-}
-
 export async function runReplayCorpus(rootPath: string, config: SupervisorConfig): Promise<ReplayCorpusRunResult> {
   const corpus = await loadReplayCorpus(rootPath);
   const results = corpus.cases.map((corpusCase) => {
@@ -161,74 +166,4 @@ export async function runReplayCorpus(rootPath: string, config: SupervisorConfig
     mismatchCount: results.filter((result) => !result.matchesExpected).length,
     results,
   };
-}
-
-export function formatReplayCorpusOutcomeMismatch(result: ReplayCorpusCaseResult): string {
-  return [
-    `Replay corpus mismatch for case "${result.caseId}" (issue #${result.issueNumber})`,
-    `  expected.nextState=${result.expected.nextState ?? "none"}`,
-    `  actual.nextState=${result.actual.nextState ?? "none"}`,
-    `  expected.shouldRunCodex=${String(result.expected.shouldRunCodex)}`,
-    `  actual.shouldRunCodex=${String(result.actual.shouldRunCodex)}`,
-    `  expected.blockedReason=${result.expected.blockedReason ?? "none"}`,
-    `  actual.blockedReason=${result.actual.blockedReason ?? "none"}`,
-    `  expected.failureSignature=${result.expected.failureSignature ?? "none"}`,
-    `  actual.failureSignature=${result.actual.failureSignature ?? "none"}`,
-  ].join("\n");
-}
-
-export function formatReplayCorpusMismatchSummaryLine(result: ReplayCorpusCaseResult): string {
-  return `Mismatch: ${result.caseId} (issue #${result.issueNumber}) expected(${formatReplayCorpusCompactOutcome(result.expected)}) actual(${formatReplayCorpusCompactOutcome(result.actual)})`;
-}
-
-export function formatReplayCorpusMismatchDetailsArtifact(
-  result: ReplayCorpusRunResult,
-  config: SupervisorConfig,
-): ReplayCorpusMismatchDetailsArtifact {
-  const mismatches = result.results
-    .filter((entry) => !entry.matchesExpected)
-    .map((entry) => ({
-      caseId: entry.caseId,
-      issueNumber: entry.issueNumber,
-      casePath: relativeReplayPath(config, entry.bundlePath),
-      expected: entry.expected,
-      actual: entry.actual,
-      compactSummary: formatReplayCorpusMismatchSummaryLine(entry),
-      detail: formatReplayCorpusOutcomeMismatch(entry),
-    }));
-
-  return {
-    schemaVersion: 1,
-    corpusPath: relativeReplayPath(config, result.rootPath),
-    manifestPath: relativeReplayPath(config, result.manifestPath),
-    totalCases: result.totalCases,
-    mismatchCount: result.mismatchCount,
-    mismatches,
-  };
-}
-
-export async function syncReplayCorpusMismatchDetailsArtifact(
-  result: ReplayCorpusRunResult,
-  config: SupervisorConfig,
-): Promise<ReplayCorpusMismatchDetailsArtifactContext | null> {
-  const artifactPath = replayCorpusMismatchDetailsArtifactPath(config);
-  if (result.mismatchCount === 0) {
-    await fs.rm(artifactPath, { force: true });
-    return null;
-  }
-
-  await writeJsonAtomic(artifactPath, formatReplayCorpusMismatchDetailsArtifact(result, config));
-  return { artifactPath };
-}
-
-export function formatReplayCorpusRunSummary(result: ReplayCorpusRunResult): string {
-  const passedCount = result.totalCases - result.mismatchCount;
-  const lines = [`Replay corpus summary: total=${result.totalCases} passed=${passedCount} failed=${result.mismatchCount}`];
-  for (const entry of result.results) {
-    if (!entry.matchesExpected) {
-      lines.push(formatReplayCorpusMismatchSummaryLine(entry));
-    }
-  }
-
-  return lines.join("\n");
 }


### PR DESCRIPTION
Closes #597
This PR was opened by codex-supervisor.
Latest Codex summary:

Extracted the replay-corpus mismatch/reporting helpers out of [`replay-corpus.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-597/src/supervisor/replay-corpus.ts) into [`replay-corpus-mismatch-formatting.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-597/src/supervisor/replay-corpus-mismatch-formatting.ts) and [`replay-corpus-mismatch-artifact.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-597/src/supervisor/replay-corpus-mismatch-artifact.ts), while keeping the existing top-level exports stable. I added direct focused coverage in [`replay-corpus-mismatch-formatting.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-597/src/supervisor/replay-corpus-mismatch-formatting.test.ts) and [`replay-corpus-mismatch-artifact.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-597/src/supervisor/replay-corpus-mismatch-artifact.test.ts); those tests first reproduced the gap with `MODULE_NOT_FOUND`, then passed after the split.

The worktree is clean, the issue journal is updated, and I committed the checkpoint as `6a1ca1d` (`Extract replay corpus mismatch helpers`).

Summary: Extracted replay-corpus mismatch formatting and artifact helpers into dedicated modules, added focused direct tests, updated the issue journal, and committed `6a1ca1d`
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/supervisor/replay-corpus-mismatch-formatting.test.ts src/supervisor/replay-corpus-mismatch-artifact.test.ts` (failed fir...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized replay corpus mismatch formatting and artifact handling into separate, specialized modules for improved code organization. Core functionality and existing exports preserved.

* **Tests**
  * Added unit tests validating mismatch formatting behavior and artifact file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->