### PR TITLE
Cache PR review-surface GraphQL fetches by head SHA

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,45 +1,36 @@
-# Issue #1082: Bound full issue inventory refresh cadence and reuse recent inventory results
+# Issue #1083: Cache PR hydration and review-surface fetches by head SHA to cut GraphQL usage
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1082
-- Branch: codex/issue-1082
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1083
+- Branch: codex/issue-1083
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 722f1a44416a93d5a9a46580ef18c684029fd0f6
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d949080a8691b276cc87ddd4f4967e55577b7a43
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ853GE78
-- Repeated failure signature count: 1
-- Updated at: 2026-03-26T17:56:13.357Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-26T18:05:53.404Z
 
 ## Latest Codex Summary
-Addressed the remaining CodeRabbit review on draft PR [#1088](https://github.com/TommyKammy/codex-supervisor/pull/1088) by fixing the two journal prose uses of `5-minute TTL`, committing the journal-only wording change as `35eccef`, pushing `codex/issue-1082`, and resolving the review thread through GitHub.
-
-I left the existing untracked supervisor runtime artifacts under `.codex-supervisor/` alone. No code paths changed this turn, so verification stayed limited to a whitespace check and a targeted journal-content search after the wording fix.
-
-Summary: Pushed a journal-only review fix to PR #1088 and resolved the remaining CodeRabbit thread
-State hint: addressing_review
-Blocked reason: none
-Tests: `git diff --check`; `rg -n "5 minute TTL" .codex-supervisor/issue-journal.md`
-Next action: Monitor PR #1088 for follow-up review; if the TTL question resurfaces, decide whether the fixed 5-minute inventory reuse TTL should stay hard-coded or become config-derived
-Failure signature: none
+- Reproduced the remaining GraphQL churn in `GitHubClient`: same-head status reads still re-fetched unresolved review threads and external review surface because only PR hydration was cached. Added focused GitHub client regression tests, then cached status-purpose review-surface fetches by `prNumber + headSha + reviewSurfaceVersion` and wired the informational callers to pass `headRefOid` plus `updatedAt`/`createdAt`. Focused tests and `npm run build` now pass locally.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the avoidable API pressure comes from `Supervisor.startRunOnceCycle()` always routing the prelude through a fresh `github.listAllIssues()` call, so a supervisor-local cache with a bounded TTL should reduce repeated full inventory reads without changing the loop’s correctness gates.
-- What changed: added `listLoopIssueInventory()` in `src/supervisor/supervisor.ts`, cached successful full inventory reads for 5 minutes, invalidated the cache on refresh failure, and wired only the loop prelude’s `listAllIssues` path through that helper. Added focused tests in `src/supervisor/supervisor.test.ts` that verify reuse at `2026-03-20T00:04:59Z` after an initial fetch at `2026-03-20T00:00:00Z`, and verify a refresh occurs again at `2026-03-20T00:05:01Z`. Pushed the branch and opened draft PR #1088.
+- Hypothesis: the remaining avoidable GraphQL usage comes from review-surface calls that sit outside the existing PR hydration cache. In particular, unresolved review threads and external review surface are re-fetched on repeated status/context reads even when the PR head and review-surface version are unchanged.
+- What changed: added focused regressions in `src/github/github.test.ts` proving that same-head status reads re-fetched unresolved review threads and external review surface. Implemented a bounded `GitHubClient` cache for status-purpose review-surface GraphQL reads keyed by fetch kind, PR number, head SHA, and review-surface version. Wired `loadActiveIssueStatusSnapshot()` to reuse unresolved review threads for informational status reads, and wired `prepareCodexTurnPrompt()` to reuse external review surface for local-review context when the PR `headRefOid` and `updatedAt`/`createdAt` are unchanged.
 - Current blocker: none locally.
-- Next exact step: monitor PR #1088 for any follow-up review; if none appears, keep the branch ready while the fixed 5-minute TTL versus config-derived TTL question remains under review.
-- Verification gap: I did not run the entire suite because `npm test -- <file>` expands to the repo-wide test glob here; verification so far is the focused supervisor cache tests plus a full TypeScript build.
-- Files touched: `src/supervisor/supervisor.ts`; `src/supervisor/supervisor.test.ts`; `.codex-supervisor/issue-journal.md`.
-- Rollback concern: moderate. A too-long TTL would delay reconciliation of full-inventory-only state changes, so the remaining review question is whether 5 minutes is the right fixed bound.
-- Last focused command: `gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId='PRRT_kwDORgvdZ853GE78'`
-- What changed this turn: reread the required memory files and current journal, accepted the CodeRabbit wording fix, updated the two prose mentions to `5-minute TTL`, committed the journal-only change as `35eccef`, pushed `codex/issue-1082`, and resolved review thread `PRRT_kwDORgvdZ853GE78`.
-- Exact failure reproduced this turn: the only reproducible issue was the journal prose wording in the existing review comment; it is now fixed locally and resolved on the PR.
-- Commands run this turn: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1082/AGENTS.generated.md`; `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1082/context-index.md`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short`; `rg -n "5 minute TTL|5-minute TTL" .codex-supervisor/issue-journal.md`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git diff -- .codex-supervisor/issue-journal.md`; `git diff --check`; `git add .codex-supervisor/issue-journal.md`; `git commit -m "chore: fix issue journal ttl wording"`; `git push origin codex/issue-1082`; `gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}}' -F threadId='PRRT_kwDORgvdZ853GE78'`; `sed -n '1,220p' .codex-supervisor/issue-journal.md`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git status --short`
+- Next exact step: review the diff once more, then commit this cache slice as a checkpoint and decide whether a follow-up focused test around repeated active-status polling is worth adding before opening or updating the draft PR.
+- Verification gap: I have not run the full repo suite; verification so far is the focused GitHub/status/orchestration tests plus a full TypeScript build.
+- Files touched: `src/github/github.ts`; `src/github/github.test.ts`; `src/supervisor/supervisor-selection-active-status.ts`; `src/turn-execution-orchestration.ts`; `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low to moderate. The cache is limited to status-purpose reads and invalidates on head or review-surface version changes, but if GitHub ever stops updating `updatedAt` for a relevant review event this could retain stale informational context longer than intended.
+- Last focused command: `npm run build`
+- What changed this turn: reread the required memory files and current journal, identified that existing PR hydration caching did not cover unresolved review threads or external review surface, added focused failing tests, implemented a bounded status-only review-surface cache in `GitHubClient`, wired the informational callers to pass cache keys derived from `headRefOid` and `updatedAt`/`createdAt`, and reran focused verification plus a TypeScript build.
+- Exact failure reproduced this turn: repeated same-head status reads called `getUnresolvedReviewThreads()` and `getExternalReviewSurface()` twice because those GraphQL surfaces had no cache even when the PR head and review-surface version were unchanged.
+- Commands run this turn: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git status --short`; `git branch --show-current`; `rg -n "head SHA|headSha|review-surface|review surface|hydrate|hydration|GraphQL|threads" src test docs`; `rg --files src test`; `sed -n '1,260p' src/github/github-pull-request-hydrator.ts`; `sed -n '740,980p' src/github/github.test.ts`; `sed -n '760,940p' src/github/github.ts`; `sed -n '1,220p' src/run-once-issue-preparation.ts`; `sed -n '220,620p' src/run-once-issue-preparation.ts`; `sed -n '1,260p' src/github/github-pull-request-hydrator.test.ts`; `sed -n '260,520p' src/github/github-pull-request-hydrator.test.ts`; `rg -n "getUnresolvedReviewThreads\\(|getExternalReviewSurface\\(" src`; `sed -n '680,840p' src/github/github.ts`; `sed -n '1,260p' src/external-review/external-review-signal-collection.ts`; `sed -n '100,220p' src/turn-execution-orchestration.ts`; `sed -n '460,560p' src/run-once-turn-execution.ts`; `sed -n '1040,1105p' src/recovery-reconciliation.ts`; `sed -n '1,120p' docs/architecture.md`; `sed -n '1,120p' docs/configuration.md`; `sed -n '1,120p' src/hydration-freshness-docs.test.ts`; `rg -n "getExternalReviewSurface|getUnresolvedReviewThreads" src/github/github.test.ts src/*test.ts`; `sed -n '1,280p' src/github/github.test.ts`; `sed -n '280,420p' src/github/github.test.ts`; `npm test -- src/github/github.test.ts`; `sed -n '1,220p' package.json`; `ls -1`; `test -d node_modules && echo yes || echo no`; `npm ci`; `npx tsx --test src/github/github.test.ts`; `sed -n '1,180p' src/supervisor/supervisor-selection-active-status.ts`; `sed -n '780,860p' src/supervisor/supervisor.ts`; `sed -n '220,320p' src/post-turn-pull-request.ts`; `rg -n "resolvePullRequestForBranch\\(|getPullRequestIfExists\\(|getPullRequest\\(" src/github/github.ts`; `sed -n '400,540p' src/github/github.ts`; `npx tsx --test src/github/github.test.ts src/turn-execution-orchestration.test.ts src/supervisor/supervisor-selection-status-active-status.test.ts`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git status --short`; `sed -n '1,240p' .codex-supervisor/issue-journal.md`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -219,6 +219,217 @@ test("GitHubClient fetches the newest unresolved review thread comments", async 
   assert.equal(threads[0]?.comments.nodes.at(-1)?.author?.typeName, "Bot");
 });
 
+test("GitHubClient reuses cached unresolved review threads for same-head status reads", async () => {
+  const config = createConfig();
+  let graphqlCalls = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: "thread-1",
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/github/github.ts",
+                      line: 803,
+                      comments: {
+                        nodes: [
+                          {
+                            id: "comment-100",
+                            body: "newest retained comment",
+                            createdAt: "2026-03-13T02:24:00Z",
+                            url: "https://example.test/comments/100",
+                            author: {
+                              login: "copilot-pull-request-reviewer",
+                              __typename: "Bot",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const first = await client.getUnresolvedReviewThreads(44, {
+    purpose: "status",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:24:00Z",
+  });
+  const second = await client.getUnresolvedReviewThreads(44, {
+    purpose: "status",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:24:00Z",
+  });
+
+  assert.equal(first.length, 1);
+  assert.equal(second.length, 1);
+  assert.equal(graphqlCalls, 1);
+});
+
+test("GitHubClient refreshes unresolved review threads when the review surface version changes", async () => {
+  const config = createConfig();
+  let graphqlCalls = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  await client.getUnresolvedReviewThreads(44, {
+    purpose: "status",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:24:00Z",
+  });
+  await client.getUnresolvedReviewThreads(44, {
+    purpose: "status",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:25:00Z",
+  });
+
+  assert.equal(graphqlCalls, 2);
+});
+
+test("GitHubClient reuses cached external review surface for same-head status reads", async () => {
+  const config = createConfig();
+  let graphqlCalls = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: {
+                  nodes: [
+                    {
+                      id: "review-1",
+                      body: "Looks good.",
+                      submittedAt: "2026-03-13T02:24:00Z",
+                      url: "https://example.test/reviews/1",
+                      state: "COMMENTED",
+                      author: {
+                        login: "copilot-pull-request-reviewer",
+                        __typename: "Bot",
+                      },
+                    },
+                  ],
+                },
+                comments: {
+                  nodes: [
+                    {
+                      id: "comment-1",
+                      body: "Top-level follow-up.",
+                      createdAt: "2026-03-13T02:25:00Z",
+                      url: "https://example.test/comments/1",
+                      author: {
+                        login: "copilot-pull-request-reviewer",
+                        __typename: "Bot",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const first = await client.getExternalReviewSurface(44, {
+    purpose: "status",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:25:00Z",
+  });
+  const second = await client.getExternalReviewSurface(44, {
+    purpose: "status",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:25:00Z",
+  });
+
+  assert.equal(first.reviews.length, 1);
+  assert.equal(second.issueComments.length, 1);
+  assert.equal(graphqlCalls, 1);
+});
+
+test("GitHubClient refreshes external review surface for action reads even on the same head", async () => {
+  const config = createConfig();
+  let graphqlCalls = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  await client.getExternalReviewSurface(44, {
+    purpose: "action",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:25:00Z",
+  });
+  await client.getExternalReviewSurface(44, {
+    purpose: "action",
+    headSha: "head-44",
+    reviewSurfaceVersion: "2026-03-13T02:25:00Z",
+  });
+
+  assert.equal(graphqlCalls, 2);
+});
+
 test("GitHubClient fetches REST and GraphQL rate-limit telemetry from a single rate_limit response", async () => {
   const config = createConfig();
   const client = new GitHubClient(config, async (_command, args) => {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -30,6 +30,7 @@ export type { GitHubCommandRunner } from "./github-transport";
 const POST_CREATE_PR_LOOKUP_RETRY_LIMIT = 2;
 const POST_CREATE_PR_LOOKUP_BASE_DELAY_MS = 200;
 const FULL_ISSUE_INVENTORY_PAGE_SIZE = 100;
+const PULL_REQUEST_GRAPHQL_SURFACE_CACHE_MAX_ENTRIES = 128;
 
 interface GitHubRestIssue {
   number: number;
@@ -61,9 +62,16 @@ interface GitHubRateLimitResponse {
   };
 }
 
+interface PullRequestReviewSurfaceOptions {
+  purpose?: "status" | "action";
+  headSha?: string | null;
+  reviewSurfaceVersion?: string | null;
+}
+
 export class GitHubClient {
   private readonly pullRequestHydrator: GitHubPullRequestHydrator;
   private readonly transport: GitHubTransport;
+  private readonly pullRequestGraphqlSurfaceCache = new Map<string, Promise<unknown>>();
 
   constructor(
     private readonly config: SupervisorConfig,
@@ -92,6 +100,50 @@ export class GitHubClient {
 
   private async runGhCommand(args: string[], options: CommandOptions = {}) {
     return this.transport.run(args, options);
+  }
+
+  private getCachedPullRequestGraphqlSurface<T>(
+    cacheKey: string,
+    fetcher: () => Promise<T>,
+  ): Promise<T> {
+    const cached = this.pullRequestGraphqlSurfaceCache.get(cacheKey) as Promise<T> | undefined;
+    if (cached) {
+      this.pullRequestGraphqlSurfaceCache.delete(cacheKey);
+      this.pullRequestGraphqlSurfaceCache.set(cacheKey, cached);
+      return cached;
+    }
+
+    const promise = fetcher().catch((error) => {
+      this.pullRequestGraphqlSurfaceCache.delete(cacheKey);
+      throw error;
+    });
+    this.pullRequestGraphqlSurfaceCache.set(cacheKey, promise);
+
+    while (this.pullRequestGraphqlSurfaceCache.size > PULL_REQUEST_GRAPHQL_SURFACE_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.pullRequestGraphqlSurfaceCache.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.pullRequestGraphqlSurfaceCache.delete(oldestKey);
+    }
+
+    return promise;
+  }
+
+  private maybeGetCachedPullRequestGraphqlSurface<T>(
+    kind: "threads" | "external-review-surface",
+    prNumber: number,
+    options: PullRequestReviewSurfaceOptions,
+    fetcher: () => Promise<T>,
+  ): Promise<T> {
+    if (options.purpose !== "status" || !options.headSha || !options.reviewSurfaceVersion) {
+      return fetcher();
+    }
+
+    return this.getCachedPullRequestGraphqlSurface(
+      `${kind}:${prNumber}:${options.headSha}:${options.reviewSurfaceVersion}`,
+      fetcher,
+    );
   }
 
   private async hydratePullRequestForPurpose(
@@ -739,7 +791,19 @@ export class GitHubClient {
     await this.runGhCommand(args, { allowExitCodes: [0, 1] });
   }
 
-  async getUnresolvedReviewThreads(prNumber: number): Promise<ReviewThread[]> {
+  async getUnresolvedReviewThreads(
+    prNumber: number,
+    options: PullRequestReviewSurfaceOptions = {},
+  ): Promise<ReviewThread[]> {
+    return this.maybeGetCachedPullRequestGraphqlSurface(
+      "threads",
+      prNumber,
+      options,
+      () => this.fetchUnresolvedReviewThreads(prNumber),
+    );
+  }
+
+  private async fetchUnresolvedReviewThreads(prNumber: number): Promise<ReviewThread[]> {
     const { owner, repo } = this.repoOwnerAndName();
 
     const query = `
@@ -814,7 +878,22 @@ export class GitHubClient {
     })).filter((thread) => !thread.isResolved && !thread.isOutdated);
   }
 
-  async getExternalReviewSurface(prNumber: number): Promise<{
+  async getExternalReviewSurface(
+    prNumber: number,
+    options: PullRequestReviewSurfaceOptions = {},
+  ): Promise<{
+    reviews: PullRequestReview[];
+    issueComments: IssueComment[];
+  }> {
+    return this.maybeGetCachedPullRequestGraphqlSurface(
+      "external-review-surface",
+      prNumber,
+      options,
+      () => this.fetchExternalReviewSurface(prNumber),
+    );
+  }
+
+  private async fetchExternalReviewSurface(prNumber: number): Promise<{
     reviews: PullRequestReview[];
     issueComments: IssueComment[];
   }> {

--- a/src/supervisor/supervisor-selection-active-status.ts
+++ b/src/supervisor/supervisor-selection-active-status.ts
@@ -25,7 +25,10 @@ import { loadPreMergeEvaluationDto } from "./supervisor-pre-merge-evaluation";
 export interface ActiveStatusGitHub {
   resolvePullRequestForBranch(branchName: string, pullRequestNumber?: number | null): Promise<GitHubPullRequest | null>;
   getChecks(pullRequestNumber: number): Promise<PullRequestCheck[]>;
-  getUnresolvedReviewThreads(pullRequestNumber: number): Promise<ReviewThread[]>;
+  getUnresolvedReviewThreads(
+    pullRequestNumber: number,
+    options?: { purpose?: "status" | "action"; headSha?: string | null; reviewSurfaceVersion?: string | null },
+  ): Promise<ReviewThread[]>;
 }
 
 export interface ActiveStatusIssueGitHub {
@@ -84,7 +87,13 @@ export async function loadActiveIssueStatusSnapshot(args: {
       : null;
     pr = await args.github.resolvePullRequestForBranch(args.activeRecord.branch, args.activeRecord.pr_number);
     checks = isOpenPullRequest(pr) ? await args.github.getChecks(pr.number) : [];
-    reviewThreads = isOpenPullRequest(pr) ? await args.github.getUnresolvedReviewThreads(pr.number) : [];
+    reviewThreads = isOpenPullRequest(pr)
+      ? await args.github.getUnresolvedReviewThreads(pr.number, {
+          purpose: "status",
+          headSha: pr.headRefOid,
+          reviewSurfaceVersion: pr.updatedAt ?? pr.createdAt,
+        })
+      : [];
     localReviewRoutingSummary = await buildLocalReviewRoutingStatusLine({
       config: args.config,
       activeRecord: args.activeRecord,

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -141,7 +141,11 @@ export async function prepareCodexTurnPrompt(args: {
   ) {
     const currentPr = args.pr!;
     const localReviewSummaryPath = args.record.local_review_summary_path!;
-    const externalReviewSurface = await args.github.getExternalReviewSurface(currentPr.number);
+    const externalReviewSurface = await args.github.getExternalReviewSurface(currentPr.number, {
+      purpose: "status",
+      headSha: currentPr.headRefOid,
+      reviewSurfaceVersion: currentPr.updatedAt ?? currentPr.createdAt,
+    });
     externalReviewMissContext = await writeExternalReviewMissArtifact({
       artifactDir: path.dirname(localReviewSummaryPath),
       issueNumber: args.issue.number,


### PR DESCRIPTION
## Summary
- cache status-purpose unresolved review-thread GraphQL reads by PR number, head SHA, and review-surface version
- cache status-purpose external review-surface GraphQL reads on the same invalidation boundary
- add focused tests for reuse, invalidation, and action-read bypass behavior

## Testing
- npx tsx --test src/github/github.test.ts src/turn-execution-orchestration.test.ts src/supervisor/supervisor-selection-status-active-status.test.ts
- npm run build

Refs #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent caching for pull request review data to reduce API calls and improve performance.

* **Tests**
  * Added regression tests validating cache behavior for review surface queries and cache invalidation when pull request state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->