### PR TITLE
Persist latest local CI result visibility

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,74 +1,56 @@
-# Issue #884: Local CI execution gate: run configured pre-PR verification before PR publication
+# Issue #885: Local CI visibility: persist and surface the latest pre-PR verification result
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/884
-- Branch: codex/issue-884
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/885
+- Branch: codex/issue-885
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 1fc7138056bf61c8ea73906623bcabfe205bf543
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 0028afa11b61b958d6167df67d63e68f4e3f8685
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ852JnTS|PRRT_kwDORgvdZ852JnTY|PRRT_kwDORgvdZ852JnTZ
-- Repeated failure signature count: 1
-- Updated at: 2026-03-23T14:40:35.535Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-23T15:23:48Z
 
 ## Latest Codex Summary
-Pushed `codex/issue-884` and opened draft PR `#901`: https://github.com/TommyKammy/codex-supervisor/pull/901
-
-I also updated the issue journal handoff so the durable state now points at PR `#901` and the next step is to monitor its checks/review. No additional code changes or verification were needed in this turn beyond the already-passing local verification from the prior step. The worktree is still dirty only because of the updated journal and untracked `.codex-supervisor/replay/`.
-
-Summary: Pushed `codex/issue-884`, opened draft PR `#901`, and updated the journal handoff to monitor PR checks
-State hint: draft_pr
-Blocked reason: none
-Tests: not run in this turn; prior verified state already passed `npm run build`, `npx tsx --test src/run-once-turn-execution.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`, and `npx tsx --test src/post-turn-pull-request.test.ts`
-Failure signature: none
-Next action: monitor draft PR `#901` checks and address any CI or review feedback
+- Persisted concise latest local-CI results on issue records, surfaced typed `localCiStatus` in status/explain activity context and replay snapshots, and added readable `local_ci_result` lines to status/explain output.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the addressed review fixes are now on `codex/issue-884` head `a5aa5f1`, the three automated threads are resolved on PR `#901`, and the remaining work is to monitor for any follow-up CI or review signal on the refreshed head.
-- What changed: added `CommandExecutionError` in `src/core/command.ts` so failed commands retain `stdout`, `stderr`, `exitCode`, and timeout metadata; updated `src/local-ci.ts` to enforce a 5-minute timeout and include `stdout`/`stderr` sections in blocked failure details; cleared stale `last_failure_kind` when the draft-to-ready local-CI gate blocks in `src/post-turn-pull-request.ts`; added focused regressions in `src/core/command.test.ts`, `src/local-ci.test.ts`, and `src/post-turn-pull-request.test.ts`; redacted machine-specific paths in this journal entry; committed the review fixes as `a5aa5f1`; pushed `codex/issue-884`; and resolved the three addressed CodeRabbit threads on PR `#901`.
+- Hypothesis: issue `#885` was missing a durable, operator-visible latest local-CI result because the supervisor only persisted the configured contract and transient failure context, not the latest pass/fail summary tied to the issue record.
+- What changed: added optional `latest_local_ci_result` metadata to `IssueRunRecord`; updated `runLocalCiGate` to return concise pass/fail result summaries; persisted the latest result on all three local-CI gate paths in `src/run-once-issue-preparation.ts`, `src/run-once-turn-execution.ts`, and `src/post-turn-pull-request.ts`; projected that state into typed `localCiStatus` activity context in `src/supervisor/supervisor-operator-activity-context.ts`; surfaced it through status/explain text rendering and replay snapshots in `src/supervisor/supervisor-detailed-status-assembly.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, and `src/supervisor/supervisor-cycle-snapshot.ts`; and added focused regressions plus fixture updates in the supervisor status/explain/replay tests and supporting service/http tests.
 - Current blocker: none
-- Next exact step: monitor PR `#901` for refreshed checks or any new review feedback on head `a5aa5f1`.
+- Next exact step: review the diff, then commit the local-CI visibility change on `codex/issue-885` and open or update the draft PR if needed.
 - Verification gap: none on the requested issue verification surface.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/core/command.test.ts`, `src/core/command.ts`, `src/local-ci.test.ts`, `src/local-ci.ts`, `src/post-turn-pull-request.test.ts`, `src/post-turn-pull-request.ts`
-- Rollback concern: low; the production behavior change is limited to bounding local-CI runtime and improving blocked diagnostics, but reverting only one half of the `command`/`local-ci` pair would reintroduce missing stdout diagnostics.
-- Last focused command: `gh api graphql -f query='mutation($id1:ID!,$id2:ID!,$id3:ID!){ r1: resolveReviewThread(input:{threadId:$id1}) { thread { isResolved } } r2: resolveReviewThread(input:{threadId:$id2}) { thread { isResolved } } r3: resolveReviewThread(input:{threadId:$id3}) { thread { isResolved } } }' -F id1=PRRT_kwDORgvdZ852JnTS -F id2=PRRT_kwDORgvdZ852JnTY -F id3=PRRT_kwDORgvdZ852JnTZ`
-- Last focused failure: none current; the first GraphQL attempt using an array variable failed with `Expected NAME, actual: LBRACKET ("[")`, then the explicit `id1`/`id2`/`id3` retry resolved all three threads.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/backend/supervisor-http-server.test.ts`, `src/core/types.ts`, `src/local-ci.ts`, `src/post-turn-pull-request.test.ts`, `src/post-turn-pull-request.ts`, `src/run-once-issue-preparation.ts`, `src/run-once-turn-execution.ts`, `src/supervisor/supervisor-cycle-snapshot.test.ts`, `src/supervisor/supervisor-cycle-snapshot.ts`, `src/supervisor/supervisor-detailed-status-assembly.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-operator-activity-context.ts`, `src/supervisor/supervisor-selection-issue-explain.test.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, `src/supervisor/supervisor-service.test.ts`
+- Rollback concern: low; the behavior change is additive and concise, but partially reverting the persistence without the typed status projection would leave stale or missing operator visibility.
+- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-cycle-snapshot.test.ts`
+- Last focused failure: `npm run build` initially failed with `sh: 1: tsc: not found` because this worktree had no installed `node_modules`; running `npm install` restored the declared dev dependency and the build then passed.
 - Last focused commands:
 ```bash
-sed -n '1,220p' <LOCAL_MEMORY_ROOT>/TommyKammy-codex-supervisor/issue-884/AGENTS.generated.md
-sed -n '1,240p' <LOCAL_MEMORY_ROOT>/TommyKammy-codex-supervisor/issue-884/context-index.md
+sed -n '1,220p' <LOCAL_MEMORY_ROOT>/TommyKammy-codex-supervisor/issue-885/AGENTS.generated.md
+sed -n '1,260p' <LOCAL_MEMORY_ROOT>/TommyKammy-codex-supervisor/issue-885/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
 git status --short --branch
+rg -n "local-ci|localCi|verification" src .codex-supervisor -g '*.ts' -g '*.md'
 sed -n '1,220p' src/local-ci.ts
-sed -n '220,320p' src/post-turn-pull-request.ts
-rg -n "<LOCAL_HOME>|localCiGate\.ok|last_failure_kind|executeLocalCiCommand|runCommand\(" .codex-supervisor/issue-journal.md src -g '*.ts'
-sed -n '1,260p' src/core/command.ts
-sed -n '1,260p' src/post-turn-pull-request.test.ts
-sed -n '1,260p' src/run-once-turn-execution.test.ts
-rg -n "runLocalCiGate|local-ci|runLocalCiCommand|last_failure_context|last_failure_kind" src/post-turn-pull-request.test.ts src/run-once-turn-execution.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/local-ci.ts
-sed -n '412,450p' src/run-once-turn-execution.ts
-sed -n '1,140p' src/supervisor/supervisor-failure-helpers.ts
-nl -ba .codex-supervisor/issue-journal.md | sed -n '28,90p'
-rg --files src | rg 'command.*test\.ts$|core/command'
-sed -n '1,260p' src/core/command.test.ts
+sed -n '330,390p' src/run-once-issue-preparation.ts
+sed -n '418,455p' src/run-once-turn-execution.ts
+sed -n '245,285p' src/post-turn-pull-request.ts
+sed -n '1,320p' src/supervisor/supervisor-operator-activity-context.ts
+sed -n '1,320p' src/supervisor/supervisor-selection-issue-explain.ts
+sed -n '1,320p' src/supervisor/supervisor-cycle-snapshot.ts
 apply_patch
-npx tsx --test src/core/command.test.ts src/local-ci.test.ts src/post-turn-pull-request.test.ts src/run-once-turn-execution.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
+npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-cycle-snapshot.test.ts
+npx tsx --test src/local-ci.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts
+cat package.json
+npm ls typescript --depth=0
+npm install
 npm run build
-date -u +%Y-%m-%dT%H:%M:%SZ
-git status --short
-git diff --stat
-git add .codex-supervisor/issue-journal.md src/core/command.ts src/core/command.test.ts src/local-ci.ts src/local-ci.test.ts src/post-turn-pull-request.ts src/post-turn-pull-request.test.ts
-git commit -m "Fix local CI review follow-ups"
-git push origin codex/issue-884
-git rev-parse HEAD
-gh api graphql -f query='mutation($ids:[ID!]!){ r1: resolveReviewThread(input:{threadId:$ids[0]}) { thread { isResolved } } r2: resolveReviewThread(input:{threadId:$ids[1]}) { thread { isResolved } } r3: resolveReviewThread(input:{threadId:$ids[2]}) { thread { isResolved } } }' -F ids[]=PRRT_kwDORgvdZ852JnTS -F ids[]=PRRT_kwDORgvdZ852JnTY -F ids[]=PRRT_kwDORgvdZ852JnTZ
-gh api graphql -f query='mutation($id1:ID!,$id2:ID!,$id3:ID!){ r1: resolveReviewThread(input:{threadId:$id1}) { thread { isResolved } } r2: resolveReviewThread(input:{threadId:$id2}) { thread { isResolved } } r3: resolveReviewThread(input:{threadId:$id3}) { thread { isResolved } } }' -F id1=PRRT_kwDORgvdZ852JnTS -F id2=PRRT_kwDORgvdZ852JnTY -F id3=PRRT_kwDORgvdZ852JnTZ
 date -u +%Y-%m-%dT%H:%M:%SZ
 ```
 ### Scratchpad

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -478,6 +478,7 @@ function createStubService(args?: {
           verificationPolicySummary: null,
           durableGuardrailSummary: null,
           externalReviewFollowUpSummary: null,
+          localCiStatus: null,
           latestRecovery: {
             issueNumber,
             at: "2026-03-22T00:00:00Z",
@@ -784,6 +785,7 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
       verificationPolicySummary: null,
       durableGuardrailSummary: null,
       externalReviewFollowUpSummary: null,
+      localCiStatus: null,
       latestRecovery: {
         issueNumber: 42,
         at: "2026-03-22T00:00:00Z",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -68,6 +68,13 @@ export interface LocalCiContractSummary {
   summary: string;
 }
 
+export interface LatestLocalCiResult {
+  outcome: "passed" | "failed";
+  summary: string;
+  ran_at: string;
+  head_sha: string | null;
+}
+
 export interface SupervisorConfig {
   repoPath: string;
   repoSlug: string;
@@ -225,6 +232,7 @@ export interface IssueRunRecord {
   local_review_degraded: boolean;
   last_local_review_signature: string | null;
   repeated_local_review_signature_count: number;
+  latest_local_ci_result?: LatestLocalCiResult | null;
   external_review_head_sha: string | null;
   external_review_misses_path: string | null;
   external_review_matched_findings_count: number;

--- a/src/local-ci.ts
+++ b/src/local-ci.ts
@@ -1,5 +1,5 @@
 import { runCommand } from "./core/command";
-import { FailureContext, SupervisorConfig } from "./core/types";
+import { FailureContext, LatestLocalCiResult, SupervisorConfig } from "./core/types";
 import { nowIso, truncate } from "./core/utils";
 
 const LOCAL_CI_COMMAND_TIMEOUT_MS = 5 * 60_000;
@@ -7,6 +7,7 @@ const LOCAL_CI_COMMAND_TIMEOUT_MS = 5 * 60_000;
 export interface LocalCiGateResult {
   ok: boolean;
   failureContext: FailureContext | null;
+  latestResult: LatestLocalCiResult | null;
 }
 
 export type LocalCiCommandRunner = (command: string, workspacePath: string) => Promise<void>;
@@ -62,12 +63,22 @@ export async function runLocalCiGate(args: {
       ? args.config.localCiCommand.trim()
       : null;
   if (!command) {
-    return { ok: true, failureContext: null };
+    return { ok: true, failureContext: null, latestResult: null };
   }
 
+  const ranAt = nowIso();
   try {
     await (args.runLocalCiCommand ?? executeLocalCiCommand)(command, args.workspacePath);
-    return { ok: true, failureContext: null };
+    return {
+      ok: true,
+      failureContext: null,
+      latestResult: {
+        outcome: "passed",
+        summary: truncate(`Configured local CI command passed ${args.gateLabel}.`, 1000) ?? "Configured local CI command passed.",
+        ran_at: ranAt,
+        head_sha: null,
+      },
+    };
   } catch (error) {
     const summary = truncate(`Configured local CI command failed ${args.gateLabel}.`, 1000) ?? "Configured local CI command failed.";
     return {
@@ -79,7 +90,13 @@ export async function runLocalCiGate(args: {
         command,
         details: buildFailureDetails(error),
         url: null,
-        updated_at: nowIso(),
+        updated_at: ranAt,
+      },
+      latestResult: {
+        outcome: "failed",
+        summary,
+        ran_at: ranAt,
+        head_sha: null,
       },
     };
   }

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -107,10 +107,16 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
   assert.equal(result.record.state, "waiting_ci");
   assert.equal(result.record.review_wait_head_sha, "head-116");
   assert.equal(result.record.last_head_sha, "head-116");
+  assert.deepEqual(result.record.latest_local_ci_result, {
+    outcome: "passed",
+    summary: "Configured local CI command passed before marking PR #116 ready.",
+    ran_at: result.record.latest_local_ci_result?.ran_at ?? "",
+    head_sha: "head-116",
+  });
   assert.equal(readyCalls, 1);
   assert.equal(localCiCalls, 1);
   assert.equal(snapshotLoads, 2);
-  assert.equal(syncJournalCalls, 0);
+  assert.equal(syncJournalCalls, 1);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when configured local CI fails", async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -256,6 +256,12 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       const failureContext = localCiGate.failureContext;
       record = stateStore.touch(record, {
         state: "blocked",
+        latest_local_ci_result: localCiGate.latestResult
+          ? {
+              ...localCiGate.latestResult,
+              head_sha: refreshed.pr.headRefOid,
+            }
+          : null,
         last_error: truncate(failureContext?.summary, 1000),
         last_failure_kind: null,
         last_failure_context: failureContext,
@@ -272,6 +278,17 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         reviewThreads: refreshed.reviewThreads,
       };
     }
+    record = stateStore.touch(record, {
+      latest_local_ci_result: localCiGate.latestResult
+        ? {
+            ...localCiGate.latestResult,
+            head_sha: refreshed.pr.headRefOid,
+          }
+        : null,
+    });
+    state.issues[String(record.issue_number)] = record;
+    await stateStore.save(state);
+    await syncJournal(record);
     await github.markPullRequestReady(refreshed.pr.number);
   }
 

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -366,6 +366,12 @@ async function hydratePullRequestContext(
       const failureContext = localCiGate.failureContext;
       const blockedRecord = args.stateStore.touch(record, {
         state: "blocked",
+        latest_local_ci_result: localCiGate.latestResult
+          ? {
+              ...localCiGate.latestResult,
+              head_sha: nextWorkspaceStatus.headSha,
+            }
+          : null,
         last_error: failureContext?.summary ?? "Configured local CI command failed before opening a pull request.",
         last_failure_kind: null,
         last_failure_context: failureContext,
@@ -377,6 +383,17 @@ async function hydratePullRequestContext(
       await args.syncJournal(blockedRecord);
       return `Issue #${blockedRecord.issue_number} blocked: ${blockedRecord.last_error}`;
     }
+    record = args.stateStore.touch(record, {
+      latest_local_ci_result: localCiGate.latestResult
+        ? {
+            ...localCiGate.latestResult,
+            head_sha: nextWorkspaceStatus.headSha,
+          }
+        : null,
+    });
+    args.state.issues[String(record.issue_number)] = record;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(record);
     await pushBranch(args.workspacePath, args.record.branch, nextWorkspaceStatus.remoteBranchExists);
     pr = await args.github.createPullRequest(args.issue, record, { draft: true });
     checks = await args.github.getChecks(pr.number);

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -428,6 +428,12 @@ export async function executeCodexTurnPhase(
           const failureContext = localCiGate.failureContext;
           record = stateStore.touch(record, {
             state: "blocked",
+            latest_local_ci_result: localCiGate.latestResult
+              ? {
+                  ...localCiGate.latestResult,
+                  head_sha: workspaceStatus.headSha,
+                }
+              : null,
             last_error: truncate(failureContext?.summary, 1000),
             last_failure_kind: null,
             last_failure_context: failureContext,
@@ -442,6 +448,17 @@ export async function executeCodexTurnPhase(
             message: `Local CI gate blocked pull request creation for issue #${record.issue_number}.`,
           };
         }
+        record = stateStore.touch(record, {
+          latest_local_ci_result: localCiGate.latestResult
+            ? {
+                ...localCiGate.latestResult,
+                head_sha: workspaceStatus.headSha,
+              }
+            : null,
+        });
+        state.issues[String(record.issue_number)] = record;
+        await stateStore.save(state);
+        await syncJournal(record);
         pr = await github.createPullRequest(issue, record, { draft: true });
       }
 

--- a/src/supervisor/supervisor-cycle-snapshot.test.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.test.ts
@@ -95,6 +95,12 @@ function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
     local_review_degraded: false,
     last_local_review_signature: "local-review:high",
     repeated_local_review_signature_count: 1,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before opening a pull request.",
+      ran_at: "2026-03-16T10:02:30Z",
+      head_sha: "head-407",
+    },
     external_review_head_sha: null,
     external_review_misses_path: null,
     external_review_matched_findings_count: 0,
@@ -224,10 +230,24 @@ test("buildSupervisorCycleDecisionSnapshot keeps the decision inputs narrow and 
   assert.equal(snapshot.local.record.merge_readiness_last_evaluated_at, "2026-03-16T10:05:00Z");
   assert.equal(snapshot.local.record.last_failure_kind, null);
   assert.equal(snapshot.local.record.last_failure_context, null);
+  assert.deepEqual(snapshot.local.record.latest_local_ci_result, {
+    outcome: "passed",
+    summary: "Configured local CI command passed before opening a pull request.",
+    ran_at: "2026-03-16T10:02:30Z",
+    head_sha: "head-407",
+  });
   assert.equal(snapshot.decision.nextState, "addressing_review");
   assert.equal(snapshot.decision.shouldRunCodex, true);
   assert.equal(snapshot.decision.blockedReason, "manual_review");
   assert.match(snapshot.decision.failureContext?.summary ?? "", /review/i);
+  assert.deepEqual(snapshot.operatorSummary?.activityContext?.localCiStatus, {
+    outcome: "passed",
+    summary: "Configured local CI command passed before opening a pull request.",
+    ranAt: "2026-03-16T10:02:30Z",
+    headSha: "head-407",
+    headStatus: "current",
+    context: "notice",
+  });
 });
 
 test("writeSupervisorCycleDecisionSnapshot serializes one cycle into the workspace replay artifact", async () => {
@@ -252,6 +272,12 @@ test("writeSupervisorCycleDecisionSnapshot serializes one cycle into the workspa
   assert.equal(persisted.local.record.timeout_retry_count, 0);
   assert.equal(persisted.local.record.provider_success_head_sha, "head-407");
   assert.equal(persisted.local.record.last_failure_context, null);
+  assert.deepEqual(persisted.local.record.latest_local_ci_result, {
+    outcome: "passed",
+    summary: "Configured local CI command passed before opening a pull request.",
+    ran_at: "2026-03-16T10:02:30Z",
+    head_sha: "head-407",
+  });
   assert.equal(persisted.github.pullRequest?.number, 88);
   assert.equal(persisted.decision.nextState, "addressing_review");
 });

--- a/src/supervisor/supervisor-cycle-snapshot.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.ts
@@ -77,6 +77,7 @@ export interface SupervisorCycleDecisionSnapshot {
       | "local_review_degraded"
       | "last_local_review_signature"
       | "repeated_local_review_signature_count"
+      | "latest_local_ci_result"
       | "processed_review_thread_ids"
       | "processed_review_thread_fingerprints"
       | "updated_at"
@@ -172,6 +173,7 @@ export function buildSupervisorCycleDecisionSnapshot(args: {
         local_review_degraded: record.local_review_degraded,
         last_local_review_signature: record.last_local_review_signature,
         repeated_local_review_signature_count: record.repeated_local_review_signature_count,
+        latest_local_ci_result: record.latest_local_ci_result ?? null,
         processed_review_thread_ids: [...record.processed_review_thread_ids],
         processed_review_thread_fingerprints: [...record.processed_review_thread_fingerprints],
         updated_at: record.updated_at,
@@ -247,6 +249,7 @@ export function buildSupervisorCycleDecisionSnapshot(args: {
         local_review_degraded: record.local_review_degraded,
         last_local_review_signature: record.last_local_review_signature,
         repeated_local_review_signature_count: record.repeated_local_review_signature_count,
+        latest_local_ci_result: record.latest_local_ci_result ?? null,
         processed_review_thread_ids: [...record.processed_review_thread_ids],
         processed_review_thread_fingerprints: [...record.processed_review_thread_fingerprints],
         updated_at: record.updated_at,

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -19,6 +19,7 @@ import {
   inferReviewBotProfile,
   reviewBotDiagnostics,
 } from "./supervisor-status-review-bot";
+import { buildIssueActivityContext, formatLocalCiStatusLine } from "./supervisor-operator-activity-context";
 import type { IssueRunRecord } from "../core/types";
 import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
 import { truncate } from "../core/utils";
@@ -142,6 +143,10 @@ export function buildActiveDetailedStatusLines(
     `local_review gating=${localReviewGating} policy=${config.localReviewPolicy} findings=${activeRecord.local_review_findings_count} root_causes=${activeRecord.local_review_root_cause_count} max_severity=${activeRecord.local_review_max_severity ?? "none"} verified_findings=${activeRecord.local_review_verified_findings_count} verified_max_severity=${activeRecord.local_review_verified_max_severity ?? "none"} head=${localReviewHead.status} reviewed_head_sha=${localReviewHead.reviewedHeadSha} pr_head_sha=${localReviewHead.prHeadSha} ran_at=${activeRecord.local_review_run_at ?? "none"}${localReviewGating === "yes" && activeRecord.local_review_blocker_summary ? ` blocker_summary=${truncate(sanitizeStatusValue(activeRecord.local_review_blocker_summary), 160)}` : ""}${localReviewHead.driftSuffix} signature=${activeRecord.last_local_review_signature ?? "none"} repeated=${activeRecord.repeated_local_review_signature_count} stalled=${localReviewStalled}`,
     `external_review head=${externalReviewHeadStatus} reviewed_head_sha=${activeRecord.external_review_head_sha ?? "none"} matched=${activeRecord.external_review_matched_findings_count} near_match=${activeRecord.external_review_near_match_findings_count} missed=${activeRecord.external_review_missed_findings_count}`,
   ];
+  const localCiStatusLine = formatLocalCiStatusLine(buildIssueActivityContext({ config, record: activeRecord, pr }));
+  if (localCiStatusLine) {
+    lines.push(localCiStatusLine);
+  }
 
   if (activeRecord.last_error) {
     lines.push(`last_error=${truncate(sanitizeStatusValue(activeRecord.last_error), 300)}`);

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -183,6 +183,7 @@ test("statusReport exposes typed active-issue and selection summary fields along
       verificationPolicySummary: null,
       durableGuardrailSummary: null,
       externalReviewFollowUpSummary: null,
+      localCiStatus: null,
       latestRecovery: null,
       retryContext: {
         timeoutRetryCount: 0,
@@ -260,6 +261,12 @@ test("statusReport exposes typed operator activity context for the active issue"
         blocked_verification_retry_count: 1,
         repeated_failure_signature_count: 4,
         last_failure_signature: "tracked-pr-refresh-loop",
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed before marking PR #58 ready.",
+          ran_at: "2026-03-22T00:10:00Z",
+          head_sha: "head-new-58",
+        },
         review_wait_started_at: "2099-01-01T00:00:30.000Z",
         review_wait_head_sha: "head-new-58",
       }),
@@ -323,6 +330,14 @@ Expose typed operator-facing issue detail fields.
     verificationPolicySummary: null,
     durableGuardrailSummary: null,
     externalReviewFollowUpSummary: null,
+    localCiStatus: {
+      outcome: "failed",
+      summary: "Configured local CI command failed before marking PR #58 ready.",
+      ranAt: "2026-03-22T00:10:00Z",
+      headSha: "head-new-58",
+      headStatus: "current",
+      context: "warning",
+    },
     latestRecovery: {
       issueNumber,
       at: "2026-03-22T00:15:00Z",
@@ -431,6 +446,7 @@ test("status surfaces repeated stale cleanup risk before the stale recovery loop
     verificationPolicySummary: null,
     durableGuardrailSummary: null,
     externalReviewFollowUpSummary: null,
+    localCiStatus: null,
     latestRecovery: null,
     retryContext: {
       timeoutRetryCount: 0,

--- a/src/supervisor/supervisor-operator-activity-context.ts
+++ b/src/supervisor/supervisor-operator-activity-context.ts
@@ -7,7 +7,7 @@ import {
   getStaleStabilizingNoPrRecoveryCount,
   STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
 } from "../no-pull-request-state";
-import type { GitHubPullRequest, IssueRunRecord, RunState, SupervisorConfig } from "../core/types";
+import type { GitHubPullRequest, IssueRunRecord, LatestLocalCiResult, RunState, SupervisorConfig } from "../core/types";
 
 export interface SupervisorLatestRecoveryDto {
   issueNumber: number;
@@ -59,6 +59,7 @@ export interface SupervisorIssueActivityContextDto {
   verificationPolicySummary: string | null;
   durableGuardrailSummary: string | null;
   externalReviewFollowUpSummary: string | null;
+  localCiStatus: SupervisorLocalCiStatusDto | null;
   latestRecovery: SupervisorLatestRecoveryDto | null;
   retryContext: SupervisorRetryContextDto;
   repeatedRecovery: SupervisorRepeatedRecoveryDto | null;
@@ -66,6 +67,15 @@ export interface SupervisorIssueActivityContextDto {
   localReviewSummaryPath: string | null;
   externalReviewMissesPath: string | null;
   reviewWaits: SupervisorReviewWaitDto[];
+}
+
+export interface SupervisorLocalCiStatusDto {
+  outcome: LatestLocalCiResult["outcome"];
+  summary: string;
+  ranAt: string;
+  headSha: string | null;
+  headStatus: "current" | "stale" | "unknown";
+  context: "blocking" | "warning" | "notice";
 }
 
 function retrySummaryHasLoopRisk(context: Pick<SupervisorIssueActivityContextDto, "retryContext" | "repeatedRecovery">): boolean {
@@ -140,6 +150,25 @@ export function formatRecoveryLoopSummaryLine(
   ].join(" ");
 }
 
+export function formatLocalCiStatusLine(
+  context: SupervisorIssueActivityContextDto | null,
+): string | null {
+  const localCiStatus = context?.localCiStatus ?? null;
+  if (!localCiStatus) {
+    return null;
+  }
+
+  return [
+    "local_ci_result",
+    `outcome=${localCiStatus.outcome}`,
+    `context=${localCiStatus.context}`,
+    `head=${localCiStatus.headStatus}`,
+    `head_sha=${localCiStatus.headSha ?? "none"}`,
+    `ran_at=${localCiStatus.ranAt}`,
+    `summary=${localCiStatus.summary.replace(/\r?\n/g, "\\n")}`,
+  ].join(" ");
+}
+
 type ActivityRecord = Pick<
   IssueRunRecord,
   | "issue_number"
@@ -149,6 +178,8 @@ type ActivityRecord = Pick<
   | "external_review_misses_path"
   | "review_wait_started_at"
   | "review_wait_head_sha"
+  | "latest_local_ci_result"
+  | "last_head_sha"
   | "timeout_retry_count"
   | "blocked_verification_retry_count"
   | "repeated_blocker_count"
@@ -157,6 +188,39 @@ type ActivityRecord = Pick<
   | "state"
   | "blocked_reason"
 >;
+
+function buildLocalCiStatusDto(
+  record: Pick<IssueRunRecord, "latest_local_ci_result" | "last_head_sha" | "blocked_reason" | "last_failure_signature">,
+  pr: GitHubPullRequest | null,
+): SupervisorLocalCiStatusDto | null {
+  const result = record.latest_local_ci_result ?? null;
+  if (!result) {
+    return null;
+  }
+
+  const currentHeadSha = pr?.headRefOid ?? record.last_head_sha ?? null;
+  const headStatus =
+    result.head_sha === null || currentHeadSha === null
+      ? "unknown"
+      : result.head_sha === currentHeadSha
+        ? "current"
+        : "stale";
+  const context =
+    result.outcome === "passed"
+      ? "notice"
+      : record.blocked_reason === "verification" && record.last_failure_signature === "local-ci-gate-failed"
+        ? "blocking"
+        : "warning";
+
+  return {
+    outcome: result.outcome,
+    summary: result.summary,
+    ranAt: result.ran_at,
+    headSha: result.head_sha,
+    headStatus,
+    context,
+  };
+}
 
 const RUN_STATE_VALUES: RunState[] = [
   "queued",
@@ -351,6 +415,7 @@ export function buildIssueActivityContext(args: {
     verificationPolicySummary: args.verificationPolicySummary ?? null,
     durableGuardrailSummary: args.durableGuardrailSummary ?? null,
     externalReviewFollowUpSummary: args.externalReviewFollowUpSummary ?? null,
+    localCiStatus: buildLocalCiStatusDto(args.record, args.pr),
     latestRecovery: buildLatestRecoveryDto(args.record),
     retryContext: buildRetryContextDto(args.record),
     repeatedRecovery: buildRepeatedRecoveryDto(args.config, args.record),
@@ -384,6 +449,7 @@ export function maybeBuildIssueActivityContext(args: {
     context.verificationPolicySummary !== null ||
     context.durableGuardrailSummary !== null ||
     context.externalReviewFollowUpSummary !== null ||
+    context.localCiStatus !== null ||
     context.latestRecovery !== null ||
     context.retryContext.timeoutRetryCount > 0 ||
     context.retryContext.blockedVerificationRetryCount > 0 ||

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -180,6 +180,12 @@ test("buildIssueExplainDto exposes typed operator activity context", async () =>
         blocked_verification_retry_count: 1,
         repeated_failure_signature_count: 4,
         last_failure_signature: "tracked-pr-refresh-loop",
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed before marking PR #605 ready.",
+          ran_at: "2026-03-22T00:10:00Z",
+          head_sha: "head-new-605",
+        },
         blocked_reason: null,
         last_error: null,
       }),
@@ -226,6 +232,14 @@ test("buildIssueExplainDto exposes typed operator activity context", async () =>
     verificationPolicySummary: null,
     durableGuardrailSummary: null,
     externalReviewFollowUpSummary: null,
+    localCiStatus: {
+      outcome: "failed",
+      summary: "Configured local CI command failed before marking PR #605 ready.",
+      ranAt: "2026-03-22T00:10:00Z",
+      headSha: "head-new-605",
+      headStatus: "current",
+      context: "warning",
+    },
     latestRecovery: {
       issueNumber,
       at: "2026-03-22T00:15:00Z",
@@ -361,6 +375,7 @@ test("buildIssueExplainDto degrades when PR resolution fails", async () => {
     verificationPolicySummary: null,
     durableGuardrailSummary: null,
     externalReviewFollowUpSummary: null,
+    localCiStatus: null,
     latestRecovery: {
       issueNumber,
       at: "2026-03-22T01:40:00Z",

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -39,6 +39,7 @@ import {
 } from "../core/types";
 import type { ActiveStatusGitHub } from "./supervisor-selection-active-status";
 import {
+  formatLocalCiStatusLine,
   formatRecoveryLoopSummaryLine,
   formatRetrySummaryLine,
   maybeBuildIssueActivityContext,
@@ -289,6 +290,7 @@ export async function buildIssueExplainDto(
 }
 
 export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
+  const localCiStatusLine = formatLocalCiStatusLine(dto.activityContext);
   const retrySummaryLine = formatRetrySummaryLine(dto.activityContext);
   const recoveryLoopSummaryLine = formatRecoveryLoopSummaryLine(dto.activityContext);
   const lines = [
@@ -299,6 +301,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     `runnable=${dto.runnable ? "yes" : "no"}`,
     ...dto.changeRiskLines,
     ...(dto.externalReviewFollowUpSummary ? [dto.externalReviewFollowUpSummary] : []),
+    ...(localCiStatusLine ? [localCiStatusLine] : []),
     ...(retrySummaryLine ? [retrySummaryLine] : []),
     ...(recoveryLoopSummaryLine ? [recoveryLoopSummaryLine] : []),
     ...(dto.latestRecoverySummary ? [dto.latestRecoverySummary] : []),

--- a/src/supervisor/supervisor-service.test.ts
+++ b/src/supervisor/supervisor-service.test.ts
@@ -220,6 +220,7 @@ test("createSupervisorService preserves typed operator observability fields on s
         verificationPolicySummary: null,
         durableGuardrailSummary: null,
         externalReviewFollowUpSummary: null,
+        localCiStatus: null,
         latestRecovery: null,
         retryContext: {
           timeoutRetryCount: 1,


### PR DESCRIPTION
## Summary
- persist the latest local CI pass/fail result on the issue run record
- surface typed local CI status in status/explain activity context and replay snapshots
- add focused regressions for local CI visibility and supporting service fixtures

## Verification
- npm run build
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-cycle-snapshot.test.ts
- npx tsx --test src/local-ci.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking and display of the latest local CI test results, including pass/fail status, summary, and execution timestamp.
  * Local CI results now appear in issue status reports and explanations for improved visibility into test execution history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->