### PR TITLE
Local CI setup guidance: show how repos adopt the pre-PR verification contract

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,56 +1,63 @@
-# Issue #885: Local CI visibility: persist and surface the latest pre-PR verification result
+# Issue #886: Local CI setup guidance: show how repos adopt the pre-PR verification contract
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/885
-- Branch: codex/issue-885
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/886
+- Branch: codex/issue-886
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 0028afa11b61b958d6167df67d63e68f4e3f8685
+- Last head SHA: 34806d2dfbd15b8b8006b28715333ab788c5d74d
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-23T15:23:48Z
+- Updated at: 2026-03-23T15:54:52Z
 
 ## Latest Codex Summary
-- Persisted concise latest local-CI results on issue records, surfaced typed `localCiStatus` in status/explain activity context and replay snapshots, and added readable `local_ci_result` lines to status/explain output.
+- Added local-CI adoption guidance to setup/docs surfaces so operators can see whether the repo-owned pre-PR verification contract is configured and why that affects PR publication behavior.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: issue `#885` was missing a durable, operator-visible latest local-CI result because the supervisor only persisted the configured contract and transient failure context, not the latest pass/fail summary tied to the issue record.
-- What changed: added optional `latest_local_ci_result` metadata to `IssueRunRecord`; updated `runLocalCiGate` to return concise pass/fail result summaries; persisted the latest result on all three local-CI gate paths in `src/run-once-issue-preparation.ts`, `src/run-once-turn-execution.ts`, and `src/post-turn-pull-request.ts`; projected that state into typed `localCiStatus` activity context in `src/supervisor/supervisor-operator-activity-context.ts`; surfaced it through status/explain text rendering and replay snapshots in `src/supervisor/supervisor-detailed-status-assembly.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, and `src/supervisor/supervisor-cycle-snapshot.ts`; and added focused regressions plus fixture updates in the supervisor status/explain/replay tests and supporting service/http tests.
+- Hypothesis: the missing acceptance surface for `#886` was not backend data but operator guidance. `SetupReadinessReport` already carried `localCiContract`, yet the setup shell did not render it and `docs/getting-started.md` did not connect setup/readiness guidance to the local-CI contract's PR-blocking behavior.
+- What changed: added focused setup-shell regressions in `src/backend/webui-dashboard.test.ts` to prove the missing local-CI guidance; rendered a dedicated "Local CI contract" panel in `src/backend/webui-setup-page.ts` and `src/backend/webui-setup-browser-script.ts`; and tightened `docs/getting-started.md` plus `src/getting-started-docs.test.ts` so the typed setup/readiness contract includes `localCiContract`, explains that setup/WebUI should surface configured-vs-missing status, and states that failing configured local CI blocks PR publication and ready-for-review promotion.
 - Current blocker: none
-- Next exact step: review the diff, then commit the local-CI visibility change on `codex/issue-885` and open or update the draft PR if needed.
-- Verification gap: none on the requested issue verification surface.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/backend/supervisor-http-server.test.ts`, `src/core/types.ts`, `src/local-ci.ts`, `src/post-turn-pull-request.test.ts`, `src/post-turn-pull-request.ts`, `src/run-once-issue-preparation.ts`, `src/run-once-turn-execution.ts`, `src/supervisor/supervisor-cycle-snapshot.test.ts`, `src/supervisor/supervisor-cycle-snapshot.ts`, `src/supervisor/supervisor-detailed-status-assembly.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-operator-activity-context.ts`, `src/supervisor/supervisor-selection-issue-explain.test.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, `src/supervisor/supervisor-service.test.ts`
-- Rollback concern: low; the behavior change is additive and concise, but partially reverting the persistence without the typed status projection would leave stale or missing operator visibility.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-cycle-snapshot.test.ts`
-- Last focused failure: `npm run build` initially failed with `sh: 1: tsc: not found` because this worktree had no installed `node_modules`; running `npm install` restored the declared dev dependency and the build then passed.
+- Next exact step: review the diff, commit the setup/docs local-CI guidance update on `codex/issue-886`, and open or update the draft PR if needed.
+- Verification gap: none on the requested issue verification surface after restoring `node_modules` in this worktree.
+- Files touched: `.codex-supervisor/issue-journal.md`, `docs/getting-started.md`, `src/backend/webui-dashboard.test.ts`, `src/backend/webui-setup-browser-script.ts`, `src/backend/webui-setup-page.ts`, `src/getting-started-docs.test.ts`
+- Rollback concern: low; the behavior is additive doc/UI guidance, and reverting it would mainly remove operator visibility into when repo-owned local CI affects PR publication.
+- Last focused command: `npx tsx --test src/getting-started-docs.test.ts src/readme-docs.test.ts src/backend/supervisor-http-server.test.ts`
+- Last focused failure: `npm run build` failed with `sh: 1: tsc: not found` before verification because this worktree had no installed `node_modules`; `npm install` restored the declared dev dependencies and the build then passed.
 - Last focused commands:
 ```bash
-sed -n '1,220p' <LOCAL_MEMORY_ROOT>/TommyKammy-codex-supervisor/issue-885/AGENTS.generated.md
-sed -n '1,260p' <LOCAL_MEMORY_ROOT>/TommyKammy-codex-supervisor/issue-885/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-886/AGENTS.generated.md
+sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-886/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
 git status --short --branch
-rg -n "local-ci|localCi|verification" src .codex-supervisor -g '*.ts' -g '*.md'
-sed -n '1,220p' src/local-ci.ts
-sed -n '330,390p' src/run-once-issue-preparation.ts
-sed -n '418,455p' src/run-once-turn-execution.ts
-sed -n '245,285p' src/post-turn-pull-request.ts
-sed -n '1,320p' src/supervisor/supervisor-operator-activity-context.ts
-sed -n '1,320p' src/supervisor/supervisor-selection-issue-explain.ts
-sed -n '1,320p' src/supervisor/supervisor-cycle-snapshot.ts
+rg -n "local CI|local-ci|local_ci|pre-PR|verification contract|GitHub Actions|workflow" README.md docs/getting-started.md src/getting-started-docs.test.ts src/readme-docs.test.ts src/backend/supervisor-http-server.test.ts src -g '*.md' -g '*.ts'
+sed -n '1,260p' README.md
+sed -n '1,320p' docs/getting-started.md
+sed -n '1,260p' src/getting-started-docs.test.ts
+sed -n '1,260p' src/readme-docs.test.ts
+sed -n '1,320p' src/backend/supervisor-http-server.test.ts
+rg -n "setup readiness|SetupReadiness|local CI contract|local_ci|localCi|reviewProvider|hostReadiness|providerPosture" src docs -g '*.ts' -g '*.md'
+sed -n '1,320p' src/setup-readiness.ts
+sed -n '1,320p' src/backend/supervisor-http-server.ts
+sed -n '1,320p' src/supervisor/supervisor-service.ts
+sed -n '240,420p' src/backend/webui-setup-browser-script.ts
+sed -n '1660,2055p' src/backend/webui-dashboard.test.ts
+sed -n '246,390p' src/doctor.test.ts
+sed -n '430,760p' src/backend/webui-dashboard-browser-smoke.test.ts
+sed -n '1,320p' src/backend/webui-setup-page.ts
 apply_patch
-npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-cycle-snapshot.test.ts
-npx tsx --test src/local-ci.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts
+npx tsx --test src/getting-started-docs.test.ts src/backend/webui-dashboard.test.ts
 cat package.json
 npm ls typescript --depth=0
 npm install
 npm run build
+npx tsx --test src/getting-started-docs.test.ts src/readme-docs.test.ts src/backend/supervisor-http-server.test.ts
 date -u +%Y-%m-%dT%H:%M:%SZ
 ```
 ### Scratchpad

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,6 +198,7 @@ interface SetupReadinessReport {
   overallStatus: "configured" | "missing" | "invalid";
   fields: SetupReadinessField[];
   blockers: SetupReadinessBlocker[];
+  localCiContract?: LocalCiContractSummary;
 }
 
 interface SetupReadinessField {
@@ -232,6 +233,7 @@ Minimum rules for that contract:
 - each field reports a typed state of `configured | missing | invalid` plus typed metadata the UI can use to render editable setup inputs without inferring from labels
 - `blockers` lists only the conditions that still prevent a safe first run
 - each blocker carries typed remediation guidance so the browser does not have to reverse-engineer next actions from free-form text
+- the setup flow and WebUI should surface whether the repo-owned local CI contract is configured so operators know whether PR publication depends on a canonical repo-owned pre-PR command or on issue-level verification guidance
 - `ready` becomes `true` only when no first-run blockers remain
 - ongoing diagnostics such as GitHub auth details, corrupted state-file findings, orphaned worktree candidates, and other repair-oriented host checks stay in `doctor`
 
@@ -250,6 +252,8 @@ Minimum expectations for that contract:
 - stdout and stderr are informative logs from the repo command, not a second machine-readable protocol the supervisor needs to interpret
 
 Backward compatibility stays simple: if no local CI contract is configured, `codex-supervisor` keeps the existing behavior. It does not invent a fallback verification command, and it continues to rely on the issue's `## Verification` guidance plus normal operator/repo workflow instead of pretending a canonical local CI entrypoint exists when the repo has not declared one.
+
+Operator impact: when configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again. Setup/readiness and WebUI guidance should make that visible so operators can tell the difference between a missing contract and a failing configured contract.
 
 Explicit non-goal: `codex-supervisor` does not infer or reconstruct workflow logic from GitHub Actions YAML, other workflow YAML, or changed-file heuristics as a substitute for this contract. If a repo wants a canonical pre-PR local verification command, the repo must expose that command directly.
 

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1778,6 +1778,12 @@ test("setup shell loads typed setup readiness without mixing in dashboard status
           warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
           summary: "Trusted inputs with unsandboxed autonomous execution.",
         },
+        localCiContract: {
+          configured: false,
+          command: null,
+          source: "config",
+          summary: "No repo-owned local CI contract is configured.",
+        },
       }),
     },
   ]);
@@ -1802,6 +1808,11 @@ test("setup shell loads typed setup readiness without mixing in dashboard status
   assert.match(harness.document.getElementById("setup-provider-posture")?.textContent ?? "", /No review provider is configured\./u);
   assert.match(harness.document.getElementById("setup-provider-details")?.textContent ?? "", /Provider profile: None.*Signal source: none.*Configured reviewers: none.*Configured: no/u);
   assert.match(harness.document.getElementById("setup-trust-details")?.textContent ?? "", /Trust mode: Trusted Repo And Authors.*Execution safety: Unsandboxed Autonomous.*Warning: Unsandboxed autonomous execution assumes trusted GitHub-authored inputs\./u);
+  assert.match(harness.document.getElementById("setup-local-ci-summary")?.textContent ?? "", /No repo-owned local CI contract is configured\./u);
+  assert.match(
+    harness.document.getElementById("setup-local-ci-details")?.textContent ?? "",
+    /Configured: no.*Command: none.*If the repo does not declare this contract, codex-supervisor falls back to the issue's ## Verification guidance and operator workflow.*When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again\./u,
+  );
   assert.equal(harness.remainingFetches.length, 0);
 });
 
@@ -1884,6 +1895,12 @@ test("setup shell saves through the narrow setup config API and revalidates read
           warning: null,
           summary: "Trusted inputs with unsandboxed autonomous execution.",
         },
+        localCiContract: {
+          configured: false,
+          command: null,
+          source: "config",
+          summary: "No repo-owned local CI contract is configured.",
+        },
       }),
     },
     {
@@ -1956,6 +1973,12 @@ test("setup shell saves through the narrow setup config API and revalidates read
         warning: null,
         summary: "Trusted inputs with unsandboxed autonomous execution.",
       },
+      localCiContract: {
+        configured: true,
+        command: "npm run ci:local",
+        source: "config",
+        summary: "Repo-owned local CI contract is configured.",
+      },
     },
   }));
   await harness.flush();
@@ -2015,6 +2038,12 @@ test("setup shell saves through the narrow setup config API and revalidates read
       warning: null,
       summary: "Trusted inputs with unsandboxed autonomous execution.",
     },
+    localCiContract: {
+      configured: true,
+      command: "npm run ci:local",
+      source: "config",
+      summary: "Repo-owned local CI contract is configured.",
+    },
   }));
 
   await submitPromise;
@@ -2041,6 +2070,11 @@ test("setup shell saves through the narrow setup config API and revalidates read
   assert.match(saveStatus.textContent, /Saved 2 setup fields\./u);
   assert.match(harness.document.getElementById("setup-overall-status")?.textContent ?? "", /configured/u);
   assert.match(harness.document.getElementById("setup-blocker-summary")?.textContent ?? "", /No blocking setup conditions remain\./u);
+  assert.match(harness.document.getElementById("setup-local-ci-summary")?.textContent ?? "", /Repo-owned local CI contract is configured\./u);
+  assert.match(
+    harness.document.getElementById("setup-local-ci-details")?.textContent ?? "",
+    /Configured: yes.*Command: npm run ci:local.*Source: config.*This repo-owned command is the canonical local verification step before PR publication or update.*When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again\./u,
+  );
   assert.equal(harness.remainingFetches.length, 0);
 });
 

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -19,6 +19,8 @@ export function renderSetupBrowserScript(): string {
         providerDetails: document.getElementById("setup-provider-details"),
         trustPosture: document.getElementById("setup-trust-posture"),
         trustDetails: document.getElementById("setup-trust-details"),
+        localCiSummary: document.getElementById("setup-local-ci-summary"),
+        localCiDetails: document.getElementById("setup-local-ci-details"),
       };
       const editableFieldOrder = [
         "repoPath",
@@ -342,6 +344,34 @@ export function renderSetupBrowserScript(): string {
             }]
             : [],
           "No trust posture details reported.",
+        );
+        const localCiContract = report.localCiContract || {
+          configured: false,
+          command: null,
+          source: "config",
+          summary: "No repo-owned local CI contract is configured.",
+        };
+        setText(elements.localCiSummary, localCiContract.summary);
+        renderChecklist(
+          elements.localCiDetails,
+          [{
+            title: "Configured: " + (localCiContract.configured ? "yes" : "no"),
+            tone: "",
+            meta: [
+              "Command: " + (localCiContract.command || "none"),
+              "Source: " + formatToken(localCiContract.source || "unknown"),
+            ],
+            notes: localCiContract.configured
+              ? [
+                "This repo-owned command is the canonical local verification step before PR publication or update.",
+                "When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again.",
+              ]
+              : [
+                "If the repo does not declare this contract, codex-supervisor falls back to the issue's ## Verification guidance and operator workflow.",
+                "When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again.",
+              ],
+          }],
+          "No local CI contract details reported.",
         );
       }
 

--- a/src/backend/webui-setup-page.ts
+++ b/src/backend/webui-setup-page.ts
@@ -343,6 +343,18 @@ export function renderSupervisorSetupPage(): string {
               </ul>
             </div>
           </article>
+
+          <article class="panel">
+            <div class="panel-header">
+              <h2>Local CI contract</h2>
+            </div>
+            <div class="panel-body">
+              <p id="setup-local-ci-summary" class="hint">Loading typed local CI contract…</p>
+              <ul id="setup-local-ci-details" class="list list--plain">
+                <li>Loading local CI contract details…</li>
+              </ul>
+            </div>
+          </article>
         </section>
 
         <section class="grid grid--details" aria-label="setup-details">

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -90,6 +90,8 @@ test("getting-started defines setup readiness as a typed first-run contract dist
     content,
     /type SetupReadinessFieldKey =[\s\S]*"repoPath"[\s\S]*"repoSlug"[\s\S]*"defaultBranch"[\s\S]*"workspaceRoot"[\s\S]*"stateFile"[\s\S]*"codexBinary"[\s\S]*"branchPrefix"[\s\S]*"reviewProvider"/,
   );
+  assert.match(content, /localCiContract\?: LocalCiContractSummary/);
+  assert.match(content, /setup flow and WebUI should surface whether the repo-owned local CI contract is configured/i);
 });
 
 test("getting-started defines the repo-owned local CI contract for pre-PR verification", async () => {
@@ -104,6 +106,8 @@ test("getting-started defines the repo-owned local CI contract for pre-PR verifi
   assert.match(content, /any non-zero exit code/i);
   assert.match(content, /if no local CI contract is configured/i);
   assert.match(content, /does not infer or reconstruct workflow logic from GitHub Actions YAML/i);
+  assert.match(content, /when configured local CI fails, PR publication stays blocked/i);
+  assert.match(content, /ready-for-review promotion stays blocked/i);
 });
 
 test("japanese docs keep overview and getting-started responsibilities separate", async () => {


### PR DESCRIPTION
## Summary
- surface the repo-owned local CI contract in the first-run setup shell
- explain in getting-started how repos adopt the pre-PR local CI contract and how it differs from GitHub Actions workflows
- make the PR-publication impact explicit when configured local CI fails

## Testing
- npm run build
- npx tsx --test src/getting-started-docs.test.ts src/readme-docs.test.ts src/backend/supervisor-http-server.test.ts

Closes #886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Local CI contract" panel to the setup page, displaying whether a repo-owned local CI contract is configured and its associated command.

* **Documentation**
  * Updated setup documentation to clarify that when a local CI contract is configured and fails, PR publication and ready-for-review promotion remain blocked until the contract passes.

* **Tests**
  * Extended test coverage for new local CI contract UI elements and status display in the setup interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->