### PR TITLE
Fix WebUI loop mode status

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,34 +1,36 @@
-# Issue #956: Artifact test isolation: standardize per-test temporary roots for artifact generation and persistence coverage
+# Issue #957: WebUI can falsely report loop mode is off while supervisor loop is running
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/956
-- Branch: codex/issue-956
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/957
+- Branch: codex/issue-957
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
+- Current phase: stabilizing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 4519e6a7fc7b57298bfe044d4992b7c705589b66
+- Last head SHA: e2ade43f36c3b5cfe705d591323d546467d23180
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-25T00:47:45.944Z
+- Updated at: 2026-03-25T01:37:13.000Z
 
 ## Latest Codex Summary
-- Standardized the scoped artifact-generation tests onto per-test temporary roots via `src/supervisor/artifact-test-helpers.ts`, added an isolation regression in `src/supervisor/post-merge-audit-artifact.test.ts`, and verified the requested test set plus `npm run build`.
+- Reproduced the false WebUI loop-off state with focused dashboard tests, then replaced the hardcoded shell copy with typed rendering driven by a new `loopRuntime` status field.
+- Added a long-lived supervisor loop-runtime lock held for the lifetime of the `loop` command and inspected that lock from `statusReport` so `/api/status` reports live loop state without guessing from issue selection.
+- Focused verification passed for the dashboard, supervisor status, CLI runtime, HTTP, service, browser smoke, and build paths after restoring local dependencies with `npm ci`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: artifact persistence coverage was still vulnerable to stale files surviving prior test runs because some tests pointed `localReviewArtifactDir` at shared `os.tmpdir()` paths instead of a per-test root.
-- What changed: added `src/supervisor/artifact-test-helpers.ts` with `createArtifactTestPaths(prefix)` to allocate isolated root/workspace/review paths per test; rewired `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/post-merge-audit-artifact.test.ts`, and `src/supervisor/post-merge-audit-summary.test.ts` to use that helper; added a focused regression asserting distinct roots do not share stale review artifacts.
+- Hypothesis: the dashboard shell hardcoded loop-off copy instead of rendering from a typed live runtime signal, so the UI could contradict a running supervisor loop between refreshes.
+- What changed: added `src/supervisor/supervisor-loop-runtime-state.ts` to manage and inspect a long-lived loop-runtime lock; exposed `loopRuntime` on `SupervisorStatusDto`; held the runtime lock for the lifetime of the `loop` CLI command; replaced hardcoded dashboard loop-off shell copy with typed elements rendered from `/api/status`; added focused regressions for loop-running and loop-off dashboard states plus a supervisor status-runtime regression.
 - Current blocker: none.
-- Next exact step: stage the isolated-root test changes, commit them on `codex/issue-956`, then open or update the draft PR if the branch does not already have one.
-- Verification gap: none in the requested scope; `npx tsx --test src/supervisor/execution-metrics-run-summary.test.ts src/supervisor/post-merge-audit-artifact.test.ts src/supervisor/post-merge-audit-summary.test.ts` and `npm run build` passed after restoring deps with `npm ci`.
-- Files touched: `src/supervisor/artifact-test-helpers.ts`, `src/supervisor/execution-metrics-run-summary.test.ts`, `src/supervisor/post-merge-audit-artifact.test.ts`, `src/supervisor/post-merge-audit-summary.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the change is test-only and isolated to temporary-path setup.
-- Last focused command: `npm run build`
-- PR status: no PR opened from `codex/issue-956` yet in this turn.
+- Next exact step: stage the loop-runtime/dashboard changes, commit them on `codex/issue-957`, and continue with broader verification or PR prep.
+- Verification gap: none in the requested scope after restoring local dependencies with `npm ci`.
+- Files touched: `src/backend/supervisor-http-server.test.ts`, `src/backend/webui-dashboard-browser-logic.ts`, `src/backend/webui-dashboard-browser-script.ts`, `src/backend/webui-dashboard-browser-smoke.test.ts`, `src/backend/webui-dashboard-page.ts`, `src/backend/webui-dashboard-panel-layout.ts`, `src/backend/webui-dashboard.test.ts`, `src/cli/supervisor-runtime.test.ts`, `src/cli/supervisor-runtime.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-loop-controller.ts`, `src/supervisor/supervisor-loop-runtime-state.ts`, `src/supervisor/supervisor-service.test.ts`, `src/supervisor/supervisor-status-report.ts`, `src/supervisor/supervisor.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: moderate; the runtime lock is intentionally long-lived for `loop` processes, so regressions would most likely show up as false loop-running state or loop startup refusal if the lock path/cleanup behavior is wrong.
+- Last focused command: `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`
+- PR status: no PR opened from `codex/issue-957` yet in this turn.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -406,6 +406,12 @@ function createStubService(args?: {
           observedMatchingOpenIssues: null,
           warning: null,
         },
+        loopRuntime: {
+          state: "off",
+          pid: null,
+          startedAt: null,
+          detail: null,
+        },
         activeIssue: null,
         selectionSummary: {
           selectedIssueNumber: null,
@@ -610,6 +616,12 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
       truncated: false,
       observedMatchingOpenIssues: null,
       warning: null,
+    },
+    loopRuntime: {
+      state: "off",
+      pid: null,
+      startedAt: null,
+      detail: null,
     },
     activeIssue: null,
     selectionSummary: {

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -36,6 +36,13 @@ export interface DashboardCandidateDiscoveryLike {
   warning?: string | null;
 }
 
+export interface DashboardLoopRuntimeLike {
+  state?: "running" | "off" | "unknown" | null;
+  pid?: number | null;
+  startedAt?: string | null;
+  detail?: string | null;
+}
+
 export interface DashboardStatusLike {
   selectionSummary?: DashboardSelectionSummaryLike | null;
   activeIssue?: DashboardActiveIssueLike | null;
@@ -48,6 +55,7 @@ export interface DashboardStatusLike {
   candidateDiscovery?: DashboardCandidateDiscoveryLike | null;
   candidateDiscoverySummary?: string | null;
   reconciliationWarning?: string | null;
+  loopRuntime?: DashboardLoopRuntimeLike | null;
 }
 
 export interface DashboardIssueShortcut {

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -77,7 +77,10 @@ export function renderDashboardBrowserScript(): string {
         refreshState: document.getElementById("refresh-state"),
         selectedIssueBadge: document.getElementById("selected-issue-badge"),
         lastRefreshBadge: document.getElementById("last-refresh-badge"),
+        loopModeBadge: document.getElementById("loop-mode-badge"),
+        loopStateSummary: document.getElementById("loop-state-summary"),
         statusReconciliation: document.getElementById("status-reconciliation"),
+        statusLoopChip: document.getElementById("status-loop-chip"),
         statusMetrics: document.getElementById("status-metrics"),
         statusWorkflow: document.getElementById("status-workflow"),
         statusLines: document.getElementById("status-lines"),
@@ -383,6 +386,42 @@ export function renderDashboardBrowserScript(): string {
         setText(elements.lastRefreshBadge, formatRefreshTime(state.lastRefreshAt));
       }
 
+      function describeLoopRuntime(loopRuntime) {
+        const runtimeState = loopRuntime && typeof loopRuntime.state === "string" ? loopRuntime.state : "unknown";
+        if (runtimeState === "running") {
+          return {
+            modeBadge: "Mode: web + loop running",
+            summary: "Loop mode is running on this host",
+            chipLabel: "loop running",
+            chipTone: "ok",
+          };
+        }
+        if (runtimeState === "off") {
+          return {
+            modeBadge: "Mode: web only (loop off)",
+            summary: "Loop mode is off on this host",
+            chipLabel: "loop off",
+            chipTone: "ok",
+          };
+        }
+        return {
+          modeBadge: "Mode: local WebUI",
+          summary: "Loop status is unavailable on this host",
+          chipLabel: "loop unknown",
+          chipTone: "info",
+        };
+      }
+
+      function renderLoopRuntime(status) {
+        const loopRuntime = describeLoopRuntime(status && status.loopRuntime);
+        setText(elements.loopModeBadge, loopRuntime.modeBadge);
+        setText(elements.loopStateSummary, loopRuntime.summary);
+        if (elements.statusLoopChip) {
+          setText(elements.statusLoopChip, loopRuntime.chipLabel);
+          elements.statusLoopChip.className = "chip " + loopRuntime.chipTone;
+        }
+      }
+
       function formatLatestRecovery(activityContext, fallbackSummary) {
         const latestRecovery = activityContext && activityContext.latestRecovery;
         if (latestRecovery) {
@@ -524,6 +563,7 @@ export function renderDashboardBrowserScript(): string {
         }
 
         const status = state.status;
+        renderLoopRuntime(status);
         const reconciliationPhase = status.reconciliationPhase || "steady";
         setText(elements.statusReconciliation, reconciliationPhase);
         elements.statusReconciliation.className = "metric " + metricClass(reconciliationPhase);

--- a/src/backend/webui-dashboard-browser-smoke.test.ts
+++ b/src/backend/webui-dashboard-browser-smoke.test.ts
@@ -72,6 +72,12 @@ function createStubService(args?: { pruneCalls?: number[] }): SupervisorService 
       cadenceDiagnostics: doctorDiagnostics.cadenceDiagnostics,
       candidateDiscoverySummary: null,
       candidateDiscovery: null,
+      loopRuntime: {
+        state: "off",
+        pid: null,
+        startedAt: null,
+        detail: null,
+      },
       activeIssue: null,
       selectionSummary: {
         selectedIssueNumber: null,
@@ -365,6 +371,12 @@ function createFirstRunSetupService(args: {
       cadenceDiagnostics: doctorDiagnostics.cadenceDiagnostics,
       candidateDiscoverySummary: null,
       candidateDiscovery: null,
+      loopRuntime: {
+        state: "off",
+        pid: null,
+        startedAt: null,
+        detail: null,
+      },
       activeIssue: null,
       selectionSummary: {
         selectedIssueNumber: null,

--- a/src/backend/webui-dashboard-page.ts
+++ b/src/backend/webui-dashboard-page.ts
@@ -1121,7 +1121,7 @@ export function renderSupervisorDashboardPage(): string {
           <div class="topbar-meta">
             <div class="topbar-pill">Layout: fixed admin dashboard</div>
             <div class="topbar-pill">Surface: local WebUI</div>
-            <div class="topbar-pill">Mode: web only (loop off)</div>
+            <div id="loop-mode-badge" class="topbar-pill">Mode: local WebUI</div>
           </div>
         </header>
 
@@ -1132,7 +1132,7 @@ export function renderSupervisorDashboardPage(): string {
                 <p class="section-kicker">Supervisor workspace</p>
                 <h2>Operational visibility without panel drag-and-drop.</h2>
                 <p>Current health, issue context, and safe actions stay in a predictable layout so repeat visits feel familiar.</p>
-                <div class="loop-off-pill">Loop mode is off on this host</div>
+                <div id="loop-state-summary" class="loop-off-pill">Loop status will appear after the first /api/status refresh</div>
               </div>
             </article>
             <aside class="summary-card">

--- a/src/backend/webui-dashboard-panel-layout.ts
+++ b/src/backend/webui-dashboard-panel-layout.ts
@@ -93,7 +93,7 @@ export const DASHBOARD_PANEL_REGISTRY = [
                 </div>
                 <div class="chip-row">
                   <span class="chip info">web mode</span>
-                  <span class="chip ok">loop off</span>
+                  <span id="status-loop-chip" class="chip info">loop status pending</span>
                 </div>
               </div>
               <div id="status-metrics" class="metric-grid">

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -254,6 +254,12 @@ function jsonResponse(body: unknown, statusCode = 200): MockResponseLike {
 function createStatus(args: {
   selectedIssueNumber?: number | null;
   includeWhyLines?: boolean;
+  loopRuntime?: {
+    state: "running" | "off" | "unknown";
+    pid: number | null;
+    startedAt: string | null;
+    detail: string | null;
+  } | null;
   trackedIssues?: Array<{
     issueNumber: number;
     state: string;
@@ -290,6 +296,13 @@ function createStatus(args: {
     trackedIssues: args.trackedIssues ?? [],
     runnableIssues: args.runnableIssues ?? [],
     blockedIssues: args.blockedIssues ?? [],
+    loopRuntime:
+      args.loopRuntime ?? {
+        state: "off",
+        pid: null,
+        startedAt: null,
+        detail: null,
+      },
     reconciliationPhase: null,
     warning: null,
     detailedStatusLines: [],
@@ -473,9 +486,9 @@ test("dashboard page frames the hero and both panel groups with labeled section 
 
   assert.match(html, /<div class="app-shell">[\s\S]*<aside class="sidebar">[\s\S]*<main class="content" data-dashboard-root>/u);
   assert.match(html, /<header class="topbar">[\s\S]*<h1>Operator dashboard<\/h1>[\s\S]*Layout: fixed admin dashboard/u);
-  assert.match(html, /Mode: web only \(loop off\)/u);
+  assert.match(html, /id="loop-mode-badge"/u);
   assert.match(html, /<section class="hero">[\s\S]*<article class="hero-card">[\s\S]*<aside class="summary-card">/u);
-  assert.match(html, /Loop mode is off on this host/u);
+  assert.match(html, /id="loop-state-summary"/u);
   assert.match(
     html,
     /<section class="stats-grid" aria-label="live summary">[\s\S]*id="connection-state"[\s\S]*id="freshness-state"[\s\S]*id="selected-issue-badge"[\s\S]*id="last-refresh-badge"/u,
@@ -595,6 +608,66 @@ test("dashboard derives the selected issue from typed status fields without pars
   assert.equal(issueNumberInput.value, "42");
   assert.match(statusWorkflow.textContent, /Execute/u);
   assert.match(statusWorkflow.textContent, /#42/u);
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
+test("dashboard does not claim loop mode is off while typed runtime status reports the loop is running", async () => {
+  const harness = createDashboardHarness([
+    {
+      path: "/api/status?why=true",
+      response: jsonResponse(
+        createStatus({
+          selectedIssueNumber: 42,
+          loopRuntime: {
+            state: "running",
+            pid: 4242,
+            startedAt: "2026-03-25T00:00:00.000Z",
+            detail: "pid 4242",
+          },
+        }),
+      ),
+    },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const loopModeBadge = harness.document.getElementById("loop-mode-badge");
+  const loopStateSummary = harness.document.getElementById("loop-state-summary");
+  assert.ok(loopModeBadge);
+  assert.ok(loopStateSummary);
+
+  assert.match(loopModeBadge.textContent, /loop running/u);
+  assert.doesNotMatch(loopModeBadge.textContent, /loop off/u);
+  assert.match(loopStateSummary.textContent, /Loop mode is running on this host/u);
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
+test("dashboard renders the loop-off presentation only when typed runtime status reports loop off", async () => {
+  const harness = createDashboardHarness([
+    {
+      path: "/api/status?why=true",
+      response: jsonResponse(
+        createStatus({
+          loopRuntime: {
+            state: "off",
+            pid: null,
+            startedAt: null,
+            detail: null,
+          },
+        }),
+      ),
+    },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const loopModeBadge = harness.document.getElementById("loop-mode-badge");
+  const loopStateSummary = harness.document.getElementById("loop-state-summary");
+  assert.ok(loopModeBadge);
+  assert.ok(loopStateSummary);
+
+  assert.match(loopModeBadge.textContent, /loop off/u);
+  assert.match(loopStateSummary.textContent, /Loop mode is off on this host/u);
   assert.equal(harness.remainingFetches.length, 0);
 });
 

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { LockHandle } from "../core/lock";
 import type { SupervisorConfig } from "../core/types";
 import type { SupervisorIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
 import type { SupervisorStatusDto } from "../supervisor/supervisor-status-report";
@@ -23,6 +24,12 @@ function createStatusDto(overrides: Partial<SupervisorStatusDto> = {}): Supervis
   return {
     gsdSummary: null,
     candidateDiscovery: null,
+    loopRuntime: {
+      state: "off",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
     activeIssue: null,
     selectionSummary: null,
     trackedIssues: [],
@@ -35,6 +42,13 @@ function createStatusDto(overrides: Partial<SupervisorStatusDto> = {}): Supervis
     whyLines: [],
     warning: null,
     ...overrides,
+  };
+}
+
+function createLoopRuntimeLockHandle(): LockHandle {
+  return {
+    acquired: true,
+    release: async () => {},
   };
 }
 
@@ -106,6 +120,7 @@ test("runSupervisorCommand stops the loop after a registered signal and aborts p
         },
       },
       loopController: {
+        acquireLoopRuntimeLock: async () => createLoopRuntimeLockHandle(),
         runCycle: async () => {
           loopRuns += 1;
           return "cycle complete";
@@ -273,6 +288,7 @@ test("runSupervisorCommand re-reads the poll cadence between loop cycles", async
         },
       },
       loopController: {
+        acquireLoopRuntimeLock: async () => createLoopRuntimeLockHandle(),
         runCycle: async () => {
           loopRuns += 1;
           return "cycle complete";
@@ -342,6 +358,7 @@ test("runSupervisorCommand skips sleep when stop is requested while resolving th
         },
       },
       loopController: {
+        acquireLoopRuntimeLock: async () => createLoopRuntimeLockHandle(),
         runCycle: async () => {
           loopRuns += 1;
           return "cycle complete";
@@ -416,6 +433,7 @@ test("runSupervisorCommand stops the loop after a corrupt-json fail-closed block
         },
       },
       loopController: {
+        acquireLoopRuntimeLock: async () => createLoopRuntimeLockHandle(),
         runCycle: async () => {
           loopRuns += 1;
           return "Blocked execution-changing command: corrupted JSON supervisor state detected at /tmp/state.json. Run status, doctor, or reset-corrupt-json-state before retrying.";

--- a/src/cli/supervisor-runtime.ts
+++ b/src/cli/supervisor-runtime.ts
@@ -241,29 +241,38 @@ export async function runSupervisorCommand(
     return;
   }
 
-  while (!shouldStop) {
-    try {
-      const message = await runSupervisorCycle(cycleController!, "loop", { dryRun: options.dryRun });
-      writeStdout(`${new Date().toISOString()} ${message}`);
-      if (isCorruptJsonFailClosedMessage(message)) {
-        shouldStop = true;
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.stack ?? error.message : String(error);
-      writeStderr(`${new Date().toISOString()} loop-error ${message}`);
-    }
+  const loopRuntimeLock = await cycleController!.acquireLoopRuntimeLock();
+  if (!loopRuntimeLock.acquired) {
+    throw new Error(`Cannot start supervisor loop: ${loopRuntimeLock.reason ?? "loop runtime unavailable"}`);
+  }
 
-    if (!shouldStop) {
-      const pollIntervalMs = await service.pollIntervalMs();
-      if (shouldStop) {
-        break;
-      }
-      sleepController = new AbortController();
+  try {
+    while (!shouldStop) {
       try {
-        await sleep(pollIntervalMs, sleepController.signal);
-      } finally {
-        sleepController = null;
+        const message = await runSupervisorCycle(cycleController!, "loop", { dryRun: options.dryRun });
+        writeStdout(`${new Date().toISOString()} ${message}`);
+        if (isCorruptJsonFailClosedMessage(message)) {
+          shouldStop = true;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.stack ?? error.message : String(error);
+        writeStderr(`${new Date().toISOString()} loop-error ${message}`);
+      }
+
+      if (!shouldStop) {
+        const pollIntervalMs = await service.pollIntervalMs();
+        if (shouldStop) {
+          break;
+        }
+        sleepController = new AbortController();
+        try {
+          await sleep(pollIntervalMs, sleepController.signal);
+        } finally {
+          sleepController = null;
+        }
       }
     }
+  } finally {
+    await loopRuntimeLock.release();
   }
 }

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -140,6 +140,38 @@ test("statusReport exposes the typed local CI contract summary from config", asy
   assert.match(status, /local_ci configured=true source=config command=npm run ci:local summary=Repo-owned local CI contract is configured\./);
 });
 
+test("statusReport exposes typed loop runtime state from the host runtime marker", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const runtimeLock = await supervisor.acquireLoopRuntimeLock();
+  assert.equal(runtimeLock.acquired, true);
+  t.after(async () => {
+    await runtimeLock.release();
+  });
+
+  const report = await supervisor.statusReport();
+
+  assert.deepEqual(report.loopRuntime, {
+    state: "running",
+    pid: process.pid,
+    startedAt: report.loopRuntime?.startedAt ?? null,
+    detail: "supervisor-loop-runtime",
+  });
+  assert.match(report.loopRuntime?.startedAt ?? "", /^\d{4}-\d{2}-\d{2}T/u);
+});
+
 test("statusReport exposes typed active-issue and selection summary fields alongside legacy lines", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-loop-controller.ts
+++ b/src/supervisor/supervisor-loop-controller.ts
@@ -1,15 +1,21 @@
 import type { CliOptions } from "../core/types";
+import type { LockHandle } from "../core/lock";
 import type { CreateSupervisorServiceOptions } from "./supervisor-service";
 import { Supervisor } from "./supervisor";
 
 export interface SupervisorLoopController {
   runCycle: (command: "loop" | "run-once", options: Pick<CliOptions, "dryRun">) => Promise<string>;
+  acquireLoopRuntimeLock: () => Promise<LockHandle>;
 }
 
 class SupervisorProcessLoopController implements SupervisorLoopController {
   constructor(
-    private readonly supervisor: Pick<Supervisor, "acquireSupervisorLock" | "runOnce">,
+    private readonly supervisor: Pick<Supervisor, "acquireLoopRuntimeLock" | "acquireSupervisorLock" | "runOnce">,
   ) {}
+
+  acquireLoopRuntimeLock(): Promise<LockHandle> {
+    return this.supervisor.acquireLoopRuntimeLock();
+  }
 
   async runCycle(command: "loop" | "run-once", options: Pick<CliOptions, "dryRun">): Promise<string> {
     const lock = await this.supervisor.acquireSupervisorLock(command);

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { acquireFileLock, inspectFileLock, type ExistingLockState, type LockHandle } from "../core/lock";
+
+export interface SupervisorLoopRuntimeDto {
+  state: "running" | "off" | "unknown";
+  pid: number | null;
+  startedAt: string | null;
+  detail: string | null;
+}
+
+const LOOP_RUNTIME_LOCK_LABEL = "supervisor-loop-runtime";
+
+export function supervisorLoopRuntimeLockPath(stateFile: string): string {
+  return path.resolve(path.dirname(stateFile), "locks", "supervisor", "loop-runtime.lock");
+}
+
+export async function acquireSupervisorLoopRuntimeLock(stateFile: string): Promise<LockHandle> {
+  return acquireFileLock(supervisorLoopRuntimeLockPath(stateFile), LOOP_RUNTIME_LOCK_LABEL, {
+    allowAmbiguousOwnerCleanup: true,
+  });
+}
+
+export async function inspectSupervisorLoopRuntimeLock(stateFile: string): Promise<ExistingLockState> {
+  return inspectFileLock(supervisorLoopRuntimeLockPath(stateFile));
+}
+
+export async function readSupervisorLoopRuntime(stateFile: string): Promise<SupervisorLoopRuntimeDto> {
+  const runtimeLock = await inspectSupervisorLoopRuntimeLock(stateFile);
+  if (runtimeLock.status === "live") {
+    return {
+      state: "running",
+      pid: runtimeLock.payload?.pid ?? null,
+      startedAt: runtimeLock.payload?.acquired_at ?? null,
+      detail: runtimeLock.payload?.label ?? LOOP_RUNTIME_LOCK_LABEL,
+    };
+  }
+
+  if (runtimeLock.status === "ambiguous_owner") {
+    return {
+      state: "unknown",
+      pid: runtimeLock.payload?.pid ?? null,
+      startedAt: runtimeLock.payload?.acquired_at ?? null,
+      detail: runtimeLock.payload?.label ?? LOOP_RUNTIME_LOCK_LABEL,
+    };
+  }
+
+  return {
+    state: "off",
+    pid: null,
+    startedAt: null,
+    detail: null,
+  };
+}

--- a/src/supervisor/supervisor-service.test.ts
+++ b/src/supervisor/supervisor-service.test.ts
@@ -201,6 +201,12 @@ test("createSupervisorService preserves typed operator observability fields on s
   const statusReport: Awaited<ReturnType<StubSupervisor["statusReport"]>> = {
     gsdSummary: null,
     candidateDiscovery: null,
+    loopRuntime: {
+      state: "off",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
     localCiContract: {
       configured: true,
       command: "npm run ci:local",

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -3,6 +3,7 @@ import { sanitizeStatusValue } from "./supervisor-status-rendering";
 import { truncate } from "../core/utils";
 import type { BlockedReason, RunState, SupervisorStateFile } from "../core/types";
 import type { SupervisorIssueActivityContextDto } from "./supervisor-operator-activity-context";
+import type { SupervisorLoopRuntimeDto } from "./supervisor-loop-runtime-state";
 import type {
   SupervisorBlockedIssueDto,
   SupervisorCandidateDiscoveryDto,
@@ -39,6 +40,7 @@ export interface SupervisorStatusDto {
   candidateDiscoverySummary?: string | null;
   candidateDiscovery: SupervisorCandidateDiscoveryDto | null;
   localCiContract?: LocalCiContractSummary;
+  loopRuntime: SupervisorLoopRuntimeDto;
   activeIssue: SupervisorActiveIssueDto | null;
   selectionSummary: SupervisorSelectionSummaryDto | null;
   trackedIssues: SupervisorTrackedIssueDto[];

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -135,6 +135,7 @@ import {
   type SupervisorRecoveryAction,
 } from "./supervisor-mutation-report";
 import { buildTrackedIssueDtos, renderSupervisorStatusDto, SupervisorStatusDto } from "./supervisor-status-report";
+import { acquireSupervisorLoopRuntimeLock, readSupervisorLoopRuntime } from "./supervisor-loop-runtime-state";
 import {
   clearCurrentReconciliationPhase,
   readCurrentReconciliationPhase,
@@ -440,6 +441,10 @@ export class Supervisor {
     } catch {
       return this.config.pollIntervalSeconds * 1000;
     }
+  }
+
+  async acquireLoopRuntimeLock(): Promise<LockHandle> {
+    return acquireSupervisorLoopRuntimeLock(this.config.stateFile);
   }
 
   private lockPath(kind: "issues" | "sessions" | "supervisor", key: string): string {
@@ -952,6 +957,7 @@ export class Supervisor {
     const cadenceDiagnostics = summarizeCadenceDiagnostics(this.config);
     const candidateDiscoverySummary = formatCandidateDiscoveryBehaviorLine(this.config);
     const localCiContract = summarizeLocalCiContract(this.config);
+    const loopRuntime = await readSupervisorLoopRuntime(this.config.stateFile);
     const gsdSummary = await describeGsdIntegration(this.config);
     const statusRecords = summarizeSupervisorStatusRecords(state);
     const trackedIssues = buildTrackedIssueDtos(state);
@@ -995,6 +1001,7 @@ export class Supervisor {
           candidateDiscoverySummary,
           candidateDiscovery,
           localCiContract,
+          loopRuntime,
           activeIssue: null,
           selectionSummary: options.why ? await buildSelectionSummary(this.github, this.config, state) : null,
           trackedIssues,
@@ -1016,6 +1023,7 @@ export class Supervisor {
           candidateDiscoverySummary,
           candidateDiscovery: buildCandidateDiscoverySummary(this.config, null),
           localCiContract,
+          loopRuntime,
           activeIssue: null,
           selectionSummary: null,
           trackedIssues,
@@ -1075,6 +1083,7 @@ export class Supervisor {
       candidateDiscoverySummary,
       candidateDiscovery: buildCandidateDiscoverySummary(this.config, null),
       localCiContract,
+      loopRuntime,
       activeIssue: {
         issueNumber: statusRecords.activeRecord.issue_number,
         state: statusRecords.activeRecord.state,


### PR DESCRIPTION
## Summary
- add typed loop-runtime status to supervisor runtime/status reporting
- drive dashboard loop messaging from live runtime state instead of hardcoded loop-off shell copy
- add focused regressions for loop-running and loop-off dashboard states

## Testing
- npx tsx --test src/backend/webui-dashboard.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-loop-controller.test.ts
- npx tsx --test src/backend/supervisor-http-server.test.ts src/supervisor/supervisor-service.test.ts src/backend/webui-dashboard-browser-smoke.test.ts
- npm run build

Closes #957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loop runtime status now displays dynamically on the dashboard, showing whether the supervisor loop is running or off based on actual runtime state, replacing previously hardcoded "loop off" messaging.
  * Dashboard status API now includes loop runtime metadata (state, process ID, start time, and detail).

* **Tests**
  * Added and updated test coverage for loop runtime state reporting and dashboard rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->