### PR TITLE
Promote additional review guardrails

### DIFF
--- a/docs/shared-memory/external-review-guardrails.json
+++ b/docs/shared-memory/external-review-guardrails.json
@@ -99,6 +99,72 @@
       "sourceArtifactPath": "promoted-from-issue-204",
       "sourceHeadSha": "issue-204",
       "lastSeenAt": "2026-03-14T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/github/github-review-signals.ts|provider-specific-review-signals-must-stay-provider-scoped",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/github/github-review-signals.ts",
+      "line": null,
+      "summary": "Flag review-bot lifecycle or status inference that accepts success or arrival signals from a different provider than the gate being evaluated.",
+      "rationale": "Multi-provider review systems stay safe only when each merge gate is driven by that provider's own signals; cross-provider success can unlock merge prematurely.",
+      "sourceArtifactPath": "promoted-from-pr-1149",
+      "sourceHeadSha": "pr-1149",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/pull-request-state.ts|bot-thread-exceptions-must-not-bypass-human-review-gates",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/pull-request-state.ts",
+      "line": null,
+      "summary": "Flag exceptions that relax configured-bot thread blocking when they also suppress human review requirements such as human CHANGES_REQUESTED or REVIEW_REQUIRED.",
+      "rationale": "Bot-specific merge exceptions are only safe when they narrow bot blocking; they must never override human review decisions.",
+      "sourceArtifactPath": "promoted-from-pr-1149",
+      "sourceHeadSha": "pr-1149",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/core/state-store.ts|new-persisted-nullable-fields-must-be-normalized-during-hydration",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/core/state-store.ts",
+      "line": null,
+      "summary": "Flag newly added persisted nullable fields that are written by current code but not normalized from older state files during load or hydration.",
+      "rationale": "Durable state remains stable only when schema additions converge old and new records to one canonical in-memory shape instead of leaking undefined drift.",
+      "sourceArtifactPath": "promoted-from-pr-1159",
+      "sourceHeadSha": "pr-1159",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/github/github.ts|per-request-diagnostic-capture-must-not-use-process-global-env-mutation",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/github/github.ts",
+      "line": null,
+      "summary": "Flag request-scoped or refresh-scoped diagnostic capture that is passed through mutable process-global environment variables across async execution.",
+      "rationale": "Concurrent operations can leak or overwrite each other's capture targets when request-local state is routed through process-global mutation.",
+      "sourceArtifactPath": "promoted-from-pr-1162",
+      "sourceHeadSha": "pr-1162",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/supervisor/supervisor-selection-issue-explain.ts|diagnostics-only-hydration-should-fail-soft-on-auxiliary-fetch-errors",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/supervisor/supervisor-selection-issue-explain.ts",
+      "line": null,
+      "summary": "Flag diagnostics-only enrichments that throw through the primary explain or status response when optional auxiliary GitHub hydration fails.",
+      "rationale": "Operator diagnostics are most useful when core output survives partial enrichment failure and clearly marks missing auxiliary data instead of aborting entirely.",
+      "sourceArtifactPath": "promoted-from-pr-1161",
+      "sourceHeadSha": "pr-1161",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/setup-readiness.ts|invalid-optional-fields-must-still-fail-readiness",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/setup-readiness.ts",
+      "line": null,
+      "summary": "Flag readiness or setup-status logic that ignores optional fields in the invalid state instead of treating them as configuration failures.",
+      "rationale": "Optional fields may be missing, but once present they must be valid; otherwise readiness can report configured state for a broken config document.",
+      "sourceArtifactPath": "promoted-from-pr-1201",
+      "sourceHeadSha": "pr-1201",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
     }
   ]
 }

--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -48,6 +48,14 @@
       "line": 114,
       "summary": "When loader output is intentionally extensible, assert on the rule or property under test instead of snapshotting the full returned array or document unless exact full output is the behavior being verified.",
       "rationale": "Full-array or full-document snapshots make maintainability guardrails brittle as new rules are added later; exact-output assertions are still appropriate when the exact structure itself is the contract."
+    },
+    {
+      "id": "ui-tests-should-assert-usability-state-not-mere-presence",
+      "title": "Assert UI usability state, not just element presence",
+      "file": "src/backend/webui-dashboard.test.ts",
+      "line": 2061,
+      "summary": "When a fake DOM or harness does not faithfully enforce hidden or disabled behavior, verifier coverage should assert that the control is visible and enabled before treating click plumbing as sufficient evidence.",
+      "rationale": "Presence-only assertions can pass while the control is still unusable to real users; tests should prove usability at the behavioral boundary."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- promote additional durable external-review guardrails from recent CodeRabbit findings
- add a verifier guardrail for UI tests that should assert usability state, not just presence

## Testing
- python3 - <<'PY'
import json, pathlib
for p in [
  pathlib.Path('docs/shared-memory/external-review-guardrails.json'),
  pathlib.Path('docs/shared-memory/verifier-guardrails.json'),
]:
  json.loads(p.read_text())
  print('OK', p)
PY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guardrail patterns with seven new safety and review constraint entries.
  * Introduced new UI test assertion guidelines focusing on control usability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->