### PR TITLE
[codex] Warn on legacy shared issue journal config

### DIFF
--- a/.codex-supervisor/issues/1118/issue-journal.md
+++ b/.codex-supervisor/issues/1118/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #1118: Warn when the active supervisor config still uses the legacy shared issue journal path
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1118
+- Branch: codex/issue-1118
+- Workspace: .
+- Journal: .codex-supervisor/issues/1118/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: bf7d80e2ff84ca9015c7b76ea77693f4626e5f4d
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-27T13:40:18.841Z
+
+## Latest Codex Summary
+- Added an operator-visible legacy issue-journal-path warning through the shared trust/config diagnostics, rendered in both `doctor` and `status`.
+- Added focused regression coverage for legacy-path warning emission and for non-warning issue-scoped/custom-path cases.
+- Verified with focused `tsx` tests and a full TypeScript build after installing pinned dev dependencies with `npm ci`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The smallest safe fix is to reuse existing operator diagnostics by attaching a legacy journal-path warning to the shared config/trust summary instead of adding a new startup-only path.
+- What changed: Added legacy-path detection in `summarizeTrustDiagnostics`, rendered it as `doctor_warning kind=config` and `config_warning=...`, and added focused tests for warning and non-warning cases.
+- Current blocker: none
+- Next exact step: Commit the checkpoint on `codex/issue-1118` and leave the branch ready for PR/draft PR follow-up.
+- Verification gap: Full `npm test` was not used as a signal because the broad script pulled in unrelated browser-smoke coverage; focused diagnostics tests and `npm run build` passed.
+- Files touched: src/core/config.ts; src/core/types.ts; src/doctor.ts; src/doctor.test.ts; src/config.test.ts; src/setup-readiness.ts; src/supervisor/supervisor-status-report.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Rollback concern: Low; the change is additive and only emits warnings when the configured path exactly matches the legacy shared journal path.
+- Last focused command: npm run build
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -95,6 +95,8 @@ test("loadConfigSummary surfaces the default trust diagnostics posture", async (
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
     warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    configWarning:
+      "Active config still uses legacy shared issue journal path .codex-supervisor/issue-journal.md; prefer .codex-supervisor/issues/{issueNumber}/issue-journal.md.",
   });
 });
 
@@ -127,6 +129,8 @@ test("loadConfigSummary accepts an explicit safer trust diagnostics posture with
     trustMode: "untrusted_or_mixed",
     executionSafetyMode: "operator_gated",
     warning: null,
+    configWarning:
+      "Active config still uses legacy shared issue journal path .codex-supervisor/issue-journal.md; prefer .codex-supervisor/issues/{issueNumber}/issue-journal.md.",
   });
 });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -20,6 +20,8 @@ import { isValidGitRefName, parseJson, resolveMaybeRelative } from "./utils";
 
 const DEFAULT_CONFIG_FILE = "supervisor.config.json";
 export const DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW = 100;
+export const LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH = ".codex-supervisor/issue-journal.md";
+export const PREFERRED_ISSUE_JOURNAL_RELATIVE_PATH = ".codex-supervisor/issues/{issueNumber}/issue-journal.md";
 const REQUIRED_STRING_CONFIG_FIELDS = [
   "repoPath",
   "repoSlug",
@@ -242,10 +244,11 @@ function extractInvalidFieldName(error: unknown): string | null {
 }
 
 export function summarizeTrustDiagnostics(
-  config: Pick<SupervisorConfig, "trustMode" | "executionSafetyMode">,
+  config: Pick<SupervisorConfig, "trustMode" | "executionSafetyMode" | "issueJournalRelativePath">,
 ): TrustDiagnosticsSummary {
   const trustMode = config.trustMode ?? "trusted_repo_and_authors";
   const executionSafetyMode = config.executionSafetyMode ?? "unsandboxed_autonomous";
+  const issueJournalRelativePath = config.issueJournalRelativePath.trim();
 
   return {
     trustMode,
@@ -253,6 +256,10 @@ export function summarizeTrustDiagnostics(
     warning:
       trustMode === "trusted_repo_and_authors" && executionSafetyMode === "unsandboxed_autonomous"
         ? "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs."
+        : null,
+    configWarning:
+      issueJournalRelativePath === LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH
+        ? `Active config still uses legacy shared issue journal path ${LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH}; prefer ${PREFERRED_ISSUE_JOURNAL_RELATIVE_PATH}.`
         : null,
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -46,6 +46,7 @@ export interface TrustDiagnosticsSummary {
   trustMode: TrustMode;
   executionSafetyMode: ExecutionSafetyMode;
   warning: string | null;
+  configWarning?: string | null;
 }
 
 export interface CadenceDiagnosticsSummary {

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -82,6 +82,48 @@ test("diagnoseSupervisorHost reports representative auth, state, and workspace f
     renderDoctorReport(diagnostics),
     /doctor_warning kind=execution_safety detail=Unsandboxed autonomous execution assumes trusted GitHub-authored inputs\./,
   );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_warning kind=config detail=Active config still uses legacy shared issue journal path \.codex-supervisor\/issue-journal\.md; prefer \.codex-supervisor\/issues\/\{issueNumber\}\/issue-journal\.md\./,
+  );
+});
+
+test("renderDoctorReport only warns for the legacy shared issue journal path", () => {
+  const baseDiagnostics = {
+    overallStatus: "pass" as const,
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    trustDiagnostics: {
+      trustMode: "untrusted_or_mixed" as const,
+      executionSafetyMode: "operator_gated" as const,
+      warning: null,
+      configWarning:
+        "Active config still uses legacy shared issue journal path .codex-supervisor/issue-journal.md; prefer .codex-supervisor/issues/{issueNumber}/issue-journal.md.",
+    },
+  };
+
+  assert.match(
+    renderDoctorReport(baseDiagnostics),
+    /doctor_warning kind=config detail=Active config still uses legacy shared issue journal path \.codex-supervisor\/issue-journal\.md; prefer \.codex-supervisor\/issues\/\{issueNumber\}\/issue-journal\.md\./,
+  );
+
+  assert.doesNotMatch(
+    renderDoctorReport({
+      ...baseDiagnostics,
+      trustDiagnostics: {
+        ...baseDiagnostics.trustDiagnostics,
+        configWarning: null,
+      },
+    }),
+    /doctor_warning kind=config/,
+  );
 });
 
 test("diagnoseSupervisorHost surfaces orphan prune candidates and representative eligibility reasons", async (t) => {
@@ -327,6 +369,8 @@ test("diagnoseSetupReadiness returns typed first-run setup state distinct from d
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
     warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    configWarning:
+      "Active config still uses legacy shared issue journal path .codex-supervisor/issue-journal.md; prefer .codex-supervisor/issues/{issueNumber}/issue-journal.md.",
     summary: "Trusted inputs with unsandboxed autonomous execution.",
   });
   assert.deepEqual(summary.localCiContract, {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -597,6 +597,9 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     ...(diagnostics.trustDiagnostics.warning === null
       ? []
       : [`doctor_warning kind=execution_safety detail=${sanitizeDoctorValue(diagnostics.trustDiagnostics.warning)}`]),
+    ...(diagnostics.trustDiagnostics.configWarning === null || diagnostics.trustDiagnostics.configWarning === undefined
+      ? []
+      : [`doctor_warning kind=config detail=${sanitizeDoctorValue(diagnostics.trustDiagnostics.configWarning)}`]),
     ...(diagnostics.candidateDiscoveryWarning === null
       ? []
       : [`doctor_warning kind=candidate_discovery detail=${sanitizeDoctorValue(diagnostics.candidateDiscoveryWarning)}`]),

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -253,6 +253,7 @@ function buildTrustPosture(config: ReturnType<typeof loadConfigSummary>["config"
     config ?? {
       trustMode: "trusted_repo_and_authors",
       executionSafetyMode: "unsandboxed_autonomous",
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
     },
   );
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -104,12 +104,49 @@ test("status surfaces the default trust posture and execution-safety warning", a
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
     warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    configWarning:
+      "Active config still uses legacy shared issue journal path .codex-supervisor/issue-journal.md; prefer .codex-supervisor/issues/{issueNumber}/issue-journal.md.",
   });
 
   const status = await supervisor.status();
   assert.match(status, /trust_mode=trusted_repo_and_authors/);
   assert.match(status, /execution_safety_mode=unsandboxed_autonomous/);
   assert.match(status, /execution_safety_warning=Unsandboxed autonomous execution assumes trusted GitHub-authored inputs\./);
+  assert.match(
+    status,
+    /config_warning=Active config still uses legacy shared issue journal path \.codex-supervisor\/issue-journal\.md; prefer \.codex-supervisor\/issues\/\{issueNumber\}\/issue-journal\.md\./,
+  );
+});
+
+test("status does not warn for issue-scoped or custom issue journal paths", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const githubStub = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const issueScopedSupervisor = new Supervisor({
+    ...fixture.config,
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  });
+  (issueScopedSupervisor as unknown as { github: Record<string, unknown> }).github = githubStub;
+  const issueScopedStatus = await issueScopedSupervisor.status();
+  assert.doesNotMatch(issueScopedStatus, /config_warning=/);
+
+  const customPathSupervisor = new Supervisor({
+    ...fixture.config,
+    issueJournalRelativePath: ".codex-supervisor/custom/issue-{issueNumber}.md",
+  });
+  (customPathSupervisor as unknown as { github: Record<string, unknown> }).github = githubStub;
+  const customPathStatus = await customPathSupervisor.status();
+  assert.doesNotMatch(customPathStatus, /config_warning=/);
 });
 
 test("status reports degraded full inventory refresh and suppresses readiness selection work", async (t) => {

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -91,6 +91,7 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
     warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    configWarning: null,
   };
   const cadenceDiagnostics = dto.cadenceDiagnostics ?? {
     pollIntervalSeconds: 120,
@@ -109,6 +110,9 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
     ...(trustDiagnostics.warning === null
       ? []
       : [`execution_safety_warning=${truncate(sanitizeStatusValue(trustDiagnostics.warning), 200)}`]),
+    ...(trustDiagnostics.configWarning === null || trustDiagnostics.configWarning === undefined
+      ? []
+      : [`config_warning=${truncate(sanitizeStatusValue(trustDiagnostics.configWarning), 200)}`]),
     `merge_critical_recheck_seconds=${mergeCriticalRecheckSeconds} merge_critical_effective_seconds=${cadenceDiagnostics.mergeCriticalEffectiveSeconds} merge_critical_recheck_enabled=${cadenceDiagnostics.mergeCriticalRecheckEnabled}`,
     ...(dto.candidateDiscoverySummary ? [dto.candidateDiscoverySummary] : []),
     `local_ci configured=${localCiContract.configured} source=${localCiContract.source} command=${truncate(sanitizeStatusValue(localCiContract.command ?? "none"), 200)} summary=${truncate(sanitizeStatusValue(localCiContract.summary), 200)}`,


### PR DESCRIPTION
## Summary
- warn operators when the active supervisor config still uses the legacy shared issue journal path
- surface the warning through the existing `status` and `doctor` diagnostic output
- add focused regression coverage for the legacy-path warning and the non-warning cases

## Root cause
Older active `supervisor.config.json` files can keep `issueJournalRelativePath` set to `.codex-supervisor/issue-journal.md`, which preserves the old shared journal behavior even though the product has moved to issue-scoped journals.

## Validation
- `npm ci`
- `npx tsx --test src/config.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts --test-name-pattern "trust diagnostics|legacy shared issue journal path|issue journal paths|default trust posture and execution-safety warning|reports representative auth, state, and workspace failures|typed first-run setup state distinct from doctor"`
- `npm run build`

## Notes
- full `npm test` was not used as a merge signal here because the broad script pulled in unrelated browser-smoke coverage outside this issue's focused scope


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deprecation warning that alerts operators when using a legacy shared issue journal path, recommending migration to the preferred format. The warning appears in diagnostic reports and supervisor status.

* **Tests**
  * Added comprehensive test coverage for configuration warning diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->