### PR TITLE
Issue #1039: remove duplicate focused issue hero action

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,36 +1,36 @@
-# Issue #1037: Harden full issue inventory loading beyond a single gh issue list JSON parse
+# Issue #1039: WebUI hero shows duplicate 'Open Issue Details' actions for the same focused issue
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1037
-- Branch: codex/issue-1037
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1039
+- Branch: codex/issue-1039
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 39589a1ef5253f4f4e98d8f86c77decb6eb41e04
+- Last head SHA: a57e983b2058fb9646d63f49ab4342cde0f6bd0b
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-26T03:45:43Z
+- Updated at: 2026-03-26T04:10:19.276Z
 
 ## Latest Codex Summary
-- Added a malformed-JSON regression test for `GitHubClient.listAllIssues()`, implemented paginated REST fallback for full issue inventory loading, ran focused inventory/explain tests plus `npm run build`, and opened draft PR `#1041`.
+- Reproduced the duplicate focused-issue hero action in the WebUI dashboard tests, then updated the browser-script hero action logic so the secondary hero button is hidden when it would duplicate the primary `Open Issue Details` action. Tightened the focused dashboard tests and verified with `npx tsx --test src/backend/webui-dashboard.test.ts` plus `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `GitHubClient.listAllIssues()` still has a single-host-parse failure mode even after the prelude degradation work, so malformed `gh issue list --json ...` stdout can still collapse full inventory loading instead of retrying through a bounded alternate transport.
-- What changed: added a focused `GitHubClient.listAllIssues()` regression test that injects malformed `gh issue list` JSON and requires paginated REST inventory fallback; implemented a bounded `gh api repos/{owner}/{repo}/issues` fallback that preserves issue metadata, excludes pull-request rows, and continues past the 500-item CLI limit.
+- Hypothesis: the dashboard hero action selection treats any focused issue as both the primary and secondary hero action target, so both buttons render `Open Issue Details` instead of suppressing the redundant secondary control.
+- What changed: tightened the focused dashboard hero tests to require a single visible issue-details action; updated the browser script to mark the secondary hero action hidden when an issue is focused; added an `is-hidden` style for the secondary button and removed the stale static fallback label from the page template.
 - Current blocker: none locally.
-- Next exact step: monitor draft PR `#1041` and address any review or CI feedback on the full inventory fallback path.
-- Verification gap: none for the focused regression coverage and `npm run build`; broader suite coverage remains optional.
-- Files touched: `src/github/github.ts`, `src/github/github.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the change is isolated to full-inventory transport fallback and one synthetic regression fixture.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-1037 --title "Issue #1037: harden full issue inventory loading" --body ...`
-- Exact failure reproduced: `GitHubClient.listAllIssues()` threw `Failed to parse JSON from gh issue list: Bad control character in string literal in JSON at position 27 (line 1 column 28)` when `gh issue list` stdout contained malformed JSON, with no alternate inventory transport attempt.
-- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1037/AGENTS.generated.md`; `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1037/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `git log --oneline --decorate -5`; `rg -n "listAllIssues|gh issue list|inventory_refresh_failure|runOnceCyclePrelude" src`; `sed -n '1,260p' src/github/github.ts`; `sed -n '1,280p' src/run-once-cycle-prelude.test.ts`; `rg -n "GitHubClient|listAllIssues\\(" src/*.test.ts src/github src | head -n 200`; `sed -n '1,260p' src/github/github.test.ts`; `sed -n '1,260p' src/github/github-transport.ts`; `rg -n "listAllIssues\\(|all issues|issues\\[[0-9]+\\]|sortCandidateIssues|createdAt.localeCompare|updatedAt.localeCompare" src | head -n 250`; `sed -n '100,220p' src/supervisor/supervisor-selection-readiness-summary.ts`; `sed -n '150,270p' src/supervisor/supervisor-selection-issue-explain.ts`; `sed -n '1,220p' src/core/utils.ts`; `sed -n '260,420p' src/github/github.test.ts`; `npx tsx --test src/github/github.test.ts`; `npx tsx --test src/run-once-cycle-prelude.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`; `npm run build`; `npm ci`; `npm run build`; `git status --short`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git diff -- src/github/github.ts src/github/github.test.ts .codex-supervisor/issue-journal.md`.
-- PR status: draft PR `#1041` open at https://github.com/TommyKammy/codex-supervisor/pull/1041 targeting `main` from `codex/issue-1037`.
+- Next exact step: commit the focused dashboard fix on `codex/issue-1039`, then open or update the draft PR for issue #1039 if needed.
+- Verification gap: manual browser verification of the focused hero state is still not performed locally; automated focused dashboard coverage and `npm run build` passed.
+- Files touched: `src/backend/webui-dashboard-browser-script.ts`, `src/backend/webui-dashboard-page.ts`, `src/backend/webui-dashboard.test.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; the behavior change is isolated to hero secondary-action rendering in the dashboard browser script plus focused tests.
+- Last focused command: `npm run build`
+- Exact failure reproduced: focused dashboard state rendered both `hero-primary-button` and `hero-secondary-button` with `Open Issue Details`, and the dashboard test suite explicitly expected the duplicate label in `src/backend/webui-dashboard.test.ts`.
+- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1039/AGENTS.generated.md`; `sed -n '1,240p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1039/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "Open Issue Details|hero-primary-button|hero-secondary-button|secondary action|primary action" src/backend/webui-dashboard-page.ts src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard.test.ts`; `sed -n '1,260p' src/backend/webui-dashboard-page.ts`; `sed -n '1,340p' src/backend/webui-dashboard-browser-script.ts`; `sed -n '1,360p' src/backend/webui-dashboard.test.ts`; `sed -n '500,590p' src/backend/webui-dashboard-browser-script.ts`; `sed -n '900,990p' src/backend/webui-dashboard.test.ts`; `sed -n '1030,1075p' src/backend/webui-dashboard.test.ts`; `rg -n "heroSecondaryButton|heroPrimaryButton|applyHero|buildHero|issue-details" src/backend/webui-dashboard-browser-script.ts`; `rg -n "hidden =|\\.hidden|setAttribute\\(\\\"hidden|removeAttribute\\(\\\"hidden|display: none|is-hidden|visually-hidden" src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard-page.ts`; `rg -n "createDashboardHarness|FakeElement|FakeDocument|style =|style:" src/backend/webui-dashboard.test.ts`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `git diff -- src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard-page.ts src/backend/webui-dashboard.test.ts`; `npm ci`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`.
+- PR status: none yet for `codex/issue-1039`.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -550,9 +550,20 @@ export function renderDashboardBrowserScript(): string {
 
       function getHeroSecondaryActionConfig(nextIssue) {
         if (hasHeroIssueFocus(nextIssue)) {
-          return { mode: "issue", label: "Open Issue Details" };
+          return { mode: "queue", label: "", hidden: true };
         }
-        return { mode: "queue", label: "Open Queue Details" };
+        return { mode: "queue", label: "Open Queue Details", hidden: false };
+      }
+
+      function setButtonVisibility(element, hidden) {
+        if (!element) {
+          return;
+        }
+        if (hidden) {
+          element.classList.add("is-hidden");
+          return;
+        }
+        element.classList.remove("is-hidden");
       }
 
       function getFocusedIssueNumber() {
@@ -694,6 +705,7 @@ export function renderDashboardBrowserScript(): string {
         }
 
         if (elements.heroSecondaryButton) {
+          setButtonVisibility(elements.heroSecondaryButton, secondaryActionConfig.hidden === true);
           setText(elements.heroSecondaryButton, secondaryActionConfig.label);
         }
 
@@ -1848,6 +1860,9 @@ export function renderDashboardBrowserScript(): string {
       elements.heroSecondaryButton?.addEventListener("click", async () => {
         const nextIssue = buildNextIssueSummary(state.status);
         const secondaryActionConfig = getHeroSecondaryActionConfig(nextIssue);
+        if (secondaryActionConfig.hidden) {
+          return;
+        }
         if (secondaryActionConfig.mode === "issue") {
           await openFocusedIssueDetails();
           return;

--- a/src/backend/webui-dashboard-page.ts
+++ b/src/backend/webui-dashboard-page.ts
@@ -441,6 +441,10 @@ export function renderSupervisorDashboardPage(setupReadiness?: SetupReadinessRep
         color: var(--text);
       }
 
+      .hero-secondary-button.is-hidden {
+        display: none;
+      }
+
       .hero-warning {
         margin: 0;
         color: var(--muted);
@@ -1199,7 +1203,7 @@ ${renderDetailsMenu()}
           </div>
           <div class="hero-action-row">
             <button type="button" id="hero-primary-button" class="hero-primary-button">Refresh Dashboard</button>
-            <button type="button" id="hero-secondary-button" class="hero-secondary-button">Open Issue Details</button>
+            <button type="button" id="hero-secondary-button" class="hero-secondary-button"></button>
             <button type="button" id="hero-tertiary-button" class="hero-tertiary-button">More Actions</button>
           </div>
           <p id="overview-warning" class="hero-warning hint"></p>

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -944,7 +944,8 @@ test("dashboard folds current state into hero badges and action buttons", async 
   assert.match(badgeText, /fresh/u);
   assert.match(badgeText, /idle/u);
   assert.match(heroPrimaryButton.textContent, /Open Issue Details/u);
-  assert.match(heroSecondaryButton.textContent, /Open Issue Details/u);
+  assert.equal(heroSecondaryButton.textContent, "");
+  assert.equal(heroSecondaryButton.classList.contains("is-hidden"), true);
 });
 
 test("dashboard hero issue-details action loads focused issue details when needed", async () => {
@@ -963,12 +964,16 @@ test("dashboard hero issue-details action loads focused issue details when neede
   ]);
   await harness.flush();
 
+  const heroPrimaryButton = harness.document.getElementById("hero-primary-button");
   const heroSecondaryButton = harness.document.getElementById("hero-secondary-button");
   const issueSummary = harness.document.getElementById("issue-summary");
+  assert.ok(heroPrimaryButton);
   assert.ok(heroSecondaryButton);
   assert.ok(issueSummary);
+  assert.equal(heroSecondaryButton.textContent, "");
+  assert.equal(heroSecondaryButton.classList.contains("is-hidden"), true);
 
-  await heroSecondaryButton.dispatch("click");
+  await heroPrimaryButton.dispatch("click");
   await harness.flush();
 
   assert.match(issueSummary.textContent, /#42 Issue 42/u);


### PR DESCRIPTION
## Summary
- hide the secondary hero action when a focused issue already makes the primary action open issue details
- remove the stale secondary button fallback label from the page template and style the hidden secondary state
- tighten the focused dashboard tests to assert a single visible issue-details hero action

## Testing
- npx tsx --test src/backend/webui-dashboard.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Secondary action button on the dashboard now hides when viewing a focused issue, preventing duplication with the primary "Open Issue Details" action.

* **Tests**
  * Updated dashboard tests to verify correct button visibility behavior in focused issue view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->