### PR TITLE
test: isolate artifact temp roots

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,34 +1,34 @@
-# Issue #955: Audit traceability guard: preserve full supporting evidence until final summary and promotion derivation
+# Issue #956: Artifact test isolation: standardize per-test temporary roots for artifact generation and persistence coverage
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/955
-- Branch: codex/issue-955
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/956
+- Branch: codex/issue-956
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 78efe2e86f614698ce30302a776393a9aada4374
+- Last head SHA: 4519e6a7fc7b57298bfe044d4992b7c705589b66
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-25T00:34:00.000Z
+- Updated at: 2026-03-25T00:47:45.944Z
 
 ## Latest Codex Summary
-- Tightened the post-merge audit summary contract so downstream derivation reads explicit full supporting evidence instead of presentation-shaped `example*` fields. Bumped the summary schema to 3, updated focused audit-summary regressions and typed runtime/server fixtures, then reran the requested audit-summary tests and `npm run build` after restoring dependencies with `npm ci`.
+- Standardized the scoped artifact-generation tests onto per-test temporary roots via `src/supervisor/artifact-test-helpers.ts`, added an isolation regression in `src/supervisor/post-merge-audit-artifact.test.ts`, and verified the requested test set plus `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the audit summary pipeline was preserving full evidence in memory but exposing it through `exampleIssueNumbers` and `exampleFindingKeys`, so promotion derivation depended on presentation-shaped fields that could be safely sampled later and lose traceability.
-- What changed: updated `src/supervisor/post-merge-audit-summary.ts` so review, failure, and recovery pattern DTOs carry explicit `supportingIssueNumbers` and `supportingFindingKeys`, and promotion candidates derive from those full-support fields; bumped the summary schema version from 2 to 3; refreshed `src/supervisor/post-merge-audit-summary.test.ts`, `src/supervisor/post-merge-audit-summary-runtime.test.ts`, and `src/backend/supervisor-http-server.test.ts` to assert the new contract.
+- Hypothesis: artifact persistence coverage was still vulnerable to stale files surviving prior test runs because some tests pointed `localReviewArtifactDir` at shared `os.tmpdir()` paths instead of a per-test root.
+- What changed: added `src/supervisor/artifact-test-helpers.ts` with `createArtifactTestPaths(prefix)` to allocate isolated root/workspace/review paths per test; rewired `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/post-merge-audit-artifact.test.ts`, and `src/supervisor/post-merge-audit-summary.test.ts` to use that helper; added a focused regression asserting distinct roots do not share stale review artifacts.
 - Current blocker: none.
-- Next exact step: commit the issue-955 traceability fix, then open or update the draft PR from `codex/issue-955`.
-- Verification gap: none in the requested scope; `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts` and `npm run build` passed after `npm ci`.
-- Files touched: `src/supervisor/post-merge-audit-summary.ts`, `src/supervisor/post-merge-audit-summary.test.ts`, `src/supervisor/post-merge-audit-summary-runtime.test.ts`, `src/backend/supervisor-http-server.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: medium-low; schema consumers now require version 3, so rollback would need the fixtures and validator to move back together.
-- Last focused command: `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts && npm run build`
-- PR status: no PR opened from `codex/issue-955` yet in this turn.
+- Next exact step: stage the isolated-root test changes, commit them on `codex/issue-956`, then open or update the draft PR if the branch does not already have one.
+- Verification gap: none in the requested scope; `npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/post-merge-audit-artifact.test.ts src/supervisor/post-merge-audit-summary.test.ts` and `npm run build` passed after restoring deps with `npm ci`.
+- Files touched: `src/supervisor/artifact-test-helpers.ts`, `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/post-merge-audit-artifact.test.ts`, `src/supervisor/post-merge-audit-summary.test.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; the change is test-only and isolated to temporary-path setup.
+- Last focused command: `npm run build`
+- PR status: no PR opened from `codex/issue-956` yet in this turn.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/supervisor/artifact-test-helpers.ts
+++ b/src/supervisor/artifact-test-helpers.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface ArtifactTestPaths {
+  rootPath: string;
+  workspacePath: string;
+  reviewDir: string;
+}
+
+export async function createArtifactTestPaths(prefix: string): Promise<ArtifactTestPaths> {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+  const workspacePath = path.join(rootPath, "workspace");
+  const reviewDir = path.join(rootPath, "reviews");
+
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.mkdir(reviewDir, { recursive: true });
+
+  return {
+    rootPath,
+    workspacePath,
+    reviewDir,
+  };
+}

--- a/src/supervisor/execution-metrics-run-summary.test.ts
+++ b/src/supervisor/execution-metrics-run-summary.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { prepareIssueExecutionContext } from "../run-once-issue-preparation";
@@ -15,6 +14,7 @@ import type {
 } from "../core/types";
 import { createConfig as createTurnConfig, createIssue, createPullRequest, createRecord } from "../turn-execution-test-helpers";
 import type { AgentRunner, AgentTurnRequest } from "./agent-runner";
+import { createArtifactTestPaths } from "./artifact-test-helpers";
 import { postMergeAuditArtifactPath } from "./post-merge-audit-artifact";
 
 interface ExecutionMetricsRunSummary {
@@ -256,8 +256,7 @@ async function readExecutionMetricsRunSummary(workspacePath: string): Promise<Ex
 }
 
 test("prepareIssueExecutionContext writes a run summary artifact for done outcomes", async () => {
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "execution-metrics-done-"));
-  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "execution-metrics-done-reviews-"));
+  const { workspacePath, reviewDir } = await createArtifactTestPaths("execution-metrics-done");
   const config = createPreparationConfig({ localReviewArtifactDir: reviewDir });
   const record = createPreparationRecord(workspacePath);
   const state = createState(record);
@@ -358,7 +357,7 @@ test("prepareIssueExecutionContext writes a run summary artifact for done outcom
 });
 
 test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes", async () => {
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "execution-metrics-blocked-"));
+  const { workspacePath } = await createArtifactTestPaths("execution-metrics-blocked");
   const record = createRecord({
     issue_number: 102,
     state: "implementing",
@@ -541,7 +540,7 @@ test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes",
 });
 
 test("executeCodexTurnPhase writes a run summary artifact for failed outcomes", async () => {
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "execution-metrics-failed-"));
+  const { workspacePath } = await createArtifactTestPaths("execution-metrics-failed");
   const record = createRecord({
     issue_number: 103,
     state: "implementing",

--- a/src/supervisor/post-merge-audit-artifact.test.ts
+++ b/src/supervisor/post-merge-audit-artifact.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { writeJsonAtomic } from "../core/utils";
 import { type LocalReviewArtifact } from "../local-review/types";
 import { createConfig, createFailureContext, createIssue, createPullRequest, createRecord } from "../turn-execution-test-helpers";
+import { createArtifactTestPaths } from "./artifact-test-helpers";
 import { type ExecutionMetricsRunSummaryArtifact } from "./execution-metrics-schema";
 import {
   executionMetricsRunSummaryPath,
@@ -17,9 +17,21 @@ import {
   type PostMergeAuditArtifact,
 } from "./post-merge-audit-artifact";
 
+test("createArtifactTestPaths returns isolated roots for each artifact test setup", async () => {
+  const first = await createArtifactTestPaths("post-merge-audit-isolation");
+  const second = await createArtifactTestPaths("post-merge-audit-isolation");
+  const sentinelPath = path.join(first.reviewDir, "sentinel.txt");
+
+  assert.notEqual(first.rootPath, second.rootPath);
+  assert.notEqual(first.workspacePath, second.workspacePath);
+  assert.notEqual(first.reviewDir, second.reviewDir);
+
+  await fs.writeFile(sentinelPath, "stale artifact", "utf8");
+  await assert.rejects(fs.stat(path.join(second.reviewDir, "sentinel.txt")), { code: "ENOENT" });
+});
+
 test("syncPostMergeAuditArtifact persists a typed completed-work artifact", async () => {
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-"));
-  const reviewDir = path.join(os.tmpdir(), "post-merge-audit-reviews");
+  const { workspacePath, reviewDir } = await createArtifactTestPaths("post-merge-audit");
   const config = createConfig({
     localReviewArtifactDir: reviewDir,
     repoSlug: "owner/repo",
@@ -176,8 +188,7 @@ test("syncPostMergeAuditArtifact persists a typed completed-work artifact", asyn
 });
 
 test("syncPostMergeAuditArtifact ignores stale execution metrics summaries", async () => {
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-stale-metrics-"));
-  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-stale-reviews-"));
+  const { workspacePath, reviewDir } = await createArtifactTestPaths("post-merge-audit-stale-metrics");
   const config = createConfig({
     localReviewArtifactDir: reviewDir,
     repoSlug: "owner/repo",
@@ -248,8 +259,7 @@ test("syncPostMergeAuditArtifact ignores stale execution metrics summaries", asy
 });
 
 test("syncPostMergeAuditArtifactSafely swallows malformed local review artifacts", async () => {
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-safe-wrapper-"));
-  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-safe-wrapper-reviews-"));
+  const { workspacePath, reviewDir } = await createArtifactTestPaths("post-merge-audit-safe-wrapper");
   const config = createConfig({
     localReviewArtifactDir: reviewDir,
     repoSlug: "owner/repo",

--- a/src/supervisor/post-merge-audit-summary.test.ts
+++ b/src/supervisor/post-merge-audit-summary.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { writeJsonAtomic } from "../core/utils";
 import { createConfig } from "../turn-execution-test-helpers";
 import type { LocalReviewArtifact } from "../local-review/types";
+import { createArtifactTestPaths } from "./artifact-test-helpers";
 import type { PostMergeAuditArtifact } from "./post-merge-audit-artifact";
 import { postMergeAuditArtifactDir } from "./post-merge-audit-artifact";
 import {
@@ -148,7 +148,7 @@ function createPostMergeArtifact(overrides: Partial<PostMergeAuditArtifact> = {}
 }
 
 test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and recovery patterns from persisted artifacts", async () => {
-  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-summary-"));
+  const { reviewDir } = await createArtifactTestPaths("post-merge-audit-summary");
   const config = createConfig({
     localReviewArtifactDir: reviewDir,
     repoSlug: "owner/repo",
@@ -322,7 +322,7 @@ test("validatePostMergeAuditPatternSummary rejects unsupported schema versions a
 });
 
 test("summarizePostMergeAuditPatterns keeps review promotion candidate keys unique per severity and preserves full finding traceability", async () => {
-  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-summary-"));
+  const { reviewDir } = await createArtifactTestPaths("post-merge-audit-summary");
   const config = createConfig({
     localReviewArtifactDir: reviewDir,
     repoSlug: "owner/repo",
@@ -485,7 +485,7 @@ test("summarizePostMergeAuditPatterns keeps review promotion candidate keys uniq
 });
 
 test("summarizePostMergeAuditPatterns tolerates root-cause summaries without finding metadata", async () => {
-  const reviewDir = await fs.mkdtemp(path.join(os.tmpdir(), "post-merge-audit-summary-"));
+  const { reviewDir } = await createArtifactTestPaths("post-merge-audit-summary");
   const config = createConfig({
     localReviewArtifactDir: reviewDir,
     repoSlug: "owner/repo",


### PR DESCRIPTION
## Summary
- standardize scoped artifact persistence tests on per-test temporary roots
- add a focused regression proving artifact setups do not share stale review artifacts
- keep runtime behavior unchanged by limiting changes to test helpers and fixtures

## Verification
- npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/post-merge-audit-artifact.test.ts src/supervisor/post-merge-audit-summary.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved artifact test isolation by introducing a shared test helper for temporary directory management.
  * Added regression test to verify artifacts remain isolated across separate test runs.
  * Updated existing tests to use the new helper infrastructure.

* **Chores**
  * Updated internal documentation to reflect current work focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->