### PR TITLE
[codex] Allow transient inventory snapshot fallback

### DIFF
--- a/.codex-supervisor/issues/1165/issue-journal.md
+++ b/.codex-supervisor/issues/1165/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1165: Do not hard-block selection on a transient full-inventory refresh failure when a fresh snapshot exists
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1165
+- Branch: codex/issue-1165
+- Workspace: .
+- Journal: .codex-supervisor/issues/1165/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 4ec11ba9e8fd150d385b98fd41a67e582a8ff437
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-28T13:17:55.424Z
+
+## Latest Codex Summary
+- Reproduced the over-blocking gap with a focused prelude test and changed the prelude to allow one snapshot-backed selection pass after a transient full-inventory refresh failure when a fresh last-known-good snapshot exists. Repeated transient failures remain blocked.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The hard block lives in `runOnceCyclePrelude` returning immediately on any full-inventory refresh failure, even when the failure is transient and the previous cycle left behind a fresh trusted snapshot.
+- What changed: Added a focused regression test for transient-failure snapshot-backed selection, added a helper that recognizes fresh snapshot support for transient GitHub transport failures, and let the prelude attempt `reserveRunnableIssueSelection` once in that bounded case. Added a second test to keep repeated transient failures blocked.
+- Current blocker: none
+- Next exact step: Commit the focused prelude/inventory changes on `codex/issue-1165`, then continue with any higher-signal status/readiness follow-up only if review finds an operator-surface mismatch.
+- Verification gap: `npm test -- src/run-once-cycle-prelude.test.ts` was misleading because the package script still expands to the full glob and hit an unrelated browser-smoke failure; targeted verification used `npx tsx --test src/run-once-cycle-prelude.test.ts` instead.
+- Files touched: `src/inventory-refresh-state.ts`, `src/run-once-cycle-prelude.ts`, `src/run-once-cycle-prelude.test.ts`
+- Rollback concern: The freshness window is currently a fixed one-hour bound; if operator expectations require a different tolerance, adjust the helper rather than broadening the transient-failure path.
+- Last focused command: `npx tsx --test src/run-once-cycle-prelude.test.ts`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/inventory-refresh-state.ts
+++ b/src/inventory-refresh-state.ts
@@ -6,12 +6,13 @@ import {
   LastSuccessfulInventorySnapshot,
   SupervisorStateFile,
 } from "./core/types";
-import { nowIso, truncate } from "./core/utils";
-import { isGitHubRateLimitFailure } from "./github/github-transport";
+import { hoursSince, nowIso, truncate } from "./core/utils";
+import { isGitHubRateLimitFailure, isTransientGitHubCommandFailure } from "./github/github-transport";
 import { GitHubInventoryRefreshError } from "./github";
 import { sanitizeStatusValue } from "./supervisor/supervisor-status-rendering";
 
 export const FULL_ISSUE_INVENTORY_SOURCE = "gh issue list";
+export const FRESH_INVENTORY_SNAPSHOT_MAX_AGE_HOURS = 1;
 
 export type InventoryStatusMode = "healthy" | "degraded";
 export type InventoryStatusPosture =
@@ -65,6 +66,30 @@ export function buildLastSuccessfulInventorySnapshot(issues: GitHubIssue[]): Las
       ...(issue.labels ? { labels: issue.labels.map((label) => ({ ...label })) } : {}),
     })),
   };
+}
+
+export function isFreshInventorySnapshot(
+  snapshot: LastSuccessfulInventorySnapshot | null | undefined,
+): snapshot is LastSuccessfulInventorySnapshot {
+  return Boolean(
+    snapshot
+    && snapshot.source === FULL_ISSUE_INVENTORY_SOURCE
+    && snapshot.issue_count > 0
+    && hoursSince(snapshot.recorded_at) <= FRESH_INVENTORY_SNAPSHOT_MAX_AGE_HOURS,
+  );
+}
+
+export function canUseSnapshotBackedSelectionAfterInventoryRefreshFailure(args: {
+  failure: InventoryRefreshFailure | null | undefined;
+  snapshot: LastSuccessfulInventorySnapshot | null | undefined;
+  previousFailure: InventoryRefreshFailure | null | undefined;
+}): boolean {
+  const { failure, snapshot, previousFailure } = args;
+  if (previousFailure !== undefined || !failure) {
+    return false;
+  }
+
+  return isTransientGitHubCommandFailure(failure.message) && isFreshInventorySnapshot(snapshot);
 }
 
 export function inventoryRefreshFailureEquals(

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -836,6 +836,145 @@ test("runOnceCyclePrelude blocks new selection when full inventory refresh is ma
   assert.equal(result.state.inventory_refresh_failure?.source, "gh issue list");
 });
 
+test("runOnceCyclePrelude allows new selection after a transient full inventory refresh failure when a fresh snapshot exists", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+    last_successful_inventory_snapshot: {
+      source: "gh issue list",
+      recorded_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      issue_count: 1,
+      issues: [
+        {
+          number: 91,
+          title: "Fresh snapshot candidate",
+          body: "## Summary\nAllow snapshot-backed selection after a transient refresh failure.",
+          createdAt: "2026-03-26T00:00:00Z",
+          updatedAt: "2026-03-26T00:00:00Z",
+          url: "https://example.test/issues/91",
+          state: "OPEN",
+        },
+      ],
+    },
+  };
+  const savedStates: SupervisorStateFile[] = [];
+  let reserveCallCount = 0;
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async (nextState) => {
+        savedStates.push(structuredClone(nextState));
+      },
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => {
+      throw new Error(
+        'Transient GitHub CLI failure after 3 attempts: gh issue list --repo owner/repo\nCommand failed: gh issue list --repo owner/repo\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+      );
+    },
+    reserveRunnableIssueSelection: async () => {
+      reserveCallCount += 1;
+      return true;
+    },
+    reconcileTrackedMergedButOpenIssues: async () => {
+      throw new Error("unexpected reconcileTrackedMergedButOpenIssues call");
+    },
+    reconcileMergedIssueClosures: async () => {
+      throw new Error("unexpected reconcileMergedIssueClosures call");
+    },
+    reconcileStaleFailedIssueStates: async () => {
+      throw new Error("unexpected reconcileStaleFailedIssueStates call");
+    },
+    reconcileRecoverableBlockedIssueStates: async () => {
+      throw new Error("unexpected reconcileRecoverableBlockedIssueStates call");
+    },
+    reconcileParentEpicClosures: async () => {
+      throw new Error("unexpected reconcileParentEpicClosures call");
+    },
+    cleanupExpiredDoneWorkspaces: async () => {
+      throw new Error("unexpected cleanupExpiredDoneWorkspaces call");
+    },
+  });
+
+  assert.ok(!("kind" in result));
+  assert.equal(savedStates.length, 1);
+  assert.equal(savedStates[0]?.inventory_refresh_failure?.source, "gh issue list");
+  assert.equal(reserveCallCount, 1);
+});
+
+test("runOnceCyclePrelude still blocks new selection after repeated transient full inventory refresh failures", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+    inventory_refresh_failure: {
+      source: "gh issue list",
+      message:
+        'Transient GitHub CLI failure after 3 attempts: gh issue list --repo owner/repo\nCommand failed: gh issue list --repo owner/repo\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+      recorded_at: "2026-03-26T00:09:00Z",
+    },
+    last_successful_inventory_snapshot: {
+      source: "gh issue list",
+      recorded_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      issue_count: 1,
+      issues: [
+        {
+          number: 91,
+          title: "Fresh snapshot candidate",
+          body: "## Summary\nBlock repeated transient refresh failures.",
+          createdAt: "2026-03-26T00:00:00Z",
+          updatedAt: "2026-03-26T00:00:00Z",
+          url: "https://example.test/issues/91",
+          state: "OPEN",
+        },
+      ],
+    },
+  };
+  let reserveCallCount = 0;
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => {},
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => {
+      throw new Error(
+        'Transient GitHub CLI failure after 3 attempts: gh issue list --repo owner/repo\nCommand failed: gh issue list --repo owner/repo\nexitCode=1\nPost "https://api.github.com/graphql": read tcp 127.0.0.1:12345->140.82.112.6:443: read: connection reset by peer',
+      );
+    },
+    reserveRunnableIssueSelection: async () => {
+      reserveCallCount += 1;
+      return true;
+    },
+    reconcileTrackedMergedButOpenIssues: async () => {
+      throw new Error("unexpected reconcileTrackedMergedButOpenIssues call");
+    },
+    reconcileMergedIssueClosures: async () => {
+      throw new Error("unexpected reconcileMergedIssueClosures call");
+    },
+    reconcileStaleFailedIssueStates: async () => {
+      throw new Error("unexpected reconcileStaleFailedIssueStates call");
+    },
+    reconcileRecoverableBlockedIssueStates: async () => {
+      throw new Error("unexpected reconcileRecoverableBlockedIssueStates call");
+    },
+    reconcileParentEpicClosures: async () => {
+      throw new Error("unexpected reconcileParentEpicClosures call");
+    },
+    cleanupExpiredDoneWorkspaces: async () => {
+      throw new Error("unexpected cleanupExpiredDoneWorkspaces call");
+    },
+  });
+
+  assert.ok(!("kind" in result));
+  assert.equal(reserveCallCount, 0);
+});
+
 test("runOnceCyclePrelude records rate-limited inventory refresh failures distinctly while keeping active tracked reconciliation available", async () => {
   const state: SupervisorStateFile = {
     activeIssueNumber: 41,

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -2,6 +2,7 @@ import { GitHubIssue, SupervisorStateFile } from "./core/types";
 import {
   buildLastSuccessfulInventorySnapshot,
   buildInventoryRefreshFailure,
+  canUseSnapshotBackedSelectionAfterInventoryRefreshFailure,
   inventoryRefreshFailureEquals,
 } from "./inventory-refresh-state";
 import {
@@ -160,8 +161,10 @@ export async function runOnceCyclePrelude(
         successfulIssues: issues,
       });
     } catch (error) {
+      const previousFailure = state.inventory_refresh_failure;
+      const nextFailure = buildInventoryRefreshFailure(error);
       await persistInventoryRefreshState({
-        nextFailure: buildInventoryRefreshFailure(error),
+        nextFailure,
       });
       if (activeRecord !== null && activeRecord.pr_number !== null) {
         await setReconciliationPhase("tracked_merged_but_open_issues");
@@ -195,6 +198,21 @@ export async function runOnceCyclePrelude(
         const recoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, []);
         recoveryEvents.push(...recoverableBlockedEvents);
         emitRecoveryEvents(recoverableBlockedEvents);
+      }
+
+      if (
+        state.activeIssueNumber === null
+        && canUseSnapshotBackedSelectionAfterInventoryRefreshFailure({
+          failure: nextFailure,
+          snapshot: state.last_successful_inventory_snapshot,
+          previousFailure,
+        })
+        && await args.reserveRunnableIssueSelection?.(state) === true
+      ) {
+        return {
+          state,
+          recoveryEvents,
+        };
       }
 
       return {


### PR DESCRIPTION
## Summary
- allow one selection pass to continue after a transient full-inventory refresh failure when a fresh last-known-good snapshot exists
- preserve degraded operator visibility and keep repeated transient failures blocked
- add focused regressions for the bounded fallback and repeated-failure block cases

## Why
A single transport-shaped full inventory refresh failure was hard-blocking selection too aggressively even when a fresh trusted snapshot already existed. This keeps the degraded posture explicit while avoiding an unnecessary stop in the narrow transient-failure case.

## Validation
- `npx tsx --test src/run-once-cycle-prelude.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved resilience to transient inventory refresh failures. When a temporary network or API connectivity issue occurs and a fresh snapshot of inventory data is available, the system now uses the cached snapshot to proceed with issue selection operations rather than blocking the cycle, ensuring better service continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->