### PR TITLE
Issue #927: expose post-merge audit reporting to operators

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,68 +1,49 @@
-# Issue #926: Post-merge promotion candidates: surface shared-memory and guardrail suggestions from recurring patterns
+# Issue #927: Post-merge audit reporting: expose learning and promotion-candidate summaries to operators
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/926
-- Branch: codex/issue-926
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/927
+- Branch: codex/issue-927
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: f43049f1222be02f076db6de85664316205dc7a2
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: b9b8a5dd126403a3902abcb04ac3c44775750b01
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ852Y1vo|PRRT_kwDORgvdZ852Y1vy|PRRT_kwDORgvdZ852Y1v7
-- Repeated failure signature count: 1
-- Updated at: 2026-03-24T11:22:58.998Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-24T11:54:02.506Z
 
 ## Latest Codex Summary
-Addressed the three open CodeRabbit review threads on PR #943 in [src/supervisor/post-merge-audit-summary.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-926/src/supervisor/post-merge-audit-summary.ts) by bumping the summary schema version to `2`, deriving review-backed promotion candidate keys from the canonical pattern key so severity-distinct patterns stay unique, and preserving all review finding keys instead of truncating them before candidate generation.
-
-I updated the focused summary assertions in [src/supervisor/post-merge-audit-summary.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-926/src/supervisor/post-merge-audit-summary.test.ts), added a regression that covers duplicate summaries across severities plus 4+ supporting finding keys, and bumped the CLI runtime DTO expectation in [src/supervisor/post-merge-audit-summary-runtime.test.ts](/home/tommy/Dev/codex-supervisor-self-worktrees/issue-926/src/supervisor/post-merge-audit-summary-runtime.test.ts).
-
-Verification ran clean in this worktree:
-- `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts`
-- `npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts`
-- `npx tsx --test src/**/*.test.ts`
-- `npm run build`
-
-Local workspace still has untracked `.codex-supervisor/replay/`, which I left alone.
-
-Summary: Fixed the three outstanding PR #943 review threads by versioning the summary DTO, making review-derived candidate keys severity-stable, and preserving full finding-key traceability with regression coverage.
-State hint: addressing_review
-Blocked reason: none
-Tests: npx tsx --test src/supervisor/post-merge-audit-summary.test.ts; npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts; npx tsx --test src/**/*.test.ts; npm run build
-Next action: Commit the review fixes, push `codex/issue-926`, and update PR #943.
-Failure signature: none
+- Added a focused Web/API regression test proving the operator-facing post-merge audit summary was not exposed through the HTTP server: `GET /api/post-merge-audits/summary` returned `404`.
+- Fixed the missing read-only route in the WebUI HTTP server so operators can query the advisory post-merge audit summary DTO without changing merge or scheduler behavior.
+- Local verification required restoring the expected toolchain with `npm ci`; after that, the full `src/**/*.test.ts` suite and `npm run build` both passed.
 
 ## Active Failure Context
-- Category: review
-- Summary: Resolved locally; the three automated PR #943 review threads were addressed in code and tests.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/943#discussion_r2980798199
-- Details:
-  - Bumped `POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION` to `2` and updated focused/runtime assertions so the new required `promotionCandidates` field is versioned correctly.
-  - Switched review-derived `guardrail` and `shared_memory` candidate keys to `slugify(pattern.key)` so the severity embedded in the canonical pattern key prevents collisions.
-  - Removed the `.slice(0, 3)` truncation on `exampleFindingKeys` and added a regression that proves 4 supporting finding keys survive into both `reviewPatterns` and `promotionCandidates`.
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the remaining PR #943 review risk was confined to DTO contract/versioning and traceability details rather than the overall promotion-candidate feature shape.
-- What changed: bumped the post-merge audit summary schema version to `2`, made review-derived promotion candidate keys derive from the canonical severity-aware review pattern key, removed the premature truncation of review finding keys, and added focused regression coverage for duplicate summary/severity splits plus 4-key traceability.
+- Hypothesis: the remaining gap for issue #927 was not the summary DTO itself but the lack of an operator-facing Web/API reporting surface for the already-generated advisory post-merge audit summary.
+- What changed: added a focused HTTP server regression test for `GET /api/post-merge-audits/summary`, implemented the missing read-only route in the WebUI server, and verified the route returns the existing advisory summary DTO through the supervisor service boundary.
 - Current blocker: none.
-- Next exact step: commit these review fixes, push `codex/issue-926`, and update PR #943 so the review threads can be resolved.
-- Verification gap: none; focused tests, the full `src/**/*.test.ts` suite, and `npm run build` all passed after the review fixes.
-- Files touched: `src/supervisor/post-merge-audit-summary.ts`, `src/supervisor/post-merge-audit-summary.test.ts`, `src/supervisor/post-merge-audit-summary-runtime.test.ts`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: low; reverting would only remove a read-only analysis surface and leave the persisted audit artifacts intact.
+- Next exact step: commit the Web/API reporting fix on `codex/issue-927`, then decide whether to open or update the draft PR for this issue branch.
+- Verification gap: none after installing dependencies locally with `npm ci`; focused HTTP-server coverage, the full `src/**/*.test.ts` suite, and `npm run build` all passed.
+- Files touched: `src/backend/supervisor-http-server.ts`, `src/backend/supervisor-http-server.test.ts`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: low; reverting would only remove the read-only operator reporting route while leaving the underlying post-merge audit artifacts and CLI summary intact.
 - Last focused command: `npm run build`
-- Last focused failure: none.
-- Draft PR: #943 https://github.com/TommyKammy/codex-supervisor/pull/943
+- Last focused failure: `GET /api/post-merge-audits/summary` returned `404` before the route was added; local build initially failed because `tsc` and `playwright-core` were unavailable until `npm ci` restored dependencies.
+- Draft PR: none
 - Last focused commands:
 ```bash
-git status --short
-rg -n "POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION|promotionCandidates|exampleFindingKeys|buildReviewPatternKey|guardrail:|shared_memory:" src/supervisor/post-merge-audit-summary.ts src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts
-sed -n '1,260p' src/supervisor/post-merge-audit-summary.ts
-sed -n '1,340p' src/supervisor/post-merge-audit-summary.test.ts
-sed -n '1,120p' src/supervisor/post-merge-audit-summary-runtime.test.ts
-npx tsx --test src/supervisor/post-merge-audit-summary.test.ts
-npx tsx --test src/supervisor/post-merge-audit-summary-runtime.test.ts
+git status --short --branch
+sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-927/AGENTS.generated.md
+sed -n '1,240p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-927/context-index.md
+sed -n '1,260p' .codex-supervisor/issue-journal.md
+rg -n "summarize-post-merge-audits|queryPostMergeAuditSummary|postMergeAuditSummary|renderPostMergeAuditPatternSummaryDto" src
+sed -n '1,260p' src/backend/supervisor-http-server.ts
+sed -n '1,320p' src/backend/supervisor-http-server.test.ts
+npx tsx --test src/backend/supervisor-http-server.test.ts
+npm ci
 npx tsx --test src/**/*.test.ts
 npm run build
 date -u +"%Y-%m-%dT%H:%M:%SZ"

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -189,6 +189,7 @@ function createStubService(args?: {
   statusWhyCalls?: boolean[];
   explainCalls?: number[];
   issueLintCalls?: number[];
+  postMergeAuditSummaryCalls?: number;
   setupReadinessCalls?: number;
   setupReadinessReport?: SetupReadinessReport;
   setupConfigPreviewCalls?: Array<string | null>;
@@ -517,6 +518,25 @@ function createStubService(args?: {
         repairGuidance: [],
       };
     },
+    queryPostMergeAuditSummary: async () => {
+      if (args) {
+        args.postMergeAuditSummaryCalls = (args.postMergeAuditSummaryCalls ?? 0) + 1;
+      }
+      return {
+        schemaVersion: 2,
+        advisoryOnly: true,
+        autoApplyGuardrails: false,
+        autoCreateFollowUpIssues: false,
+        generatedAt: "2026-03-24T12:00:00Z",
+        artifactDir: "/tmp/post-merge-audits",
+        artifactsAnalyzed: 3,
+        artifactsSkipped: 1,
+        reviewPatterns: [],
+        failurePatterns: [],
+        recoveryPatterns: [],
+        promotionCandidates: [],
+      };
+    },
     queryDoctor: async () => doctorDiagnostics,
     querySetupReadiness: async () => {
       if (args) {
@@ -548,9 +568,15 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
   const statusWhyCalls: boolean[] = [];
   const explainCalls: number[] = [];
   const issueLintCalls: number[] = [];
-  const serviceCallCounts = { setupReadinessCalls: 0 };
+  const serviceArgs = {
+    statusWhyCalls,
+    explainCalls,
+    issueLintCalls,
+    postMergeAuditSummaryCalls: 0,
+    setupReadinessCalls: 0,
+  };
   const server = createSupervisorHttpServer({
-    service: createStubService({ statusWhyCalls, explainCalls, issueLintCalls, setupReadinessCalls: 0 }),
+    service: createStubService(serviceArgs),
   });
   t.after(async () => {
     await closeServer(server);
@@ -626,6 +652,24 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
     },
     candidateDiscoverySummary: "candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+  });
+
+  const postMergeAuditSummaryResponse = await readJson({ server, path: "/api/post-merge-audits/summary" });
+  assert.equal(postMergeAuditSummaryResponse.statusCode, 200);
+  assert.equal(serviceArgs.postMergeAuditSummaryCalls, 1);
+  assert.deepEqual(postMergeAuditSummaryResponse.body, {
+    schemaVersion: 2,
+    advisoryOnly: true,
+    autoApplyGuardrails: false,
+    autoCreateFollowUpIssues: false,
+    generatedAt: "2026-03-24T12:00:00Z",
+    artifactDir: "/tmp/post-merge-audits",
+    artifactsAnalyzed: 3,
+    artifactsSkipped: 1,
+    reviewPatterns: [],
+    failurePatterns: [],
+    recoveryPatterns: [],
+    promotionCandidates: [],
   });
 
   const setupReadinessResponse = await readJson({ server, path: "/api/setup-readiness" });

--- a/src/backend/supervisor-http-server.ts
+++ b/src/backend/supervisor-http-server.ts
@@ -138,6 +138,15 @@ async function handleRequest(
     return;
   }
 
+  if (pathname === "/api/post-merge-audits/summary") {
+    if (!service.queryPostMergeAuditSummary) {
+      writeJson(response, 404, { error: "Not found." });
+      return;
+    }
+    writeJson(response, 200, await service.queryPostMergeAuditSummary());
+    return;
+  }
+
   if (pathname === "/api/setup-readiness") {
     if (!service.querySetupReadiness) {
       writeJson(response, 404, { error: "Not found." });


### PR DESCRIPTION
## Summary
- expose the advisory post-merge audit summary through the WebUI HTTP server at `GET /api/post-merge-audits/summary`
- add focused regression coverage proving the operator-facing route returns the existing summary DTO
- keep the reporting read-only and separate from pre-merge evaluation behavior

## Verification
- npx tsx --test src/backend/supervisor-http-server.test.ts
- npx tsx --test src/**/*.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/post-merge-audits/summary` API endpoint to retrieve post-merge audit summary data, enabling operators to query existing audit information.
  * Endpoint returns HTTP 404 when audit summary data is unavailable.

* **Tests**
  * Added comprehensive test coverage for the new audit summary endpoint, including verification of successful retrieval and proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->