### PR TITLE
Run focused malformed-inventory regression tests in CI

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,36 +1,36 @@
-# Issue #1039: WebUI hero shows duplicate 'Open Issue Details' actions for the same focused issue
+# Issue #1044: Run focused malformed-inventory regression tests in CI
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1039
-- Branch: codex/issue-1039
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1044
+- Branch: codex/issue-1044
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: a57e983b2058fb9646d63f49ab4342cde0f6bd0b
+- Last head SHA: 15434d1acc2a0415244256de3c36000738981b87
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-26T04:10:19.276Z
+- Updated at: 2026-03-26T04:23:00Z
 
 ## Latest Codex Summary
-- Reproduced the duplicate focused-issue hero action in the WebUI dashboard tests, then updated the browser-script hero action logic so the secondary hero button is hidden when it would duplicate the primary `Open Issue Details` action. Tightened the focused dashboard tests and verified with `npx tsx --test src/backend/webui-dashboard.test.ts` plus `npm run build`.
+- Reproduced the issue by confirming the malformed-inventory regression suite already passes locally but is not invoked from `.github/workflows/ci.yml`. Added a dedicated focused npm script, required the workflow step in `src/ci-workflow.test.ts`, wired the Ubuntu CI job to run the focused suite, and verified with the workflow test, the exact five-file `npx tsx --test ...` command, the named script, and `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the dashboard hero action selection treats any focused issue as both the primary and secondary hero action target, so both buttons render `Open Issue Details` instead of suppressing the redundant secondary control.
-- What changed: tightened the focused dashboard hero tests to require a single visible issue-details action; updated the browser script to mark the secondary hero action hidden when an issue is focused; added an `is-hidden` style for the secondary button and removed the stale static fallback label from the page template.
+- Hypothesis: the malformed-inventory regression coverage already exists in focused tests, but pull-request CI only runs `replay-corpus` and `npm run build`, so the `#1040` / `#1041` failure surface is not enforced on PRs.
+- What changed: added `test:malformed-inventory-regressions` to `package.json`, added a focused workflow assertion in `src/ci-workflow.test.ts`, and inserted an Ubuntu-only `npm run test:malformed-inventory-regressions` step into `.github/workflows/ci.yml` after the replay-corpus step.
 - Current blocker: none locally.
-- Next exact step: commit the focused dashboard fix on `codex/issue-1039`, then open or update the draft PR for issue #1039 if needed.
-- Verification gap: manual browser verification of the focused hero state is still not performed locally; automated focused dashboard coverage and `npm run build` passed.
-- Files touched: `src/backend/webui-dashboard-browser-script.ts`, `src/backend/webui-dashboard-page.ts`, `src/backend/webui-dashboard.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the behavior change is isolated to hero secondary-action rendering in the dashboard browser script plus focused tests.
+- Next exact step: review the diff, commit the CI workflow change set on `codex/issue-1044`, and prepare the branch for PR creation or update if requested.
+- Verification gap: none in the requested local scope; GitHub Actions execution of the new step is not yet observed remotely.
+- Files touched: `.github/workflows/ci.yml`, `package.json`, `src/ci-workflow.test.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; the change only adds a narrow Ubuntu CI step and its corresponding workflow assertion.
 - Last focused command: `npm run build`
-- Exact failure reproduced: focused dashboard state rendered both `hero-primary-button` and `hero-secondary-button` with `Open Issue Details`, and the dashboard test suite explicitly expected the duplicate label in `src/backend/webui-dashboard.test.ts`.
-- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1039/AGENTS.generated.md`; `sed -n '1,240p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1039/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "Open Issue Details|hero-primary-button|hero-secondary-button|secondary action|primary action" src/backend/webui-dashboard-page.ts src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard.test.ts`; `sed -n '1,260p' src/backend/webui-dashboard-page.ts`; `sed -n '1,340p' src/backend/webui-dashboard-browser-script.ts`; `sed -n '1,360p' src/backend/webui-dashboard.test.ts`; `sed -n '500,590p' src/backend/webui-dashboard-browser-script.ts`; `sed -n '900,990p' src/backend/webui-dashboard.test.ts`; `sed -n '1030,1075p' src/backend/webui-dashboard.test.ts`; `rg -n "heroSecondaryButton|heroPrimaryButton|applyHero|buildHero|issue-details" src/backend/webui-dashboard-browser-script.ts`; `rg -n "hidden =|\\.hidden|setAttribute\\(\\\"hidden|removeAttribute\\(\\\"hidden|display: none|is-hidden|visually-hidden" src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard-page.ts`; `rg -n "createDashboardHarness|FakeElement|FakeDocument|style =|style:" src/backend/webui-dashboard.test.ts`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `git diff -- src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard-page.ts src/backend/webui-dashboard.test.ts`; `npm ci`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`.
-- PR status: none yet for `codex/issue-1039`.
+- Exact failure reproduced: `.github/workflows/ci.yml` ran `npm ci`, Ubuntu replay-corpus, and `npm run build`, but did not run the focused malformed-inventory regression suite, so PR checks could pass without exercising malformed `gh issue list` fallback and degraded active-issue reevaluation coverage.
+- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1044/AGENTS.generated.md`; `sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1044/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `sed -n '1,240p' .github/workflows/ci.yml`; `rg -n "run-once-cycle-prelude|supervisor-pr-review-blockers|supervisor-diagnostics-status-selection|supervisor-diagnostics-explain|github\\.test\\.ts" src .github/workflows package.json`; `npx tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`; `sed -n '1,220p' package.json`; `rg -n '"scripts"|tsx --test|replay-corpus|build' package.json src .github/workflows`; `sed -n '1,220p' src/ci-workflow.test.ts`; `rg -n "ci-workflow|workflow" src/*.test.ts src/**/*.test.ts`; `npx tsx --test src/ci-workflow.test.ts`; `npm ci`; `npx tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`; `npm run test:malformed-inventory-regressions`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git diff -- .github/workflows/ci.yml package.json src/ci-workflow.test.ts .codex-supervisor/issue-journal.md`.
+- PR status: none yet for `codex/issue-1044`.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - id: replay_corpus
         if: matrix.os == 'ubuntu-latest'
         run: npx tsx src/index.ts replay-corpus
+      - if: matrix.os == 'ubuntu-latest'
+        run: npm run test:malformed-inventory-regressions
       - if: ${{ failure() && matrix.os == 'ubuntu-latest' && steps.replay_corpus.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify:paths": "tsx scripts/check-workstation-local-paths.ts",
     "verify:pre-pr": "npm run verify:paths && npm run build && npm test",
     "test": "tsx --test \"src/**/*.test.ts\"",
+    "test:malformed-inventory-regressions": "tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts",
     "test:webui-smoke": "tsx --test src/backend/webui-dashboard-browser-smoke.test.ts",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js"

--- a/src/ci-workflow.test.ts
+++ b/src/ci-workflow.test.ts
@@ -32,3 +32,12 @@ test("CI workflow uploads replay corpus mismatch details only when the Ubuntu re
     /-\s*if:\s*\$\{\{\s*failure\(\)\s*&&\s*matrix\.os == 'ubuntu-latest'\s*&&\s*steps\.replay_corpus\.outcome == 'failure'\s*\}\}\s*uses:\s*actions\/upload-artifact@v4[\s\S]*?name:\s*replay-corpus-mismatch-details[\s\S]*?path:\s*\.codex-supervisor\/replay\/replay-corpus-mismatch-details\.json(?:\s|$)/,
   );
 });
+
+test("CI workflow runs the focused malformed-inventory regression suite on Ubuntu pull request jobs", async () => {
+  const workflow = await fs.readFile(workflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /-\s*if:\s*matrix\.os == 'ubuntu-latest'\s*run:\s*npm run test:malformed-inventory-regressions(?:\s|$)/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a dedicated focused malformed-inventory regression script for the existing five-file suite
- run that focused suite in the Ubuntu CI job alongside replay-corpus and build
- lock the workflow shape with a focused CI workflow test

## Testing
- npx tsx --test src/ci-workflow.test.ts
- npx tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run test:malformed-inventory-regressions
- npm run build

Closes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added focused regression test suite for inventory validation scenarios
  * Added CI workflow assertion ensuring regression tests execute on Ubuntu builds

* **Chores**
  * Enhanced CI/CD pipeline to automatically run targeted regression tests on Ubuntu
  * Added npm script for running inventory validation regression tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->