### PR TITLE
[codex] Bootstrap issue branches from authoritative fresh default-branch refs

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -162,6 +162,35 @@ async function createSplitRemoteRepositoryFixture(): Promise<SupervisorConfig & 
   return { ...config, githubPath };
 }
 
+async function createDivergedDefaultBranchFixture(): Promise<SupervisorConfig> {
+  const config = await createRepositoryFixture();
+  const root = path.dirname(config.repoPath);
+  const githubPath = path.join(root, "github.git");
+  const githubClonePath = path.join(root, "github-clone");
+
+  await execFileAsync("git", ["init", "--bare", githubPath]);
+  await git(config.repoPath, "remote", "add", "github", githubPath);
+  await git(config.repoPath, "push", "-u", "github", config.defaultBranch);
+
+  await fs.writeFile(path.join(config.repoPath, "origin-only.txt"), "origin-only change\n", "utf8");
+  await git(config.repoPath, "add", "origin-only.txt");
+  await git(config.repoPath, "commit", "-m", "Origin-only commit");
+  await git(config.repoPath, "push", "origin", config.defaultBranch);
+
+  await execFileAsync("git", ["clone", githubPath, githubClonePath]);
+  await git(githubClonePath, "config", "user.name", "GitHub Collaborator");
+  await git(githubClonePath, "config", "user.email", "github@example.test");
+  await git(githubClonePath, "checkout", "-b", config.defaultBranch, `origin/${config.defaultBranch}`);
+  await fs.writeFile(path.join(githubClonePath, "github-only.txt"), "github-only change\n", "utf8");
+  await git(githubClonePath, "add", "github-only.txt");
+  await git(githubClonePath, "commit", "-m", "GitHub-only commit");
+  await git(githubClonePath, "push", "origin", config.defaultBranch);
+
+  await git(config.repoPath, "fetch", "github", config.defaultBranch);
+
+  return config;
+}
+
 test("ensureWorkspace reports when a recreated workspace restores from an existing local branch", async () => {
   const config = await createRepositoryFixture();
   const issueNumber = 721;
@@ -186,6 +215,28 @@ test("ensureWorkspace reports when a recreated workspace bootstraps from the def
   assert.equal(ensured.workspacePath, path.join(config.workspaceRoot, `issue-${issueNumber}`));
   assert.equal(ensured.restore.source, "bootstrap_default_branch");
   assert.equal(ensured.restore.ref, `origin/${config.defaultBranch}`);
+});
+
+test("ensureWorkspace keeps origin authoritative when the local default branch has unpublished commits", async () => {
+  const config = await createRepositoryFixture();
+  const issueNumber = 726;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+
+  await fs.writeFile(path.join(config.repoPath, "local-only.txt"), "local-only change\n", "utf8");
+  await git(config.repoPath, "add", "local-only.txt");
+  await git(config.repoPath, "commit", "-m", "Local-only commit");
+
+  const originDefaultSha = await gitOutput(config.repoPath, "rev-parse", `origin/${config.defaultBranch}`);
+  const localDefaultSha = await gitOutput(config.repoPath, "rev-parse", config.defaultBranch);
+  assert.notEqual(localDefaultSha, originDefaultSha);
+
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+  const branchHeadSha = await gitOutput(ensured.workspacePath, "rev-parse", "HEAD");
+
+  assert.equal(ensured.restore.source, "bootstrap_default_branch");
+  assert.equal(ensured.restore.ref, `origin/${config.defaultBranch}`);
+  assert.equal(branchHeadSha, originDefaultSha);
+  assert.notEqual(branchHeadSha, localDefaultSha);
 });
 
 test("ensureWorkspace reports when a recreated workspace discovers an existing remote branch", async () => {
@@ -243,9 +294,48 @@ test("ensureWorkspace bootstraps from the fresh default-branch ref instead of st
 
   assert.equal(ensured.workspacePath, path.join(config.workspaceRoot, `issue-${issueNumber}`));
   assert.equal(ensured.restore.source, "bootstrap_default_branch");
-  assert.equal(ensured.restore.ref, config.defaultBranch);
+  assert.equal(ensured.restore.ref, `github/${config.defaultBranch}`);
   assert.equal(branchHeadSha, githubDefaultSha);
   assert.notEqual(branchHeadSha, originDefaultSha);
+});
+
+test("ensureWorkspace ignores similarly suffixed remote-tracking refs when bootstrapping", async () => {
+  const config = await createRepositoryFixture();
+  const issueNumber = 727;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+
+  await git(config.repoPath, "checkout", "-b", "release/main", `origin/${config.defaultBranch}`);
+  await fs.writeFile(path.join(config.repoPath, "release-main.txt"), "release branch change\n", "utf8");
+  await git(config.repoPath, "add", "release-main.txt");
+  await git(config.repoPath, "commit", "-m", "Release branch commit");
+  await git(config.repoPath, "push", "-u", "origin", "release/main");
+  await git(config.repoPath, "checkout", config.defaultBranch);
+
+  const originDefaultSha = await gitOutput(config.repoPath, "rev-parse", `origin/${config.defaultBranch}`);
+  const releaseMainSha = await gitOutput(config.repoPath, "rev-parse", "origin/release/main");
+  assert.notEqual(releaseMainSha, originDefaultSha);
+
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+  const branchHeadSha = await gitOutput(ensured.workspacePath, "rev-parse", "HEAD");
+
+  assert.equal(ensured.restore.source, "bootstrap_default_branch");
+  assert.equal(ensured.restore.ref, `origin/${config.defaultBranch}`);
+  assert.equal(branchHeadSha, originDefaultSha);
+  assert.notEqual(branchHeadSha, releaseMainSha);
+});
+
+test("ensureWorkspace skips bootstrap-base resolution when restoring an existing local issue branch", async () => {
+  const config = await createDivergedDefaultBranchFixture();
+  const issueNumber = 728;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+
+  await git(config.repoPath, "branch", branch, config.defaultBranch);
+
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+
+  assert.equal(ensured.workspacePath, path.join(config.workspaceRoot, `issue-${issueNumber}`));
+  assert.equal(ensured.restore.source, "local_branch");
+  assert.equal(ensured.restore.ref, branch);
 });
 
 test("issue-scoped journals do not manufacture merge conflicts between unrelated issue branches", async () => {

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -59,10 +59,11 @@ async function listDefaultBranchCandidateRefs(repoPath: string, defaultBranch: s
     candidates.add(defaultBranch);
   }
 
-  const remoteRefs = await runCommand("git", ["-C", repoPath, "for-each-ref", "--format=%(refname:short)", "refs/remotes"]);
-  for (const ref of remoteRefs.stdout.split("\n").map((line) => line.trim()).filter(Boolean)) {
-    if (ref.endsWith(`/${defaultBranch}`)) {
-      candidates.add(ref);
+  const remotes = await runCommand("git", ["-C", repoPath, "remote"]);
+  for (const remote of remotes.stdout.split("\n").map((line) => line.trim()).filter(Boolean)) {
+    const remoteRef = `refs/remotes/${remote}/${defaultBranch}`;
+    if (await gitRefExists(repoPath, remoteRef)) {
+      candidates.add(`${remote}/${defaultBranch}`);
     }
   }
 
@@ -100,15 +101,17 @@ async function resolveBootstrapBaseRef(repoPath: string, defaultBranch: string):
     throw new Error(`No available default-branch refs found for ${defaultBranch}`);
   }
 
+  const remoteCandidateRefs = candidateRefs.filter((ref) => ref !== defaultBranch);
+  const refsToCompare = remoteCandidateRefs.length > 0 ? remoteCandidateRefs : candidateRefs;
   const candidateShas = new Map<string, string>();
-  for (const ref of candidateRefs) {
+  for (const ref of refsToCompare) {
     candidateShas.set(ref, await revParse(repoPath, ref));
   }
 
   const maximalRefs: string[] = [];
-  for (const candidateRef of candidateRefs) {
+  for (const candidateRef of refsToCompare) {
     let containsAllOthers = true;
-    for (const otherRef of candidateRefs) {
+    for (const otherRef of refsToCompare) {
       if (candidateRef === otherRef) {
         continue;
       }
@@ -124,7 +127,7 @@ async function resolveBootstrapBaseRef(repoPath: string, defaultBranch: string):
 
   if (maximalRefs.length === 0) {
     throw new Error(
-      `Could not determine an authoritative default-branch ref for ${defaultBranch}; candidates diverged: ${candidateRefs.join(", ")}`,
+      `Could not determine an authoritative default-branch ref for ${defaultBranch}; candidates diverged: ${refsToCompare.join(", ")}`,
     );
   }
 
@@ -185,7 +188,6 @@ export async function ensureWorkspace(
   const workspacePath = workspacePathForIssue(config, issueNumber);
   await ensureDir(config.workspaceRoot);
   await runCommand("git", ["-C", config.repoPath, "fetch", "origin", config.defaultBranch]);
-  const bootstrapBaseRef = await resolveBootstrapBaseRef(config.repoPath, config.defaultBranch);
   const remoteBranchExists = await fetchIssueRemoteTrackingRef(config.repoPath, branch);
 
   if (fs.existsSync(path.join(workspacePath, ".git"))) {
@@ -215,6 +217,7 @@ export async function ensureWorkspace(
     });
   }
 
+  const bootstrapBaseRef = await resolveBootstrapBaseRef(config.repoPath, config.defaultBranch);
   await runCommand("git", [
     "-C",
     config.repoPath,


### PR DESCRIPTION
## Summary
- stop new issue worktree bootstrap from blindly branching off `origin/<defaultBranch>`
- resolve the freshest non-diverged local default-branch ref and use that as the bootstrap base
- add a split-remote regression covering stale `origin/main` and fresh authoritative upstream refs

## Root cause
Bootstrap assumed `origin/<defaultBranch>` was authoritative. On split-remote hosts, that assumption can be false, so new issue branches could start from an outdated base even when a fresher default-branch ref already existed locally.

## Validation
- `npx tsx --test src/core/workspace.test.ts`
- `npm run build`

Closes #1127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for workspace bootstrapping across complex default-branch scenarios, including split-remote and diverged-default-branch setups.

* **Improvements**
  * Bootstrapping now selects the most appropriate, up-to-date default-branch reference among available remotes, preserves authoritative remote when local commits are unpublished, ignores misleading similarly named refs, and skips base resolution for existing local issue branches to improve restore consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->