### PR TITLE
refactor: extract supervisor selection active-status helpers

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #598: Replay-corpus refactor: slim replay-corpus.ts into a thin facade
+# Issue #601: Supervisor-selection-status refactor: extract active-status snapshot helpers
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/598
-- Branch: codex/issue-598
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/601
+- Branch: codex/issue-601
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 6e37aa7f08c9c82b0d987bde286625b0f30f0a65
+- Last head SHA: 8cade09bf4b2663f967a39640577b3a68abb70bf
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-19T00:20:46.257Z
+- Updated at: 2026-03-19T00:48:53.079Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,17 +21,16 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: issue #598 is satisfied because `src/supervisor/replay-corpus.ts` is now a thin export-only facade while checked-in replay config and corpus execution moved into dedicated modules with focused tests pinned to those boundaries.
-- What changed: added `src/supervisor/replay-corpus-config.ts` and `src/supervisor/replay-corpus-runner.ts` with dedicated tests, rewrote `src/supervisor/replay-corpus.test.ts` into a facade re-export smoke test, pointed mismatch-artifact coverage at `replay-corpus-config.ts`, and reused `loadReplayCorpus(...)` from `src/supervisor/replay-corpus-runner.ts` inside `src/supervisor/replay-corpus-promotion.ts`.
+- Hypothesis: issue #601 is satisfied because active-status snapshot loading and status-record summarization now live in dedicated modules, leaving `supervisor-selection-status.ts` focused on readiness, explain, and lint assembly.
+- What changed: added `src/supervisor/supervisor-selection-active-status.ts` and `src/supervisor/supervisor-selection-status-records.ts`, moved `loadActiveIssueStatusSnapshot(...)` and `summarizeSupervisorStatusRecords(...)` into those modules, rewired `src/supervisor/supervisor.ts` and the focused helper tests to the new boundaries, and kept `src/supervisor/supervisor-selection-status.ts` as the explain/readiness/lint owner with compatibility re-exports.
 - Current blocker: none
-- Next exact step: commit the replay-corpus facade slimming on `codex/issue-598`, then open or update the draft PR if one is not already present.
-- Verification gap: none for the local refactor slice; focused replay-corpus tests and `npm run build` both passed after restoring local dev dependencies with `npm install`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/replay-corpus.ts`, `src/supervisor/replay-corpus.test.ts`, `src/supervisor/replay-corpus-config.ts`, `src/supervisor/replay-corpus-config.test.ts`, `src/supervisor/replay-corpus-runner.ts`, `src/supervisor/replay-corpus-runner.test.ts`, `src/supervisor/replay-corpus-mismatch-artifact.test.ts`, `src/supervisor/replay-corpus-promotion.ts`
-- Rollback concern: reverting this split would pull checked-in replay config and corpus execution back into `replay-corpus.ts`, restoring the broad facade/catch-all shape without changing replay behavior.
-- Last focused command: `npx tsx --test src/supervisor/replay-corpus.test.ts src/supervisor/replay-corpus-config.test.ts src/supervisor/replay-corpus-runner.test.ts src/supervisor/replay-corpus-loading.test.ts src/supervisor/replay-corpus-promotion.test.ts src/supervisor/replay-corpus-mismatch-formatting.test.ts src/supervisor/replay-corpus-mismatch-artifact.test.ts`; `npm install`; `npm run build`
+- Next exact step: commit the active-status helper extraction on `codex/issue-601`, then open or update the draft PR if one is not already present.
+- Verification gap: none for the local refactor slice; focused supervisor status tests and `npm run build` passed after restoring local dev dependencies with `npm install`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-selection-active-status.ts`, `src/supervisor/supervisor-selection-status-records.ts`, `src/supervisor/supervisor-selection-status.ts`, `src/supervisor/supervisor-selection-status-active-status.test.ts`, `src/supervisor/supervisor.ts`
+- Rollback concern: reverting this split would move active-status snapshot loading and record summarization back into `supervisor-selection-status.ts`, restoring the broader catch-all file shape without changing status behavior.
+- Last focused command: `npx tsx --test src/supervisor/supervisor-selection-status-active-status.test.ts src/supervisor/supervisor-status-model.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts`; `npm install`; `npm run build`
 ### Scratchpad
-- 2026-03-19 (JST): Reproduced issue #598 by adding dedicated `replay-corpus-config` and `replay-corpus-runner` tests; the first run failed with `MODULE_NOT_FOUND` for `./replay-corpus-config` and `./replay-corpus-runner`, confirming the facade still owned those responsibilities. Fixed it by extracting `createCheckedInReplayCorpusConfig(...)` and `loadReplayCorpus(...)`/`runReplayCorpus(...)` into new modules, slimming `replay-corpus.ts` to re-exports, and shrinking `replay-corpus.test.ts` into a facade smoke test. Focused verification passed with `npx tsx --test src/supervisor/replay-corpus.test.ts src/supervisor/replay-corpus-config.test.ts src/supervisor/replay-corpus-runner.test.ts src/supervisor/replay-corpus-loading.test.ts src/supervisor/replay-corpus-promotion.test.ts src/supervisor/replay-corpus-mismatch-formatting.test.ts src/supervisor/replay-corpus-mismatch-artifact.test.ts`; `npm run build` first failed with `sh: 1: tsc: not found`, so ran `npm install` and reran `npm run build` successfully.
-- 2026-03-19 (JST): Addressed CodeRabbit thread `PRRT_kwDORgvdZ851UWEj` by changing the provider-wait promotion hint guard to use a non-nullish check for `configuredBotCurrentHeadObservedAt` and adding a focused regression for the missing-field case. The first new assertion failed because the shared snapshot fixture still emitted `retry-escalation` via `timeout_retry_count=1`; after zeroing the retry counters in the test setup, `npx tsx --test src/supervisor/replay-corpus-promotion.test.ts` passed and `npm run build` remained green.
+- 2026-03-19 (JST): Reproduced issue #601 by adding focused helper coverage for `summarizeSupervisorStatusRecords(...)` and `loadActiveIssueStatusSnapshot(...)`; the first active-status assertion failed because the test workspace was not a git repo with an `origin/main...HEAD` diff, so I tightened the fixture into a real temporary git workspace and corrected the verification-intensity expectation to `focused`. Extracted the helpers into `supervisor-selection-active-status.ts` and `supervisor-selection-status-records.ts`, kept compatibility re-exports in `supervisor-selection-status.ts`, rerouted `supervisor.ts` to the narrower modules, and verified with `npx tsx --test src/supervisor/supervisor-selection-status-active-status.test.ts src/supervisor/supervisor-status-model.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts` plus `npm run build` after `npm install`.
 - 2026-03-19 (JST): Reproduced issue #561 with a focused docs regression in `src/agent-instructions-docs.test.ts`; it failed with `ENOENT` because `docs/agent-instructions.md` did not exist. Added the new bootstrap hub doc with prerequisites, read order, first-run sequence, escalation rules, and canonical links. Focused verification passed with `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts` and `npm run build` after restoring local dev dependencies via `npm install`.
 - 2026-03-19 (JST): Pushed `codex/issue-559` and opened draft PR #582 (`https://github.com/TommyKammy/codex-supervisor/pull/582`) after the focused hinting slice passed local verification.
 - 2026-03-19 (JST): Reproduced issue #559 with a focused `replay-corpus-promote` regression that expected advisory hints for `stale-head-prevents-merge` but only saw the existing explicit-case-id guidance and suggestions. Fixed it by adding deterministic `deriveReplayCorpusPromotionWorthinessHints(...)` coverage for stale-head safety, provider waits, and retry escalation, then surfacing those hints in both CLI suggestion mode and successful promotion summaries. Focused verification passed with `npx tsx --test src/index.test.ts --test-name-pattern "replay-corpus-promote"`, `npx tsx --test src/supervisor/replay-corpus.test.ts --test-name-pattern "PromotionWorthinessHints|promoteCapturedReplaySnapshot|checked-in safety case bundles|runReplayCorpus replays the checked-in PR lifecycle safety cases without mismatches"`, and `npm run build` after restoring local dev dependencies via `npm install`.

--- a/src/supervisor/supervisor-selection-active-status.ts
+++ b/src/supervisor/supervisor-selection-active-status.ts
@@ -1,0 +1,104 @@
+import { readIssueJournal, summarizeIssueJournalHandoff } from "../core/journal";
+import {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+} from "../core/types";
+
+import {
+  buildChangeClassesStatusLine,
+  buildDurableGuardrailStatusLine,
+  buildExternalReviewFollowUpStatusLine,
+  buildVerificationPolicyStatusLine,
+  loadStatusChangedFiles,
+} from "./supervisor-status-rendering";
+
+export interface ActiveStatusGitHub {
+  resolvePullRequestForBranch(branchName: string, pullRequestNumber?: number | null): Promise<GitHubPullRequest | null>;
+  getChecks(pullRequestNumber: number): Promise<PullRequestCheck[]>;
+  getUnresolvedReviewThreads(pullRequestNumber: number): Promise<ReviewThread[]>;
+}
+
+export interface ActiveStatusIssueGitHub {
+  getIssue(issueNumber: number): Promise<GitHubIssue>;
+}
+
+export interface ActiveIssueStatusSnapshot {
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  handoffSummary: string | null;
+  changeClassesSummary: string | null;
+  verificationPolicySummary: string | null;
+  durableGuardrailSummary: string | null;
+  externalReviewFollowUpSummary: string | null;
+  warningMessage: string | null;
+}
+
+function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
+  return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
+}
+
+export async function loadActiveIssueStatusSnapshot(args: {
+  github: ActiveStatusGitHub & Partial<ActiveStatusIssueGitHub>;
+  config: SupervisorConfig;
+  activeRecord: IssueRunRecord;
+}): Promise<ActiveIssueStatusSnapshot> {
+  let handoffSummary: string | null = null;
+  let pr: GitHubPullRequest | null = null;
+  let checks: PullRequestCheck[] = [];
+  let reviewThreads: ReviewThread[] = [];
+  let changeClassesSummary: string | null = null;
+  let verificationPolicySummary: string | null = null;
+  let durableGuardrailSummary: string | null = null;
+  let externalReviewFollowUpSummary: string | null = null;
+  let warningMessage: string | null = null;
+
+  if (args.activeRecord.journal_path) {
+    try {
+      handoffSummary = summarizeIssueJournalHandoff(await readIssueJournal(args.activeRecord.journal_path));
+    } catch (error) {
+      warningMessage = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  try {
+    const changedFiles = await loadStatusChangedFiles(args.config, args.activeRecord.workspace);
+    const issue = args.github.getIssue
+      ? await args.github.getIssue(args.activeRecord.issue_number)
+      : null;
+    pr = await args.github.resolvePullRequestForBranch(args.activeRecord.branch, args.activeRecord.pr_number);
+    checks = isOpenPullRequest(pr) ? await args.github.getChecks(pr.number) : [];
+    reviewThreads = isOpenPullRequest(pr) ? await args.github.getUnresolvedReviewThreads(pr.number) : [];
+    changeClassesSummary = buildChangeClassesStatusLine(changedFiles);
+    verificationPolicySummary = buildVerificationPolicyStatusLine({ issue, changedFiles });
+    durableGuardrailSummary = await buildDurableGuardrailStatusLine({
+      config: args.config,
+      activeRecord: args.activeRecord,
+      pr,
+      changedFiles,
+    });
+    externalReviewFollowUpSummary = await buildExternalReviewFollowUpStatusLine({
+      activeRecord: args.activeRecord,
+      currentHeadSha: pr?.headRefOid ?? args.activeRecord.last_head_sha,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warningMessage = warningMessage ? `${warningMessage}; ${message}` : message;
+  }
+
+  return {
+    pr,
+    checks,
+    reviewThreads,
+    handoffSummary,
+    changeClassesSummary,
+    verificationPolicySummary,
+    durableGuardrailSummary,
+    externalReviewFollowUpSummary,
+    warningMessage,
+  };
+}

--- a/src/supervisor/supervisor-selection-status-active-status.test.ts
+++ b/src/supervisor/supervisor-selection-status-active-status.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import {
+  loadActiveIssueStatusSnapshot,
+} from "./supervisor-selection-active-status";
+import {
+  summarizeSupervisorStatusRecords,
+} from "./supervisor-selection-status-records";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, SupervisorStateFile } from "../core/types";
+
+const execFileAsync = promisify(execFile);
+
+function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return {
+    repoPath: "/tmp/repo",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "/tmp/workspaces",
+    stateBackend: "json",
+    stateFile: "/tmp/state.json",
+    codexBinary: "/usr/bin/codex",
+    codexModelStrategy: "inherit",
+    codexReasoningEffortByState: {},
+    codexReasoningEscalateOnRepeatedFailure: true,
+    sharedMemoryFiles: [],
+    gsdEnabled: false,
+    gsdAutoInstall: false,
+    gsdInstallScope: "global",
+    gsdPlanningFiles: [],
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewRoles: [],
+    localReviewArtifactDir: "/tmp/reviews",
+    localReviewConfidenceThreshold: 0.7,
+    localReviewReviewerThresholds: {
+      generic: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+      specialist: { confidenceThreshold: 0.7, minimumSeverity: "low" },
+    },
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+    reviewBotLogins: [],
+    humanReviewBlocksMerge: true,
+    issueJournalRelativePath: ".codex-supervisor/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    skipTitlePrefixes: [],
+    branchPrefix: "codex/issue-",
+    pollIntervalSeconds: 60,
+    copilotReviewWaitMinutes: 10,
+    copilotReviewTimeoutAction: "continue",
+    codexExecTimeoutMinutes: 30,
+    maxCodexAttemptsPerIssue: 5,
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 5,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+    ...overrides,
+  };
+}
+
+function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return {
+    issue_number: 58,
+    state: "reproducing",
+    branch: "codex/issue-58",
+    pr_number: 58,
+    workspace: "/tmp/workspaces/issue-58",
+    journal_path: "/tmp/workspaces/issue-58/.codex-supervisor/issue-journal.md",
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: "session-1",
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 2,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    last_head_sha: "cafebabe",
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: "2026-03-11T01:50:41.997Z",
+    ...overrides,
+  };
+}
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 58,
+    title: "Status helpers",
+    body: "## Summary\nRefactor active status helpers.",
+    createdAt: "2026-03-11T00:00:00Z",
+    updatedAt: "2026-03-11T00:00:00Z",
+    url: "https://example.test/issues/58",
+    ...overrides,
+  };
+}
+
+function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 58,
+    title: "Status helpers",
+    url: "https://example.test/pr/58",
+    state: "OPEN",
+    createdAt: "2026-03-11T14:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-58",
+    headRefOid: "deadbeef",
+    mergedAt: null,
+    ...overrides,
+  };
+}
+
+test("summarizeSupervisorStatusRecords selects the active, latest, and latest recovery records", () => {
+  const activeRecord = createRecord({
+    issue_number: 58,
+    updated_at: "2026-03-11T01:50:41.997Z",
+  });
+  const latestRecord = createRecord({
+    issue_number: 59,
+    updated_at: "2026-03-14T05:00:00.000Z",
+  });
+  const latestRecoveryRecord = createRecord({
+    issue_number: 60,
+    updated_at: "2026-03-13T04:00:00.000Z",
+    last_recovery_reason: "merged_pr_convergence: tracked PR #60 merged",
+    last_recovery_at: "2026-03-15T09:30:00.000Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 58,
+    issues: {
+      "58": activeRecord,
+      "59": latestRecord,
+      "60": latestRecoveryRecord,
+    },
+  };
+
+  assert.deepEqual(summarizeSupervisorStatusRecords(state), {
+    activeRecord,
+    latestRecord,
+    latestRecoveryRecord,
+    trackedIssueCount: 3,
+  });
+});
+
+test("loadActiveIssueStatusSnapshot keeps journal handoff, summarizes status, and skips closed PR checks", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "selection-status-"));
+  const workspace = path.join(tempDir, "workspace");
+  const remote = path.join(tempDir, "remote.git");
+  const journalPath = path.join(workspace, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    [
+      "# Issue #58: Status helpers",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      "- Current blocker: verification waiting on active PR signal",
+      "- Next exact step: extract active status helpers into their own module",
+      "",
+      "### Scratchpad",
+      "- Keep this section short.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const checks: PullRequestCheck[] = [{ name: "ci", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-1",
+      isResolved: false,
+      isOutdated: false,
+      path: "src/supervisor/supervisor-selection-status.ts",
+      line: 12,
+      comments: { nodes: [] },
+    },
+  ];
+
+  const record = createRecord({
+    workspace,
+    journal_path: journalPath,
+    external_review_head_sha: "cafebabe",
+  });
+
+  try {
+    await execFileAsync("git", ["init", "--bare", remote]);
+    await execFileAsync("git", ["init", "-b", "main", workspace]);
+    await execFileAsync("git", ["config", "user.name", "Codex"], { cwd: workspace });
+    await execFileAsync("git", ["config", "user.email", "codex@example.test"], { cwd: workspace });
+    await execFileAsync("git", ["remote", "add", "origin", remote], { cwd: workspace });
+    await fs.mkdir(path.join(workspace, "src", "supervisor"), { recursive: true });
+    await fs.writeFile(path.join(workspace, "README.md"), "base\n", "utf8");
+    await execFileAsync("git", ["add", "README.md"], { cwd: workspace });
+    await execFileAsync("git", ["commit", "-m", "base"], { cwd: workspace });
+    await execFileAsync("git", ["push", "-u", "origin", "main"], { cwd: workspace });
+    await execFileAsync("git", ["checkout", "-b", "codex/issue-58"], { cwd: workspace });
+    await fs.writeFile(
+      path.join(workspace, "src", "supervisor", "supervisor-status-model.test.ts"),
+      "export const changed = true;\n",
+      "utf8",
+    );
+    await execFileAsync("git", ["add", "src/supervisor/supervisor-status-model.test.ts"], { cwd: workspace });
+    await execFileAsync("git", ["commit", "-m", "add test change"], { cwd: workspace });
+
+    const snapshot = await loadActiveIssueStatusSnapshot({
+      config: createConfig({ defaultBranch: "main" }),
+      activeRecord: record,
+      github: {
+        async getIssue() {
+          return createIssue();
+        },
+        async resolvePullRequestForBranch() {
+          return createPullRequest({
+            state: "CLOSED",
+            mergedAt: "2026-03-12T00:00:00Z",
+          });
+        },
+        async getChecks() {
+          return checks;
+        },
+        async getUnresolvedReviewThreads() {
+          return reviewThreads;
+        },
+      },
+    });
+
+    assert.equal(
+      snapshot.handoffSummary,
+      "blocker: verification waiting on active PR signal | next: extract active status helpers into their own module",
+    );
+    assert.equal(snapshot.pr?.state, "CLOSED");
+    assert.deepEqual(snapshot.checks, []);
+    assert.deepEqual(snapshot.reviewThreads, []);
+    assert.equal(snapshot.changeClassesSummary, "change_classes=tests");
+    assert.equal(snapshot.verificationPolicySummary, "verification_policy intensity=focused driver=changed_files:tests");
+    assert.equal(snapshot.durableGuardrailSummary, null);
+    assert.equal(snapshot.externalReviewFollowUpSummary, null);
+    assert.equal(snapshot.warningMessage, null);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadActiveIssueStatusSnapshot aggregates journal and GitHub warnings", async () => {
+  const record = createRecord({
+    workspace: "/tmp/workspaces/issue-58",
+    journal_path: "/tmp/workspaces/issue-58/.codex-supervisor/missing-issue-journal.md",
+  });
+
+  const snapshot = await loadActiveIssueStatusSnapshot({
+    config: createConfig(),
+    activeRecord: record,
+    github: {
+      async resolvePullRequestForBranch() {
+        throw new Error("pull request lookup failed");
+      },
+      async getChecks(): Promise<PullRequestCheck[]> {
+        throw new Error("should not be called");
+      },
+      async getUnresolvedReviewThreads(): Promise<ReviewThread[]> {
+        throw new Error("should not be called");
+      },
+    },
+  });
+
+  assert.equal(snapshot.pr, null);
+  assert.deepEqual(snapshot.checks, []);
+  assert.deepEqual(snapshot.reviewThreads, []);
+  assert.equal(snapshot.handoffSummary, null);
+  assert.match(snapshot.warningMessage ?? "", /pull request lookup failed/);
+});

--- a/src/supervisor/supervisor-selection-status-records.ts
+++ b/src/supervisor/supervisor-selection-status-records.ts
@@ -1,0 +1,36 @@
+import { IssueRunRecord, SupervisorStateFile } from "../core/types";
+
+export interface SupervisorStatusRecords {
+  activeRecord: IssueRunRecord | null;
+  latestRecord: IssueRunRecord | null;
+  latestRecoveryRecord: IssueRunRecord | null;
+  trackedIssueCount: number;
+}
+
+export function summarizeSupervisorStatusRecords(state: SupervisorStateFile): SupervisorStatusRecords {
+  const activeRecord =
+    state.activeIssueNumber !== null ? state.issues[String(state.activeIssueNumber)] ?? null : null;
+  let latestRecord: IssueRunRecord | null = null;
+  let latestRecoveryRecord: IssueRunRecord | null = null;
+
+  for (const record of Object.values(state.issues)) {
+    if (latestRecord === null || record.updated_at.localeCompare(latestRecord.updated_at) > 0) {
+      latestRecord = record;
+    }
+    if (
+      record.last_recovery_reason &&
+      record.last_recovery_at &&
+      (latestRecoveryRecord === null ||
+        record.last_recovery_at.localeCompare(latestRecoveryRecord.last_recovery_at ?? "") > 0)
+    ) {
+      latestRecoveryRecord = record;
+    }
+  }
+
+  return {
+    activeRecord,
+    latestRecord,
+    latestRecoveryRecord,
+    trackedIssueCount: Object.keys(state.issues).length,
+  };
+}

--- a/src/supervisor/supervisor-selection-status.ts
+++ b/src/supervisor/supervisor-selection-status.ts
@@ -6,7 +6,6 @@ import {
   parseIssueMetadata,
   validateIssueMetadataSyntax,
 } from "../issue-metadata";
-import { readIssueJournal, summarizeIssueJournalHandoff } from "../core/journal";
 import {
   attemptBudgetForLane,
   hasAttemptBudgetRemaining,
@@ -19,7 +18,6 @@ import {
 import { shouldAutoRetryTimeout } from "./supervisor-failure-helpers";
 import {
   buildChangeClassesStatusLine,
-  buildDurableGuardrailStatusLine,
   buildExternalReviewFollowUpStatusLine,
   buildVerificationPolicyStatusLine,
   loadStatusChangedFiles,
@@ -31,23 +29,21 @@ import {
   GitHubIssue,
   GitHubPullRequest,
   IssueRunRecord,
-  PullRequestCheck,
-  ReviewThread,
   SupervisorConfig,
   SupervisorStateFile,
 } from "../core/types";
 import type { ClarificationBlock, ExecutionReadyLintResult } from "../issue-metadata";
+import type { ActiveStatusGitHub } from "./supervisor-selection-active-status";
+export type { ActiveIssueStatusSnapshot } from "./supervisor-selection-active-status";
+export { loadActiveIssueStatusSnapshot } from "./supervisor-selection-active-status";
+export type { SupervisorStatusRecords } from "./supervisor-selection-status-records";
+export { summarizeSupervisorStatusRecords } from "./supervisor-selection-status-records";
 
 type ReadinessSummaryGitHub = Pick<GitHubClient, "listCandidateIssues">;
 type SelectionWhyGitHub = Pick<GitHubClient, "listAllIssues" | "listCandidateIssues">;
 type ExplainIssueGitHub = Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
   Partial<ActiveStatusGitHub>;
 type IssueLintGitHub = Pick<GitHubClient, "getIssue">;
-type ActiveStatusGitHub = Pick<
-  GitHubClient,
-  "resolvePullRequestForBranch" | "getChecks" | "getUnresolvedReviewThreads"
->;
-type ActiveStatusIssueGitHub = Pick<GitHubClient, "getIssue">;
 
 async function buildExplainChangeRiskSummary(args: {
   config: SupervisorConfig;
@@ -95,118 +91,6 @@ async function buildExplainExternalReviewFollowUpSummary(args: {
     activeRecord: args.record,
     currentHeadSha: pr?.headRefOid ?? args.record.last_head_sha,
   });
-}
-
-export interface SupervisorStatusRecords {
-  activeRecord: IssueRunRecord | null;
-  latestRecord: IssueRunRecord | null;
-  latestRecoveryRecord: IssueRunRecord | null;
-  trackedIssueCount: number;
-}
-
-export interface ActiveIssueStatusSnapshot {
-  pr: GitHubPullRequest | null;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  handoffSummary: string | null;
-  changeClassesSummary: string | null;
-  verificationPolicySummary: string | null;
-  durableGuardrailSummary: string | null;
-  externalReviewFollowUpSummary: string | null;
-  warningMessage: string | null;
-}
-
-function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
-  return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
-}
-
-export function summarizeSupervisorStatusRecords(state: SupervisorStateFile): SupervisorStatusRecords {
-  const activeRecord =
-    state.activeIssueNumber !== null ? state.issues[String(state.activeIssueNumber)] ?? null : null;
-  let latestRecord: IssueRunRecord | null = null;
-  let latestRecoveryRecord: IssueRunRecord | null = null;
-
-  for (const record of Object.values(state.issues)) {
-    if (latestRecord === null || record.updated_at.localeCompare(latestRecord.updated_at) > 0) {
-      latestRecord = record;
-    }
-    if (
-      record.last_recovery_reason &&
-      record.last_recovery_at &&
-      (latestRecoveryRecord === null ||
-        record.last_recovery_at.localeCompare(latestRecoveryRecord.last_recovery_at ?? "") > 0)
-    ) {
-      latestRecoveryRecord = record;
-    }
-  }
-
-  return {
-    activeRecord,
-    latestRecord,
-    latestRecoveryRecord,
-    trackedIssueCount: Object.keys(state.issues).length,
-  };
-}
-
-export async function loadActiveIssueStatusSnapshot(args: {
-  github: ActiveStatusGitHub & Partial<ActiveStatusIssueGitHub>;
-  config: SupervisorConfig;
-  activeRecord: IssueRunRecord;
-}): Promise<ActiveIssueStatusSnapshot> {
-  let handoffSummary: string | null = null;
-  let pr: GitHubPullRequest | null = null;
-  let checks: PullRequestCheck[] = [];
-  let reviewThreads: ReviewThread[] = [];
-  let changeClassesSummary: string | null = null;
-  let verificationPolicySummary: string | null = null;
-  let durableGuardrailSummary: string | null = null;
-  let externalReviewFollowUpSummary: string | null = null;
-  let warningMessage: string | null = null;
-
-  if (args.activeRecord.journal_path) {
-    try {
-      handoffSummary = summarizeIssueJournalHandoff(await readIssueJournal(args.activeRecord.journal_path));
-    } catch (error) {
-      warningMessage = error instanceof Error ? error.message : String(error);
-    }
-  }
-
-  try {
-    const changedFiles = await loadStatusChangedFiles(args.config, args.activeRecord.workspace);
-    const issue = args.github.getIssue
-      ? await args.github.getIssue(args.activeRecord.issue_number)
-      : null;
-    pr = await args.github.resolvePullRequestForBranch(args.activeRecord.branch, args.activeRecord.pr_number);
-    checks = isOpenPullRequest(pr) ? await args.github.getChecks(pr.number) : [];
-    reviewThreads = isOpenPullRequest(pr) ? await args.github.getUnresolvedReviewThreads(pr.number) : [];
-    changeClassesSummary = buildChangeClassesStatusLine(changedFiles);
-    verificationPolicySummary = buildVerificationPolicyStatusLine({ issue, changedFiles });
-    durableGuardrailSummary = await buildDurableGuardrailStatusLine({
-      config: args.config,
-      activeRecord: args.activeRecord,
-      pr,
-      changedFiles,
-    });
-    externalReviewFollowUpSummary = await buildExternalReviewFollowUpStatusLine({
-      activeRecord: args.activeRecord,
-      currentHeadSha: pr?.headRefOid ?? args.activeRecord.last_head_sha,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    warningMessage = warningMessage ? `${warningMessage}; ${message}` : message;
-  }
-
-  return {
-    pr,
-    checks,
-    reviewThreads,
-    handoffSummary,
-    changeClassesSummary,
-    verificationPolicySummary,
-    durableGuardrailSummary,
-    externalReviewFollowUpSummary,
-    warningMessage,
-  };
 }
 
 export async function buildReadinessSummary(

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -88,9 +88,9 @@ import {
   buildIssueLintSummary,
   buildReadinessSummary,
   buildSelectionWhySummary,
-  loadActiveIssueStatusSnapshot,
-  summarizeSupervisorStatusRecords,
 } from "./supervisor-selection-status";
+import { loadActiveIssueStatusSnapshot } from "./supervisor-selection-active-status";
+import { summarizeSupervisorStatusRecords } from "./supervisor-selection-status-records";
 import { inferFailureContext } from "./supervisor-failure-context";
 import { StateStore } from "../core/state-store";
 import { diagnoseSupervisorHost, loadStateReadonlyForDoctor, renderDoctorReport } from "../doctor";


### PR DESCRIPTION
## Summary
- extract supervisor active-status snapshot loading into a dedicated module
- extract supervisor status-record summarization into its own module
- add focused tests that pin active-status snapshot and status-record behavior

## Testing
- npx tsx --test src/supervisor/supervisor-selection-status-active-status.test.ts src/supervisor/supervisor-status-model.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal supervisor status handling into focused modules for improved maintainability and code clarity.
  * Added comprehensive test coverage for status snapshot loading and record summarization logic.
  * Maintained backward compatibility through updated exports—no changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->