### PR TITLE
Issue #1078: promote reconnect polling backoff guardrail

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,36 +1,36 @@
-# Issue #1077: Replace setup reconnect real sleeps with deterministic timer control
+# Issue #1078: Promote reconnect polling backoff into shared-memory guardrails
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1077
-- Branch: codex/issue-1077
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1078
+- Branch: codex/issue-1078
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 7a1261897a3e30640fbe6735c87fe32a1ab0cb06
+- Last head SHA: 4628bb00171f510bdedd4335f883756019760cdb
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-26T15:21:19Z
+- Updated at: 2026-03-26T15:42:42.430Z
 
 ## Latest Codex Summary
-- Replaced the setup-shell reconnect test's real 75 ms sleeps with deterministic harness timer advancement, pushed `codex/issue-1077`, and opened draft PR #1084 after focused backend WebUI verification.
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the only product-risky behavior here is test harness timing. The reconnect flow can stay unchanged if the setup-page harness exposes deterministic timer control for the poll loop.
-- What changed: added a small manual timer controller to `src/backend/webui-dashboard.test.ts`, wired `createSetupHarness()` to use it, exposed `harness.advanceTime(ms)`, and updated the setup reconnect test to advance 50 ms polling intervals instead of sleeping in wall-clock time.
+- Hypothesis: the durable issue is the setup reconnect loop itself, not just test timing. Repeated reconnect failures or unhealthy readiness responses should back off with a bounded delay instead of polling every 50 ms forever.
+- What changed: added a focused setup reconnect regression test in `src/backend/webui-dashboard.test.ts`, changed `src/backend/webui-setup-browser-script.ts` to use capped exponential backoff for unsuccessful reconnect polls, updated the existing reconnect success-path test to match the new `50 ms -> 100 ms` schedule, and promoted the generic polling backoff rule into `docs/shared-memory/external-review-guardrails.json`.
 - Current blocker: none.
-- Next exact step: watch draft PR #1084 CI and only widen verification if review or CI finds another timing-dependent WebUI test path.
-- Verification gap: full `npm test` has not been run; focused backend WebUI reconnect and setup/server coverage are green.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/backend/webui-dashboard.test.ts`.
-- Rollback concern: low. The change is test-only and limited to how the setup harness schedules reconnect polling.
-- Last focused command: `gh pr create --draft --base main --head codex/issue-1077 --title "Issue #1077: replace setup reconnect sleeps with timer control" --body ...`
-- What changed this turn: reread the required memory files and journal, traced the setup reconnect test and the setup-page browser poll loop, reproduced that the focused reconnect test still depended on two real `setTimeout(..., 75)` waits, added a manual timer controller to the dashboard/setup HTML harness, updated the reconnect test to advance deterministic timer state across the `reconnecting -> unavailable -> ready` sequence, reran focused backend WebUI verification, committed the change as `7a12618`, pushed `codex/issue-1077`, and opened draft PR #1084.
-- Exact failure reproduced this turn: `src/backend/webui-dashboard.test.ts` used wall-clock sleeps to let the setup reconnect polling loop advance between readiness responses, making the reconnect-state assertions depend on scheduler timing instead of harness-controlled time.
-- Commands run this turn: `sed -n '1,220p' <always-read-memory>`; `sed -n '1,260p' <context-index>`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "setTimeout\\(.*75|reconnect|reconnecting|unavailable|ready" webui src test .`; `rg --files . | rg "setup-shell|dashboard|harness|timer|vitest|playwright|webui"`; `rg -n "setTimeout\\(|75\\)|reconnect|reconnecting|unavailable|ready|advance.*timer|clock|fake.*timer" src/backend`; `sed -n '1,260p' src/backend/webui-dashboard.test.ts`; `sed -n '1,260p' src/backend/restartable-webui-shell-service.test.ts`; `sed -n '2280,2875p' src/backend/webui-dashboard.test.ts`; `sed -n '260,520p' src/backend/webui-dashboard.test.ts`; `sed -n '1,220p' src/backend/webui-setup-browser-script.ts`; `sed -n '220,430p' src/backend/webui-setup-browser-script.ts`; `node --test src/backend/webui-dashboard.test.ts`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `rg -n "create(Html|Setup|Dashboard)Harness|flush\\(|setTimeout\\(|clearTimeout\\(" src/backend/webui-dashboard.test.ts`; `apply_patch ...`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `rg -n "await new Promise\\(\\(resolve\\) => setTimeout\\(resolve, 75\\)\\)" src/backend/webui-dashboard.test.ts src/backend`; `git diff -- src/backend/webui-dashboard.test.ts`; `git rev-parse HEAD`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `npx tsx --test src/backend/restartable-webui-shell-service.test.ts src/backend/supervisor-http-server.test.ts`; `git add .codex-supervisor/issue-journal.md src/backend/webui-dashboard.test.ts`; `git commit -m "Replace setup reconnect sleeps with timer control"`; `git push -u origin codex/issue-1077`; `gh pr view --json number,url,isDraft,headRefName,baseRefName,state`; `gh pr create --draft --base main --head codex/issue-1077 --title "Issue #1077: replace setup reconnect sleeps with timer control" --body ...`.
+- Next exact step: commit the reconnect backoff + shared-memory guardrail changes on `codex/issue-1078`, push the branch, and open a draft PR if one does not already exist.
+- Verification gap: full `npm test` has not been run; focused setup WebUI reconnect coverage and committed-guardrail validation are green.
+- Files touched: `.codex-supervisor/issue-journal.md`; `docs/shared-memory/external-review-guardrails.json`; `src/backend/webui-dashboard.test.ts`; `src/backend/webui-setup-browser-script.ts`.
+- Rollback concern: low. The runtime change is limited to the setup-page reconnect poll cadence and the tests cover both recovery and repeated-failure timing.
+- Last focused command: `npx tsx src/committed-guardrails-cli.ts check`
+- What changed this turn: reread the required memory files and journal, traced the setup reconnect path to `monitorManagedRestartReconnect()`, reproduced that the browser script retried readiness fetches every fixed 50 ms on both unhealthy responses and fetch errors, added a deterministic timer-based regression test for repeated failures, changed the reconnect loop to use capped exponential backoff, normalized the promoted durable guardrail entry, and reran focused verification.
+- Exact failure reproduced this turn: after launcher-managed restart, `src/backend/webui-setup-browser-script.ts` kept polling `/api/setup-readiness` every 50 ms forever while the worker stayed unhealthy, so repeated failures never widened the retry interval.
+- Commands run this turn: `sed -n '1,220p' <always-read-memory>`; `sed -n '1,260p' <context-index>`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `rg -n "external-review-guardrails|reconnect|readiness|polling|backoff|50ms|50 ms|setTimeout\\(|retry" docs src test`; `sed -n '1,260p' docs/shared-memory/external-review-guardrails.json`; `rg --files src test docs | rg "setup-shell|webui-setup|restartable|dashboard|guardrail|shared-memory"`; `rg -n "reconnect|poll|backoff|setTimeout\\(|50\\)|50,|schedule|retry" src/backend/restartable-webui-shell-service.ts src/backend/webui-setup-browser-script.ts src/backend/webui-dashboard.test.ts src/backend/restartable-webui-shell-service.test.ts`; `sed -n '1,260p' src/backend/restartable-webui-shell-service.ts`; `sed -n '1,280p' src/backend/restartable-webui-shell-service.test.ts`; `sed -n '1,260p' src/backend/webui-setup-browser-script.ts`; `sed -n '260,430p' src/backend/webui-setup-browser-script.ts`; `sed -n '2560,2945p' src/backend/webui-dashboard.test.ts`; `rg -n "advanceTime|manual timer|createSetupHarness|fetchCalls|refreshSetupReadiness|Waiting for the restarted worker to reconnect|temporarily unavailable" src/backend/webui-dashboard.test.ts`; `sed -n '1,220p' src/committed-guardrails.test.ts`; `sed -n '1,220p' src/verifier-guardrails.test.ts`; `sed -n '1,120p' src/backend/webui-dashboard.test.ts`; `sed -n '260,540p' src/backend/webui-dashboard.test.ts`; `rg -n "backoff|exponential|retryDelay|retryInterval|pollIntervalMs|delay\\(" src | head -n 200`; `apply_patch ...`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `apply_patch ...`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `apply_patch ...`; `apply_patch ...`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `rg -n "validateCommittedGuardrails|committed-guardrails|external-review-guardrails" src package.json`; `cat package.json`; `apply_patch ...`; `npx tsx --test src/backend/webui-dashboard.test.ts`; `npm run guardrails:check`; `npx tsx src/committed-guardrails-cli.ts check`; `npx tsx src/committed-guardrails-cli.ts fix`; `npx tsx src/committed-guardrails-cli.ts check`; `git diff -- src/backend/webui-setup-browser-script.ts src/backend/webui-dashboard.test.ts docs/shared-memory/external-review-guardrails.json`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `gh pr view --json number,url,isDraft,headRefName,baseRefName,state`.
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/shared-memory/external-review-guardrails.json
+++ b/docs/shared-memory/external-review-guardrails.json
@@ -2,6 +2,17 @@
   "version": 1,
   "patterns": [
     {
+      "fingerprint": "src/backend/webui-setup-browser-script.ts|reconnect-or-readiness-polling-must-use-bounded-backoff-under-repeated-failures",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/backend/webui-setup-browser-script.ts",
+      "line": null,
+      "summary": "Flag reconnect or readiness polling loops that keep retrying at a fixed rapid interval after repeated failures or unhealthy responses instead of backing off with an explicit cap.",
+      "rationale": "When a worker or endpoint stays unhealthy, fixed high-frequency polling can keep hammering the same failing path indefinitely. Retry loops should slow down under consecutive failures while keeping the delay bounded so recovery is still detected promptly.",
+      "sourceArtifactPath": "promoted-from-pr-1074",
+      "sourceHeadSha": "pr-1074",
+      "lastSeenAt": "2026-03-27T00:00:00Z"
+    },
+    {
       "fingerprint": "scripts/run-web.sh|set-euo-command-v-must-preserve-explicit-error-paths",
       "reviewerLogin": "coderabbitai",
       "file": "scripts/run-web.sh",

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -2900,7 +2900,7 @@ test("setup shell refreshes readiness after launcher-managed restart until the w
   assert.match(restartStatus.textContent ?? "", /Restart required/u);
   assert.match(restartGuidance.textContent ?? "", /temporarily unavailable while the worker is still reconnecting/u);
 
-  await harness.advanceTime(50);
+  await harness.advanceTime(100);
 
   reconnectedReadinessResponse.resolve(jsonResponse({
     kind: "setup_readiness",
@@ -2966,6 +2966,236 @@ test("setup shell refreshes readiness after launcher-managed restart until the w
     ],
   );
   assert.equal(harness.remainingFetches.length, 0);
+});
+
+test("setup shell backs off reconnect polling after repeated readiness failures", async () => {
+  const setupConfigResponse = createDeferred<MockResponseLike>();
+  const setupReadinessRefreshResponse = createDeferred<MockResponseLike>();
+  const managedRestartResponse = createDeferred<MockResponseLike>();
+  const harness = createSetupHarness([
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse({
+        kind: "setup_readiness",
+        managedRestart: {
+          supported: true,
+          launcher: "systemd",
+          state: "ready",
+          summary: "Managed restart is available through the systemd launcher.",
+        },
+        ready: false,
+        overallStatus: "missing",
+        configPath: "/tmp/supervisor.config.json",
+        fields: [
+          {
+            key: "reviewProvider",
+            label: "Review provider",
+            state: "missing",
+            value: null,
+            message: "Configure at least one review provider before first-run setup is complete.",
+            required: true,
+            metadata: {
+              source: "config",
+              editable: true,
+              valueType: "review_provider",
+            },
+          },
+        ],
+        blockers: [],
+        hostReadiness: { overallStatus: "pass", checks: [] },
+        providerPosture: {
+          profile: "none",
+          provider: "none",
+          reviewers: [],
+          signalSource: "none",
+          configured: false,
+          summary: "No review provider is configured.",
+        },
+        trustPosture: {
+          trustMode: "trusted_repo_and_authors",
+          executionSafetyMode: "unsandboxed_autonomous",
+          warning: null,
+          summary: "Trusted inputs with unsandboxed autonomous execution.",
+        },
+        localCiContract: {
+          configured: false,
+          command: null,
+          source: "config",
+          summary: "No repo-owned local CI contract is configured.",
+        },
+      }),
+    },
+    {
+      path: "/api/setup-config",
+      method: "POST",
+      body: JSON.stringify({
+        changes: {
+          reviewProvider: "codex",
+        },
+      }),
+      response: setupConfigResponse.promise,
+    },
+    {
+      path: "/api/setup-readiness",
+      response: setupReadinessRefreshResponse.promise,
+    },
+    {
+      path: "/api/commands/managed-restart",
+      method: "POST",
+      body: JSON.stringify({}),
+      response: managedRestartResponse.promise,
+    },
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse({ error: "setup reconnect attempt 1 failed" }, 503),
+    },
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse({ error: "setup reconnect attempt 2 failed" }, 503),
+    },
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse({ error: "setup reconnect attempt 3 failed" }, 503),
+    },
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse({ error: "setup reconnect attempt 4 failed" }, 503),
+    },
+  ]);
+  await harness.flush();
+
+  const reviewProviderInput = harness.document.getElementById("setup-input-reviewProvider");
+  const setupForm = harness.document.getElementById("setup-form");
+  const restartButton = harness.document.getElementById("setup-restart-button");
+  const restartGuidance = harness.document.getElementById("setup-restart-guidance");
+  assert.ok(reviewProviderInput);
+  assert.ok(setupForm);
+  assert.ok(restartButton);
+  assert.ok(restartGuidance);
+
+  reviewProviderInput.value = "codex";
+  const submitPromise = setupForm.dispatch("submit", { preventDefault() {} });
+  await harness.flush();
+
+  setupConfigResponse.resolve(jsonResponse({
+    kind: "setup_config_update",
+    managedRestart: {
+      supported: true,
+      launcher: "systemd",
+      state: "ready",
+      summary: "Managed restart is available through the systemd launcher.",
+    },
+    configPath: "/tmp/supervisor.config.json",
+    backupPath: null,
+    updatedFields: ["reviewProvider"],
+    restartRequired: true,
+    restartScope: "supervisor",
+    restartTriggeredByFields: ["reviewProvider"],
+    document: {
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    },
+    readiness: {
+      kind: "setup_readiness",
+      managedRestart: {
+        supported: true,
+        launcher: "systemd",
+        state: "ready",
+        summary: "Managed restart is available through the systemd launcher.",
+      },
+      ready: false,
+      overallStatus: "missing",
+      configPath: "/tmp/supervisor.config.json",
+      fields: [],
+      blockers: [],
+      hostReadiness: { overallStatus: "pass", checks: [] },
+      providerPosture: {
+        profile: "codex",
+        provider: "codex",
+        reviewers: ["chatgpt-codex-connector"],
+        signalSource: "review_bot_logins",
+        configured: true,
+        summary: "Codex Connector is configured.",
+      },
+      trustPosture: {
+        trustMode: "trusted_repo_and_authors",
+        executionSafetyMode: "unsandboxed_autonomous",
+        warning: null,
+        summary: "Trusted inputs with unsandboxed autonomous execution.",
+      },
+      localCiContract: {
+        configured: false,
+        command: null,
+        source: "config",
+        summary: "No repo-owned local CI contract is configured.",
+      },
+    },
+  }));
+  await harness.flush();
+
+  setupReadinessRefreshResponse.resolve(jsonResponse({
+    kind: "setup_readiness",
+    managedRestart: {
+      supported: true,
+      launcher: "systemd",
+      state: "ready",
+      summary: "Managed restart is available through the systemd launcher.",
+    },
+    ready: true,
+    overallStatus: "configured",
+    configPath: "/tmp/supervisor.config.json",
+    fields: [],
+    blockers: [],
+    hostReadiness: { overallStatus: "pass", checks: [] },
+    providerPosture: {
+      profile: "codex",
+      provider: "codex",
+      reviewers: ["chatgpt-codex-connector"],
+      signalSource: "review_bot_logins",
+      configured: true,
+      summary: "Codex Connector is configured.",
+    },
+    trustPosture: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: null,
+      summary: "Trusted inputs with unsandboxed autonomous execution.",
+    },
+    localCiContract: {
+      configured: false,
+      command: null,
+      source: "config",
+      summary: "No repo-owned local CI contract is configured.",
+    },
+  }));
+  await submitPromise;
+  await harness.flush();
+
+  const restartPromise = restartButton.dispatch("click");
+  await harness.flush();
+  managedRestartResponse.resolve(jsonResponse({
+    command: "managed-restart",
+    accepted: true,
+    summary: "Managed restart requested through the systemd launcher. The worker is reconnecting while this WebUI shell stays available.",
+  }));
+  await restartPromise;
+  await harness.flush();
+
+  assert.equal(harness.fetchCalls.filter((call) => call.path === "/api/setup-readiness").length, 3);
+  assert.match(restartGuidance.textContent ?? "", /setup reconnect attempt 1 failed/u);
+
+  await harness.advanceTime(49);
+  assert.equal(harness.fetchCalls.filter((call) => call.path === "/api/setup-readiness").length, 3);
+
+  await harness.advanceTime(1);
+  assert.equal(harness.fetchCalls.filter((call) => call.path === "/api/setup-readiness").length, 4);
+  assert.match(restartGuidance.textContent ?? "", /setup reconnect attempt 2 failed/u);
+
+  await harness.advanceTime(99);
+  assert.equal(harness.fetchCalls.filter((call) => call.path === "/api/setup-readiness").length, 4);
+
+  await harness.advanceTime(1);
+  assert.equal(harness.fetchCalls.filter((call) => call.path === "/api/setup-readiness").length, 5);
+  assert.match(restartGuidance.textContent ?? "", /setup reconnect attempt 3 failed/u);
 });
 
 test("dashboard leaves unrelated later supervisor events unlabeled in the operator timeline", async () => {

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -48,7 +48,8 @@ export function renderSetupBrowserScript(): string {
       let restartInFlight = false;
       let restartRequested = false;
       let reconnectPollToken = 0;
-      const reconnectPollIntervalMs = 50;
+      const reconnectPollInitialIntervalMs = 50;
+      const reconnectPollMaxIntervalMs = 1000;
 
       function formatFieldList(fields) {
         const values = Array.isArray(fields) ? fields.filter((field) => typeof field === "string" && field.length > 0) : [];
@@ -275,6 +276,11 @@ export function renderSetupBrowserScript(): string {
         });
       }
 
+      function reconnectPollDelayMs(failureCount) {
+        const exponent = Math.max(0, Number(failureCount) || 0);
+        return Math.min(reconnectPollInitialIntervalMs * Math.pow(2, exponent), reconnectPollMaxIntervalMs);
+      }
+
       function syncRestartButton() {
         if (!elements.restartButton) {
           return;
@@ -347,6 +353,7 @@ export function renderSetupBrowserScript(): string {
 
       async function monitorManagedRestartReconnect() {
         const pollToken = ++reconnectPollToken;
+        let unsuccessfulPollCount = 0;
         setSaveStatus("Waiting for the restarted worker to reconnect...");
 
         while (restartRequested && pollToken === reconnectPollToken) {
@@ -355,7 +362,8 @@ export function renderSetupBrowserScript(): string {
             const capability = managedRestartCapability(report);
             if (capability.state !== "ready") {
               setText(elements.restartGuidance, capability.summary);
-              await delay(reconnectPollIntervalMs);
+              await delay(reconnectPollDelayMs(unsuccessfulPollCount));
+              unsuccessfulPollCount += 1;
               continue;
             }
 
@@ -375,7 +383,8 @@ export function renderSetupBrowserScript(): string {
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             setText(elements.restartGuidance, "Waiting for the restarted worker to reconnect: " + message);
-            await delay(reconnectPollIntervalMs);
+            await delay(reconnectPollDelayMs(unsuccessfulPollCount));
+            unsuccessfulPollCount += 1;
           }
         }
       }


### PR DESCRIPTION
## Summary
- promote a durable external-review guardrail for reconnect/readiness polling loops that must use bounded backoff under repeated failures
- switch the setup-shell managed-restart reconnect monitor from fixed 50 ms polling to capped exponential backoff
- add a focused setup reconnect regression test for repeated readiness failures and update the reconnect success-path timing expectations

## Testing
- npx tsx --test src/backend/webui-dashboard.test.ts
- npx tsx src/committed-guardrails-cli.ts check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reconnection polling during setup restart by implementing exponential backoff, reducing server load during repeated failures while maintaining quick recovery on success.

* **Tests**
  * Added regression test validating reconnection backoff behavior under repeated failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->