### PR TITLE
Issue #926: Surface post-merge promotion candidates

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,37 +5,64 @@
 - Branch: codex/issue-926
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 66ed008de890b56d5c973f6be68570069aab3a71
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: f43049f1222be02f076db6de85664316205dc7a2
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-03-24T11:08:43Z
+- Last failure signature: PRRT_kwDORgvdZ852Y1vo|PRRT_kwDORgvdZ852Y1vy|PRRT_kwDORgvdZ852Y1v7
+- Repeated failure signature count: 1
+- Updated at: 2026-03-24T11:22:58.998Z
 
 ## Latest Codex Summary
-- None yet.
+Addressed the three open CodeRabbit review threads on PR #943 in [src/supervisor/post-merge-audit-summary.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-926/src/supervisor/post-merge-audit-summary.ts) by bumping the summary schema version to `2`, deriving review-backed promotion candidate keys from the canonical pattern key so severity-distinct patterns stay unique, and preserving all review finding keys instead of truncating them before candidate generation.
+
+I updated the focused summary assertions in [src/supervisor/post-merge-audit-summary.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-926/src/supervisor/post-merge-audit-summary.test.ts), added a regression that covers duplicate summaries across severities plus 4+ supporting finding keys, and bumped the CLI runtime DTO expectation in [src/supervisor/post-merge-audit-summary-runtime.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-926/src/supervisor/post-merge-audit-summary-runtime.test.ts).
+
+Verification ran clean in this worktree:
+- `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts`
+- `npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts`
+- `npx tsx --test src/**/*.test.ts`
+- `npm run build`
+
+Local workspace still has untracked `.codex-supervisor/replay/`, which I left alone.
+
+Summary: Fixed the three outstanding PR #943 review threads by versioning the summary DTO, making review-derived candidate keys severity-stable, and preserving full finding-key traceability with regression coverage.
+State hint: addressing_review
+Blocked reason: none
+Tests: npx tsx --test src/supervisor/post-merge-audit-summary.test.ts; npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts; npx tsx --test src/**/*.test.ts; npm run build
+Next action: Commit the review fixes, push `codex/issue-926`, and update PR #943.
+Failure signature: none
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: Resolved locally; the three automated PR #943 review threads were addressed in code and tests.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/943#discussion_r2980798199
+- Details:
+  - Bumped `POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION` to `2` and updated focused/runtime assertions so the new required `promotionCandidates` field is versioned correctly.
+  - Switched review-derived `guardrail` and `shared_memory` candidate keys to `slugify(pattern.key)` so the severity embedded in the canonical pattern key prevents collisions.
+  - Removed the `.slice(0, 3)` truncation on `exampleFindingKeys` and added a regression that proves 4 supporting finding keys survive into both `reviewPatterns` and `promotionCandidates`.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the persisted post-merge audit aggregate already exposed recurring review, failure, and recovery buckets, but it still lacked an explicit advisory layer that translated repeated patterns into promotion candidates operators could evaluate deliberately.
-- What changed: extended `summarizePostMergeAuditPatterns` to emit advisory-only `promotionCandidates` derived from recurring review, failure, and recovery patterns; added category-specific candidates for `guardrail`, `shared_memory`, `checklist`, and `documentation`; preserved traceability through source pattern keys, supporting issue numbers, and supporting finding keys; updated the runtime DTO test for the new field.
+- Hypothesis: the remaining PR #943 review risk was confined to DTO contract/versioning and traceability details rather than the overall promotion-candidate feature shape.
+- What changed: bumped the post-merge audit summary schema version to `2`, made review-derived promotion candidate keys derive from the canonical severity-aware review pattern key, removed the premature truncation of review finding keys, and added focused regression coverage for duplicate summary/severity splits plus 4-key traceability.
 - Current blocker: none.
-- Next exact step: monitor draft PR #943 for review or CI follow-up on the promotion-candidate summary change.
-- Verification gap: none in the current workspace after installing dependencies; the focused summary tests, full `src/**/*.test.ts` suite, and `npm run build` all passed.
+- Next exact step: commit these review fixes, push `codex/issue-926`, and update PR #943 so the review threads can be resolved.
+- Verification gap: none; focused tests, the full `src/**/*.test.ts` suite, and `npm run build` all passed after the review fixes.
 - Files touched: `src/supervisor/post-merge-audit-summary.ts`, `src/supervisor/post-merge-audit-summary.test.ts`, `src/supervisor/post-merge-audit-summary-runtime.test.ts`, `.codex-supervisor/issue-journal.md`
 - Rollback concern: low; reverting would only remove a read-only analysis surface and leave the persisted audit artifacts intact.
-- Last focused command: `npx tsx --test src/**/*.test.ts`
-- Last focused failure: the new reproducer initially failed with `TypeError: Cannot read properties of undefined (reading 'map')` because `summarizePostMergeAuditPatterns` did not return `promotionCandidates`; resolved by adding the new DTO field and derivation logic.
+- Last focused command: `npm run build`
+- Last focused failure: none.
 - Draft PR: #943 https://github.com/TommyKammy/codex-supervisor/pull/943
 - Last focused commands:
 ```bash
+git status --short
+rg -n "POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION|promotionCandidates|exampleFindingKeys|buildReviewPatternKey|guardrail:|shared_memory:" src/supervisor/post-merge-audit-summary.ts src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts
+sed -n '1,260p' src/supervisor/post-merge-audit-summary.ts
+sed -n '1,340p' src/supervisor/post-merge-audit-summary.test.ts
+sed -n '1,120p' src/supervisor/post-merge-audit-summary-runtime.test.ts
 npx tsx --test src/supervisor/post-merge-audit-summary.test.ts
 npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts
-npm install
 npx tsx --test src/**/*.test.ts
 npm run build
 date -u +"%Y-%m-%dT%H:%M:%SZ"

--- a/src/supervisor/post-merge-audit-summary-runtime.test.ts
+++ b/src/supervisor/post-merge-audit-summary-runtime.test.ts
@@ -37,7 +37,7 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
           throw new Error("unexpected resetCorruptJsonState");
         },
         queryPostMergeAuditSummary: async () => ({
-          schemaVersion: 1,
+          schemaVersion: 2,
           advisoryOnly: true,
           autoApplyGuardrails: false,
           autoCreateFollowUpIssues: false,
@@ -59,7 +59,7 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
 
   assert.equal(stdout.length, 1);
   assert.deepEqual(JSON.parse(stdout[0] ?? ""), {
-    schemaVersion: 1,
+    schemaVersion: 2,
     advisoryOnly: true,
     autoApplyGuardrails: false,
     autoCreateFollowUpIssues: false,

--- a/src/supervisor/post-merge-audit-summary.test.ts
+++ b/src/supervisor/post-merge-audit-summary.test.ts
@@ -224,7 +224,7 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
 
   const summary = await summarizePostMergeAuditPatterns(config);
 
-  assert.equal(summary.schemaVersion, 1);
+  assert.equal(summary.schemaVersion, 2);
   assert.equal(summary.advisoryOnly, true);
   assert.equal(summary.autoApplyGuardrails, false);
   assert.equal(summary.autoCreateFollowUpIssues, false);
@@ -251,13 +251,13 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
     })),
     [
       {
-        key: "guardrail:correctness:retry-path-reused-stale-review-context-after-the-head-changed",
+        key: "guardrail:correctness-medium-retry-path-reused-stale-review-context-after-the-head-changed",
         category: "guardrail",
         sourcePatternKeys: ["correctness:medium:retry-path-reused-stale-review-context-after-the-head-changed"],
         supportingIssueNumbers: [102, 103],
       },
       {
-        key: "shared_memory:correctness:retry-path-reused-stale-review-context-after-the-head-changed",
+        key: "shared_memory:correctness-medium-retry-path-reused-stale-review-context-after-the-head-changed",
         category: "shared_memory",
         sourcePatternKeys: ["correctness:medium:retry-path-reused-stale-review-context-after-the-head-changed"],
         supportingIssueNumbers: [102, 103],
@@ -281,6 +281,169 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
   assert.equal(summary.promotionCandidates[0]?.autoCreateFollowUpIssue, false);
   assert.deepEqual(summary.promotionCandidates[0]?.supportingFindingKeys, [
     "src/supervisor.ts|210|214|retry path|stale context",
+  ]);
+});
+
+test("summarizePostMergeAuditPatterns keeps review promotion candidate keys unique per severity and preserves full finding traceability", async () => {
+  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-summary-"));
+  const config = createConfig({
+    localReviewArtifactDir: reviewDir,
+    repoSlug: "owner/repo",
+  });
+  const artifactDir = postMergeAuditArtifactDir(config);
+  const repeatedSummary = "Review loop reused stale context after the head changed.";
+
+  await fs.mkdir(artifactDir, { recursive: true });
+  await writeJsonAtomic(
+    path.join(artifactDir, "issue-201-head-merged-head.json"),
+    createPostMergeArtifact({
+      issueNumber: 201,
+      localReview: {
+        summaryPath: null,
+        findingsPath: null,
+        runAt: "2026-03-24T13:00:00Z",
+        recommendation: "changes_requested",
+        degraded: false,
+        findingsCount: 4,
+        rootCauseCount: 2,
+        maxSeverity: "high",
+        verifiedFindingsCount: 0,
+        verifiedMaxSeverity: "none",
+        artifact: createLocalReviewArtifact({
+          issueNumber: 201,
+          prNumber: 201,
+          branch: "codex/issue-201",
+          headSha: "merged-head-201",
+          findingsCount: 4,
+          rootCauseCount: 2,
+          maxSeverity: "high",
+          rootCauseSummaries: [
+            {
+              summary: repeatedSummary,
+              severity: "medium",
+              category: "correctness",
+              file: "src/supervisor.ts",
+              start: 210,
+              end: 214,
+              roles: ["reviewer"],
+              findingsCount: 2,
+              findingKeys: ["medium-finding-d", "medium-finding-b"],
+            },
+            {
+              summary: repeatedSummary,
+              severity: "high",
+              category: "correctness",
+              file: "src/supervisor.ts",
+              start: 220,
+              end: 224,
+              roles: ["reviewer"],
+              findingsCount: 2,
+              findingKeys: ["high-finding-d", "high-finding-b"],
+            },
+          ],
+        }),
+      },
+      failureTaxonomy: {
+        latestFailure: null,
+        latestRecovery: null,
+        staleStabilizingNoPrRecoveryCount: 0,
+      },
+    }),
+  );
+  await writeJsonAtomic(
+    path.join(artifactDir, "issue-202-head-merged-head.json"),
+    createPostMergeArtifact({
+      issueNumber: 202,
+      localReview: {
+        summaryPath: null,
+        findingsPath: null,
+        runAt: "2026-03-24T14:00:00Z",
+        recommendation: "changes_requested",
+        degraded: false,
+        findingsCount: 4,
+        rootCauseCount: 2,
+        maxSeverity: "high",
+        verifiedFindingsCount: 0,
+        verifiedMaxSeverity: "none",
+        artifact: createLocalReviewArtifact({
+          issueNumber: 202,
+          prNumber: 202,
+          branch: "codex/issue-202",
+          headSha: "merged-head-202",
+          findingsCount: 4,
+          rootCauseCount: 2,
+          maxSeverity: "high",
+          rootCauseSummaries: [
+            {
+              summary: repeatedSummary,
+              severity: "medium",
+              category: "correctness",
+              file: "src/supervisor.ts",
+              start: 210,
+              end: 214,
+              roles: ["reviewer"],
+              findingsCount: 2,
+              findingKeys: ["medium-finding-c", "medium-finding-a"],
+            },
+            {
+              summary: repeatedSummary,
+              severity: "high",
+              category: "correctness",
+              file: "src/supervisor.ts",
+              start: 220,
+              end: 224,
+              roles: ["reviewer"],
+              findingsCount: 2,
+              findingKeys: ["high-finding-c", "high-finding-a"],
+            },
+          ],
+        }),
+      },
+      failureTaxonomy: {
+        latestFailure: null,
+        latestRecovery: null,
+        staleStabilizingNoPrRecoveryCount: 0,
+      },
+    }),
+  );
+
+  const summary = await summarizePostMergeAuditPatterns(config);
+
+  assert.deepEqual(
+    summary.reviewPatterns.map((pattern) => pattern.key),
+    [
+      "correctness:high:review-loop-reused-stale-context-after-the-head-changed",
+      "correctness:medium:review-loop-reused-stale-context-after-the-head-changed",
+    ],
+  );
+
+  const reviewCandidateKeys = summary.promotionCandidates
+    .filter((candidate) => candidate.category === "guardrail" || candidate.category === "shared_memory")
+    .map((candidate) => candidate.key);
+  assert.equal(new Set(reviewCandidateKeys).size, reviewCandidateKeys.length);
+  assert.deepEqual(reviewCandidateKeys, [
+    "guardrail:correctness-high-review-loop-reused-stale-context-after-the-head-changed",
+    "guardrail:correctness-medium-review-loop-reused-stale-context-after-the-head-changed",
+    "shared_memory:correctness-high-review-loop-reused-stale-context-after-the-head-changed",
+    "shared_memory:correctness-medium-review-loop-reused-stale-context-after-the-head-changed",
+  ]);
+
+  const mediumPattern = summary.reviewPatterns.find((pattern) => pattern.severity === "medium");
+  assert.deepEqual(mediumPattern?.exampleFindingKeys, [
+    "medium-finding-a",
+    "medium-finding-b",
+    "medium-finding-c",
+    "medium-finding-d",
+  ]);
+
+  const mediumGuardrailCandidate = summary.promotionCandidates.find(
+    (candidate) => candidate.key === "guardrail:correctness-medium-review-loop-reused-stale-context-after-the-head-changed",
+  );
+  assert.deepEqual(mediumGuardrailCandidate?.supportingFindingKeys, [
+    "medium-finding-a",
+    "medium-finding-b",
+    "medium-finding-c",
+    "medium-finding-d",
   ]);
 });
 

--- a/src/supervisor/post-merge-audit-summary.ts
+++ b/src/supervisor/post-merge-audit-summary.ts
@@ -6,7 +6,7 @@ import type { ActionableSeverity, LocalReviewRootCauseSummary } from "../local-r
 import type { PostMergeAuditArtifact } from "./post-merge-audit-artifact";
 import { postMergeAuditArtifactDir } from "./post-merge-audit-artifact";
 
-export const POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION = 1;
+export const POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION = 2;
 
 export interface PostMergeAuditReviewPatternDto {
   key: string;
@@ -216,7 +216,7 @@ function createReviewPromotionCandidates(
   const summaryLabel = pattern.summary.replace(/\.$/u, "");
   return [
     {
-      key: `guardrail:${slugify(pattern.category ?? "uncategorized")}:${slugify(pattern.summary)}`,
+      key: `guardrail:${slugify(pattern.key)}`,
       category: "guardrail",
       title: `Promote guardrail for ${summaryLabel}`,
       summary: `Recurring review pattern: ${pattern.summary}`,
@@ -229,7 +229,7 @@ function createReviewPromotionCandidates(
       autoCreateFollowUpIssue: false,
     },
     {
-      key: `shared_memory:${slugify(pattern.category ?? "uncategorized")}:${slugify(pattern.summary)}`,
+      key: `shared_memory:${slugify(pattern.key)}`,
       category: "shared_memory",
       title: `Promote shared memory for ${summaryLabel}`,
       summary: `Capture the recurring lesson behind: ${pattern.summary}`,
@@ -420,7 +420,7 @@ export async function summarizePostMergeAuditPatterns(
       artifactCount: pattern.artifactNumbers.size,
       evidenceCount: pattern.evidenceCount,
       exampleIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
-      exampleFindingKeys: [...pattern.findingKeys].sort(compareStringsAscending).slice(0, 3),
+      exampleFindingKeys: [...pattern.findingKeys].sort(compareStringsAscending),
     }))
     .sort((left, right) =>
       right.artifactCount - left.artifactCount ||


### PR DESCRIPTION
## Summary
- surface advisory post-merge promotion candidates from recurring review, failure, and recovery patterns
- classify candidates as guardrail, shared_memory, checklist, or documentation with source-pattern traceability
- extend the post-merge audit summary tests and runtime DTO coverage for the new field

## Verification
- npx tsx --test src/supervisor/post-merge-audit-summary.test.ts
- npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts
- npx tsx --test src/**/*.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-merge audit summaries now use schema v2 and include promotion candidates (guardrail, shared_memory, checklist, documentation), with preserved full finding keys, slugified candidate keys, severity-aware uniqueness, and stable ordering.

* **Tests**
  * Expanded test coverage including runtime and unit tests plus a regression for duplicate summary/severity splits and promotion candidate aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->