### PR TITLE
Fix AGENTS path hygiene after #1169

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This repository uses GitHub issue bodies as execution inputs. Treat issue author
 
 ## Canonical source
 
-- Before creating or updating a `codex` issue, follow [`docs/issue-metadata.md`](/Users/tomoakikawada/Dev/codex-supervisor-self/docs/issue-metadata.md).
-- If README examples, chat instructions, and issue history disagree, prefer [`docs/issue-metadata.md`](/Users/tomoakikawada/Dev/codex-supervisor-self/docs/issue-metadata.md).
+- Before creating or updating a `codex` issue, follow [`docs/issue-metadata.md`](docs/issue-metadata.md).
+- If README examples, chat instructions, and issue history disagree, prefer [`docs/issue-metadata.md`](docs/issue-metadata.md).
 
 ## Required format for `codex` issues
 


### PR DESCRIPTION
## Summary

- fix `AGENTS.md` to use repo-relative links instead of workstation-local absolute paths
- unblock the `verify:paths` failure introduced by #1169

## Testing

- `npm run verify:paths`
