### PR TITLE
Record failure and recovery execution metrics summaries

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #894: Execution metrics review loop: capture structured review-iteration metrics
+# Issue #895: Execution metrics failure and recovery: record structured failure and recovery summaries
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/894
-- Branch: codex/issue-894
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/895
+- Branch: codex/issue-895
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 42936a3cc15e80a430dd699c30d92fd5d2372600
+- Last head SHA: e998202c3cf1ae538515dc42f0cc78e94ad0d4e4
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-23T18:39:24.018Z
+- Updated at: 2026-03-23T19:12:40.085Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,44 +21,49 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: issue #894 can be satisfied by deriving a coarse review-loop metrics block at run-summary write time from the already persisted `processed_review_thread_ids`, without changing PR or review handling behavior.
-- What changed: bumped `src/supervisor/execution-metrics-schema.ts` to schema version 3 and added a nullable `reviewMetrics` block with a fixed contract: `classification`, `iterationCount`, `totalCount`, and `totalCountKind`; updated `src/supervisor/execution-metrics-lifecycle.ts` to derive `reviewMetrics` from unique `threadId@headSha` history so `iterationCount` counts distinct reviewed heads and `totalCount` counts actionable thread instances; updated `src/supervisor/execution-metrics-run-summary.ts` to pass `processed_review_thread_ids`; expanded `src/supervisor/execution-metrics-schema.test.ts`, `src/supervisor/execution-metrics-lifecycle.test.ts`, and `src/supervisor/execution-metrics-run-summary.test.ts` to cover the new contract and a focused review-loop regression.
+- Hypothesis: issue #895 can be satisfied by extending the execution-metrics run-summary contract with nullable `failureMetrics` and `recoveryMetrics` blocks derived from already persisted failure/recovery state plus in-flight `RecoveryEvent`s, so metrics improve without changing retry, recovery, or stop decisions.
+- What changed: added a focused reproducer in `src/supervisor/execution-metrics-failure-recovery.test.ts`; bumped `src/supervisor/execution-metrics-schema.ts` to schema version 4 with nullable `failureMetrics` and `recoveryMetrics` blocks plus validation rules; updated `src/supervisor/execution-metrics-lifecycle.ts` to derive latest failure metrics from `last_failure_context`/`last_failure_kind`/`blocked_reason` and latest recovery metrics from issue-scoped `RecoveryEvent`s or persisted `last_recovery_*`; threaded the extra state through `src/supervisor/execution-metrics-run-summary.ts`, `src/run-once-issue-preparation.ts`, and `src/supervisor/supervisor.ts`; refreshed `src/supervisor/execution-metrics-schema.test.ts`, `src/supervisor/execution-metrics-lifecycle.test.ts`, and `src/supervisor/execution-metrics-run-summary.test.ts` for the version-4 contract.
 - Current blocker: none
-- Next exact step: monitor draft PR #907, confirm CI and any downstream schema consumers tolerate run-summary schema version 3, and address review feedback if it appears.
-- Verification gap: none in the requested scope after `npm ci`; `npm run build` and the focused execution-metrics tests pass.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/execution-metrics-lifecycle.ts`, `src/supervisor/execution-metrics-lifecycle.test.ts`, `src/supervisor/execution-metrics-run-summary.ts`, `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/execution-metrics-schema.ts`, `src/supervisor/execution-metrics-schema.test.ts`
-- Rollback concern: medium-low; schema version 3 extends the persisted run-summary shape, so any external consumers pinned to version 2 would need to handle the new version.
+- Next exact step: stage the execution-metrics changes, commit the issue-895 checkpoint, and then open or update the branch PR if supervisor policy requires it this turn.
+- Verification gap: none in the requested scope after `npm ci`; `npm run build`, `npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`, and the focused execution-metrics suite all pass.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/run-once-issue-preparation.ts`, `src/supervisor/execution-metrics-failure-recovery.test.ts`, `src/supervisor/execution-metrics-lifecycle.ts`, `src/supervisor/execution-metrics-lifecycle.test.ts`, `src/supervisor/execution-metrics-run-summary.ts`, `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/execution-metrics-schema.ts`, `src/supervisor/execution-metrics-schema.test.ts`, `src/supervisor/supervisor.ts`
+- Rollback concern: medium; schema version 4 extends persisted run-summary artifacts, so downstream consumers pinned to version 3 need to tolerate or migrate to the new failure/recovery blocks.
 - Last focused command: `npm run build`
-- Last focused failure: `npm run build` initially failed with `sh: 1: tsc: not found` because this worktree had no `node_modules`; running `npm ci` resolved the environment issue and the subsequent build passed.
+- Last focused failure: `npm run build` first failed with `sh: 1: tsc: not found` because this worktree lacked `node_modules`; after `npm ci`, a subsequent build surfaced a TypeScript scope error in `src/supervisor/supervisor.ts` from passing `recoveryEvents` outside its context, and threading `recoveryEvents` through `runPreparedIssue` resolved it.
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-894/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-894/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-895/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-895/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
 git status --short
 git branch --show-current && git rev-parse HEAD
-rg -n "review iteration|review metrics|actionable-thread|processed_review_thread_ids|review_wait_started_at" src . --glob '!node_modules'
+rg -n "failure|recovery|run summary|runSummary|execution metrics|structured" src/supervisor src --glob '!node_modules'
 sed -n '1,260p' src/supervisor/execution-metrics-run-summary.ts
 sed -n '1,260p' src/supervisor/execution-metrics-schema.ts
-sed -n '1,240p' src/supervisor/execution-metrics-lifecycle.ts
-sed -n '1,620p' src/supervisor/execution-metrics-run-summary.test.ts
-sed -n '1,260p' src/supervisor/execution-metrics-schema.test.ts
+sed -n '1,320p' src/supervisor/execution-metrics-lifecycle.ts
+sed -n '1,320p' src/supervisor/supervisor-recovery-reconciliation.test.ts
+sed -n '1,360p' src/supervisor/execution-metrics-run-summary.test.ts
+sed -n '1,280p' src/supervisor/execution-metrics-schema.test.ts
 sed -n '1,260p' src/supervisor/execution-metrics-lifecycle.test.ts
-sed -n '1,260p' src/review-handling.ts
-sed -n '1,260p' src/review-thread-reporting.ts
-sed -n '1,260p' src/core/review-providers.ts
-sed -n '1,320p' src/pull-request-state.ts
-sed -n '1,260p' src/supervisor/supervisor-lifecycle.ts
+sed -n '1,320p' src/recovery-reconciliation.ts
+sed -n '1,260p' src/run-once-cycle-prelude.ts
+sed -n '280,440p' src/run-once-issue-preparation.ts
+sed -n '420,620p' src/run-once-turn-execution.ts
+sed -n '620,820p' src/supervisor/supervisor.ts
 apply_patch
+npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts
+apply_patch
+npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts
+npx tsx --test src/supervisor/execution-metrics-lifecycle.test.ts src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-run-summary.test.ts
+apply_patch
+npx tsx -e 'import { buildExecutionMetricsRunSummaryArtifact } from "./src/supervisor/execution-metrics-lifecycle.ts"; console.log(JSON.stringify(buildExecutionMetricsRunSummaryArtifact({ issueNumber: 894, terminalState: "done", issueCreatedAt: "2026-03-24T03:55:00Z", startedAt: "2026-03-24T04:00:00Z", prCreatedAt: "2026-03-24T03:59:30Z", prMergedAt: "2026-03-24T04:04:00Z", finishedAt: "2026-03-24T04:05:00Z", blockedReason: null, failureKind: null, failureContext: null, repeatedFailureSignatureCount: 0, processedReviewThreadIds: ["thread-1@head-a","thread-2@head-a","thread-2@head-b"], lastRecoveryReason: null, lastRecoveryAt: null, staleStabilizingNoPrRecoveryCount: 0 }), null, 2));'
 npx tsx --test src/supervisor/execution-metrics-schema.test.ts
-npx tsx --test src/supervisor/execution-metrics-lifecycle.test.ts
-npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts
-apply_patch
-npx tsx --test src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-lifecycle.test.ts src/supervisor/execution-metrics-run-summary.test.ts
+npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
+npx tsx --test src/supervisor/execution-metrics-lifecycle.test.ts src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-run-summary.test.ts
 npm run build
 npm ci
-npx tsx --test src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-lifecycle.test.ts src/supervisor/execution-metrics-run-summary.test.ts
 npm run build
+npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
 git status --short
 date -u +%Y-%m-%dT%H:%M:%SZ
 ```

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -319,6 +319,7 @@ async function hydratePullRequestContext(
         nextRecord: doneRecord,
         issue: args.issue,
         pullRequest: resolvedPr,
+        recoveryEvents: [recoveryEvent],
       });
       return { kind: "restart", recoveryEvents: [recoveryEvent] };
     } else if (resolvedPr.state === "CLOSED") {

--- a/src/supervisor/execution-metrics-failure-recovery.test.ts
+++ b/src/supervisor/execution-metrics-failure-recovery.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildExecutionMetricsRunSummaryArtifact } from "./execution-metrics-lifecycle";
+
+test("buildExecutionMetricsRunSummaryArtifact records structured failure and recovery summaries when present", () => {
+  assert.deepEqual(
+    buildExecutionMetricsRunSummaryArtifact({
+      issueNumber: 895,
+      terminalState: "blocked",
+      issueCreatedAt: "2026-03-24T00:00:00Z",
+      startedAt: "2026-03-24T00:01:00Z",
+      finishedAt: "2026-03-24T00:09:00Z",
+      blockedReason: "verification",
+      failureKind: "command_error",
+      failureContext: {
+        category: "review",
+        summary: "Verification failed",
+        signature: "verify-failed",
+        command: "npm test",
+        details: ["suite=supervisor"],
+        url: "https://example.test/issues/895",
+        updated_at: "2026-03-24T00:04:00Z",
+      },
+      repeatedFailureSignatureCount: 2,
+      recoveryEvents: [
+        {
+          issueNumber: 895,
+          reason: "operator_requeue: requeued issue #895 from blocked to queued",
+          at: "2026-03-24T00:06:00Z",
+        },
+      ],
+      lastRecoveryReason: "operator_requeue: requeued issue #895 from blocked to queued",
+      lastRecoveryAt: "2026-03-24T00:06:00Z",
+    }),
+    {
+      schemaVersion: 4,
+      issueNumber: 895,
+      terminalState: "blocked",
+      terminalOutcome: {
+        category: "blocked",
+        reason: "verification",
+      },
+      issueCreatedAt: "2026-03-24T00:00:00Z",
+      startedAt: "2026-03-24T00:01:00Z",
+      prCreatedAt: null,
+      prMergedAt: null,
+      finishedAt: "2026-03-24T00:09:00Z",
+      runDurationMs: 480000,
+      issueLeadTimeMs: 540000,
+      issueToPrCreatedMs: null,
+      prOpenDurationMs: null,
+      reviewMetrics: null,
+      failureMetrics: {
+        classification: "latest_failure",
+        category: "review",
+        failureKind: "command_error",
+        blockedReason: "verification",
+        occurrenceCount: 2,
+        lastOccurredAt: "2026-03-24T00:04:00Z",
+      },
+      recoveryMetrics: {
+        classification: "latest_recovery",
+        reason: "operator_requeue",
+        occurrenceCount: 1,
+        lastRecoveredAt: "2026-03-24T00:06:00Z",
+        timeToLatestRecoveryMs: 120000,
+      },
+    },
+  );
+});
+
+test("buildExecutionMetricsRunSummaryArtifact keeps successful runs without failures free of synthetic failure summaries", () => {
+  assert.deepEqual(
+    buildExecutionMetricsRunSummaryArtifact({
+      issueNumber: 895,
+      terminalState: "done",
+      issueCreatedAt: "2026-03-24T00:00:00Z",
+      startedAt: "2026-03-24T00:01:00Z",
+      prCreatedAt: "2026-03-24T00:02:00Z",
+      prMergedAt: "2026-03-24T00:05:00Z",
+      finishedAt: "2026-03-24T00:06:00Z",
+    }),
+    {
+      schemaVersion: 4,
+      issueNumber: 895,
+      terminalState: "done",
+      terminalOutcome: {
+        category: "completed",
+        reason: "merged",
+      },
+      issueCreatedAt: "2026-03-24T00:00:00Z",
+      startedAt: "2026-03-24T00:01:00Z",
+      prCreatedAt: "2026-03-24T00:02:00Z",
+      prMergedAt: "2026-03-24T00:05:00Z",
+      finishedAt: "2026-03-24T00:06:00Z",
+      runDurationMs: 300000,
+      issueLeadTimeMs: 360000,
+      issueToPrCreatedMs: 120000,
+      prOpenDurationMs: 180000,
+      reviewMetrics: null,
+      failureMetrics: null,
+      recoveryMetrics: null,
+    },
+  );
+});

--- a/src/supervisor/execution-metrics-lifecycle.test.ts
+++ b/src/supervisor/execution-metrics-lifecycle.test.ts
@@ -15,7 +15,7 @@ test("buildExecutionMetricsRunSummaryArtifact derives lead-time and PR milestone
       processedReviewThreadIds: ["thread-1@head-a", "thread-2@head-a", "thread-2@head-b"],
     }),
     {
-      schemaVersion: 3,
+      schemaVersion: 4,
       issueNumber: 893,
       terminalState: "done",
       terminalOutcome: {
@@ -37,6 +37,8 @@ test("buildExecutionMetricsRunSummaryArtifact derives lead-time and PR milestone
         totalCount: 3,
         totalCountKind: "actionable_thread_instances",
       },
+      failureMetrics: null,
+      recoveryMetrics: null,
     },
   );
 });

--- a/src/supervisor/execution-metrics-lifecycle.ts
+++ b/src/supervisor/execution-metrics-lifecycle.ts
@@ -1,6 +1,9 @@
-import type { BlockedReason, FailureKind } from "../core/types";
+import type { BlockedReason, FailureContext, FailureKind } from "../core/types";
+import type { RecoveryEvent } from "../run-once-cycle-prelude";
 import {
   EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
+  type ExecutionMetricsFailureMetrics,
+  type ExecutionMetricsRecoveryMetrics,
   type ExecutionMetricsReviewMetrics,
   type ExecutionMetricsRunSummaryArtifact,
   type ExecutionMetricsTerminalOutcome,
@@ -68,6 +71,66 @@ function buildReviewMetrics(processedReviewThreadIds: string[]): ExecutionMetric
   };
 }
 
+function buildFailureMetrics(args: {
+  failureContext?: FailureContext | null;
+  failureKind?: FailureKind;
+  blockedReason?: BlockedReason | null;
+  repeatedFailureSignatureCount?: number;
+}): ExecutionMetricsFailureMetrics | null {
+  if (!args.failureContext?.category) {
+    return null;
+  }
+
+  return {
+    classification: "latest_failure",
+    category: args.failureContext.category,
+    failureKind: args.failureKind ?? null,
+    blockedReason: args.blockedReason ?? null,
+    occurrenceCount: Math.max(args.repeatedFailureSignatureCount ?? 0, 1),
+    lastOccurredAt: args.failureContext.updated_at,
+  };
+}
+
+function parseRecoveryReasonCategory(reason: string): string {
+  const separatorIndex = reason.indexOf(":");
+  return (separatorIndex >= 0 ? reason.slice(0, separatorIndex) : reason).trim();
+}
+
+function buildRecoveryMetrics(args: {
+  issueNumber: number;
+  failureMetrics: ExecutionMetricsFailureMetrics | null;
+  recoveryEvents?: RecoveryEvent[];
+  lastRecoveryReason?: string | null;
+  lastRecoveryAt?: string | null;
+  staleStabilizingNoPrRecoveryCount?: number;
+}): ExecutionMetricsRecoveryMetrics | null {
+  const issueRecoveryEvents = (args.recoveryEvents ?? []).filter((event) => event.issueNumber === args.issueNumber);
+  const latestRecoveryEvent = issueRecoveryEvents.reduce<RecoveryEvent | null>(
+    (latest, event) => latest === null || Date.parse(event.at) > Date.parse(latest.at) ? event : latest,
+    null,
+  );
+  const lastRecoveredAt = latestRecoveryEvent?.at ?? args.lastRecoveryAt ?? null;
+  const latestRecoveryReason = latestRecoveryEvent?.reason ?? args.lastRecoveryReason ?? null;
+
+  if (!lastRecoveredAt || !latestRecoveryReason) {
+    return null;
+  }
+
+  const derivedRecoveryDelay =
+    args.failureMetrics === null ? null : durationMs(args.failureMetrics.lastOccurredAt, lastRecoveredAt);
+  return {
+    classification: "latest_recovery",
+    reason: parseRecoveryReasonCategory(latestRecoveryReason),
+    occurrenceCount: Math.max(
+      issueRecoveryEvents.length,
+      args.staleStabilizingNoPrRecoveryCount ?? 0,
+      1,
+    ),
+    lastRecoveredAt,
+    timeToLatestRecoveryMs: derivedRecoveryDelay,
+  };
+}
+
 export function buildExecutionMetricsRunSummaryArtifact(args: {
   issueNumber: number;
   terminalState: ExecutionMetricsRunSummaryArtifact["terminalState"];
@@ -78,11 +141,31 @@ export function buildExecutionMetricsRunSummaryArtifact(args: {
   finishedAt: string;
   blockedReason?: BlockedReason | null;
   failureKind?: FailureKind;
+  failureContext?: FailureContext | null;
+  repeatedFailureSignatureCount?: number;
   processedReviewThreadIds?: string[];
+  recoveryEvents?: RecoveryEvent[];
+  lastRecoveryReason?: string | null;
+  lastRecoveryAt?: string | null;
+  staleStabilizingNoPrRecoveryCount?: number;
 }): ExecutionMetricsRunSummaryArtifact {
   const issueCreatedAt = args.issueCreatedAt ?? null;
   const prCreatedAt = args.prCreatedAt ?? null;
   const prMergedAt = args.prMergedAt ?? null;
+  const failureMetrics = buildFailureMetrics({
+    failureContext: args.failureContext,
+    failureKind: args.failureKind,
+    blockedReason: args.blockedReason,
+    repeatedFailureSignatureCount: args.repeatedFailureSignatureCount,
+  });
+  const recoveryMetrics = buildRecoveryMetrics({
+    issueNumber: args.issueNumber,
+    failureMetrics,
+    recoveryEvents: args.recoveryEvents,
+    lastRecoveryReason: args.lastRecoveryReason,
+    lastRecoveryAt: args.lastRecoveryAt,
+    staleStabilizingNoPrRecoveryCount: args.staleStabilizingNoPrRecoveryCount,
+  });
 
   return {
     schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
@@ -99,5 +182,7 @@ export function buildExecutionMetricsRunSummaryArtifact(args: {
     issueToPrCreatedMs: durationMs(issueCreatedAt, prCreatedAt),
     prOpenDurationMs: durationMs(prCreatedAt, prMergedAt),
     reviewMetrics: buildReviewMetrics(args.processedReviewThreadIds ?? []),
+    failureMetrics,
+    recoveryMetrics,
   };
 }

--- a/src/supervisor/execution-metrics-run-summary.test.ts
+++ b/src/supervisor/execution-metrics-run-summary.test.ts
@@ -17,7 +17,7 @@ import { createConfig as createTurnConfig, createIssue, createPullRequest, creat
 import type { AgentRunner, AgentTurnRequest } from "./agent-runner";
 
 interface ExecutionMetricsRunSummary {
-  schemaVersion: 3;
+  schemaVersion: 4;
   issueNumber: number;
   terminalState: "done" | "blocked" | "failed";
   terminalOutcome: {
@@ -38,6 +38,33 @@ interface ExecutionMetricsRunSummary {
     iterationCount: number;
     totalCount: number;
     totalCountKind: "actionable_thread_instances";
+  } | null;
+  failureMetrics: {
+    classification: "latest_failure";
+    category: "checks" | "review" | "conflict" | "codex" | "manual" | "blocked";
+    failureKind: "timeout" | "command_error" | "codex_exit" | "codex_failed" | null;
+    blockedReason:
+      | "requirements"
+      | "clarification"
+      | "permissions"
+      | "secrets"
+      | "verification"
+      | "review_bot_timeout"
+      | "copilot_timeout"
+      | "manual_review"
+      | "manual_pr_closed"
+      | "handoff_missing"
+      | "unknown"
+      | null;
+    occurrenceCount: number;
+    lastOccurredAt: string;
+  } | null;
+  recoveryMetrics: {
+    classification: "latest_recovery";
+    reason: string;
+    occurrenceCount: number;
+    lastRecoveredAt: string;
+    timeToLatestRecoveryMs: number | null;
   } | null;
 }
 
@@ -277,7 +304,7 @@ test("prepareIssueExecutionContext writes a run summary artifact for done outcom
 
   const artifact = await readExecutionMetricsRunSummary(workspacePath);
   assert.deepEqual(artifact, {
-    schemaVersion: 3,
+    schemaVersion: 4,
     issueNumber: 240,
     terminalState: "done",
     terminalOutcome: {
@@ -294,6 +321,14 @@ test("prepareIssueExecutionContext writes a run summary artifact for done outcom
     issueToPrCreatedMs: 180000,
     prOpenDurationMs: 120000,
     reviewMetrics: null,
+    failureMetrics: null,
+    recoveryMetrics: {
+      classification: "latest_recovery",
+      reason: "merged_pr_convergence",
+      occurrenceCount: 1,
+      lastRecoveredAt: "2026-03-24T00:05:30Z",
+      timeToLatestRecoveryMs: null,
+    },
   });
 });
 
@@ -446,7 +481,7 @@ test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes",
   });
   const artifact = await readExecutionMetricsRunSummary(workspacePath);
   assert.deepEqual(artifact, {
-    schemaVersion: 3,
+    schemaVersion: 4,
     issueNumber: 102,
     terminalState: "blocked",
     terminalOutcome: {
@@ -468,6 +503,15 @@ test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes",
       totalCount: 3,
       totalCountKind: "actionable_thread_instances",
     },
+    failureMetrics: {
+      classification: "latest_failure",
+      category: "blocked",
+      failureKind: null,
+      blockedReason: "verification",
+      occurrenceCount: 1,
+      lastOccurredAt: "2026-03-24T01:05:00Z",
+    },
+    recoveryMetrics: null,
   });
 });
 
@@ -611,7 +655,7 @@ test("executeCodexTurnPhase writes a run summary artifact for failed outcomes", 
   });
   const artifact = await readExecutionMetricsRunSummary(workspacePath);
   assert.deepEqual(artifact, {
-    schemaVersion: 3,
+    schemaVersion: 4,
     issueNumber: 103,
     terminalState: "failed",
     terminalOutcome: {
@@ -628,5 +672,14 @@ test("executeCodexTurnPhase writes a run summary artifact for failed outcomes", 
     issueToPrCreatedMs: null,
     prOpenDurationMs: null,
     reviewMetrics: null,
+    failureMetrics: {
+      classification: "latest_failure",
+      category: "codex",
+      failureKind: "command_error",
+      blockedReason: null,
+      occurrenceCount: 1,
+      lastOccurredAt: artifact.finishedAt,
+    },
+    recoveryMetrics: null,
   });
 });

--- a/src/supervisor/execution-metrics-run-summary.ts
+++ b/src/supervisor/execution-metrics-run-summary.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { GitHubIssue, GitHubPullRequest, IssueRunRecord } from "../core/types";
+import type { RecoveryEvent } from "../run-once-cycle-prelude";
 import { isTerminalState, writeJsonAtomic } from "../core/utils";
 import {
   type ExecutionMetricsRunSummaryArtifact,
@@ -15,10 +16,21 @@ export async function syncExecutionMetricsRunSummary(args: {
   previousRecord: Pick<IssueRunRecord, "issue_number" | "updated_at">;
   nextRecord: Pick<
     IssueRunRecord,
-    "state" | "workspace" | "updated_at" | "blocked_reason" | "last_failure_kind" | "processed_review_thread_ids"
+    | "state"
+    | "workspace"
+    | "updated_at"
+    | "blocked_reason"
+    | "last_failure_kind"
+    | "last_failure_context"
+    | "repeated_failure_signature_count"
+    | "processed_review_thread_ids"
+    | "last_recovery_reason"
+    | "last_recovery_at"
+    | "stale_stabilizing_no_pr_recovery_count"
   >;
   issue?: Pick<GitHubIssue, "createdAt"> | null;
   pullRequest?: Pick<GitHubPullRequest, "createdAt" | "mergedAt"> | null;
+  recoveryEvents?: RecoveryEvent[];
 }): Promise<string | null> {
   const { state } = args.nextRecord;
   if (!isTerminalState(state) || !args.nextRecord.workspace) {
@@ -41,7 +53,13 @@ export async function syncExecutionMetricsRunSummary(args: {
     finishedAt: args.nextRecord.updated_at,
     blockedReason: args.nextRecord.blocked_reason,
     failureKind: args.nextRecord.last_failure_kind,
+    failureContext: args.nextRecord.last_failure_context,
+    repeatedFailureSignatureCount: args.nextRecord.repeated_failure_signature_count,
     processedReviewThreadIds: args.nextRecord.processed_review_thread_ids,
+    recoveryEvents: args.recoveryEvents,
+    lastRecoveryReason: args.nextRecord.last_recovery_reason,
+    lastRecoveryAt: args.nextRecord.last_recovery_at,
+    staleStabilizingNoPrRecoveryCount: args.nextRecord.stale_stabilizing_no_pr_recovery_count,
   });
 
   const artifactPath = executionMetricsRunSummaryPath(args.nextRecord.workspace);

--- a/src/supervisor/execution-metrics-schema.test.ts
+++ b/src/supervisor/execution-metrics-schema.test.ts
@@ -34,6 +34,21 @@ test("validateExecutionMetricsRunSummary accepts the versioned contract and reje
         totalCount: 3,
         totalCountKind: "actionable_thread_instances",
       },
+      failureMetrics: {
+        classification: "latest_failure",
+        category: "review",
+        failureKind: "command_error",
+        blockedReason: "verification",
+        occurrenceCount: 2,
+        lastOccurredAt: "2026-03-24T03:59:00Z",
+      },
+      recoveryMetrics: {
+        classification: "latest_recovery",
+        reason: "operator_requeue",
+        occurrenceCount: 1,
+        lastRecoveredAt: "2026-03-24T03:59:30Z",
+        timeToLatestRecoveryMs: 30000,
+      },
     }),
     {
       schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
@@ -58,13 +73,28 @@ test("validateExecutionMetricsRunSummary accepts the versioned contract and reje
         totalCount: 3,
         totalCountKind: "actionable_thread_instances",
       },
+      failureMetrics: {
+        classification: "latest_failure",
+        category: "review",
+        failureKind: "command_error",
+        blockedReason: "verification",
+        occurrenceCount: 2,
+        lastOccurredAt: "2026-03-24T03:59:00Z",
+      },
+      recoveryMetrics: {
+        classification: "latest_recovery",
+        reason: "operator_requeue",
+        occurrenceCount: 1,
+        lastRecoveredAt: "2026-03-24T03:59:30Z",
+        timeToLatestRecoveryMs: 30000,
+      },
     },
   );
 
   assert.throws(
     () =>
       validateExecutionMetricsRunSummary({
-        schemaVersion: 2,
+        schemaVersion: 3,
         issueNumber: 892,
         terminalState: "done",
         terminalOutcome: {
@@ -81,8 +111,10 @@ test("validateExecutionMetricsRunSummary accepts the versioned contract and reje
         issueToPrCreatedMs: 270000,
         prOpenDurationMs: 15000,
         reviewMetrics: null,
+        failureMetrics: null,
+        recoveryMetrics: null,
       }),
-    /schemaVersion must be 3/u,
+    /schemaVersion must be 4/u,
   );
 });
 
@@ -101,7 +133,12 @@ test("syncExecutionMetricsRunSummary rejects malformed run summaries before writ
         updated_at: "2026-03-24T04:00:00Z",
         blocked_reason: null,
         last_failure_kind: null,
+        last_failure_context: null,
+        repeated_failure_signature_count: 0,
         processed_review_thread_ids: [],
+        last_recovery_reason: null,
+        last_recovery_at: null,
+        stale_stabilizing_no_pr_recovery_count: 0,
       },
     }),
     /startedAt must be an ISO-8601 timestamp/u,
@@ -131,6 +168,8 @@ test("validateExecutionMetricsRunSummary rejects negative derived lifecycle dura
         issueToPrCreatedMs: 360000,
         prOpenDurationMs: 0,
         reviewMetrics: null,
+        failureMetrics: null,
+        recoveryMetrics: null,
       }),
     /prOpenDurationMs timestamps must be chronological/u,
   );
@@ -150,7 +189,12 @@ test("syncExecutionMetricsRunSummary records coarse review metrics from processe
       updated_at: "2026-03-24T04:05:00Z",
       blocked_reason: null,
       last_failure_kind: null,
+      last_failure_context: null,
+      repeated_failure_signature_count: 0,
       processed_review_thread_ids: ["thread-1@head-a", "thread-2@head-a", "thread-2@head-b"],
+      last_recovery_reason: null,
+      last_recovery_at: null,
+      stale_stabilizing_no_pr_recovery_count: 0,
     },
     issue: {
       createdAt: "2026-03-24T03:55:00Z",
@@ -164,7 +208,7 @@ test("syncExecutionMetricsRunSummary records coarse review metrics from processe
   assert.deepEqual(
     JSON.parse(await fs.readFile(executionMetricsRunSummaryPath(workspacePath), "utf8")),
     {
-      schemaVersion: 3,
+      schemaVersion: 4,
       issueNumber: 894,
       terminalState: "done",
       terminalOutcome: {
@@ -186,6 +230,8 @@ test("syncExecutionMetricsRunSummary records coarse review metrics from processe
         totalCount: 3,
         totalCountKind: "actionable_thread_instances",
       },
+      failureMetrics: null,
+      recoveryMetrics: null,
     },
   );
 });

--- a/src/supervisor/execution-metrics-schema.ts
+++ b/src/supervisor/execution-metrics-schema.ts
@@ -1,4 +1,6 @@
-export const EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION = 3;
+import type { BlockedReason, FailureContextCategory, FailureKind } from "../core/types";
+
+export const EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION = 4;
 const EXECUTION_METRICS_RUN_SUMMARY_KEYS = [
   "schemaVersion",
   "issueNumber",
@@ -14,11 +16,30 @@ const EXECUTION_METRICS_RUN_SUMMARY_KEYS = [
   "issueToPrCreatedMs",
   "prOpenDurationMs",
   "reviewMetrics",
+  "failureMetrics",
+  "recoveryMetrics",
 ] as const;
 const TERMINAL_STATES = ["done", "blocked", "failed"] as const;
 const TERMINAL_OUTCOME_CATEGORIES = ["completed", "blocked", "failed"] as const;
 const REVIEW_METRICS_CLASSIFICATIONS = ["configured_bot_threads"] as const;
 const REVIEW_METRICS_TOTAL_COUNT_KINDS = ["actionable_thread_instances"] as const;
+const FAILURE_METRICS_CLASSIFICATIONS = ["latest_failure"] as const;
+const FAILURE_METRICS_CATEGORIES = ["checks", "review", "conflict", "codex", "manual", "blocked"] as const;
+const FAILURE_METRICS_KINDS = ["timeout", "command_error", "codex_exit", "codex_failed"] as const;
+const FAILURE_METRICS_BLOCKED_REASONS = [
+  "requirements",
+  "clarification",
+  "permissions",
+  "secrets",
+  "verification",
+  "review_bot_timeout",
+  "copilot_timeout",
+  "manual_review",
+  "manual_pr_closed",
+  "handoff_missing",
+  "unknown",
+] as const;
+const RECOVERY_METRICS_CLASSIFICATIONS = ["latest_recovery"] as const;
 
 export interface ExecutionMetricsTerminalOutcome {
   category: (typeof TERMINAL_OUTCOME_CATEGORIES)[number];
@@ -30,6 +51,23 @@ export interface ExecutionMetricsReviewMetrics {
   iterationCount: number;
   totalCount: number;
   totalCountKind: (typeof REVIEW_METRICS_TOTAL_COUNT_KINDS)[number];
+}
+
+export interface ExecutionMetricsFailureMetrics {
+  classification: (typeof FAILURE_METRICS_CLASSIFICATIONS)[number];
+  category: Exclude<FailureContextCategory, null>;
+  failureKind: Exclude<FailureKind, null> | null;
+  blockedReason: Exclude<BlockedReason, null> | null;
+  occurrenceCount: number;
+  lastOccurredAt: string;
+}
+
+export interface ExecutionMetricsRecoveryMetrics {
+  classification: (typeof RECOVERY_METRICS_CLASSIFICATIONS)[number];
+  reason: string;
+  occurrenceCount: number;
+  lastRecoveredAt: string;
+  timeToLatestRecoveryMs: number | null;
 }
 
 export interface ExecutionMetricsRunSummaryArtifact {
@@ -47,6 +85,8 @@ export interface ExecutionMetricsRunSummaryArtifact {
   issueToPrCreatedMs: number | null;
   prOpenDurationMs: number | null;
   reviewMetrics: ExecutionMetricsReviewMetrics | null;
+  failureMetrics: ExecutionMetricsFailureMetrics | null;
+  recoveryMetrics: ExecutionMetricsRecoveryMetrics | null;
 }
 
 function failValidation(message: string): never {
@@ -171,6 +211,116 @@ function expectReviewMetrics(value: unknown): ExecutionMetricsReviewMetrics | nu
   };
 }
 
+function expectFailureMetrics(value: unknown): ExecutionMetricsFailureMetrics | null {
+  if (value === null) {
+    return null;
+  }
+
+  const failureMetrics = expectObject(value);
+  const keys = Object.keys(failureMetrics);
+  if (
+    keys.length !== 6 ||
+    !keys.includes("classification") ||
+    !keys.includes("category") ||
+    !keys.includes("failureKind") ||
+    !keys.includes("blockedReason") ||
+    !keys.includes("occurrenceCount") ||
+    !keys.includes("lastOccurredAt")
+  ) {
+    failValidation(
+      "failureMetrics must contain classification, category, failureKind, blockedReason, occurrenceCount, and lastOccurredAt.",
+    );
+  }
+
+  if (
+    typeof failureMetrics.classification !== "string" ||
+    !FAILURE_METRICS_CLASSIFICATIONS.includes(
+      failureMetrics.classification as ExecutionMetricsFailureMetrics["classification"],
+    )
+  ) {
+    failValidation(
+      `failureMetrics.classification must be one of: ${FAILURE_METRICS_CLASSIFICATIONS.join(", ")}.`,
+    );
+  }
+  if (
+    typeof failureMetrics.category !== "string" ||
+    !FAILURE_METRICS_CATEGORIES.includes(failureMetrics.category as ExecutionMetricsFailureMetrics["category"])
+  ) {
+    failValidation(`failureMetrics.category must be one of: ${FAILURE_METRICS_CATEGORIES.join(", ")}.`);
+  }
+  if (
+    failureMetrics.failureKind !== null &&
+    (typeof failureMetrics.failureKind !== "string" ||
+      !FAILURE_METRICS_KINDS.includes(failureMetrics.failureKind as Exclude<FailureKind, null>))
+  ) {
+    failValidation(`failureMetrics.failureKind must be one of: ${FAILURE_METRICS_KINDS.join(", ")} or null.`);
+  }
+  if (
+    failureMetrics.blockedReason !== null &&
+    (typeof failureMetrics.blockedReason !== "string" ||
+      !FAILURE_METRICS_BLOCKED_REASONS.includes(failureMetrics.blockedReason as Exclude<BlockedReason, null>))
+  ) {
+    failValidation(
+      `failureMetrics.blockedReason must be one of: ${FAILURE_METRICS_BLOCKED_REASONS.join(", ")} or null.`,
+    );
+  }
+
+  return {
+    classification: failureMetrics.classification as ExecutionMetricsFailureMetrics["classification"],
+    category: failureMetrics.category as ExecutionMetricsFailureMetrics["category"],
+    failureKind: failureMetrics.failureKind as ExecutionMetricsFailureMetrics["failureKind"],
+    blockedReason: failureMetrics.blockedReason as ExecutionMetricsFailureMetrics["blockedReason"],
+    occurrenceCount: expectNonNegativeInteger(failureMetrics.occurrenceCount, "failureMetrics.occurrenceCount"),
+    lastOccurredAt: expectIsoTimestamp(failureMetrics.lastOccurredAt, "failureMetrics.lastOccurredAt"),
+  };
+}
+
+function expectRecoveryMetrics(value: unknown): ExecutionMetricsRecoveryMetrics | null {
+  if (value === null) {
+    return null;
+  }
+
+  const recoveryMetrics = expectObject(value);
+  const keys = Object.keys(recoveryMetrics);
+  if (
+    keys.length !== 5 ||
+    !keys.includes("classification") ||
+    !keys.includes("reason") ||
+    !keys.includes("occurrenceCount") ||
+    !keys.includes("lastRecoveredAt") ||
+    !keys.includes("timeToLatestRecoveryMs")
+  ) {
+    failValidation(
+      "recoveryMetrics must contain classification, reason, occurrenceCount, lastRecoveredAt, and timeToLatestRecoveryMs.",
+    );
+  }
+
+  if (
+    typeof recoveryMetrics.classification !== "string" ||
+    !RECOVERY_METRICS_CLASSIFICATIONS.includes(
+      recoveryMetrics.classification as ExecutionMetricsRecoveryMetrics["classification"],
+    )
+  ) {
+    failValidation(
+      `recoveryMetrics.classification must be one of: ${RECOVERY_METRICS_CLASSIFICATIONS.join(", ")}.`,
+    );
+  }
+  if (typeof recoveryMetrics.reason !== "string" || recoveryMetrics.reason.trim().length === 0) {
+    failValidation("recoveryMetrics.reason must be a non-empty string.");
+  }
+
+  return {
+    classification: recoveryMetrics.classification as ExecutionMetricsRecoveryMetrics["classification"],
+    reason: recoveryMetrics.reason,
+    occurrenceCount: expectNonNegativeInteger(recoveryMetrics.occurrenceCount, "recoveryMetrics.occurrenceCount"),
+    lastRecoveredAt: expectIsoTimestamp(recoveryMetrics.lastRecoveredAt, "recoveryMetrics.lastRecoveredAt"),
+    timeToLatestRecoveryMs: expectNullableNonNegativeInteger(
+      recoveryMetrics.timeToLatestRecoveryMs,
+      "recoveryMetrics.timeToLatestRecoveryMs",
+    ),
+  };
+}
+
 function expectDerivedDuration(
   value: number | null,
   start: string | null,
@@ -221,11 +371,31 @@ export function validateExecutionMetricsRunSummary(raw: unknown): ExecutionMetri
   const issueToPrCreatedMs = expectNullableNonNegativeInteger(summary.issueToPrCreatedMs, "issueToPrCreatedMs");
   const prOpenDurationMs = expectNullableNonNegativeInteger(summary.prOpenDurationMs, "prOpenDurationMs");
   const reviewMetrics = expectReviewMetrics(summary.reviewMetrics);
+  const failureMetrics = expectFailureMetrics(summary.failureMetrics);
+  const recoveryMetrics = expectRecoveryMetrics(summary.recoveryMetrics);
 
   expectDerivedDuration(runDurationMs, startedAt, finishedAt, "runDurationMs");
   expectDerivedDuration(issueLeadTimeMs, issueCreatedAt, finishedAt, "issueLeadTimeMs");
   expectDerivedDuration(issueToPrCreatedMs, issueCreatedAt, prCreatedAt, "issueToPrCreatedMs");
   expectDerivedDuration(prOpenDurationMs, prCreatedAt, prMergedAt, "prOpenDurationMs");
+
+  if (failureMetrics && Date.parse(failureMetrics.lastOccurredAt) > Date.parse(finishedAt)) {
+    failValidation("failureMetrics.lastOccurredAt must not be after finishedAt.");
+  }
+  if (recoveryMetrics && Date.parse(recoveryMetrics.lastRecoveredAt) > Date.parse(finishedAt)) {
+    failValidation("recoveryMetrics.lastRecoveredAt must not be after finishedAt.");
+  }
+  if (
+    recoveryMetrics &&
+    failureMetrics &&
+    recoveryMetrics.timeToLatestRecoveryMs !== null &&
+    recoveryMetrics.timeToLatestRecoveryMs !== Date.parse(recoveryMetrics.lastRecoveredAt) - Date.parse(failureMetrics.lastOccurredAt)
+  ) {
+    failValidation("recoveryMetrics.timeToLatestRecoveryMs must equal the derived duration from the latest failure to the latest recovery.");
+  }
+  if (!failureMetrics && recoveryMetrics && recoveryMetrics.timeToLatestRecoveryMs !== null) {
+    failValidation("recoveryMetrics.timeToLatestRecoveryMs must be null when failureMetrics is absent.");
+  }
 
   return {
     schemaVersion: EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
@@ -242,5 +412,7 @@ export function validateExecutionMetricsRunSummary(raw: unknown): ExecutionMetri
     issueToPrCreatedMs,
     prOpenDurationMs,
     reviewMetrics,
+    failureMetrics,
+    recoveryMetrics,
   };
 }

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -230,6 +230,7 @@ async function ensureRecordJournalContext(
 interface PreparedIssueRunContext extends PreparedIssueExecutionContext {
   state: SupervisorStateFile;
   options: Pick<CliOptions, "dryRun">;
+  recoveryEvents: RecoveryEvent[];
   recoveryLog: string | null;
 }
 
@@ -607,6 +608,7 @@ export class Supervisor {
       memoryArtifacts,
       options,
       recoveryLog,
+      recoveryEvents,
     } = context;
     let record = context.record;
     let workspaceStatus = context.workspaceStatus;
@@ -658,6 +660,7 @@ export class Supervisor {
           nextRecord: record,
           issue,
           pullRequest: pr,
+          recoveryEvents,
         });
         await syncJournal(record);
         return prependRecoveryLog(
@@ -717,7 +720,7 @@ export class Supervisor {
         pr,
         options,
       });
-      record = await this.handlePostTurnMergeAndCompletion(state, issue, postTurn.record, postTurn.pr, options);
+      record = await this.handlePostTurnMergeAndCompletion(state, issue, postTurn.record, postTurn.pr, options, recoveryEvents);
       await syncJournal(record);
       return prependRecoveryLog(formatStatus(record), recoveryLog);
     }
@@ -767,6 +770,7 @@ export class Supervisor {
     record: IssueRunRecord,
     pr: GitHubPullRequest,
     options: Pick<CliOptions, "dryRun">,
+    recoveryEvents: RecoveryEvent[] = [],
   ): Promise<IssueRunRecord> {
     let nextRecord = record;
 
@@ -788,6 +792,7 @@ export class Supervisor {
       nextRecord,
       issue,
       pullRequest: pr,
+      recoveryEvents,
     });
     return nextRecord;
   }
@@ -1279,6 +1284,7 @@ export class Supervisor {
           ...preparedIssue,
           state,
           options,
+          recoveryEvents,
           recoveryLog,
         }),
       };


### PR DESCRIPTION
## Summary
- record structured failure and recovery blocks in execution metrics run summaries
- derive the metrics from persisted failure/recovery state and issue-scoped recovery events without changing recovery decisions
- add focused regression coverage for failure/recovery summaries and refresh the schema/run-summary tests

Closes #895

## Verification
- npm run build
- npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added failure and recovery metrics to execution summaries, including failure classification, recovery timing, and occurrence counts.

* **Tests**
  * Updated test suite to validate new failure and recovery metrics with schema version 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->