### PR TITLE
Prioritize runnable issue claim before reconciliation

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,38 +1,38 @@
-# Issue #974: Reconciliation stall isolation: keep slow unrelated GitHub fetches from delaying active merged-issue convergence
+# Issue #975: Selected runnable issue can starve behind repeated reconciliation before claim
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/974
-- Branch: codex/issue-974
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/975
+- Branch: codex/issue-975
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 7113d23f46334b956f09389af118b7916f52b36b
+- Last head SHA: 2af9471670be918fcc0d160ad6ac0d1cb5f03473
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-25T08:30:49.696Z
+- Updated at: 2026-03-25T09:05:11.094Z
 
 ## Latest Codex Summary
-- Isolated active merged-issue convergence from unrelated tracked-PR fetches by widening the prelude fast path in `src/run-once-cycle-prelude.ts` to cover any active issue with a tracked PR, not just `merging`, and added a focused orchestration regression for an active `waiting_ci` issue in `src/supervisor/supervisor-execution-orchestration.test.ts`.
-- Local verification passed for `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/github/github-transport.test.ts src/supervisor/supervisor-execution-orchestration.test.ts` and `npm run build` after installing missing dev dependencies with `npm install`.
-- Pushed commit `9adc05c` to `origin/codex/issue-974` and opened draft PR [#988](https://github.com/TommyKammy/codex-supervisor/pull/988).
+- Reserved runnable issues before the broad reconciliation sweep so `runOnce()` can claim and start selected work without touching unrelated tracked PRs first.
+- Added a focused orchestration regression covering a runnable selection with `activeIssueNumber=null` and an unrelated tracked PR that would previously have been reconciled before claim.
+- Local verification passed for `npx tsx --test src/run-once-issue-selection.test.ts`, `npx tsx --test src/run-once-cycle-prelude.test.ts`, `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`, and `npm run build` after installing missing dev dependencies with `npm install`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: active merged issues outside the `merging` state were still falling back to the full tracked-merged reconciliation sweep, so a slow unrelated `getPullRequestIfExists()` call could delay convergence even though the active issue already had a tracked merged PR.
-- What changed: widened the isolated active reconciliation fast path in `src/run-once-cycle-prelude.ts` from `activeRecord.state === "merging"` to any non-null active record with `pr_number !== null`, and added a focused regression in `src/supervisor/supervisor-execution-orchestration.test.ts` that covers an active `waiting_ci` issue whose merged PR must converge before an unrelated tracked PR is fetched.
+- Hypothesis: when `activeIssueNumber` is still `null`, the prelude can spend a full cycle in unrelated reconciliation before the selected runnable issue is ever reserved, so repeated runs can keep restarting broad reconciliation without ever claiming the chosen work.
+- What changed: added `reserveRunnableIssueSelection()` in `src/run-once-issue-selection.ts`, invoked it from `src/supervisor/supervisor.ts` before the broad prelude reconciliation, and taught `src/run-once-cycle-prelude.ts` to return early once a runnable issue has been reserved so the normal issue phase can claim/start it immediately. Added a focused regression in `src/supervisor/supervisor-execution-orchestration.test.ts` that throws if unrelated tracked-PR reconciliation runs before the selected runnable issue is claimed.
 - Current blocker: none.
-- Next exact step: monitor draft PR #988 for CI or review feedback and address follow-up issues if they appear.
-- Verification gap: none in the requested local scope after rerunning `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/github/github-transport.test.ts src/supervisor/supervisor-execution-orchestration.test.ts` and `npm run build`.
-- Files touched: `src/run-once-cycle-prelude.ts`, `src/supervisor/supervisor-execution-orchestration.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the change only affects reconciliation scheduling for the active issue by isolating its tracked-PR convergence ahead of the broader tracked-PR sweep, and leaves underlying GitHub fetch semantics unchanged.
+- Next exact step: review the diff, commit the runnable-reservation fast path on `codex/issue-975`, and open or update a draft PR if needed.
+- Verification gap: none in the requested local scope after rerunning `npx tsx --test src/run-once-issue-selection.test.ts`, `npx tsx --test src/run-once-cycle-prelude.test.ts`, `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`, and `npm run build`.
+- Files touched: `src/run-once-issue-selection.ts`, `src/run-once-cycle-prelude.ts`, `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-execution-orchestration.test.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; the change only reorders the reservation boundary so runnable work is claimed before unrelated reconciliation, while leaving the existing selection logic and reconciliation behavior intact for later cycles.
 - Last focused command: `npm run build`
-- Exact failure reproduced: with active issue #92 in `waiting_ci`, unrelated issue #91 also carrying a tracked PR, and the active PR #192 already merged, `runOnce()` fetched unrelated PR #191 first and threw `unrelated reconciliation touched PR #191 before active merged convergence`.
-- Commands run: `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern "runOnce converges an active merged waiting_ci issue before unrelated tracked-PR reconciliation work"`; `npx tsx --test src/run-once-cycle-prelude.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/github/github-transport.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`; `npm install`; `npm run build`; `git commit -m "Isolate active merged reconciliation from unrelated fetches"`; `git push -u origin codex/issue-974`; `gh pr create --draft --base main --head codex/issue-974 --title "Isolate active merged reconciliation from unrelated fetches" --body ...`.
-- PR status: draft PR #988 (`https://github.com/TommyKammy/codex-supervisor/pull/988`).
+- Exact failure reproduced: with `activeIssueNumber=null`, runnable issue #91 returned from `listCandidateIssues()`, and unrelated issue #92 already tracking PR #192, `runOnce()` hit broad tracked-PR reconciliation before claim; the focused regression throws `unrelated reconciliation touched PR #192 before selected issue #91 was claimed` unless the runnable issue is reserved first.
+- Commands run: `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern "runOnce reserves a runnable issue before unrelated tracked-PR reconciliation work"`; `npx tsx --test src/run-once-issue-selection.test.ts`; `npx tsx --test src/run-once-cycle-prelude.test.ts`; `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`; `npm run build`; `npm install`; `npm run build`.
+- PR status: none.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -32,6 +32,7 @@ interface RunOnceCyclePreludeArgs {
   setReconciliationPhase?: (phase: string | null) => Promise<void>;
   setReconciliationProgress?: (progress: ReconciliationProgressUpdate | null) => Promise<void>;
   reconcileStaleActiveIssueReservation: (state: SupervisorStateFile) => Promise<RecoveryEvent[]>;
+  reserveRunnableIssueSelection?: (state: SupervisorStateFile) => Promise<boolean>;
   handleAuthFailure: (state: SupervisorStateFile) => Promise<string | null>;
   listAllIssues: () => Promise<GitHubIssue[]>;
   reconcileTrackedMergedButOpenIssues: (
@@ -111,6 +112,13 @@ export async function runOnceCyclePrelude(
     const staleReservationEvents = await args.reconcileStaleActiveIssueReservation(state);
     recoveryEvents.push(...staleReservationEvents);
     emitRecoveryEvents(staleReservationEvents);
+
+    if (state.activeIssueNumber === null && await args.reserveRunnableIssueSelection?.(state) === true) {
+      return {
+        state,
+        recoveryEvents,
+      };
+    }
 
     const issues = await args.listAllIssues();
 

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -50,8 +50,10 @@ export interface RestartRunOnce {
 
 type IssueSelectionResult = ReadyIssueContext | RestartRunOnce | string;
 
-type IssueSelectionGitHub = Pick<GitHubClient, "listCandidateIssues" | "getIssue">;
-type IssueSelectionStateStore = Pick<StateStore, "save" | "touch">;
+type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues">;
+type IssueSelectionGitHub = IssueSelectionCandidateGitHub & Pick<GitHubClient, "getIssue">;
+type IssueSelectionSaveStateStore = Pick<StateStore, "save">;
+type IssueSelectionStateStore = IssueSelectionSaveStateStore & Pick<StateStore, "touch">;
 
 type IssueJournalContext = Pick<IssueRunRecord, "workspace" | "journal_path">;
 
@@ -76,6 +78,15 @@ interface ResolveRunnableIssueContextArgs {
   acquireIssueLock?: (record: IssueRunRecord) => Promise<LockHandle>;
   ensureRecordJournalContext?: (record: IssueRunRecord) => Promise<IssueJournalContext>;
   syncIssueJournal?: (args: SyncIssueJournalArgs) => Promise<void>;
+  emitEvent?: SupervisorEventSink;
+}
+
+interface ReserveRunnableIssueSelectionArgs {
+  github: Pick<IssueSelectionGitHub, "listCandidateIssues">;
+  config: SupervisorConfig;
+  stateStore: Pick<IssueSelectionStateStore, "save">;
+  state: SupervisorStateFile;
+  currentRecord: IssueRunRecord | null;
   emitEvent?: SupervisorEventSink;
 }
 
@@ -213,9 +224,9 @@ async function defaultEnsureRecordJournalContext(
 }
 
 async function selectIssueRecord(
-  github: IssueSelectionGitHub,
+  github: IssueSelectionCandidateGitHub,
   config: SupervisorConfig,
-  stateStore: IssueSelectionStateStore,
+  stateStore: IssueSelectionSaveStateStore,
   state: SupervisorStateFile,
   currentRecord: IssueRunRecord | null,
 ): Promise<SelectedIssueRecord | string> {
@@ -262,6 +273,34 @@ async function selectIssueRecord(
     record,
     persistReservation: false,
   };
+}
+
+export async function reserveRunnableIssueSelection(
+  args: ReserveRunnableIssueSelectionArgs,
+): Promise<IssueRunRecord | null> {
+  const { github, config, stateStore, state, currentRecord, emitEvent } = args;
+  const selectedRecord = await selectIssueRecord(github, config, stateStore, state, currentRecord);
+  if (typeof selectedRecord === "string") {
+    return null;
+  }
+
+  const { record, persistReservation } = selectedRecord;
+  if (!persistReservation) {
+    return record;
+  }
+
+  const previousIssueNumber = state.activeIssueNumber;
+  state.activeIssueNumber = record.issue_number;
+  state.issues[String(record.issue_number)] = record;
+  await stateStore.save(state);
+  emitSupervisorEvent(emitEvent, buildActiveIssueChangedEvent({
+    issueNumber: record.issue_number,
+    previousIssueNumber,
+    nextIssueNumber: record.issue_number,
+    reason: "reserved_for_cycle",
+    at: record.updated_at,
+  }));
+  return record;
 }
 
 export async function resolveRunnableIssueContext(

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -260,6 +260,84 @@ test("runOnce dry-run selects an issue and hydrates workspace and PR context bef
   assert.equal(reviewThreadCalls, 1);
 });
 
+test("runOnce reserves a runnable issue before unrelated tracked-PR reconciliation work", async () => {
+  const fixture = await createSupervisorFixture();
+  const selectedIssueNumber = 91;
+  const unrelatedIssueNumber = 92;
+  const selectedBranch = branchName(fixture.config, selectedIssueNumber);
+  const unrelatedBranch = branchName(fixture.config, unrelatedIssueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(unrelatedIssueNumber)]: createRecord({
+        issue_number: unrelatedIssueNumber,
+        state: "waiting_ci",
+        branch: unrelatedBranch,
+        pr_number: 192,
+        codex_session_id: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const selectedIssue: GitHubIssue = {
+    number: selectedIssueNumber,
+    title: "Reserve the next runnable issue before broad reconciliation",
+    body: executionReadyBody("Reserve the runnable issue before unrelated reconciliation."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${selectedIssueNumber}`,
+    state: "OPEN",
+  };
+  const unrelatedIssue: GitHubIssue = {
+    number: unrelatedIssueNumber,
+    title: "Slow unrelated reconciliation target",
+    body: executionReadyBody("Remain unrelated to the selected runnable issue."),
+    createdAt: "2026-03-13T00:05:00Z",
+    updatedAt: "2026-03-13T00:05:00Z",
+    url: `https://example.test/issues/${unrelatedIssueNumber}`,
+    state: "OPEN",
+  };
+
+  let selectedIssueFetched = false;
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [selectedIssue, unrelatedIssue],
+    listCandidateIssues: async () => [selectedIssue],
+    getIssue: async (issueNumber: number) => {
+      assert.equal(issueNumber, selectedIssueNumber);
+      selectedIssueFetched = true;
+      return selectedIssue;
+    },
+    resolvePullRequestForBranch: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async (prNumber: number) => {
+      throw new Error(
+        `unrelated reconciliation touched PR #${prNumber} before selected issue #${selectedIssueNumber} was claimed`,
+      );
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
+  assert.equal(selectedIssueFetched, true);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  assert.equal(persisted.activeIssueNumber, selectedIssueNumber);
+  assert.equal(persisted.issues[String(selectedIssueNumber)]?.state, "reproducing");
+  assert.equal(persisted.issues[String(unrelatedIssueNumber)]?.state, "waiting_ci");
+  assert.equal(persisted.issues[String(unrelatedIssueNumber)]?.pr_number, 192);
+});
+
 test("prepareIssueExecutionContext blocks PR publication when configured local CI fails before draft PR creation", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.localCiCommand = "npm run ci:local";

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -62,6 +62,7 @@ import {
 } from "../post-turn-pull-request";
 import { buildChecksFailureContext, buildConflictFailureContext } from "../pull-request-failure-context";
 import {
+  reserveRunnableIssueSelection,
   resolveRunnableIssueContext as resolveIssueSelectionContext,
   RestartRunOnce as SelectionRestartRunOnce,
 } from "../run-once-issue-selection";
@@ -1346,6 +1347,17 @@ export class Supervisor {
         classifyStaleStabilizingNoPrBranchState: (record) =>
           this.classifyStaleStabilizingNoPrBranchState(record),
       }),
+      reserveRunnableIssueSelection: async (state) => {
+        const reserved = await reserveRunnableIssueSelection({
+          github: this.github,
+          config: this.config,
+          stateStore: this.stateStore,
+          state,
+          currentRecord: null,
+          emitEvent: this.onEvent,
+        });
+        return reserved !== null;
+      },
       handleAuthFailure: (state) => handleAuthFailure(this.github, this.stateStore, state),
       listAllIssues: () => this.github.listAllIssues(),
       reconcileTrackedMergedButOpenIssues: (state, issues, updateReconciliationProgress, options) =>


### PR DESCRIPTION
## Summary
- reserve the selected runnable issue before the broad reconciliation sweep
- short-circuit the prelude once runnable work is reserved so the normal issue phase can claim/start it immediately
- add a focused regression proving unrelated tracked-PR reconciliation cannot run before selected work is claimed

## Testing
- npx tsx --test src/run-once-issue-selection.test.ts
- npx tsx --test src/run-once-cycle-prelude.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build

Closes #975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced issue selection and reservation to execute at an earlier stage in the operational cycle, ensuring the next runnable issue is properly reserved before unrelated tracked PR reconciliation processes occur. This prevents potential conflicts and ensures more reliable issue claiming when managing multiple tracked issues simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->