### PR TITLE
Require fresh PR hydration for readiness transitions

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,47 +1,47 @@
-# Issue #737: Hydration consumer split: separate informational PR hydration from action-taking reads
+# Issue #738: Hydration freshness for transitions: require fresh PR reads for readiness and review-wait decisions
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/737
-- Branch: codex/issue-737
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/738
+- Branch: codex/issue-738
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 2a2663f8cc327b2d4c1756d1637feb3fd0e0787b
+- Last head SHA: 06412e75f85ab23dfb283a5c3a3d615a3623bec7
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-21T09:09:33+09:00
+- Updated at: 2026-03-21T00:43:32Z
 
 ## Latest Codex Summary
-- None yet.
+- Transition-driving PR reads now bypass same-head hydration cache while informational/status reads still reuse it.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the narrowest safe split is to keep branch/status discovery on cached hydration while forcing action-oriented direct PR reads through an explicitly fresh hydrator path.
-- What changed: added explicit `hydrateForStatus` and `hydrateForAction` paths in the PR hydrator, routed `resolvePullRequestForBranch`/branch discovery through the status path, and routed `getPullRequest` through the action path. Added focused client tests proving repeated action reads stay `fresh` while informational reads reuse cached hydration.
+- Hypothesis: readiness and review-wait transitions should resolve branch PRs through an explicit action-purpose hydration path so same-head review-state changes are never hidden behind informational cache reuse.
+- What changed: added a `purpose` selector to PR branch/tracked lookups in `GitHubClient`, kept status reads on cached hydration, and routed transition-driving `resolvePullRequestForBranch` calls in issue preparation and post-turn execution through `{ purpose: "action" }`. Added focused tests proving action-purpose branch reads stay `fresh` and that both preparation and post-turn execution request the action path.
 - Current blocker: none
-- Next exact step: commit the hydration consumer split checkpoint, then open or update the draft PR for issue #737.
-- Verification gap: the issue guidance references `src/pull-request-state.test.ts`, but that file does not exist in this worktree; I verified the split with `src/github/github.test.ts` plus the listed hydrator/lifecycle suites instead.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-pull-request-hydrator.ts`, `src/github/github.ts`, `src/github/github.test.ts`
-- Rollback concern: collapsing the two hydrator entry points back into one would reintroduce cached reads on post-turn action paths and remove the explicit seam needed for later freshness tightening.
+- Next exact step: commit this readiness/review-wait freshness checkpoint and open or update the draft PR for issue #738.
+- Verification gap: the issue guidance references `src/pull-request-state.test.ts`, but that file does not exist in this worktree; I verified the transition freshness with the listed lifecycle/state suites plus focused preparation/turn execution coverage.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github.ts`, `src/github/github.test.ts`, `src/run-once-issue-preparation.ts`, `src/run-once-issue-preparation.test.ts`, `src/run-once-turn-execution.ts`, `src/run-once-turn-execution.test.ts`
+- Rollback concern: removing the action-purpose resolver or reverting its transition call sites would let same-head cached hydration hide newly arrived configured-bot review signals during readiness and review-wait decisions.
 - Last focused command: `npm run build`
-- Last focused failure: `GitHubClient getPullRequest does not reuse cached hydration for action reads` failed with `'cached' !== 'fresh'` before the split.
+- Last focused failure: `npm run build` initially failed with `sh: 1: tsc: not found` before restoring dependencies with `npm ci`.
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-737/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-737/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-738/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-738/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
-rg -n "hydrate|hydration|pull request hydrator|HydratedPullRequest|hydrationProvenance" src
-sed -n '1,240p' src/github/github.ts
-sed -n '90,170p' src/github/github-pull-request-hydrator.ts
-sed -n '1,260p' src/github/github.test.ts
-npx tsx --test src/github/github.test.ts
-npx tsx --test src/github/github-pull-request-hydrator.test.ts src/supervisor/supervisor-lifecycle.test.ts src/github/github.test.ts
+rg -n "review-wait|readiness|ready|wait.*review|coderabbit|settled|getPullRequest\\(|resolvePullRequestForBranch|hydrateForAction|hydrateForStatus" src
+sed -n '1,360p' src/post-turn-pull-request.ts
+sed -n '340,470p' src/run-once-turn-execution.ts
+sed -n '220,320p' src/run-once-issue-preparation.ts
+npx tsx --test src/github/github.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts
 npm ci
+npx tsx --test src/pull-request-state-coderabbit-settled-waits.test.ts src/supervisor/supervisor-lifecycle.test.ts src/github/github.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts
 npm run build
 ```
 ### Scratchpad

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -597,3 +597,54 @@ test("GitHubClient resolvePullRequestForBranch reuses cached hydration for infor
   assert.equal(second?.hydrationProvenance, "cached");
   assert.equal(graphqlCalls, 1);
 });
+
+test("GitHubClient resolvePullRequestForBranch refreshes same-head hydration for action reads", async () => {
+  const config = createConfig();
+  const branch = "codex/issue-363";
+  const pullRequest = createPullRequest({
+    number: 363,
+    headRefName: branch,
+    headRefOid: "head-363",
+  });
+  let graphqlCalls = 0;
+
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "list" && args.includes("--state") && args.includes("open")) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([pullRequest]),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const first = await client.resolvePullRequestForBranch(branch, null, { purpose: "action" });
+  const second = await client.resolvePullRequestForBranch(branch, null, { purpose: "action" });
+
+  assert.equal(first?.hydrationProvenance, "fresh");
+  assert.equal(second?.hydrationProvenance, "fresh");
+  assert.equal(graphqlCalls, 2);
+});

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -58,6 +58,13 @@ export class GitHubClient {
     return this.transport.run(args, options);
   }
 
+  private async hydratePullRequestForPurpose(
+    pr: GitHubPullRequest | null,
+    purpose: "status" | "action",
+  ): Promise<GitHubPullRequest | null> {
+    return purpose === "action" ? this.hydratePullRequestForAction(pr) : this.hydratePullRequestForStatus(pr);
+  }
+
   async authStatus(): Promise<{ ok: boolean; message: string | null }> {
     try {
       const result = await this.runGhCommand(
@@ -137,7 +144,10 @@ export class GitHubClient {
     return parseJson<GitHubIssue>(result.stdout, `gh issue view #${issueNumber}`);
   }
 
-  async findOpenPullRequest(branch: string): Promise<GitHubPullRequest | null> {
+  async findOpenPullRequest(
+    branch: string,
+    options: { purpose?: "status" | "action" } = {},
+  ): Promise<GitHubPullRequest | null> {
     const result = await this.runGhCommand([
       "pr",
       "list",
@@ -153,10 +163,13 @@ export class GitHubClient {
       "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
     ]);
     const pullRequests = parseJson<GitHubPullRequest[]>(result.stdout, `gh pr list --head ${branch}`);
-    return this.hydratePullRequestForStatus(pullRequests[0] ?? null);
+    return this.hydratePullRequestForPurpose(pullRequests[0] ?? null, options.purpose ?? "status");
   }
 
-  async findLatestPullRequestForBranch(branch: string): Promise<GitHubPullRequest | null> {
+  async findLatestPullRequestForBranch(
+    branch: string,
+    options: { purpose?: "status" | "action" } = {},
+  ): Promise<GitHubPullRequest | null> {
     const result = await this.runGhCommand([
       "pr",
       "list",
@@ -177,7 +190,7 @@ export class GitHubClient {
       const rightTimestamp = Date.parse(right.updatedAt ?? right.createdAt);
       return rightTimestamp - leftTimestamp;
     });
-    return this.hydratePullRequestForStatus(sorted[0] ?? null);
+    return this.hydratePullRequestForPurpose(sorted[0] ?? null, options.purpose ?? "status");
   }
 
   async getPullRequest(prNumber: number): Promise<GitHubPullRequest> {
@@ -194,7 +207,10 @@ export class GitHubClient {
     return (await this.hydratePullRequestForAction(pullRequest)) as GitHubPullRequest;
   }
 
-  async getPullRequestIfExists(prNumber: number): Promise<GitHubPullRequest | null> {
+  async getPullRequestIfExists(
+    prNumber: number,
+    options: { purpose?: "status" | "action" } = {},
+  ): Promise<GitHubPullRequest | null> {
     const result = await this.runGhCommand(
       [
         "pr",
@@ -210,7 +226,7 @@ export class GitHubClient {
 
     if (result.exitCode === 0) {
       const pullRequest = parseJson<GitHubPullRequest>(result.stdout, `gh pr view #${prNumber}`);
-      return this.hydratePullRequestForStatus(pullRequest);
+      return this.hydratePullRequestForPurpose(pullRequest, options.purpose ?? "status");
     }
 
     const stderr = result.stderr.toLowerCase();
@@ -230,20 +246,22 @@ export class GitHubClient {
   async resolvePullRequestForBranch(
     branch: string,
     trackedPrNumber: number | null,
+    options: { purpose?: "status" | "action" } = {},
   ): Promise<GitHubPullRequest | null> {
-    const openPullRequest = await this.findOpenPullRequest(branch);
+    const purpose = options.purpose ?? "status";
+    const openPullRequest = await this.findOpenPullRequest(branch, { purpose });
     if (openPullRequest) {
       return openPullRequest;
     }
 
     if (trackedPrNumber !== null) {
-      const trackedPullRequest = await this.getPullRequestIfExists(trackedPrNumber);
+      const trackedPullRequest = await this.getPullRequestIfExists(trackedPrNumber, { purpose });
       if (trackedPullRequest && trackedPullRequest.headRefName === branch) {
         return trackedPullRequest;
       }
     }
 
-    return this.findLatestPullRequestForBranch(branch);
+    return this.findLatestPullRequestForBranch(branch, { purpose });
   }
 
   async getMergedPullRequestsClosingIssue(issueNumber: number): Promise<GitHubPullRequest[]> {

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -186,6 +186,7 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
   const workspaceStatus = createWorkspaceStatus({ headSha: "workspace-head-240" });
   const saveSnapshots: SupervisorStateFile[] = [];
   const touchedRecords: IssueRunRecord[] = [];
+  const resolvePurposes: Array<"status" | "action" | undefined> = [];
   const replaySnapshots: Array<{
     pr: GitHubPullRequest | null;
     checks: { name: string; state: string; bucket: string }[];
@@ -195,7 +196,10 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
 
   const result = await prepareIssueExecutionContext({
     github: {
-      resolvePullRequestForBranch: async () => null,
+      resolvePullRequestForBranch: async (_branch, _prNumber, options) => {
+        resolvePurposes.push(options?.purpose);
+        return null;
+      },
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
       createPullRequest: async () => {
@@ -253,6 +257,7 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
   assert.equal(result.workspacePath, "/tmp/workspaces/issue-240");
   assert.equal(result.journalPath, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
   assert.equal(result.pr, null);
+  assert.deepEqual(resolvePurposes, ["action"]);
   assert.equal(saveSnapshots.length, 2);
   assert.equal(saveSnapshots[0]?.issues["240"]?.journal_path, "/tmp/workspaces/issue-240/.codex-supervisor/issue-journal.md");
   assert.equal(saveSnapshots[1]?.issues["240"]?.last_head_sha, "workspace-head-240");

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -263,7 +263,11 @@ async function hydratePullRequestContext(
     );
   }
 
-  const resolvedPr = await args.github.resolvePullRequestForBranch(args.record.branch, args.record.pr_number);
+  const resolvedPr = await args.github.resolvePullRequestForBranch(
+    args.record.branch,
+    args.record.pr_number,
+    { purpose: "action" },
+  );
   let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
   let checks = pr ? await args.github.getChecks(pr.number) : [];
   let reviewThreads = pr ? await args.github.getUnresolvedReviewThreads(pr.number) : [];

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -46,6 +46,7 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
 
   let journalReads = 0;
   let resolveCalls = 0;
+  const resolvePurposes: Array<"status" | "action" | undefined> = [];
   const result = await executeCodexTurnPhase({
     config,
     stateStore: {
@@ -53,8 +54,9 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
       save: async () => undefined,
     },
     github: {
-      resolvePullRequestForBranch: async () => {
+      resolvePullRequestForBranch: async (_branch, _prNumber, options) => {
         resolveCalls += 1;
+        resolvePurposes.push(options?.purpose);
         return resolveCalls === 1 ? refreshedPr : refreshedPr;
       },
       createPullRequest: async () => {
@@ -175,6 +177,7 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
   assert.equal(state.issues["102"]?.last_head_sha, "head-b");
   assert.deepEqual(state.issues["102"]?.processed_review_thread_ids, ["thread-1@head-a"]);
   assert.deepEqual(state.issues["102"]?.processed_review_thread_fingerprints, ["thread-1@head-a#comment-1"]);
+  assert.deepEqual(resolvePurposes, ["action"]);
 });
 
 test("executeCodexTurnPhase skips prompt preparation side effects when the session lock is unavailable", async () => {

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -396,7 +396,11 @@ export async function executeCodexTurnPhase(
         workspaceStatus = await getWorkspaceStatusImpl(workspacePath, record.branch, config.defaultBranch);
       }
 
-      const refreshedResolvedPr = await github.resolvePullRequestForBranch(record.branch, record.pr_number);
+      const refreshedResolvedPr = await github.resolvePullRequestForBranch(
+        record.branch,
+        record.pr_number,
+        { purpose: "action" },
+      );
       pr = isOpenPullRequest(refreshedResolvedPr) ? refreshedResolvedPr : null;
       if (
         !pr &&


### PR DESCRIPTION
## Summary
- require fresh branch PR hydration reads for readiness and review-wait transitions
- keep informational/status PR reads on cached hydration paths
- add focused tests for same-head transition freshness in preparation and post-turn execution

## Testing
- npx tsx --test src/pull-request-state-coderabbit-settled-waits.test.ts src/supervisor/supervisor-lifecycle.test.ts src/github/github.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts
- npm run build

Closes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pull request data retrieval logic to ensure fresh data is used for critical operations while maintaining efficiency for status checks.

* **Tests**
  * Added comprehensive tests to validate pull request hydration behavior in different operation contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->