### PR TITLE
Paginate candidate discovery across the matching open backlog

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,45 +1,41 @@
-# Issue #777: Candidate discovery config: add an explicit fetch-window surface for scheduler candidate discovery
+# Issue #778: Candidate discovery pagination: fetch matching open issues beyond the first 100 for runnable selection
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/777
-- Branch: codex/issue-777
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/778
+- Branch: codex/issue-778
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: draft_pr
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 759441b34c02da7efb720145cd3c91a42f121390
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: f26a201bc28c82ba162d47151a945d95a8cdf021
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-21T13:35:42.384Z
+- Updated at: 2026-03-21T13:56:05.278Z
 
 ## Latest Codex Summary
-Checked draft PR [#789](https://github.com/TommyKammy/codex-supervisor/pull/789) after opening it. Both CI build jobs are green, there are no human or bot review findings, and the only remaining remote signal is CodeRabbit's draft-skip comment with a still-pending `CodeRabbit` status context while the PR remains draft. The worktree is otherwise clean apart from the pre-existing untracked `.codex-supervisor/replay/` directory.
-
-Summary: Checked PR `#789`; CI passed and only the draft-skipped pending CodeRabbit status remains.
-State hint: draft_pr
-Blocked reason: none
-Tests: not run this turn; checked remote PR status after prior green `npx tsx --test src/config.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts` and `npm run build`
-Failure signature: none
-Next action: keep watching PR `#789`; if the branch is ready for review, decide whether to move it out of draft or explicitly trigger the pending CodeRabbit review
+- Reproduced the first-page-only discovery bug with a focused `src/github/github.test.ts` regression, switched candidate discovery to paginated matching-open backlog fetches, updated status/doctor wording to `strategy=paginated`, and aligned docs that previously described first-page-only selection. Focused tests and `npm run build` now pass after installing the local dev dependencies that were missing from this worktree.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: candidate discovery needs an explicit fetch-window config plus an always-visible diagnostics line so operators can see the effective first-page-only behavior even when truncation is not currently observed.
-- What changed: checked draft PR `#789` after opening it. Remote CI is now green (`build (ubuntu-latest)=SUCCESS`, `build (macos-latest)=SUCCESS`), there are no review findings, and CodeRabbit left only a draft-skip informational comment while its `CodeRabbit` status context remains `PENDING`. The branch still contains the explicit `candidateDiscoveryFetchWindow` config surface, GitHub candidate discovery honors that window, and `status`/`doctor` show `candidate_discovery fetch_window=<n> strategy=first_page_only`.
+- Hypothesis: runnable selection was still limited by treating `candidateDiscoveryFetchWindow` as a total cap rather than a page size, so a paginated client fetch should expose runnable issues beyond the first 100 matches without changing readiness semantics.
+- What changed: added focused GitHub client regressions for a 101-issue backlog and a small-backlog no-regression case, changed candidate discovery to page through the matching open backlog via `gh api`, kept deterministic created-at ordering with number tiebreaks, updated status/doctor summaries to `candidate_discovery fetch_window=<n> strategy=paginated`, and rewrote docs/tests that still claimed first-page-only discovery.
 - Current blocker: none
-- Next exact step: continue watching PR `#789`; if the branch is ready to leave draft, decide whether to mark it ready for review and/or explicitly trigger CodeRabbit so the pending status context no longer blocks remote readiness.
-- Verification gap: no new local verification was necessary this turn because there were no code changes; remote CI is green, but PR `#789` still reports `mergeStateStatus=UNSTABLE` because the `CodeRabbit` status context is pending on the draft PR. `.codex-supervisor/replay/` remains untracked and untouched.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/config.test.ts`, `src/core/config.ts`, `src/core/types.ts`, `src/doctor.test.ts`, `src/doctor.ts`, `src/github/github-pull-request-hydrator.test.ts`, `src/github/github.test.ts`, `src/github/github.ts`, `src/pull-request-state-test-helpers.ts`, `src/review-handling.test.ts`, `src/run-once-issue-preparation.test.ts`, `src/run-once-issue-selection.test.ts`, `src/supervisor/replay-corpus-config.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-selection-readiness-summary.ts`, `src/supervisor/supervisor-status-report.ts`, `src/supervisor/supervisor-test-helpers.ts`, `src/supervisor/supervisor.ts`, `src/turn-execution-test-helpers.ts`, `src/codex/codex-policy.test.ts`, `src/codex/codex-runner.test.ts`
-- Rollback concern: removing the explicit fetch-window config or the new top-level diagnostics line would return candidate discovery behavior to an implicit hard-coded detail and hide the effective first-page-only scope from operators.
-- Last focused command: `gh pr view 789 --json url,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews`
-- Last focused failure: `none`
+- Next exact step: review the diff, commit the paginated discovery change on `codex/issue-778`, and open or update the draft PR with the verified checkpoint.
+- Verification gap: none for the requested local scope. `npm run build` initially failed because this worktree had no `node_modules` and `tsc` was missing; after `npm install`, the targeted tests and build both passed. `.codex-supervisor/replay/` remains untracked and untouched.
+- Files touched: `.codex-supervisor/issue-journal.md`, `docs/getting-started.ja.md`, `docs/getting-started.md`, `docs/issue-metadata.md`, `src/config.test.ts`, `src/doctor.test.ts`, `src/getting-started-docs.test.ts`, `src/github/github.test.ts`, `src/github/github.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-selection-readiness-summary.ts`
+- Rollback concern: reverting the paginated fetch would reintroduce the first-100 blind spot and make `status`/`doctor` overstate coverage relative to actual runnable selection behavior.
+- Last focused command: `npm run build`
+- Last focused failure: `npm run build` failed with `sh: 1: tsc: not found` until local dev dependencies were installed with `npm install`
 - Last focused commands:
 ```bash
-gh pr view 789 --json url,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews
+npx tsx --test src/github/github.test.ts
+npx tsx --test src/run-once-issue-selection.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/getting-started-docs.test.ts src/config.test.ts
+npm install
+npm run build
 ```
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -78,9 +78,9 @@ config の全項目、model policy、durable memory、provider guidance は [Con
 
 ## execution-ready issue を書く
 
-scheduler は「新しく open された issue」ではなく「今 runnable な issue」を選びます。ただし現状は matching する open issues のうち最初に取得した 1 page の範囲だけで判断しています。したがって、issue 側の metadata を explicit にしておく必要があります。
+scheduler は「新しく open された issue」ではなく「今 runnable な issue」を選びます。matching する open issues を candidate discovery fetch window ごとに page しながら backlog 全体を見て、deterministic な順序で最初に runnable な issue を選びます。したがって、issue 側の metadata を explicit にしておく必要があります。
 
-現在の制約: candidate discovery は GitHub から取得した matching open issues の最初の 1 page だけを評価し、backlog 全体を評価していません。repo が大きいと、より古い runnable issue はその 1 page に入ってくるまで選定対象から見えないことがあります。backlog の順番がおかしく見える時は、metadata だけでなく想定 issue がこの first-page fetch window の外にいないかも確認してください。
+candidate discovery は matching する open backlog 全体を評価します。repo が大きくても、より古い runnable issue が最初の page の外にあるだけで選定対象から見えなくなることはありません。backlog の順番がおかしく見える時は、まず metadata を確認してください。
 
 最低限そろえたい項目:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,9 +86,9 @@ If you need the full field-by-field setup, model policy, durable memory, or prov
 
 ## Write execution-ready issues
 
-The scheduler is readiness-driven within the current candidate discovery window. It does not just pick the newest open issue; it picks the first issue that is actually runnable from the first fetched page of matching open issues.
+The scheduler is readiness-driven across the matching open backlog. It does not just pick the newest open issue; it pages through matching open issues using the configured candidate discovery fetch window as the page size, then picks the first issue that is actually runnable in deterministic order.
 
-Current limitation: candidate discovery only evaluates the first fetched page of matching open issues from GitHub today, not the entire open backlog. In large repositories, older runnable issues can be invisible to selection until they move onto that first page or the earlier page contents change. If the backlog order looks wrong, check both the issue metadata and whether the runnable issue is currently outside that first-page fetch window.
+Candidate discovery now evaluates the matching open backlog rather than stopping after the first page. In large repositories, older runnable issues remain discoverable even when they begin beyond the first page. If the backlog order looks wrong, check the issue metadata before assuming discovery skipped part of the backlog.
 
 Before you run the supervisor, make sure each candidate issue includes:
 
@@ -149,7 +149,7 @@ What to check after `run-once`:
 - the issue journal shows a sensible hypothesis, blocker, and next step
 - any opened PR or status transition matches the actual repo state
 
-If the first pass picks the wrong issue, first check whether the expected issue is present in the first fetched page of matching open issues. Then fix the issue metadata before running again. Do not treat issue creation time as the source of truth.
+If the first pass picks the wrong issue, inspect `status` or `doctor` for the effective candidate discovery settings and then fix the issue metadata before running again. Do not treat issue creation time as the source of truth.
 If `status` or `doctor` reports corrupted JSON state, stop treating that file as a safe checkpoint. Inspect the file and recent operator actions first, then explicitly acknowledge the corruption or reset the state before trusting future runs.
 
 ## Move from run-once to loop
@@ -192,7 +192,7 @@ When should orphaned workspaces be cleaned up?
 Treat orphaned `issue-*` worktrees as explicit cleanup work, not as the same thing as delayed cleanup for tracked done workspaces. Preserve orphan workspaces that are locked, recently touched, or intentionally kept for manual recovery, and prune abandoned orphan workspaces only when you have made that operator decision explicitly.
 
 What if the backlog order looks wrong?
-Fix `Depends on` and `Execution order` in GitHub, and confirm the expected issue is still inside the first fetched page of matching open issues. The scheduler follows runnable order within that current candidate page, not operator intuition or chat history, and it does not evaluate the entire open backlog yet.
+Fix `Depends on` and `Execution order` in GitHub. The scheduler pages through the matching open backlog and follows runnable order across that full candidate set, not operator intuition or chat history.
 
 What if the loop keeps hitting blocked work?
 Stop treating the issue as execution-ready. Tighten the issue body, split the work, or use GSD to rebuild the backlog.

--- a/docs/issue-metadata.md
+++ b/docs/issue-metadata.md
@@ -102,14 +102,14 @@ Use verification steps for the exact commands or manual checks that prove the is
 
 ## How scheduling uses the fields
 
-The supervisor is readiness-driven within the current candidate discovery window. It does not just pick the newest issue, but today it only evaluates the first fetched page of matching open issues rather than the entire open backlog.
+The supervisor is readiness-driven across the matching open backlog. It does not just pick the newest issue; it pages through matching open issues using the configured candidate discovery fetch window as the page size, then selects the first runnable issue in deterministic order.
 
 - `Depends on` blocks an issue while any listed dependency is still open.
 - `Part of` plus `Execution order` blocks later siblings until earlier siblings are done.
 - `Acceptance criteria` and `Verification` make the issue execution-ready for implementation and review.
 - `Parallelizable` is documentation today; it does not override explicit dependencies.
 
-Operator expectation: a correctly authored older issue can still be invisible to runnable selection when it falls outside that first fetched page. If selection looks wrong in a large backlog, confirm both the metadata and whether the issue is currently outside the candidate fetch window.
+Operator expectation: a correctly authored older issue should remain discoverable even when it starts beyond the first page. If selection looks wrong in a large backlog, confirm the metadata before assuming candidate discovery skipped it.
 
 When in doubt, make the dependency explicit. A conservative queue is better than an ambiguous one.
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -788,9 +788,9 @@ test("getting started links to focused configuration and local review references
   assert.match(issueMetadata, /^# Issue Metadata$/m);
   assert.match(issueMetadata, /^## Canonical fields$/m);
   assert.match(issueMetadata, /^## How scheduling uses the fields$/m);
-  assert.match(issueMetadata, /first fetched page of matching open issues/i);
-  assert.match(issueMetadata, /rather than the entire open backlog/i);
-  assert.match(issueMetadata, /older issue can still be invisible to runnable selection/i);
+  assert.match(issueMetadata, /pages through matching open issues/i);
+  assert.match(issueMetadata, /matching open backlog/i);
+  assert.match(issueMetadata, /older issue should remain discoverable/i);
   assert.match(issueMetadata, /^## Issue body template$/m);
   assert.match(issueMetadata, /Part of: #42/m);
   assert.match(issueMetadata, /Depends on: #41/m);

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -263,7 +263,7 @@ test("renderDoctorReport surfaces merge-critical recheck cadence visibility", ()
       mergeCriticalEffectiveSeconds: 30,
       mergeCriticalRecheckEnabled: true,
     },
-    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=first_page_only",
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
   };
 
@@ -272,7 +272,7 @@ test("renderDoctorReport surfaces merge-critical recheck cadence visibility", ()
   assert.match(report, /doctor_cadence poll_interval_seconds=120 merge_critical_recheck_seconds=30 merge_critical_effective_seconds=30 enabled=true/);
 });
 
-test("diagnoseSupervisorHost and renderDoctorReport warn when candidate discovery may be truncated", async (t) => {
+test("diagnoseSupervisorHost and renderDoctorReport surface paginated candidate discovery", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {
     await fs.rm(root, { recursive: true, force: true });
@@ -299,18 +299,15 @@ test("diagnoseSupervisorHost and renderDoctorReport warn when candidate discover
       getCandidateDiscoveryDiagnostics: async () => ({
         fetchWindow: 250,
         observedMatchingOpenIssues: 251,
-        truncated: true,
+        truncated: false,
       }),
     },
   });
 
   const report = renderDoctorReport(diagnostics);
 
-  assert.match(report, /doctor_candidate_discovery fetch_window=250 strategy=first_page_only/);
-  assert.match(
-    report,
-    /doctor_warning kind=candidate_discovery detail=Candidate discovery may be truncated: more than 250 matching open issues exceed the current first-page fetch window, so runnable selection may be incomplete\./,
-  );
+  assert.match(report, /doctor_candidate_discovery fetch_window=250 strategy=paginated/);
+  assert.doesNotMatch(report, /doctor_warning kind=candidate_discovery/);
 });
 
 test("diagnoseSupervisorHost uses a strict default state loader for existing invalid JSON", async (t) => {

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -53,17 +53,17 @@ test("getting-started stays focused on operator setup and flow", async () => {
   assert.doesNotMatch(content, /^## State machine$/m);
 });
 
-test("getting-started explains the current first-page candidate discovery limit", async () => {
+test("getting-started explains paginated candidate discovery across the open backlog", async () => {
   const [gettingStarted, japaneseGettingStarted] = await Promise.all([
     readGettingStarted(),
     readJapaneseGettingStarted(),
   ]);
 
-  assert.match(gettingStarted, /first fetched page of matching open issues/i);
-  assert.match(gettingStarted, /does not evaluate the entire open backlog/i);
-  assert.match(gettingStarted, /older runnable issues can be invisible/i);
-  assert.match(japaneseGettingStarted, /最初に取得した 1 page/i);
-  assert.match(japaneseGettingStarted, /backlog 全体を評価していません/i);
+  assert.match(gettingStarted, /pages through matching open issues/i);
+  assert.match(gettingStarted, /matching open backlog/i);
+  assert.match(gettingStarted, /older runnable issues remain discoverable/i);
+  assert.match(japaneseGettingStarted, /backlog 全体を見て/i);
+  assert.match(japaneseGettingStarted, /最初の page の外にあるだけで選定対象から見えなくなることはありません/i);
 });
 
 test("japanese docs keep overview and getting-started responsibilities separate", async () => {

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -288,6 +288,96 @@ test("GitHubClient falls back from gh pr checks to statusCheckRollup", async () 
   ]);
 });
 
+test("GitHubClient listCandidateIssues discovers matching open issues beyond the first 100 results", async () => {
+  const config = createConfig();
+  const backlog = Array.from({ length: 101 }, (_value, index) =>
+    createIssue({
+      number: index + 1,
+      title: `Issue ${index + 1}`,
+      createdAt: `2026-03-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+      updatedAt: `2026-03-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+      url: `https://example.test/issues/${index + 1}`,
+    }),
+  );
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "repos/owner/repo/issues") {
+      const page = Number(args.find((arg) => arg.startsWith("page="))?.slice("page=".length) ?? "1");
+      const perPage = Number(args.find((arg) => arg.startsWith("per_page="))?.slice("per_page=".length) ?? "100");
+      const start = (page - 1) * perPage;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(backlog.slice(start, start + perPage).map((issue) => ({
+          number: issue.number,
+          title: issue.title,
+          body: issue.body,
+          created_at: issue.createdAt,
+          updated_at: issue.updatedAt,
+          html_url: issue.url,
+          state: issue.state ?? "OPEN",
+          labels: issue.labels ?? [],
+        }))),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const issues = await client.listCandidateIssues();
+
+  assert.equal(issues.length, 101);
+  assert.equal(issues[0]?.number, 1);
+  assert.equal(issues.at(-1)?.number, 84);
+  assert.ok(issues.some((issue) => issue.number === 101));
+});
+
+test("GitHubClient listCandidateIssues preserves small backlogs without extra paging churn", async () => {
+  const config = createConfig();
+  const backlog = [
+    createIssue({
+      number: 12,
+      title: "Later-created issue",
+      createdAt: "2026-03-12T00:00:00Z",
+      updatedAt: "2026-03-12T00:00:00Z",
+      url: "https://example.test/issues/12",
+    }),
+    createIssue({
+      number: 11,
+      title: "Earlier-created issue",
+      createdAt: "2026-03-11T00:00:00Z",
+      updatedAt: "2026-03-11T00:00:00Z",
+      url: "https://example.test/issues/11",
+    }),
+  ];
+  let pagesFetched = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "repos/owner/repo/issues") {
+      pagesFetched += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(backlog.map((issue) => ({
+          number: issue.number,
+          title: issue.title,
+          body: issue.body,
+          created_at: issue.createdAt,
+          updated_at: issue.updatedAt,
+          html_url: issue.url,
+          state: issue.state ?? "OPEN",
+          labels: issue.labels ?? [],
+        }))),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const issues = await client.listCandidateIssues();
+
+  assert.equal(pagesFetched, 1);
+  assert.deepEqual(issues.map((issue) => issue.number), [11, 12]);
+});
+
 test("GitHubClient createPullRequest recovers when the first open-branch lookup misses the new PR", async () => {
   const config = createConfig();
   const createdPr = createPullRequest();

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -27,6 +27,22 @@ export type { GitHubCommandRunner } from "./github-transport";
 const POST_CREATE_PR_LOOKUP_RETRY_LIMIT = 2;
 const POST_CREATE_PR_LOOKUP_BASE_DELAY_MS = 200;
 
+interface GitHubRestIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  state: string;
+  labels?: Array<{ name: string }>;
+  pull_request?: unknown;
+}
+
+interface GitHubSearchIssuesResponse {
+  items: GitHubRestIssue[];
+}
+
 export class GitHubClient {
   private readonly pullRequestHydrator: GitHubPullRequestHydrator;
   private readonly transport: GitHubTransport;
@@ -106,47 +122,126 @@ export class GitHubClient {
     return parseJson<GitHubIssue[]>(result.stdout, "gh issue list");
   }
 
-  private buildCandidateIssueListArgs(limit: number): string[] {
+  private candidateDiscoveryPageSize(): number {
+    return this.config.candidateDiscoveryFetchWindow ?? DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW;
+  }
+
+  private mapRestIssue(issue: GitHubRestIssue): GitHubIssue | null {
+    if (issue.pull_request) {
+      return null;
+    }
+
+    return {
+      number: issue.number,
+      title: issue.title,
+      body: issue.body ?? "",
+      createdAt: issue.created_at,
+      updatedAt: issue.updated_at,
+      url: issue.html_url,
+      labels: issue.labels?.map((label) => ({ name: label.name })),
+      state: issue.state.toUpperCase(),
+    };
+  }
+
+  private sortCandidateIssues(issues: GitHubIssue[]): GitHubIssue[] {
+    return [...issues].sort((left, right) => {
+      const createdAtOrder = left.createdAt.localeCompare(right.createdAt);
+      if (createdAtOrder !== 0) {
+        return createdAtOrder;
+      }
+
+      return left.number - right.number;
+    });
+  }
+
+  private async listRepositoryCandidateIssuePage(page: number, perPage: number): Promise<GitHubIssue[]> {
+    const { owner, repo } = this.repoOwnerAndName();
     const args = [
-      "issue",
-      "list",
-      "--repo",
-      this.config.repoSlug,
-      "--state",
-      "open",
-      "--limit",
-      String(limit),
-      "--json",
-      "number,title,body,createdAt,updatedAt,url,labels,state",
+      "api",
+      `repos/${owner}/${repo}/issues`,
+      "--method",
+      "GET",
+      "-f",
+      "state=open",
+      "-f",
+      `per_page=${perPage}`,
+      "-f",
+      `page=${page}`,
     ];
 
     if (this.config.issueLabel) {
-      args.push("--label", this.config.issueLabel);
+      args.push("-f", `labels=${this.config.issueLabel}`);
     }
 
-    if (this.config.issueSearch) {
-      args.push("--search", this.config.issueSearch);
+    const result = await this.runGhCommand(args);
+    const issues = parseJson<GitHubRestIssue[]>(result.stdout, `gh api repos/${owner}/${repo}/issues page=${page}`);
+    return issues
+      .map((issue) => this.mapRestIssue(issue))
+      .filter((issue): issue is GitHubIssue => issue !== null);
+  }
+
+  private buildCandidateSearchQuery(): string {
+    const qualifiers = [`repo:${this.config.repoSlug}`, "is:issue", "is:open"];
+    if (this.config.issueLabel) {
+      qualifiers.push(`label:"${this.config.issueLabel.replace(/["\\]/g, "\\$&")}"`);
     }
 
-    return args;
+    if (this.config.issueSearch && this.config.issueSearch.trim() !== "") {
+      qualifiers.push(this.config.issueSearch.trim());
+    }
+
+    return qualifiers.join(" ");
+  }
+
+  private async listSearchCandidateIssuePage(page: number, perPage: number): Promise<GitHubIssue[]> {
+    const args = [
+      "api",
+      "search/issues",
+      "--method",
+      "GET",
+      "-f",
+      `q=${this.buildCandidateSearchQuery()}`,
+      "-f",
+      `per_page=${perPage}`,
+      "-f",
+      `page=${page}`,
+    ];
+    const result = await this.runGhCommand(args);
+    const response = parseJson<GitHubSearchIssuesResponse>(result.stdout, `gh api search/issues page=${page}`);
+    return response.items
+      .map((issue) => this.mapRestIssue(issue))
+      .filter((issue): issue is GitHubIssue => issue !== null);
+  }
+
+  private async fetchAllCandidateIssues(): Promise<GitHubIssue[]> {
+    const perPage = this.candidateDiscoveryPageSize();
+    const issues: GitHubIssue[] = [];
+
+    for (let page = 1; ; page += 1) {
+      const pageIssues =
+        this.config.issueSearch && this.config.issueSearch.trim() !== ""
+          ? await this.listSearchCandidateIssuePage(page, perPage)
+          : await this.listRepositoryCandidateIssuePage(page, perPage);
+      issues.push(...pageIssues);
+      if (pageIssues.length < perPage) {
+        break;
+      }
+    }
+
+    return this.sortCandidateIssues(issues);
   }
 
   async listCandidateIssues(): Promise<GitHubIssue[]> {
-    const fetchWindow = this.config.candidateDiscoveryFetchWindow ?? DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW;
-    const result = await this.runGhCommand(this.buildCandidateIssueListArgs(fetchWindow));
-    const issues = parseJson<GitHubIssue[]>(result.stdout, "gh issue list --candidate");
-    return issues.sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+    return this.fetchAllCandidateIssues();
   }
 
   async getCandidateDiscoveryDiagnostics(): Promise<CandidateDiscoveryDiagnostics> {
-    const fetchWindow = this.config.candidateDiscoveryFetchWindow ?? DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW;
-    const probeLimit = fetchWindow + 1;
-    const result = await this.runGhCommand(this.buildCandidateIssueListArgs(probeLimit));
-    const issues = parseJson<GitHubIssue[]>(result.stdout, "gh issue list --candidate-window-probe");
+    const fetchWindow = this.candidateDiscoveryPageSize();
+    const issues = await this.fetchAllCandidateIssues();
     return {
       fetchWindow,
       observedMatchingOpenIssues: issues.length,
-      truncated: issues.length > fetchWindow,
+      truncated: false,
     };
   }
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -460,7 +460,7 @@ Execution order: 3 of 3`,
   );
 });
 
-test("status warns when candidate discovery may be truncated by the first-page fetch window", async () => {
+test("status reports paginated candidate discovery without a truncation warning", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
@@ -497,7 +497,7 @@ Keep selection behavior unchanged while surfacing the current discovery limit.
     getCandidateDiscoveryDiagnostics: async () => ({
       fetchWindow: 250,
       observedMatchingOpenIssues: 251,
-      truncated: true,
+      truncated: false,
     }),
     getPullRequestIfExists: async () => null,
     getChecks: async () => [],
@@ -505,18 +505,12 @@ Keep selection behavior unchanged while surfacing the current discovery limit.
   };
 
   const report = await supervisor.statusReport();
-  assert.equal(report.candidateDiscoverySummary, "candidate_discovery fetch_window=250 strategy=first_page_only");
-  assert.match(
-    report.readinessLines.join("\n"),
-    /candidate_discovery_warning=matching_open_issues_exceed_first_page_window fetch_window=250 observed_matching_open_issues=251\+ runnable_selection_incomplete=yes/,
-  );
+  assert.equal(report.candidateDiscoverySummary, "candidate_discovery fetch_window=250 strategy=paginated");
+  assert.doesNotMatch(report.readinessLines.join("\n"), /candidate_discovery_warning=/);
 
   const status = await supervisor.status();
-  assert.match(status, /candidate_discovery fetch_window=250 strategy=first_page_only/);
-  assert.match(
-    status,
-    /candidate_discovery_warning=matching_open_issues_exceed_first_page_window fetch_window=250 observed_matching_open_issues=251\+ runnable_selection_incomplete=yes/,
-  );
+  assert.match(status, /candidate_discovery fetch_window=250 strategy=paginated/);
+  assert.doesNotMatch(status, /candidate_discovery_warning=/);
 });
 
 test("status surfaces the current reconciliation phase only while reconciliation is in progress", async () => {

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -33,7 +33,7 @@ export function formatCandidateDiscoveryBehaviorLine(
   prefix = "candidate_discovery",
 ): string {
   const fetchWindow = config.candidateDiscoveryFetchWindow ?? DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW;
-  return `${prefix} fetch_window=${fetchWindow} strategy=first_page_only`;
+  return `${prefix} fetch_window=${fetchWindow} strategy=paginated`;
 }
 
 export function formatCandidateDiscoveryStatusLine(


### PR DESCRIPTION
## Summary
- page through matching open issues for candidate discovery instead of stopping at the first 100 matches
- preserve deterministic created-at ordering with issue-number tiebreaks
- update status, doctor, and docs to describe paginated candidate discovery

## Testing
- npx tsx --test src/github/github.test.ts
- npx tsx --test src/run-once-issue-selection.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/getting-started-docs.test.ts src/config.test.ts
- npm run build

Closes #778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Candidate discovery now pages through the entire open issues backlog to find runnable candidates, instead of limiting selection to the first batch of results. Older issues remain discoverable and selectable by the scheduler.

* **Documentation**
  * Updated scheduling and configuration guidance across multiple languages to reflect full-backlog pagination behavior for candidate discovery.

* **Tests**
  * Updated test expectations to verify pagination-based candidate discovery and confirm issues beyond the initial batch are properly discovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->