### PR TITLE
[codex] Fail closed on mismatched workspace reuse

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -338,6 +338,51 @@ test("ensureWorkspace skips bootstrap-base resolution when restoring an existing
   assert.equal(ensured.restore.ref, branch);
 });
 
+test("ensureWorkspace rejects reusing an existing workspace on the wrong branch", async () => {
+  const config = await createRepositoryFixture();
+  const issueNumber = 729;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+
+  await git(ensured.workspacePath, "checkout", "-b", "unexpected-branch");
+
+  await assert.rejects(
+    () => ensureWorkspace(config, issueNumber, branch),
+    /expected branch/i,
+  );
+});
+
+test("ensureWorkspace rejects reusing an existing workspace on a detached HEAD", async () => {
+  const config = await createRepositoryFixture();
+  const issueNumber = 731;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+  const headSha = await gitOutput(ensured.workspacePath, "rev-parse", "HEAD");
+
+  await git(ensured.workspacePath, "checkout", "--detach", headSha);
+
+  await assert.rejects(
+    () => ensureWorkspace(config, issueNumber, branch),
+    /detached head/i,
+  );
+});
+
+test("ensureWorkspace rejects reusing an existing workspace from a foreign repository", async () => {
+  const config = await createRepositoryFixture();
+  const foreignConfig = await createRepositoryFixture();
+  const issueNumber = 730;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+  const workspacePath = path.join(config.workspaceRoot, `issue-${issueNumber}`);
+
+  await fs.mkdir(config.workspaceRoot, { recursive: true });
+  await execFileAsync("git", ["clone", foreignConfig.repoPath, workspacePath]);
+
+  await assert.rejects(
+    () => ensureWorkspace(config, issueNumber, branch),
+    /worktree|repository|workspace/i,
+  );
+});
+
 test("issue-scoped journals do not manufacture merge conflicts between unrelated issue branches", async () => {
   const config = await createRepositoryFixture();
   const issueA = 801;

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -179,6 +179,84 @@ export function formatWorkspaceRestoreStatusLine(restore: WorkspaceRestoreMetada
   return `workspace_restore source=${restore.source} ref=${restore.ref}`;
 }
 
+interface GitWorktreeEntry {
+  worktreePath: string;
+  branchRef: string | null;
+}
+
+function parseGitWorktreeList(stdout: string): GitWorktreeEntry[] {
+  const entries: GitWorktreeEntry[] = [];
+  let current: GitWorktreeEntry | null = null;
+
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "") {
+      if (current) {
+        entries.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    if (line.startsWith("worktree ")) {
+      if (current) {
+        entries.push(current);
+      }
+      current = {
+        worktreePath: path.resolve(line.slice("worktree ".length).trim()),
+        branchRef: null,
+      };
+      continue;
+    }
+
+    if (line.startsWith("branch ") && current) {
+      current.branchRef = line.slice("branch ".length).trim();
+    }
+  }
+
+  if (current) {
+    entries.push(current);
+  }
+
+  return entries;
+}
+
+async function assertReusableExistingWorkspace(
+  config: Pick<SupervisorConfig, "repoPath">,
+  workspacePath: string,
+  branch: string,
+): Promise<void> {
+  const resolvedWorkspacePath = path.resolve(workspacePath);
+  const worktreeList = await runCommand("git", ["-C", config.repoPath, "worktree", "list", "--porcelain"]);
+  const worktreeEntry = parseGitWorktreeList(worktreeList.stdout).find(
+    (entry) => entry.worktreePath === resolvedWorkspacePath,
+  );
+
+  if (!worktreeEntry) {
+    throw new Error(`Existing workspace is not a registered worktree for repository ${config.repoPath}: ${workspacePath}`);
+  }
+
+  const headBranch = await runCommand(
+    "git",
+    ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"],
+    { allowExitCodes: [0, 1] },
+  );
+  if (headBranch.exitCode !== 0) {
+    throw new Error(`Existing workspace is on a detached HEAD; expected branch ${branch}: ${workspacePath}`);
+  }
+
+  const actualBranch = headBranch.stdout.trim();
+  if (actualBranch !== branch) {
+    throw new Error(`Existing workspace is on branch ${actualBranch}; expected branch ${branch}: ${workspacePath}`);
+  }
+
+  if (worktreeEntry.branchRef !== `refs/heads/${branch}`) {
+    throw new Error(
+      `Existing workspace worktree metadata points at ${worktreeEntry.branchRef ?? "detached HEAD"}; expected refs/heads/${branch}: ${workspacePath}`,
+    );
+  }
+}
+
 export async function ensureWorkspace(
   config: SupervisorConfig,
   issueNumber: number,
@@ -191,6 +269,7 @@ export async function ensureWorkspace(
   const remoteBranchExists = await fetchIssueRemoteTrackingRef(config.repoPath, branch);
 
   if (fs.existsSync(path.join(workspacePath, ".git"))) {
+    await assertReusableExistingWorkspace(config, workspacePath, branch);
     return buildEnsuredWorkspace(workspacePath, {
       source: "existing_workspace",
       ref: branch,


### PR DESCRIPTION
## Summary
- fail closed when reusing an existing issue workspace that no longer matches the expected branch or worktree identity
- preserve the fast path for valid existing issue workspaces
- add focused regressions for wrong-branch, detached-HEAD, and foreign-repository reuse

## Root cause
`ensureWorkspace()` previously treated the presence of `<workspace>/.git` as sufficient proof that an existing issue workspace was safe to reuse. That allowed ambiguous or stale checkouts to be resumed without revalidating branch identity or worktree ownership.

## Validation
- `npm run build`
- `npx tsx --test src/core/workspace.test.ts`
- `npm test` (unrelated existing failure: `src/backend/webui-dashboard-browser-smoke.test.ts` times out in this environment)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for workspace validation failure scenarios including branch mismatch, detached HEAD state, and foreign repository detection.

* **Refactor**
  * Enhanced git worktree validation logic with stricter verification of workspace state and branch matching for existing directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->