### PR TITLE
[codex] Fix duplicate dashboard queue hero action

### DIFF
--- a/.codex-supervisor/issues/1143/issue-journal.md
+++ b/.codex-supervisor/issues/1143/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1143: Avoid duplicate Open Queue Details hero actions in the WebUI dashboard
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1143
+- Branch: codex/issue-1143
+- Workspace: .
+- Journal: .codex-supervisor/issues/1143/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: dbce5077f9abffec6e9fe31497d05985dc072d6f
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-28T00:12:25.451Z
+
+## Latest Codex Summary
+- Added a focused dashboard regression for the healthy no-focused-issue state and fixed hero secondary-action selection so queue navigation is not duplicated when it is already the primary fallback.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The duplicate hero buttons come from both primary and secondary action selectors independently falling back to the same queue action when refresh is healthy, doctor passes, and there is no focused issue.
+- What changed: Added a regression test for the no-focused-issue healthy dashboard state and changed the secondary hero-action selector to hide itself when the primary action already resolves to queue navigation.
+- Current blocker: none
+- Next exact step: Commit the focused fix on `codex/issue-1143`; manual browser verification is still optional if required later.
+- Verification gap: Did not run manual WebUI verification against `dist/index.js web`; only the focused dashboard test file was run.
+- Files touched: src/backend/webui-dashboard.test.ts; src/backend/webui-dashboard-browser-script.ts; .codex-supervisor/issues/1143/issue-journal.md
+- Rollback concern: Low; behavior change is limited to secondary hero-button visibility when queue navigation is already the primary action.
+- Last focused command: npx tsx --test src/backend/webui-dashboard.test.ts
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -549,7 +549,8 @@ export function renderDashboardBrowserScript(): string {
       }
 
       function getHeroSecondaryActionConfig(nextIssue) {
-        if (hasHeroIssueFocus(nextIssue)) {
+        const primaryActionConfig = getHeroPrimaryActionConfig(nextIssue);
+        if (hasHeroIssueFocus(nextIssue) || primaryActionConfig.mode === "queue") {
           return { mode: "queue", label: "", hidden: true };
         }
         return { mode: "queue", label: "Open Queue Details", hidden: false };

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1031,6 +1031,22 @@ test("dashboard folds current state into hero badges and action buttons", async 
   assert.equal(heroSecondaryButton.classList.contains("is-hidden"), true);
 });
 
+test("dashboard avoids duplicate queue hero actions when no issue is focused", async () => {
+  const harness = createDashboardHarness([
+    { path: "/api/status?why=true", response: jsonResponse(createStatus()) },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const heroPrimaryButton = harness.document.getElementById("hero-primary-button");
+  const heroSecondaryButton = harness.document.getElementById("hero-secondary-button");
+  assert.ok(heroPrimaryButton);
+  assert.ok(heroSecondaryButton);
+
+  assert.match(heroPrimaryButton.textContent, /Open Queue Details/u);
+  assert.doesNotMatch(heroSecondaryButton.textContent, /Open Queue Details/u);
+});
+
 test("dashboard hero issue-details action loads focused issue details when needed", async () => {
   const harness = createDashboardHarness([
     {


### PR DESCRIPTION
## What changed
- Added a focused dashboard regression for the healthy no-focused-issue state.
- Hid the secondary hero queue action when the primary hero action already resolves to queue navigation.

## Why
The dashboard could render `Open Queue Details` for both hero buttons in the healthy no-focused-issue path because both selectors independently fell back to the same queue action.

## Impact
Operators now see a distinct hero-action pairing in this state instead of two identical queue buttons.

## Validation
- npx tsx --test src/backend/webui-dashboard.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed regression in WebUI dashboard preventing duplicate "Open Queue Details" hero actions from appearing when no issue is focused.

* **Tests**
  * Added test coverage to verify the dashboard correctly prevents duplicate queue-related actions when no issue is in focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->