### PR TITLE
Fix audit summary supporting evidence traceability

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,34 +1,34 @@
-# Issue #954: Refreshed snapshot propagation: require downstream state, actions, and metrics to use the latest source-of-truth snapshot
+# Issue #955: Audit traceability guard: preserve full supporting evidence until final summary and promotion derivation
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/954
-- Branch: codex/issue-954
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/955
+- Branch: codex/issue-955
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
-- Attempt count: 3 (implementation=3, repair=0)
-- Last head SHA: 794f64da7412bdb82c35eb66b9241a47f843a51b
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 78efe2e86f614698ce30302a776393a9aada4374
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-24T23:22:53.207Z
+- Updated at: 2026-03-25T00:34:00.000Z
 
 ## Latest Codex Summary
-- Reproduced a refreshed-snapshot propagation gap in `handlePostTurnMergeAndCompletion`: after a fresh merge-readiness snapshot downgraded a stale `ready_to_merge` record to `blocked`, the state transition kept the stale `last_error` instead of the refreshed failure context/signature. Tightened `src/supervisor/supervisor-pr-readiness.test.ts` to assert the refreshed local-review blocker details, then updated `src/supervisor/supervisor.ts` to propagate the refreshed failure context, last error, and failure signature through the post-refresh state write.
+- Tightened the post-merge audit summary contract so downstream derivation reads explicit full supporting evidence instead of presentation-shaped `example*` fields. Bumped the summary schema to 3, updated focused audit-summary regressions and typed runtime/server fixtures, then reran the requested audit-summary tests and `npm run build` after restoring dependencies with `npm ci`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: one refreshed-snapshot path still used stale downstream state fields after recomputing merge readiness, specifically the post-ready-to-merge refresh path that could downgrade to `blocked` without carrying the refreshed failure context forward.
-- What changed: tightened `src/supervisor/supervisor-pr-readiness.test.ts` so the stale-ready-to-merge regression asserts refreshed local-review blocker details; updated `handlePostTurnMergeAndCompletion()` in `src/supervisor/supervisor.ts` to propagate refreshed failure context, `last_error`, and failure-signature tracking when a refreshed snapshot downgrades the PR after rechecking merge readiness.
+- Hypothesis: the audit summary pipeline was preserving full evidence in memory but exposing it through `exampleIssueNumbers` and `exampleFindingKeys`, so promotion derivation depended on presentation-shaped fields that could be safely sampled later and lose traceability.
+- What changed: updated `src/supervisor/post-merge-audit-summary.ts` so review, failure, and recovery pattern DTOs carry explicit `supportingIssueNumbers` and `supportingFindingKeys`, and promotion candidates derive from those full-support fields; bumped the summary schema version from 2 to 3; refreshed `src/supervisor/post-merge-audit-summary.test.ts`, `src/supervisor/post-merge-audit-summary-runtime.test.ts`, and `src/backend/supervisor-http-server.test.ts` to assert the new contract.
 - Current blocker: none.
-- Next exact step: commit the issue-954 fix, then open or update the draft PR from `codex/issue-954`.
-- Verification gap: none in the requested scope; `npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts`, `npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts`, and `npm run build` passed after `npm ci`.
-- Files touched: `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-pr-readiness.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the runtime change only affects refreshed post-merge-readiness downgrades and aligns persisted failure fields with the already-computed refreshed lifecycle snapshot.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts && npm run build`
-- PR status: no PR opened from `codex/issue-954` yet in this turn.
+- Next exact step: commit the issue-955 traceability fix, then open or update the draft PR from `codex/issue-955`.
+- Verification gap: none in the requested scope; `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts` and `npm run build` passed after `npm ci`.
+- Files touched: `src/supervisor/post-merge-audit-summary.ts`, `src/supervisor/post-merge-audit-summary.test.ts`, `src/supervisor/post-merge-audit-summary-runtime.test.ts`, `src/backend/supervisor-http-server.test.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: medium-low; schema consumers now require version 3, so rollback would need the fixtures and validator to move back together.
+- Last focused command: `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts && npm run build`
+- PR status: no PR opened from `codex/issue-955` yet in this turn.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -523,7 +523,7 @@ function createStubService(args?: {
         args.postMergeAuditSummaryCalls = (args.postMergeAuditSummaryCalls ?? 0) + 1;
       }
       return {
-        schemaVersion: 2,
+        schemaVersion: 3,
         advisoryOnly: true,
         autoApplyGuardrails: false,
         autoCreateFollowUpIssues: false,
@@ -658,7 +658,7 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
   assert.equal(postMergeAuditSummaryResponse.statusCode, 200);
   assert.equal(serviceArgs.postMergeAuditSummaryCalls, 1);
   assert.deepEqual(postMergeAuditSummaryResponse.body, {
-    schemaVersion: 2,
+    schemaVersion: 3,
     advisoryOnly: true,
     autoApplyGuardrails: false,
     autoCreateFollowUpIssues: false,

--- a/src/supervisor/post-merge-audit-summary-runtime.test.ts
+++ b/src/supervisor/post-merge-audit-summary-runtime.test.ts
@@ -37,7 +37,7 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
           throw new Error("unexpected resetCorruptJsonState");
         },
         queryPostMergeAuditSummary: async () => ({
-          schemaVersion: 2,
+          schemaVersion: 3,
           advisoryOnly: true,
           autoApplyGuardrails: false,
           autoCreateFollowUpIssues: false,
@@ -59,7 +59,7 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
 
   assert.equal(stdout.length, 1);
   assert.deepEqual(JSON.parse(stdout[0] ?? ""), {
-    schemaVersion: 2,
+    schemaVersion: 3,
     advisoryOnly: true,
     autoApplyGuardrails: false,
     autoCreateFollowUpIssues: false,

--- a/src/supervisor/post-merge-audit-summary.test.ts
+++ b/src/supervisor/post-merge-audit-summary.test.ts
@@ -230,7 +230,7 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
 
   assert.deepEqual(validatePostMergeAuditPatternSummary(summary), summary);
   assert.deepEqual(Object.keys(summary).sort(), [...POST_MERGE_AUDIT_PATTERN_SUMMARY_TOP_LEVEL_KEYS].sort());
-  assert.equal(summary.schemaVersion, 2);
+  assert.equal(summary.schemaVersion, 3);
   assert.equal(summary.advisoryOnly, true);
   assert.equal(summary.autoApplyGuardrails, false);
   assert.equal(summary.autoCreateFollowUpIssues, false);
@@ -239,7 +239,7 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
   assert.equal(summary.reviewPatterns.length, 1);
   assert.equal(summary.reviewPatterns[0]?.artifactCount, 2);
   assert.equal(summary.reviewPatterns[0]?.evidenceCount, 4);
-  assert.deepEqual(summary.reviewPatterns[0]?.exampleIssueNumbers, [102, 103]);
+  assert.deepEqual(summary.reviewPatterns[0]?.supportingIssueNumbers, [102, 103]);
   assert.equal(summary.failurePatterns.length, 1);
   assert.equal(summary.failurePatterns[0]?.artifactCount, 2);
   assert.equal(summary.failurePatterns[0]?.repeatedCount, 3);
@@ -292,7 +292,7 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
 
 test("validatePostMergeAuditPatternSummary rejects unsupported schema versions and missing required fields", () => {
   const summary = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     generatedAt: "2026-03-25T00:00:00Z",
     artifactDir: "/tmp/post-merge",
     advisoryOnly: true,
@@ -310,7 +310,7 @@ test("validatePostMergeAuditPatternSummary rejects unsupported schema versions a
 
   assert.throws(
     () => validatePostMergeAuditPatternSummary({ ...summary, schemaVersion: 1 }),
-    /schemaVersion must be 2\./u,
+    /schemaVersion must be 3\./u,
   );
 
   const { promotionCandidates, ...summaryWithoutPromotionCandidates } = summary;
@@ -466,7 +466,7 @@ test("summarizePostMergeAuditPatterns keeps review promotion candidate keys uniq
   ]);
 
   const mediumPattern = summary.reviewPatterns.find((pattern) => pattern.severity === "medium");
-  assert.deepEqual(mediumPattern?.exampleFindingKeys, [
+  assert.deepEqual(mediumPattern?.supportingFindingKeys, [
     "medium-finding-a",
     "medium-finding-b",
     "medium-finding-c",
@@ -507,5 +507,5 @@ test("summarizePostMergeAuditPatterns tolerates root-cause summaries without fin
   assert.equal(summary.artifactsSkipped, 0);
   assert.equal(summary.reviewPatterns.length, 1);
   assert.equal(summary.reviewPatterns[0]?.evidenceCount, 0);
-  assert.deepEqual(summary.reviewPatterns[0]?.exampleFindingKeys, []);
+  assert.deepEqual(summary.reviewPatterns[0]?.supportingFindingKeys, []);
 });

--- a/src/supervisor/post-merge-audit-summary.ts
+++ b/src/supervisor/post-merge-audit-summary.ts
@@ -6,7 +6,7 @@ import type { ActionableSeverity, LocalReviewRootCauseSummary } from "../local-r
 import type { PostMergeAuditArtifact } from "./post-merge-audit-artifact";
 import { postMergeAuditArtifactDir } from "./post-merge-audit-artifact";
 
-export const POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION = 2;
+export const POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION = 3;
 export const POST_MERGE_AUDIT_PATTERN_SUMMARY_TOP_LEVEL_KEYS = [
   "schemaVersion",
   "generatedAt",
@@ -28,8 +28,8 @@ const POST_MERGE_AUDIT_REVIEW_PATTERN_KEYS = [
   "severity",
   "artifactCount",
   "evidenceCount",
-  "exampleIssueNumbers",
-  "exampleFindingKeys",
+  "supportingIssueNumbers",
+  "supportingFindingKeys",
 ] as const;
 const POST_MERGE_AUDIT_FAILURE_PATTERN_KEYS = [
   "key",
@@ -39,7 +39,7 @@ const POST_MERGE_AUDIT_FAILURE_PATTERN_KEYS = [
   "summary",
   "artifactCount",
   "repeatedCount",
-  "exampleIssueNumbers",
+  "supportingIssueNumbers",
   "lastSeenAt",
 ] as const;
 const POST_MERGE_AUDIT_RECOVERY_PATTERN_KEYS = [
@@ -47,7 +47,7 @@ const POST_MERGE_AUDIT_RECOVERY_PATTERN_KEYS = [
   "reason",
   "artifactCount",
   "occurrenceCount",
-  "exampleIssueNumbers",
+  "supportingIssueNumbers",
   "latestRecoveredAt",
 ] as const;
 const POST_MERGE_AUDIT_PROMOTION_CANDIDATE_KEYS = [
@@ -71,8 +71,8 @@ export interface PostMergeAuditReviewPatternDto {
   severity: ActionableSeverity;
   artifactCount: number;
   evidenceCount: number;
-  exampleIssueNumbers: number[];
-  exampleFindingKeys: string[];
+  supportingIssueNumbers: number[];
+  supportingFindingKeys: string[];
 }
 
 export interface PostMergeAuditFailurePatternDto {
@@ -83,7 +83,7 @@ export interface PostMergeAuditFailurePatternDto {
   summary: string | null;
   artifactCount: number;
   repeatedCount: number;
-  exampleIssueNumbers: number[];
+  supportingIssueNumbers: number[];
   lastSeenAt: string | null;
 }
 
@@ -92,7 +92,7 @@ export interface PostMergeAuditRecoveryPatternDto {
   reason: string;
   artifactCount: number;
   occurrenceCount: number;
-  exampleIssueNumbers: number[];
+  supportingIssueNumbers: number[];
   latestRecoveredAt: string | null;
 }
 
@@ -221,11 +221,14 @@ function expectReviewPattern(value: unknown, index: number): PostMergeAuditRevie
     severity,
     artifactCount: expectSummaryInteger(pattern.artifactCount, `reviewPatterns[${index}].artifactCount`),
     evidenceCount: expectSummaryInteger(pattern.evidenceCount, `reviewPatterns[${index}].evidenceCount`),
-    exampleIssueNumbers: expectIntegerArray(
-      pattern.exampleIssueNumbers,
-      `reviewPatterns[${index}].exampleIssueNumbers`,
+    supportingIssueNumbers: expectIntegerArray(
+      pattern.supportingIssueNumbers,
+      `reviewPatterns[${index}].supportingIssueNumbers`,
     ),
-    exampleFindingKeys: expectStringArray(pattern.exampleFindingKeys, `reviewPatterns[${index}].exampleFindingKeys`),
+    supportingFindingKeys: expectStringArray(
+      pattern.supportingFindingKeys,
+      `reviewPatterns[${index}].supportingFindingKeys`,
+    ),
   };
 }
 
@@ -241,9 +244,9 @@ function expectFailurePattern(value: unknown, index: number): PostMergeAuditFail
     summary: expectNullableSummaryString(pattern.summary, `failurePatterns[${index}].summary`),
     artifactCount: expectSummaryInteger(pattern.artifactCount, `failurePatterns[${index}].artifactCount`),
     repeatedCount: expectSummaryInteger(pattern.repeatedCount, `failurePatterns[${index}].repeatedCount`),
-    exampleIssueNumbers: expectIntegerArray(
-      pattern.exampleIssueNumbers,
-      `failurePatterns[${index}].exampleIssueNumbers`,
+    supportingIssueNumbers: expectIntegerArray(
+      pattern.supportingIssueNumbers,
+      `failurePatterns[${index}].supportingIssueNumbers`,
     ),
     lastSeenAt: expectNullableSummaryString(pattern.lastSeenAt, `failurePatterns[${index}].lastSeenAt`),
   };
@@ -258,9 +261,9 @@ function expectRecoveryPattern(value: unknown, index: number): PostMergeAuditRec
     reason: expectSummaryString(pattern.reason, `recoveryPatterns[${index}].reason`),
     artifactCount: expectSummaryInteger(pattern.artifactCount, `recoveryPatterns[${index}].artifactCount`),
     occurrenceCount: expectSummaryInteger(pattern.occurrenceCount, `recoveryPatterns[${index}].occurrenceCount`),
-    exampleIssueNumbers: expectIntegerArray(
-      pattern.exampleIssueNumbers,
-      `recoveryPatterns[${index}].exampleIssueNumbers`,
+    supportingIssueNumbers: expectIntegerArray(
+      pattern.supportingIssueNumbers,
+      `recoveryPatterns[${index}].supportingIssueNumbers`,
     ),
     latestRecoveredAt: expectNullableSummaryString(
       pattern.latestRecoveredAt,
@@ -510,8 +513,8 @@ function createReviewPromotionCandidates(
       summary: `Recurring review pattern: ${pattern.summary}`,
       rationale: `This ${pattern.severity}-severity review pattern recurred across ${pattern.artifactCount} post-merge audits.`,
       sourcePatternKeys: [pattern.key],
-      supportingIssueNumbers: [...pattern.exampleIssueNumbers],
-      supportingFindingKeys: [...pattern.exampleFindingKeys],
+      supportingIssueNumbers: [...pattern.supportingIssueNumbers],
+      supportingFindingKeys: [...pattern.supportingFindingKeys],
       advisoryOnly: true,
       autoApply: false,
       autoCreateFollowUpIssue: false,
@@ -523,8 +526,8 @@ function createReviewPromotionCandidates(
       summary: `Capture the recurring lesson behind: ${pattern.summary}`,
       rationale: `The same review lesson appeared in ${pattern.artifactCount} merged issues and should stay queryable for future sessions.`,
       sourcePatternKeys: [pattern.key],
-      supportingIssueNumbers: [...pattern.exampleIssueNumbers],
-      supportingFindingKeys: [...pattern.exampleFindingKeys],
+      supportingIssueNumbers: [...pattern.supportingIssueNumbers],
+      supportingFindingKeys: [...pattern.supportingFindingKeys],
       advisoryOnly: true,
       autoApply: false,
       autoCreateFollowUpIssue: false,
@@ -554,7 +557,7 @@ function createFailurePromotionCandidates(
       summary,
       rationale: `The same failure pattern recurred across ${pattern.artifactCount} post-merge audits with ${pattern.repeatedCount} total repeats.`,
       sourcePatternKeys: [pattern.key],
-      supportingIssueNumbers: [...pattern.exampleIssueNumbers],
+      supportingIssueNumbers: [...pattern.supportingIssueNumbers],
       supportingFindingKeys: [],
       advisoryOnly: true,
       autoApply: false,
@@ -578,7 +581,7 @@ function createRecoveryPromotionCandidates(
       summary: pattern.reason,
       rationale: `Operators recovered this way in ${pattern.artifactCount} post-merge audits, so the workflow is a documentation candidate.`,
       sourcePatternKeys: [pattern.key],
-      supportingIssueNumbers: [...pattern.exampleIssueNumbers],
+      supportingIssueNumbers: [...pattern.supportingIssueNumbers],
       supportingFindingKeys: [],
       advisoryOnly: true,
       autoApply: false,
@@ -707,8 +710,8 @@ export async function summarizePostMergeAuditPatterns(
       severity: pattern.severity,
       artifactCount: pattern.artifactNumbers.size,
       evidenceCount: pattern.evidenceCount,
-      exampleIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
-      exampleFindingKeys: [...pattern.findingKeys].sort(compareStringsAscending),
+      supportingIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
+      supportingFindingKeys: [...pattern.findingKeys].sort(compareStringsAscending),
     }))
     .sort((left, right) =>
       right.artifactCount - left.artifactCount ||
@@ -724,7 +727,7 @@ export async function summarizePostMergeAuditPatterns(
       summary: pattern.summary,
       artifactCount: pattern.artifactNumbers.size,
       repeatedCount: pattern.repeatedCount,
-      exampleIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
+      supportingIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
       lastSeenAt: pattern.lastSeenAt,
     }))
     .sort((left, right) =>
@@ -739,7 +742,7 @@ export async function summarizePostMergeAuditPatterns(
       reason: pattern.reason,
       artifactCount: pattern.artifactNumbers.size,
       occurrenceCount: pattern.occurrenceCount,
-      exampleIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
+      supportingIssueNumbers: [...pattern.artifactNumbers].sort(compareNumbersAscending),
       latestRecoveredAt: pattern.latestRecoveredAt,
     }))
     .sort((left, right) =>


### PR DESCRIPTION
## Summary
- preserve explicit full supporting evidence in post-merge audit summary patterns
- derive promotion candidates from supporting evidence fields instead of presentation-shaped example fields
- bump the audit summary schema to 3 and update typed fixtures/tests

## Testing
- npm ci
- npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts
- npm run build

Closes #955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Schema Updates**
  * Post-merge audit summary schema bumped from version 2 to 3.
  * Audit evidence fields restructured to require explicit supporting information instead of example data.
  * Enhanced downstream promotion validation through improved audit traceability.

* **Tests**
  * Test fixtures and assertions updated for schema version 3 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->