### PR TITLE
[codex] Expose inventory degradation posture to operators

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,42 +1,36 @@
-# Issue #1069: Persist a last-known-good inventory snapshot for diagnostics and read-only degraded support
+# Issue #1070: Expose inventory degradation provenance and recovery posture to operators
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1069
-- Branch: codex/issue-1069
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1070
+- Branch: codex/issue-1070
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=1, repair=2)
-- Last head SHA: c302da0f3123dc0f58bbfe6a57b0e39eb7151941
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 8fa62a81c56953abcc4e90be0e2a5a46529b1868
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ853DJPt|PRRT_kwDORgvdZ853DJP1|PRRT_kwDORgvdZ853DJP3
-- Repeated failure signature count: 1
-- Updated at: 2026-03-26T23:00:49Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-26T23:17:49Z
 
 ## Latest Codex Summary
-- Addressed the three remaining PR review findings locally: snapshot normalization now realigns `issue_count`, sqlite loads preserve snapshot-only persisted state, and degraded readiness always emits `selection_reason=inventory_refresh_degraded`. While merging `origin/main`, kept the newer GitHub rate-limit telemetry alongside the issue-1069 inventory snapshot status lines in `Supervisor.statusReport()`.
+- Added structured inventory posture reporting so status and WebUI can distinguish healthy full inventory, targeted degraded reconciliation, and snapshot-only degraded support.
 
 ## Active Failure Context
-- Category: review
-- Summary: 3 unresolved automated review thread(s) were addressed locally and the merged tree now passes focused verification.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1076#discussion_r2995680189
-- Details:
-  - `src/core/state-store.ts`: recompute normalized snapshot `issue_count` from the filtered issue list.
-  - `src/core/state-store.ts`: treat snapshot-only sqlite metadata as persisted state during load.
-  - `src/supervisor/supervisor-selection-readiness-summary.ts`: always emit `selection_reason=inventory_refresh_degraded` on degraded readiness responses.
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the remaining review work is limited to these three actionable comments plus base-branch reconciliation. Keeping the last-known-good snapshot strictly non-authoritative remains the central safety constraint.
-- What changed: committed the focused review fixes as `c302da0`, fetched and started merging `origin/main`, and resolved the overlapping `supervisor.ts` status-report paths so the branch keeps both the new GitHub rate-limit reporting from `main` and the inventory snapshot diagnostics from this issue.
+- Hypothesis: operator-facing inventory posture needed a typed status object plus a single explicit posture line so both CLI status and the WebUI can prioritize degraded inventory correctly.
+- What changed: added `InventoryOperatorStatus` helpers, threaded `inventoryStatus` through `statusReport()`, emitted an `inventory_posture=...` line, and taught the dashboard overview/attention helpers to prefer degraded inventory posture over raw runnable counts.
 - Current blocker: none.
-- Next exact step: complete the merge commit, push `codex/issue-1069`, and then let PR #1076 re-run CI on the updated head.
-- Verification gap: full `npm test` has not run; focused review-fix suites and `npm run build` are green on the merged tree.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/core/state-store.ts`; `src/core/state-store.test.ts`; `src/supervisor/supervisor-selection-readiness-summary.ts`; `src/supervisor/supervisor-selection-readiness-summary.test.ts`; `src/supervisor/supervisor.ts`
-- Rollback concern: moderate. The changes sit in persisted state normalization and degraded status/reporting, so a bad merge could either drop the snapshot fallback or make stale data appear more authoritative than intended.
-- Last focused command: `git merge --no-edit origin/main`
-- What changed this turn: reread the required memory files and review-handling skill, verified the three unresolved review comments against the local code, ran focused tests for the review-fix diff, committed the code/test changes, fetched and merged `origin/main`, resolved the `supervisor.ts` and journal conflicts, and reran focused verification plus a TypeScript build on the merged tree.
-- Exact failure reproduced this turn: before the fixes, snapshot normalization preserved a stale `issue_count`, sqlite could discard snapshot-only metadata on load, and degraded readiness could omit `selection_reason=inventory_refresh_degraded` entirely when no snapshot summary existed.
-- Commands run this turn: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1069/AGENTS.generated.md`; `sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1069/context-index.md`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `sed -n '1,220p' /home/tommy/.codex/plugins/cache/openai-curated/github/96adb50181823339d6e0973d7ce1d567bff204bd/skills/gh-address-comments/SKILL.md`; `git status --short --branch`; `git log --oneline --decorate -n 8`; `sed -n '1,260p' src/core/state-store.ts`; `sed -n '1,260p' src/supervisor/supervisor-selection-readiness-summary.ts`; `sed -n '1,320p' src/core/state-store.test.ts`; `sed -n '1,280p' src/supervisor/supervisor-selection-readiness-summary.test.ts`; `rg -n "loadFromSqlite|last_successful_inventory_snapshot|inventory_refresh_failure|reconciliation_state|hasPersistedState" src/core/state-store.ts`; `sed -n '260,460p' src/core/state-store.ts`; `git fetch origin main`; `git rev-list --left-right --count origin/main...HEAD`; `git diff -- src/core/state-store.ts src/core/state-store.test.ts src/supervisor/supervisor-selection-readiness-summary.ts src/supervisor/supervisor-selection-readiness-summary.test.ts`; `git diff --name-only origin/main...HEAD`; `npx tsx --test src/core/state-store.test.ts`; `npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts`; `git add src/core/state-store.ts src/core/state-store.test.ts src/supervisor/supervisor-selection-readiness-summary.ts src/supervisor/supervisor-selection-readiness-summary.test.ts`; `git commit -m "Address PR feedback for inventory snapshot fallback"`; `git stash push -m "issue-1069-journal" -- .codex-supervisor/issue-journal.md`; `git merge --no-edit origin/main`; `rg -n "^(<<<<<<<|=======|>>>>>>>)" .codex-supervisor/issue-journal.md src/supervisor/supervisor.ts`; `sed -n '1056,1148p' src/supervisor/supervisor.ts`; `sed -n '1240,1270p' src/supervisor/supervisor.ts`; `npx tsx --test src/core/state-store.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+- Next exact step: commit the inventory posture changes on `codex/issue-1070`, then rerun broader verification once the workspace has a local TypeScript compiler available.
+- Verification gap: `npm run build` cannot complete in this workspace because `tsc` is not installed; focused status and dashboard tests are green.
+- Files touched: `.codex-supervisor/issue-journal.md`; `src/backend/webui-dashboard-browser-logic.test.ts`; `src/backend/webui-dashboard-browser-logic.ts`; `src/inventory-refresh-state.ts`; `src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `src/supervisor/supervisor-status-report.ts`; `src/supervisor/supervisor.ts`
+- Rollback concern: moderate. A bad posture classifier could overstate degraded capabilities and make snapshot-backed readiness look more authoritative than it is.
+- Last focused command: `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts`
+- What changed this turn: reread the required memory files and journal, identified that `statusReport()` only exposed inventory degradation as free-form lines and warnings, added focused failing tests for typed posture and dashboard prioritization, implemented typed operator posture/guidance, reran the focused suites, and attempted a broader TypeScript build.
+- Exact failure reproduced this turn: before the fix, `statusReport().inventoryStatus` was undefined and the dashboard overview still reported runnable work as healthy even when inventory refresh was degraded and selection was blocked.
+- Commands run this turn: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,260p' <redacted-local-path>`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `git log --oneline --decorate -n 12`; `rg -n "inventory_refresh|degraded|last_successful_inventory|snapshot|reconciliation_state|recovery" src test .`; `rg --files src | rg "supervisor|state-store|inventory|diagnostics|webui|status"`; `sed -n '1,260p' src/supervisor/supervisor-status-model.ts`; `sed -n '1,280p' src/supervisor/supervisor-status-rendering.ts`; `sed -n '1,320p' src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `sed -n '1,320p' src/backend/webui-dashboard.test.ts`; `rg -n "inventory_refresh|inventory_snapshot|last_successful_inventory|fallback|degraded" src/supervisor src/backend`; `sed -n '1,260p' src/supervisor/supervisor-status-report.ts`; `sed -n '1,260p' src/backend/webui-dashboard.ts`; `sed -n '1,260p' src/backend/webui-dashboard-browser-logic.ts`; `sed -n '1,360p' src/supervisor/supervisor-selection-readiness-summary.ts`; `sed -n '760,980p' src/backend/webui-dashboard-browser-script.ts`; `rg -n "selectionSummary|warning|inventory_refresh|inventory_snapshot|last-known-good|degraded" src/backend/webui-dashboard-browser-script.ts src/backend/webui-dashboard.test.ts`; `sed -n '640,760p' src/backend/webui-dashboard-browser-script.ts`; `sed -n '980,1080p' src/backend/webui-dashboard-browser-script.ts`; `sed -n '300,420p' src/backend/webui-dashboard.test.ts`; `sed -n '1,240p' src/inventory-refresh-state.ts`; `rg -n "inventory_refresh_failure|last_successful_inventory_snapshot|classification" src/core/types.ts src/core`; `sed -n '1,260p' src/core/types.ts`; `sed -n '980,1115p' src/supervisor/supervisor.ts`; `sed -n '1115,1205p' src/supervisor/supervisor.ts`; `sed -n '1,340p' src/backend/webui-dashboard-browser-logic.test.ts`; `sed -n '340,520p' src/backend/webui-dashboard-browser-logic.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts`; `npm run build`; `npx tsc -p tsconfig.json`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -342,6 +342,40 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
   );
 
   assert.deepEqual(
+    buildOverviewSummary({
+      status: {
+        inventoryStatus: {
+          mode: "degraded",
+          posture: "snapshot_support",
+          recoveryState: "partially_degraded",
+          selectionBlocked: true,
+          summary: "Full inventory refresh is degraded; using the last-known-good snapshot for diagnostics only.",
+          recoveryGuidance:
+            "Restore a successful full inventory refresh before relying on new queue selection; the snapshot is for degraded diagnostics only.",
+          recoveryActions: ["restore_full_inventory_refresh"],
+          lastSuccessfulFullRefreshAt: "2026-03-26T00:05:00Z",
+          failure: {
+            source: "gh issue list",
+            message: "Failed to parse JSON from gh issue list",
+            recordedAt: "2026-03-26T00:10:00Z",
+            classification: "unknown",
+          },
+        },
+        runnableIssues: [{ issueNumber: 92, title: "Snapshot candidate", readiness: "execution_ready" }],
+      },
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    {
+      headline: "Inventory refresh is degraded",
+      detail: "Using last-known-good snapshot support from 2026-03-26T00:05:00Z while new selection stays blocked.",
+      tone: "warn",
+    },
+  );
+
+  assert.deepEqual(
     buildNextIssueSummary({
       runnableIssues: [{ issueNumber: 77, title: "Ready issue", readiness: "execution_ready" }],
     }),
@@ -399,6 +433,44 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
       title: "Resolve environment checks",
       detail: "A required dependency is failing, so the supervisor should not advance until checks recover.",
     },
+  );
+
+  assert.deepEqual(
+    buildAttentionItems({
+      status: {
+        inventoryStatus: {
+          mode: "degraded",
+          posture: "targeted_degraded_reconciliation",
+          recoveryState: "partially_degraded",
+          selectionBlocked: true,
+          summary: "Full inventory refresh is degraded; targeted reconciliation can continue for tracked pull requests.",
+          recoveryGuidance:
+            "Restore a successful full inventory refresh to resume authoritative queue selection; tracked PR reconciliation can continue meanwhile.",
+          recoveryActions: [
+            "restore_full_inventory_refresh",
+            "continue_targeted_pr_reconciliation",
+          ],
+          lastSuccessfulFullRefreshAt: "2026-03-26T00:05:00Z",
+          failure: {
+            source: "gh issue list",
+            message: "secondary rate limit exceeded for the REST API",
+            recordedAt: "2026-03-26T00:10:00Z",
+            classification: "rate_limited",
+          },
+        },
+        blockedIssues: [],
+        runnableIssues: [],
+      },
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    [
+      "Inventory posture: targeted degraded reconciliation.",
+      "Last successful full refresh: 2026-03-26T00:05:00Z.",
+      "Recovery: Restore a successful full inventory refresh to resume authoritative queue selection; tracked PR reconciliation can continue meanwhile.",
+    ],
   );
 
   assert.deepEqual(

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -43,6 +43,28 @@ export interface DashboardLoopRuntimeLike {
   detail?: string | null;
 }
 
+export interface DashboardInventoryStatusLike {
+  mode?: "healthy" | "degraded" | null;
+  posture?:
+    | "fresh_full_inventory"
+    | "targeted_degraded_reconciliation"
+    | "snapshot_support"
+    | "blocked"
+    | null;
+  recoveryState?: "healthy" | "partially_degraded" | "blocked" | null;
+  selectionBlocked?: boolean | null;
+  summary?: string | null;
+  recoveryGuidance?: string | null;
+  recoveryActions?: string[] | null;
+  lastSuccessfulFullRefreshAt?: string | null;
+  failure?: {
+    source?: string | null;
+    message?: string | null;
+    recordedAt?: string | null;
+    classification?: string | null;
+  } | null;
+}
+
 export interface DashboardStatusLike {
   selectionSummary?: DashboardSelectionSummaryLike | null;
   activeIssue?: DashboardActiveIssueLike | null;
@@ -54,6 +76,7 @@ export interface DashboardStatusLike {
   whyLines?: string[] | null;
   candidateDiscovery?: DashboardCandidateDiscoveryLike | null;
   candidateDiscoverySummary?: string | null;
+  inventoryStatus?: DashboardInventoryStatusLike | null;
   reconciliationWarning?: string | null;
   reconciliationPhase?: string | null;
   loopRuntime?: DashboardLoopRuntimeLike | null;
@@ -454,6 +477,7 @@ export function buildOverviewSummary(args: {
   const selectedIssueNumber = parseSelectedIssueNumber(args.status);
   const runnableIssues = Array.isArray(args.status?.runnableIssues) ? args.status.runnableIssues : [];
   const blockedIssues = Array.isArray(args.status?.blockedIssues) ? args.status.blockedIssues : [];
+  const inventoryStatus = args.status?.inventoryStatus ?? null;
   const doctorStatus = typeof args.doctor?.overallStatus === "string" ? args.doctor.overallStatus.toLowerCase() : "";
 
   if (!args.hasSuccessfulRefresh) {
@@ -477,6 +501,23 @@ export function buildOverviewSummary(args: {
       headline: "Environment checks need attention",
       detail: "A required dependency is failing, so supervisor actions may not be safe yet.",
       tone: "fail",
+    };
+  }
+
+  if (inventoryStatus?.mode === "degraded") {
+    const lastRefresh = inventoryStatus.lastSuccessfulFullRefreshAt;
+    const detail =
+      inventoryStatus.posture === "targeted_degraded_reconciliation"
+        ? "Tracked PR reconciliation can continue while new queue selection stays blocked."
+        : inventoryStatus.posture === "snapshot_support"
+          ? "Using last-known-good snapshot support" +
+            (lastRefresh ? " from " + lastRefresh : "") +
+            " while new selection stays blocked."
+          : inventoryStatus.summary || "Queue reconciliation is degraded until a fresh full inventory refresh succeeds.";
+    return {
+      headline: "Inventory refresh is degraded",
+      detail,
+      tone: inventoryStatus.recoveryState === "blocked" ? "fail" : "warn",
     };
   }
 
@@ -623,6 +664,7 @@ export function buildAttentionItems(args: {
   const items: string[] = [];
   const blockedIssues = Array.isArray(args.status?.blockedIssues) ? args.status.blockedIssues : [];
   const runnableIssues = Array.isArray(args.status?.runnableIssues) ? args.status.runnableIssues : [];
+  const inventoryStatus = args.status?.inventoryStatus ?? null;
   const doctorChecks = Array.isArray(args.doctor?.checks) ? args.doctor.checks : [];
   const statusWarning = args.status?.warning?.message ?? null;
   const reconciliationWarning = args.status?.reconciliationWarning ?? null;
@@ -641,6 +683,16 @@ export function buildAttentionItems(args: {
 
   if (args.refreshPhase === "failed") {
     items.push("The last refresh failed, so some details may be stale.");
+  }
+
+  if (inventoryStatus?.mode === "degraded") {
+    items.push("Inventory posture: " + (inventoryStatus.posture ?? "degraded").replace(/_/gu, " ") + ".");
+    if (inventoryStatus.lastSuccessfulFullRefreshAt) {
+      items.push("Last successful full refresh: " + inventoryStatus.lastSuccessfulFullRefreshAt + ".");
+    }
+    if (inventoryStatus.recoveryGuidance) {
+      items.push("Recovery: " + inventoryStatus.recoveryGuidance);
+    }
   }
 
   if (blockedIssues.length > 0) {

--- a/src/inventory-refresh-state.ts
+++ b/src/inventory-refresh-state.ts
@@ -1,9 +1,40 @@
-import { GitHubIssue, InventoryRefreshFailure, LastSuccessfulInventorySnapshot } from "./core/types";
+import {
+  GitHubIssue,
+  InventoryRefreshFailure,
+  IssueRunRecord,
+  LastSuccessfulInventorySnapshot,
+  SupervisorStateFile,
+} from "./core/types";
 import { nowIso, truncate } from "./core/utils";
 import { isGitHubRateLimitFailure } from "./github/github-transport";
 import { sanitizeStatusValue } from "./supervisor/supervisor-status-rendering";
 
 export const FULL_ISSUE_INVENTORY_SOURCE = "gh issue list";
+
+export type InventoryStatusMode = "healthy" | "degraded";
+export type InventoryStatusPosture =
+  | "fresh_full_inventory"
+  | "targeted_degraded_reconciliation"
+  | "snapshot_support"
+  | "blocked";
+export type InventoryRecoveryState = "healthy" | "partially_degraded" | "blocked";
+
+export interface InventoryOperatorStatus {
+  mode: InventoryStatusMode;
+  posture: InventoryStatusPosture;
+  recoveryState: InventoryRecoveryState;
+  selectionBlocked: boolean;
+  summary: string;
+  recoveryGuidance: string;
+  recoveryActions: string[];
+  lastSuccessfulFullRefreshAt: string | null;
+  failure: {
+    source: string;
+    message: string;
+    recordedAt: string;
+    classification: "rate_limited" | "unknown";
+  } | null;
+}
 
 export function buildInventoryRefreshFailure(error: unknown): InventoryRefreshFailure {
   const message = truncate(error instanceof Error ? error.message : String(error), 500) ?? "Unknown inventory refresh failure.";
@@ -75,5 +106,103 @@ export function formatLastSuccessfulInventorySnapshotStatusLine(
     `recorded_at=${snapshot.recorded_at}`,
     `issue_count=${snapshot.issue_count}`,
     "authority=non_authoritative",
+  ].join(" ");
+}
+
+export function buildInventoryOperatorStatus(args: {
+  state: SupervisorStateFile;
+  activeRecord?: Pick<IssueRunRecord, "pr_number"> | null;
+  trackedRecords?: Array<Pick<IssueRunRecord, "pr_number">>;
+}): InventoryOperatorStatus {
+  const { state, activeRecord = null, trackedRecords = [] } = args;
+  const snapshot = state.last_successful_inventory_snapshot;
+  const failure = state.inventory_refresh_failure;
+  const lastSuccessfulFullRefreshAt = snapshot?.recorded_at ?? null;
+
+  if (!failure) {
+    return {
+      mode: "healthy",
+      posture: "fresh_full_inventory",
+      recoveryState: "healthy",
+      selectionBlocked: false,
+      summary: "Fresh full inventory is available.",
+      recoveryGuidance: "No operator recovery is required.",
+      recoveryActions: [],
+      lastSuccessfulFullRefreshAt,
+      failure: null,
+    };
+  }
+
+  const targetedTrackedPrAvailable =
+    activeRecord?.pr_number !== null && activeRecord?.pr_number !== undefined
+    || trackedRecords.some((record) => record.pr_number !== null && record.pr_number !== undefined);
+  if (targetedTrackedPrAvailable) {
+    return {
+      mode: "degraded",
+      posture: "targeted_degraded_reconciliation",
+      recoveryState: "partially_degraded",
+      selectionBlocked: true,
+      summary: "Full inventory refresh is degraded; targeted reconciliation can continue for tracked pull requests.",
+      recoveryGuidance:
+        "Restore a successful full inventory refresh to resume authoritative queue selection; tracked PR reconciliation can continue meanwhile.",
+      recoveryActions: [
+        "restore_full_inventory_refresh",
+        "continue_targeted_pr_reconciliation",
+      ],
+      lastSuccessfulFullRefreshAt,
+      failure: {
+        source: failure.source,
+        message: failure.message,
+        recordedAt: failure.recorded_at,
+        classification: failure.classification ?? "unknown",
+      },
+    };
+  }
+
+  if (snapshot) {
+    return {
+      mode: "degraded",
+      posture: "snapshot_support",
+      recoveryState: "partially_degraded",
+      selectionBlocked: true,
+      summary: "Full inventory refresh is degraded; using the last-known-good snapshot for diagnostics only.",
+      recoveryGuidance:
+        "Restore a successful full inventory refresh before relying on new queue selection; the snapshot is for degraded diagnostics only.",
+      recoveryActions: ["restore_full_inventory_refresh"],
+      lastSuccessfulFullRefreshAt,
+      failure: {
+        source: failure.source,
+        message: failure.message,
+        recordedAt: failure.recorded_at,
+        classification: failure.classification ?? "unknown",
+      },
+    };
+  }
+
+  return {
+    mode: "degraded",
+    posture: "blocked",
+    recoveryState: "blocked",
+    selectionBlocked: true,
+    summary: "Full inventory refresh is degraded; reconciliation is blocked until a fresh full refresh succeeds.",
+    recoveryGuidance:
+      "Restore a successful full inventory refresh before relying on queue status because no degraded fallback posture is available.",
+    recoveryActions: ["restore_full_inventory_refresh"],
+    lastSuccessfulFullRefreshAt,
+    failure: {
+      source: failure.source,
+      message: failure.message,
+      recordedAt: failure.recorded_at,
+      classification: failure.classification ?? "unknown",
+    },
+  };
+}
+
+export function formatInventoryOperatorPostureLine(status: InventoryOperatorStatus): string {
+  return [
+    `inventory_posture=${status.posture}`,
+    `recovery_state=${status.recoveryState}`,
+    `selection_blocked=${status.selectionBlocked ? "yes" : "no"}`,
+    `last_successful_full_refresh_at=${status.lastSuccessfulFullRefreshAt ?? "none"}`,
   ].join(" ");
 }

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -250,6 +250,87 @@ Depends on: #91`,
   assert.match(status, /^selection_reason=inventory_refresh_degraded$/m);
 });
 
+test("statusReport exposes typed targeted degraded reconciliation posture for operators", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 58,
+    issues: {
+      "58": createRecord({
+        issue_number: 58,
+        state: "reproducing",
+        pr_number: 108,
+        branch: branchName(fixture.config, 58),
+        workspace: path.join(fixture.workspaceRoot, "issue-58"),
+        journal_path: null,
+      }),
+    },
+    inventory_refresh_failure: {
+      source: "gh issue list",
+      message: "secondary rate limit exceeded for the REST API",
+      recorded_at: "2026-03-26T00:10:00Z",
+      classification: "rate_limited",
+    },
+    last_successful_inventory_snapshot: {
+      source: "gh issue list",
+      recorded_at: "2026-03-26T00:05:00Z",
+      issue_count: 1,
+      issues: [{
+        number: 58,
+        title: "Tracked issue remains active",
+        body: executionReadyBody("Keep the tracked issue active while inventory refresh is degraded."),
+        createdAt: "2026-03-26T00:00:00Z",
+        updatedAt: "2026-03-26T00:00:00Z",
+        url: "https://example.test/issues/58",
+        state: "OPEN",
+      }],
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    listCandidateIssues: async () => {
+      throw new Error("unexpected listCandidateIssues call");
+    },
+    listAllIssues: async () => {
+      throw new Error("unexpected listAllIssues call");
+    },
+  };
+
+  const report = await supervisor.statusReport();
+
+  assert.deepEqual(report.inventoryStatus, {
+    mode: "degraded",
+    posture: "targeted_degraded_reconciliation",
+    recoveryState: "partially_degraded",
+    selectionBlocked: true,
+    summary: "Full inventory refresh is degraded; targeted reconciliation can continue for tracked pull requests.",
+    recoveryGuidance:
+      "Restore a successful full inventory refresh to resume authoritative queue selection; tracked PR reconciliation can continue meanwhile.",
+    recoveryActions: [
+      "restore_full_inventory_refresh",
+      "continue_targeted_pr_reconciliation",
+    ],
+    lastSuccessfulFullRefreshAt: "2026-03-26T00:05:00Z",
+    failure: {
+      source: "gh issue list",
+      message: "secondary rate limit exceeded for the REST API",
+      recordedAt: "2026-03-26T00:10:00Z",
+      classification: "rate_limited",
+    },
+  });
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^inventory_posture=targeted_degraded_reconciliation recovery_state=partially_degraded selection_blocked=yes last_successful_full_refresh_at=2026-03-26T00:05:00Z$/m,
+  );
+});
+
 test("statusReport exposes the typed local CI contract summary from config", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -17,6 +17,7 @@ import type {
   SupervisorSelectionSummaryDto,
 } from "./supervisor-selection-readiness-summary";
 import {
+  type InventoryOperatorStatus,
   formatInventoryRefreshStatusLine,
   formatLastSuccessfulInventorySnapshotStatusLine,
 } from "../inventory-refresh-state";
@@ -56,6 +57,7 @@ export interface SupervisorStatusDto {
   trustDiagnostics?: TrustDiagnosticsSummary | null;
   cadenceDiagnostics?: CadenceDiagnosticsSummary | null;
   githubRateLimit?: GitHubRateLimitTelemetry | null;
+  inventoryStatus?: InventoryOperatorStatus;
   candidateDiscoverySummary?: string | null;
   candidateDiscovery: SupervisorCandidateDiscoveryDto | null;
   localCiContract?: LocalCiContractSummary;

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -132,6 +132,8 @@ import {
 } from "./supervisor-status-rendering";
 import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
 import {
+  buildInventoryOperatorStatus,
+  formatInventoryOperatorPostureLine,
   formatInventoryRefreshStatusLine,
   formatLastSuccessfulInventorySnapshotStatusLine,
 } from "../inventory-refresh-state";
@@ -1009,6 +1011,12 @@ export class Supervisor {
     const gsdSummary = await describeGsdIntegration(this.config);
     const statusRecords = summarizeSupervisorStatusRecords(state);
     const trackedIssues = buildTrackedIssueDtos(state);
+    const inventoryStatus = buildInventoryOperatorStatus({
+      state,
+      activeRecord: statusRecords.activeRecord,
+      trackedRecords: trackedIssues.map((issue) => ({ pr_number: issue.prNumber ?? null })),
+    });
+    const inventoryPostureLine = formatInventoryOperatorPostureLine(inventoryStatus);
     const inventoryRefreshStatusLine = formatInventoryRefreshStatusLine(state.inventory_refresh_failure);
     const inventorySnapshotStatusLine = formatLastSuccessfulInventorySnapshotStatusLine(
       state.last_successful_inventory_snapshot,
@@ -1074,6 +1082,7 @@ export class Supervisor {
         const inactiveDetailedStatusLines =
           [
             ...detailedStatusLines,
+            inventoryPostureLine,
             ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
             ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
             ...githubRateLimitStatus.githubRateLimitLines,
@@ -1083,6 +1092,7 @@ export class Supervisor {
           trustDiagnostics,
           cadenceDiagnostics,
           githubRateLimit: githubRateLimitStatus.githubRateLimit,
+          inventoryStatus,
           candidateDiscoverySummary,
           candidateDiscovery: buildCandidateDiscoverySummary(this.config, null),
           localCiContract,
@@ -1134,6 +1144,7 @@ export class Supervisor {
         const inactiveDetailedStatusLines =
           [
             ...detailedStatusLines,
+            inventoryPostureLine,
             ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
             ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
             ...githubRateLimitStatus.githubRateLimitLines,
@@ -1143,6 +1154,7 @@ export class Supervisor {
           trustDiagnostics,
           cadenceDiagnostics,
           githubRateLimit: githubRateLimitStatus.githubRateLimit,
+          inventoryStatus,
           candidateDiscoverySummary,
           candidateDiscovery,
           localCiContract,
@@ -1166,6 +1178,7 @@ export class Supervisor {
         const inactiveDetailedStatusLines =
           [
             ...detailedStatusLines,
+            inventoryPostureLine,
             ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
             ...githubRateLimitStatus.githubRateLimitLines,
           ];
@@ -1174,6 +1187,7 @@ export class Supervisor {
           trustDiagnostics,
           cadenceDiagnostics,
           githubRateLimit: githubRateLimitStatus.githubRateLimit,
+          inventoryStatus,
           candidateDiscoverySummary,
           candidateDiscovery: buildCandidateDiscoverySummary(this.config, null),
           localCiContract,
@@ -1237,6 +1251,7 @@ export class Supervisor {
     const detailedStatusLinesWithInventory =
       [
         ...detailedStatusLines,
+        inventoryPostureLine,
         ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
         ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
@@ -1247,6 +1262,7 @@ export class Supervisor {
       trustDiagnostics,
       cadenceDiagnostics,
       githubRateLimit: githubRateLimitStatus.githubRateLimit,
+      inventoryStatus,
       candidateDiscoverySummary,
       candidateDiscovery: buildCandidateDiscoverySummary(this.config, null),
       localCiContract,


### PR DESCRIPTION
## Summary
- expose a typed inventory degradation posture in supervisor status so operators can distinguish healthy inventory from degraded targeted reconciliation, snapshot support, and blocked states
- include explicit provenance, recovery guidance, and last successful full refresh timing in operator-facing status and dashboard summaries
- prioritize degraded inventory posture in dashboard overview and attention helpers instead of implying health from runnable work alone

## Validation
- `npm run build`
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts`

## Notes
- `npm test` still hangs in `src/backend/webui-dashboard-browser-smoke.test.ts`
- the same smoke test times out on `origin/main`, so that full-suite gap appears pre-existing rather than introduced by this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays inventory refresh status and health indicators.
  * Degraded inventory states show recovery guidance and recommended actions to users.
  * Status reports now include detailed inventory posture and recovery information.

* **Tests**
  * Added tests for inventory status monitoring and dashboard display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->