### PR TITLE
Return restart requirements from typed setup config writes

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,38 +1,38 @@
-# Issue #1053: Restyle the setup shell to match the dashboard-grade admin layout
+# Issue #1054: Return restart requirements from typed setup config writes
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1053
-- Branch: codex/issue-1053
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1054
+- Branch: codex/issue-1054
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
+- Current phase: implementing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 45773f144b3302ac37d287ba1845a6af491ae7dd
+- Last head SHA: d2488cb1b1da430e3202f355ce44ab979dfa203a
 - Blocked reason: none
-- Last failure signature: none
+- Last failure signature: setup-config-update-missing-restart-metadata
 - Repeated failure signature count: 0
-- Updated at: 2026-03-26T06:44:57.215Z
+- Updated at: 2026-03-26T16:10:55+09:00
 
 ## Latest Codex Summary
-- Added a focused setup-shell structure regression test that reproduces the missing dashboard-grade frame on `/setup`.
-- Restyled `src/backend/webui-setup-page.ts` to reuse the dashboard admin shell language with a masthead, sticky sidebar, shared card treatment, stable progress/guided-config/diagnostics sections, and a dashboard-style footer while keeping the existing setup ids and save/readiness behavior.
-- Focused setup WebUI tests, the dedicated setup HTTP route test, and `npm run build` now pass locally.
+- Added restart metadata to typed setup config writes so the response now reports `restartRequired`, `restartScope`, and `restartTriggeredByFields` based on semantic field changes rather than raw requested fields.
+- Classified all supported typed setup fields as requiring a supervisor restart when their effective configured value changes under the current architecture, while preserving no-op writes as `restartRequired: false`.
+- Tightened focused tests in `src/config.test.ts` and `src/backend/supervisor-http-server.test.ts`, updated setup-shell/browser fixtures to the new response shape, and verified the contract with focused tests plus `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the `/setup` shell feels like a separate low-fidelity page because it uses a bespoke stacked layout instead of the dashboard's admin frame vocabulary, so reusing the dashboard shell structure should improve hierarchy without changing the typed setup flow.
-- What changed: added a focused structure assertion in `src/backend/webui-dashboard.test.ts`; rebuilt `src/backend/webui-setup-page.ts` around a dashboard-grade masthead/sidebar/content/footer shell and reorganized setup content into progress, guided config, and diagnostics sections while preserving the existing `setup-*` ids and browser-script contract.
+- Hypothesis: typed setup config writes already know which fields were requested, and because the supervisor loads config at process startup, the write response can deterministically flag restart-required semantic changes without introducing any restart behavior.
+- What changed: extended `SetupConfigUpdateResult` in `src/setup-config-write.ts` with `restartRequired`, `restartScope`, and `restartTriggeredByFields`; classified semantic field changes against the current config summary so no-op writes stay restart-free; added focused restart/no-restart tests in `src/config.test.ts`; added API coverage in `src/backend/supervisor-http-server.test.ts`; and updated setup-shell/browser fixtures in `src/backend/webui-dashboard.test.ts` and `src/backend/webui-dashboard-browser-smoke.test.ts`.
 - Current blocker: none locally.
-- Next exact step: compare `/setup` and `/dashboard` in a local browser and refine any visual polish before moving the draft PR toward review.
-- Verification gap: none in the requested local scope after focused setup WebUI verification and a successful local build.
-- Files touched: `src/backend/webui-dashboard.test.ts`, `src/backend/webui-setup-page.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; the change is presentational and structural, but future edits should preserve the existing `setup-*` ids because the setup browser script still binds directly to them.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-1053 --title "Restyle the setup shell to match the dashboard" ...`
-- Exact failure reproduced: `renderSupervisorSetupHtml()` rendered a standalone `.shell`/`.hero` page without the dashboard-style `page-shell`, `masthead`, `app-layout`, `side-nav`, or stable setup section anchors, so `/setup` looked and read like a separate lower-fidelity surface.
-- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1053/AGENTS.generated.md`; `sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1053/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg --files | rg 'setup|dashboard|webui|ui|app'`; `rg -n "setup" src .`; `rg -n "dashboard" src .`; `sed -n '1,260p' src/backend/webui-setup-page.ts`; `sed -n '1660,1825p' src/backend/webui-dashboard.test.ts`; `sed -n '1,220p' src/backend/webui-dashboard-page.ts`; `sed -n '260,520p' src/backend/webui-setup-page.ts`; `rg -n "renderSupervisorSetup|setup page|setup shell" src/backend/webui-dashboard.test.ts src/backend/supervisor-http-server.test.ts src/backend/webui-setup.ts src/backend/webui-setup-page.ts`; `sed -n '430,540p' src/backend/webui-dashboard.test.ts`; `rg -n "setup-" src/backend/webui-setup-browser-script.ts`; `sed -n '1,260p' src/backend/webui-setup-browser-script.ts`; `npx tsx --test src/backend/webui-dashboard.test.ts --test-name-pattern "setup page reuses the dashboard-grade admin shell with stable setup sections"`; `rg -n "masthead|topbar|dashboard-footer|overview-grid|details-grid|eyebrow" src/backend/webui-dashboard-page.ts`; `sed -n '220,520p' src/backend/webui-dashboard-page.ts`; `sed -n '1120,1285p' src/backend/webui-dashboard-page.ts`; `npx tsx --test src/backend/webui-dashboard.test.ts --test-name-pattern "setup page reuses the dashboard-grade admin shell with stable setup sections|setup shell loads typed setup readiness without mixing in dashboard status endpoints|setup shell saves through the narrow setup config API and revalidates readiness after the write"`; `npx tsx --test src/backend/supervisor-http-server.test.ts --test-name-pattern "serves a dedicated setup shell and keeps the dashboard on its own route"`; `sed -n '1,220p' package.json`; `ls package-lock.json npm-shrinkwrap.json pnpm-lock.yaml yarn.lock`; `npm ci`; `npm run build`; `git add src/backend/webui-setup-page.ts src/backend/webui-dashboard.test.ts .codex-supervisor/issue-journal.md`; `git commit -m "Restyle the setup shell to match the dashboard"`; `gh pr status`; `git push -u origin codex/issue-1053`; `gh pr create --draft --base main --head codex/issue-1053 --title "Restyle the setup shell to match the dashboard" ...`.
-- PR status: draft PR open at `https://github.com/TommyKammy/codex-supervisor/pull/1057`.
+- Next exact step: stage the typed setup config contract changes, create a checkpoint commit on `codex/issue-1054`, and open or update the draft PR once the branch diff is ready.
+- Verification gap: none in the requested local scope after focused setup-config tests, API response coverage, setup-shell contract coverage, and a successful local build.
+- Files touched: `src/setup-config-write.ts`, `src/config.test.ts`, `src/backend/supervisor-http-server.test.ts`, `src/backend/webui-dashboard.test.ts`, `src/backend/webui-dashboard-browser-smoke.test.ts`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; the change is API-contract-only, but future work should preserve the semantic no-op detection so the browser can distinguish restart-needed changes from harmless rewrites.
+- Last focused command: `npm run build`
+- Exact failure reproduced: `updateSetupConfig()` returned only `updatedFields` and refreshed readiness, so typed `/api/setup-config` saves provided no deterministic restart metadata and could not distinguish restart-required semantic changes from no-op writes.
+- Commands run: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1054/AGENTS.generated.md`; `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1054/context-index.md`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "setup_config_update|setup-config|restartRequired|restartScope|typed setup" src .`; `rg --files | rg 'setup|config|supervisor-http|webui-setup|typed'`; `sed -n '1,280p' src/setup-config-write.ts`; `sed -n '1,260p' src/config.test.ts`; `sed -n '1030,1145p' src/backend/supervisor-http-server.test.ts`; `sed -n '1,220p' src/supervisor/supervisor-service.ts`; `sed -n '1,260p' src/supervisor/supervisor.ts`; `sed -n '1320,1365p' src/supervisor/supervisor.ts`; `sed -n '334,470p' src/core/config.ts`; `sed -n '1,260p' src/setup-readiness.ts`; `rg -n "restartScope|restartRequired|restart" src`; `sed -n '180,230p' src/backend/supervisor-http-server.test.ts`; `sed -n '560,620p' src/backend/supervisor-http-server.test.ts`; `sed -n '930,1035p' src/config.test.ts`; `sed -n '470,525p' src/backend/webui-dashboard-browser-smoke.test.ts`; `sed -n '1915,1955p' src/backend/webui-dashboard.test.ts`; `rg -n "updatedFields|restartRequired|restartScope|setup_config_update" src/backend/webui-setup-browser-script.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-smoke.test.ts`; `sed -n '390,510p' src/backend/webui-setup-browser-script.ts`; `npx tsx --test src/config.test.ts --test-name-pattern "updateSetupConfig preserves unrelated fields, writes a backup, and refreshes readiness|updateSetupConfig reports no restart requirement when a typed setup write is a no-op"`; `sed -n '1,220p' src/core/review-providers.ts`; `sed -n '1,180p' src/backend/webui-dashboard-browser-smoke.test.ts`; `sed -n '1,130p' src/backend/supervisor-http-server.test.ts`; `npx tsx --test src/backend/supervisor-http-server.test.ts --test-name-pattern "accepts narrow setup config writes and returns refreshed readiness|surfaces no-op setup config writes without a restart requirement"`; `npx tsx --test src/backend/webui-dashboard.test.ts --test-name-pattern "setup shell saves through the narrow setup config API and revalidates readiness after the write"`; `npm run build`; `sed -n '1,220p' package.json`; `ls -1 node_modules/typescript node_modules/.bin/tsc package-lock.json`; `npm ci`; `npm run build`; `git status --short`; `git diff -- src/setup-config-write.ts src/config.test.ts src/backend/supervisor-http-server.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-smoke.test.ts`; `date -Iseconds`.
+- PR status: none yet for `codex/issue-1054`.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local replay output, not part of the fix.

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -387,6 +387,9 @@ function createStubService(args?: {
     configPath: "/tmp/supervisor.config.json",
     backupPath: "/tmp/supervisor.config.json.bak",
     updatedFields: ["reviewProvider"],
+    restartRequired: true,
+    restartScope: "supervisor",
+    restartTriggeredByFields: ["reviewProvider"],
     document: {
       repoPath: ".",
       repoSlug: "owner/repo",
@@ -1098,6 +1101,9 @@ test("createSupervisorHttpServer accepts narrow setup config writes and returns 
     configPath: "/tmp/supervisor.config.json",
     backupPath: "/tmp/supervisor.config.json.bak",
     updatedFields: ["reviewProvider"],
+    restartRequired: true,
+    restartScope: "supervisor",
+    restartTriggeredByFields: ["reviewProvider"],
     document: {
       repoPath: ".",
       repoSlug: "owner/repo",
@@ -1198,6 +1204,119 @@ test("createSupervisorHttpServer accepts narrow setup config writes and returns 
         signalSource: "none",
         configured: false,
         summary: "No review provider is configured.",
+      },
+      trustPosture: {
+        trustMode: "trusted_repo_and_authors",
+        executionSafetyMode: "unsandboxed_autonomous",
+        warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+        summary: "Trusted inputs with unsandboxed autonomous execution.",
+      },
+    },
+  });
+});
+
+test("createSupervisorHttpServer surfaces no-op setup config writes without a restart requirement", async (t) => {
+  const server = createSupervisorHttpServer({
+    service: createStubService({
+      setupConfigUpdateResult: {
+        kind: "setup_config_update",
+        configPath: "/tmp/supervisor.config.json",
+        backupPath: "/tmp/supervisor.config.json.bak",
+        updatedFields: ["reviewProvider"],
+        restartRequired: false,
+        restartScope: null,
+        restartTriggeredByFields: [],
+        document: {
+          repoPath: ".",
+          repoSlug: "owner/repo",
+          defaultBranch: "main",
+          workspaceRoot: "/tmp/worktrees",
+          stateFile: "/tmp/state.json",
+          codexBinary: "codex",
+          branchPrefix: "codex/issue-",
+          reviewBotLogins: ["chatgpt-codex-connector"],
+        },
+        readiness: {
+          kind: "setup_readiness",
+          ready: true,
+          overallStatus: "configured",
+          configPath: "/tmp/supervisor.config.json",
+          fields: [],
+          blockers: [],
+          hostReadiness: { overallStatus: "pass", checks: [] },
+          providerPosture: {
+            profile: "codex",
+            provider: "codex",
+            reviewers: ["chatgpt-codex-connector"],
+            signalSource: "review_bot_logins",
+            configured: true,
+            summary: "Codex Connector is configured.",
+          },
+          trustPosture: {
+            trustMode: "trusted_repo_and_authors",
+            executionSafetyMode: "unsandboxed_autonomous",
+            warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+            summary: "Trusted inputs with unsandboxed autonomous execution.",
+          },
+        },
+      },
+    }),
+  });
+  t.after(async () => {
+    await closeServer(server);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.on("error", reject);
+  });
+
+  const response = await readJson({
+    server,
+    path: "/api/setup-config",
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      changes: {
+        reviewProvider: "codex",
+      },
+    }),
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.body, {
+    kind: "setup_config_update",
+    configPath: "/tmp/supervisor.config.json",
+    backupPath: "/tmp/supervisor.config.json.bak",
+    updatedFields: ["reviewProvider"],
+    restartRequired: false,
+    restartScope: null,
+    restartTriggeredByFields: [],
+    document: {
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "/tmp/worktrees",
+      stateFile: "/tmp/state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    },
+    readiness: {
+      kind: "setup_readiness",
+      ready: true,
+      overallStatus: "configured",
+      configPath: "/tmp/supervisor.config.json",
+      fields: [],
+      blockers: [],
+      hostReadiness: { overallStatus: "pass", checks: [] },
+      providerPosture: {
+        profile: "codex",
+        provider: "codex",
+        reviewers: ["chatgpt-codex-connector"],
+        signalSource: "review_bot_logins",
+        configured: true,
+        summary: "Codex Connector is configured.",
       },
       trustPosture: {
         trustMode: "trusted_repo_and_authors",

--- a/src/backend/webui-dashboard-browser-smoke.test.ts
+++ b/src/backend/webui-dashboard-browser-smoke.test.ts
@@ -499,6 +499,9 @@ function createFirstRunSetupService(args: {
         configPath: readiness.configPath,
         backupPath: null,
         updatedFields: ["repoPath", "reviewProvider"],
+        restartRequired: true,
+        restartScope: "supervisor",
+        restartTriggeredByFields: ["repoPath", "reviewProvider"],
         document: {
           repoPath: options.changes.repoPath ?? "/tmp/repo",
           reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1933,6 +1933,9 @@ test("setup shell saves through the narrow setup config API and revalidates read
     configPath: "/tmp/supervisor.config.json",
     backupPath: null,
     updatedFields: ["repoPath", "reviewProvider"],
+    restartRequired: true,
+    restartScope: "supervisor",
+    restartTriggeredByFields: ["repoPath", "reviewProvider"],
     document: {
       repoPath: "/tmp/repo",
       reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -970,10 +970,53 @@ test("updateSetupConfig preserves unrelated fields, writes a backup, and refresh
   const backupDocument = JSON.parse(await fs.readFile(result.backupPath, "utf8")) as Record<string, unknown>;
 
   assert.deepEqual(result.updatedFields, ["reviewProvider"]);
+  assert.equal(result.restartRequired, true);
+  assert.equal(result.restartScope, "supervisor");
+  assert.deepEqual(result.restartTriggeredByFields, ["reviewProvider"]);
   assert.deepEqual(updatedDocument.reviewBotLogins, ["chatgpt-codex-connector"]);
   assert.deepEqual(updatedDocument.experimentalFlag, { keep: true });
   assert.deepEqual(backupDocument.reviewBotLogins, []);
   assert.deepEqual(backupDocument.experimentalFlag, { keep: true });
+  assert.equal(result.readiness.kind, "setup_readiness");
+  assert.equal(result.readiness.providerPosture.profile, "codex");
+});
+
+test("updateSetupConfig reports no restart requirement when a typed setup write is a no-op", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-noop-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        repoPath: ".",
+        repoSlug: "owner/repo",
+        defaultBranch: "main",
+        workspaceRoot: "./worktrees",
+        stateFile: "./state.json",
+        codexBinary: "codex",
+        branchPrefix: "codex/issue-",
+        reviewBotLogins: ["chatgpt-codex-connector"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const result = await updateSetupConfig({
+    configPath,
+    changes: {
+      reviewProvider: "codex",
+    },
+  });
+
+  assert.deepEqual(result.updatedFields, ["reviewProvider"]);
+  assert.equal(result.restartRequired, false);
+  assert.equal(result.restartScope, null);
+  assert.deepEqual(result.restartTriggeredByFields, []);
   assert.equal(result.readiness.kind, "setup_readiness");
   assert.equal(result.readiness.providerPosture.profile, "codex");
 });

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveConfigPath } from "./core/config";
+import { loadConfigSummary, resolveConfigPath } from "./core/config";
+import { reviewProviderProfileFromConfig } from "./core/review-providers";
 import { isValidGitRefName, parseJson, writeJsonAtomic } from "./core/utils";
 import type { SetupConfigPreviewSelectableReviewProviderProfile } from "./setup-config-preview";
 import { diagnoseSetupReadiness, type SetupReadinessFieldKey, type SetupReadinessReport } from "./setup-readiness";
@@ -26,6 +27,9 @@ export interface SetupConfigUpdateResult {
   configPath: string;
   backupPath: string | null;
   updatedFields: SetupReadinessFieldKey[];
+  restartRequired: boolean;
+  restartScope: "supervisor" | null;
+  restartTriggeredByFields: SetupReadinessFieldKey[];
   document: Record<string, unknown>;
   readiness: SetupReadinessReport;
 }
@@ -40,6 +44,8 @@ const CONFIGURABLE_FIELDS: SetupReadinessFieldKey[] = [
   "branchPrefix",
   "reviewProvider",
 ];
+
+const RESTART_REQUIRED_FIELDS = new Set<SetupReadinessFieldKey>(CONFIGURABLE_FIELDS);
 
 const REVIEW_PROVIDER_LOGIN_MAP: Record<SetupConfigPreviewSelectableReviewProviderProfile, string[]> = {
   none: [],
@@ -182,10 +188,91 @@ function applySetupChanges(document: Record<string, unknown>, changes: SetupConf
   return nextDocument;
 }
 
+function displayStringValue(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function currentSemanticFieldValue(args: {
+  configSummary: ReturnType<typeof loadConfigSummary>;
+  existingDocument: Record<string, unknown>;
+  field: SetupReadinessFieldKey;
+}): string | null {
+  const { configSummary, existingDocument, field } = args;
+  const resolvedConfig = configSummary.config;
+
+  if (field === "reviewProvider") {
+    if (resolvedConfig !== null) {
+      return reviewProviderProfileFromConfig(resolvedConfig).profile;
+    }
+
+    const reviewBotLogins = Array.isArray(existingDocument.reviewBotLogins)
+      ? existingDocument.reviewBotLogins.filter((value): value is string => typeof value === "string")
+      : [];
+    return reviewProviderProfileFromConfig({
+      reviewBotLogins,
+      configuredReviewProviders: undefined,
+    }).profile;
+  }
+
+  if (resolvedConfig !== null) {
+    return displayStringValue(resolvedConfig[field]);
+  }
+
+  return displayStringValue(existingDocument[field]);
+}
+
+function nextSemanticFieldValue(field: SetupReadinessFieldKey, changes: SetupConfigChanges): string | null {
+  switch (field) {
+    case "repoPath":
+      return changes.repoPath ?? null;
+    case "repoSlug":
+      return changes.repoSlug ?? null;
+    case "defaultBranch":
+      return changes.defaultBranch ?? null;
+    case "workspaceRoot":
+      return changes.workspaceRoot ?? null;
+    case "stateFile":
+      return changes.stateFile ?? null;
+    case "codexBinary":
+      return changes.codexBinary ?? null;
+    case "branchPrefix":
+      return changes.branchPrefix ?? null;
+    case "reviewProvider":
+      return changes.reviewProvider ?? null;
+  }
+}
+
+function determineRestartTriggeredFields(args: {
+  configSummary: ReturnType<typeof loadConfigSummary>;
+  existingDocument: Record<string, unknown>;
+  changes: SetupConfigChanges;
+}): SetupReadinessFieldKey[] {
+  const { configSummary, existingDocument, changes } = args;
+  const updatedFields = CONFIGURABLE_FIELDS.filter((field) => field in changes);
+  return updatedFields.filter((field) => {
+    if (!RESTART_REQUIRED_FIELDS.has(field)) {
+      return false;
+    }
+
+    return currentSemanticFieldValue({ configSummary, existingDocument, field }) !== nextSemanticFieldValue(field, changes);
+  });
+}
+
 export async function updateSetupConfig(args: UpdateSetupConfigArgs): Promise<SetupConfigUpdateResult> {
   const configPath = resolveConfigPath(args.configPath);
   const changes = normalizeSetupChanges(args.changes);
   const existing = await readExistingConfigDocument(configPath);
+  const configSummary = loadConfigSummary(configPath);
+  const restartTriggeredByFields = determineRestartTriggeredFields({
+    configSummary,
+    existingDocument: existing.document,
+    changes,
+  });
   const nextDocument = applySetupChanges(existing.document, changes);
 
   let backupPath: string | null = null;
@@ -203,6 +290,9 @@ export async function updateSetupConfig(args: UpdateSetupConfigArgs): Promise<Se
     configPath,
     backupPath,
     updatedFields: CONFIGURABLE_FIELDS.filter((field) => field in changes),
+    restartRequired: restartTriggeredByFields.length > 0,
+    restartScope: restartTriggeredByFields.length > 0 ? "supervisor" : null,
+    restartTriggeredByFields,
     document: nextDocument,
     readiness,
   };


### PR DESCRIPTION
## Summary
- extend typed setup config writes to return deterministic restart metadata
- report restart requirements only for semantic config changes and keep no-op writes restart-free
- cover the API/setup-shell contract with focused tests

## Testing
- npx tsx --test src/config.test.ts --test-name-pattern "updateSetupConfig preserves unrelated fields, writes a backup, and refreshes readiness|updateSetupConfig reports no restart requirement when a typed setup write is a no-op"
- npx tsx --test src/backend/supervisor-http-server.test.ts --test-name-pattern "accepts narrow setup config writes and returns refreshed readiness|surfaces no-op setup config writes without a restart requirement"
- npx tsx --test src/backend/webui-dashboard.test.ts --test-name-pattern "setup shell saves through the narrow setup config API and revalidates readiness after the write"
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup configuration updates now provide restart metadata, indicating whether a restart is required, the restart scope, and which fields triggered the requirement.

* **Tests**
  * Expanded test coverage for setup configuration updates and restart behavior across multiple test suites, including no-op write scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->