### PR TITLE
[codex] Re-arm short configured-bot arrival wait after Ready for review

### DIFF
--- a/src/pull-request-state-coderabbit-settled-waits.test.ts
+++ b/src/pull-request-state-coderabbit-settled-waits.test.ts
@@ -138,6 +138,38 @@ test("inferStateFromPullRequest re-arms CodeRabbit waiting after ready-for-revie
   });
 });
 
+test("inferStateFromPullRequest keeps waiting after ready-for-review when the local review wait was re-armed but current-head CI hydration is missing", () => {
+  withStubbedDateNow("2026-03-13T02:30:10Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+      configuredBotInitialGraceWaitSeconds: 90,
+    });
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: "2026-03-13T02:30:00Z",
+      review_wait_head_sha: "head123",
+    });
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          copilotReviewState: "not_requested",
+          copilotReviewArrivedAt: null,
+          currentHeadCiGreenAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          configuredBotDraftSkipAt: null,
+        }),
+        passingChecks(),
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
 test("inferStateFromPullRequest re-arms CodeRabbit latest-head waiting when the PR advances after an earlier review arrived", () => {
   withStubbedDateNow("2026-03-13T02:32:29Z", () => {
     const config = createConfig({

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -330,14 +330,18 @@ function shouldWaitForConfiguredBotLatestHeadRearm(
     return false;
   }
 
-  const actionableSignalAt = latestConfiguredBotActionableSignalAt(pr);
-  if (!actionableSignalAt) {
+  const reviewWaitStartedAtMs = Date.parse(record.review_wait_started_at);
+  if (Number.isNaN(reviewWaitStartedAtMs)) {
     return false;
   }
 
-  const reviewWaitStartedAtMs = Date.parse(record.review_wait_started_at);
+  const actionableSignalAt = latestConfiguredBotActionableSignalAt(pr);
+  if (!actionableSignalAt) {
+    return Date.now() < reviewWaitStartedAtMs + configuredBotInitialGraceWaitMs(config);
+  }
+
   const actionableSignalAtMs = Date.parse(actionableSignalAt);
-  if (Number.isNaN(reviewWaitStartedAtMs) || Number.isNaN(actionableSignalAtMs)) {
+  if (Number.isNaN(actionableSignalAtMs)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- keep CodeRabbit-style configured-bot waits active after `Ready for review` when the supervisor has already re-armed `review_wait_started_at` on the current head
- stop relying on hydrated `currentHeadCiGreenAt` alone to preserve that short bounded arrival window
- add a focused regression for the #1164 timing where checks were already green, the local review wait was re-armed, and no configured-bot signal had arrived yet

## Root cause
The merge gate could fall through to `ready_to_merge` immediately after `Ready for review` when the local record had a fresh current-head review-wait marker but the hydrated PR facts had not populated `currentHeadCiGreenAt` yet. That left no active predicate to keep the PR in `waiting_ci` during the configured bot-arrival grace window.

## Impact
PRs now remain in the short configured-bot arrival wait after draft removal on the current head even if CI hydration is late. Existing behavior for already-arrived configured-bot signals, explicit blockers, and bounded wait expiry stays intact.

## Verification
- `npx tsx --test src/pull-request-state-coderabbit-settled-waits.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-lifecycle.test.ts src/post-turn-pull-request.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pull request state detection when CI is pending and review wait conditions are re-armed, including proper grace-wait period handling.

* **Tests**
  * Added test coverage for edge cases in pull request state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->