### PR TITLE
Compact durable review journal entries

### DIFF
--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test, { mock } from "node:test";
 import { syncIssueJournal } from "./core/journal";
 import { GitHubIssue, IssueRunRecord } from "./core/types";
+import { buildReviewFailureContext } from "./review-thread-reporting";
 
 const issue: GitHubIssue = {
   number: 177,
@@ -447,6 +448,71 @@ test("syncIssueJournal preserves an appended failure signature when the summary 
   const renderedSummary = extractLatestCodexSummary(content);
   assert.ok(renderedSummary.length <= 4000);
   assert.match(renderedSummary, /Failure signature: retry-budget$/);
+});
+
+test("syncIssueJournal stores review failure details as concise summary plus link", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-review-summary-link-"));
+  const journalPath = path.join(tempDir, ".codex-supervisor", "issue-journal.md");
+  const failureContext = buildReviewFailureContext([
+    {
+      id: "thread-1",
+      isResolved: false,
+      isOutdated: false,
+      path: "src/auth.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: [
+              "Bug: this fallback skips the permission guard and allows unauthorized writes.",
+              "",
+              "<details>",
+              "<summary>Generated review payload</summary>",
+              "",
+              "```suggestion",
+              "if (!viewer.canWrite()) {",
+              "  return;",
+              "}",
+              "```",
+              "",
+              "<table><tr><td>html payload</td></tr></table>",
+              "</details>",
+            ].join("\n"),
+            createdAt: "2026-03-14T00:00:00Z",
+            url: "https://example.test/pr/880#discussion_r2973644268",
+            author: {
+              login: "coderabbitai[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ]);
+
+  assert.ok(failureContext);
+
+  await syncIssueJournal({
+    issue,
+    record: createRecord({
+      workspace: tempDir,
+      journal_path: journalPath,
+      state: "addressing_review",
+      last_failure_context: failureContext,
+    }),
+    journalPath,
+  });
+
+  const content = await fs.readFile(journalPath, "utf8");
+  assert.match(content, /- Summary: 1 unresolved automated review thread\(s\) remain\./);
+  assert.match(content, /src\/auth\.ts:42/i);
+  assert.match(content, /permission guard and allows unauthorized writes/i);
+  assert.match(content, /https:\/\/example\.test\/pr\/880#discussion_r2973644268/);
+  assert.doesNotMatch(content, /Generated review payload/);
+  assert.doesNotMatch(content, /```suggestion/);
+  assert.doesNotMatch(content, /<details>/i);
+  assert.doesNotMatch(content, /<table>/i);
 });
 
 test("syncIssueJournal preserves a replaced failure signature when the summary is truncated", async () => {

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -15,6 +15,34 @@ export function latestReviewComment(thread: ReviewThread) {
   return thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
 }
 
+function normalizeReviewCommentWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function extractReviewCommentSummary(body: string): string {
+  const normalized = normalizeReviewCommentWhitespace(
+    body
+      .replace(/```[\s\S]*?```/g, " ")
+      .replace(/<[^>]+>/g, " "),
+  );
+  if (normalized.length === 0) {
+    return "review details available at source link";
+  }
+
+  const sentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/)?.[1] ?? normalized;
+  const summary = sentence.trim();
+  return summary.length > 180 ? `${summary.slice(0, 177)}...` : summary;
+}
+
+function renderReviewThreadDetail(thread: ReviewThread, includeAuthor = false): string {
+  const latestComment = latestReviewComment(thread);
+  const location = `${thread.path ?? "unknown"}:${thread.line ?? "?"}`;
+  const author = includeAuthor ? ` reviewer=${latestComment?.author?.login ?? "unknown"}` : "";
+  const summary = ` summary=${extractReviewCommentSummary(latestComment?.body ?? "")}`;
+  const url = latestComment?.url ? ` url=${latestComment.url}` : "";
+  return `${location}${author}${summary}${url}`;
+}
+
 export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
   return reviewThreads.filter((thread) => !isAllowedReviewBotThread(config, thread));
 }
@@ -85,10 +113,7 @@ export function buildReviewFailureContext(reviewThreads: ReviewThread[]): Failur
     return null;
   }
 
-  const details = reviewThreads.slice(0, 5).map((thread) => {
-    const latestComment = latestReviewComment(thread);
-    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
-  });
+  const details = reviewThreads.slice(0, 5).map((thread) => renderReviewThreadDetail(thread));
 
   return {
     category: "review",
@@ -106,11 +131,7 @@ export function buildManualReviewFailureContext(reviewThreads: ReviewThread[]): 
     return null;
   }
 
-  const details = reviewThreads.slice(0, 5).map((thread) => {
-    const latestComment = latestReviewComment(thread);
-    const author = latestComment?.author?.login ?? "unknown";
-    return `${thread.path ?? "unknown"}:${thread.line ?? "?"} reviewer=${author} ${latestComment?.body.replace(/\s+/g, " ").trim() ?? ""}`;
-  });
+  const details = reviewThreads.slice(0, 5).map((thread) => renderReviewThreadDetail(thread, true));
 
   return {
     category: "manual",


### PR DESCRIPTION
## Summary
- store unresolved review-thread journal details as concise summaries plus source links
- avoid persisting raw generated review payloads like HTML/details/suggestion blocks into durable journal state
- add focused regression coverage for the compact journal format

Closes #1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced review failure details in issue journals with cleaner, truncated summaries (up to ~180 characters), essential context including file location and reviewer information, while stripping out HTML and markdown formatting for improved readability.

* **Tests**
  * Added test coverage for review failure summary storage and formatting sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->