### PR TITLE
Create residual follow-up issues for mergeable final evals

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,62 +1,54 @@
-# Issue #919: Final evaluation sequencing: keep downstream sibling work waiting until evaluation resolves
+# Issue #920: Final evaluation follow-ups: create explicit residual follow-up issues when merge is allowed
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/919
-- Branch: codex/issue-919
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/920
+- Branch: codex/issue-920
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: 7a5421d5224abecc816d9a2fd39ec2e72fd82484
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 71295fb41972d9ee50cd590bc3c0d0ce0205698e
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-24T04:13:36.988Z
+- Updated at: 2026-03-24T04:41:12.046Z
 
 ## Latest Codex Summary
-Installed the missing local dev dependencies with `npm install`, which restored both `tsc` and `playwright-core` in this worktree. The sequencing fix from `7a5421d` still passes its focused regressions, and `npm run build` is now green locally.
+- Added explicit residual follow-up issue creation for `follow_up_eligible` pre-merge final evaluations. The post-turn PR flow now turns each `follow_up_candidate` residual into an execution-ready GitHub issue that depends on the source issue, carries forward the parent epic when present, reuses the source verification section, and includes source-issue / PR / artifact traceability before the draft PR is allowed to proceed.
 
-The prior full-suite blocker turned out to be a stale expected-file allowlist in [src/external-review/external-review-family-layout.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-919/src/external-review/external-review-family-layout.test.ts), not a sequencing regression. I updated that test to include the two current runtime modules (`external-review-miss-digest.ts` and `external-review-prevention-targets.ts`), and the full `npx tsx --test src/**/*.test.ts` run now passes.
+- Added a focused regression in `src/post-turn-pull-request.test.ts` that first reproduced the missing follow-up issue creation path, then verified the generated issue body keeps scheduler-compatible metadata (`Part of`, `Depends on`, `Execution order`, `Parallelizable`) and source traceability intact. Added `GitHubClient.createIssue()` to support the new path.
 
-Summary: Sequencing remains blocked on unresolved final evaluation as intended, local build/test verification is clean, and the draft PR is open with the stale external-review layout test synchronized so the repo suite passes again
-State hint: draft_pr
-Blocked reason: none
-Tests: `npm install`; `npx tsx --test src/issue-metadata/issue-metadata.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`; `npm run build`; `npx tsx --test src/external-review/external-review-family-layout.test.ts`; `npx tsx --test src/**/*.test.ts`
-Next action: Monitor draft PR #934 and address any CI or review feedback
-Failure signature: none
+- Verification is green locally after restoring dependencies with `npm install`: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-readiness.test.ts src/github/github.test.ts`; `npm run build`; `npx tsx --test src/**/*.test.ts`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: sequencing currently treats `record.state === "done"` as sufficient, so downstream siblings become runnable before the predecessor's pre-merge final evaluation resolves.
-- What changed: added focused regressions in `src/issue-metadata/issue-metadata.test.ts` and `src/supervisor/supervisor-selection-readiness-summary.test.ts`; introduced `isRecordDoneForSequencing()` in `src/issue-metadata/issue-metadata.ts`; updated `findBlockingIssue()`, readiness summaries, and selection/explain formatting to require a resolved final-evaluation outcome (`mergeable` or `follow_up_eligible`) before a predecessor counts as cleared; installed local dependencies; and synchronized `src/external-review/external-review-family-layout.test.ts` with the current runtime modules so the full suite passes again.
+- Hypothesis: `follow_up_eligible` final evaluations were persisted only as counts/outcome on the source record, so merge could proceed without creating explicit scheduler-visible residual follow-up issues.
+- What changed: added focused regression coverage in `src/post-turn-pull-request.test.ts`; introduced follow-up issue drafting in `src/post-turn-pull-request.ts` that converts each `follow_up_candidate` residual into an execution-ready issue with inherited parent-epic metadata, `Depends on: #<source>`, `Execution order: 1 of 1`, `Parallelizable: Yes`, and explicit source traceability; added `GitHubClient.createIssue()` in `src/github/github.ts`; restored local dependencies so `npm run build` works in this worktree.
 - Current blocker: none.
-- Next exact step: monitor draft PR #934, then address any CI or review feedback if it appears.
-- Verification gap: none locally; focused sequencing tests, `npm run build`, the external-review layout test, and the full test suite are green in this workspace.
-- Files touched: `src/issue-metadata/issue-metadata.ts`, `src/issue-metadata/issue-metadata.test.ts`, `src/supervisor/supervisor-selection-readiness-summary.ts`, `src/supervisor/supervisor-selection-readiness-summary.test.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, `src/external-review/external-review-family-layout.test.ts`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: low to moderate; reverting would let downstream sibling work start while the predecessor is still pending or blocked in final evaluation, and diagnostics would again disagree with actual sequencing behavior.
+- Next exact step: review the diff, commit the follow-up-issue creation change, and open or update the branch PR if needed.
+- Verification gap: none locally; focused post-turn regression, adjacent PR-readiness / GitHub tests, `npm run build`, and the full test suite are green in this workspace.
+- Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `src/github/github.ts`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: moderate; reverting would restore the previous silent gap where mergeable residual work was not turned into explicit follow-up issues, so operators would lose scheduler-visible tracking for bounded post-merge work.
 - Last focused command: `npx tsx --test src/**/*.test.ts`
 - Last focused failure: none
-- Draft PR: #934 (`https://github.com/TommyKammy/codex-supervisor/pull/934`)
+- Draft PR: none
 - Last focused commands:
 ```bash
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-919/AGENTS.generated.md
-sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-919/context-index.md
+sed -n '1,240p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-920/AGENTS.generated.md
+sed -n '1,240p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-920/context-index.md
 sed -n '1,260p' .codex-supervisor/issue-journal.md
-sed -n '1,260p' src/issue-metadata/issue-metadata.ts
-sed -n '1,280p' src/supervisor/supervisor-selection-readiness-summary.ts
-npx tsx --test src/issue-metadata/issue-metadata.test.ts
-npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts
-npx tsx --test src/issue-metadata/issue-metadata.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
-npx tsx --test src/**/*.test.ts
-npm run build
+rg -n "follow_up|follow-up|follow up|final evaluation|residual" src .codex-supervisor -g '!node_modules'
+sed -n '1,320p' src/post-turn-pull-request.ts
+sed -n '1,260p' src/post-turn-pull-request.test.ts
+sed -n '1,360p' src/github/github.ts
+npx tsx --test src/post-turn-pull-request.test.ts
+npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-readiness.test.ts src/github/github.test.ts
 npm install
-npx tsx --test src/external-review/external-review-family-layout.test.ts
+npm run build
 npx tsx --test src/**/*.test.ts
-git push -u origin codex/issue-919
-gh pr create --draft --base main --head codex/issue-919 --title "Keep downstream sibling work blocked until final eval resolves" --body ...
 ```
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -527,6 +527,28 @@ export class GitHubClient {
     return created;
   }
 
+  async createIssue(title: string, body: string): Promise<GitHubIssue> {
+    const { owner, repo } = this.repoOwnerAndName();
+    const result = await this.runGhCommand([
+      "api",
+      `repos/${owner}/${repo}/issues`,
+      "--method",
+      "POST",
+      "-f",
+      `title=${title}`,
+      "-f",
+      `body=${body}`,
+    ]);
+
+    const created = parseJson<GitHubRestIssue>(result.stdout, `gh api repos/${owner}/${repo}/issues`);
+    const mapped = this.mapRestIssue(created);
+    if (!mapped) {
+      throw new Error("Created GitHub issue response unexpectedly described a pull request.");
+    }
+
+    return mapped;
+  }
+
   private async findPullRequestAfterCreation(branch: string): Promise<GitHubPullRequest | null> {
     for (let attempt = 0; attempt <= POST_CREATE_PR_LOOKUP_RETRY_LIMIT; attempt += 1) {
       const pullRequest = await this.findOpenPullRequest(branch);

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -215,6 +215,166 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion 
   assert.match(result.record.last_error ?? "", /Configured local CI command failed before marking PR #116 ready\./);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase creates execution-ready follow-up issues for follow-up-eligible residuals", async () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+  });
+  const issue = createIssue({
+    title: "Track residual post-merge work",
+    body: `## Summary
+Allow merge after local review while tracking bounded residual work.
+
+## Scope
+- keep follow-up issue creation explicit
+- keep blocking findings on the source issue
+- leave unrelated scheduling behavior unchanged
+
+## Acceptance criteria
+- follow-up-eligible residuals create explicit issues
+- blocking residuals still block the source issue
+
+## Verification
+- npx tsx --test src/post-turn-pull-request.test.ts
+
+Part of: #900
+Depends on: none
+Execution order: 1 of 1
+Parallelizable: No`,
+  });
+  const draftPr = createPullRequest({ title: "Create residual follow-up issues", isDraft: true });
+  const createdIssues: Array<{ title: string; body: string }> = [];
+  let readyCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      createIssue: async (title: string, body: string) => {
+        createdIssues.push({ title, body });
+        return createIssue({
+          number: 205,
+          title,
+          body,
+          url: "https://example.test/issues/205",
+        });
+      },
+      markPullRequestReady: async () => {
+        readyCalls += 1;
+      },
+    },
+    context: {
+      state: {
+        activeIssueNumber: 102,
+        issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+      },
+      record: createRecord({ state: "draft_pr", pr_number: draftPr.number }),
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record, pr) => ({
+      recordForState: record,
+      nextState: "waiting_ci",
+      failureContext: null,
+      reviewWaitPatch: { review_wait_started_at: "2026-03-13T06:26:22Z", review_wait_head_sha: pr.headRefOid },
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalReviewImpl: async () => ({
+      ranAt: "2026-03-24T00:11:00Z",
+      summaryPath: "/tmp/reviews/owner-repo/issue-102/head-116.md",
+      findingsPath: "/tmp/reviews/owner-repo/issue-102/head-116.json",
+      summary: "Local review found a bounded medium-severity residual.",
+      blockerSummary: "medium src/example.ts:20-21 This still needs follow-up.",
+      findingsCount: 1,
+      rootCauseCount: 1,
+      maxSeverity: "medium",
+      verifiedFindingsCount: 0,
+      verifiedMaxSeverity: "none",
+      recommendation: "changes_requested",
+      degraded: false,
+      finalEvaluation: {
+        outcome: "follow_up_eligible",
+        residualFindings: [
+          {
+            findingKey: "src/example.ts|20|21|medium issue|this still needs follow-up.",
+            summary: "This still needs follow-up.",
+            severity: "medium",
+            category: "tests",
+            file: "src/example.ts",
+            start: 20,
+            end: 21,
+            source: "local_review",
+            resolution: "follow_up_candidate",
+            rationale: "Residual non-high-severity finding is eligible for explicit follow-up instead of blocking merge by itself.",
+          },
+        ],
+        mustFixCount: 0,
+        manualReviewCount: 0,
+        followUpCount: 1,
+      },
+      rawOutput: "raw output",
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(createdIssues.length, 1);
+  assert.match(createdIssues[0]?.title ?? "", /follow-up/i);
+  assert.match(createdIssues[0]?.body ?? "", /Depends on: #102/);
+  assert.match(createdIssues[0]?.body ?? "", /Part of: #900/);
+  assert.match(createdIssues[0]?.body ?? "", /Execution order: 1 of 1/);
+  assert.match(createdIssues[0]?.body ?? "", /Parallelizable: Yes/);
+  assert.match(createdIssues[0]?.body ?? "", /Source issue: #102/);
+  assert.equal(readyCalls, 1);
+  assert.equal(result.record.pre_merge_evaluation_outcome, "follow_up_eligible");
+});
+
 test("handlePostTurnPullRequestTransitionsPhase emits typed review-wait change events", async () => {
   const config = createConfig();
   const issue = createIssue({ title: "Emit review wait changes" });

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -3,6 +3,8 @@ import {
   LOCAL_REVIEW_DEGRADED_BLOCKER_SUMMARY,
   runLocalReview,
   shouldRunLocalReview,
+  type LocalReviewResult,
+  type PreMergeResidualFinding,
 } from "./local-review";
 import {
   localReviewBlocksReady,
@@ -35,6 +37,7 @@ import {
   maybeBuildReviewWaitChangedEvent,
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
+import { parseIssueMetadata } from "./issue-metadata";
 
 export interface PostTurnPullRequestContext {
   state: SupervisorStateFile;
@@ -72,10 +75,137 @@ export interface PullRequestLifecycleSnapshot {
   >;
 }
 
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findMarkdownSectionContent(body: string, title: string): string | null {
+  const lines = body.split(/\r?\n/);
+  const headingPattern = new RegExp(`^\\s*##\\s*${escapeRegExp(title)}\\s*$`, "i");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!headingPattern.test(lines[index] ?? "")) {
+      continue;
+    }
+
+    const sectionLines: string[] = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (/^\s*##\s*\S/.test(lines[cursor] ?? "")) {
+        break;
+      }
+
+      sectionLines.push(lines[cursor] ?? "");
+    }
+
+    const content = sectionLines.join("\n").trim();
+    return content.length > 0 ? content : null;
+  }
+
+  return null;
+}
+
+function renderResidualLines(finding: Pick<PreMergeResidualFinding, "start" | "end">): string | null {
+  if (finding.start == null) {
+    return null;
+  }
+
+  return finding.end != null && finding.end !== finding.start
+    ? `${finding.start}-${finding.end}`
+    : `${finding.start}`;
+}
+
+function buildResidualFollowUpIssueDraft(args: {
+  sourceIssue: GitHubIssue;
+  pr: GitHubPullRequest;
+  localReview: LocalReviewResult;
+  residualFinding: PreMergeResidualFinding;
+}): { title: string; body: string } {
+  const { sourceIssue, pr, localReview, residualFinding } = args;
+  const metadata = parseIssueMetadata(sourceIssue);
+  const sourceVerification = findMarkdownSectionContent(sourceIssue.body, "Verification");
+  const renderedLines = renderResidualLines(residualFinding);
+  const location = residualFinding.file
+    ? `\`${residualFinding.file}${renderedLines ? `:${renderedLines}` : ""}\``
+    : "the bounded residual area";
+  const title = truncate(
+    `Follow-up: ${sourceIssue.title} (#${sourceIssue.number}) - ${residualFinding.summary}`,
+    240,
+  ) ?? `Follow-up: issue #${sourceIssue.number}`;
+  const verificationLines = sourceVerification
+    ? sourceVerification.split(/\r?\n/)
+    : [`- add and run the narrowest targeted verification for ${location}.`];
+
+  return {
+    title,
+    body: [
+      "## Summary",
+      `Resolve the residual non-blocking finding left behind by source issue #${sourceIssue.number} after PR #${pr.number} merges.`,
+      "",
+      "## Scope",
+      `- address the residual finding: ${residualFinding.summary}`,
+      `- focus changes on ${location}.`,
+      "- keep unrelated behavior unchanged outside this follow-up.",
+      "",
+      "## Acceptance criteria",
+      `- the residual finding from source issue #${sourceIssue.number} is resolved or explicitly dismissed with rationale.`,
+      "- any targeted coverage or guardrail needed for this residual is added.",
+      `- traceability back to source issue #${sourceIssue.number} and PR #${pr.number} remains documented.`,
+      "",
+      "## Verification",
+      ...verificationLines,
+      `- confirm the residual finding for ${location} is covered by the updated verification.`,
+      "",
+      ...(metadata.parentIssueNumber ? [`Part of: #${metadata.parentIssueNumber}`] : []),
+      `Depends on: #${sourceIssue.number}`,
+      "Execution order: 1 of 1",
+      "Parallelizable: Yes",
+      "",
+      "## Traceability",
+      `- Source issue: #${sourceIssue.number}`,
+      `- Source PR: #${pr.number}`,
+      `- Pre-merge final evaluation outcome: ${localReview.finalEvaluation.outcome}`,
+      `- Residual finding key: \`${residualFinding.findingKey}\``,
+      `- Severity: ${residualFinding.severity}`,
+      ...(residualFinding.category ? [`- Category: ${residualFinding.category}`] : []),
+      ...(residualFinding.file ? [`- File: \`${residualFinding.file}\``] : []),
+      ...(renderedLines ? [`- Lines: ${renderedLines}`] : []),
+      `- Summary: ${residualFinding.summary}`,
+      `- Rationale: ${residualFinding.rationale}`,
+      `- Source artifact: \`${localReview.summaryPath}\``,
+    ].join("\n"),
+  };
+}
+
+async function createResidualFollowUpIssues(args: {
+  github: Partial<Pick<GitHubClient, "createIssue">>;
+  issue: GitHubIssue;
+  pr: GitHubPullRequest;
+  localReview: LocalReviewResult;
+}): Promise<void> {
+  if (!args.github.createIssue) {
+    throw new Error("GitHub issue creation is unavailable for follow-up-eligible residual findings.");
+  }
+
+  const residualFindings = args.localReview.finalEvaluation.residualFindings.filter(
+    (finding) => finding.resolution === "follow_up_candidate",
+  );
+
+  for (const residualFinding of residualFindings) {
+    const draft = buildResidualFollowUpIssueDraft({
+      sourceIssue: args.issue,
+      pr: args.pr,
+      localReview: args.localReview,
+      residualFinding,
+    });
+    await args.github.createIssue(draft.title, draft.body);
+  }
+}
+
 export interface HandlePostTurnPullRequestTransitionsArgs {
   config: SupervisorConfig;
   stateStore: Pick<StateStore, "touch" | "save">;
-  github: Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads" | "markPullRequestReady">;
+  github: Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads" | "markPullRequestReady"> &
+    Partial<Pick<GitHubClient, "createIssue">>;
   context: PostTurnPullRequestContext;
   derivePullRequestLifecycleSnapshot: (
     record: IssueRunRecord,
@@ -208,6 +338,15 @@ export async function handlePostTurnPullRequestTransitionsPhase(
               )
             : null,
       });
+
+      if (localReview.finalEvaluation.outcome === "follow_up_eligible") {
+        await createResidualFollowUpIssues({
+          github,
+          issue,
+          pr: refreshed.pr,
+          localReview,
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       record = stateStore.touch(record, {


### PR DESCRIPTION
## Summary
- create explicit execution-ready follow-up issues when local review ends in `follow_up_eligible`
- preserve scheduler-compatible metadata and traceability back to the source issue and PR
- keep merge blocked only for blocking residuals, not for non-blocking follow-up candidates

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-readiness.test.ts src/github/github.test.ts
- npm run build
- npx tsx --test src/**/*.test.ts