### PR TITLE
Add explicit orphan workspace prune command

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,44 +1,43 @@
-# Issue #728: Orphan cleanup age gate: preserve recent orphaned workspaces until they age out
+# Issue #729: Orphan prune command: add an explicit operator path for eligible orphaned workspace cleanup
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/728
-- Branch: codex/issue-728
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/729
+- Branch: codex/issue-729
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: draft_pr
+- Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 7c121e78f96818fc49d5e051d1d9f20ff6028cf6
+- Last head SHA: 80f5b3ecbff3dd665dc647a0b37e1e6f13610d21
 - Blocked reason: none
-- Last failure signature: orphan-age-gate-coupled-to-done-cleanup
+- Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-20T21:34:38Z
+- Updated at: 2026-03-20T22:07:48.725Z
 
 ## Latest Codex Summary
-- Added a dedicated orphan-workspace age gate so automatic orphan pruning preserves recent orphaned worktrees even when tracked done-workspace cleanup is disabled; committed as `0818ff1` and opened draft PR `#752`.
+- Added an explicit `prune-orphaned-workspaces` operator command that reuses orphan-prune safety checks and returns deterministic JSON describing pruned and skipped workspaces.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: orphan auto-prune needs its own age threshold because reusing `cleanupDoneWorkspacesAfterHours` drops the orphan grace period whenever tracked done cleanup is disabled.
-- What changed: added a focused `runOnce` regression that preserves a recent orphan while still keeping an aged orphan pruneable in `src/supervisor/supervisor-execution-cleanup.test.ts`; introduced `cleanupOrphanedWorkspacesAfterHours` in config parsing and docs; updated `inspectOrphanedWorkspacePruneCandidates()` in `src/recovery-reconciliation.ts` to classify recent orphans against the dedicated threshold instead of `cleanupDoneWorkspacesAfterHours`.
+- Hypothesis: the missing operator path should be a dedicated top-level CLI command, not a broad admin surface, and it should reuse `inspectOrphanedWorkspacePruneCandidates()` so the same lock/age/safe-target gates apply to explicit pruning.
+- What changed: added `prune-orphaned-workspaces` to CLI parsing and supervisor runtime dispatch; added a structured prune result DTO and supervisor service method; implemented `pruneOrphanedWorkspacesForOperator()` in `src/recovery-reconciliation.ts`; added focused coverage in `src/cli/entrypoint.test.ts`, `src/cli/supervisor-runtime.test.ts`, `src/supervisor/supervisor-execution-cleanup.test.ts`, and `src/supervisor/supervisor-diagnostics-status-selection.test.ts` for one eligible prune and one skipped recent orphan.
 - Current blocker: none
-- Next exact step: monitor draft PR `#752` CI and address any follow-up review or build feedback without widening scope beyond orphan auto-prune age gating.
-- Verification gap: targeted tests and build passed, but the full repo test suite was not rerun.
-- Files touched: `src/core/config.ts`, `src/core/types.ts`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-execution-cleanup.test.ts`, `docs/configuration.md`, `docs/examples/atlaspm.md`, `docs/examples/atlaspm.supervisor.config.example.json`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: reverting these changes would couple orphan pruning back to tracked done-workspace retention and let recent orphaned workspaces be auto-pruned immediately when done cleanup is disabled.
-- Last focused command: `npm run build`
-- Last focused failure: `orphan-age-gate-coupled-to-done-cleanup`
+- Next exact step: commit the explicit orphan-prune command checkpoint and, if needed, open or update a draft PR for issue #729.
+- Verification gap: requested targeted tests and `npm run build` passed after hydrating dependencies with `npm ci`; the full repo test suite was not rerun.
+- Files touched: `src/cli/entrypoint.test.ts`, `src/cli/parse-args.test.ts`, `src/cli/parse-args.ts`, `src/cli/supervisor-runtime.test.ts`, `src/cli/supervisor-runtime.ts`, `src/core/types.ts`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-execution-cleanup.test.ts`, `src/supervisor/supervisor-mutation-report.ts`, `src/supervisor/supervisor-service.ts`, `src/supervisor/supervisor.ts`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: reverting these changes would remove the supported operator cleanup path and force orphan cleanup back onto manual state editing or indirect automatic behavior.
+- Last focused command: `npx tsx --test src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-execution-cleanup.test.ts`
+- Last focused failure: `none`
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-728/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-728/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-729/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-729/context-index.md
 sed -n '1,320p' .codex-supervisor/issue-journal.md
 git status --short --branch
-npx tsx --test src/supervisor/supervisor-execution-cleanup.test.ts
-npx tsx --test src/supervisor/supervisor-execution-cleanup.test.ts src/run-once-cycle-prelude.test.ts
-npx tsx --test src/doctor.test.ts
+npx tsx --test src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
+npx tsx --test src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-execution-cleanup.test.ts
 npm ci
 npm run build
 date -u +"%Y-%m-%dT%H:%M:%SZ"

--- a/src/cli/entrypoint.test.ts
+++ b/src/cli/entrypoint.test.ts
@@ -127,6 +127,29 @@ test("runCli routes reset-corrupt-json-state through the supervisor runtime boun
   });
 });
 
+test("runCli routes prune-orphaned-workspaces through the supervisor runtime boundary", async () => {
+  const service = { tag: "service" };
+  let runtimeCommand: Record<string, unknown> | undefined;
+
+  await runCli(["prune-orphaned-workspaces"], {
+    createSupervisorService: () => service as never,
+    runSupervisorCommand: async (command, dependencies) => {
+      runtimeCommand = {
+        ...command,
+        service: dependencies.service,
+      };
+    },
+  });
+
+  assert.deepEqual(runtimeCommand, {
+    command: "prune-orphaned-workspaces",
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    service,
+  });
+});
+
 test("runCliMain reports failures to stderr and exits with code 1", async () => {
   const stderr: string[] = [];
   const exitCodes: number[] = [];

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -54,6 +54,19 @@ test("parseArgs accepts reset-corrupt-json-state without an issue number", () =>
   });
 });
 
+test("parseArgs accepts prune-orphaned-workspaces without an issue number", () => {
+  assert.deepEqual(parseArgs(["prune-orphaned-workspaces"]), {
+    command: "prune-orphaned-workspaces",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
 test("parseArgs accepts replay with a snapshot path", () => {
   assert.deepEqual(parseArgs(["replay", "/tmp/decision-cycle-snapshot.json"]), {
     command: "replay",

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -23,6 +23,7 @@ export function parseArgs(argv: string[]): CliOptions {
       token === "loop" ||
       token === "status" ||
       token === "requeue" ||
+      token === "prune-orphaned-workspaces" ||
       token === "reset-corrupt-json-state" ||
       token === "explain" ||
       token === "issue-lint" ||

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -78,6 +78,9 @@ test("runSupervisorCommand stops the loop after a registered signal and aborts p
         runRecoveryAction: async () => {
           throw new Error("unexpected runRecoveryAction");
         },
+        pruneOrphanedWorkspaces: async () => {
+          throw new Error("unexpected pruneOrphanedWorkspaces");
+        },
         resetCorruptJsonState: async () => {
           throw new Error("unexpected resetCorruptJsonState");
         },
@@ -144,6 +147,9 @@ test("runSupervisorCommand stops the loop after a corrupt-json fail-closed block
         runRecoveryAction: async () => {
           throw new Error("unexpected runRecoveryAction");
         },
+        pruneOrphanedWorkspaces: async () => {
+          throw new Error("unexpected pruneOrphanedWorkspaces");
+        },
         resetCorruptJsonState: async () => {
           throw new Error("unexpected resetCorruptJsonState");
         },
@@ -207,6 +213,10 @@ test("runSupervisorCommand routes query commands through the supervisor service 
         runRecoveryAction: async () => {
           calls.push("recovery");
           throw new Error("unexpected runRecoveryAction");
+        },
+        pruneOrphanedWorkspaces: async () => {
+          calls.push("pruneOrphanedWorkspaces");
+          throw new Error("unexpected pruneOrphanedWorkspaces");
         },
         resetCorruptJsonState: async () => {
           calls.push("resetCorruptJsonState");
@@ -303,6 +313,9 @@ test("runSupervisorCommand renders a structured requeue result", async () => {
             recoveryReason: "operator_requeue: requeued issue #123 from blocked to queued",
           };
         },
+        pruneOrphanedWorkspaces: async () => {
+          throw new Error("unexpected pruneOrphanedWorkspaces");
+        },
         resetCorruptJsonState: async () => {
           throw new Error("unexpected resetCorruptJsonState");
         },
@@ -356,6 +369,102 @@ test("runSupervisorCommand renders a structured requeue result", async () => {
   });
 });
 
+test("runSupervisorCommand renders a structured orphan prune result", async () => {
+  const stdout: string[] = [];
+
+  await runSupervisorCommand(
+    { command: "prune-orphaned-workspaces", dryRun: false, why: false, issueNumber: undefined },
+    {
+      service: {
+        config: {} as SupervisorConfig,
+        pollIntervalMs: () => 50,
+        acquireSupervisorLock: async () => ({
+          acquired: true,
+          release: async () => {},
+        }),
+        runOnce: async () => {
+          throw new Error("unexpected runOnce");
+        },
+        queryStatus: async () => {
+          throw new Error("unexpected queryStatus");
+        },
+        queryExplain: async () => {
+          throw new Error("unexpected queryExplain");
+        },
+        queryIssueLint: async () => {
+          throw new Error("unexpected queryIssueLint");
+        },
+        queryDoctor: async () => {
+          throw new Error("unexpected queryDoctor");
+        },
+        runRecoveryAction: async () => {
+          throw new Error("unexpected runRecoveryAction");
+        },
+        pruneOrphanedWorkspaces: async () => ({
+          action: "prune-orphaned-workspaces",
+          outcome: "completed",
+          summary: "Pruned 1 orphaned workspace(s); skipped 1 orphaned workspace(s).",
+          pruned: [
+            {
+              issueNumber: 123,
+              workspaceName: "issue-123",
+              workspacePath: "/tmp/workspaces/issue-123",
+              branch: "codex/reopen-issue-123",
+              modifiedAt: "2026-03-21T00:00:00.000Z",
+              reason: "safe orphaned git worktree",
+            },
+          ],
+          skipped: [
+            {
+              issueNumber: 124,
+              workspaceName: "issue-124",
+              workspacePath: "/tmp/workspaces/issue-124",
+              branch: "codex/reopen-issue-124",
+              modifiedAt: "2026-03-21T00:00:00.000Z",
+              eligibility: "recent",
+              reason: "workspace modified within 24h grace period",
+            },
+          ],
+        }),
+        resetCorruptJsonState: async () => {
+          throw new Error("unexpected resetCorruptJsonState");
+        },
+      },
+      writeStdout: (line) => {
+        stdout.push(line);
+      },
+    },
+  );
+
+  assert.equal(stdout.length, 1);
+  assert.deepEqual(JSON.parse(stdout[0] ?? ""), {
+    action: "prune-orphaned-workspaces",
+    outcome: "completed",
+    summary: "Pruned 1 orphaned workspace(s); skipped 1 orphaned workspace(s).",
+    pruned: [
+      {
+        issueNumber: 123,
+        workspaceName: "issue-123",
+        workspacePath: "/tmp/workspaces/issue-123",
+        branch: "codex/reopen-issue-123",
+        modifiedAt: "2026-03-21T00:00:00.000Z",
+        reason: "safe orphaned git worktree",
+      },
+    ],
+    skipped: [
+      {
+        issueNumber: 124,
+        workspaceName: "issue-124",
+        workspacePath: "/tmp/workspaces/issue-124",
+        branch: "codex/reopen-issue-124",
+        modifiedAt: "2026-03-21T00:00:00.000Z",
+        eligibility: "recent",
+        reason: "workspace modified within 24h grace period",
+      },
+    ],
+  });
+});
+
 test("runSupervisorCommand renders a structured corrupt-json reset result", async () => {
   const stdout: string[] = [];
 
@@ -386,6 +495,9 @@ test("runSupervisorCommand renders a structured corrupt-json reset result", asyn
         },
         runRecoveryAction: async () => {
           throw new Error("unexpected runRecoveryAction");
+        },
+        pruneOrphanedWorkspaces: async () => {
+          throw new Error("unexpected pruneOrphanedWorkspaces");
         },
         resetCorruptJsonState: async () => ({
           action: "reset-corrupt-json-state",

--- a/src/cli/supervisor-runtime.ts
+++ b/src/cli/supervisor-runtime.ts
@@ -4,6 +4,7 @@ import { ensureGsdInstalled as defaultEnsureGsdInstalled } from "../gsd";
 import { renderDoctorReport } from "../doctor";
 import { renderJsonCorruptStateResetResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderSupervisorMutationResultDto } from "../supervisor/supervisor-mutation-report";
+import { renderSupervisorOrphanPruneResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderIssueExplainDto } from "../supervisor/supervisor-selection-status";
 import { isCorruptJsonFailClosedMessage } from "../supervisor/supervisor";
 import { type SupervisorLock, type SupervisorService } from "../supervisor/supervisor-service";
@@ -11,7 +12,15 @@ import { renderSupervisorStatusDto } from "../supervisor/supervisor-status-repor
 
 type SupervisorRuntimeCommand = Extract<
   CliOptions["command"],
-  "run-once" | "loop" | "status" | "requeue" | "reset-corrupt-json-state" | "explain" | "issue-lint" | "doctor"
+  | "run-once"
+  | "loop"
+  | "status"
+  | "requeue"
+  | "prune-orphaned-workspaces"
+  | "reset-corrupt-json-state"
+  | "explain"
+  | "issue-lint"
+  | "doctor"
 >;
 
 interface SupervisorRuntimeDependencies {
@@ -29,6 +38,7 @@ export function isSupervisorRuntimeCommand(command: CliOptions["command"]): comm
     command === "loop" ||
     command === "status" ||
     command === "requeue" ||
+    command === "prune-orphaned-workspaces" ||
     command === "reset-corrupt-json-state" ||
     command === "explain" ||
     command === "issue-lint" ||
@@ -40,6 +50,7 @@ function requiresGsdInstall(command: SupervisorRuntimeCommand): boolean {
   return (
     command !== "status" &&
     command !== "requeue" &&
+    command !== "prune-orphaned-workspaces" &&
     command !== "reset-corrupt-json-state" &&
     command !== "explain" &&
     command !== "issue-lint" &&
@@ -106,6 +117,11 @@ export async function runSupervisorCommand(
 
   if (options.command === "requeue") {
     writeStdout(renderSupervisorMutationResultDto(await service.runRecoveryAction("requeue", options.issueNumber!)));
+    return;
+  }
+
+  if (options.command === "prune-orphaned-workspaces") {
+    writeStdout(renderSupervisorOrphanPruneResultDto(await service.pruneOrphanedWorkspaces()));
     return;
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -359,6 +359,7 @@ export interface CliOptions {
     | "loop"
     | "status"
     | "requeue"
+    | "prune-orphaned-workspaces"
     | "reset-corrupt-json-state"
     | "explain"
     | "issue-lint"

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -13,8 +13,11 @@ import { hoursSince, nowIso } from "./core/utils";
 import { branchNameForIssue, cleanupWorkspace, isSafeCleanupTarget } from "./core/workspace";
 import {
   buildSupervisorMutationRecordSnapshot,
+  type PrunedOrphanedWorkspaceResultDto,
+  type SkippedOrphanedWorkspaceResultDto,
   type SupervisorMutationRecordSnapshotDto,
   type SupervisorMutationResultDto,
+  type SupervisorOrphanPruneResultDto,
 } from "./supervisor/supervisor-mutation-report";
 
 const OWNER_GUARDED_ACTIVE_STATES = new Set<RunState>([
@@ -285,6 +288,61 @@ async function cleanupOrphanedIssueWorkspaces(
   }
 
   return recoveryEvents;
+}
+
+export async function pruneOrphanedWorkspacesForOperator(
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+): Promise<SupervisorOrphanPruneResultDto> {
+  const candidates = await inspectOrphanedWorkspacePruneCandidates(config, state);
+  const pruned: PrunedOrphanedWorkspaceResultDto[] = [];
+  const skipped: SkippedOrphanedWorkspaceResultDto[] = [];
+
+  for (const candidate of candidates) {
+    if (candidate.eligibility === "eligible" && candidate.branch) {
+      await cleanupWorkspace(config.repoPath, candidate.workspacePath, candidate.branch);
+      pruned.push({
+        issueNumber: candidate.issueNumber,
+        workspaceName: candidate.workspaceName,
+        workspacePath: candidate.workspacePath,
+        branch: candidate.branch,
+        modifiedAt: candidate.modifiedAt,
+        reason: candidate.reason,
+      });
+      continue;
+    }
+
+    if (candidate.eligibility === "eligible") {
+      skipped.push({
+        issueNumber: candidate.issueNumber,
+        workspaceName: candidate.workspaceName,
+        workspacePath: candidate.workspacePath,
+        branch: candidate.branch,
+        modifiedAt: candidate.modifiedAt,
+        eligibility: "unsafe_target",
+        reason: candidate.reason,
+      });
+      continue;
+    }
+
+    skipped.push({
+      issueNumber: candidate.issueNumber,
+      workspaceName: candidate.workspaceName,
+      workspacePath: candidate.workspacePath,
+      branch: candidate.branch,
+      modifiedAt: candidate.modifiedAt,
+      eligibility: candidate.eligibility,
+      reason: candidate.reason,
+    });
+  }
+
+  return {
+    action: "prune-orphaned-workspaces",
+    outcome: "completed",
+    summary: `Pruned ${pruned.length} orphaned workspace(s); skipped ${skipped.length} orphaned workspace(s).`,
+    pruned,
+    skipped,
+  };
 }
 
 export function buildRecoveryEvent(issueNumber: number, reason: string): RecoveryEvent {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -9,6 +9,7 @@ import {
   branchName,
   createRecord,
   createSupervisorFixture,
+  git,
 } from "./supervisor-test-helpers";
 import {
   clearCurrentReconciliationPhase,
@@ -518,6 +519,71 @@ test("runRecoveryAction fail-closes requeue while corrupted JSON state is quaran
   assert.equal(result.previousState, null);
   assert.equal(result.nextState, null);
   assert.equal(result.recoveryReason, null);
+});
+
+test("pruneOrphanedWorkspaces prunes eligible orphan workspaces and reports skipped ineligible ones", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  fixture.config.cleanupOrphanedWorkspacesAfterHours = 24;
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const eligibleIssueNumber = 91;
+  const eligibleBranch = branchName(fixture.config, eligibleIssueNumber);
+  const eligibleWorkspace = path.join(fixture.workspaceRoot, `issue-${eligibleIssueNumber}`);
+  git(["-C", fixture.repoPath, "worktree", "add", "-b", eligibleBranch, eligibleWorkspace, "origin/main"]);
+
+  const recentIssueNumber = 92;
+  const recentBranch = branchName(fixture.config, recentIssueNumber);
+  const recentWorkspace = path.join(fixture.workspaceRoot, `issue-${recentIssueNumber}`);
+  git(["-C", fixture.repoPath, "worktree", "add", "-b", recentBranch, recentWorkspace, "origin/main"]);
+
+  const oldTime = new Date("2026-03-18T00:00:00.000Z");
+  await fs.utimes(eligibleWorkspace, oldTime, oldTime);
+  const recentTime = new Date(Date.now() - 60 * 60 * 1000);
+  await fs.utimes(recentWorkspace, recentTime, recentTime);
+
+  const supervisor = new Supervisor(fixture.config);
+  const result = await supervisor.pruneOrphanedWorkspaces();
+
+  assert.deepEqual(result, {
+    action: "prune-orphaned-workspaces",
+    outcome: "completed",
+    summary: "Pruned 1 orphaned workspace(s); skipped 1 orphaned workspace(s).",
+    pruned: [
+      {
+        issueNumber: eligibleIssueNumber,
+        workspaceName: `issue-${eligibleIssueNumber}`,
+        workspacePath: eligibleWorkspace,
+        branch: eligibleBranch,
+        modifiedAt: oldTime.toISOString(),
+        reason: "safe orphaned git worktree",
+      },
+    ],
+    skipped: [
+      {
+        issueNumber: recentIssueNumber,
+        workspaceName: `issue-${recentIssueNumber}`,
+        workspacePath: recentWorkspace,
+        branch: recentBranch,
+        modifiedAt: recentTime.toISOString(),
+        eligibility: "recent",
+        reason: "workspace modified within 24h grace period",
+      },
+    ],
+  });
+
+  await assert.rejects(fs.access(eligibleWorkspace));
+  await fs.access(recentWorkspace);
+  assert.match(git(["-C", fixture.repoPath, "branch", "--list", eligibleBranch]), /^$/);
+  assert.match(git(["-C", fixture.repoPath, "branch", "--list", recentBranch]), new RegExp(recentBranch));
 });
 
 test("acquireSupervisorLock emits typed run-lock blockage events", async (t) => {

--- a/src/supervisor/supervisor-execution-cleanup.test.ts
+++ b/src/supervisor/supervisor-execution-cleanup.test.ts
@@ -700,6 +700,68 @@ test("runOnce preserves recent orphaned worktrees until the orphan age gate expi
   assert.match(git(["-C", fixture.repoPath, "branch", "--list", orphanBranch]), new RegExp(orphanBranch));
 });
 
+test("pruneOrphanedWorkspaces prunes eligible orphan worktrees and skips recent ones", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.cleanupOrphanedWorkspacesAfterHours = 24;
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const eligibleIssueNumber = 92;
+  const eligibleBranch = branchName(fixture.config, eligibleIssueNumber);
+  const eligibleWorkspace = path.join(fixture.workspaceRoot, `issue-${eligibleIssueNumber}`);
+  await fs.mkdir(fixture.workspaceRoot, { recursive: true });
+  git(["-C", fixture.repoPath, "worktree", "add", "-b", eligibleBranch, eligibleWorkspace, "origin/main"]);
+
+  const recentIssueNumber = 93;
+  const recentBranch = branchName(fixture.config, recentIssueNumber);
+  const recentWorkspace = path.join(fixture.workspaceRoot, `issue-${recentIssueNumber}`);
+  git(["-C", fixture.repoPath, "worktree", "add", "-b", recentBranch, recentWorkspace, "origin/main"]);
+
+  const oldTime = new Date("2026-03-18T00:00:00.000Z");
+  await fs.utimes(eligibleWorkspace, oldTime, oldTime);
+  const recentTime = new Date(Date.now() - 60 * 60 * 1000);
+  await fs.utimes(recentWorkspace, recentTime, recentTime);
+
+  const supervisor = new Supervisor(fixture.config);
+  const result = await supervisor.pruneOrphanedWorkspaces();
+
+  assert.deepEqual(result, {
+    action: "prune-orphaned-workspaces",
+    outcome: "completed",
+    summary: "Pruned 1 orphaned workspace(s); skipped 1 orphaned workspace(s).",
+    pruned: [
+      {
+        issueNumber: eligibleIssueNumber,
+        workspaceName: `issue-${eligibleIssueNumber}`,
+        workspacePath: eligibleWorkspace,
+        branch: eligibleBranch,
+        modifiedAt: oldTime.toISOString(),
+        reason: "safe orphaned git worktree",
+      },
+    ],
+    skipped: [
+      {
+        issueNumber: recentIssueNumber,
+        workspaceName: `issue-${recentIssueNumber}`,
+        workspacePath: recentWorkspace,
+        branch: recentBranch,
+        modifiedAt: recentTime.toISOString(),
+        eligibility: "recent",
+        reason: "workspace modified within 24h grace period",
+      },
+    ],
+  });
+
+  await assert.rejects(fs.access(eligibleWorkspace));
+  await fs.access(recentWorkspace);
+  assert.match(git(["-C", fixture.repoPath, "branch", "--list", eligibleBranch]), /^$/);
+  assert.match(git(["-C", fixture.repoPath, "branch", "--list", recentBranch]), new RegExp(recentBranch));
+});
+
 test("runOnce releases the current issue lock before restarting after a merged PR", async () => {
   const fixture = await createSupervisorFixture();
   const mergedIssueNumber = 91;

--- a/src/supervisor/supervisor-mutation-report.ts
+++ b/src/supervisor/supervisor-mutation-report.ts
@@ -1,6 +1,7 @@
 import type { IssueRunRecord, JsonCorruptStateResetResult, RunState } from "../core/types";
 
 export type SupervisorRecoveryAction = "requeue";
+export type SupervisorOrphanPruneAction = "prune-orphaned-workspaces";
 
 export type SupervisorMutationRecordSnapshotDto = Pick<
   IssueRunRecord,
@@ -38,6 +39,33 @@ export interface SupervisorMutationResultDto {
   recoveryReason: string | null;
 }
 
+export interface PrunedOrphanedWorkspaceResultDto {
+  issueNumber: number;
+  workspaceName: string;
+  workspacePath: string;
+  branch: string;
+  modifiedAt: string | null;
+  reason: string;
+}
+
+export interface SkippedOrphanedWorkspaceResultDto {
+  issueNumber: number;
+  workspaceName: string;
+  workspacePath: string;
+  branch: string | null;
+  modifiedAt: string | null;
+  eligibility: "locked" | "recent" | "unsafe_target";
+  reason: string;
+}
+
+export interface SupervisorOrphanPruneResultDto {
+  action: SupervisorOrphanPruneAction;
+  outcome: "completed" | "rejected";
+  summary: string;
+  pruned: PrunedOrphanedWorkspaceResultDto[];
+  skipped: SkippedOrphanedWorkspaceResultDto[];
+}
+
 export function buildSupervisorMutationRecordSnapshot(
   record: IssueRunRecord,
 ): SupervisorMutationRecordSnapshotDto {
@@ -72,6 +100,10 @@ export function buildSupervisorMutationRecordSnapshot(
 }
 
 export function renderSupervisorMutationResultDto(dto: SupervisorMutationResultDto): string {
+  return JSON.stringify(dto);
+}
+
+export function renderSupervisorOrphanPruneResultDto(dto: SupervisorOrphanPruneResultDto): string {
   return JSON.stringify(dto);
 }
 

--- a/src/supervisor/supervisor-service.ts
+++ b/src/supervisor/supervisor-service.ts
@@ -1,6 +1,10 @@
 import type { CliOptions, JsonCorruptStateResetResult, SupervisorConfig } from "../core/types";
 import type { DoctorDiagnostics } from "../doctor";
-import type { SupervisorMutationResultDto, SupervisorRecoveryAction } from "./supervisor-mutation-report";
+import type {
+  SupervisorMutationResultDto,
+  SupervisorOrphanPruneResultDto,
+  SupervisorRecoveryAction,
+} from "./supervisor-mutation-report";
 import type { SupervisorExplainDto } from "./supervisor-selection-status";
 import type { SupervisorStatusDto } from "./supervisor-status-report";
 import type { SupervisorEventSink } from "./supervisor-events";
@@ -19,6 +23,7 @@ export interface SupervisorService {
   runOnce: (options: Pick<CliOptions, "dryRun">) => Promise<string>;
   queryStatus: (options: Pick<CliOptions, "why">) => Promise<SupervisorStatusDto>;
   runRecoveryAction: (action: SupervisorRecoveryAction, issueNumber: number) => Promise<SupervisorMutationResultDto>;
+  pruneOrphanedWorkspaces: () => Promise<SupervisorOrphanPruneResultDto>;
   resetCorruptJsonState: () => Promise<JsonCorruptStateResetResult>;
   queryExplain: (issueNumber: number) => Promise<SupervisorExplainDto>;
   queryIssueLint: (issueNumber: number) => Promise<string[]>;
@@ -54,6 +59,10 @@ class SupervisorApplicationService implements SupervisorService {
 
   runRecoveryAction(action: SupervisorRecoveryAction, issueNumber: number): Promise<SupervisorMutationResultDto> {
     return this.supervisor.runRecoveryAction(action, issueNumber);
+  }
+
+  pruneOrphanedWorkspaces(): Promise<SupervisorOrphanPruneResultDto> {
+    return this.supervisor.pruneOrphanedWorkspaces();
   }
 
   resetCorruptJsonState(): Promise<JsonCorruptStateResetResult> {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -9,6 +9,7 @@ import {
   cleanupExpiredDoneWorkspaces,
   formatRecoveryLog,
   prependRecoveryLog,
+  pruneOrphanedWorkspacesForOperator,
   requeueIssueForOperator,
   reconcileMergedIssueClosures,
   reconcileParentEpicClosures,
@@ -114,7 +115,11 @@ import {
   sanitizeStatusValue,
 } from "./supervisor-status-rendering";
 import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
-import { type SupervisorMutationResultDto, type SupervisorRecoveryAction } from "./supervisor-mutation-report";
+import {
+  type SupervisorMutationResultDto,
+  type SupervisorOrphanPruneResultDto,
+  type SupervisorRecoveryAction,
+} from "./supervisor-mutation-report";
 import { renderSupervisorStatusDto, SupervisorStatusDto } from "./supervisor-status-report";
 import {
   clearCurrentReconciliationPhase,
@@ -935,6 +940,32 @@ export class Supervisor {
         };
       }
       return requeueIssueForOperator(this.stateStore, state, issueNumber);
+    } finally {
+      await lock.release();
+    }
+  }
+
+  async pruneOrphanedWorkspaces(): Promise<SupervisorOrphanPruneResultDto> {
+    const lock = await acquireFileLock(this.lockPath("supervisor", "run"), "supervisor-recovery-prune-orphaned-workspaces", {
+      allowAmbiguousOwnerCleanup: true,
+    });
+    if (!lock.acquired) {
+      throw new Error(`Cannot run recovery action while supervisor is active: ${lock.reason ?? "lock unavailable"}`);
+    }
+
+    try {
+      const state = await this.stateStore.load();
+      const quarantine = readJsonParseErrorQuarantine(this.config, state);
+      if (quarantine) {
+        return {
+          action: "prune-orphaned-workspaces",
+          outcome: "rejected",
+          summary: buildCorruptJsonFailClosedMessage(this.config, quarantine),
+          pruned: [],
+          skipped: [],
+        };
+      }
+      return pruneOrphanedWorkspacesForOperator(this.config, state);
     } finally {
       await lock.release();
     }


### PR DESCRIPTION
## Summary
- add an explicit `prune-orphaned-workspaces` operator command for eligible orphan cleanup
- reuse the existing orphan prune safety checks and return deterministic prune/skip JSON output
- add focused CLI and cleanup coverage for one eligible prune and one skipped recent orphan

## Testing
- npx tsx --test src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-execution-cleanup.test.ts
- npm run build

Refs #729


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit `prune-orphaned-workspaces` operator command for pruning eligible orphaned workspaces with deterministic structured JSON output showing pruned workspaces, skipped candidates, eligibility classifications, and reasons.

* **Tests**
  * Added comprehensive test coverage for the new command including CLI routing, argument parsing, and full execution flow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->