### PR TITLE
Split informational and action PR hydration reads

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,55 +1,48 @@
-# Issue #736: Hydration provenance visibility: surface cached-vs-fresh PR hydration results
+# Issue #737: Hydration consumer split: separate informational PR hydration from action-taking reads
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/736
-- Branch: codex/issue-736
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/737
+- Branch: codex/issue-737
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: 49fa60219bda219462266360d13794c08db1dd2d
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 2a2663f8cc327b2d4c1756d1637feb3fd0e0787b
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-20T23:36:28.000Z
+- Updated at: 2026-03-21T09:09:33+09:00
 
 ## Latest Codex Summary
-Added a narrow hydration provenance signal end to end. Hydrated PRs now carry `hydrationProvenance: "fresh" | "cached"` in [src/core/types.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-736/src/core/types.ts), the hydrator sets it deterministically in [src/github/github-pull-request-hydrator.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-736/src/github/github-pull-request-hydrator.ts), and detailed supervisor status renders `pr_hydration provenance=...` in [src/supervisor/supervisor-detailed-status-assembly.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-736/src/supervisor/supervisor-detailed-status-assembly.ts). Action behavior is unchanged.
-
-Focused coverage was added in [src/github/github-pull-request-hydrator.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-736/src/github/github-pull-request-hydrator.test.ts) and [src/supervisor/supervisor-status-rendering-supervisor.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-736/src/supervisor/supervisor-status-rendering-supervisor.test.ts). I also updated the issue journal and committed the checkpoint as `49fa602` (`Surface PR hydration provenance`). The only remaining workspace dirt is pre-existing untracked `.codex-supervisor/replay/`.
-
-Summary: Added deterministic fresh-vs-cached PR hydration provenance and surfaced it in supervisor status, with focused regressions and successful local verification on the acceptance test slice
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/github/github-pull-request-hydrator.test.ts`; `npx tsx --test src/supervisor/supervisor-status-rendering-supervisor.test.ts`; `npx tsx --test src/pull-request-state.test.ts src/supervisor/supervisor-lifecycle.test.ts src/doctor.test.ts`; `npm ci`; `npm run build`
-Failure signature: none
-Next action: monitor or address review and CI for draft PR #755
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: a small PR-level provenance field is enough for this issue because later behavior changes can reuse it without changing any action paths now.
-- What changed: added `hydrationProvenance` to hydrated pull requests, set it deterministically to `fresh` or `cached` in the GitHub PR hydrator, and rendered it as `pr_hydration provenance=...` in detailed supervisor status output.
+- Hypothesis: the narrowest safe split is to keep branch/status discovery on cached hydration while forcing action-oriented direct PR reads through an explicitly fresh hydrator path.
+- What changed: added explicit `hydrateForStatus` and `hydrateForAction` paths in the PR hydrator, routed `resolvePullRequestForBranch`/branch discovery through the status path, and routed `getPullRequest` through the action path. Added focused client tests proving repeated action reads stay `fresh` while informational reads reuse cached hydration.
 - Current blocker: none
-- Next exact step: push the journal checkpoint for PR #755 so the branch is clean, then monitor CI and review feedback.
-- Verification gap: none on code; `npm run build` initially failed only because `node_modules/.bin/tsc` was missing before `npm ci`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/core/types.ts`, `src/github/github-pull-request-hydrator.ts`, `src/github/github-pull-request-hydrator.test.ts`, `src/supervisor/supervisor-detailed-status-assembly.ts`, `src/supervisor/supervisor-status-rendering-supervisor.test.ts`
-- Rollback concern: removing the provenance field would drop the only deterministic operator-visible cached-vs-fresh hydration signal needed by later action-path issues.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-736 --title "Surface cached-vs-fresh PR hydration provenance" ...`
-- Last focused failure: none
+- Next exact step: commit the hydration consumer split checkpoint, then open or update the draft PR for issue #737.
+- Verification gap: the issue guidance references `src/pull-request-state.test.ts`, but that file does not exist in this worktree; I verified the split with `src/github/github.test.ts` plus the listed hydrator/lifecycle suites instead.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-pull-request-hydrator.ts`, `src/github/github.ts`, `src/github/github.test.ts`
+- Rollback concern: collapsing the two hydrator entry points back into one would reintroduce cached reads on post-turn action paths and remove the explicit seam needed for later freshness tightening.
+- Last focused command: `npm run build`
+- Last focused failure: `GitHubClient getPullRequest does not reuse cached hydration for action reads` failed with `'cached' !== 'fresh'` before the split.
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-736/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-736/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-737/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-737/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
-npx tsx --test src/pull-request-state.test.ts src/supervisor/supervisor-lifecycle.test.ts src/doctor.test.ts
+rg -n "hydrate|hydration|pull request hydrator|HydratedPullRequest|hydrationProvenance" src
+sed -n '1,240p' src/github/github.ts
+sed -n '90,170p' src/github/github-pull-request-hydrator.ts
+sed -n '1,260p' src/github/github.test.ts
+npx tsx --test src/github/github.test.ts
+npx tsx --test src/github/github-pull-request-hydrator.test.ts src/supervisor/supervisor-lifecycle.test.ts src/github/github.test.ts
+npm ci
 npm run build
-gh pr view --json number,state,isDraft,headRefName,baseRefName,url 2>/dev/null || true
-git diff --stat origin/main...HEAD
-git push -u origin codex/issue-736
-gh pr create --draft --base main --head codex/issue-736 --title "Surface cached-vs-fresh PR hydration provenance" --body ...
 ```
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -108,7 +108,22 @@ export class GitHubPullRequestHydrator {
     this.reviewSummaryCache = new ConfiguredBotReviewSummaryCache(now);
   }
 
-  async hydrate(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+  async hydrateForAction(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+    if (!pr) {
+      return null;
+    }
+
+    try {
+      const summary = await this.fetchConfiguredBotReviewSummary(pr.number, pr.headRefOid);
+      return withHydrationProvenance(applyConfiguredBotReviewSummary(pr, summary), "fresh");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Failed to hydrate Copilot review lifecycle for PR #${pr.number}: ${truncate(message, 500) ?? "unknown error"}`);
+      return withHydrationProvenance(applyConfiguredBotReviewSummary(pr, null), "fresh");
+    }
+  }
+
+  async hydrateForStatus(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
     if (!pr) {
       return null;
     }
@@ -133,6 +148,10 @@ export class GitHubPullRequestHydrator {
       console.warn(`Failed to hydrate Copilot review lifecycle for PR #${pr.number}: ${truncate(message, 500) ?? "unknown error"}`);
       return withHydrationProvenance(applyConfiguredBotReviewSummary(pr, null), "fresh");
     }
+  }
+
+  async hydrate(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+    return this.hydrateForStatus(pr);
   }
 
   private async fetchConfiguredBotReviewSummary(

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -496,3 +496,104 @@ test("GitHubClient resolvePullRequestForBranch ignores a tracked PR from another
   assert.equal(resolved?.number, 360);
   assert.equal(resolved?.headRefName, branch);
 });
+
+test("GitHubClient getPullRequest does not reuse cached hydration for action reads", async () => {
+  const config = createConfig();
+  const pullRequest = createPullRequest({
+    number: 361,
+    headRefName: "codex/issue-361",
+    headRefOid: "head-361",
+  });
+  let graphqlCalls = 0;
+
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view" && args[2] === "361") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(pullRequest),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const first = await client.getPullRequest(361);
+  const second = await client.getPullRequest(361);
+
+  assert.equal(first.hydrationProvenance, "fresh");
+  assert.equal(second.hydrationProvenance, "fresh");
+  assert.equal(graphqlCalls, 2);
+});
+
+test("GitHubClient resolvePullRequestForBranch reuses cached hydration for informational reads", async () => {
+  const config = createConfig();
+  const branch = "codex/issue-362";
+  const pullRequest = createPullRequest({
+    number: 362,
+    headRefName: branch,
+    headRefOid: "head-362",
+  });
+  let graphqlCalls = 0;
+
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("open")) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([pullRequest]),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const first = await client.resolvePullRequestForBranch(branch, null);
+  const second = await client.resolvePullRequestForBranch(branch, null);
+
+  assert.equal(first?.hydrationProvenance, "fresh");
+  assert.equal(second?.hydrationProvenance, "cached");
+  assert.equal(graphqlCalls, 1);
+});

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -153,7 +153,7 @@ export class GitHubClient {
       "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
     ]);
     const pullRequests = parseJson<GitHubPullRequest[]>(result.stdout, `gh pr list --head ${branch}`);
-    return this.hydratePullRequest(pullRequests[0] ?? null);
+    return this.hydratePullRequestForStatus(pullRequests[0] ?? null);
   }
 
   async findLatestPullRequestForBranch(branch: string): Promise<GitHubPullRequest | null> {
@@ -177,7 +177,7 @@ export class GitHubClient {
       const rightTimestamp = Date.parse(right.updatedAt ?? right.createdAt);
       return rightTimestamp - leftTimestamp;
     });
-    return this.hydratePullRequest(sorted[0] ?? null);
+    return this.hydratePullRequestForStatus(sorted[0] ?? null);
   }
 
   async getPullRequest(prNumber: number): Promise<GitHubPullRequest> {
@@ -191,7 +191,7 @@ export class GitHubClient {
       "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
     ]);
     const pullRequest = parseJson<GitHubPullRequest>(result.stdout, `gh pr view #${prNumber}`);
-    return (await this.hydratePullRequest(pullRequest)) as GitHubPullRequest;
+    return (await this.hydratePullRequestForAction(pullRequest)) as GitHubPullRequest;
   }
 
   async getPullRequestIfExists(prNumber: number): Promise<GitHubPullRequest | null> {
@@ -210,7 +210,7 @@ export class GitHubClient {
 
     if (result.exitCode === 0) {
       const pullRequest = parseJson<GitHubPullRequest>(result.stdout, `gh pr view #${prNumber}`);
-      return this.hydratePullRequest(pullRequest);
+      return this.hydratePullRequestForStatus(pullRequest);
     }
 
     const stderr = result.stderr.toLowerCase();
@@ -676,7 +676,11 @@ export class GitHubClient {
     };
   }
 
-  private async hydratePullRequest(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
-    return this.pullRequestHydrator.hydrate(pr);
+  private async hydratePullRequestForStatus(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+    return this.pullRequestHydrator.hydrateForStatus(pr);
+  }
+
+  private async hydratePullRequestForAction(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+    return this.pullRequestHydrator.hydrateForAction(pr);
   }
 }


### PR DESCRIPTION
## Summary
- add explicit status vs action hydration entry points in the PR hydrator
- keep branch/status discovery on cached hydration while direct action reads use fresh hydration
- add focused client coverage for both paths

## Testing
- npx tsx --test src/github/github.test.ts
- npx tsx --test src/github/github-pull-request-hydrator.test.ts src/supervisor/supervisor-lifecycle.test.ts src/github/github.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Pull request data fetching now uses context-specific strategies: status operations utilize cached data for improved performance, while action-oriented operations fetch fresh data to ensure accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->