### PR TITLE
Retain execution metrics summaries beyond worktree cleanup

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,83 +1,64 @@
-# Issue #911: Execution metrics bug: keep run-summary validation from breaking legitimate terminal paths
+# Issue #912: Execution metrics durability: retain run summaries beyond worktree cleanup
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/911
-- Branch: codex/issue-911
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/912
+- Branch: codex/issue-912
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: draft_pr
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: 6c1bd02fbdb6149371077ce03ea0433a8adcce63
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d0a58c906a8e042ba9a289be9e5d80b22293d27c
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-23T22:37:08Z
+- Updated at: 2026-03-23T23:17:06.037Z
 
 ## Latest Codex Summary
-Normalized execution-metrics summary assembly so `finishedAt` now tracks the latest legitimate terminal observation instead of assuming the record timestamp is always last. That keeps run-summary validation from breaking merged-PR, closed-PR, and local-CI-blocked terminal paths, and it keeps metrics persistence observational-only instead of rerouting control flow into unexpected-failure recovery.
-
-Added focused regression coverage in [src/supervisor/execution-metrics-failure-recovery.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-911/src/supervisor/execution-metrics-failure-recovery.test.ts) and updated the issue journal in [.codex-supervisor/issue-journal.md](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-911/.codex-supervisor/issue-journal.md). The implementation change is in [src/supervisor/execution-metrics-lifecycle.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-911/src/supervisor/execution-metrics-lifecycle.ts). Commit: `6c1bd02fbdb6149371077ce03ea0433a8adcce63`.
-
-Summary: Normalized execution-metrics `finishedAt` to include later failure/recovery observations, added focused regression coverage, updated the issue journal, committed the fix, pushed `codex/issue-911`, and opened draft PR #921.
-State hint: pr_open
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/supervisor/execution-metrics-schema.test.ts`; `npx tsx --test src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-schema.test.ts`; `npm run build`
-Next action: monitor draft PR #921 and address CI or review feedback on `codex/issue-911`
-Failure signature: none
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: execution-metrics summaries should treat terminal `updated_at` as a lower bound, not a hard upper bound, because legitimate terminal transitions can record failure or recovery observations slightly later than the record timestamp.
-- What changed: updated `src/supervisor/execution-metrics-lifecycle.ts` so the run-summary artifact `finishedAt` becomes the latest of the terminal record timestamp, `failureMetrics.lastOccurredAt`, and `recoveryMetrics.lastRecoveredAt`; added regression coverage in `src/supervisor/execution-metrics-failure-recovery.test.ts` for the late-failure/late-recovery case; committed the fix as `6c1bd02`, pushed branch `codex/issue-911`, and opened draft PR #921 (`https://github.com/TommyKammy/codex-supervisor/pull/921`).
+- Hypothesis: execution-metrics durability should keep the per-worktree `run-summary.json` for local debugging, but also retain a second copy under a supervisor-owned path derived from `stateFile` so worktree cleanup cannot delete the aggregation source; daily rollups should read from that retained store through a supported CLI/runtime command.
+- What changed: added retained execution-metrics path helpers in `src/supervisor/execution-metrics-run-summary.ts`; `syncExecutionMetricsRunSummary()` now writes the existing worktree-local artifact and an optional retained copy under `<dirname(stateFile)>/execution-metrics/run-summaries/issue-<n>.json`; added retained-summary discovery and `syncRetainedExecutionMetricsDailyRollups()` in `src/supervisor/execution-metrics-aggregation.ts`; threaded the retention root through terminal summary writes in the preparation, execution, recovery, and supervisor failure paths; added the operator command `rollup-execution-metrics` through `src/core/types.ts`, `src/cli/parse-args.ts`, `src/cli/supervisor-runtime.ts`, `src/supervisor/supervisor-service.ts`, `src/supervisor/supervisor.ts`, and `src/supervisor/supervisor-mutation-report.ts`; documented the retained summary and rollup locations in `README.md` and `docs/getting-started.md`.
 - Current blocker: none
-- Next exact step: monitor draft PR #921 for CI and review feedback, then address any follow-up on top of `fb1ef9d7dc3d30f13897420e03d8d902a523cfaf`.
-- Verification gap: no known local gap in the targeted terminal-path regressions; broader execution-metrics aggregation/reporting coverage was not rerun beyond the prescribed issue checks and the focused lifecycle unit coverage.
-- Files touched: `src/supervisor/execution-metrics-lifecycle.ts`, `src/supervisor/execution-metrics-failure-recovery.test.ts`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: low; the change only broadens the summary artifact timestamp envelope so validation reflects legitimate terminal observations and cannot redirect supervisor control flow.
-- Last focused command: `npx tsx --test src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-schema.test.ts`
-- Last focused failure: initial `gh pr create` invocation printed `/bin/bash: line 1: finishedAt: command not found` because shell backticks in the PR body triggered command substitution, but the PR creation still succeeded as draft PR #921; the code fix itself has no remaining known local failure.
+- Next exact step: stage the issue-912 changes, create a checkpoint commit on `codex/issue-912`, and open or update a draft PR if one does not already exist.
+- Verification gap: no known local gap in the targeted durability and rollup paths; broader full-suite coverage was not rerun beyond the focused execution-metrics, runtime, and recovery tests plus `npm run build`.
+- Files touched: `src/supervisor/execution-metrics-run-summary.ts`, `src/supervisor/execution-metrics-aggregation.ts`, `src/run-once-issue-preparation.ts`, `src/run-once-turn-execution.ts`, `src/turn-execution-failure-helpers.ts`, `src/supervisor/supervisor-failure-helpers.ts`, `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-service.ts`, `src/supervisor/supervisor-mutation-report.ts`, `src/core/types.ts`, `src/cli/parse-args.ts`, `src/cli/supervisor-runtime.ts`, `src/supervisor/execution-metrics-schema.test.ts`, `src/supervisor/execution-metrics-aggregation.test.ts`, `src/cli/parse-args.test.ts`, `src/cli/entrypoint.test.ts`, `src/cli/supervisor-runtime.test.ts`, `src/supervisor/supervisor-recovery-failure-flows.test.ts`, `README.md`, `docs/getting-started.md`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: low; the changes only add retained observational artifacts and a new operator-triggered rollup path, without altering supervisor execution decisions or worktree cleanup eligibility.
+- Last focused command: `npx tsx --test src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-aggregation.test.ts src/cli/parse-args.test.ts src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts src/supervisor/supervisor-service.test.ts && npm run build`
+- Last focused failure: initial `npm run build` failed because `node_modules` was absent and `tsc` was not installed in the worktree; `npm ci` resolved the environment issue and the rerun passed.
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-911/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-911/context-index.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-912/AGENTS.generated.md
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-912/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
 git status --short
 git branch --show-current
-rg -n "run-summary|executionMetricsRunSummary|terminal.*path|closed|merged|local ci|local-CI|unexpected-failure|metrics validation|execution metrics" src
+rg -n "execution metrics|execution-metrics|run summary|run-summary|daily rollup|rollup|aggregate" src docs
 sed -n '1,260p' src/supervisor/execution-metrics-run-summary.ts
+sed -n '1,280p' src/supervisor/execution-metrics-aggregation.ts
+sed -n '1,320p' src/supervisor/execution-metrics-aggregation.test.ts
 sed -n '1,260p' src/supervisor/execution-metrics-schema.ts
-sed -n '240,420p' src/supervisor/execution-metrics-run-summary.test.ts
-sed -n '430,620p' src/run-once-issue-preparation.test.ts
-sed -n '360,520p' src/run-once-turn-execution.test.ts
-sed -n '1,260p' src/supervisor/execution-metrics-lifecycle.ts
-npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts
-npx tsx --test src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/supervisor/execution-metrics-schema.test.ts
-sed -n '300,430p' src/supervisor/execution-metrics-schema.ts
-sed -n '300,380p' src/run-once-turn-execution.test.ts
-rg -n "buildCodexFailureContext\(|updated_at: now\(|updated_at:" src | sed -n '1,200p'
-rg -n "function buildRecoveryEvent|const buildRecoveryEvent|buildRecoveryEvent\(" src | sed -n '1,120p'
+sed -n '1,240p' src/cli/entrypoint.ts
+sed -n '1,260p' src/cli/parse-args.ts
+sed -n '1,240p' src/cli/supervisor-runtime.ts
+sed -n '1,260p' src/supervisor/supervisor-service.ts
+sed -n '1,260p' src/core/types.ts
+sed -n '200,270p' src/core/workspace.ts
 apply_patch
 apply_patch
-npx tsx --test src/supervisor/execution-metrics-failure-recovery.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/supervisor/execution-metrics-schema.test.ts
+apply_patch
+npx tsx --test src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-aggregation.test.ts src/cli/parse-args.test.ts src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-service.test.ts
 npm run build
 test -d node_modules && echo present || echo missing
 sed -n '1,220p' package.json
 ls | rg 'package-lock.json|pnpm-lock.yaml|yarn.lock'
 npm ci
-npx tsx --test src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/execution-metrics-schema.test.ts
+npx tsx --test src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-aggregation.test.ts src/cli/parse-args.test.ts src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts src/supervisor/supervisor-service.test.ts
 npm run build
-date -u +"%Y-%m-%dT%H:%M:%SZ"
-git add .codex-supervisor/issue-journal.md src/supervisor/execution-metrics-failure-recovery.test.ts src/supervisor/execution-metrics-lifecycle.ts
-git commit -m "Normalize execution metrics terminal timestamps"
-git rev-parse HEAD
-git add .codex-supervisor/issue-journal.md
-git commit -m "Update issue 911 journal handoff"
-git push -u origin codex/issue-911
-gh pr create --draft --base main --head codex/issue-911 --title "Keep execution metrics validation from breaking legitimate terminal paths" --body ...
-gh pr view --json number,state,isDraft,headRefName,baseRefName,url,title
 ```
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Not a fit:
    ```bash
    node dist/index.js run-once --config /path/to/supervisor.config.json
    node dist/index.js status --config /path/to/supervisor.config.json
+   node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json
    node dist/index.js loop --config /path/to/supervisor.config.json
    ```
 
@@ -91,6 +92,8 @@ State-file contract: missing JSON state is an empty bootstrap case, but corrupte
 Workspace restore contract: `ensureWorkspace()` should prefer an existing local issue branch first, then an existing remote issue branch, and only then bootstrap a fresh issue branch from `origin/<defaultBranch>`. Bootstrapping from the default branch is the fallback path when no existing issue branch can be restored.
 
 Workspace cleanup contract: tracked done workspaces and orphaned workspaces are different cases. Tracked done workspace cleanup is the bounded delayed cleanup controlled by the done-workspace settings. An orphaned workspace is an untracked `issue-*` worktree under `workspaceRoot` that no longer has a live state entry; preserve locked, recent, or manually kept orphan workspaces, and only prune abandoned orphan workspaces through an explicit operator action rather than an implicit background cleanup.
+
+Execution metrics durability contract: terminal run summaries are retained under `<dirname(stateFile)>/execution-metrics/run-summaries/`, so worktree cleanup does not remove the aggregation source. Run `node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json` to write the current daily rollup to `<dirname(stateFile)>/execution-metrics/daily-rollups.json`.
 
 ## Provider Profiles
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,6 +146,7 @@ Start with a single supervised pass so you can inspect the repo selection, workt
 ```bash
 node dist/index.js run-once --config /path/to/supervisor.config.json
 node dist/index.js status --config /path/to/supervisor.config.json
+node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json
 ```
 
 What to check after `run-once`:
@@ -159,6 +160,8 @@ What to check after `run-once`:
 
 If the first pass picks the wrong issue, inspect `status` or `doctor` for the effective candidate discovery settings and then fix the issue metadata before running again. Do not treat issue creation time as the source of truth.
 If `status` or `doctor` reports corrupted JSON state, stop treating that file as a safe checkpoint. Inspect the file and recent operator actions first, then explicitly acknowledge the corruption or reset the state before trusting future runs.
+
+Execution metrics are retained independently of issue worktree cleanup. Terminal run summaries live under `<dirname(stateFile)>/execution-metrics/run-summaries/`, and `node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json` writes `<dirname(stateFile)>/execution-metrics/daily-rollups.json` from those retained summaries.
 
 ### Setup/readiness contract for first-run UX
 

--- a/src/cli/entrypoint.test.ts
+++ b/src/cli/entrypoint.test.ts
@@ -162,6 +162,29 @@ test("runCli routes requeue through the supervisor runtime boundary", async () =
   });
 });
 
+test("runCli routes rollup-execution-metrics through the supervisor runtime boundary", async () => {
+  const service = { tag: "service" };
+  let runtimeCommand: Record<string, unknown> | undefined;
+
+  await runCli(["rollup-execution-metrics"], {
+    createSupervisorService: () => service as never,
+    runSupervisorCommand: async (command, dependencies) => {
+      runtimeCommand = {
+        ...command,
+        service: dependencies.service,
+      };
+    },
+  });
+
+  assert.deepEqual(runtimeCommand, {
+    command: "rollup-execution-metrics",
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    service,
+  });
+});
+
 test("runCli routes reset-corrupt-json-state through the supervisor runtime boundary", async () => {
   const service = { tag: "service" };
   let runtimeCommand: Record<string, unknown> | undefined;

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -54,6 +54,19 @@ test("parseArgs accepts requeue with an issue number", () => {
   });
 });
 
+test("parseArgs accepts rollup-execution-metrics without an issue number", () => {
+  assert.deepEqual(parseArgs(["rollup-execution-metrics"]), {
+    command: "rollup-execution-metrics",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
 test("parseArgs accepts reset-corrupt-json-state without an issue number", () => {
   assert.deepEqual(parseArgs(["reset-corrupt-json-state"]), {
     command: "reset-corrupt-json-state",

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -23,6 +23,7 @@ export function parseArgs(argv: string[]): CliOptions {
       token === "loop" ||
       token === "status" ||
       token === "requeue" ||
+      token === "rollup-execution-metrics" ||
       token === "prune-orphaned-workspaces" ||
       token === "reset-corrupt-json-state" ||
       token === "explain" ||

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -694,6 +694,63 @@ test("runSupervisorCommand renders a structured requeue result", async () => {
   });
 });
 
+test("runSupervisorCommand renders a structured execution metrics rollup result", async () => {
+  const stdout: string[] = [];
+
+  await runSupervisorCommand(
+    { command: "rollup-execution-metrics", dryRun: false, why: false, issueNumber: undefined },
+    {
+      service: {
+        config: {} as SupervisorConfig,
+        pollIntervalMs: async () => 50,
+        runOnce: async () => {
+          throw new Error("unexpected runOnce");
+        },
+        queryStatus: async () => {
+          throw new Error("unexpected queryStatus");
+        },
+        queryExplain: async () => {
+          throw new Error("unexpected queryExplain");
+        },
+        queryIssueLint: async () => {
+          throw new Error("unexpected queryIssueLint");
+        },
+        queryDoctor: async () => {
+          throw new Error("unexpected queryDoctor");
+        },
+        runRecoveryAction: async () => {
+          throw new Error("unexpected runRecoveryAction");
+        },
+        pruneOrphanedWorkspaces: async () => {
+          throw new Error("unexpected pruneOrphanedWorkspaces");
+        },
+        rollupExecutionMetrics: async () => ({
+          action: "rollup-execution-metrics",
+          outcome: "completed",
+          summary: "Wrote daily execution metrics rollups from 2 retained run summaries.",
+          artifactPath: "/tmp/.local/execution-metrics/daily-rollups.json",
+          runSummaryCount: 2,
+        }),
+        resetCorruptJsonState: async () => {
+          throw new Error("unexpected resetCorruptJsonState");
+        },
+      },
+      writeStdout: (line) => {
+        stdout.push(line);
+      },
+    },
+  );
+
+  assert.equal(stdout.length, 1);
+  assert.deepEqual(JSON.parse(stdout[0] ?? ""), {
+    action: "rollup-execution-metrics",
+    outcome: "completed",
+    summary: "Wrote daily execution metrics rollups from 2 retained run summaries.",
+    artifactPath: "/tmp/.local/execution-metrics/daily-rollups.json",
+    runSummaryCount: 2,
+  });
+});
+
 test("runSupervisorCommand renders a structured orphan prune result", async () => {
   const stdout: string[] = [];
 

--- a/src/cli/supervisor-runtime.ts
+++ b/src/cli/supervisor-runtime.ts
@@ -4,6 +4,7 @@ import { sleep as defaultSleep } from "../core/utils";
 import { ensureGsdInstalled as defaultEnsureGsdInstalled } from "../gsd";
 import { renderDoctorReport } from "../doctor";
 import { renderJsonCorruptStateResetResultDto } from "../supervisor/supervisor-mutation-report";
+import { renderSupervisorExecutionMetricsRollupResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderSupervisorMutationResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderSupervisorOrphanPruneResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderIssueExplainDto } from "../supervisor/supervisor-selection-status";
@@ -19,6 +20,7 @@ type SupervisorRuntimeCommand = Extract<
   | "loop"
   | "status"
   | "requeue"
+  | "rollup-execution-metrics"
   | "prune-orphaned-workspaces"
   | "reset-corrupt-json-state"
   | "explain"
@@ -50,6 +52,7 @@ export function isSupervisorRuntimeCommand(command: CliOptions["command"]): comm
     command === "loop" ||
     command === "status" ||
     command === "requeue" ||
+    command === "rollup-execution-metrics" ||
     command === "prune-orphaned-workspaces" ||
     command === "reset-corrupt-json-state" ||
     command === "explain" ||
@@ -63,6 +66,7 @@ function requiresGsdInstall(command: SupervisorRuntimeCommand): boolean {
   return (
     command !== "status" &&
     command !== "requeue" &&
+    command !== "rollup-execution-metrics" &&
     command !== "prune-orphaned-workspaces" &&
     command !== "reset-corrupt-json-state" &&
     command !== "explain" &&
@@ -146,6 +150,14 @@ export async function runSupervisorCommand(
 
   if (options.command === "requeue") {
     writeStdout(renderSupervisorMutationResultDto(await service.runRecoveryAction("requeue", options.issueNumber!)));
+    return;
+  }
+
+  if (options.command === "rollup-execution-metrics") {
+    if (!service.rollupExecutionMetrics) {
+      throw new Error("Missing supervisor execution metrics rollup support.");
+    }
+    writeStdout(renderSupervisorExecutionMetricsRollupResultDto(await service.rollupExecutionMetrics()));
     return;
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -406,6 +406,7 @@ export interface CliOptions {
     | "loop"
     | "status"
     | "requeue"
+    | "rollup-execution-metrics"
     | "prune-orphaned-workspaces"
     | "reset-corrupt-json-state"
     | "explain"

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -28,7 +28,10 @@ import {
 import { shouldPreserveNoPrFailureTracking } from "./no-pull-request-state";
 import { runLocalCiGate, type LocalCiCommandRunner } from "./local-ci";
 import { writeSupervisorCycleDecisionSnapshot as writeSupervisorCycleDecisionSnapshotImpl } from "./supervisor/supervisor-cycle-snapshot";
-import { syncExecutionMetricsRunSummary } from "./supervisor/execution-metrics-run-summary";
+import {
+  executionMetricsRetentionRootPath,
+  syncExecutionMetricsRunSummary,
+} from "./supervisor/execution-metrics-run-summary";
 
 export type IssueJournalSync = (record: IssueRunRecord) => Promise<void>;
 export type MemoryArtifacts = Awaited<ReturnType<typeof syncMemoryArtifactsImpl>>;
@@ -320,6 +323,7 @@ async function hydratePullRequestContext(
         issue: args.issue,
         pullRequest: resolvedPr,
         recoveryEvents: [recoveryEvent],
+        retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
       });
       return { kind: "restart", recoveryEvents: [recoveryEvent] };
     } else if (resolvedPr.state === "CLOSED") {
@@ -358,6 +362,7 @@ async function hydratePullRequestContext(
         nextRecord: blockedRecord,
         issue: args.issue,
         pullRequest: resolvedPr,
+        retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
       });
       await args.syncJournal(blockedRecord);
       return `Issue #${blockedRecord.issue_number} blocked because PR #${resolvedPr.number} was closed without merge.`;
@@ -398,6 +403,7 @@ async function hydratePullRequestContext(
         previousRecord: record,
         nextRecord: blockedRecord,
         issue: args.issue,
+        retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
       });
       await args.syncJournal(blockedRecord);
       return `Issue #${blockedRecord.issue_number} blocked: ${blockedRecord.last_error}`;

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -43,7 +43,10 @@ import {
 import { truncate } from "./core/utils";
 import { getWorkspaceStatus, pushBranch } from "./core/workspace";
 import { AgentRunner, createCodexAgentRunner } from "./supervisor/agent-runner";
-import { syncExecutionMetricsRunSummary } from "./supervisor/execution-metrics-run-summary";
+import {
+  executionMetricsRetentionRootPath,
+  syncExecutionMetricsRunSummary,
+} from "./supervisor/execution-metrics-run-summary";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -89,6 +92,7 @@ export interface CodexTurnShortCircuit {
 }
 
 interface RecoverUnexpectedCodexTurnFailureArgs {
+  config: Pick<SupervisorConfig, "stateFile">;
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
   record: IssueRunRecord;
@@ -155,6 +159,7 @@ interface ExecuteCodexTurnPhaseArgs {
       record: IssueRunRecord,
       failureContext: FailureContext | null,
     ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   persistCodexTurnExitFailure?: (args: {
     stateStore: Pick<StateStore, "touch" | "save">;
@@ -174,6 +179,7 @@ interface ExecuteCodexTurnPhaseArgs {
       record: IssueRunRecord,
       failureContext: FailureContext | null,
     ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   persistMissingCodexJournalHandoff?: (args: {
     stateStore: Pick<StateStore, "touch" | "save">;
@@ -191,6 +197,7 @@ interface ExecuteCodexTurnPhaseArgs {
       record: IssueRunRecord,
       failureContext: FailureContext | null,
     ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   persistHintedCodexTurnState?: (args: {
     stateStore: Pick<StateStore, "touch" | "save">;
@@ -214,6 +221,7 @@ interface ExecuteCodexTurnPhaseArgs {
     ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
     normalizeBlockerSignature: (message: string | null | undefined) => string | null;
     isVerificationBlockedMessage: (message: string | null | undefined) => boolean;
+    retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   getWorkspaceStatus?: typeof getWorkspaceStatus;
   pushBranch?: typeof pushBranch;
@@ -329,6 +337,7 @@ export async function executeCodexTurnPhase(
           issueNumber: record.issue_number,
           buildCodexFailureContext: args.buildCodexFailureContext,
           applyFailureSignature: args.applyFailureSignature,
+          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
         });
         return {
           kind: "returned",
@@ -353,6 +362,7 @@ export async function executeCodexTurnPhase(
           classifyFailure: args.classifyFailure,
           buildCodexFailureContext: args.buildCodexFailureContext,
           applyFailureSignature: args.applyFailureSignature,
+          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
         });
         return {
           kind: "returned",
@@ -376,6 +386,7 @@ export async function executeCodexTurnPhase(
           classifyFailure: args.classifyFailure,
           buildCodexFailureContext: args.buildCodexFailureContext,
           applyFailureSignature: args.applyFailureSignature,
+          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
         });
         return {
           kind: "returned",
@@ -399,6 +410,7 @@ export async function executeCodexTurnPhase(
           applyFailureSignature: args.applyFailureSignature,
           normalizeBlockerSignature: args.normalizeBlockerSignature,
           isVerificationBlockedMessage: args.isVerificationBlockedMessage,
+          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
         });
         return {
           kind: "returned",
@@ -455,6 +467,7 @@ export async function executeCodexTurnPhase(
             previousRecord: args.context.record,
             nextRecord: record,
             issue,
+            retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
           });
           await syncJournal(record);
           return {
@@ -540,6 +553,7 @@ export async function executeCodexTurnPhase(
         nextRecord: record,
         issue,
         pullRequest: pr,
+        retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
       });
       await syncJournal(record);
 
@@ -556,6 +570,7 @@ export async function executeCodexTurnPhase(
     }
   } catch (error) {
     record = await args.recoverUnexpectedCodexTurnFailure({
+      config,
       stateStore,
       state,
       record,

--- a/src/supervisor/execution-metrics-aggregation.test.ts
+++ b/src/supervisor/execution-metrics-aggregation.test.ts
@@ -5,9 +5,13 @@ import path from "node:path";
 import test from "node:test";
 import {
   buildExecutionMetricsDailyRollupsArtifact,
+  executionMetricsDailyRollupsPath,
+  listRetainedExecutionMetricsRunSummaryPaths,
+  syncRetainedExecutionMetricsDailyRollups,
   syncExecutionMetricsDailyRollups,
 } from "./execution-metrics-aggregation";
 import type { ExecutionMetricsRunSummaryArtifact } from "./execution-metrics-schema";
+import { executionMetricsRetentionRootPath, retainedExecutionMetricsRunSummaryPath } from "./execution-metrics-run-summary";
 
 function createRunSummary(
   issueNumber: number,
@@ -244,4 +248,125 @@ test("daily rollups aggregate persisted run summaries by finished-at day", async
 
   assert.equal(context.artifactPath, outputPath);
   assert.deepEqual(JSON.parse(await fs.readFile(outputPath, "utf8")), artifact);
+});
+
+test("retained daily rollups load summaries from the durable retention root", async () => {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), "execution-metrics-retained-rollups-"));
+  const stateFilePath = path.join(rootPath, ".local", "state.json");
+  const retentionRootPath = executionMetricsRetentionRootPath(stateFilePath);
+  const summaryA = createRunSummary(201);
+  const summaryB = createRunSummary(202, {
+    terminalState: "failed",
+    terminalOutcome: {
+      category: "failed",
+      reason: "command_error",
+    },
+    issueCreatedAt: "2026-03-25T00:00:00Z",
+    startedAt: "2026-03-25T02:00:00Z",
+    prCreatedAt: null,
+    prMergedAt: null,
+    finishedAt: "2026-03-25T03:00:00Z",
+    runDurationMs: 3_600_000,
+    issueLeadTimeMs: 10_800_000,
+    issueToPrCreatedMs: null,
+    prOpenDurationMs: null,
+    reviewMetrics: null,
+    failureMetrics: {
+      classification: "latest_failure",
+      category: "codex",
+      failureKind: "command_error",
+      blockedReason: null,
+      occurrenceCount: 1,
+      lastOccurredAt: "2026-03-25T03:00:00Z",
+    },
+  });
+  await fs.mkdir(path.dirname(retainedExecutionMetricsRunSummaryPath(retentionRootPath, 201)), { recursive: true });
+  await fs.writeFile(
+    retainedExecutionMetricsRunSummaryPath(retentionRootPath, 201),
+    `${JSON.stringify(summaryA, null, 2)}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    retainedExecutionMetricsRunSummaryPath(retentionRootPath, 202),
+    `${JSON.stringify(summaryB, null, 2)}\n`,
+    "utf8",
+  );
+
+  assert.deepEqual(await listRetainedExecutionMetricsRunSummaryPaths(retentionRootPath), [
+    retainedExecutionMetricsRunSummaryPath(retentionRootPath, 201),
+    retainedExecutionMetricsRunSummaryPath(retentionRootPath, 202),
+  ]);
+
+  const result = await syncRetainedExecutionMetricsDailyRollups({
+    stateFilePath,
+    generatedAt: "2026-03-26T00:00:00Z",
+  });
+
+  assert.deepEqual(result, {
+    artifactPath: executionMetricsDailyRollupsPath(retentionRootPath),
+    runSummaryCount: 2,
+  });
+  assert.deepEqual(JSON.parse(await fs.readFile(result.artifactPath, "utf8")), {
+    schemaVersion: 1,
+    generatedAt: "2026-03-26T00:00:00Z",
+    days: [
+      {
+        day: "2026-03-24",
+        runCount: 1,
+        terminalStates: {
+          done: 1,
+          blocked: 0,
+          failed: 0,
+        },
+        leadTimeMs: {
+          average: 10_800_000,
+          total: 10_800_000,
+          count: 1,
+        },
+        reviewIterations: {
+          average: 2,
+          total: 2,
+          count: 1,
+        },
+        reviewThreadInstances: {
+          average: 4,
+          total: 4,
+          count: 1,
+        },
+        failurePatterns: [],
+      },
+      {
+        day: "2026-03-25",
+        runCount: 1,
+        terminalStates: {
+          done: 0,
+          blocked: 0,
+          failed: 1,
+        },
+        leadTimeMs: {
+          average: 10_800_000,
+          total: 10_800_000,
+          count: 1,
+        },
+        reviewIterations: {
+          average: null,
+          total: 0,
+          count: 0,
+        },
+        reviewThreadInstances: {
+          average: null,
+          total: 0,
+          count: 0,
+        },
+        failurePatterns: [
+          {
+            category: "codex",
+            failureKind: "command_error",
+            blockedReason: null,
+            count: 1,
+          },
+        ],
+      },
+    ],
+  });
 });

--- a/src/supervisor/execution-metrics-aggregation.ts
+++ b/src/supervisor/execution-metrics-aggregation.ts
@@ -1,9 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { nowIso, readJsonIfExists, writeJsonAtomic } from "../core/utils";
 import {
   type ExecutionMetricsFailureMetrics,
   type ExecutionMetricsRunSummaryArtifact,
   validateExecutionMetricsRunSummary,
 } from "./execution-metrics-schema";
+import { executionMetricsRetentionRootPath } from "./execution-metrics-run-summary";
 
 export const EXECUTION_METRICS_DAILY_ROLLUPS_SCHEMA_VERSION = 1;
 
@@ -40,6 +43,28 @@ export interface ExecutionMetricsDailyRollupsArtifact {
   schemaVersion: typeof EXECUTION_METRICS_DAILY_ROLLUPS_SCHEMA_VERSION;
   generatedAt: string;
   days: ExecutionMetricsDailyRollup[];
+}
+
+export function executionMetricsDailyRollupsPath(retentionRootPath: string): string {
+  return path.join(retentionRootPath, "daily-rollups.json");
+}
+
+export async function listRetainedExecutionMetricsRunSummaryPaths(retentionRootPath: string): Promise<string[]> {
+  const summariesRoot = path.join(retentionRootPath, "run-summaries");
+  let entries: string[];
+  try {
+    entries = await fs.readdir(summariesRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  return entries
+    .filter((entry) => entry.endsWith(".json"))
+    .sort((left, right) => left.localeCompare(right))
+    .map((entry) => path.join(summariesRoot, entry));
 }
 
 interface ExecutionMetricsDailyRollupInput {
@@ -217,4 +242,21 @@ export async function syncExecutionMetricsDailyRollups(args: {
   });
   await writeJsonAtomic(args.outputPath, artifact);
   return { artifactPath: args.outputPath };
+}
+
+export async function syncRetainedExecutionMetricsDailyRollups(args: {
+  stateFilePath: string;
+  generatedAt?: string;
+}): Promise<{ artifactPath: string; runSummaryCount: number }> {
+  const retentionRootPath = executionMetricsRetentionRootPath(args.stateFilePath);
+  const runSummaryPaths = await listRetainedExecutionMetricsRunSummaryPaths(retentionRootPath);
+  const context = await syncExecutionMetricsDailyRollups({
+    outputPath: executionMetricsDailyRollupsPath(retentionRootPath),
+    runSummaryPaths,
+    generatedAt: args.generatedAt,
+  });
+  return {
+    artifactPath: context.artifactPath,
+    runSummaryCount: runSummaryPaths.length,
+  };
 }

--- a/src/supervisor/execution-metrics-run-summary.ts
+++ b/src/supervisor/execution-metrics-run-summary.ts
@@ -12,6 +12,14 @@ export function executionMetricsRunSummaryPath(workspacePath: string): string {
   return path.join(workspacePath, ".codex-supervisor", "execution-metrics", "run-summary.json");
 }
 
+export function executionMetricsRetentionRootPath(stateFilePath: string): string {
+  return path.join(path.dirname(stateFilePath), "execution-metrics");
+}
+
+export function retainedExecutionMetricsRunSummaryPath(retentionRootPath: string, issueNumber: number): string {
+  return path.join(retentionRootPath, "run-summaries", `issue-${issueNumber}.json`);
+}
+
 export async function syncExecutionMetricsRunSummary(args: {
   previousRecord: Pick<IssueRunRecord, "issue_number" | "updated_at">;
   nextRecord: Pick<
@@ -31,6 +39,7 @@ export async function syncExecutionMetricsRunSummary(args: {
   issue?: Pick<GitHubIssue, "createdAt"> | null;
   pullRequest?: Pick<GitHubPullRequest, "createdAt" | "mergedAt"> | null;
   recoveryEvents?: RecoveryEvent[];
+  retentionRootPath?: string;
 }): Promise<string | null> {
   const { state } = args.nextRecord;
   if (!isTerminalState(state) || !args.nextRecord.workspace) {
@@ -63,6 +72,13 @@ export async function syncExecutionMetricsRunSummary(args: {
   });
 
   const artifactPath = executionMetricsRunSummaryPath(args.nextRecord.workspace);
-  await writeJsonAtomic(artifactPath, validateExecutionMetricsRunSummary(artifact));
+  const validatedArtifact = validateExecutionMetricsRunSummary(artifact);
+  await writeJsonAtomic(artifactPath, validatedArtifact);
+  if (args.retentionRootPath) {
+    await writeJsonAtomic(
+      retainedExecutionMetricsRunSummaryPath(args.retentionRootPath, args.previousRecord.issue_number),
+      validatedArtifact,
+    );
+  }
   return artifactPath;
 }

--- a/src/supervisor/execution-metrics-schema.test.ts
+++ b/src/supervisor/execution-metrics-schema.test.ts
@@ -7,7 +7,12 @@ import {
   EXECUTION_METRICS_RUN_SUMMARY_SCHEMA_VERSION,
   validateExecutionMetricsRunSummary,
 } from "./execution-metrics-schema";
-import { executionMetricsRunSummaryPath, syncExecutionMetricsRunSummary } from "./execution-metrics-run-summary";
+import {
+  executionMetricsRetentionRootPath,
+  executionMetricsRunSummaryPath,
+  retainedExecutionMetricsRunSummaryPath,
+  syncExecutionMetricsRunSummary,
+} from "./execution-metrics-run-summary";
 
 test("validateExecutionMetricsRunSummary accepts the versioned contract and rejects unsupported schema versions", () => {
   assert.deepEqual(
@@ -234,4 +239,44 @@ test("syncExecutionMetricsRunSummary records coarse review metrics from processe
       recoveryMetrics: null,
     },
   );
+});
+
+test("syncExecutionMetricsRunSummary retains a durable copy outside the workspace lifecycle", async () => {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), "execution-metrics-retained-"));
+  const workspacePath = path.join(rootPath, "workspaces", "issue-895");
+  const stateFilePath = path.join(rootPath, ".local", "state.json");
+  const retentionRootPath = executionMetricsRetentionRootPath(stateFilePath);
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  await syncExecutionMetricsRunSummary({
+    previousRecord: {
+      issue_number: 895,
+      updated_at: "2026-03-24T04:00:00Z",
+    },
+    nextRecord: {
+      state: "done",
+      workspace: workspacePath,
+      updated_at: "2026-03-24T04:05:00Z",
+      blocked_reason: null,
+      last_failure_kind: null,
+      last_failure_context: null,
+      repeated_failure_signature_count: 0,
+      processed_review_thread_ids: [],
+      last_recovery_reason: null,
+      last_recovery_at: null,
+      stale_stabilizing_no_pr_recovery_count: 0,
+    },
+    retentionRootPath,
+  });
+
+  const retainedPath = retainedExecutionMetricsRunSummaryPath(retentionRootPath, 895);
+  assert.deepEqual(
+    JSON.parse(await fs.readFile(retainedPath, "utf8")),
+    JSON.parse(await fs.readFile(executionMetricsRunSummaryPath(workspacePath), "utf8")),
+  );
+
+  await fs.rm(workspacePath, { recursive: true, force: true });
+
+  await assert.rejects(fs.stat(executionMetricsRunSummaryPath(workspacePath)), { code: "ENOENT" });
+  assert.equal(JSON.parse(await fs.readFile(retainedPath, "utf8")).issueNumber, 895);
 });

--- a/src/supervisor/supervisor-failure-helpers.ts
+++ b/src/supervisor/supervisor-failure-helpers.ts
@@ -10,7 +10,10 @@ import {
   WorkspaceStatus,
 } from "../core/types";
 import { nowIso, truncate } from "../core/utils";
-import { syncExecutionMetricsRunSummary } from "./execution-metrics-run-summary";
+import {
+  executionMetricsRetentionRootPath,
+  syncExecutionMetricsRunSummary,
+} from "./execution-metrics-run-summary";
 
 type AuthFailureGitHub = Pick<GitHubClient, "authStatus">;
 type FailureHelperStateStore = Pick<StateStore, "save" | "touch">;
@@ -120,6 +123,7 @@ export async function handleAuthFailure(
 }
 
 export async function recoverUnexpectedCodexTurnFailure(args: {
+  config: Pick<SupervisorConfig, "stateFile">;
   stateStore: FailureHelperStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
@@ -129,7 +133,7 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha"> | null;
   pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "createdAt" | "mergedAt"> | null;
 }): Promise<IssueRunRecord> {
-  const { stateStore, state, record, issue, journalSync, error, workspaceStatus, pr } = args;
+  const { config, stateStore, state, record, issue, journalSync, error, workspaceStatus, pr } = args;
   const message = error instanceof Error ? error.stack ?? error.message : String(error);
   const failureKind = classifyFailure(message);
   const failureContext = buildCodexFailureContext(
@@ -169,6 +173,7 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
       nextRecord: updated,
       issue,
       pullRequest: pr,
+      retentionRootPath: executionMetricsRetentionRootPath(config.stateFile),
     });
   } catch (metricsError) {
     console.warn(

--- a/src/supervisor/supervisor-mutation-report.ts
+++ b/src/supervisor/supervisor-mutation-report.ts
@@ -2,6 +2,7 @@ import type { IssueRunRecord, JsonCorruptStateResetResult, RunState } from "../c
 
 export type SupervisorRecoveryAction = "requeue";
 export type SupervisorOrphanPruneAction = "prune-orphaned-workspaces";
+export type SupervisorExecutionMetricsRollupAction = "rollup-execution-metrics";
 
 export type SupervisorMutationRecordSnapshotDto = Pick<
   IssueRunRecord,
@@ -66,6 +67,14 @@ export interface SupervisorOrphanPruneResultDto {
   skipped: SkippedOrphanedWorkspaceResultDto[];
 }
 
+export interface SupervisorExecutionMetricsRollupResultDto {
+  action: SupervisorExecutionMetricsRollupAction;
+  outcome: "completed" | "rejected";
+  summary: string;
+  artifactPath: string | null;
+  runSummaryCount: number;
+}
+
 export function buildSupervisorMutationRecordSnapshot(
   record: IssueRunRecord,
 ): SupervisorMutationRecordSnapshotDto {
@@ -104,6 +113,10 @@ export function renderSupervisorMutationResultDto(dto: SupervisorMutationResultD
 }
 
 export function renderSupervisorOrphanPruneResultDto(dto: SupervisorOrphanPruneResultDto): string {
+  return JSON.stringify(dto);
+}
+
+export function renderSupervisorExecutionMetricsRollupResultDto(dto: SupervisorExecutionMetricsRollupResultDto): string {
   return JSON.stringify(dto);
 }
 

--- a/src/supervisor/supervisor-recovery-failure-flows.test.ts
+++ b/src/supervisor/supervisor-recovery-failure-flows.test.ts
@@ -132,6 +132,7 @@ test("recoverUnexpectedCodexTurnFailure preserves dirty recovery context and tim
   };
 
   const updated = await recoverUnexpectedCodexTurnFailure({
+    config: { stateFile: "/tmp/state.json" },
     stateStore: stateStore as unknown as Parameters<typeof recoverUnexpectedCodexTurnFailure>[0]["stateStore"],
     state,
     record,
@@ -202,6 +203,7 @@ test("recoverUnexpectedCodexTurnFailure records unavailable workspace inspection
   };
 
   const updated = await recoverUnexpectedCodexTurnFailure({
+    config: { stateFile: "/tmp/state.json" },
     stateStore: stateStore as unknown as Parameters<typeof recoverUnexpectedCodexTurnFailure>[0]["stateStore"],
     state,
     record,
@@ -259,6 +261,7 @@ test("recoverUnexpectedCodexTurnFailure continues journal sync when run summary 
 
   try {
     const updated = await recoverUnexpectedCodexTurnFailure({
+      config: { stateFile: "/tmp/state.json" },
       stateStore: {
         touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
           return { ...current, ...patch, updated_at: "2026-03-24T04:00:00.000Z" };

--- a/src/supervisor/supervisor-service.ts
+++ b/src/supervisor/supervisor-service.ts
@@ -4,6 +4,7 @@ import type { SetupConfigPreview, SetupConfigPreviewSelectableReviewProviderProf
 import type { SetupConfigChanges, SetupConfigUpdateResult } from "../setup-config-write";
 import type { SetupReadinessReport } from "../setup-readiness";
 import type {
+  SupervisorExecutionMetricsRollupResultDto,
   SupervisorMutationResultDto,
   SupervisorOrphanPruneResultDto,
   SupervisorRecoveryAction,
@@ -23,6 +24,7 @@ export interface SupervisorService {
   queryStatus: (options: Pick<CliOptions, "why">) => Promise<SupervisorStatusDto>;
   runRecoveryAction: (action: SupervisorRecoveryAction, issueNumber: number) => Promise<SupervisorMutationResultDto>;
   pruneOrphanedWorkspaces: () => Promise<SupervisorOrphanPruneResultDto>;
+  rollupExecutionMetrics?: () => Promise<SupervisorExecutionMetricsRollupResultDto>;
   resetCorruptJsonState: () => Promise<JsonCorruptStateResetResult>;
   queryExplain: (issueNumber: number) => Promise<SupervisorExplainDto>;
   queryIssueLint: (issueNumber: number) => Promise<SupervisorIssueLintDto>;
@@ -86,6 +88,10 @@ class SupervisorApplicationService implements SupervisorService {
 
   pruneOrphanedWorkspaces(): Promise<SupervisorOrphanPruneResultDto> {
     return this.supervisor.pruneOrphanedWorkspaces();
+  }
+
+  rollupExecutionMetrics(): Promise<SupervisorExecutionMetricsRollupResultDto> {
+    return this.supervisor.rollupExecutionMetrics();
   }
 
   resetCorruptJsonState(): Promise<JsonCorruptStateResetResult> {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -76,7 +76,11 @@ import {
   shouldAutoRetryTimeout,
 } from "./supervisor-failure-helpers";
 import { AgentRunner, createCodexAgentRunner } from "./agent-runner";
-import { syncExecutionMetricsRunSummary } from "./execution-metrics-run-summary";
+import { syncRetainedExecutionMetricsDailyRollups } from "./execution-metrics-aggregation";
+import {
+  executionMetricsRetentionRootPath,
+  syncExecutionMetricsRunSummary,
+} from "./execution-metrics-run-summary";
 import {
   attemptBudgetForLane,
   attemptLane,
@@ -124,6 +128,7 @@ import {
 } from "./supervisor-status-rendering";
 import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
 import {
+  type SupervisorExecutionMetricsRollupResultDto,
   type SupervisorMutationResultDto,
   type SupervisorOrphanPruneResultDto,
   type SupervisorRecoveryAction,
@@ -586,6 +591,7 @@ export class Supervisor {
         recoverUnexpectedCodexTurnFailure: (args) =>
           recoverUnexpectedCodexTurnFailure({
             ...args,
+            config: this.config,
             stateStore: this.stateStore,
           }),
         agentRunner: this.agentRunner,
@@ -661,6 +667,7 @@ export class Supervisor {
           issue,
           pullRequest: pr,
           recoveryEvents,
+          retentionRootPath: executionMetricsRetentionRootPath(this.config.stateFile),
         });
         await syncJournal(record);
         return prependRecoveryLog(
@@ -793,6 +800,7 @@ export class Supervisor {
       issue,
       pullRequest: pr,
       recoveryEvents,
+      retentionRootPath: executionMetricsRetentionRootPath(this.config.stateFile),
     });
     return nextRecord;
   }
@@ -1061,6 +1069,43 @@ export class Supervisor {
         };
       }
       return pruneOrphanedWorkspacesForOperator(this.config, state);
+    } finally {
+      await lock.release();
+    }
+  }
+
+  async rollupExecutionMetrics(): Promise<SupervisorExecutionMetricsRollupResultDto> {
+    const lock = await acquireFileLock(this.lockPath("supervisor", "run"), "supervisor-recovery-rollup-execution-metrics", {
+      allowAmbiguousOwnerCleanup: true,
+    });
+    if (!lock.acquired) {
+      throw new Error(`Cannot run recovery action while supervisor is active: ${lock.reason ?? "lock unavailable"}`);
+    }
+
+    try {
+      const state = await this.stateStore.load();
+      const quarantine = readJsonParseErrorQuarantine(this.config, state);
+      if (quarantine) {
+        return {
+          action: "rollup-execution-metrics",
+          outcome: "rejected",
+          summary: buildCorruptJsonFailClosedMessage(this.config, quarantine),
+          artifactPath: null,
+          runSummaryCount: 0,
+        };
+      }
+      const result = await syncRetainedExecutionMetricsDailyRollups({
+        stateFilePath: this.config.stateFile,
+      });
+      return {
+        action: "rollup-execution-metrics",
+        outcome: "completed",
+        summary:
+          `Wrote daily execution metrics rollups from ${result.runSummaryCount} retained run summar` +
+          `${result.runSummaryCount === 1 ? "y" : "ies"}.`,
+        artifactPath: result.artifactPath,
+        runSummaryCount: result.runSummaryCount,
+      };
     } finally {
       await lock.release();
     }

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -23,6 +23,7 @@ interface PersistTurnExecutionFailureArgs {
     record: IssueRunRecord,
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  retentionRootPath?: string;
 }
 
 interface PersistCodexExitFailureArgs {
@@ -43,6 +44,7 @@ interface PersistCodexExitFailureArgs {
     record: IssueRunRecord,
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  retentionRootPath?: string;
 }
 
 interface PersistMissingJournalHandoffArgs {
@@ -61,6 +63,7 @@ interface PersistMissingJournalHandoffArgs {
     record: IssueRunRecord,
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  retentionRootPath?: string;
 }
 
 interface PersistHintedCodexTurnStateArgs {
@@ -85,6 +88,7 @@ interface PersistHintedCodexTurnStateArgs {
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
   normalizeBlockerSignature: (message: string | null | undefined) => string | null;
   isVerificationBlockedMessage: (message: string | null | undefined) => boolean;
+  retentionRootPath?: string;
 }
 
 function timeoutRetryPatch(
@@ -122,6 +126,7 @@ async function persistTurnFailurePatch(args: {
   issue: Pick<GitHubIssue, "createdAt">;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   patch: Partial<IssueRunRecord>;
+  retentionRootPath?: string;
 }): Promise<IssueRunRecord> {
   const updated = args.stateStore.touch(args.record, args.patch);
   args.state.issues[String(args.record.issue_number)] = updated;
@@ -131,6 +136,7 @@ async function persistTurnFailurePatch(args: {
       previousRecord: args.record,
       nextRecord: updated,
       issue: args.issue,
+      retentionRootPath: args.retentionRootPath,
     });
   } catch (metricsError) {
     console.warn(
@@ -162,6 +168,7 @@ export async function persistCodexTurnExecutionFailure(args: PersistTurnExecutio
     record: args.record,
     issue: args.issue,
     syncJournal: args.syncJournal,
+    retentionRootPath: args.retentionRootPath,
     patch: {
       state: "failed",
       last_error: truncate(message),
@@ -191,6 +198,7 @@ export async function persistCodexTurnExitFailure(args: PersistCodexExitFailureA
     record: args.record,
     issue: args.issue,
     syncJournal: args.syncJournal,
+    retentionRootPath: args.retentionRootPath,
     patch: {
       state: "failed",
       last_error: truncate(failureOutput),
@@ -218,6 +226,7 @@ export async function persistMissingCodexJournalHandoff(
     record: args.record,
     issue: args.issue,
     syncJournal: args.syncJournal,
+    retentionRootPath: args.retentionRootPath,
     patch: {
       state: "blocked",
       last_error: truncate(failureContext.summary),
@@ -245,6 +254,7 @@ export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnSt
     record: args.record,
     issue: args.issue,
     syncJournal: args.syncJournal,
+    retentionRootPath: args.retentionRootPath,
     patch: {
       state: args.hintedState,
       last_error: truncate(args.lastMessage),


### PR DESCRIPTION
## Summary
- retain terminal execution-metrics summaries under the supervisor state directory so worktree cleanup cannot delete the aggregation source
- add a supported `rollup-execution-metrics` CLI/runtime path that builds daily rollups from retained summaries
- document the retained summary and rollup locations for operators

## Verification
- npx tsx --test src/supervisor/execution-metrics-schema.test.ts src/supervisor/execution-metrics-aggregation.test.ts src/cli/parse-args.test.ts src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts src/supervisor/supervisor-service.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rollup-execution-metrics` CLI command to generate daily summaries of execution metrics
  * Execution metrics are now retained separately from workspace cleanup, ensuring durability across issue lifecycle

* **Documentation**
  * Updated README and getting-started guide with new CLI command and metrics retention behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->