### PR TITLE
Fix #970: surface reconciliation target and wait step

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,36 +1,36 @@
-# Issue #961: Stale failed PR reconciliation bug: reclassify failed records when the live PR is now blocked
+# Issue #970: Reconciliation observability: surface the current target issue, PR, and GitHub wait step
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/961
-- Branch: codex/issue-961
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/970
+- Branch: codex/issue-970
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: dd1e5c782fc385f19d69295bc6693985cde6c939
+- Last head SHA: 3be269ddce0433ba7e86f1c892c0b4ee25452b75
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-25T03:57:40.423Z
+- Updated at: 2026-03-25T05:07:44.606Z
 
 ## Latest Codex Summary
-- Reproduced the stale failed tracked-PR reconciliation gap with focused `failed -> blocked/manual_review` and `failed -> blocked/verification` tests, then updated stale failed PR reconciliation to reuse live PR lifecycle blocker/failure semantics so restarted supervisors reclassify stale failed records into blocked with fresh `blocked_reason` and failure context. Focused reconciliation/policy/status tests and `npm run build` passed after restoring missing local dev dependencies with `npm ci`. Draft PR `#983` is open.
+- Added typed reconciliation progress visibility so status can report the active reconciliation phase, current target issue/PR, and any inferred GitHub wait step while reconciliation is running.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `reconcileStaleFailedIssueStates()` was explicitly skipping live tracked PRs whose refreshed lifecycle inferred `blocked`, so stale failed records kept generic failure metadata instead of being reclassified to blocked with the live PR blocker reason.
-- What changed: added focused regressions in `src/supervisor/supervisor-recovery-reconciliation.test.ts` for stale `failed -> blocked/manual_review` and `failed -> blocked/verification` recovery, then updated `src/recovery-reconciliation.ts` and `src/supervisor/supervisor.ts` so stale failed tracked-PR reconciliation reuses live PR lifecycle inputs to populate blocked state, `blocked_reason`, and fresh failure context/signature metadata.
+- Hypothesis: reconciliation only persisted a coarse phase string, so operators could not tell which tracked issue/PR the supervisor was reconciling or which GitHub-side wait gate was delaying convergence.
+- What changed: added focused regressions in `src/run-once-cycle-prelude.test.ts` and `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, extended the reconciliation snapshot to carry typed target issue/PR and wait-step context, threaded live progress updates through `runOnceCyclePrelude()`, and taught tracked-PR reconciliation to publish target context plus inferred GitHub wait steps.
 - Current blocker: none.
-- Exact failure reproduced: `reconcileStaleFailedIssueStates` left the record in `failed` when the live tracked PR inferred `blocked`, reproducing as `actual=failed expected=blocked` in the new focused recovery reconciliation tests.
-- Commands run: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-selection-status-active-status.test.ts`; `npm ci`; `npm run build`.
-- Next exact step: monitor CI and review feedback on draft PR `#983`, then address any reported failures or review comments.
-- Verification gap: none in the requested local scope after rerunning the focused reconciliation/policy/status tests and build.
-- Files touched: `src/recovery-reconciliation.ts`, `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the change only affects stale failed tracked-PR reconciliation and now aligns that recovery path with the existing live PR lifecycle blocker/failure semantics.
+- Next exact step: commit the reconciler observability change on `codex/issue-970`, then open or update the draft PR for review.
+- Verification gap: none in the requested local scope after rerunning the focused reconciliation status tests and build.
+- Files touched: `src/pull-request-state.ts`, `src/recovery-reconciliation.ts`, `src/run-once-cycle-prelude.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-reconciliation-phase.ts`, `src/supervisor/supervisor-status-report.ts`, `src/supervisor/supervisor.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; the change is additive observability over existing reconciliation behavior and reuses existing PR lifecycle wait classification.
 - Last focused command: `npm run build`
-- PR status: draft PR `#983` is open at `https://github.com/TommyKammy/codex-supervisor/pull/983`.
+- Exact failure reproduced: `runOnceCyclePrelude` exposed only phase transitions and `statusReport()` exposed only `reconciliationPhase`, so no status output identified the active reconciliation target issue/PR or GitHub wait step.
+- Commands run: `npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`; `npm ci`; `npm run build`.
+- PR status: none.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -48,6 +48,14 @@ interface ConfiguredBotRateLimitWaitStatus {
   waitUntil: string | null;
 }
 
+export type GitHubWaitStep =
+  | "configured_bot_rate_limit_wait"
+  | "configured_bot_initial_grace_wait"
+  | "configured_bot_settled_wait"
+  | "copilot_review_propagation_wait"
+  | "copilot_review_requested_wait"
+  | "checks_pending";
+
 function reviewSatisfied(pr: GitHubPullRequest): boolean {
   return (
     (pr.reviewDecision !== "CHANGES_REQUESTED" || pr.configuredBotTopLevelReviewStrength === "nitpick_only") &&
@@ -713,4 +721,47 @@ export function inferStateFromPullRequest(
   }
 
   return "pr_open";
+}
+
+export function inferGitHubWaitStep(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+): GitHubWaitStep | null {
+  const configuredBotRateLimitWait = determineConfiguredBotRateLimitWait(config, pr);
+  if (configuredBotRateLimitWait.active) {
+    return "configured_bot_rate_limit_wait";
+  }
+
+  if (shouldWaitForConfiguredBotLatestHeadRearm(config, record, pr)) {
+    return "configured_bot_initial_grace_wait";
+  }
+
+  if (shouldWaitForConfiguredBotDraftSkipRearm(config, record, pr)) {
+    return "configured_bot_initial_grace_wait";
+  }
+
+  if (shouldWaitForConfiguredBotInitialGracePeriod(config, pr)) {
+    return "configured_bot_initial_grace_wait";
+  }
+
+  if (shouldWaitForConfiguredBotCurrentHeadQuietPeriod(config, pr)) {
+    return "configured_bot_settled_wait";
+  }
+
+  if (shouldWaitForCopilotReviewPropagation(config, record, pr)) {
+    return "copilot_review_propagation_wait";
+  }
+
+  const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
+  if (copilotReviewPending(config, record, pr) && !copilotTimeout.timedOut) {
+    return "copilot_review_requested_wait";
+  }
+
+  if (summarizeChecks(checks).hasPending) {
+    return "checks_pending";
+  }
+
+  return null;
 }

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -741,6 +741,11 @@ export async function reconcileTrackedMergedButOpenIssues(
   state: SupervisorStateFile,
   config: SupervisorConfig,
   issues: GitHubIssue[],
+  updateReconciliationProgress: ((patch: {
+    targetIssueNumber?: number | null;
+    targetPrNumber?: number | null;
+    waitStep?: string | null;
+  }) => Promise<void>) | null = null,
 ): Promise<RecoveryEvent[]> {
   let changed = false;
   const recoveryEvents: RecoveryEvent[] = [];
@@ -750,6 +755,12 @@ export async function reconcileTrackedMergedButOpenIssues(
     if (record.pr_number === null) {
       continue;
     }
+
+    await updateReconciliationProgress?.({
+      targetIssueNumber: record.issue_number,
+      targetPrNumber: record.pr_number,
+      waitStep: null,
+    });
 
     const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);
     if (trackedPullRequest && !matchesTrackedBranch(record, trackedPullRequest)) {
@@ -923,7 +934,18 @@ export async function reconcileStaleFailedIssueStates(
       record: IssueRunRecord,
       pr: NonNullable<Awaited<ReturnType<RecoveryGitHubLike["getPullRequestIfExists"]>>>,
     ) => Partial<IssueRunRecord>;
+    inferGitHubWaitStep?: (
+      config: SupervisorConfig,
+      record: IssueRunRecord,
+      pr: NonNullable<Awaited<ReturnType<RecoveryGitHubLike["getPullRequestIfExists"]>>>,
+      checks: PullRequestCheck[],
+    ) => string | null;
   },
+  updateReconciliationProgress: ((patch: {
+    targetIssueNumber?: number | null;
+    targetPrNumber?: number | null;
+    waitStep?: string | null;
+  }) => Promise<void>) | null = null,
 ): Promise<void> {
   let changed = false;
   const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
@@ -932,6 +954,12 @@ export async function reconcileStaleFailedIssueStates(
     if (record.state !== "failed" || record.pr_number === null) {
       continue;
     }
+
+    await updateReconciliationProgress?.({
+      targetIssueNumber: record.issue_number,
+      targetPrNumber: record.pr_number,
+      waitStep: null,
+    });
 
     if (issueStateByNumber.get(record.issue_number) !== "OPEN") {
       continue;
@@ -956,6 +984,12 @@ export async function reconcileStaleFailedIssueStates(
       ...copilotReviewTimeoutPatch,
     };
     const nextState = deps.inferStateFromPullRequest(config, recordForState, pr, checks, reviewThreads);
+    await updateReconciliationProgress?.({
+      waitStep:
+        nextState === "waiting_ci"
+          ? (deps.inferGitHubWaitStep?.(config, recordForState, pr, checks) ?? null)
+          : null,
+    });
 
     if (nextState === "failed") {
       continue;

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -217,6 +217,91 @@ test("runOnceCyclePrelude publishes the active reconciliation phase and clears i
   ]);
 });
 
+test("runOnceCyclePrelude publishes reconciliation target updates within a phase", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const observedProgress: unknown[] = [];
+
+  await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+    },
+    carryoverRecoveryEvents: [],
+    setReconciliationProgress: async (progress) => {
+      observedProgress.push(progress);
+    },
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => [],
+    reconcileTrackedMergedButOpenIssues: async (_loadedState, _loadedIssues, updateReconciliationProgress) => {
+      await updateReconciliationProgress({
+        targetIssueNumber: 77,
+        targetPrNumber: 170,
+      });
+      return [];
+    },
+    reconcileMergedIssueClosures: async () => [],
+    reconcileStaleFailedIssueStates: async () => {},
+    reconcileRecoverableBlockedIssueStates: async () => [],
+    reconcileParentEpicClosures: async () => {},
+    cleanupExpiredDoneWorkspaces: async () => [],
+  });
+
+  assert.deepEqual(observedProgress, [
+    {
+      phase: "stale_active_issue_reservation",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "tracked_merged_but_open_issues",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "tracked_merged_but_open_issues",
+      targetIssueNumber: 77,
+      targetPrNumber: 170,
+      waitStep: null,
+    },
+    {
+      phase: "merged_issue_closures",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "stale_failed_issue_states",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "recoverable_blocked_issue_states",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "parent_epic_closures",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "cleanup_expired_done_workspaces",
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    },
+    null,
+  ]);
+});
+
 test("runOnceCyclePrelude emits typed recovery events for transport adapters", async () => {
   const state: SupervisorStateFile = {
     activeIssueNumber: null,

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -4,6 +4,7 @@ import {
   emitSupervisorEvent,
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
+import type { ReconciliationProgressUpdate } from "./supervisor/supervisor-reconciliation-phase";
 
 export interface RecoveryEvent {
   issueNumber: number;
@@ -22,17 +23,21 @@ export interface RunOnceCyclePreludeAuthFailure {
   recoveryEvents: RecoveryEvent[];
 }
 
+type ReconciliationProgressPatch = Partial<Omit<ReconciliationProgressUpdate, "phase">>;
+
 interface RunOnceCyclePreludeArgs {
   stateStore: Pick<{ load(): Promise<SupervisorStateFile> }, "load">;
   carryoverRecoveryEvents: RecoveryEvent[];
   emitEvent?: SupervisorEventSink;
   setReconciliationPhase?: (phase: string | null) => Promise<void>;
+  setReconciliationProgress?: (progress: ReconciliationProgressUpdate | null) => Promise<void>;
   reconcileStaleActiveIssueReservation: (state: SupervisorStateFile) => Promise<RecoveryEvent[]>;
   handleAuthFailure: (state: SupervisorStateFile) => Promise<string | null>;
   listAllIssues: () => Promise<GitHubIssue[]>;
   reconcileTrackedMergedButOpenIssues: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
+    updateReconciliationProgress: (patch: ReconciliationProgressPatch) => Promise<void>,
   ) => Promise<RecoveryEvent[]>;
   reconcileMergedIssueClosures: (
     state: SupervisorStateFile,
@@ -41,6 +46,7 @@ interface RunOnceCyclePreludeArgs {
   reconcileStaleFailedIssueStates: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
+    updateReconciliationProgress: (patch: ReconciliationProgressPatch) => Promise<void>,
   ) => Promise<void>;
   reconcileRecoverableBlockedIssueStates: (
     state: SupervisorStateFile,
@@ -58,7 +64,32 @@ export async function runOnceCyclePrelude(
 ): Promise<RunOnceCyclePreludeResult | RunOnceCyclePreludeAuthFailure> {
   const state = await args.stateStore.load();
   const recoveryEvents: RecoveryEvent[] = [...args.carryoverRecoveryEvents];
-  const setReconciliationPhase = args.setReconciliationPhase ?? (async () => {});
+  let currentReconciliationProgress: ReconciliationProgressUpdate | null = null;
+  const setReconciliationProgress = async (progress: ReconciliationProgressUpdate | null) => {
+    currentReconciliationProgress = progress;
+    if (args.setReconciliationProgress) {
+      await args.setReconciliationProgress(progress);
+      return;
+    }
+    await (args.setReconciliationPhase ?? (async () => {}))(progress?.phase ?? null);
+  };
+  const setReconciliationPhase = async (phase: string) => {
+    await setReconciliationProgress({
+      phase,
+      targetIssueNumber: null,
+      targetPrNumber: null,
+      waitStep: null,
+    });
+  };
+  const updateReconciliationProgress = async (patch: ReconciliationProgressPatch) => {
+    if (currentReconciliationProgress === null) {
+      return;
+    }
+    await setReconciliationProgress({
+      ...currentReconciliationProgress,
+      ...patch,
+    });
+  };
   const emitRecoveryEvents = (events: RecoveryEvent[]) => {
     for (const event of events) {
       emitSupervisorEvent(args.emitEvent, buildRecoverySupervisorEvent(event));
@@ -83,7 +114,7 @@ export async function runOnceCyclePrelude(
     const issues = await args.listAllIssues();
 
     await setReconciliationPhase("tracked_merged_but_open_issues");
-    const trackedMergedEvents = await args.reconcileTrackedMergedButOpenIssues(state, issues);
+    const trackedMergedEvents = await args.reconcileTrackedMergedButOpenIssues(state, issues, updateReconciliationProgress);
     recoveryEvents.push(...trackedMergedEvents);
     emitRecoveryEvents(trackedMergedEvents);
 
@@ -93,7 +124,7 @@ export async function runOnceCyclePrelude(
     emitRecoveryEvents(mergedIssueClosureEvents);
 
     await setReconciliationPhase("stale_failed_issue_states");
-    await args.reconcileStaleFailedIssueStates(state, issues);
+    await args.reconcileStaleFailedIssueStates(state, issues, updateReconciliationProgress);
 
     await setReconciliationPhase("recoverable_blocked_issue_states");
     const recoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues);
@@ -113,6 +144,6 @@ export async function runOnceCyclePrelude(
       recoveryEvents,
     };
   } finally {
-    await setReconciliationPhase(null);
+    await setReconciliationProgress(null);
   }
 }

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1063,6 +1063,55 @@ test("status surfaces the current reconciliation phase only while reconciliation
   assert.doesNotMatch(afterReconciliation, /reconciliation_phase=/);
 });
 
+test("statusReport exposes typed reconciliation target and wait-step context while reconciliation is in progress", async () => {
+  const fixture = await createSupervisorFixture();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  fixture.config.configuredReviewProviders = [
+    {
+      kind: "coderabbit",
+      reviewerLogins: ["coderabbitai"],
+      signalSource: "review_threads",
+    },
+  ];
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  await writeCurrentReconciliationPhase(fixture.config, {
+    phase: "stale_failed_issue_states",
+    targetIssueNumber: 58,
+    targetPrNumber: 91,
+    waitStep: "configured_bot_initial_grace_wait",
+  });
+
+  const report = await supervisor.statusReport();
+  assert.deepEqual(report.reconciliationProgress, {
+    phase: "stale_failed_issue_states",
+    startedAt: report.reconciliationProgress?.startedAt ?? null,
+    targetIssueNumber: 58,
+    targetPrNumber: 91,
+    waitStep: "configured_bot_initial_grace_wait",
+  });
+  assert.equal(report.reconciliationPhase, "stale_failed_issue_states");
+
+  const status = await supervisor.status();
+  assert.match(status, /reconciliation_phase=stale_failed_issue_states/);
+  assert.match(
+    status,
+    /reconciliation_progress phase=stale_failed_issue_states target_issue=#58 target_pr=#91 wait_step=configured_bot_initial_grace_wait/,
+  );
+});
+
 test("status emits a warning only after reconciliation exceeds the long-running threshold", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-reconciliation-phase.ts
+++ b/src/supervisor/supervisor-reconciliation-phase.ts
@@ -6,11 +6,24 @@ import type { SupervisorConfig } from "../core/types";
 interface ReconciliationPhaseSnapshot {
   phase: string;
   startedAt: string;
+  targetIssueNumber?: number | null;
+  targetPrNumber?: number | null;
+  waitStep?: string | null;
 }
 
 export interface CurrentReconciliationPhaseSnapshot {
   phase: string;
   startedAt: string | null;
+  targetIssueNumber: number | null;
+  targetPrNumber: number | null;
+  waitStep: string | null;
+}
+
+export interface ReconciliationProgressUpdate {
+  phase: string;
+  targetIssueNumber?: number | null;
+  targetPrNumber?: number | null;
+  waitStep?: string | null;
 }
 
 export function reconciliationPhasePath(config: Pick<SupervisorConfig, "repoPath">): string {
@@ -19,12 +32,23 @@ export function reconciliationPhasePath(config: Pick<SupervisorConfig, "repoPath
 
 export async function writeCurrentReconciliationPhase(
   config: Pick<SupervisorConfig, "repoPath">,
-  phase: string,
+  progress: string | ReconciliationProgressUpdate,
 ): Promise<void> {
   const snapshotPath = reconciliationPhasePath(config);
   await ensureDir(path.dirname(snapshotPath));
   const startedAt = (await readCurrentReconciliationPhaseSnapshot(config))?.startedAt ?? new Date(Date.now()).toISOString();
-  await fs.writeFile(snapshotPath, `${JSON.stringify({ phase, startedAt } satisfies ReconciliationPhaseSnapshot)}\n`, "utf8");
+  const nextProgress = typeof progress === "string" ? { phase: progress } : progress;
+  await fs.writeFile(
+    snapshotPath,
+    `${JSON.stringify({
+      phase: nextProgress.phase,
+      startedAt,
+      targetIssueNumber: nextProgress.targetIssueNumber ?? null,
+      targetPrNumber: nextProgress.targetPrNumber ?? null,
+      waitStep: nextProgress.waitStep ?? null,
+    } satisfies ReconciliationPhaseSnapshot)}\n`,
+    "utf8",
+  );
 }
 
 export async function clearCurrentReconciliationPhase(
@@ -58,6 +82,9 @@ export async function readCurrentReconciliationPhaseSnapshot(
     return {
       phase: parsed.phase,
       startedAt: typeof parsed.startedAt === "string" && parsed.startedAt.length > 0 ? parsed.startedAt : null,
+      targetIssueNumber: typeof parsed.targetIssueNumber === "number" ? parsed.targetIssueNumber : null,
+      targetPrNumber: typeof parsed.targetPrNumber === "number" ? parsed.targetPrNumber : null,
+      waitStep: typeof parsed.waitStep === "string" && parsed.waitStep.length > 0 ? parsed.waitStep : null,
     };
   } catch (error) {
     if (

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -33,6 +33,14 @@ export interface SupervisorTrackedIssueDto {
   blockedReason: BlockedReason | null;
 }
 
+export interface SupervisorReconciliationProgressDto {
+  phase: string;
+  startedAt: string | null;
+  targetIssueNumber: number | null;
+  targetPrNumber: number | null;
+  waitStep: string | null;
+}
+
 export interface SupervisorStatusDto {
   gsdSummary: string | null;
   trustDiagnostics?: TrustDiagnosticsSummary | null;
@@ -48,6 +56,7 @@ export interface SupervisorStatusDto {
   blockedIssues: SupervisorBlockedIssueDto[];
   detailedStatusLines: string[];
   reconciliationPhase: string | null;
+  reconciliationProgress?: SupervisorReconciliationProgressDto | null;
   reconciliationWarning: string | null;
   readinessLines: string[];
   whyLines: string[];
@@ -87,6 +96,18 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
     ...(dto.candidateDiscoverySummary ? [dto.candidateDiscoverySummary] : []),
     `local_ci configured=${localCiContract.configured} source=${localCiContract.source} command=${truncate(sanitizeStatusValue(localCiContract.command ?? "none"), 200)} summary=${truncate(sanitizeStatusValue(localCiContract.summary), 200)}`,
     ...(dto.reconciliationPhase === null ? [] : [`reconciliation_phase=${dto.reconciliationPhase}`]),
+    ...(dto.reconciliationProgress === null || dto.reconciliationProgress === undefined
+      ? []
+      : [
+        [
+          "reconciliation_progress",
+          `phase=${dto.reconciliationProgress.phase}`,
+          `target_issue=${dto.reconciliationProgress.targetIssueNumber === null ? "none" : `#${dto.reconciliationProgress.targetIssueNumber}`}`,
+          `target_pr=${dto.reconciliationProgress.targetPrNumber === null ? "none" : `#${dto.reconciliationProgress.targetPrNumber}`}`,
+          `wait_step=${dto.reconciliationProgress.waitStep ?? "none"}`,
+          `started_at=${dto.reconciliationProgress.startedAt ?? "none"}`,
+        ].join(" "),
+      ]),
     ...(dto.reconciliationWarning === null ? [] : [dto.reconciliationWarning]),
     ...dto.readinessLines,
     ...dto.whyLines,

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -22,6 +22,7 @@ import {
   blockedReasonFromReviewState,
   buildCopilotReviewTimeoutFailureContext,
   inferStateFromPullRequest,
+  inferGitHubWaitStep,
   syncCopilotReviewRequestObservation,
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,
@@ -968,6 +969,15 @@ export class Supervisor {
     const reconciliationSnapshot = await readCurrentReconciliationPhaseSnapshot(this.config);
     const reconciliationPhase = reconciliationSnapshot?.phase ?? null;
     const reconciliationWarning = buildLongReconciliationWarning(reconciliationSnapshot);
+    const reconciliationProgress = reconciliationSnapshot === null
+      ? null
+      : {
+        phase: reconciliationSnapshot.phase,
+        startedAt: reconciliationSnapshot.startedAt,
+        targetIssueNumber: reconciliationSnapshot.targetIssueNumber,
+        targetPrNumber: reconciliationSnapshot.targetPrNumber,
+        waitStep: reconciliationSnapshot.waitStep,
+      };
 
     if (!statusRecords.activeRecord) {
       const detailedStatusLines = buildDetailedStatusModel({
@@ -1013,6 +1023,7 @@ export class Supervisor {
           blockedIssues: readinessSummary.blockedIssues,
           detailedStatusLines: [...detailedStatusLines, ...stateDiagnosticLines],
           reconciliationPhase,
+          reconciliationProgress,
           reconciliationWarning,
           readinessLines: readinessSummary.readinessLines,
           whyLines,
@@ -1035,6 +1046,7 @@ export class Supervisor {
           blockedIssues: [],
           detailedStatusLines: [...detailedStatusLines, ...stateDiagnosticLines],
           reconciliationPhase,
+          reconciliationProgress,
           reconciliationWarning,
           readinessLines: [],
           whyLines: [],
@@ -1105,6 +1117,7 @@ export class Supervisor {
       blockedIssues: [],
       detailedStatusLines: [...detailedStatusLines, ...summaryLines, ...stateDiagnosticLines],
       reconciliationPhase,
+      reconciliationProgress,
       reconciliationWarning,
       readinessLines: [],
       whyLines: [],
@@ -1335,11 +1348,18 @@ export class Supervisor {
       }),
       handleAuthFailure: (state) => handleAuthFailure(this.github, this.stateStore, state),
       listAllIssues: () => this.github.listAllIssues(),
-      reconcileTrackedMergedButOpenIssues: (state, issues) =>
-        reconcileTrackedMergedButOpenIssues(this.github, this.stateStore, state, this.config, issues),
+      reconcileTrackedMergedButOpenIssues: (state, issues, updateReconciliationProgress) =>
+        reconcileTrackedMergedButOpenIssues(
+          this.github,
+          this.stateStore,
+          state,
+          this.config,
+          issues,
+          updateReconciliationProgress,
+        ),
       reconcileMergedIssueClosures: (state, issues) =>
         reconcileMergedIssueClosures(this.github, this.stateStore, state, this.config, issues),
-      reconcileStaleFailedIssueStates: (state, issues) =>
+      reconcileStaleFailedIssueStates: (state, issues, updateReconciliationProgress) =>
         reconcileStaleFailedIssueStates(this.github, this.stateStore, state, this.config, issues, {
           inferStateFromPullRequest,
           inferFailureContext,
@@ -1348,7 +1368,8 @@ export class Supervisor {
           syncReviewWaitWindow,
           syncCopilotReviewRequestObservation,
           syncCopilotReviewTimeoutState,
-        }),
+          inferGitHubWaitStep,
+        }, updateReconciliationProgress),
       reconcileRecoverableBlockedIssueStates: (state, issues) =>
         reconcileRecoverableBlockedIssueStates(this.stateStore, state, this.config, issues, {
           shouldAutoRetryHandoffMissing,


### PR DESCRIPTION
## Summary
- add typed reconciliation progress context for the active phase, target issue, target PR, and inferred GitHub wait step
- thread live reconciliation progress updates through the run-once prelude and tracked-PR reconciliation paths
- add focused status and prelude regressions covering the new observability surface

## Testing
- npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts
- npm run build

Closes #970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reconciliation now provides typed progress updates showing the active phase, target issue/PR, and reasons for any waits (e.g., CI checks, rate limits, copilot reviews).
  * Enhanced status reporting includes detailed reconciliation progress information.

* **Tests**
  * Added tests verifying reconciliation progress tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->