### PR TITLE
docs: refresh issue 723 journal handoff

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -6,37 +6,37 @@
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 6 (implementation=5, repair=1)
-- Last head SHA: b39d4b7d25e71d70b0fc716f62f5421e865ca6e3
+- Attempt count: 7 (implementation=5, repair=2)
+- Last head SHA: 0ef9686ad9684330a37c476a8efcb2a9f29fb0c0
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ851y9tc|PRRT_kwDORgvdZ851y9tg
-- Repeated failure signature count: 1
-- Updated at: 2026-03-20T19:33:27.886Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-20T19:36:39Z
 
 ## Latest Codex Summary
-`codex/issue-723` still differs from `origin/main` only by journal handoff updates for already-shipped behavior. For PR [#748](https://github.com/TommyKammy/codex-supervisor/pull/748), I addressed the two outstanding CodeRabbit comments in `.codex-supervisor/issue-journal.md` by removing filesystem-specific paths from the copied review context and consolidating the duplicate last-command heading; no product-code change was needed.
+`codex/issue-723` still differs from `origin/main` only by journal handoff updates for already-shipped behavior. I committed the PR `#748` review fix as `0ef9686` (`docs: address issue 723 review notes`), pushed it to `origin/codex/issue-723`, and resolved both previously open CodeRabbit threads after confirming the change stayed journal-only.
 
-Summary: Applied the two journal-only PR review fixes for #723 without changing the shipped remote-restore behavior.
-State hint: addressing_review
+Summary: Applied, pushed, and resolved the two journal-only PR review fixes for #723 without changing the shipped remote-restore behavior.
+State hint: draft_pr
 Blocked reason: none
 Tests: not run (docs-only journal update)
 Failure signature: none
-Next action: Commit and push the journal-only review fix, then resolve or recheck the PR `#748` review threads
+Next action: Decide whether to merge or close draft PR `#748`, since the branch still carries only journal handoff updates for behavior already shipped in PR `#747`
 
 ## Active Failure Context
-- Category: review
-- Summary: No remaining local failure after applying the 2 journal-only automated review fixes for PR `#748`.
+- None active. The 2 previously open PR `#748` review threads (`PRRT_kwDORgvdZ851y9tc`, `PRRT_kwDORgvdZ851y9tg`) are resolved after commit `0ef9686`.
 - Reference: https://github.com/TommyKammy/codex-supervisor/pull/748#discussion_r2967580502
 - Details:
   - `.codex-supervisor/issue-journal.md`: removed the filesystem-specific `/home/tommy/...` paths that were copied into the journal's review context so the handoff remains repository-portable.
   - `.codex-supervisor/issue-journal.md`: removed the duplicate `Last focused command` label and kept a single `Last focused commands` section for the command log.
+  - GitHub verification: `gh api graphql` now reports both targeted review threads as `isResolved: true`.
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: No product-code change is required for #723 because the requested local -> remote -> bootstrap restore behavior is already shipped on `origin/main`; the only remaining work on this branch is clearing journal-only PR review feedback.
-- What changed: re-read the required memory files and journal, verified the first CodeRabbit comment was stale against the live summary text but still valid because the copied review context embedded absolute filesystem paths, rewrote that context into a repository-portable summary, and consolidated the duplicate `Last focused command(s)` heading into a single commands block.
+- What changed: re-read the required memory files and journal, verified the first CodeRabbit comment was stale against the live summary text but still valid because the copied review context embedded absolute filesystem paths, rewrote that context into a repository-portable summary, consolidated the duplicate `Last focused command(s)` heading into a single commands block, committed the result as `0ef9686`, pushed `codex/issue-723`, and resolved both CodeRabbit review threads with `gh api graphql`.
 - Current blocker: none
-- Next exact step: commit and push this journal-only review fix to `origin/codex/issue-723`, then resolve or recheck the remaining PR `#748` review threads.
+- Next exact step: decide whether to merge or close draft PR `#748`, because the branch still carries only journal handoff updates for behavior already shipped in PR `#747`.
 - Verification gap: no code verification rerun this turn because the change is limited to `.codex-supervisor/issue-journal.md`.
 - Files touched: `.codex-supervisor/issue-journal.md`
 - Rollback concern: reverting this journal update would only reopen the journal-only PR review comments; product behavior would stay unchanged because it is already on `origin/main`.
@@ -48,6 +48,13 @@ sed -n '1,220p' .codex-supervisor/issue-journal.md
 nl -ba .codex-supervisor/issue-journal.md | sed -n '1,140p'
 git status --short --branch
 git diff -- .codex-supervisor/issue-journal.md
+git add .codex-supervisor/issue-journal.md
+git commit -m "docs: address issue 723 review notes"
+git rev-parse HEAD
+git push origin codex/issue-723
+gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId=PRRT_kwDORgvdZ851y9tc
+gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId=PRRT_kwDORgvdZ851y9tg
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:20){nodes{id isResolved}}}}}' -F owner=TommyKammy -F repo=codex-supervisor -F number=748
 date -u +"%Y-%m-%dT%H:%M:%SZ"
 ```
 ### Scratchpad


### PR DESCRIPTION
## Summary
- refresh the issue #723 journal handoff on the dedicated issue branch
- document that the requested remote-restore behavior is already present on `origin/main`
- keep this branch attached to a draft PR instead of re-entering no-PR recovery

## Context
Issue #723 was effectively satisfied by `Remote branch discovery before bootstrap (#747)` on `origin/main` before this dedicated issue branch had a remote or PR. This draft PR exists to preserve the branch checkpoint and make the already-shipped state explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal issue-tracking metadata and supervisor journal entries.
  * Cleared active failure context and resolved prior review-thread items.
  * Cleaned and condensed working notes, removing local filesystem paths and duplicate headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->