### PR TITLE
Stale recovery convergence: stop repeated no-progress stale cleanup at manual review earlier (#863)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,70 +1,53 @@
-# Issue #862: Stale recovery counter: add dedicated repetition tracking for stale stabilizing no-PR cleanup
+# Issue #863: Stale recovery convergence: stop repeated no-progress stale cleanup at manual review earlier
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/862
-- Branch: codex/issue-862
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/863
+- Branch: codex/issue-863
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 4 (implementation=1, repair=3)
-- Last head SHA: b45d12b3a08904f885d19d65e4654a3677c478b8
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 93fbe8647b116495fe63437324a8d844c494b60f
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-23T02:12:08Z
+- Updated at: 2026-03-23T02:35:27.011Z
 
 ## Latest Codex Summary
-Reformatted the unresolved review blob in [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-862/.codex-supervisor/issue-journal.md) into multi-line Markdown so the CodeRabbit entry no longer relies on the inline code-span pattern that triggered `MD038`. Confirmed the targeted lint output no longer reports `MD038`, committed the journal cleanup as `b45d12b`, pushed `codex/issue-862`, and resolved GitHub review thread `PRRT_kwDORgvdZ852BDOu`.
-
-Focused verification passed: `npx markdownlint-cli2 .codex-supervisor/issue-journal.md 2>&1 | rg -n "MD038|no-space-in-code"` returned no matches. Full-file `markdownlint-cli2` still reports the journal's pre-existing style warnings outside this review fix. Local status is clean except for the pre-existing untracked `.codex-supervisor/replay/`.
-
-Summary: Fixed the journal's inline review blob formatting, verified the MD038 warning no longer appears, pushed `b45d12b`, and resolved the remaining review thread on PR #867.
-State hint: pr_open
-Blocked reason: none
-Tests: `npx markdownlint-cli2 .codex-supervisor/issue-journal.md 2>&1 | rg -n "MD038|no-space-in-code"`
-Failure signature: none
-Next action: Monitor PR #867 for any follow-up review or CI activity after the resolved thread and pushed head `b45d12b`.
+- None yet.
 
 ## Active Failure Context
-- Category: review
-- Summary: No unresolved automated review threads remain after resolving `PRRT_kwDORgvdZ852BDOu`.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/867#discussion_r2972494600
-- Details:
-  - Rewrote the line-33 review blob as a multi-line Markdown block with fenced snippets and confirmed the targeted markdownlint output no longer reports `MD038`.
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the only remaining risk was the journal's inline review blob formatting; now that the entry is multi-line and the targeted lint output is clear, the PR should be back to passive monitoring unless new review or CI activity appears.
-- What changed: reformatted `.codex-supervisor/issue-journal.md` to eliminate the inline review blob that triggered `MD038`, committed the cleanup as `b45d12b`, pushed `codex/issue-862`, and resolved thread `PRRT_kwDORgvdZ852BDOu`.
+- Hypothesis: stale stabilizing no-PR recovery was preserving its repeat count in direct helper coverage but dropping it in the full run loop because the lifecycle reset compared against the current `queued` state instead of the inferred next `stabilizing` state.
+- What changed: updated no-PR stale recovery preservation so queued stale requeues keep `stale_stabilizing_no_pr_recovery_count` and related stale-loop tracking when the next lifecycle state is `stabilizing`; added focused helper/lifecycle coverage for the queued-to-stabilizing case and tightened the orchestration replay to prove the next stale cleanup converges to `manual_review`.
 - Current blocker: none
-- Next exact step: monitor PR `#867` for any follow-up review or CI activity after the resolved thread and pushed head `b45d12b`.
-- Verification gap: the targeted `MD038` check is clear; full-file `markdownlint-cli2` still reports the journal's pre-existing line-length, heading-spacing, bare-URL, and inline-HTML warnings outside the scope of this review fix.
-- Files touched: `.codex-supervisor/issue-journal.md`
-- Rollback concern: low; the change is limited to journal formatting and preserves the same review context with more stable Markdown structure.
-- Last focused command: `gh api graphql -f query='mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { isResolved id } } }' -F threadId=PRRT_kwDORgvdZ852BDOu`
-- Last focused failure: none
+- Next exact step: review the diff, commit the stale recovery convergence fix, and decide whether to open a draft PR if one is still absent for `codex/issue-863`.
+- Verification gap: focused stale recovery and supervisor verification are green locally; broader repository test suites remain unrun this turn.
+- Files touched: `src/no-pull-request-state.ts`, `src/no-pull-request-state.test.ts`, `src/run-once-turn-execution.ts`, `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-lifecycle.ts`, `src/supervisor/supervisor-lifecycle.test.ts`, `src/supervisor/supervisor-execution-orchestration.test.ts`
+- Rollback concern: medium-low; the behavior change is intentionally narrow to queued stale no-PR requeues, but it touches the generic no-PR lifecycle reset path and should stay covered by the focused orchestration replay.
+- Last focused command: `npx tsx --test src/no-pull-request-state.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`
+- Last focused failure: `stale-no-pr-recovery-count-reset-after-queued-requeue`
 - Last focused commands:
 ```bash
-sed -n '1,220p' "<local-memory>/issue-862/AGENTS.generated.md"
-sed -n '1,220p' "<local-memory>/issue-862/context-index.md"
+sed -n '1,220p' "<local-memory>/issue-863/AGENTS.generated.md"
+sed -n '1,220p' "<local-memory>/issue-863/context-index.md"
 sed -n '1,260p' .codex-supervisor/issue-journal.md
 git status --short
-nl -ba .codex-supervisor/issue-journal.md | sed -n '24,60p'
-git diff -- .codex-supervisor/issue-journal.md
-rg -n "MD038|no-space-in-code|suggestion_start|getStaleStabilizingNoPrRecoveryCount" .codex-supervisor/issue-journal.md
+rg -n "stale_stabilizing_no_pr_recovery_count|shouldPreserveStaleStabilizingNoPrRecoveryTracking|resetNoPrLifecycleFailureTracking|manual_review" src
+npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts
+npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
 apply_patch
-nl -ba .codex-supervisor/issue-journal.md | sed -n '28,92p'
-npx markdownlint-cli2 .codex-supervisor/issue-journal.md
-npx markdownlint-cli2 .codex-supervisor/issue-journal.md 2>&1 | rg -n "MD038|no-space-in-code"
-git diff -- .codex-supervisor/issue-journal.md
-git add .codex-supervisor/issue-journal.md
-git commit -m "Fix issue journal review markdown"
-git rev-parse HEAD
-git push origin codex/issue-862
-gh api graphql -f query='mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { isResolved id } } }' -F threadId=PRRT_kwDORgvdZ852BDOu
+npx tsx --test src/no-pull-request-state.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
+npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts
+rm .codex-supervisor/replay/decision-cycle-snapshot.json && rmdir .codex-supervisor/replay
 date -u +%Y-%m-%dT%H:%M:%SZ
 ```
 ### Scratchpad
+- 2026-03-23T02:44:29Z: reproduced the stale convergence bug with `src/supervisor/supervisor-execution-orchestration.test.ts`; the stale cleanup requeued the issue but the next cycle reset `stale_stabilizing_no_pr_recovery_count` to `0` before the successful no-PR turn finished.
+- 2026-03-23T02:44:29Z: fixed the queued-to-stabilizing preservation gap by passing the inferred next no-PR state into `resetNoPrLifecycleFailureTracking`, widened stale preservation to queued stale requeues, and passed `npx tsx --test src/no-pull-request-state.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts`.
 - 2026-03-23T02:12:08Z: committed the journal markdown cleanup as `b45d12b`, pushed `codex/issue-862`, and resolved GitHub review thread `PRRT_kwDORgvdZ852BDOu`.
 - 2026-03-23T02:11:10Z: rewrote the unresolved `.codex-supervisor/issue-journal.md` review blob into multi-line Markdown, then confirmed `npx markdownlint-cli2 .codex-supervisor/issue-journal.md 2>&1 | rg -n "MD038|no-space-in-code"` returned no matches even though full-file markdownlint still reports pre-existing non-MD038 journal warnings.
 - 2026-03-23T01:57:27Z: pushed review-fix commit `4c2e232` to `codex/issue-862` and resolved GitHub review thread `PRRT_kwDORgvdZ852A-pm` with `gh api graphql`.

--- a/src/no-pull-request-state.test.ts
+++ b/src/no-pull-request-state.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   inferStateWithoutPullRequest,
+  STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
   shouldPreserveNoPrFailureTracking,
   shouldPreserveStaleStabilizingNoPrRecoveryTracking,
 } from "./no-pull-request-state";
@@ -161,6 +162,21 @@ test("shouldPreserveNoPrFailureTracking only keeps repeated blocked no-PR failur
       }),
     ),
     false,
+  );
+});
+
+test("shouldPreserveStaleStabilizingNoPrRecoveryTracking keeps stale no-PR recovery count across queued requeue cycles", () => {
+  assert.equal(
+    shouldPreserveStaleStabilizingNoPrRecoveryTracking(
+      createRecord({
+        state: "queued",
+        pr_number: null,
+        last_failure_signature: STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
+        repeated_failure_signature_count: 2,
+      }),
+      "stabilizing",
+    ),
+    true,
   );
 });
 

--- a/src/no-pull-request-state.ts
+++ b/src/no-pull-request-state.ts
@@ -50,7 +50,7 @@ export function shouldPreserveStaleStabilizingNoPrRecoveryTracking(
 ): boolean {
   return (
     record.pr_number === null &&
-    record.state === "stabilizing" &&
+    (record.state === "queued" || record.state === "stabilizing") &&
     nextState === "stabilizing" &&
     record.last_failure_signature === STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE &&
     getStaleStabilizingNoPrRecoveryCount(record) > 0

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -18,7 +18,10 @@ import {
 } from "./post-turn-pull-request";
 import { IssueJournalSync, MemoryArtifacts } from "./run-once-issue-preparation";
 import { StateStore } from "./core/state-store";
-import { shouldPreserveStaleStabilizingNoPrRecoveryTracking } from "./no-pull-request-state";
+import {
+  getStaleStabilizingNoPrRecoveryCount,
+  shouldPreserveStaleStabilizingNoPrRecoveryTracking,
+} from "./no-pull-request-state";
 import {
   nextProcessedReviewThreadPatch,
   prepareCodexTurnPrompt,
@@ -289,6 +292,9 @@ export async function executeCodexTurnPhase(
       const hintedState = structuredResult?.stateHint ?? null;
       const hintedBlockedReason = structuredResult?.blockedReason ?? null;
       const hintedFailureSignature = structuredResult?.failureSignature ?? null;
+      const preTurnFailureContext = record.last_failure_context;
+      const preTurnFailureSignature = record.last_failure_signature;
+      const preTurnStaleNoPrRecoveryCount = getStaleStabilizingNoPrRecoveryCount(record);
       const preTurnLastError = record.last_error;
       const journalAfterRun = await readIssueJournalImpl(journalPath);
       record = stateStore.touch(record, {
@@ -446,7 +452,7 @@ export async function executeCodexTurnPhase(
         repeated_blocker_count: 0,
         last_blocker_signature: null,
         stale_stabilizing_no_pr_recovery_count: preserveStaleNoPrRecoveryTracking
-          ? record.stale_stabilizing_no_pr_recovery_count ?? record.repeated_failure_signature_count
+          ? preTurnStaleNoPrRecoveryCount
           : 0,
         last_error:
           preserveStaleNoPrRecoveryTracking
@@ -455,11 +461,11 @@ export async function executeCodexTurnPhase(
             ? truncate(postRunSnapshot.failureContext.summary, 1000)
             : record.last_error,
         last_failure_context:
-          preserveStaleNoPrRecoveryTracking ? record.last_failure_context : postRunSnapshot?.failureContext ?? null,
+          preserveStaleNoPrRecoveryTracking ? preTurnFailureContext : postRunSnapshot?.failureContext ?? null,
         ...(
           preserveStaleNoPrRecoveryTracking
             ? {
-                last_failure_signature: record.last_failure_signature,
+                last_failure_signature: preTurnFailureSignature,
                 repeated_failure_signature_count: 0,
               }
             : args.applyFailureSignature(record, postRunSnapshot?.failureContext ?? null)

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -454,12 +454,8 @@ test("runOnce preserves stale no-PR recovery tracking across a successful no-PR 
   assert.equal(firstRecord.state, "stabilizing");
   assert.equal(firstRecord.pr_number, null);
   assert.equal(firstRecord.codex_session_id, "thread-stale-no-pr");
-  assert.equal(
-    firstRecord.last_error,
-    "Issue #91 re-entered stale stabilizing recovery without a tracked PR; the supervisor will retry while the repeat count remains below 3.",
-  );
-  assert.equal(firstRecord.last_failure_signature, "stale-stabilizing-no-pr-recovery-loop");
-  assert.equal(firstRecord.repeated_failure_signature_count, 2);
+  assert.equal(firstRecord.repeated_failure_signature_count, 0);
+  assert.equal(firstRecord.stale_stabilizing_no_pr_recovery_count, 2);
 
   const secondMessage = await supervisor.runOnce({ dryRun: false });
   assert.match(
@@ -474,8 +470,17 @@ test("runOnce preserves stale no-PR recovery tracking across a successful no-PR 
   assert.equal(secondRecord.pr_number, null);
   assert.equal(secondRecord.codex_session_id, null);
   assert.equal(secondRecord.blocked_reason, "manual_review");
+  assert.match(secondRecord.last_error ?? "", /manual intervention is required/i);
+  assert.match(
+    secondRecord.last_failure_context?.summary ?? "",
+    /re-entered stale stabilizing recovery without a tracked PR 3 times; manual intervention is required/i,
+  );
   assert.equal(secondRecord.last_failure_signature, "stale-stabilizing-no-pr-recovery-loop");
-  assert.equal(secondRecord.repeated_failure_signature_count, fixture.config.sameFailureSignatureRepeatLimit);
+  assert.equal(secondRecord.repeated_failure_signature_count, 0);
+  assert.equal(
+    secondRecord.stale_stabilizing_no_pr_recovery_count,
+    fixture.config.sameFailureSignatureRepeatLimit,
+  );
 });
 
 test("runOnce returns no matching issue when no runnable candidate is available", async () => {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   derivePullRequestLifecycleSnapshot,
+  resetNoPrLifecycleFailureTracking,
   selectSupervisorPollIntervalMs,
   shouldRunCodex,
 } from "./supervisor-lifecycle";
@@ -440,4 +441,45 @@ test("shouldRunCodex only returns true for actionable supervisor states", () => 
     ),
     true,
   );
+});
+
+test("resetNoPrLifecycleFailureTracking preserves stale no-PR recovery tracking across queued-to-stabilizing cycles", () => {
+  const record = createRecord({
+    state: "queued",
+    pr_number: null,
+    last_failure_context: {
+      category: "blocked",
+      summary:
+        "Issue #366 re-entered stale stabilizing recovery without a tracked PR; the supervisor will retry while the repeat count remains below 3.",
+      signature: "stale-stabilizing-no-pr-recovery-loop",
+      command: null,
+      details: [
+        "state=stabilizing",
+        "tracked_pr=none",
+        "branch_state=recoverable",
+        "repeat_count=2/3",
+      ],
+      url: null,
+      updated_at: "2026-03-13T00:00:00.000Z",
+    },
+    last_failure_signature: "stale-stabilizing-no-pr-recovery-loop",
+    repeated_failure_signature_count: 0,
+    stale_stabilizing_no_pr_recovery_count: 2,
+  });
+
+  assert.deepEqual(resetNoPrLifecycleFailureTracking(record, "stabilizing"), {
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
+    merge_readiness_last_evaluated_at: null,
+    last_failure_context: record.last_failure_context,
+    last_failure_signature: "stale-stabilizing-no-pr-recovery-loop",
+    repeated_failure_signature_count: 0,
+    stale_stabilizing_no_pr_recovery_count: 2,
+    blocked_reason: null,
+  });
 });

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -195,6 +195,7 @@ export function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPul
 
 export function resetNoPrLifecycleFailureTracking(
   record: IssueRunRecord,
+  nextState: RunState = record.state,
 ): Pick<
   IssueRunRecord,
   | "copilot_review_requested_observed_at"
@@ -217,7 +218,7 @@ export function resetNoPrLifecycleFailureTracking(
     record.last_failure_context?.category === "blocked" &&
     record.last_failure_signature !== null &&
     record.repeated_failure_signature_count > 0;
-  const preserveStaleNoPrRecoveryCount = shouldPreserveStaleStabilizingNoPrRecoveryTracking(record, record.state);
+  const preserveStaleNoPrRecoveryCount = shouldPreserveStaleStabilizingNoPrRecoveryTracking(record, nextState);
   return {
     copilot_review_requested_observed_at: null,
     copilot_review_requested_head_sha: null,

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -659,9 +659,10 @@ export class Supervisor {
         );
       }
     } else {
+      const nextState = inferStateWithoutPullRequest(record, workspaceStatus);
       record = this.stateStore.touch(record, {
-        state: inferStateWithoutPullRequest(record, workspaceStatus),
-        ...resetNoPrLifecycleFailureTracking(record),
+        state: nextState,
+        ...resetNoPrLifecycleFailureTracking(record, nextState),
       });
     }
     const shouldExecuteCodex = shouldRunCodex(record, pr, checks, reviewThreads, this.config);


### PR DESCRIPTION
Closes #863
This PR was opened by codex-supervisor.
Latest Codex summary:

Preserved stale no-PR recovery tracking across `queued -> stabilizing` requeues so the next stale cleanup now converges to `manual_review` at the intended threshold instead of silently looping. The fix passes the inferred next state into `resetNoPrLifecycleFailureTracking`, broadens stale-count preservation for queued stale requeues, and keeps the execution-phase preservation logic anchored to the pre-turn stale snapshot. I also tightened focused coverage in [`src/no-pull-request-state.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-863/src/no-pull-request-state.test.ts), [`src/supervisor/supervisor-lifecycle.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-863/src/supervisor/supervisor-lifecycle.test.ts), and [`src/supervisor/supervisor-execution-orchestration.test.ts`](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-863/src/supervisor/supervisor-execution-orchestration.test.ts). The checkpoint is committed as `5d43cb0`.

Verification passed with:
`npx tsx --test src/no-pull-request-state.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`
and
`npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts`

Summary: Preserved stale no-PR recovery counts across queued requeues so repeated stale cleanup now stops at manual review on the next threshold-crossing cycle, with focused helper, lifecycle, and orchestra...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved preservation of stale recovery tracking information during state transitions in no-pull-request scenarios.
  * Enhanced error context tracking to use pre-transition values instead of potentially-mutated values.
  * Fixed state transition logic to account for queued and stabilizing states when preserving recovery metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->