### PR TITLE
Add operator-gated execution safety mode plumbing

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,44 +1,43 @@
-# Issue #709: Prompt hardening: frame GitHub-authored issue and review text as non-authoritative input
+# Issue #710: Safer mode: add a configurable supervisor execution mode without bypassed approvals/sandbox
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/709
-- Branch: codex/issue-709
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/710
+- Branch: codex/issue-710
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: f322faa895d82261ca1b8fb969ec2d8585068b26
+- Last head SHA: f62f64bb8c00ab694f65cccd7d6dbc6a7192a14d
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-21T05:10:00Z
+- Updated at: 2026-03-21T05:40:16Z
 
 ## Latest Codex Summary
-- Hardened prompt text so GitHub-authored issue bodies, review-thread excerpts, and review-derived local-review context are explicitly marked non-authoritative while preserving their factual content.
+- Added configurable execution-safety plumbing to Codex and local-review command construction so `operator_gated` omits bypass flags while explicit `unsandboxed_autonomous` behavior remains unchanged.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Codex execution and local-review prompts were still presenting GitHub-authored issue bodies and review-derived text as plain prompt content, so a narrow trust-boundary label plus precedence guidance should reduce prompt-injection risk without changing supervisor flow.
-- What changed: added focused prompt tests first, then updated `buildCodexPrompt()` to label the issue body and unresolved review-thread excerpts as `GitHub-authored ... (non-authoritative input)` with explicit precedence guidance. Updated local-review prompt rendering so prior external misses are framed as GitHub-authored review-derived context whose instructions are outranked by supervisor guidance, the current diff, and local repository evidence.
+- Hypothesis: `executionSafetyMode` was already configurable in loaded config and diagnostics, but the actual Codex execution paths still hard-coded `--dangerously-bypass-approvals-and-sandbox`, so focused runner tests should reproduce the gap before wiring the mode into command assembly.
+- What changed: added focused runner tests proving `operator_gated` must omit bypass flags for both `runCodexTurn()` and `runCodexReviewTurn()`. Added shared `buildCodexExecutionSafetyArgs()` in `src/codex/codex-policy.ts` and used it in the normal Codex runner and local-review runner so only explicit `unsandboxed_autonomous` includes the bypass flag.
 - Current blocker: none
-- Next exact step: monitor draft PR #762 for CI and review feedback on commit `c8347cc`.
-- Verification gap: none for the requested scope; `npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts` and `npm run build` pass locally after installing dev dependencies in this worktree.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/codex/codex-prompt.test.ts`, `src/codex/codex-prompt.ts`, `src/local-review/prompt.test.ts`, `src/local-review/prompt.ts`
-- Rollback concern: removing the new non-authoritative framing would restore the old prompt shape where GitHub-authored instructions appear with implicit supervisor-level authority, increasing prompt-injection risk in execution and local-review turns.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-709 --title "Prompt hardening: frame GitHub-authored prompt context" --body ...`
-- Last focused failure: none
+- Next exact step: commit this safer-mode checkpoint and open or update a draft PR for branch `codex/issue-710`.
+- Verification gap: none for the requested scope; `npx tsx --test src/codex/codex-runner.test.ts src/local-review/runner.test.ts src/config.test.ts` and `npm run build` pass locally after installing dev dependencies in this worktree.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/codex/codex-policy.ts`, `src/codex/codex-runner.test.ts`, `src/codex/codex-runner.ts`, `src/local-review/runner.test.ts`, `src/local-review/runner.ts`
+- Rollback concern: removing the shared execution-safety arg helper or its runner call sites would silently restore forced bypassed approvals/sandbox even when the safer `operator_gated` mode is selected.
+- Last focused command: `npx tsx --test src/codex/codex-runner.test.ts src/local-review/runner.test.ts src/config.test.ts && npm run build`
+- Last focused failure: before the fix, the new operator-gated runner tests failed because both execution paths still appended `--dangerously-bypass-approvals-and-sandbox`.
 - Last focused commands:
 ```bash
-npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts
-npm install
+npx tsx --test src/codex/codex-runner.test.ts src/local-review/runner.test.ts
+npx tsx --test src/codex/codex-runner.test.ts src/local-review/runner.test.ts src/config.test.ts
 npm run build
-git diff --stat
-gh pr view codex/issue-709 --json number,url,isDraft,state
-git push -u origin codex/issue-709
-gh pr create --draft --base main --head codex/issue-709 --title "Prompt hardening: frame GitHub-authored prompt context" --body ...
+npm install
+git status --short
+git diff -- src/codex/codex-policy.ts src/codex/codex-runner.ts src/codex/codex-runner.test.ts src/local-review/runner.ts src/local-review/runner.test.ts .codex-supervisor/issue-journal.md
 date -u +"%Y-%m-%dT%H:%M:%SZ"
 ```
 ### Scratchpad

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -153,3 +153,11 @@ export function buildCodexConfigOverrideArgs(policy: CodexExecutionPolicy): stri
   args.push("-c", `model_reasoning_effort="${policy.reasoningEffort}"`);
   return args;
 }
+
+export function buildCodexExecutionSafetyArgs(
+  config: Pick<SupervisorConfig, "executionSafetyMode">,
+): string[] {
+  return config.executionSafetyMode === "operator_gated"
+    ? []
+    : ["--dangerously-bypass-approvals-and-sandbox"];
+}

--- a/src/codex/codex-runner.test.ts
+++ b/src/codex/codex-runner.test.ts
@@ -177,6 +177,46 @@ exit 0
   assert.equal(args.includes("-C"), false);
 });
 
+test("runCodexTurn omits bypass flags when execution safety mode is operator gated", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  await writeExecutableScript(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "${argsPath}"
+printf 'operator gated stdout\n'
+exit 0
+`,
+  );
+
+  const result = await runCodexTurn(
+    createConfig({
+      codexBinary,
+      executionSafetyMode: "operator_gated",
+    }),
+    workspacePath,
+    "operator gated prompt",
+    "implementing",
+  );
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(args.includes("--dangerously-bypass-approvals-and-sandbox"), false);
+  assert.deepEqual(args.slice(0, 5), [
+    "exec",
+    "-c",
+    'model_reasoning_effort="high"',
+    "--json",
+    "-C",
+  ]);
+  assert.equal(args[5], workspacePath);
+});
+
 test("runCodexTurn removes its temp dir when command execution fails", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
   const workspacePath = path.join(root, "workspace");

--- a/src/codex/codex-runner.ts
+++ b/src/codex/codex-runner.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { runCommand } from "../core/command";
-import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
+import { buildCodexConfigOverrideArgs, buildCodexExecutionSafetyArgs, resolveCodexExecutionPolicy } from "./codex-policy";
 import { CodexTurnResult, IssueRunRecord, RunState, SupervisorConfig } from "../core/types";
 
 function extractSessionId(stdout: string, sessionId?: string | null): string | null {
@@ -46,13 +46,14 @@ export async function runCodexTurn(
   const messageFile = path.join(tempDir, "last-message.txt");
   try {
     const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(config, state, record));
+    const executionSafetyArgs = buildCodexExecutionSafetyArgs(config);
     const commandArgs = sessionId
       ? [
           "exec",
           "resume",
           ...overrideArgs,
           "--json",
-          "--dangerously-bypass-approvals-and-sandbox",
+          ...executionSafetyArgs,
           "-o",
           messageFile,
           sessionId,
@@ -62,7 +63,7 @@ export async function runCodexTurn(
           "exec",
           ...overrideArgs,
           "--json",
-          "--dangerously-bypass-approvals-and-sandbox",
+          ...executionSafetyArgs,
           "-C",
           workspacePath,
           "-o",

--- a/src/local-review/runner.test.ts
+++ b/src/local-review/runner.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { runRoleReview, runVerifierReview, type LocalReviewTurnRequest } from "./runner";
+import { runCodexReviewTurn, runRoleReview, runVerifierReview, type LocalReviewTurnRequest } from "./runner";
 import {
   createConfig,
   createFakeLocalReviewRunner,
@@ -277,6 +277,63 @@ test("runVerifierReview routes verifier turns through the injected execution con
   } finally {
     await fs.rm(workspacePath, { recursive: true, force: true });
   }
+});
+
+test("runCodexReviewTurn omits bypass flags when execution safety mode is operator gated", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-runner-test-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "${argsPath}"
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+cat <<'EOF' > "$out"
+Review summary: Operator gated local review ran
+Recommendation: ready
+REVIEW_FINDINGS_JSON_START
+{"findings":[]}
+REVIEW_FINDINGS_JSON_END
+EOF
+exit 0
+`,
+    "utf8",
+  );
+  await fs.chmod(codexBinary, 0o755);
+
+  const result = await runCodexReviewTurn({
+    config: createConfig({
+      codexBinary,
+      executionSafetyMode: "operator_gated",
+    }),
+    workspacePath,
+    role: "reviewer",
+    outputFileName: "reviewer.txt",
+    prompt: "operator gated local review prompt",
+    executionTarget: "local_review_generic",
+  });
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.rawOutput, /Operator gated local review ran/);
+  assert.equal(args.includes("--dangerously-bypass-approvals-and-sandbox"), false);
+  assert.deepEqual(args.slice(0, 5), [
+    "exec",
+    "-c",
+    'model_reasoning_effort="low"',
+    "--json",
+    "-C",
+  ]);
+  assert.equal(args[5], workspacePath);
 });
 
 test("runRoleReview accepts empty fake-runner output as a configured result", async () => {

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { runCommand } from "../core/command";
-import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "../codex/codex-policy";
+import { buildCodexConfigOverrideArgs, buildCodexExecutionSafetyArgs, resolveCodexExecutionPolicy } from "../codex/codex-policy";
 import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "../external-review/external-review-misses";
 import { reviewDir } from "./artifacts";
 import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./prompt";
@@ -38,13 +38,14 @@ export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<
   const overrideArgs = buildCodexConfigOverrideArgs(
     resolveCodexExecutionPolicy(args.config, "local_review", undefined, args.executionTarget),
   );
+  const executionSafetyArgs = buildCodexExecutionSafetyArgs(args.config);
   const result = await runCommand(
     args.config.codexBinary,
     [
       "exec",
       ...overrideArgs,
       "--json",
-      "--dangerously-bypass-approvals-and-sandbox",
+      ...executionSafetyArgs,
       "-C",
       args.workspacePath,
       "-o",


### PR DESCRIPTION
## Summary
- add focused runner coverage for operator-gated execution safety mode
- omit bypassed approval/sandbox flags from Codex and local-review turns in operator-gated mode
- preserve explicit unsandboxed autonomous behavior via shared execution-safety arg plumbing

## Testing
- npx tsx --test src/codex/codex-runner.test.ts src/local-review/runner.test.ts src/config.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced operator-gated execution safety mode for enhanced control over Codex execution policies and approvals.

* **Tests**
  * Added test coverage verifying correct behavior of the new execution safety mode across Codex execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->