### PR TITLE
[codex] Capture malformed inventory payloads

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,45 +1,37 @@
-# Issue #1071: Harden full inventory transport without collapsing distinct failure classes
+# Issue #1091: Capture malformed full-inventory payloads when GitHub issue inventory JSON parsing fails
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1071
-- Branch: codex/issue-1071
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1091
+- Branch: codex/issue-1091
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: draft_pr
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: 1aed17074dfc11cdd25347882dedc5beea3f7f85
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 3a6838f9d558b7ac6a481f96820659cb677ee081
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-26T23:57:16Z
+- Updated at: 2026-03-27T00:19:42Z
 
 ## Latest Codex Summary
-The implementation checkpoint remains `598f2c0` (`Harden full inventory transport fallback`): `GitHubClient.listAllIssues()` only uses the REST full-inventory fallback for malformed array-shaped `gh issue list` JSON, while transport-shaped primary failures remain fatal and fallback transport failures stay attributable.
-
-This turn restored local dev dependencies with `npm ci`, reran the issue-focused regressions, and verified `npm run build`. The focused transport coverage still passes. `npm test` now runs with the installed toolchain but fails later in the existing browser-smoke suite instead of on missing dependencies.
-
-Summary: Restored local verification, confirmed the inventory hardening checkpoint still passes focused coverage and build, isolated the remaining broad-suite failure to the browser-smoke path rather than this inventory transport change, and opened draft PR #1093.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npm ci` (passed); `npx tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts` (passed); `npm run build` (passed); `npm test` (failed in `src/backend/webui-dashboard-browser-smoke.test.ts` after ~31s: `browser smoke loads the read-only dashboard against the live HTTP fixture`)
-Next action: watch draft PR #1093 CI and review feedback, and only revisit the browser-smoke failure here if CI or review shows it is newly introduced by this branch.
-Failure signature: browser_smoke_dashboard_fixture_timeout
+- Added env-gated malformed full-inventory payload capture in `GitHubClient.listAllIssues()` and the REST fallback page parser. On JSON parse failure, the client now writes a timestamped JSON artifact with the invoked command, source, page, stdout text plus base64, stderr, and parse error when `CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR` is set.
+- Added focused regression coverage for primary `gh issue list` capture, REST fallback page capture, and bounded pruning via `CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT`. Documented loop-host retrieval in `docs/getting-started.md`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `listAllIssues()` was still treating any `gh issue list` parse failure as fallback-eligible, which collapses some primary transport failures into the same path as malformed payloads and can return silent success when the primary transport actually failed.
-- What changed: added a JSON-array shape gate in `GitHubClient.listAllIssues()` so only malformed full-inventory payloads that still look like the expected array output can fall back to REST pagination; transport-shaped non-JSON output now throws the primary failure directly. Added focused regression coverage for transport-shaped stdout staying fatal and for preserving both primary parse failure and fallback transport failure details.
+- Hypothesis: the intermittent `Bad control character in string literal` failure is still not locally reproducible, so the next useful step is preserving raw payload evidence from the exact parse-failure site instead of broadening fallback behavior again.
+- What changed: added temporary, opt-in capture instrumentation behind `CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR`. Primary `gh issue list` JSON parse failures and malformed REST fallback pages now write bounded timestamped artifacts that include command arguments, source, page context, stdout text and base64, stderr, and the parse error. The thrown error now includes the capture path when a capture was written.
 - Current blocker: none.
-- Next exact step: monitor draft PR #1093 on `codex/issue-1071`, and only revisit the browser-smoke suite here if CI or review indicates the failure is branch-specific.
-- Verification gap: full `npm test` still fails in `src/backend/webui-dashboard-browser-smoke.test.ts` with `browser smoke loads the read-only dashboard against the live HTTP fixture` timing out after roughly 31 seconds. Focused inventory regressions and `npm run build` now pass with local dependencies installed.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/github/github.test.ts`; `src/github/github.ts`
-- Rollback concern: low. The new guard only narrows when the full-inventory fallback is allowed; the main risk is being too strict and surfacing a malformed-but-recoverable payload as fatal.
-- Last focused command: `npx tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts`
-- What changed this turn: reread the required memory files and journal, confirmed the branch already contains checkpoint commit `598f2c0`, restored local dependencies with `npm ci`, reran focused inventory regressions, reran `npm run build`, checked `npm test`, committed the journal refresh as `1aed170`, pushed `codex/issue-1071`, and opened draft PR #1093.
-- Exact failure reproduced this turn: `npm test` now reaches `src/backend/webui-dashboard-browser-smoke.test.ts` and reports `browser smoke loads the read-only dashboard against the live HTTP fixture` failing after about 31 seconds; the inventory transport regressions continue to pass.
-- Commands run this turn: `sed -n '1,220p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1071/AGENTS.generated.md`; `sed -n '1,260p' /home/tommy/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1071/context-index.md`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `git log --oneline --decorate -n 6`; `sed -n '1,220p' package.json`; `ls -1`; `gh pr status`; `test -d node_modules && echo present || echo absent`; `sed -n '1,240p' <github-yeet-skill>`; `git branch -vv`; `npm ci`; `npx tsx --test src/github/github.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`; `npm test`; `sed -n '1,260p' src/backend/webui-dashboard-browser-smoke.test.ts`; `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `which google-chrome || true`; `which chromium || true`; `printenv CHROME_BIN || true`; `timeout 45s npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `git remote get-url origin`; `gh auth status`; `git diff -- .codex-supervisor/issue-journal.md`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `git branch --show-current`; `gh repo view --json nameWithOwner,defaultBranchRef`; `git add .codex-supervisor/issue-journal.md`; `git commit -m "docs: update issue 1071 journal for draft PR"`; `git push -u origin codex/issue-1071`; `gh pr create --draft --base main --head codex/issue-1071 --title "[codex] Harden full inventory transport fallback" --body-file -`
+- Next exact step: commit this checkpoint, push `codex/issue-1091`, open a draft PR, then let loop-host reproduction collect the first real malformed payload artifact.
+- Verification gap: full `npm test` was not rerun this turn; only the focused GitHub inventory tests, docs guard, and `npm run build` were exercised.
+- Files touched: `.codex-supervisor/issue-journal.md`; `docs/getting-started.md`; `src/github/github.test.ts`; `src/github/github.ts`
+- Rollback concern: low. The new behavior is env-gated and only activates on JSON parse failure, but the capture artifact stores raw stdout text, so operators should point it at a controlled directory when enabling it on loop hosts.
+- Last focused command: `npx tsx --test src/github/github.test.ts`
+- What changed this turn: read the required memory and journal, located the live `listAllIssues()` parse sites, added a failing reproducer for missing capture, implemented env-gated capture plus bounded pruning, documented retrieval, restored `node_modules` with `npm ci`, reran the focused suite, and verified the TypeScript build.
+- Exact failure reproduced this turn: before the fix, `GitHubClient listAllIssues captures malformed gh issue list payloads when debug capture is enabled` failed because no artifact was written to the configured capture directory.
+- Commands run this turn: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,260p' <redacted-local-path>`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `git status --short --branch`; `git log --oneline --decorate -n 8`; `rg -n "listAllIssues|gh issue list|Failed to parse JSON|Bad control character|inventory" src`; `sed -n '1,280p' src/github/github.ts`; `sed -n '1,920p' src/github/github.test.ts`; `rg -n "artifact|capture|debug|inventory_refresh_failure|malformed" src .codex-supervisor`; `sed -n '1,240p' src/core/command.ts`; `sed -n '1,260p' src/github/github-transport.ts`; `rg -n "inventory refresh|inventory failure|diagnostic artifact|artifact dir|loop host|operator" README.md docs src`; `sed -n '1,260p' docs/getting-started.md`; `npx tsx --test src/github/github.test.ts`; `test -d node_modules && echo present || echo absent`; `npm ci`; `npx tsx --test src/getting-started-docs.test.ts`; `npm run build`; `gh pr status`; `git diff -- src/github/github.ts src/github/github.test.ts docs/getting-started.md .codex-supervisor/issue-journal.md`; `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -168,6 +168,7 @@ What to check after `run-once`:
 
 If the first pass picks the wrong issue, inspect `status` or `doctor` for the effective candidate discovery settings and then fix the issue metadata before running again. Do not treat issue creation time as the source of truth.
 If `status` or `doctor` reports corrupted JSON state, stop treating that file as a safe checkpoint. Inspect the file and recent operator actions first, then explicitly acknowledge the corruption or reset the state before trusting future runs.
+If full inventory refreshes intermittently fail with malformed JSON, you can temporarily capture the raw failing payloads by exporting `CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR=/path/to/captures` before `run-once` or `loop`. Each parse failure writes one timestamped JSON artifact such as `20260327T001537.030Z-gh-issue-list.json` or `20260327T001537.030Z-rest-page-2.json`, and the supervisor prunes older files after the newest 10 by default. Use `CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT=<n>` if you need a different bound, then inspect or copy the capture directory from the loop host after the next failure.
 
 Execution metrics are retained independently of issue worktree cleanup. Terminal run summaries live under `<dirname(stateFile)>/execution-metrics/run-summaries/`, and `node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json` writes `<dirname(stateFile)>/execution-metrics/daily-rollups.json` from those retained summaries.
 

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { GitHubClient } from "./github";
 import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../core/types";
 
@@ -849,6 +852,191 @@ test("GitHubClient listAllIssues preserves both primary parse failures and fallb
 
   assert.equal(issueListCalls, 1);
   assert.equal(fallbackPageCalls, 1);
+});
+
+test("GitHubClient listAllIssues captures malformed gh issue list payloads when debug capture is enabled", async () => {
+  const captureDir = await fs.mkdtemp(path.join(os.tmpdir(), "inventory-capture-"));
+  const previousCaptureDir = process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR;
+  process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR = captureDir;
+
+  try {
+    const config = createConfig();
+    const client = new GitHubClient(config, async (_command, args) => {
+      if (args[0] === "issue" && args[1] === "list") {
+        return {
+          exitCode: 0,
+          stdout: "[{\"number\":500,\"title\":\"bad\njson\"}]",
+          stderr: "graphql transport stderr",
+        };
+      }
+
+      if (args[0] === "api" && args[1] === "repos/owner/repo/issues") {
+        throw new Error("HTTP 502: Bad Gateway");
+      }
+
+      throw new Error(`Unexpected args: ${args.join(" ")}`);
+    });
+
+    await assert.rejects(() => client.listAllIssues(), /Failed to load full issue inventory/);
+
+    const artifacts = await fs.readdir(captureDir);
+    assert.equal(artifacts.length, 1);
+    assert.match(artifacts[0] ?? "", /^\d{8}T\d{6}\.\d{3}Z-gh-issue-list\.json$/);
+
+    const artifact = JSON.parse(await fs.readFile(path.join(captureDir, artifacts[0] ?? ""), "utf8")) as {
+      source: string;
+      command: string[];
+      stdout: { text: string; base64: string };
+      stderr: string;
+      parseError: string;
+    };
+
+    assert.equal(artifact.source, "gh issue list");
+    assert.deepEqual(artifact.command.slice(0, 2), ["gh", "issue"]);
+    assert.equal(artifact.stderr, "graphql transport stderr");
+    assert.match(artifact.parseError, /Failed to parse JSON from gh issue list/);
+    assert.equal(artifact.stdout.text, "[{\"number\":500,\"title\":\"bad\njson\"}]");
+    assert.equal(Buffer.from(artifact.stdout.base64, "base64").toString("utf8"), artifact.stdout.text);
+  } finally {
+    if (previousCaptureDir === undefined) {
+      delete process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR;
+    } else {
+      process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR = previousCaptureDir;
+    }
+    await fs.rm(captureDir, { recursive: true, force: true });
+  }
+});
+
+test("GitHubClient listAllIssues captures malformed REST fallback pages with the page number when debug capture is enabled", async () => {
+  const captureDir = await fs.mkdtemp(path.join(os.tmpdir(), "inventory-capture-rest-"));
+  const previousCaptureDir = process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR;
+  process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR = captureDir;
+
+  try {
+    const config = createConfig();
+    const client = new GitHubClient(config, async (_command, args) => {
+      if (args[0] === "issue" && args[1] === "list") {
+        return {
+          exitCode: 0,
+          stdout: "[{\"number\":500,\"title\":\"bad\njson\"}]",
+          stderr: "",
+        };
+      }
+
+      if (args[0] === "api" && args[1] === "repos/owner/repo/issues") {
+        const page = Number(args.find((arg) => arg.startsWith("page="))?.slice("page=".length) ?? "1");
+        return {
+          exitCode: 0,
+          stdout:
+            page === 1
+              ? JSON.stringify(
+                  Array.from({ length: 100 }, (_value, index) => ({
+                    number: 500 - index,
+                    title: `Issue ${500 - index}`,
+                    body: `Body ${500 - index}`,
+                    created_at: "2026-03-01T00:00:00Z",
+                    updated_at: "2026-03-01T12:00:00Z",
+                    html_url: `https://example.test/issues/${500 - index}`,
+                    state: "open",
+                    labels: [],
+                  })),
+                )
+              : "[{\"number\":499,\"title\":\"bad\njson\"}]",
+          stderr: page === 2 ? "rest stderr" : "",
+        };
+      }
+
+      throw new Error(`Unexpected args: ${args.join(" ")}`);
+    });
+
+    await assert.rejects(
+      () => client.listAllIssues(),
+      /Fallback transport: Failed to parse JSON from gh api repos\/owner\/repo\/issues page=2/,
+    );
+
+    const artifacts = (await fs.readdir(captureDir)).sort();
+    assert.equal(artifacts.length, 2);
+    assert.match(artifacts[0] ?? "", /^\d{8}T\d{6}\.\d{3}Z-gh-issue-list\.json$/);
+    assert.match(artifacts[1] ?? "", /^\d{8}T\d{6}\.\d{3}Z-rest-page-2\.json$/);
+
+    const artifact = JSON.parse(await fs.readFile(path.join(captureDir, artifacts[1] ?? ""), "utf8")) as {
+      source: string;
+      page: number | null;
+      stderr: string;
+      stdout: { text: string; base64: string };
+    };
+    assert.equal(artifact.source, "gh api repos/owner/repo/issues");
+    assert.equal(artifact.page, 2);
+    assert.equal(artifact.stderr, "rest stderr");
+    assert.equal(artifact.stdout.text, "[{\"number\":499,\"title\":\"bad\njson\"}]");
+  } finally {
+    if (previousCaptureDir === undefined) {
+      delete process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR;
+    } else {
+      process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR = previousCaptureDir;
+    }
+    await fs.rm(captureDir, { recursive: true, force: true });
+  }
+});
+
+test("GitHubClient listAllIssues prunes older malformed inventory captures when the debug capture limit is exceeded", async () => {
+  const captureDir = await fs.mkdtemp(path.join(os.tmpdir(), "inventory-capture-limit-"));
+  const previousCaptureDir = process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR;
+  const previousCaptureLimit = process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT;
+  process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR = captureDir;
+  process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT = "2";
+
+  try {
+    const config = createConfig();
+    const nowValues = [
+      Date.parse("2026-03-27T00:00:00.000Z"),
+      Date.parse("2026-03-27T00:00:01.000Z"),
+      Date.parse("2026-03-27T00:00:02.000Z"),
+    ];
+    let nowIndex = 0;
+    const client = new GitHubClient(
+      config,
+      async (_command, args) => {
+        if (args[0] === "issue" && args[1] === "list") {
+          return {
+            exitCode: 0,
+            stdout: "[{\"number\":500,\"title\":\"bad\njson\"}]",
+            stderr: "",
+          };
+        }
+
+        if (args[0] === "api" && args[1] === "repos/owner/repo/issues") {
+          throw new Error("HTTP 502: Bad Gateway");
+        }
+
+        throw new Error(`Unexpected args: ${args.join(" ")}`);
+      },
+      undefined,
+      () => nowValues[Math.min(nowIndex++, nowValues.length - 1)] ?? nowValues[nowValues.length - 1]!,
+    );
+
+    await assert.rejects(() => client.listAllIssues(), /Failed to load full issue inventory/);
+    await assert.rejects(() => client.listAllIssues(), /Failed to load full issue inventory/);
+    await assert.rejects(() => client.listAllIssues(), /Failed to load full issue inventory/);
+
+    const artifacts = (await fs.readdir(captureDir)).sort();
+    assert.deepEqual(artifacts, [
+      "20260327T000001.000Z-gh-issue-list.json",
+      "20260327T000002.000Z-gh-issue-list.json",
+    ]);
+  } finally {
+    if (previousCaptureDir === undefined) {
+      delete process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR;
+    } else {
+      process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR = previousCaptureDir;
+    }
+    if (previousCaptureLimit === undefined) {
+      delete process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT;
+    } else {
+      process.env.CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT = previousCaptureLimit;
+    }
+    await fs.rm(captureDir, { recursive: true, force: true });
+  }
 });
 
 test("GitHubClient createPullRequest recovers when the first open-branch lookup misses the new PR", async () => {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import {
   CandidateDiscoveryDiagnostics,
   GitHubIssue,
@@ -12,7 +14,7 @@ import {
   SupervisorConfig,
 } from "../core/types";
 import { DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW } from "../core/config";
-import { CommandOptions, runCommand } from "../core/command";
+import { CommandOptions, CommandResult, runCommand } from "../core/command";
 import {
   normalizeRollupChecks,
   PullRequestStatusCheckRollupResponse,
@@ -20,7 +22,7 @@ import {
 import { GitHubPullRequestHydrator } from "./github-pull-request-hydrator";
 import { GitHubTransport, isGitHubRateLimitFailure } from "./github-transport";
 import type { GitHubCommandRunner } from "./github-transport";
-import { parseJson, truncate } from "../core/utils";
+import { ensureDir, parseJson, truncate, writeJsonAtomic } from "../core/utils";
 
 export { isTransientGitHubCommandFailure } from "./github-transport";
 export { isGitHubRateLimitFailure } from "./github-transport";
@@ -31,9 +33,41 @@ const POST_CREATE_PR_LOOKUP_RETRY_LIMIT = 2;
 const POST_CREATE_PR_LOOKUP_BASE_DELAY_MS = 200;
 const FULL_ISSUE_INVENTORY_PAGE_SIZE = 100;
 const PULL_REQUEST_GRAPHQL_SURFACE_CACHE_MAX_ENTRIES = 128;
+const MALFORMED_INVENTORY_CAPTURE_DIR_ENV = "CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_DIR";
+const MALFORMED_INVENTORY_CAPTURE_LIMIT_ENV = "CODEX_SUPERVISOR_MALFORMED_INVENTORY_CAPTURE_LIMIT";
+const DEFAULT_MALFORMED_INVENTORY_CAPTURE_LIMIT = 10;
 
 function looksLikeJsonArrayPayload(raw: string): boolean {
   return raw.trimStart().startsWith("[");
+}
+
+function inventoryCaptureTimestamp(isoTimestamp: string): string {
+  return isoTimestamp.replace(/[-:]/g, "").replace(/\.\d{3}Z$/u, (match) => match);
+}
+
+function inventoryCaptureSourceSlug(source: string, page?: number): string {
+  if (source === "gh issue list") {
+    return "gh-issue-list";
+  }
+
+  if (page !== undefined) {
+    return `rest-page-${page}`;
+  }
+
+  return source
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function inventoryCaptureLimit(): number {
+  const raw = process.env[MALFORMED_INVENTORY_CAPTURE_LIMIT_ENV];
+  if (!raw) {
+    return DEFAULT_MALFORMED_INVENTORY_CAPTURE_LIMIT;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MALFORMED_INVENTORY_CAPTURE_LIMIT;
 }
 
 interface GitHubRestIssue {
@@ -231,10 +265,28 @@ export class GitHubClient {
     try {
       return parseJson<GitHubIssue[]>(result.stdout, "gh issue list");
     } catch (error) {
+      const capturePath = await this.captureMalformedInventoryPayload({
+        source: "gh issue list",
+        args: [
+          "issue",
+          "list",
+          "--repo",
+          this.config.repoSlug,
+          "--state",
+          "all",
+          "--limit",
+          "500",
+          "--json",
+          "number,title,body,createdAt,updatedAt,url,labels,state",
+        ],
+        result,
+        parseError: error,
+      });
       const primaryFailureMessage = [
         error instanceof Error ? error.message : String(error),
         result.stderr.trim(),
         result.stdout.trim(),
+        capturePath ? `Malformed inventory capture: ${capturePath}` : null,
       ]
         .filter(Boolean)
         .join("\n");
@@ -321,10 +373,37 @@ export class GitHubClient {
           "-f",
           `page=${page}`,
         ]);
-        const pageResponse = parseJson<GitHubRestIssue[]>(
-          result.stdout,
-          `gh api repos/${owner}/${repo}/issues page=${page}`,
-        );
+        let pageResponse: GitHubRestIssue[];
+        try {
+          pageResponse = parseJson<GitHubRestIssue[]>(
+            result.stdout,
+            `gh api repos/${owner}/${repo}/issues page=${page}`,
+          );
+        } catch (parseError) {
+          const capturePath = await this.captureMalformedInventoryPayload({
+            source: `gh api repos/${owner}/${repo}/issues`,
+            page,
+            args: [
+              "api",
+              `repos/${owner}/${repo}/issues`,
+              "--method",
+              "GET",
+              "-f",
+              "state=all",
+              "-f",
+              `per_page=${FULL_ISSUE_INVENTORY_PAGE_SIZE}`,
+              "-f",
+              `page=${page}`,
+            ],
+            result,
+            parseError,
+          });
+          const parseMessage = parseError instanceof Error ? parseError.message : String(parseError);
+          throw new Error(
+            capturePath ? `${parseMessage}\nMalformed inventory capture: ${capturePath}` : parseMessage,
+            { cause: parseError },
+          );
+        }
         const pageIssues = pageResponse
           .map((issue) => this.mapRestIssue(issue))
           .filter((issue): issue is GitHubIssue => issue !== null);
@@ -348,6 +427,53 @@ export class GitHubClient {
         { cause: fallbackError },
       );
     }
+  }
+
+  private async captureMalformedInventoryPayload(args: {
+    source: string;
+    args: string[];
+    result: CommandResult;
+    parseError: unknown;
+    page?: number;
+  }): Promise<string | null> {
+    const captureDir = process.env[MALFORMED_INVENTORY_CAPTURE_DIR_ENV]?.trim();
+    if (!captureDir) {
+      return null;
+    }
+
+    const capturedAt = new Date(this.now()).toISOString();
+    const fileName = `${inventoryCaptureTimestamp(capturedAt)}-${inventoryCaptureSourceSlug(args.source, args.page)}.json`;
+    const artifactPath = path.join(captureDir, fileName);
+    const parseMessage = args.parseError instanceof Error ? args.parseError.message : String(args.parseError);
+    await ensureDir(captureDir);
+    await writeJsonAtomic(artifactPath, {
+      capturedAt,
+      source: args.source,
+      page: args.page ?? null,
+      command: ["gh", ...args.args],
+      parseError: parseMessage,
+      stdout: {
+        text: args.result.stdout,
+        base64: Buffer.from(args.result.stdout, "utf8").toString("base64"),
+      },
+      stderr: args.result.stderr,
+    });
+    await this.pruneMalformedInventoryCaptures(captureDir);
+    return artifactPath;
+  }
+
+  private async pruneMalformedInventoryCaptures(captureDir: string): Promise<void> {
+    const entries = await fs.readdir(captureDir, { withFileTypes: true });
+    const captureFiles = entries
+      .filter((entry) => entry.isFile() && /^\d{8}T\d{6}\.\d{3}Z-.*\.json$/u.test(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+    const extraFiles = captureFiles.length - inventoryCaptureLimit();
+    if (extraFiles <= 0) {
+      return;
+    }
+
+    await Promise.all(captureFiles.slice(0, extraFiles).map((fileName) => fs.rm(path.join(captureDir, fileName), { force: true })));
   }
 
   private buildCandidateSearchQuery(): string {


### PR DESCRIPTION
## Summary
- capture malformed full-inventory JSON payloads from `gh issue list` and REST fallback pages when opt-in debug capture is enabled
- bound retained artifacts and include the written capture path in parse-failure errors
- add focused regression coverage and operator docs for retrieving artifacts from loop hosts

## Testing
- npx tsx --test src/github/github.test.ts
- npx tsx --test src/getting-started-docs.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug capture for malformed inventory payloads to aid troubleshooting of intermittent refresh failures, with configurable retention (default: 10 latest artifacts).

* **Documentation**
  * Added operator workflow guide for enabling and inspecting malformed payload captures via environment variables.

* **Tests**
  * Added comprehensive test coverage for the capture artifact functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->