### PR TITLE
Execution metrics enrichment: add lifecycle and PR milestones

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,64 +1,59 @@
-# Issue #892: Execution metrics schema: define and validate a versioned run-summary contract
+# Issue #893: Execution metrics enrichment: add core lifecycle and PR milestone fields
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/892
-- Branch: codex/issue-892
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/893
+- Branch: codex/issue-893
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: stabilizing
+- Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 31b0d794d5b93585cc77a0e6e87d9ee7a73d6966
+- Last head SHA: 8121cfeb93e4d994e68aed8143c984a03c305bec
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-23T17:38:10Z
+- Updated at: 2026-03-23T18:11:47Z
 
 ## Latest Codex Summary
-- Added a checked-in execution metrics run-summary contract and now validate artifacts before persistence. Reproduced the gap with a focused failing test for malformed timestamps, then passed `npx tsx --test src/supervisor/execution-metrics-schema.test.ts`, `npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts`, and `npm run build` after `npm ci`, committed the change as `2bd6da1`, pushed `codex/issue-892`, and opened draft PR #905: https://github.com/TommyKammy/codex-supervisor/pull/905
+- Reproduced the missing lifecycle fields with a focused execution-metrics test, then implemented schema v2 run summaries with derived lifecycle durations, PR milestones, and structured terminal outcomes across all terminal write paths.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the issue is satisfied by a versioned typed contract plus write-time validation for persisted execution metrics run summaries; no aggregation consumers were added.
-- What changed: added `src/supervisor/execution-metrics-schema.ts` as the checked-in contract for run summaries, updated `src/supervisor/execution-metrics-run-summary.ts` to validate artifacts before writing, and added `src/supervisor/execution-metrics-schema.test.ts` to pin the schema version and malformed-timestamp rejection path.
+- Hypothesis: issue #893 is satisfied by deriving enriched run-summary lifecycle fields from existing issue, run, and PR timestamps at write time, then validating the persisted artifact against a stricter schema version.
+- What changed: added `src/supervisor/execution-metrics-lifecycle.ts` plus `src/supervisor/execution-metrics-lifecycle.test.ts` to derive non-negative durations and structured terminal outcomes; bumped `src/supervisor/execution-metrics-schema.ts` to schema version 2 with lifecycle and PR milestone fields; updated `src/supervisor/execution-metrics-run-summary.ts` and all terminal summary write paths to pass issue, PR, blocked-reason, and failure-kind metadata; expanded execution-metrics and failure-helper tests to cover the new contract.
 - Current blocker: none
-- Next exact step: monitor draft PR #905 for CI and review feedback, then address any follow-up if checks fail or comments land.
-- Verification gap: none in the requested scope; full build and focused execution-metrics tests passed after `npm ci`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/execution-metrics-run-summary.ts`, `src/supervisor/execution-metrics-schema.ts`, `src/supervisor/execution-metrics-schema.test.ts`
-- Rollback concern: low; the change is isolated to execution metrics summary validation and should only reject malformed summary artifacts that were previously written unchecked.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-892 --title "Execution metrics schema: define and validate a versioned run-summary contract" --body "..."`
-- Last focused failure: `npx tsx --test src/supervisor/execution-metrics-schema.test.ts` initially failed with `AssertionError [ERR_ASSERTION]: Missing expected rejection` because `syncExecutionMetricsRunSummary` wrote malformed timestamps without validation.
+- Next exact step: review the final diff, commit the enriched execution-metrics changes on `codex/issue-893`, and open or update a draft PR if one is still absent.
+- Verification gap: none in the requested scope after `npm ci`; build, focused execution-metrics tests, and the touched failure-helper regression tests all pass.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/run-once-issue-preparation.ts`, `src/run-once-turn-execution.ts`, `src/supervisor/execution-metrics-lifecycle.ts`, `src/supervisor/execution-metrics-lifecycle.test.ts`, `src/supervisor/execution-metrics-run-summary.ts`, `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/execution-metrics-schema.ts`, `src/supervisor/execution-metrics-schema.test.ts`, `src/supervisor/supervisor-failure-helpers.ts`, `src/supervisor/supervisor-recovery-failure-flows.test.ts`, `src/supervisor/supervisor.ts`, `src/turn-execution-failure-helpers.ts`, `src/turn-execution-failure-helpers.test.ts`
+- Rollback concern: medium-low; schema version 2 changes the persisted run-summary shape, so any out-of-tree consumers expecting version 1 would need a matching update.
+- Last focused command: `npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-lifecycle.test.ts src/turn-execution-failure-helpers.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts`
+- Last focused failure: `npm run build` initially failed with `sh: 1: tsc: not found` because this worktree had no `node_modules`; `npm ci` resolved the environment issue and the subsequent build passed.
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-892/AGENTS.generated.md
-sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-892/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-893/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-893/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
 git status --short
 git branch --show-current && git rev-parse HEAD
-rg -n "execution metrics|run summary|run-summary|schema version|schemaVersion|summary" src test . --glob '!node_modules'
-rg --files src | rg 'execution|metrics|summary'
+rg -n "execution-metrics|run summary|run-summary|lifecycle|pr milestone|close reason" src . --glob '!node_modules'
+rg --files src | rg 'execution-metrics|lifecycle|summary'
 sed -n '1,260p' src/supervisor/execution-metrics-run-summary.ts
-sed -n '1,520p' src/supervisor/execution-metrics-run-summary.test.ts
-sed -n '1,260p' src/supervisor/replay-corpus-validation.ts
-sed -n '1,220p' src/core/utils.ts
-ls src/supervisor | sed -n '1,200p'
-rg -n "validate.*schema|schema contract|versioned schema|validate.*summary" src/supervisor src
-sed -n '1,220p' src/committed-guardrails.ts
-sed -n '140,240p' src/committed-guardrails.test.ts
+sed -n '1,260p' src/supervisor/execution-metrics-schema.ts
+sed -n '1,620p' src/supervisor/execution-metrics-run-summary.test.ts
+sed -n '1,220p' src/supervisor/execution-metrics-schema.test.ts
+sed -n '1,240p' src/run-once-turn-execution.ts
+sed -n '1,260p' src/turn-execution-failure-helpers.ts
 apply_patch
-npx tsx --test src/supervisor/execution-metrics-schema.test.ts
-apply_patch
-npx tsx --test src/supervisor/execution-metrics-schema.test.ts
 npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts
+apply_patch
+npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-lifecycle.test.ts
+npm run build
 npm ci
 npm run build
-git add .codex-supervisor/issue-journal.md src/supervisor/execution-metrics-run-summary.ts src/supervisor/execution-metrics-schema.ts src/supervisor/execution-metrics-schema.test.ts
-git commit -m "Validate execution metrics run summaries"
-git push -u origin codex/issue-892
-gh pr create --draft --base main --head codex/issue-892 --title "Execution metrics schema: define and validate a versioned run-summary contract" --body "..."
-git diff -- src/supervisor/execution-metrics-run-summary.ts src/supervisor/execution-metrics-schema.ts src/supervisor/execution-metrics-schema.test.ts
+npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-lifecycle.test.ts src/turn-execution-failure-helpers.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts
+git diff -- src/supervisor/execution-metrics-schema.ts src/supervisor/execution-metrics-lifecycle.ts src/supervisor/execution-metrics-run-summary.ts src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-lifecycle.test.ts src/run-once-issue-preparation.ts src/run-once-turn-execution.ts src/turn-execution-failure-helpers.ts src/turn-execution-failure-helpers.test.ts src/supervisor/supervisor.ts src/supervisor/supervisor-failure-helpers.ts src/supervisor/supervisor-recovery-failure-flows.test.ts
 date -u +%Y-%m-%dT%H:%M:%SZ
 apply_patch
 ```

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -317,6 +317,8 @@ async function hydratePullRequestContext(
       await syncExecutionMetricsRunSummary({
         previousRecord: record,
         nextRecord: doneRecord,
+        issue: args.issue,
+        pullRequest: resolvedPr,
       });
       return { kind: "restart", recoveryEvents: [recoveryEvent] };
     } else if (resolvedPr.state === "CLOSED") {
@@ -353,6 +355,8 @@ async function hydratePullRequestContext(
       await syncExecutionMetricsRunSummary({
         previousRecord: record,
         nextRecord: blockedRecord,
+        issue: args.issue,
+        pullRequest: resolvedPr,
       });
       await args.syncJournal(blockedRecord);
       return `Issue #${blockedRecord.issue_number} blocked because PR #${resolvedPr.number} was closed without merge.`;
@@ -392,6 +396,7 @@ async function hydratePullRequestContext(
       await syncExecutionMetricsRunSummary({
         previousRecord: record,
         nextRecord: blockedRecord,
+        issue: args.issue,
       });
       await args.syncJournal(blockedRecord);
       return `Issue #${blockedRecord.issue_number} blocked: ${blockedRecord.last_error}`;

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -96,7 +96,7 @@ interface RecoverUnexpectedCodexTurnFailureArgs {
   journalSync: (record: IssueRunRecord) => Promise<void>;
   error: unknown;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha"> | null;
-  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "createdAt" | "mergedAt"> | null;
 }
 
 interface ExecuteCodexTurnPhaseArgs {
@@ -141,6 +141,7 @@ interface ExecuteCodexTurnPhaseArgs {
     stateStore: Pick<StateStore, "touch" | "save">;
     state: SupervisorStateFile;
     record: IssueRunRecord;
+    issue: Pick<GitHubIssue, "createdAt">;
     syncJournal: (record: IssueRunRecord) => Promise<void>;
     issueNumber: number;
     error: unknown;
@@ -159,6 +160,7 @@ interface ExecuteCodexTurnPhaseArgs {
     stateStore: Pick<StateStore, "touch" | "save">;
     state: SupervisorStateFile;
     record: IssueRunRecord;
+    issue: Pick<GitHubIssue, "createdAt">;
     syncJournal: (record: IssueRunRecord) => Promise<void>;
     issueNumber: number;
     codexResult: Pick<import("./core/types").CodexTurnResult, "lastMessage" | "stderr" | "stdout">;
@@ -177,6 +179,7 @@ interface ExecuteCodexTurnPhaseArgs {
     stateStore: Pick<StateStore, "touch" | "save">;
     state: SupervisorStateFile;
     record: IssueRunRecord;
+    issue: Pick<GitHubIssue, "createdAt">;
     syncJournal: (record: IssueRunRecord) => Promise<void>;
     issueNumber: number;
     buildCodexFailureContext: (
@@ -193,6 +196,7 @@ interface ExecuteCodexTurnPhaseArgs {
     stateStore: Pick<StateStore, "touch" | "save">;
     state: SupervisorStateFile;
     record: IssueRunRecord;
+    issue: Pick<GitHubIssue, "createdAt">;
     syncJournal: (record: IssueRunRecord) => Promise<void>;
     issueNumber: number;
     lastMessage: string;
@@ -320,6 +324,7 @@ export async function executeCodexTurnPhase(
           stateStore,
           state,
           record,
+          issue,
           syncJournal,
           issueNumber: record.issue_number,
           buildCodexFailureContext: args.buildCodexFailureContext,
@@ -341,6 +346,7 @@ export async function executeCodexTurnPhase(
           stateStore,
           state,
           record,
+          issue,
           syncJournal,
           issueNumber: record.issue_number,
           error: new Error(message),
@@ -359,6 +365,7 @@ export async function executeCodexTurnPhase(
           stateStore,
           state,
           record,
+          issue,
           syncJournal,
           issueNumber: record.issue_number,
           codexResult: {
@@ -381,6 +388,7 @@ export async function executeCodexTurnPhase(
           stateStore,
           state,
           record,
+          issue,
           syncJournal,
           issueNumber: record.issue_number,
           lastMessage: turnResult.supervisorMessage,
@@ -446,6 +454,7 @@ export async function executeCodexTurnPhase(
           await syncExecutionMetricsRunSummary({
             previousRecord: args.context.record,
             nextRecord: record,
+            issue,
           });
           await syncJournal(record);
           return {
@@ -529,6 +538,8 @@ export async function executeCodexTurnPhase(
       await syncExecutionMetricsRunSummary({
         previousRecord: args.context.record,
         nextRecord: record,
+        issue,
+        pullRequest: pr,
       });
       await syncJournal(record);
 

--- a/src/supervisor/execution-metrics-lifecycle.test.ts
+++ b/src/supervisor/execution-metrics-lifecycle.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildExecutionMetricsRunSummaryArtifact } from "./execution-metrics-lifecycle";
+
+test("buildExecutionMetricsRunSummaryArtifact derives lead-time and PR milestone durations", () => {
+  assert.deepEqual(
+    buildExecutionMetricsRunSummaryArtifact({
+      issueNumber: 893,
+      terminalState: "done",
+      issueCreatedAt: "2026-03-24T00:00:00Z",
+      startedAt: "2026-03-24T00:01:00Z",
+      prCreatedAt: "2026-03-24T00:03:00Z",
+      prMergedAt: "2026-03-24T00:05:00Z",
+      finishedAt: "2026-03-24T00:06:00Z",
+    }),
+    {
+      schemaVersion: 2,
+      issueNumber: 893,
+      terminalState: "done",
+      terminalOutcome: {
+        category: "completed",
+        reason: "merged",
+      },
+      issueCreatedAt: "2026-03-24T00:00:00Z",
+      startedAt: "2026-03-24T00:01:00Z",
+      prCreatedAt: "2026-03-24T00:03:00Z",
+      prMergedAt: "2026-03-24T00:05:00Z",
+      finishedAt: "2026-03-24T00:06:00Z",
+      runDurationMs: 300000,
+      issueLeadTimeMs: 360000,
+      issueToPrCreatedMs: 180000,
+      prOpenDurationMs: 120000,
+    },
+  );
+});
+
+test("buildExecutionMetricsRunSummaryArtifact rejects negative chronology", () => {
+  assert.throws(
+    () =>
+      buildExecutionMetricsRunSummaryArtifact({
+        issueNumber: 893,
+        terminalState: "done",
+        issueCreatedAt: "2026-03-24T00:00:00Z",
+        startedAt: "2026-03-24T00:06:00Z",
+        prCreatedAt: "2026-03-24T00:03:00Z",
+        prMergedAt: "2026-03-24T00:05:00Z",
+        finishedAt: "2026-03-24T00:04:00Z",
+      }),
+    /Invalid execution metrics chronology/u,
+  );
+});

--- a/src/supervisor/execution-metrics-lifecycle.ts
+++ b/src/supervisor/execution-metrics-lifecycle.ts
@@ -1,0 +1,77 @@
+import type { BlockedReason, FailureKind } from "../core/types";
+import {
+  EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
+  type ExecutionMetricsRunSummaryArtifact,
+  type ExecutionMetricsTerminalOutcome,
+} from "./execution-metrics-schema";
+
+function durationMs(start: string | null, end: string | null): number | null {
+  if (start === null || end === null) {
+    return null;
+  }
+
+  const duration = Date.parse(end) - Date.parse(start);
+  if (duration < 0) {
+    throw new Error(`Invalid execution metrics chronology: ${start} must be at or before ${end}.`);
+  }
+
+  return duration;
+}
+
+function terminalOutcomeForState(args: {
+  terminalState: ExecutionMetricsRunSummaryArtifact["terminalState"];
+  blockedReason?: BlockedReason | null;
+  failureKind?: FailureKind;
+  prMergedAt?: string | null;
+}): ExecutionMetricsTerminalOutcome {
+  if (args.terminalState === "done") {
+    return {
+      category: "completed",
+      reason: args.prMergedAt ? "merged" : null,
+    };
+  }
+
+  if (args.terminalState === "blocked") {
+    return {
+      category: "blocked",
+      reason: args.blockedReason ?? "unknown",
+    };
+  }
+
+  return {
+    category: "failed",
+    reason: args.failureKind ?? "unknown",
+  };
+}
+
+export function buildExecutionMetricsRunSummaryArtifact(args: {
+  issueNumber: number;
+  terminalState: ExecutionMetricsRunSummaryArtifact["terminalState"];
+  issueCreatedAt?: string | null;
+  startedAt: string;
+  prCreatedAt?: string | null;
+  prMergedAt?: string | null;
+  finishedAt: string;
+  blockedReason?: BlockedReason | null;
+  failureKind?: FailureKind;
+}): ExecutionMetricsRunSummaryArtifact {
+  const issueCreatedAt = args.issueCreatedAt ?? null;
+  const prCreatedAt = args.prCreatedAt ?? null;
+  const prMergedAt = args.prMergedAt ?? null;
+
+  return {
+    schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
+    issueNumber: args.issueNumber,
+    terminalState: args.terminalState,
+    terminalOutcome: terminalOutcomeForState(args),
+    issueCreatedAt,
+    startedAt: args.startedAt,
+    prCreatedAt,
+    prMergedAt,
+    finishedAt: args.finishedAt,
+    runDurationMs: durationMs(args.startedAt, args.finishedAt) ?? 0,
+    issueLeadTimeMs: durationMs(issueCreatedAt, args.finishedAt),
+    issueToPrCreatedMs: durationMs(issueCreatedAt, prCreatedAt),
+    prOpenDurationMs: durationMs(prCreatedAt, prMergedAt),
+  };
+}

--- a/src/supervisor/execution-metrics-run-summary.test.ts
+++ b/src/supervisor/execution-metrics-run-summary.test.ts
@@ -17,11 +17,22 @@ import { createConfig as createTurnConfig, createIssue, createPullRequest, creat
 import type { AgentRunner, AgentTurnRequest } from "./agent-runner";
 
 interface ExecutionMetricsRunSummary {
-  schemaVersion: 1;
+  schemaVersion: 2;
   issueNumber: number;
   terminalState: "done" | "blocked" | "failed";
+  terminalOutcome: {
+    category: "completed" | "blocked" | "failed";
+    reason: string | null;
+  };
+  issueCreatedAt: string | null;
   startedAt: string;
+  prCreatedAt: string | null;
+  prMergedAt: string | null;
   finishedAt: string;
+  runDurationMs: number;
+  issueLeadTimeMs: number | null;
+  issueToPrCreatedMs: number | null;
+  prOpenDurationMs: number | null;
 }
 
 function executionMetricsRunSummaryPath(workspacePath: string): string {
@@ -217,6 +228,7 @@ test("prepareIssueExecutionContext writes a run summary artifact for done outcom
   const mergedPr = createPreparationPullRequest({
     number: 191,
     state: "MERGED",
+    createdAt: "2026-03-24T00:03:00Z",
     mergedAt: "2026-03-24T00:05:00Z",
     headRefOid: "merged-head-191",
   });
@@ -259,11 +271,22 @@ test("prepareIssueExecutionContext writes a run summary artifact for done outcom
 
   const artifact = await readExecutionMetricsRunSummary(workspacePath);
   assert.deepEqual(artifact, {
-    schemaVersion: 1,
+    schemaVersion: 2,
     issueNumber: 240,
     terminalState: "done",
+    terminalOutcome: {
+      category: "completed",
+      reason: "merged",
+    },
+    issueCreatedAt: "2026-03-24T00:00:00Z",
     startedAt: "2026-03-24T00:00:00Z",
+    prCreatedAt: "2026-03-24T00:03:00Z",
+    prMergedAt: "2026-03-24T00:05:00Z",
     finishedAt: "2026-03-24T00:06:00Z",
+    runDurationMs: 360000,
+    issueLeadTimeMs: 360000,
+    issueToPrCreatedMs: 180000,
+    prOpenDurationMs: 120000,
   });
 });
 
@@ -283,7 +306,12 @@ test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes",
       "102": record,
     },
   };
-  const issue = createIssue({ number: 102, title: "Blocked metrics summary" });
+  const issue = createIssue({
+    number: 102,
+    title: "Blocked metrics summary",
+    createdAt: "2026-03-24T00:59:00Z",
+    updatedAt: "2026-03-24T00:59:00Z",
+  });
 
   let blockedJournalReads = 0;
   const result = await executeCodexTurnPhase({
@@ -410,11 +438,22 @@ test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes",
   });
   const artifact = await readExecutionMetricsRunSummary(workspacePath);
   assert.deepEqual(artifact, {
-    schemaVersion: 1,
+    schemaVersion: 2,
     issueNumber: 102,
     terminalState: "blocked",
+    terminalOutcome: {
+      category: "blocked",
+      reason: "verification",
+    },
+    issueCreatedAt: "2026-03-24T00:59:00Z",
     startedAt: "2026-03-24T01:00:00Z",
+    prCreatedAt: null,
+    prMergedAt: null,
     finishedAt: "2026-03-24T01:05:00Z",
+    runDurationMs: 300000,
+    issueLeadTimeMs: 360000,
+    issueToPrCreatedMs: null,
+    prOpenDurationMs: null,
   });
 });
 
@@ -462,7 +501,12 @@ test("executeCodexTurnPhase writes a run summary artifact for failed outcomes", 
     context: {
       state,
       record,
-      issue: createIssue({ number: 103, title: "Failed metrics summary" }),
+      issue: createIssue({
+        number: 103,
+        title: "Failed metrics summary",
+        createdAt: "2026-03-24T01:58:00Z",
+        updatedAt: "2026-03-24T01:58:00Z",
+      }),
       previousCodexSummary: null,
       previousError: null,
       workspacePath,
@@ -553,10 +597,21 @@ test("executeCodexTurnPhase writes a run summary artifact for failed outcomes", 
   });
   const artifact = await readExecutionMetricsRunSummary(workspacePath);
   assert.deepEqual(artifact, {
-    schemaVersion: 1,
+    schemaVersion: 2,
     issueNumber: 103,
     terminalState: "failed",
+    terminalOutcome: {
+      category: "failed",
+      reason: "command_error",
+    },
+    issueCreatedAt: "2026-03-24T01:58:00Z",
     startedAt: "2026-03-24T02:00:00Z",
+    prCreatedAt: null,
+    prMergedAt: null,
     finishedAt: "2026-03-24T02:04:00Z",
+    runDurationMs: 240000,
+    issueLeadTimeMs: 360000,
+    issueToPrCreatedMs: null,
+    prOpenDurationMs: null,
   });
 });

--- a/src/supervisor/execution-metrics-run-summary.ts
+++ b/src/supervisor/execution-metrics-run-summary.ts
@@ -1,11 +1,11 @@
 import path from "node:path";
-import type { IssueRunRecord } from "../core/types";
+import type { GitHubIssue, GitHubPullRequest, IssueRunRecord } from "../core/types";
 import { isTerminalState, writeJsonAtomic } from "../core/utils";
 import {
-  EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
   type ExecutionMetricsRunSummaryArtifact,
   validateExecutionMetricsRunSummary,
 } from "./execution-metrics-schema";
+import { buildExecutionMetricsRunSummaryArtifact } from "./execution-metrics-lifecycle";
 
 export function executionMetricsRunSummaryPath(workspacePath: string): string {
   return path.join(workspacePath, ".codex-supervisor", "execution-metrics", "run-summary.json");
@@ -13,7 +13,9 @@ export function executionMetricsRunSummaryPath(workspacePath: string): string {
 
 export async function syncExecutionMetricsRunSummary(args: {
   previousRecord: Pick<IssueRunRecord, "issue_number" | "updated_at">;
-  nextRecord: Pick<IssueRunRecord, "state" | "workspace" | "updated_at">;
+  nextRecord: Pick<IssueRunRecord, "state" | "workspace" | "updated_at" | "blocked_reason" | "last_failure_kind">;
+  issue?: Pick<GitHubIssue, "createdAt"> | null;
+  pullRequest?: Pick<GitHubPullRequest, "createdAt" | "mergedAt"> | null;
 }): Promise<string | null> {
   const { state } = args.nextRecord;
   if (!isTerminalState(state) || !args.nextRecord.workspace) {
@@ -26,13 +28,17 @@ export async function syncExecutionMetricsRunSummary(args: {
           throw new Error(`Unexpected non-terminal state: ${state}`);
         })();
 
-  const artifact: ExecutionMetricsRunSummaryArtifact = {
-    schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
+  const artifact: ExecutionMetricsRunSummaryArtifact = buildExecutionMetricsRunSummaryArtifact({
     issueNumber: args.previousRecord.issue_number,
     terminalState,
+    issueCreatedAt: args.issue?.createdAt ?? null,
     startedAt: args.previousRecord.updated_at,
+    prCreatedAt: args.pullRequest?.createdAt ?? null,
+    prMergedAt: args.pullRequest?.mergedAt ?? null,
     finishedAt: args.nextRecord.updated_at,
-  };
+    blockedReason: args.nextRecord.blocked_reason,
+    failureKind: args.nextRecord.last_failure_kind,
+  });
 
   const artifactPath = executionMetricsRunSummaryPath(args.nextRecord.workspace);
   await writeJsonAtomic(artifactPath, validateExecutionMetricsRunSummary(artifact));

--- a/src/supervisor/execution-metrics-schema.test.ts
+++ b/src/supervisor/execution-metrics-schema.test.ts
@@ -15,28 +15,61 @@ test("validateExecutionMetricsRunSummary accepts the versioned contract and reje
       schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
       issueNumber: 892,
       terminalState: "done",
+      terminalOutcome: {
+        category: "completed",
+        reason: "merged",
+      },
+      issueCreatedAt: "2026-03-24T03:55:00Z",
       startedAt: "2026-03-24T03:59:00Z",
+      prCreatedAt: "2026-03-24T03:59:30Z",
+      prMergedAt: "2026-03-24T03:59:45Z",
       finishedAt: "2026-03-24T04:00:00Z",
+      runDurationMs: 60000,
+      issueLeadTimeMs: 300000,
+      issueToPrCreatedMs: 270000,
+      prOpenDurationMs: 15000,
     }),
     {
       schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
       issueNumber: 892,
       terminalState: "done",
+      terminalOutcome: {
+        category: "completed",
+        reason: "merged",
+      },
+      issueCreatedAt: "2026-03-24T03:55:00Z",
       startedAt: "2026-03-24T03:59:00Z",
+      prCreatedAt: "2026-03-24T03:59:30Z",
+      prMergedAt: "2026-03-24T03:59:45Z",
       finishedAt: "2026-03-24T04:00:00Z",
+      runDurationMs: 60000,
+      issueLeadTimeMs: 300000,
+      issueToPrCreatedMs: 270000,
+      prOpenDurationMs: 15000,
     },
   );
 
   assert.throws(
     () =>
       validateExecutionMetricsRunSummary({
-        schemaVersion: 2,
+        schemaVersion: 3,
         issueNumber: 892,
         terminalState: "done",
+        terminalOutcome: {
+          category: "completed",
+          reason: "merged",
+        },
+        issueCreatedAt: "2026-03-24T03:55:00Z",
         startedAt: "2026-03-24T03:59:00Z",
+        prCreatedAt: "2026-03-24T03:59:30Z",
+        prMergedAt: "2026-03-24T03:59:45Z",
         finishedAt: "2026-03-24T04:00:00Z",
+        runDurationMs: 60000,
+        issueLeadTimeMs: 300000,
+        issueToPrCreatedMs: 270000,
+        prOpenDurationMs: 15000,
       }),
-    /schemaVersion must be 1/u,
+    /schemaVersion must be 2/u,
   );
 });
 
@@ -53,10 +86,37 @@ test("syncExecutionMetricsRunSummary rejects malformed run summaries before writ
         state: "done",
         workspace: workspacePath,
         updated_at: "2026-03-24T04:00:00Z",
+        blocked_reason: null,
+        last_failure_kind: null,
       },
     }),
     /startedAt must be an ISO-8601 timestamp/u,
   );
 
   await assert.rejects(fs.stat(executionMetricsRunSummaryPath(workspacePath)), { code: "ENOENT" });
+});
+
+test("validateExecutionMetricsRunSummary rejects negative derived lifecycle durations", () => {
+  assert.throws(
+    () =>
+      validateExecutionMetricsRunSummary({
+        schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
+        issueNumber: 893,
+        terminalState: "done",
+        terminalOutcome: {
+          category: "completed",
+          reason: "merged",
+        },
+        issueCreatedAt: "2026-03-24T03:55:00Z",
+        startedAt: "2026-03-24T03:59:00Z",
+        prCreatedAt: "2026-03-24T04:01:00Z",
+        prMergedAt: "2026-03-24T04:00:30Z",
+        finishedAt: "2026-03-24T04:00:00Z",
+        runDurationMs: 60000,
+        issueLeadTimeMs: 300000,
+        issueToPrCreatedMs: 360000,
+        prOpenDurationMs: 0,
+      }),
+    /prOpenDurationMs timestamps must be chronological/u,
+  );
 });

--- a/src/supervisor/execution-metrics-schema.ts
+++ b/src/supervisor/execution-metrics-schema.ts
@@ -1,19 +1,41 @@
-export const EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION = 1;
+export const EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION = 2;
 const EXECUTION_METRICS_RUN_SUMMARY_KEYS = [
   "schemaVersion",
   "issueNumber",
   "terminalState",
+  "terminalOutcome",
+  "issueCreatedAt",
   "startedAt",
+  "prCreatedAt",
+  "prMergedAt",
   "finishedAt",
+  "runDurationMs",
+  "issueLeadTimeMs",
+  "issueToPrCreatedMs",
+  "prOpenDurationMs",
 ] as const;
 const TERMINAL_STATES = ["done", "blocked", "failed"] as const;
+const TERMINAL_OUTCOME_CATEGORIES = ["completed", "blocked", "failed"] as const;
+
+export interface ExecutionMetricsTerminalOutcome {
+  category: (typeof TERMINAL_OUTCOME_CATEGORIES)[number];
+  reason: string | null;
+}
 
 export interface ExecutionMetricsRunSummaryArtifact {
   schemaVersion: typeof EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION;
   issueNumber: number;
   terminalState: (typeof TERMINAL_STATES)[number];
+  terminalOutcome: ExecutionMetricsTerminalOutcome;
+  issueCreatedAt: string | null;
   startedAt: string;
+  prCreatedAt: string | null;
+  prMergedAt: string | null;
   finishedAt: string;
+  runDurationMs: number;
+  issueLeadTimeMs: number | null;
+  issueToPrCreatedMs: number | null;
+  prOpenDurationMs: number | null;
 }
 
 function failValidation(message: string): never {
@@ -44,12 +66,78 @@ function expectIsoTimestamp(value: unknown, field: string): string {
   return value;
 }
 
+function expectNullableIsoTimestamp(value: unknown, field: string): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return expectIsoTimestamp(value, field);
+}
+
 function expectTerminalState(value: unknown): ExecutionMetricsRunSummaryArtifact["terminalState"] {
   if (typeof value !== "string" || !TERMINAL_STATES.includes(value as ExecutionMetricsRunSummaryArtifact["terminalState"])) {
     failValidation(`terminalState must be one of: ${TERMINAL_STATES.join(", ")}.`);
   }
 
   return value as ExecutionMetricsRunSummaryArtifact["terminalState"];
+}
+
+function expectTerminalOutcome(value: unknown): ExecutionMetricsTerminalOutcome {
+  const outcome = expectObject(value);
+  const keys = Object.keys(outcome);
+  if (keys.length !== 2 || !keys.includes("category") || !keys.includes("reason")) {
+    failValidation("terminalOutcome must contain category and reason.");
+  }
+  if (
+    typeof outcome.category !== "string" ||
+    !TERMINAL_OUTCOME_CATEGORIES.includes(outcome.category as ExecutionMetricsTerminalOutcome["category"])
+  ) {
+    failValidation(`terminalOutcome.category must be one of: ${TERMINAL_OUTCOME_CATEGORIES.join(", ")}.`);
+  }
+  if (outcome.reason !== null && typeof outcome.reason !== "string") {
+    failValidation("terminalOutcome.reason must be a string or null.");
+  }
+
+  return {
+    category: outcome.category as ExecutionMetricsTerminalOutcome["category"],
+    reason: outcome.reason as string | null,
+  };
+}
+
+function expectNullableNonNegativeInteger(value: unknown, field: string): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  return expectNonNegativeInteger(value, field);
+}
+
+function expectDerivedDuration(
+  value: number | null,
+  start: string | null,
+  end: string | null,
+  field: string,
+): number | null {
+  if (start === null || end === null) {
+    if (value !== null) {
+      failValidation(`${field} must be null when its timestamps are absent.`);
+    }
+    return null;
+  }
+
+  if (value === null) {
+    failValidation(`${field} must be present when its timestamps exist.`);
+  }
+
+  const duration = Date.parse(end) - Date.parse(start);
+  if (duration < 0) {
+    failValidation(`${field} timestamps must be chronological.`);
+  }
+  if (value !== duration) {
+    failValidation(`${field} must equal the derived duration from its timestamps.`);
+  }
+
+  return value;
 }
 
 export function validateExecutionMetricsRunSummary(raw: unknown): ExecutionMetricsRunSummaryArtifact {
@@ -64,11 +152,34 @@ export function validateExecutionMetricsRunSummary(raw: unknown): ExecutionMetri
     failValidation(`schemaVersion must be ${EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION}.`);
   }
 
+  const issueCreatedAt = expectNullableIsoTimestamp(summary.issueCreatedAt, "issueCreatedAt");
+  const startedAt = expectIsoTimestamp(summary.startedAt, "startedAt");
+  const prCreatedAt = expectNullableIsoTimestamp(summary.prCreatedAt, "prCreatedAt");
+  const prMergedAt = expectNullableIsoTimestamp(summary.prMergedAt, "prMergedAt");
+  const finishedAt = expectIsoTimestamp(summary.finishedAt, "finishedAt");
+  const runDurationMs = expectNonNegativeInteger(summary.runDurationMs, "runDurationMs");
+  const issueLeadTimeMs = expectNullableNonNegativeInteger(summary.issueLeadTimeMs, "issueLeadTimeMs");
+  const issueToPrCreatedMs = expectNullableNonNegativeInteger(summary.issueToPrCreatedMs, "issueToPrCreatedMs");
+  const prOpenDurationMs = expectNullableNonNegativeInteger(summary.prOpenDurationMs, "prOpenDurationMs");
+
+  expectDerivedDuration(runDurationMs, startedAt, finishedAt, "runDurationMs");
+  expectDerivedDuration(issueLeadTimeMs, issueCreatedAt, finishedAt, "issueLeadTimeMs");
+  expectDerivedDuration(issueToPrCreatedMs, issueCreatedAt, prCreatedAt, "issueToPrCreatedMs");
+  expectDerivedDuration(prOpenDurationMs, prCreatedAt, prMergedAt, "prOpenDurationMs");
+
   return {
     schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
     issueNumber: expectNonNegativeInteger(summary.issueNumber, "issueNumber"),
     terminalState: expectTerminalState(summary.terminalState),
-    startedAt: expectIsoTimestamp(summary.startedAt, "startedAt"),
-    finishedAt: expectIsoTimestamp(summary.finishedAt, "finishedAt"),
+    terminalOutcome: expectTerminalOutcome(summary.terminalOutcome),
+    issueCreatedAt,
+    startedAt,
+    prCreatedAt,
+    prMergedAt,
+    finishedAt,
+    runDurationMs,
+    issueLeadTimeMs,
+    issueToPrCreatedMs,
+    prOpenDurationMs,
   };
 }

--- a/src/supervisor/supervisor-failure-helpers.ts
+++ b/src/supervisor/supervisor-failure-helpers.ts
@@ -127,7 +127,7 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
   journalSync: (record: IssueRunRecord) => Promise<void>;
   error: unknown;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha"> | null;
-  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "createdAt" | "mergedAt"> | null;
 }): Promise<IssueRunRecord> {
   const { stateStore, state, record, issue, journalSync, error, workspaceStatus, pr } = args;
   const message = error instanceof Error ? error.stack ?? error.message : String(error);
@@ -167,6 +167,8 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
     await syncExecutionMetricsRunSummary({
       previousRecord: record,
       nextRecord: updated,
+      issue,
+      pullRequest: pr,
     });
   } catch (metricsError) {
     console.warn(

--- a/src/supervisor/supervisor-recovery-failure-flows.test.ts
+++ b/src/supervisor/supervisor-recovery-failure-flows.test.ts
@@ -154,7 +154,9 @@ test("recoverUnexpectedCodexTurnFailure preserves dirty recovery context and tim
     },
     pr: {
       number: 55,
+      createdAt: "2026-03-13T00:10:00Z",
       headRefOid: "feed123",
+      mergedAt: null,
     },
   });
 

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -656,6 +656,8 @@ export class Supervisor {
         await syncExecutionMetricsRunSummary({
           previousRecord: lifecycle.recordForState,
           nextRecord: record,
+          issue,
+          pullRequest: pr,
         });
         await syncJournal(record);
         return prependRecoveryLog(
@@ -715,7 +717,7 @@ export class Supervisor {
         pr,
         options,
       });
-      record = await this.handlePostTurnMergeAndCompletion(state, postTurn.record, postTurn.pr, options);
+      record = await this.handlePostTurnMergeAndCompletion(state, issue, postTurn.record, postTurn.pr, options);
       await syncJournal(record);
       return prependRecoveryLog(formatStatus(record), recoveryLog);
     }
@@ -761,6 +763,7 @@ export class Supervisor {
 
   private async handlePostTurnMergeAndCompletion(
     state: SupervisorStateFile,
+    issue: GitHubIssue,
     record: IssueRunRecord,
     pr: GitHubPullRequest,
     options: Pick<CliOptions, "dryRun">,
@@ -783,6 +786,8 @@ export class Supervisor {
     await syncExecutionMetricsRunSummary({
       previousRecord: record,
       nextRecord,
+      issue,
+      pullRequest: pr,
     });
     return nextRecord;
   }

--- a/src/turn-execution-failure-helpers.test.ts
+++ b/src/turn-execution-failure-helpers.test.ts
@@ -25,6 +25,7 @@ test("persistHintedCodexTurnState records blocked reasons and repeated blocker b
     },
     state,
     record: state.issues["102"]!,
+    issue: { createdAt: "2026-03-13T00:00:00Z" },
     syncJournal: async () => {
       syncJournalCalls += 1;
     },
@@ -108,6 +109,7 @@ test("persistHintedCodexTurnState continues journal sync when run summary persis
       },
       state,
       record: state.issues["103"]!,
+      issue: { createdAt: "2026-03-24T03:00:00Z" },
       syncJournal: async () => {
         syncJournalCalls += 1;
       },

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -1,5 +1,5 @@
 import { StateStore } from "./core/state-store";
-import { CodexTurnResult, FailureContext, IssueRunRecord, SupervisorStateFile } from "./core/types";
+import { CodexTurnResult, FailureContext, GitHubIssue, IssueRunRecord, SupervisorStateFile } from "./core/types";
 import { truncate } from "./core/utils";
 import { syncExecutionMetricsRunSummary } from "./supervisor/execution-metrics-run-summary";
 
@@ -9,6 +9,7 @@ interface PersistTurnExecutionFailureArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
+  issue: Pick<GitHubIssue, "createdAt">;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   error: unknown;
@@ -28,6 +29,7 @@ interface PersistCodexExitFailureArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
+  issue: Pick<GitHubIssue, "createdAt">;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   codexResult: Pick<CodexTurnResult, "lastMessage" | "stderr" | "stdout">;
@@ -47,6 +49,7 @@ interface PersistMissingJournalHandoffArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
+  issue: Pick<GitHubIssue, "createdAt">;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   buildCodexFailureContext: (
@@ -64,6 +67,7 @@ interface PersistHintedCodexTurnStateArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
+  issue: Pick<GitHubIssue, "createdAt">;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   lastMessage: string;
@@ -115,6 +119,7 @@ async function persistTurnFailurePatch(args: {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
+  issue: Pick<GitHubIssue, "createdAt">;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   patch: Partial<IssueRunRecord>;
 }): Promise<IssueRunRecord> {
@@ -125,6 +130,7 @@ async function persistTurnFailurePatch(args: {
     await syncExecutionMetricsRunSummary({
       previousRecord: args.record,
       nextRecord: updated,
+      issue: args.issue,
     });
   } catch (metricsError) {
     console.warn(
@@ -154,6 +160,7 @@ export async function persistCodexTurnExecutionFailure(args: PersistTurnExecutio
     stateStore: args.stateStore,
     state: args.state,
     record: args.record,
+    issue: args.issue,
     syncJournal: args.syncJournal,
     patch: {
       state: "failed",
@@ -182,6 +189,7 @@ export async function persistCodexTurnExitFailure(args: PersistCodexExitFailureA
     stateStore: args.stateStore,
     state: args.state,
     record: args.record,
+    issue: args.issue,
     syncJournal: args.syncJournal,
     patch: {
       state: "failed",
@@ -208,6 +216,7 @@ export async function persistMissingCodexJournalHandoff(
     stateStore: args.stateStore,
     state: args.state,
     record: args.record,
+    issue: args.issue,
     syncJournal: args.syncJournal,
     patch: {
       state: "blocked",
@@ -234,6 +243,7 @@ export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnSt
     stateStore: args.stateStore,
     state: args.state,
     record: args.record,
+    issue: args.issue,
     syncJournal: args.syncJournal,
     patch: {
       state: args.hintedState,


### PR DESCRIPTION
## Summary
- enrich execution metrics run summaries with lifecycle timestamps, derived durations, and structured terminal outcomes
- record PR creation and merge milestones when present and validate chronology via schema v2
- cover the new contract across run-summary, lifecycle, and failure-helper tests

## Verification
- npm run build
- npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-lifecycle.test.ts src/turn-execution-failure-helpers.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced execution metrics now include terminal outcome classification (completed, blocked, failed) with detailed reasons and calculated lifecycle durations (issue lead time, PR open duration, time-to-merge).

* **Tests**
  * Added comprehensive validation tests for metrics lifecycle calculations and chronological integrity.

* **Chores**
  * Updated workstream documentation and internal metrics schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->