### PR TITLE
[codex] Surface local CI posture in steady-state doctor and dashboard status

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -66,6 +66,14 @@ export interface DashboardInventoryStatusLike {
   } | null;
 }
 
+export interface DashboardLocalCiContractLike {
+  configured?: boolean | null;
+  command?: string | null;
+  recommendedCommand?: string | null;
+  source?: "config" | "repo_script_candidate" | null;
+  summary?: string | null;
+}
+
 export interface DashboardStatusLike {
   selectionSummary?: DashboardSelectionSummaryLike | null;
   activeIssue?: DashboardActiveIssueLike | null;
@@ -77,6 +85,7 @@ export interface DashboardStatusLike {
   whyLines?: string[] | null;
   candidateDiscovery?: DashboardCandidateDiscoveryLike | null;
   candidateDiscoverySummary?: string | null;
+  localCiContract?: DashboardLocalCiContractLike | null;
   inventoryStatus?: DashboardInventoryStatusLike | null;
   reconciliationWarning?: string | null;
   reconciliationPhase?: string | null;
@@ -377,6 +386,23 @@ export function formatCandidateDiscovery(status: DashboardStatusLike | null | un
 }
 
 export function buildStatusLines(status: DashboardStatusLike | null | undefined): string[] {
+  const localCiContract = status?.localCiContract ?? null;
+  const localCiLines =
+    localCiContract === null
+      ? []
+      : [
+        [
+          "local ci",
+          "configured=" + (localCiContract.configured ? "yes" : "no"),
+          "source=" + String(localCiContract.source ?? "config").replace(/_/gu, " "),
+          "command=" + (localCiContract.command ?? "none"),
+          "recommended command=" + (localCiContract.recommendedCommand ?? "none"),
+        ].join(" "),
+        ...(typeof localCiContract.summary === "string" && localCiContract.summary.trim() !== ""
+          ? [localCiContract.summary]
+          : []),
+      ];
+
   return [
     ...formatTrackedIssueSummary(status),
     ...formatRunnableIssues(status),
@@ -385,6 +411,7 @@ export function buildStatusLines(status: DashboardStatusLike | null | undefined)
     ...(status?.readinessLines ?? []),
     ...(status?.whyLines ?? []),
     ...formatCandidateDiscovery(status),
+    ...localCiLines,
     ...(status?.reconciliationWarning ? [status.reconciliationWarning] : []),
   ];
 }

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -366,6 +366,13 @@ function createManualTimerController(): ManualTimerController {
 function createStatus(args: {
   selectedIssueNumber?: number | null;
   includeWhyLines?: boolean;
+  localCiContract?: {
+    configured: boolean;
+    command: string | null;
+    recommendedCommand?: string | null;
+    source: "config" | "repo_script_candidate";
+    summary: string;
+  } | null;
   loopRuntime?: {
     state: "running" | "off" | "unknown";
     pid: number | null;
@@ -424,6 +431,7 @@ function createStatus(args: {
         ? ["selected_issue=none"]
         : [`selected_issue=#${selectedIssueNumber}`]
       : [],
+    localCiContract: args.localCiContract ?? null,
     candidateDiscoverySummary: null,
     candidateDiscovery: args.candidateDiscovery ?? null,
     reconciliationWarning: null,
@@ -948,6 +956,41 @@ test("dashboard keeps Summary focused on current state and only shows tracked is
   assert.match(
     statusLines.textContent,
     /candidate discovery fetch_window=250 strategy=paginated truncated=yes observed_matching_open_issues=251/u,
+  );
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
+test("dashboard status panel surfaces advisory local CI posture without reopening setup", async () => {
+  const harness = createDashboardHarness([
+    {
+      path: "/api/status?why=true",
+      response: jsonResponse(
+        createStatus({
+          includeWhyLines: false,
+          localCiContract: {
+            configured: false,
+            command: null,
+            recommendedCommand: "npm run verify:supervisor-pre-pr",
+            source: "repo_script_candidate",
+            summary:
+              "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:supervisor-pre-pr.",
+          },
+        }),
+      ),
+    },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const statusLines = harness.document.getElementById("status-lines");
+  assert.ok(statusLines);
+  assert.match(
+    statusLines.textContent,
+    /local ci configured=no source=repo script candidate command=none recommended command=npm run verify:supervisor-pre-pr/u,
+  );
+  assert.match(
+    statusLines.textContent,
+    /Repo-owned local CI candidate exists but localCiCommand is unset\. Recommended command: npm run verify:supervisor-pre-pr\./u,
   );
   assert.equal(harness.remainingFetches.length, 0);
 });

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -588,6 +588,73 @@ test("renderDoctorReport surfaces merge-critical recheck cadence visibility", ()
   assert.match(report, /doctor_local_ci configured=true source=config command=npm run ci:local summary=Repo-owned local CI contract is configured\./);
 });
 
+test("renderDoctorReport surfaces advisory local CI posture when a repo-owned candidate exists", () => {
+  const report = renderDoctorReport({
+    overallStatus: "pass",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+      configWarning: null,
+    },
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: "npm run verify:supervisor-pre-pr",
+      source: "repo_script_candidate",
+      summary:
+        "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:supervisor-pre-pr.",
+    },
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  assert.match(
+    report,
+    /doctor_local_ci configured=false source=repo_script_candidate command=none summary=Repo-owned local CI candidate exists but localCiCommand is unset\. Recommended command: npm run verify:supervisor-pre-pr\./,
+  );
+});
+
+test("renderDoctorReport surfaces absent local CI posture when no repo-owned contract exists", () => {
+  const report = renderDoctorReport({
+    overallStatus: "pass",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+      configWarning: null,
+    },
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: null,
+      source: "config",
+      summary: "No repo-owned local CI contract is configured.",
+    },
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  assert.match(
+    report,
+    /doctor_local_ci configured=false source=config command=none summary=No repo-owned local CI contract is configured\./,
+  );
+});
+
 test("renderDoctorReport omits execution-safety warnings when trust posture does not require one", () => {
   const report = renderDoctorReport({
     overallStatus: "pass",


### PR DESCRIPTION
## Summary
- surface repo-owned local CI posture in steady-state doctor output
- expose the same configured, recommended, and absent posture in steady-state dashboard status
- keep setup readiness and blocker semantics unchanged

## Why
The local CI recommendation already existed in setup readiness, but operators had to reopen `/setup` to tell whether local CI was configured, merely recommended, or unavailable. The steady-state dashboard path also already carried the typed contract, but the browser status rendering did not surface it.

## Impact
Operators can now see local CI posture directly from doctor and the steady-state dashboard without leaving the normal status view.

## Root cause
`/api/status` already included `localCiContract`, but the steady-state dashboard status line builder ignored it.

## Verification
- `npx tsx --test src/doctor.test.ts src/backend/webui-dashboard.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard status now displays local CI contract information including configuration status, commands, recommended commands, and advisory summaries to guide users on their local CI setup.

* **Tests**
  * Added comprehensive test coverage for local CI contract status display and formatting within dashboard and doctor report outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->