### PR TITLE
Issue #1064: run managed restart regressions in CI

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,51 +1,39 @@
-# Issue #1061: Allow one bounded follow-up repair turn after partial configured-bot review progress
+# Issue #1064: Run focused managed-restart and launcher-wiring regressions in CI
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1061
-- Branch: codex/issue-1061
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1064
+- Branch: codex/issue-1064
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: repairing_ci
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 91a34db8121eb5748f84ae59b2eaef15c44adc85
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: f42178839f6fd52153a1af8fd3d78a87a65fba45
 - Blocked reason: none
-- Last failure signature: build (ubuntu-latest):fail
+- Last failure signature: handoff-missing
 - Repeated failure signature count: 1
-- Updated at: 2026-03-26T11:19:55Z
+- Updated at: 2026-03-26T12:34:45Z
 
 ## Latest Codex Summary
-I reproduced the failing `ubuntu-latest` check locally from PR `#1066` and confirmed it was not a TypeScript build break. The failure came from `npm run test:malformed-inventory-regressions`, where [`src/supervisor/supervisor-pr-review-blockers.test.ts`](src/supervisor/supervisor-pr-review-blockers.test.ts) still expected the pre-change manual-review status text instead of the new `without measurable progress` wording emitted by the bounded same-head follow-up implementation. I updated that stale expectation, reran the failing regression bundle, reran the focused issue-1061 tests, and reran `npm run build`.
-
-The journal is updated in [`issue-journal.md`](.codex-supervisor/issue-journal.md) alongside the test repair so the branch can be committed and pushed back to draft PR `#1066`.
-
-Summary: Reproduced the failing Ubuntu CI check, fixed the stale manual-review status expectation in the regression, and reverified the repair locally.
-State hint: repairing_ci
-Blocked reason: none
-Tests: `npm run test:malformed-inventory-regressions`; `npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/turn-execution-orchestration.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts`; `npm run build`
-Next action: commit and push the test repair to `codex/issue-1061`, then wait for PR `#1066` CI to rerun
-Failure signature: build (ubuntu-latest):fail
+- Added a dedicated `npm run test:managed-restart-regressions` target and wired it into the Ubuntu CI lane.
+- Tightened launcher asset assertions to check the exact managed-restart variables and added shell-script regressions for the explicit missing-binary path under `set -euo pipefail`.
+- Fixed `scripts/install-launchd-web.sh` so the `id -u` lookup happens after the node/npm availability guard.
 
 ## Active Failure Context
-- Category: checks
-- Summary: PR #1066 still shows the earlier failing `ubuntu-latest` check until the repaired branch is pushed and CI reruns.
-- Command or source: gh pr checks
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1066
-- Details:
-  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/23591411395/job/68697299661
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the CI failure is a stale assertion left behind by the wording change in the manual-review failure context, not a behavior regression in the bounded same-head follow-up logic itself.
-- What changed: updated the `failure_context` expectation in `src/supervisor/supervisor-pr-review-blockers.test.ts` so the regression matches the current `without measurable progress and now require manual attention` status text emitted by the no-progress escalation path.
-- Current blocker: none locally; waiting to push the repair and rerun PR CI.
-- Next exact step: commit the repaired test and journal update, push `codex/issue-1061`, and confirm PR `#1066` starts a fresh checks run.
-- Verification gap: broader full-suite verification is still outstanding; this turn covered the exact failing regression bundle, the focused issue-1061 tests, and `npm run build`.
-- Files touched: `src/supervisor/supervisor-pr-review-blockers.test.ts`, `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low. The code path did not change; this is a test expectation realignment to the already-shipped wording.
-- Last focused command: `npm run test:malformed-inventory-regressions`
-- What changed this turn: reproduced the failing Ubuntu job locally, patched the stale status assertion, reran the failing regression command, reran the focused same-head follow-up tests, and reran `npm run build`.
-- Exact failure reproduced this turn: `AssertionError [ERR_ASSERTION]` in `src/supervisor/supervisor-pr-review-blockers.test.ts:156` because the test expected `...after processing on the current head and now require manual attention.` while the status output now includes `without measurable progress`.
-- Commands run this turn: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `gh run view 23591411395 --job 68697299661 --log`; `npm run build`; `sed -n '120,200p' src/supervisor/supervisor-pr-review-blockers.test.ts`; `npm run test:malformed-inventory-regressions`; `git fetch origin main`; `git rev-parse HEAD origin/main`; `git merge-base HEAD origin/main`; `git log --oneline --decorate -n 5 --graph --all`; `rg -n "without measurable progress|remain unresolved after processing on the current head" src`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `apply_patch ...`; `npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/turn-execution-orchestration.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts`.
-- PR status: draft PR open: `#1066` (`https://github.com/TommyKammy/codex-supervisor/pull/1066`); local repair is ready to push.
+- Hypothesis: the repo already had the core managed-restart regression coverage, but CI was missing a dedicated target and the launcher asset checks were still loose enough to miss exact wiring regressions.
+- What changed: added `test:managed-restart-regressions` in `package.json`; wired it into `.github/workflows/ci.yml`; extended `src/ci-workflow.test.ts`; tightened `src/managed-restart-launcher-assets.test.ts` to assert exact variables and to execute the WebUI launcher scripts with a PATH that omits node/npm; moved `UID_VALUE="$(id -u)"` in `scripts/install-launchd-web.sh` below the explicit node/npm guard.
+- Current blocker: none locally.
+- Next exact step: commit this checkpoint, push `codex/issue-1064`, and open/update the PR so GitHub Actions runs the new focused regression target.
+- Verification gap: none for the issue acceptance criteria. Local verification covered the new focused regression target and `npm run build`.
+- Files touched: `package.json`, `.github/workflows/ci.yml`, `src/ci-workflow.test.ts`, `src/managed-restart-launcher-assets.test.ts`, `scripts/install-launchd-web.sh`, `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low. The code change is limited to launcher-script guard ordering; the rest is focused test and CI wiring.
+- Last focused command: `npm run test:managed-restart-regressions`
+- What changed this turn: found that `codex/issue-1064` was still at `main`, reused the existing restart/dashboard/server tests via a dedicated npm target, added missing-binary launcher-script regressions, and wired the target into the Ubuntu CI lane.
+- Exact failure reproduced this turn: the first draft of the new shell regression used an empty PATH and exposed that `dirname` disappears too; the final test now uses a temporary PATH containing only the shell helpers needed before the node/npm guard.
+- Commands run this turn: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1064/AGENTS.generated.md`; `sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1064/context-index.md`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `git log --oneline --decorate --graph -n 12`; `git diff --stat origin/main...HEAD`; `git diff --name-only origin/main...HEAD`; `gh pr view 1066 --json number,title,state,isDraft,headRefName,baseRefName,statusCheckRollup,url`; `rg -n "managed restart|managed-restart|restart acceptance|launcher|set -euo pipefail|test:malformed-inventory-regressions|webui" package.json src .github`; `sed -n '1,220p' package.json`; `sed -n '1,260p' .github/workflows/ci.yml`; `sed -n '1,220p' src/managed-restart-launcher-assets.test.ts`; `sed -n '2440,2525p' src/backend/webui-dashboard.test.ts`; `sed -n '1260,1425p' src/backend/supervisor-http-server.test.ts`; `sed -n '1,220p' src/ci-workflow.test.ts`; `sed -n '1,240p' scripts/run-web.sh`; `sed -n '1,260p' scripts/install-systemd-web.sh`; `sed -n '1,260p' scripts/install-launchd-web.sh`; `sed -n '1,240p' launchd/io.codex.supervisor.web.plist.template`; `sed -n '1,240p' systemd/codex-supervisor-web.service.template`; `sed -n '1,220p' src/managed-restart.test.ts`; `apply_patch ...`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npx tsx --test src/ci-workflow.test.ts`; `npm run test:managed-restart-regressions`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`.
+- PR status: no PR for `codex/issue-1064` yet.
 ### Scratchpad
 - Leave `.codex-supervisor/replay/` untracked; it is local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: npx tsx src/index.ts replay-corpus
       - if: matrix.os == 'ubuntu-latest'
         run: npm run test:malformed-inventory-regressions
+      - if: matrix.os == 'ubuntu-latest'
+        run: npm run test:managed-restart-regressions
       - if: ${{ failure() && matrix.os == 'ubuntu-latest' && steps.replay_corpus.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify:paths": "tsx scripts/check-workstation-local-paths.ts",
     "verify:pre-pr": "npm run verify:paths && npm run build && npm test",
     "test": "tsx --test \"src/**/*.test.ts\"",
+    "test:managed-restart-regressions": "tsx --test src/managed-restart.test.ts src/backend/supervisor-http-server.test.ts src/backend/webui-dashboard.test.ts src/managed-restart-launcher-assets.test.ts src/ci-workflow.test.ts",
     "test:malformed-inventory-regressions": "tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts",
     "test:webui-smoke": "tsx --test src/backend/webui-dashboard-browser-smoke.test.ts",
     "dev": "tsx src/index.ts",

--- a/scripts/install-launchd-web.sh
+++ b/scripts/install-launchd-web.sh
@@ -6,7 +6,6 @@ ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PLIST_TEMPLATE="${ROOT}/launchd/io.codex.supervisor.web.plist.template"
 PLIST_TARGET="${HOME}/Library/LaunchAgents/io.codex.supervisor.web.plist"
 LOG_DIR="${ROOT}/.local/logs"
-UID_VALUE="$(id -u)"
 NODE_BIN="${NODE_BIN:-$(command -v node || true)}"
 NPM_BIN="${NPM_BIN:-$(command -v npm || true)}"
 PATH_VALUE="${PATH}"
@@ -20,6 +19,7 @@ if [[ -z "${NODE_BIN}" || -z "${NPM_BIN}" ]]; then
   exit 1
 fi
 
+UID_VALUE="$(id -u)"
 mkdir -p "${HOME}/Library/LaunchAgents" "${LOG_DIR}"
 ROOT_ESCAPED="$(escape_sed_replacement "${ROOT}")"
 PATH_ESCAPED="$(escape_sed_replacement "${PATH_VALUE}")"

--- a/src/ci-workflow.test.ts
+++ b/src/ci-workflow.test.ts
@@ -41,3 +41,12 @@ test("CI workflow runs the focused malformed-inventory regression suite on Ubunt
     /-\s*if:\s*matrix\.os == 'ubuntu-latest'\s*run:\s*npm run test:malformed-inventory-regressions(?:\s|$)/,
   );
 });
+
+test("CI workflow runs the focused managed-restart regression suite on Ubuntu pull request jobs", async () => {
+  const workflow = await fs.readFile(workflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /-\s*if:\s*matrix\.os == 'ubuntu-latest'\s*run:\s*npm run test:managed-restart-regressions(?:\s|$)/,
+  );
+});

--- a/src/managed-restart-launcher-assets.test.ts
+++ b/src/managed-restart-launcher-assets.test.ts
@@ -1,10 +1,74 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const bashPath = "/bin/bash";
 
 async function readRepoFile(relativePath: string): Promise<string> {
   return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
+}
+
+function assertShellExport(script: string, variable: string, fallbackValue: string): void {
+  const expectedLine = `export ${variable}="\${${variable}:-${fallbackValue}}"`;
+  assert.equal(script.split(/\r?\n/u).includes(expectedLine), true);
+}
+
+function assertLaunchdEnvironmentVariable(plist: string, variable: string, value: string): void {
+  assert.match(
+    plist,
+    new RegExp(`<key>${escapeRegex(variable)}</key>\\s*<string>${escapeRegex(value)}</string>`, "u"),
+  );
+}
+
+function assertSystemdEnvironmentVariable(unit: string, variable: string, value: string): void {
+  assert.match(unit, new RegExp(`^Environment=${escapeRegex(variable)}=${escapeRegex(value)}$`, "mu"));
+}
+
+async function createMissingNodePath(commands: string[]): Promise<string> {
+  const pathDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-restart-path-"));
+
+  await Promise.all(commands.map(async (commandName) => {
+    const commandPath = (await execFileAsync(bashPath, ["-lc", `command -v ${commandName}`])).stdout.trim();
+    await fs.symlink(commandPath, path.join(pathDir, commandName));
+  }));
+
+  return pathDir;
+}
+
+async function assertMissingBinaryMessage(relativePath: string, requiredCommands: string[]): Promise<void> {
+  const scriptPath = path.join(process.cwd(), relativePath);
+  const pathDir = await createMissingNodePath(requiredCommands);
+
+  try {
+    await assert.rejects(
+      async () => execFileAsync(bashPath, [scriptPath], {
+        env: {
+          HOME: os.tmpdir(),
+          PATH: pathDir,
+        },
+      }),
+      (error: unknown) => {
+        assert.equal(typeof error, "object");
+        assert.notEqual(error, null);
+        assert.equal((error as NodeJS.ErrnoException).code, 1);
+        const stderr = (error as { stderr?: string }).stderr ?? "";
+        assert.equal(stderr.trim(), "node and npm must be available on PATH");
+        assert.doesNotMatch(stderr, /command not found/u);
+        return true;
+      },
+    );
+  } finally {
+    await fs.rm(pathDir, { recursive: true, force: true });
+  }
 }
 
 test("dedicated WebUI launcher assets enable managed restart for launcher-backed WebUI sessions", async () => {
@@ -23,18 +87,18 @@ test("dedicated WebUI launcher assets enable managed restart for launcher-backed
   ]);
 
   assert.match(runWeb, /dist\/index\.js" web --config/u);
-  assert.match(runWeb, /\bCODEX_SUPERVISOR_MANAGED_RESTART(?!_LAUNCHER)\b/u);
-  assert.match(runWeb, /CODEX_SUPERVISOR_MANAGED_RESTART_LAUNCHER/u);
+  assertShellExport(runWeb, "CODEX_SUPERVISOR_MANAGED_RESTART", "1");
+  assertShellExport(runWeb, "CODEX_SUPERVISOR_MANAGED_RESTART_LAUNCHER", "custom");
 
   assert.match(launchdTemplate, /io\.codex\.supervisor\.web/u);
   assert.match(launchdTemplate, /scripts\/run-web\.sh/u);
-  assert.match(launchdTemplate, /\bCODEX_SUPERVISOR_MANAGED_RESTART(?!_LAUNCHER)\b/u);
-  assert.match(launchdTemplate, /<string>launchd<\/string>/u);
+  assertLaunchdEnvironmentVariable(launchdTemplate, "CODEX_SUPERVISOR_MANAGED_RESTART", "1");
+  assertLaunchdEnvironmentVariable(launchdTemplate, "CODEX_SUPERVISOR_MANAGED_RESTART_LAUNCHER", "launchd");
 
   assert.match(systemdTemplate, /codex-supervisor WebUI/u);
   assert.match(systemdTemplate, /scripts\/run-web\.sh/u);
-  assert.match(systemdTemplate, /Environment=CODEX_SUPERVISOR_MANAGED_RESTART=1/u);
-  assert.match(systemdTemplate, /Environment=CODEX_SUPERVISOR_MANAGED_RESTART_LAUNCHER=systemd/u);
+  assertSystemdEnvironmentVariable(systemdTemplate, "CODEX_SUPERVISOR_MANAGED_RESTART", "1");
+  assertSystemdEnvironmentVariable(systemdTemplate, "CODEX_SUPERVISOR_MANAGED_RESTART_LAUNCHER", "systemd");
 
   assert.match(installLaunchdWeb, /io\.codex\.supervisor\.web/u);
   assert.match(installLaunchdWeb, /io\.codex\.supervisor\.web\.plist/u);
@@ -53,7 +117,15 @@ test("existing loop launcher assets stay scoped to loop mode without managed res
   ]);
 
   assert.match(runLoop, /dist\/index\.js" loop --config/u);
-  assert.doesNotMatch(runLoop, /CODEX_SUPERVISOR_MANAGED_RESTART/u);
-  assert.doesNotMatch(launchdTemplate, /CODEX_SUPERVISOR_MANAGED_RESTART/u);
-  assert.doesNotMatch(systemdTemplate, /CODEX_SUPERVISOR_MANAGED_RESTART/u);
+  assert.doesNotMatch(runLoop, /^export CODEX_SUPERVISOR_MANAGED_RESTART(?:_LAUNCHER)?=/mu);
+  assert.doesNotMatch(launchdTemplate, /<key>CODEX_SUPERVISOR_MANAGED_RESTART(?:_LAUNCHER)?<\/key>/u);
+  assert.doesNotMatch(systemdTemplate, /^Environment=CODEX_SUPERVISOR_MANAGED_RESTART(?:_LAUNCHER)?=/mu);
+});
+
+test("launcher-backed WebUI shell scripts keep their explicit missing-binary diagnostics under set -euo pipefail", async () => {
+  await Promise.all([
+    assertMissingBinaryMessage("scripts/run-web.sh", ["dirname"]),
+    assertMissingBinaryMessage("scripts/install-launchd-web.sh", ["dirname"]),
+    assertMissingBinaryMessage("scripts/install-systemd-web.sh", ["dirname"]),
+  ]);
 });


### PR DESCRIPTION
## Summary
- add a dedicated managed-restart regression npm target
- run that target in Ubuntu CI and assert the workflow wiring in tests
- tighten launcher asset and shell-script regressions around managed restart wiring

## Verification
- npm run test:managed-restart-regressions
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected script execution order to ensure dependency validation completes before system-level operations proceed.

* **Tests**
  * Added managed-restart regression test suite to Ubuntu CI workflow.
  * Enhanced launcher asset validation with stricter assertions for environment variables and improved error detection for missing dependencies.

* **Chores**
  * Integrated new regression test targets and Ubuntu-specific validation into CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->