### PR TITLE
Bound stderr in command runner errors

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,35 +1,36 @@
-# Issue #636: Command error hygiene: add redacted command rendering for failure and timeout errors
+# Issue #637: Command error hygiene: bound stderr included in failure and timeout errors
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/636
-- Branch: codex/issue-636
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/637
+- Branch: codex/issue-637
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: aeaa38b86e47b3984b9bd693b52e73f42b3e92d9
+- Last head SHA: c1584f4769eb12fd00a16bed741fd5f196cd4d17
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-19T12:44:17.592Z
+- Updated at: 2026-03-19T13:05:34.651Z
 
 ## Latest Codex Summary
-- Reproduced the raw-argument leak in `runCommand(...)` with focused core tests, then switched timeout and non-zero errors to a deterministic summarized command renderer that keeps the command plus the first two args and replaces the remainder with `+N arg(s)`. Reused the same renderer in GitHub transport sanitization, verified with `npx tsx --test src/core/command.test.ts src/github/github-transport.test.ts` plus `npm run build` after restoring local dev dependencies via `npm install`, committed the change as `5bb08a4`, pushed `codex/issue-636`, and opened draft PR #639.
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the narrowest safe fix is to change only how `runCommand(...)` renders commands in thrown timeout and non-zero errors, so callers keep the same execution semantics while failure messages stop echoing full raw argument lists by default.
-- What changed: added `src/core/command.test.ts` to reproduce both the non-zero-exit and timeout leaks with sentinel secret arguments, then updated `src/core/command.ts` to use a shared `renderCommandSummary(...)` helper for timeout and failure errors as well as the timeout line appended to `stderr`. Reused the same helper in `src/github/github-transport.ts` so transient GitHub sanitization stays aligned with the core summary shape.
+- Hypothesis: the narrowest safe fix is to bound only the `stderr` payload injected into thrown `runCommand(...)` timeout and non-zero-exit errors, leaving captured `stderr` unchanged on the success path.
+- What changed: added focused `src/core/command.test.ts` coverage that reproduces noisy `stderr` for both non-zero exit and timeout failures, then updated `src/core/command.ts` to splice oversized `stderr` with a deterministic middle `...` marker before building the thrown error message.
 - Current blocker: none
-- Next exact step: monitor draft PR #639 and address any CI or review feedback if it appears.
-- Verification gap: focused coverage for the core command runner and GitHub transport passed locally, and `npm run build` passed after `npm install`; I did not run the repository-wide `npm test` because the issue asked for focused command-runner coverage plus build verification.
-- Files touched: `src/core/command.ts`, `src/core/command.test.ts`, `src/github/github-transport.ts`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: reverting this checkpoint would restore raw argument echoing in thrown timeout and non-zero-exit errors, including the timeout marker appended to `stderr`.
-- Last focused command: `npx tsx --test src/core/command.test.ts src/github/github-transport.test.ts`; `npm install`; `npm run build`; `git commit -m "Redact command summaries in runner errors"`; `git push -u origin codex/issue-636`; `gh pr create --draft --base main --head codex/issue-636 ...`
+- Next exact step: commit this stderr-bounding slice on `codex/issue-637`, then decide whether to push and open a draft PR if none exists yet.
+- Verification gap: `npx tsx --test src/core/command.test.ts` and `npm run build` passed locally after `npm install`; I did not run the repository-wide test suite because the issue asks for focused command-runner coverage plus build verification.
+- Files touched: `src/core/command.ts`, `src/core/command.test.ts`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: reverting this checkpoint would restore unbounded raw `stderr` blocks inside thrown timeout and non-zero-exit command errors.
+- Last focused command: `npm install`; `npx tsx --test src/core/command.test.ts`; `npm run build`
 ### Scratchpad
+- 2026-03-19 (JST): Reproduced issue #637 with focused `runCommand` failures that emitted 1.2k-character `stderr` payloads; initial tests failed because thrown non-zero and timeout errors included the full `stderr` body. Fixed `src/core/command.ts` so error messages splice oversized `stderr` with a deterministic middle ellipsis while preserving both the prefix and suffix, including the timeout marker appended at the end. Focused verification passed with `npx tsx --test src/core/command.test.ts` and `npm run build` after `npm install`.
 - 2026-03-19 (JST): Reproduced issue #561 with a focused docs regression in `src/agent-instructions-docs.test.ts`; it failed with `ENOENT` because `docs/agent-instructions.md` did not exist. Added the new bootstrap hub doc with prerequisites, read order, first-run sequence, escalation rules, and canonical links. Focused verification passed with `npx tsx --test src/agent-instructions-docs.test.ts src/getting-started-docs.test.ts` and `npm run build` after restoring local dev dependencies via `npm install`.
 - 2026-03-19 (JST): Pushed `codex/issue-559` and opened draft PR #582 (`https://github.com/TommyKammy/codex-supervisor/pull/582`) after the focused hinting slice passed local verification.
 - 2026-03-19 (JST): Reproduced issue #559 with a focused `replay-corpus-promote` regression that expected advisory hints for `stale-head-prevents-merge` but only saw the existing explicit-case-id guidance and suggestions. Fixed it by adding deterministic `deriveReplayCorpusPromotionWorthinessHints(...)` coverage for stale-head safety, provider waits, and retry escalation, then surfacing those hints in both CLI suggestion mode and successful promotion summaries. Focused verification passed with `npx tsx --test src/index.test.ts --test-name-pattern "replay-corpus-promote"`, `npx tsx --test src/supervisor/replay-corpus.test.ts --test-name-pattern "PromotionWorthinessHints|promoteCapturedReplaySnapshot|checked-in safety case bundles|runReplayCorpus replays the checked-in PR lifecycle safety cases without mismatches"`, and `npm run build` after restoring local dev dependencies via `npm install`.

--- a/src/core/command.test.ts
+++ b/src/core/command.test.ts
@@ -28,6 +28,35 @@ test("runCommand failure errors redact trailing raw arguments", async () => {
   );
 });
 
+test("runCommand failure errors bound noisy stderr", async () => {
+  const noisyPrefix = "prefix-line";
+  const noisySuffix = "suffix-line";
+  const noisyMiddle = "x".repeat(1_200);
+
+  await assert.rejects(
+    () =>
+      runCommand(process.execPath, [
+        "-e",
+        "process.stderr.write(process.env.NOISY_STDERR ?? ''); process.exit(9);",
+      ], {
+        env: {
+          ...process.env,
+          NOISY_STDERR: `${noisyPrefix}\n${noisyMiddle}\n${noisySuffix}\n`,
+        },
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Command failed:/);
+      assert.match(error.message, /exitCode=9/);
+      assert.match(error.message, new RegExp(noisyPrefix));
+      assert.match(error.message, new RegExp(noisySuffix));
+      assert.match(error.message, /\n\.\.\.\n/);
+      assert.ok(error.message.length < 900, `expected bounded error message, got length ${error.message.length}`);
+      return true;
+    },
+  );
+});
+
 test("runCommand timeout errors redact trailing raw arguments", async () => {
   const secretArg = "token=timeout-secret-value";
 
@@ -51,6 +80,40 @@ test("runCommand timeout errors redact trailing raw arguments", async () => {
       assert.match(error.message, /exitCode=/);
       assert.match(error.message, /Command timed out after 10ms: .* -e .* \+1 arg/);
       assert.doesNotMatch(error.message, /timeout-secret-value/);
+      return true;
+    },
+  );
+});
+
+test("runCommand timeout errors bound noisy stderr while keeping timeout context", async () => {
+  const noisyPrefix = "timeout-prefix";
+  const noisySuffix = "timeout-suffix";
+  const noisyMiddle = "y".repeat(1_200);
+
+  await assert.rejects(
+    () =>
+      runCommand(
+        process.execPath,
+        [
+          "-e",
+          "process.stderr.write(process.env.NOISY_STDERR ?? ''); setTimeout(() => process.exit(0), 1000);",
+        ],
+        {
+          env: {
+            ...process.env,
+            NOISY_STDERR: `${noisyPrefix}\n${noisyMiddle}\n${noisySuffix}\n`,
+          },
+          timeoutMs: 50,
+        },
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Command timed out:/);
+      assert.match(error.message, new RegExp(noisyPrefix));
+      assert.match(error.message, new RegExp(noisySuffix));
+      assert.match(error.message, /Command timed out after 50ms:/);
+      assert.match(error.message, /\n\.\.\.\n/);
+      assert.ok(error.message.length < 950, `expected bounded timeout error message, got length ${error.message.length}`);
       return true;
     },
   );

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
 
+const COMMAND_ERROR_STDERR_LIMIT = 500;
+const STDERR_TRUNCATION_MARKER = "\n...\n";
+
 export interface CommandOptions {
   cwd?: string;
   allowExitCodes?: number[];
@@ -11,6 +14,22 @@ export interface CommandResult {
   exitCode: number;
   stdout: string;
   stderr: string;
+}
+
+function formatCommandErrorStderr(stderr: string): string | null {
+  const trimmed = stderr.trim();
+  if (trimmed === "") {
+    return null;
+  }
+
+  if (trimmed.length <= COMMAND_ERROR_STDERR_LIMIT) {
+    return trimmed;
+  }
+
+  const availableLength = COMMAND_ERROR_STDERR_LIMIT - STDERR_TRUNCATION_MARKER.length;
+  const prefixLength = Math.ceil(availableLength / 2);
+  const suffixLength = Math.floor(availableLength / 2);
+  return `${trimmed.slice(0, prefixLength)}${STDERR_TRUNCATION_MARKER}${trimmed.slice(trimmed.length - suffixLength)}`;
 }
 
 export function renderCommandSummary(command: string, args: string[], visibleArgCount = 2): string {
@@ -131,7 +150,7 @@ export async function runCommand(
             [
               `Command timed out: ${commandSummary}`,
               `exitCode=${exitCode}`,
-              stderr.trim(),
+              formatCommandErrorStderr(stderr),
             ]
               .filter(Boolean)
               .join("\n"),
@@ -146,7 +165,7 @@ export async function runCommand(
             [
               `Command failed: ${commandSummary}`,
               `exitCode=${exitCode}`,
-              stderr.trim(),
+              formatCommandErrorStderr(stderr),
             ]
               .filter(Boolean)
               .join("\n"),


### PR DESCRIPTION
## Summary
- bound noisy stderr included in thrown `runCommand(...)` timeout and non-zero-exit errors
- preserve success-path stderr capture while keeping timeout context visible in error messages
- add focused command-runner regression coverage for deterministic truncation

Closes #637

## Verification
- npx tsx --test src/core/command.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command failure and timeout error messages now display bounded error output, showing the beginning and end of the message with a truncation indicator for improved readability when handling large error outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->