### PR TITLE
Refine the operator dashboard for summary-first navigation

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -319,10 +319,53 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
     },
   );
 
-  assert.deepEqual(buildPrimaryActionSummary({ blockedIssues: [{ issueNumber: 91, blockedBy: "verification" }] }), {
-    title: "Recover blocked work",
-    detail: "The queue has blockers and no runnable issue, so the next supervisor state is recovery-oriented.",
-  });
+  assert.deepEqual(
+    buildPrimaryActionSummary({
+      status: { blockedIssues: [{ issueNumber: 91, blockedBy: "verification" }] },
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    {
+      title: "Recover blocked work",
+      detail: "The queue has blockers and no runnable issue, so the next supervisor state is recovery-oriented.",
+    },
+  );
+
+  assert.deepEqual(
+    buildPrimaryActionSummary({
+      status: {
+        selectionSummary: { selectedIssueNumber: 77 },
+        runnableIssues: [{ issueNumber: 77, title: "Ready issue", readiness: "execution_ready" }],
+      },
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "reconnecting",
+      refreshPhase: "failed",
+      hasSuccessfulRefresh: true,
+    }),
+    {
+      title: "Recover dashboard freshness",
+      detail: "Wait for a healthy refresh before relying on the next supervisor state shown here.",
+    },
+  );
+
+  assert.deepEqual(
+    buildPrimaryActionSummary({
+      status: {
+        selectionSummary: { selectedIssueNumber: 77 },
+        runnableIssues: [{ issueNumber: 77, title: "Ready issue", readiness: "execution_ready" }],
+      },
+      doctor: { overallStatus: "fail", checks: [{ name: "github_auth", status: "fail", summary: "No auth." }] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    {
+      title: "Resolve environment checks",
+      detail: "A required dependency is failing, so the supervisor should not advance until checks recover.",
+    },
+  );
 
   assert.deepEqual(
     buildAttentionItems({

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -55,6 +55,7 @@ export interface DashboardStatusLike {
   candidateDiscovery?: DashboardCandidateDiscoveryLike | null;
   candidateDiscoverySummary?: string | null;
   reconciliationWarning?: string | null;
+  reconciliationPhase?: string | null;
   loopRuntime?: DashboardLoopRuntimeLike | null;
   warning?: { message?: string | null } | null;
 }
@@ -552,10 +553,38 @@ export function buildNextIssueSummary(status: DashboardStatusLike | null | undef
   };
 }
 
-export function buildPrimaryActionSummary(status: DashboardStatusLike | null | undefined): DashboardNextStateSummary {
-  const selectedIssueNumber = parseSelectedIssueNumber(status);
-  const blockedCount = Array.isArray(status?.blockedIssues) ? status.blockedIssues.length : 0;
-  const runnableCount = Array.isArray(status?.runnableIssues) ? status.runnableIssues.length : 0;
+export function buildPrimaryActionSummary(args: {
+  status: DashboardStatusLike | null | undefined;
+  doctor: DashboardDoctorLike | null | undefined;
+  connectionPhase: DashboardConnectionPhase;
+  refreshPhase: DashboardRefreshPhase;
+  hasSuccessfulRefresh: boolean;
+}): DashboardNextStateSummary {
+  const selectedIssueNumber = parseSelectedIssueNumber(args.status);
+  const blockedCount = Array.isArray(args.status?.blockedIssues) ? args.status.blockedIssues.length : 0;
+  const runnableCount = Array.isArray(args.status?.runnableIssues) ? args.status.runnableIssues.length : 0;
+  const doctorStatus = typeof args.doctor?.overallStatus === "string" ? args.doctor.overallStatus.toLowerCase() : "";
+
+  if (!args.hasSuccessfulRefresh) {
+    return {
+      title: "Wait for the first refresh",
+      detail: "Let the dashboard finish loading before relying on the next supervisor state.",
+    };
+  }
+
+  if (args.refreshPhase === "failed" || args.connectionPhase === "reconnecting") {
+    return {
+      title: "Recover dashboard freshness",
+      detail: "Wait for a healthy refresh before relying on the next supervisor state shown here.",
+    };
+  }
+
+  if (doctorStatus === "fail") {
+    return {
+      title: "Resolve environment checks",
+      detail: "A required dependency is failing, so the supervisor should not advance until checks recover.",
+    };
+  }
 
   if (selectedIssueNumber !== null) {
     return {

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -67,6 +67,7 @@ export function renderDashboardBrowserScript(): string {
         doctor: null,
         explain: null,
         issueLint: null,
+        issueLoadError: null,
         commandInFlight: false,
         commandResult: null,
         events: [],
@@ -425,6 +426,9 @@ export function renderDashboardBrowserScript(): string {
         setPillState(elements.refreshState, state.refreshPhase, refreshTone, "summary-pill");
         setText(elements.lastRefreshBadge, formatRefreshTime(state.lastRefreshAt));
         setPillState(elements.lastRefreshPill, "Last updated: " + formatRefreshTime(state.lastRefreshAt), "", "topbar-pill");
+        renderOverviewSummary();
+        renderPrimaryActionSummary();
+        renderAttentionSummary();
       }
 
       function describeLoopRuntime(loopRuntime) {
@@ -486,7 +490,13 @@ export function renderDashboardBrowserScript(): string {
       }
 
       function renderPrimaryActionSummary() {
-        const action = buildPrimaryActionSummary(state.status);
+        const action = buildPrimaryActionSummary({
+          status: state.status,
+          doctor: state.doctor,
+          connectionPhase: state.connectionPhase,
+          refreshPhase: state.refreshPhase,
+          hasSuccessfulRefresh: state.hasSuccessfulRefresh,
+        });
         setText(elements.primaryActionTitle, action.title);
         setText(elements.primaryActionDetail, action.detail);
       }
@@ -524,6 +534,25 @@ export function renderDashboardBrowserScript(): string {
         }
         if (elements.selectedIssueSummaryNotes) {
           elements.selectedIssueSummaryNotes.innerHTML = "";
+        }
+
+        if (state.issueLoadError) {
+          const failedIssueLabel =
+            typeof state.loadedIssueNumber === "number" ? formatIssueRef(state.loadedIssueNumber) : "Requested issue";
+          setText(elements.selectedIssueHeading, failedIssueLabel + " could not load");
+          setText(elements.selectedIssueDetail, state.issueLoadError);
+          appendMetricTile(
+            elements.selectedIssueSummaryMetrics,
+            "Load state",
+            "failed",
+            "fail",
+            "The issue summary could not be loaded from the backend.",
+          );
+          appendDetailSection(elements.selectedIssueSummaryNotes, "What to do next", [
+            ["retry", "Load the issue again after the backend error is resolved."],
+            ["requeue", "Requeue stays disabled until the issue details load successfully."],
+          ]);
+          return;
         }
 
         if (explain) {
@@ -1319,6 +1348,7 @@ export function renderDashboardBrowserScript(): string {
         state.loadedIssueNumber = requestedIssueNumber;
         state.explain = null;
         state.issueLint = null;
+        state.issueLoadError = null;
         renderSelectedIssue();
         setText(elements.issueSummary, "Loading issue...");
         setText(elements.issueExplain, "Loading /api/issues/" + requestedIssueNumber + "/explain...");
@@ -1335,12 +1365,16 @@ export function renderDashboardBrowserScript(): string {
           }
           state.explain = explain;
           state.issueLint = issueLint;
+          state.issueLoadError = null;
           renderSelectedIssue();
           renderIssue();
         } catch (error) {
           if (state.loadedIssueNumber !== requestedIssueNumber) {
             return;
           }
+          state.issueLoadError = error instanceof Error ? error.message : String(error);
+          renderSelectedIssue();
+          renderSelectedIssueSummary();
           throw error;
         }
       }

--- a/src/backend/webui-dashboard-page.ts
+++ b/src/backend/webui-dashboard-page.ts
@@ -1,10 +1,36 @@
 import { renderDashboardBrowserScript } from "./webui-dashboard-browser-script";
-import { listDashboardPanels } from "./webui-dashboard-panel-layout";
+import { type DashboardPanelDefinition, type DashboardPanelId, listDashboardPanels } from "./webui-dashboard-panel-layout";
 
 function renderDashboardPanelSection(section: "overview" | "details"): string {
   return listDashboardPanels(section)
     .map((panel) => panel.markup)
     .join("\n");
+}
+
+function toTitleCase(value: string): string {
+  return value.replace(/\b([a-z])/gu, (match) => match.toUpperCase());
+}
+
+const panelNavIcons: Record<DashboardPanelId, string> = {
+  status:
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M3 12h2V6H3zm4 0h2V3H7zm4 0h2V8h-2z"/></svg>',
+  doctor:
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M7 2h2v3h3v2H9v3H7V7H4V5h3z"/></svg>',
+  "issue-details":
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M3 2.5h10v11H3zm2 2v1h6v-1zm0 3v1h6v-1zm0 3v1h4v-1z"/></svg>',
+  "tracked-history":
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M8 2.5a5.5 5.5 0 105.5 5.5h-2A3.5 3.5 0 118 4.5V2.5zm-.5 2h1v4l2.5 1.5-.5.9L7.5 9z"/></svg>',
+  "operator-actions":
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M6.5 2l1 2.2L10 5l-1.8 1.7.4 2.5L6.5 8.1 4.4 9.2l.4-2.5L3 5l2.5-.8zM11 9h2v5h-2zM3 10h2v4H3z"/></svg>',
+  "live-events":
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M2.5 8a5.5 5.5 0 1111 0h-2a3.5 3.5 0 10-7 0z"/><circle cx="8" cy="8" r="1.5"/></svg>',
+  "operator-timeline":
+    '<svg viewBox="0 0 16 16" focusable="false"><path d="M4 3.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0 6a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM7 5h6v1H7zm0 6h6v1H7z"/></svg>',
+};
+
+function renderPanelNavLink(panel: DashboardPanelDefinition): string {
+  const icon = panelNavIcons[panel.id];
+  return `<a id="nav-panel-${panel.id}" class="side-nav-link" href="#panel-${panel.id}" data-open-details="true"><span class="side-nav-icon" aria-hidden="true">${icon}</span><span>${toTitleCase(panel.title)}</span></a>`;
 }
 
 function renderDetailsMenu(): string {
@@ -17,13 +43,12 @@ function renderDetailsMenu(): string {
           <div class="side-nav-section">
             <p class="eyebrow">Details</p>
             <a id="nav-overview-heading" class="side-nav-link" href="#overview-heading" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M8 2.5l5 2v4c0 2.9-2.1 4.7-5 5.5-2.9-.8-5-2.6-5-5.5v-4zm0 2.1L5 5.7v2.8c0 1.8 1.2 3.1 3 3.8 1.8-.7 3-2 3-3.8V5.7zM7.2 7h1.6v2.2H7.2zm0 2.8h1.6v1.2H7.2z"/></svg></span><span>Queue Diagnostics</span></a>
-            <a id="nav-panel-status" class="side-nav-link" href="#panel-status" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M3 12h2V6H3zm4 0h2V3H7zm4 0h2V8h-2z"/></svg></span><span>Queue Details</span></a>
-            <a id="nav-panel-doctor" class="side-nav-link" href="#panel-doctor" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M7 2h2v3h3v2H9v3H7V7H4V5h3z"/></svg></span><span>Environment Checks</span></a>
-            <a id="nav-panel-issue-details" class="side-nav-link" href="#panel-issue-details" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M3 2.5h10v11H3zm2 2v1h6v-1zm0 3v1h6v-1zm0 3v1h4v-1z"/></svg></span><span>Issue Details</span></a>
-            <a id="nav-panel-tracked-history" class="side-nav-link" href="#panel-tracked-history" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M8 2.5a5.5 5.5 0 105.5 5.5h-2A3.5 3.5 0 118 4.5V2.5zm-.5 2h1v4l2.5 1.5-.5.9L7.5 9z"/></svg></span><span>Queue</span></a>
-            <a id="nav-panel-operator-actions" class="side-nav-link" href="#panel-operator-actions" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M6.5 2l1 2.2L10 5l-1.8 1.7.4 2.5L6.5 8.1 4.4 9.2l.4-2.5L3 5l2.5-.8zM11 9h2v5h-2zM3 10h2v4H3z"/></svg></span><span>Secondary Actions</span></a>
-            <a id="nav-panel-live-events" class="side-nav-link" href="#panel-live-events" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M2.5 8a5.5 5.5 0 1111 0h-2a3.5 3.5 0 10-7 0z"/><circle cx="8" cy="8" r="1.5"/></svg></span><span>Live Events</span></a>
-            <a id="nav-panel-operator-timeline" class="side-nav-link" href="#panel-operator-timeline" data-open-details="true"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M4 3.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0 6a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM7 5h6v1H7zm0 6h6v1H7z"/></svg></span><span>Operator Timeline</span></a>
+${listDashboardPanels("overview")
+  .map((panel) => "            " + renderPanelNavLink(panel))
+  .join("\n")}
+${listDashboardPanels("details")
+  .map((panel) => "            " + renderPanelNavLink(panel))
+  .join("\n")}
           </div>
         </nav>`;
 }

--- a/src/backend/webui-dashboard-panel-layout.ts
+++ b/src/backend/webui-dashboard-panel-layout.ts
@@ -12,6 +12,8 @@ export type DashboardPanelSection = "overview" | "details";
 export interface DashboardPanelDefinition {
   id: DashboardPanelId;
   section: DashboardPanelSection;
+  title: string;
+  subtitle: string;
   markup: string;
 }
 
@@ -53,6 +55,8 @@ function renderDashboardPanelShell(options: DashboardPanelShellOptions): Dashboa
   return {
     id: options.id,
     section: options.section,
+    title: options.title,
+    subtitle: options.subtitle,
     markup: `
         <article id="panel-${options.id}" class="panel" data-panel-id="${options.id}" data-panel-section="${options.section}">
           <div class="panel-shell">

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -500,6 +500,16 @@ test("dashboard page frames a summary-first shell and a collapsible details area
   );
 });
 
+test("dashboard page renders sidebar links from the panel registry", () => {
+  const html = renderSupervisorDashboardHtml();
+
+  for (const panel of DASHBOARD_PANEL_REGISTRY) {
+    assert.match(html, new RegExp(`id="nav-panel-${panel.id}"`, "u"));
+    const expectedLabel = panel.title.replace(/\b([a-z])/gu, (match) => match.toUpperCase());
+    assert.match(html, new RegExp(`>${expectedLabel}<`, "u"));
+  }
+});
+
 test("dashboard panel registry exposes a shared shell structure for every panel", () => {
   for (const panel of DASHBOARD_PANEL_REGISTRY) {
     assert.match(panel.markup, /<article id="panel-[^"]+" class="panel" data-panel-id="[^"]+" data-panel-section="[^"]+">[\s\S]*<div class="panel-shell">/u);
@@ -848,10 +858,14 @@ test("dashboard keeps requeue disabled after an issue load fails", async () => {
   const issueForm = harness.document.getElementById("issue-form");
   const issueSummary = harness.document.getElementById("issue-summary");
   const requeueButton = harness.document.getElementById("requeue-button");
+  const selectedIssueHeading = harness.document.getElementById("selected-issue-heading");
+  const selectedIssueDetail = harness.document.getElementById("selected-issue-detail");
   assert.ok(issueNumberInput);
   assert.ok(issueForm);
   assert.ok(issueSummary);
   assert.ok(requeueButton);
+  assert.ok(selectedIssueHeading);
+  assert.ok(selectedIssueDetail);
 
   issueNumberInput.value = "42";
   await issueForm.dispatch("submit", {
@@ -861,7 +875,53 @@ test("dashboard keeps requeue disabled after an issue load fails", async () => {
 
   assert.equal(requeueButton.disabled, true);
   assert.match(issueSummary.textContent, /Explain failed/u);
+  assert.match(selectedIssueHeading.textContent, /#42 could not load/u);
+  assert.match(selectedIssueDetail.textContent, /Explain failed/u);
   assert.equal(harness.remainingFetches.length, 0);
+});
+
+test("dashboard opens the details disclosure when a sidebar detail link is selected", async () => {
+  const harness = createDashboardHarness([
+    { path: "/api/status?why=true", response: jsonResponse(createStatus()) },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const detailsDisclosure = harness.document.getElementById("details-disclosure") as FakeElement & { open?: boolean };
+  const navPanelOperatorActions = harness.document.getElementById("nav-panel-operator-actions");
+  assert.ok(detailsDisclosure);
+  assert.ok(navPanelOperatorActions);
+  assert.equal(detailsDisclosure.open, undefined);
+
+  await navPanelOperatorActions.dispatch("click");
+
+  assert.equal(detailsDisclosure.open, true);
+});
+
+test("dashboard next state prefers stale-data recovery over stale selected issue guidance", async () => {
+  const harness = createDashboardHarness([
+    {
+      path: "/api/status?why=true",
+      response: jsonResponse(
+        createStatus({
+          selectedIssueNumber: 42,
+          runnableIssues: [{ issueNumber: 42, title: "Ready issue", readiness: "execution_ready" }],
+        }),
+      ),
+    },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const primaryActionTitle = harness.document.getElementById("primary-action-title");
+  const eventSource = MockEventSource.instances[0];
+  assert.ok(primaryActionTitle);
+  assert.ok(eventSource);
+  assert.match(primaryActionTitle.textContent, /Execute the selected issue/u);
+
+  await eventSource.dispatch("error");
+
+  assert.match(primaryActionTitle.textContent, /Recover dashboard freshness/u);
 });
 
 test("dashboard renders typed issue activity context without scraping legacy summary lines", async () => {


### PR DESCRIPTION
## Why
The previous dashboard front-loaded too much operator detail for first-time users. It was possible to inspect everything, but it was harder to answer the three questions that matter most on first load:
- What is the current status?
- What will the supervisor do next?
- Which issue should I look at first?

## What changed
### Summary-first default view
- replace the metadata-heavy hero with a compact top-level summary
- make the default view focus on `Current status`, `Next state`, `Next issue`, `Why this state`, and `Issue summary`
- keep the UI copy in English, but simplify labels and status copy for readability

### Details moved out of the critical path
- move queue history, diagnostics, events, timeline, and maintenance controls behind the details section
- add a left sidebar menu so operators can jump to detail panels without scanning the whole page
- add clearer Title Case labels and distinct SVG icons for sidebar entries

### Loop-first workflow framing
- stop presenting `Run once` as the main workflow
- keep `Run once` inside `Secondary actions` as a testing/manual check tool
- position `Next state` beside `Current status` so the primary workflow reads left-to-right

## Review guide
### Default view
Please verify that the first screen now makes it easy to answer:
- Is the supervisor healthy?
- What is the next state?
- What is the next issue to inspect?

### Details navigation
Please verify that:
- the left sidebar makes detail sections easier to find
- detail links open the details area when needed
- advanced diagnostics no longer compete with the default summary

### Actions
Please verify that:
- `Run once` is no longer treated as the primary CTA
- maintenance and recovery actions remain available, but feel secondary

## Testing
- `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts`
- `npx tsx --test src/backend/webui-dashboard.test.ts`
