### PR TITLE
Issue #1007: Write issue journals atomically

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,36 +1,36 @@
-# Issue #1005: Atomic write durability: use unique temporary file names for JSON state writes
+# Issue #1007: Journal durability: write issue journals atomically to avoid handoff corruption on interruption
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1005
-- Branch: codex/issue-1005
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1007
+- Branch: codex/issue-1007
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 12df3764d28f05fe1e216eecfbc6e6d74e02007b
+- Last head SHA: 2bf4803c0e3c41b562f65b97583ca65a322586fd
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-25T16:07:21Z
+- Updated at: 2026-03-25T16:20:21Z
 
 ## Latest Codex Summary
-- Reproduced that `writeJsonAtomic` reused the fixed `${filePath}.tmp` path across multiple writes, added a focused regression in `src/core/utils.test.ts`, and changed the helper to append a per-write UUID suffix before the atomic rename. Focused tests and `npm run build` now pass.
+- Reproduced that `syncIssueJournal` wrote directly to `.codex-supervisor/issue-journal.md`, added a focused regression that asserts the journal is staged through a temp file and renamed into place, and switched journal persistence to the shared atomic write helper. Focused tests and `npm run build` now pass.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the atomic JSON helper in `src/core/utils.ts` is the only code path that needs changing for this issue, because it currently writes through a fixed `${filePath}.tmp` path and therefore reuses the same temp name on every attempt.
-- What changed: added `src/core/utils.test.ts` with a focused regression asserting repeated `writeJsonAtomic` calls targeting the same file use distinct temp paths and leave only the final JSON file behind after success. Updated `src/core/utils.ts` to generate temp paths as `${filePath}.tmp.${randomUUID()}` while preserving the existing write-then-rename flow.
+- Hypothesis: `src/core/journal.ts` is the only journal writer and its direct `fs.writeFile(journalPath, nextContent, "utf8")` call is what can leave a truncated handoff behind if the process is interrupted mid-write.
+- What changed: added a focused regression in `src/journal.test.ts` that mocks `fs.writeFile` and `fs.rename` to prove `syncIssueJournal` stages through a temp file before replacing the live journal. Added `writeFileAtomic` in `src/core/utils.ts`, kept `writeJsonAtomic` on the same helper, and switched `syncIssueJournal` to that atomic path without changing journal content or interfaces.
 - Current blocker: none.
-- Next exact step: monitor draft PR `#1024` for CI or review feedback and respond if anything regresses.
-- Verification gap: none after `npx tsx --test src/core/utils.test.ts src/core/state-store.test.ts` and `npm run build`.
-- Files touched: `src/core/utils.ts`; `src/core/utils.test.ts`; `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the runtime change is limited to temp-file naming inside the existing atomic JSON write helper, and the rest is direct regression coverage plus journal state.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-1005 --title 'Issue #1005: Use unique temp names for atomic JSON writes' --body-file -`
-- Exact failure reproduced: `npx tsx --test src/core/utils.test.ts` failed with `AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to: '/tmp/.../state.json.tmp'`, confirming that consecutive atomic writes reused the same fixed temp path instead of generating distinct temp files.
-- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1005/AGENTS.generated.md`; `sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1005/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "tmp|atomic|writeJson|write.*JSON|rename" src -g'*.ts'`; `rg --files src | rg 'utils|state-store'`; `sed -n '1,240p' src/core/utils.ts`; `sed -n '1,320p' src/core/state-store.test.ts`; `rg --files src/core`; `rg -n "writeJsonAtomic|parseJson|truncatePreservingStartAndEnd|nowIso" src/core -g'*.test.ts'`; `sed -n '1,260p' src/core/state-store.ts`; `rg -n "writeJsonAtomic" src/core src -g'*.ts'`; `npx tsx --test src/core/utils.test.ts`; `npx tsx --test src/core/utils.test.ts`; `npx tsx --test src/core/state-store.test.ts`; `git diff --check -- src/core/utils.ts src/core/utils.test.ts .codex-supervisor/issue-journal.md`; `npm run build`; `test -d node_modules && echo node_modules-present || echo node_modules-missing`; `test -f package-lock.json && echo lock-present || echo no-lock`; `npm ci`; `npx tsx --test src/core/utils.test.ts src/core/state-store.test.ts`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `gh pr view --json number,state,isDraft,url,headRefName,baseRefName`; `git status --short`.
-- PR status: draft PR `#1024` open at https://github.com/TommyKammy/codex-supervisor/pull/1024.
+- Next exact step: commit the journal atomic-write change on `codex/issue-1007`, then open or update a draft PR if one does not already exist for this branch.
+- Verification gap: none after `npx tsx --test src/journal.test.ts src/core/utils.test.ts` and `npm run build`.
+- Files touched: `src/core/journal.ts`; `src/core/utils.ts`; `src/journal.test.ts`; `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; journal output bytes are unchanged, and the runtime change is limited to writing the file through a temp path and atomic rename.
+- Last focused command: `npm run build`
+- Exact failure reproduced: `npx tsx --test src/journal.test.ts` failed with `AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to: '<redacted-local-path>'`, confirming that `syncIssueJournal` wrote directly to the live journal path instead of staging through a temp file.
+- Commands run: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "issue-journal|journal|writeFile|rename|writeJsonAtomic|atomic" src test -g'*.ts'`; `sed -n '1,260p' src/core/utils.ts`; `rg --files src | rg 'journal|utils|state-store'`; `git diff -- src/core/utils.ts src/core/utils.test.ts .codex-supervisor/issue-journal.md`; `sed -n '1,280p' src/core/journal.ts`; `sed -n '1,320p' src/journal.test.ts`; `rg -n "syncIssueJournal|readIssueJournal|issueJournalPath|writeFile\\(|appendFile\\(|rename\\(" src/core src -g'*.ts'`; `sed -n '480,540p' src/core/journal.ts`; `sed -n '320,520p' src/journal.test.ts`; `npx tsx --test src/journal.test.ts`; `rg -n "mock\\.method|t\\.mock|import .*mock.*node:test|spyOn" src -g'*.test.ts'`; `sed -n '1,220p' src/core/utils.test.ts`; `npx tsx --test src/journal.test.ts`; `git diff --check -- src/core/journal.ts src/core/utils.ts src/journal.test.ts`; `test -d node_modules && echo node_modules-present || echo node_modules-missing`; `test -f package-lock.json && echo lock-present || echo lock-missing`; `sed -n '1,220p' package.json`; `npm ci`; `npx tsx --test src/journal.test.ts src/core/utils.test.ts`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git status --short`.
+- PR status: none yet on this branch.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { GitHubIssue, IssueRunRecord } from "./types";
-import { ensureDir, truncate } from "./utils";
+import { ensureDir, truncate, writeFileAtomic } from "./utils";
 
 const NOTES_MARKER = "## Codex Working Notes";
 const DURABLE_PATH_TOKEN_PATTERN =
@@ -515,5 +515,5 @@ export async function syncIssueJournal(args: {
   const notes = existing ? normalizeDurableJournalText(preserveCodexNotes(existing), record.workspace) : null;
   const snapshot = buildSupervisorSnapshot({ issue, record, journalPath });
   const nextContent = `${snapshot}\n${notes ? compactCodexNotes(notes, maxChars) : NOTES_TEMPLATE}`;
-  await fs.writeFile(journalPath, nextContent, "utf8");
+  await writeFileAtomic(journalPath, nextContent);
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -45,11 +45,15 @@ export function truncatePreservingStartAndEnd(
   return `${input.slice(0, prefixLength)}${truncationMarker}${input.slice(input.length - suffixLength)}`;
 }
 
-export async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
   await ensureDir(path.dirname(filePath));
   const tempPath = `${filePath}.tmp.${randomUUID()}`;
-  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fs.writeFile(tempPath, content, "utf8");
   await fs.rename(tempPath, filePath);
+}
+
+export async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  await writeFileAtomic(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {

--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { mock } from "node:test";
 import { syncIssueJournal } from "./core/journal";
 import { GitHubIssue, IssueRunRecord } from "./core/types";
 
@@ -472,4 +472,48 @@ test("syncIssueJournal preserves a replaced failure signature when the summary i
   assert.ok(renderedSummary.length <= 4000);
   assert.match(renderedSummary, /Failure signature: PRRT_kwDORgvdZ852E4Jy$/);
   assert.doesNotMatch(renderedSummary, /Failure signature: stale-footer/);
+});
+
+test("syncIssueJournal writes through a temp file before atomically replacing the journal", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-atomic-write-"));
+  const journalPath = path.join(tempDir, ".codex-supervisor", "issue-journal.md");
+  const writeTargets: string[] = [];
+  const renameTargets: Array<{ from: string; to: string }> = [];
+  const originalWriteFile = fs.writeFile.bind(fs);
+  const originalRename = fs.rename.bind(fs);
+  const writeFileMock = mock.method(
+    fs,
+    "writeFile",
+    async (...args: Parameters<typeof fs.writeFile>) => {
+      writeTargets.push(String(args[0]));
+      return originalWriteFile(...args);
+    },
+  );
+  const renameMock = mock.method(
+    fs,
+    "rename",
+    async (...args: Parameters<typeof fs.rename>) => {
+      renameTargets.push({ from: String(args[0]), to: String(args[1]) });
+      return originalRename(...args);
+    },
+  );
+  t.after(() => {
+    writeFileMock.mock.restore();
+    renameMock.mock.restore();
+  });
+
+  await syncIssueJournal({
+    issue,
+    record: createRecord({ workspace: tempDir, journal_path: journalPath }),
+    journalPath,
+  });
+
+  assert.equal(writeTargets.length, 1);
+  assert.notEqual(writeTargets[0], journalPath);
+  assert.match(path.basename(writeTargets[0] ?? ""), /^issue-journal\.md\.tmp(\.|$)/);
+  assert.deepEqual(renameTargets, [{ from: writeTargets[0] ?? "", to: journalPath }]);
+  assert.deepEqual(
+    (await fs.readdir(path.dirname(journalPath))).sort(),
+    ["issue-journal.md"],
+  );
 });


### PR DESCRIPTION
## Summary
- write issue journals through an atomic temp-file-and-rename path
- add a focused regression proving  does not write directly to the live journal file
- keep journal content semantics unchanged by reusing the shared atomic file helper

## Verification
- npx tsx --test src/journal.test.ts src/core/utils.test.ts
- npm run build