### PR TITLE
docs: define orphan cleanup contract

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,60 +1,52 @@
-# Issue #723: Remote branch restore: recover missing local issue branches from origin before bootstrapping from default
+# Issue #725: Orphan cleanup docs: define preservation rules and explicit prune expectations
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/723
-- Branch: codex/issue-723
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/725
+- Branch: codex/issue-725
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 7 (implementation=5, repair=2)
-- Last head SHA: 0ef9686ad9684330a37c476a8efcb2a9f29fb0c0
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 1687069f7b72b7988663a43bbc89257c7ecd57fd
 - Blocked reason: none
-- Last failure signature: none
+- Last failure signature: docs-orphan-cleanup-contract-missing
 - Repeated failure signature count: 0
-- Updated at: 2026-03-20T19:36:39Z
+- Updated at: 2026-03-20T19:59:57Z
 
 ## Latest Codex Summary
-`codex/issue-723` still differs from `origin/main` only by journal handoff updates for already-shipped behavior. I committed the PR `#748` review fix as `0ef9686` (`docs: address issue 723 review notes`), pushed it to `origin/codex/issue-723`, and resolved both previously open CodeRabbit threads after confirming the change stayed journal-only.
-
-Summary: Applied, pushed, and resolved the two journal-only PR review fixes for #723 without changing the shipped remote-restore behavior.
-State hint: draft_pr
-Blocked reason: none
-Tests: not run (docs-only journal update)
-Failure signature: none
-Next action: Decide whether to merge or close draft PR `#748`, since the branch still carries only journal handoff updates for behavior already shipped in PR `#747`
+- Added a narrow docs regression test for orphan-cleanup guidance, reproduced the gap when `src/execution-safety-docs.test.ts` failed because the docs did not define orphaned workspaces, updated `README.md`, `docs/architecture.md`, `docs/getting-started.md`, and `docs/configuration.md` to distinguish tracked done cleanup from explicit orphan pruning with preservation rules for locked, recent, and manually kept workspaces, and verified with `npx tsx --test src/execution-safety-docs.test.ts` plus `npm run build`.
 
 ## Active Failure Context
-- None active. The 2 previously open PR `#748` review threads (`PRRT_kwDORgvdZ851y9tc`, `PRRT_kwDORgvdZ851y9tg`) are resolved after commit `0ef9686`.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/748#discussion_r2967580502
-- Details:
-  - `.codex-supervisor/issue-journal.md`: removed the filesystem-specific `/home/tommy/...` paths that were copied into the journal's review context so the handoff remains repository-portable.
-  - `.codex-supervisor/issue-journal.md`: removed the duplicate `Last focused command` label and kept a single `Last focused commands` section for the command log.
-  - GitHub verification: `gh api graphql` now reports both targeted review threads as `isResolved: true`.
+- Reproduced before the doc edits with `npx tsx --test src/execution-safety-docs.test.ts --test-name-pattern="workspace cleanup docs distinguish tracked done cleanup from explicit orphan pruning"` failing on `expected README.md to mention orphan workspaces`.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: No product-code change is required for #723 because the requested local -> remote -> bootstrap restore behavior is already shipped on `origin/main`; the only remaining work on this branch is clearing journal-only PR review feedback.
-- What changed: re-read the required memory files and journal, verified the first CodeRabbit comment was stale against the live summary text but still valid because the copied review context embedded absolute filesystem paths, rewrote that context into a repository-portable summary, consolidated the duplicate `Last focused command(s)` heading into a single commands block, committed the result as `0ef9686`, pushed `codex/issue-723`, and resolved both CodeRabbit review threads with `gh api graphql`.
+- Hypothesis: The issue is documentation drift, not runtime behavior: the repo needs one explicit orphan-cleanup contract across the top-level docs, plus a regression test that prevents architecture from implying orphan cleanup is the same as delayed cleanup for tracked `done` workspaces.
+- What changed: re-read the required memory files and journal, inspected the current orphan-cleanup wording across the requested docs, added a focused assertion to `src/execution-safety-docs.test.ts`, reproduced the gap once dependencies were installed, then updated the four docs to define orphaned workspaces, preservation rules, and explicit prune expectations.
 - Current blocker: none
-- Next exact step: decide whether to merge or close draft PR `#748`, because the branch still carries only journal handoff updates for behavior already shipped in PR `#747`.
-- Verification gap: no code verification rerun this turn because the change is limited to `.codex-supervisor/issue-journal.md`.
-- Files touched: `.codex-supervisor/issue-journal.md`
-- Rollback concern: reverting this journal update would only reopen the journal-only PR review comments; product behavior would stay unchanged because it is already on `origin/main`.
+- Next exact step: review the final diff, commit the docs and test updates, and open or update the draft PR for issue #725 if needed.
+- Verification gap: full repo test suite was not rerun; verification this turn is the focused docs test file and `npm run build`.
+- Files touched: `src/execution-safety-docs.test.ts`, `README.md`, `docs/architecture.md`, `docs/getting-started.md`, `docs/configuration.md`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: reverting the doc updates would restore the previous ambiguity where orphan cleanup could be misread as implicit delayed cleanup for tracked `done` workspaces.
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-723/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-723/context-index.md
-sed -n '1,220p' .codex-supervisor/issue-journal.md
-nl -ba .codex-supervisor/issue-journal.md | sed -n '1,140p'
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-725/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-725/context-index.md
+sed -n '1,260p' .codex-supervisor/issue-journal.md
+rg -n "orphan|cleanup|prune|worktree" README.md docs/architecture.md docs/getting-started.md docs/configuration.md
+sed -n '1,260p' README.md
+sed -n '1,260p' docs/getting-started.md
+sed -n '1,260p' docs/architecture.md
+sed -n '1,260p' docs/configuration.md
+sed -n '1,220p' src/getting-started-docs.test.ts
+sed -n '1,260p' src/execution-safety-docs.test.ts
+sed -n '1,260p' src/readme-docs.test.ts
+npm install
+npx tsx --test src/execution-safety-docs.test.ts --test-name-pattern="workspace cleanup docs distinguish tracked done cleanup from explicit orphan pruning"
+npx tsx --test src/execution-safety-docs.test.ts
+npm run build
 git status --short --branch
-git diff -- .codex-supervisor/issue-journal.md
-git add .codex-supervisor/issue-journal.md
-git commit -m "docs: address issue 723 review notes"
-git rev-parse HEAD
-git push origin codex/issue-723
-gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId=PRRT_kwDORgvdZ851y9tc
-gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId=PRRT_kwDORgvdZ851y9tg
-gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:20){nodes{id isResolved}}}}}' -F owner=TommyKammy -F repo=codex-supervisor -F number=748
+git diff -- README.md docs/architecture.md docs/getting-started.md docs/configuration.md src/execution-safety-docs.test.ts
 date -u +"%Y-%m-%dT%H:%M:%SZ"
 ```
 ### Scratchpad

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ State-file contract: missing JSON state is an empty bootstrap case, but corrupte
 
 Workspace restore contract: `ensureWorkspace()` should prefer an existing local issue branch first, then an existing remote issue branch, and only then bootstrap a fresh issue branch from `origin/<defaultBranch>`. Bootstrapping from the default branch is the fallback path when no existing issue branch can be restored.
 
+Workspace cleanup contract: tracked done workspaces and orphaned workspaces are different cases. Tracked done workspace cleanup is the bounded delayed cleanup controlled by the done-workspace settings. An orphaned workspace is an untracked `issue-*` worktree under `workspaceRoot` that no longer has a live state entry; preserve locked, recent, or manually kept orphan workspaces, and only prune abandoned orphan workspaces through an explicit operator action rather than an implicit background cleanup.
+
 ## Provider Profiles
 
 Choose the review provider profile that matches how PR feedback arrives in your repo, then keep any provider-side setup aligned with that choice.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,8 @@ These are the recovery points after crashes, process restarts, or thread loss, b
 
 For issue workspaces, the intended restore precedence is: prefer an existing local issue branch first, then an existing remote issue branch, and only then bootstrap a fresh issue branch from `origin/<defaultBranch>`. That default-branch bootstrap is the fallback path when no existing issue branch can be restored.
 
+For workspace cleanup, keep tracked done workspaces separate from orphaned workspaces. Tracked done cleanup is the bounded cleanup policy for issue workspaces that still have supervisor state and have reached `done`. An orphaned workspace is an untracked canonical `issue-*` worktree under `workspaceRoot` that no longer has a live state entry. Locked orphan workspaces, recently touched orphan workspaces, and orphan workspaces the operator intentionally keeps for manual recovery should be preserved. More aggressive orphan prune actions are explicit operator cleanup actions, not an implicit equivalent of delayed done-workspace cleanup.
+
 For the JSON backend, missing JSON state means there is no durable state yet and the supervisor can bootstrap from empty state. Corrupted JSON state is different: it is a recovery event, not a normal bootstrap case, and it is not safe to treat as durable state until an operator has inspected the file and explicitly acknowledged or reset it.
 
 ## Main safety boundaries
@@ -46,4 +48,5 @@ The same fail-open vs fail-closed distinction applies to state recovery guidance
 - closed child issues -> close parent epic
 - timeout failure -> bounded retry
 - verification blocker -> bounded retry
-- stale worktree cleanup -> delayed cleanup for `done` issues
+- tracked done workspace cleanup -> delayed cleanup for `done` issues
+- orphaned workspace prune action -> explicit operator action with preservation rules for locked, recent, or manually kept workspaces

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,8 @@ Workspace cleanup:
 - `maxDoneWorkspaces`
 - `cleanupDoneWorkspacesAfterHours`
 
+These settings apply to tracked done workspaces, not to every orphaned `issue-*` worktree under `workspaceRoot`. An orphaned workspace is an untracked canonical issue workspace that no longer has a live state entry. Preserve orphan workspaces that are locked, recently touched, or intentionally kept for manual recovery. If you want to prune abandoned orphan workspaces more aggressively, treat that as an explicit operator cleanup action rather than an implicit side effect of the done-workspace settings.
+
 ## Model and Reasoning Guidance
 
 Recommended default:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,6 +143,7 @@ What to check after `run-once`:
 - the selected issue is the one you expected
 - the issue worktree was created under `workspaceRoot`
 - any restored issue workspace reused the expected local branch first, otherwise the expected remote branch, instead of silently falling back to a fresh bootstrap
+- any untracked orphaned `issue-*` worktree under `workspaceRoot` was not treated like tracked done-workspace cleanup; locked, recent, or manually kept orphan workspaces should be preserved unless you explicitly prune them
 - the issue journal shows a sensible hypothesis, blocker, and next step
 - any opened PR or status transition matches the actual repo state
 
@@ -184,6 +185,9 @@ Open or update a draft PR as soon as the branch has a coherent checkpoint. The s
 
 When should I enable local review?
 Enable it when you want a committed pre-merge review gate or an additional local advisory pass before CI and external reviews. Use the [Local review reference](./local-review.md) for role selection, thresholds, artifacts, and policy choices.
+
+When should orphaned workspaces be cleaned up?
+Treat orphaned `issue-*` worktrees as explicit cleanup work, not as the same thing as delayed cleanup for tracked done workspaces. Preserve orphan workspaces that are locked, recently touched, or intentionally kept for manual recovery, and prune abandoned orphan workspaces only when you have made that operator decision explicitly.
 
 What if the backlog order looks wrong?
 Fix `Depends on` and `Execution order` in GitHub. The scheduler follows runnable order, not operator intuition or chat history.

--- a/src/execution-safety-docs.test.ts
+++ b/src/execution-safety-docs.test.ts
@@ -109,3 +109,36 @@ test("workspace restore docs define local-branch, remote-branch, and bootstrap p
     );
   }
 });
+
+test("workspace cleanup docs distinguish tracked done cleanup from explicit orphan pruning", async () => {
+  const [readme, architecture, gettingStarted, configuration] = await Promise.all([
+    readDoc("README.md"),
+    readDoc(path.join("docs", "architecture.md")),
+    readDoc(path.join("docs", "getting-started.md")),
+    readDoc(path.join("docs", "configuration.md")),
+  ]);
+
+  for (const [label, content] of [
+    ["README.md", readme],
+    ["docs/architecture.md", architecture],
+    ["docs/getting-started.md", gettingStarted],
+    ["docs/configuration.md", configuration],
+  ] as const) {
+    assert.match(content, /orphan(?:ed)? work(?:tree|space)/i, `expected ${label} to mention orphan workspaces`);
+    assert.match(content, /preserv/i, `expected ${label} to describe preservation rules`);
+    assert.match(content, /lock(?:ed)?|recent|manual(?:ly)? kept/i, `expected ${label} to mention preserve cases`);
+    assert.match(content, /explicit/i, `expected ${label} to require explicit orphan pruning`);
+    assert.match(content, /prune/i, `expected ${label} to mention prune expectations`);
+    assert.match(
+      content,
+      /done work(?:tree|space)|tracked done work(?:tree|space)/i,
+      `expected ${label} to distinguish tracked done cleanup from orphan cleanup`,
+    );
+  }
+
+  assert.doesNotMatch(
+    architecture,
+    /stale worktree cleanup -> delayed cleanup for `done` issues/i,
+    "docs/architecture.md should not equate orphan cleanup with tracked done cleanup",
+  );
+});


### PR DESCRIPTION
## Summary
- add a focused docs regression test for orphan cleanup guidance
- document orphaned workspace preservation and explicit prune expectations across the main operator docs
- distinguish orphan cleanup from tracked done-workspace cleanup

Closes #725

## Verification
- npx tsx --test src/execution-safety-docs.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workspace cleanup contract distinguishing tracked done workspaces from orphaned workspaces, with explicit preservation rules for locked, recent, and manually kept orphan workspaces.
  * Specified that orphan workspace pruning requires explicit operator action rather than implicit background cleanup.

* **Tests**
  * Added regression test validating documentation content accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->