### PR TITLE
[codex] Document steady-state local CI posture and remediation flow

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,9 @@ Repository-owned local CI policy:
 - the repo is the source of truth for the command contents; the supervisor should only run the configured entrypoint and observe its exit status
 - exit code `0` means the repo-declared local verification passed; any non-zero exit code means the repo-declared local verification failed
 - if no local CI contract is configured, preserve backward compatibility by not inventing one from workflow YAML or changed-file heuristics
+- `No repo-owned local CI contract is configured.` means no canonical repo-owned local gate is active.
+- `Repo-owned local CI candidate exists but localCiCommand is unset.` means setup/readiness found a repo script candidate. The source is `repo script candidate`. codex-supervisor will not run it until localCiCommand is configured. This warning is advisory only.
+- `Repo-owned local CI contract is configured.` means the configured command is active and fail-closed. When configured local CI fails, PR publication stays blocked until the command passes again.
 
 Workspace cleanup:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -351,6 +351,12 @@ Minimum expectations for that contract:
 
 Backward compatibility stays simple: if no local CI contract is configured, `codex-supervisor` keeps the existing behavior. It does not invent a fallback verification command, and it continues to rely on the issue's `## Verification` guidance plus normal operator/repo workflow instead of pretending a canonical local CI entrypoint exists when the repo has not declared one.
 
+Steady-state posture to read after setup:
+
+- `No repo-owned local CI contract is configured.` That means no canonical repo-owned pre-PR command is active, so PR publication does not depend on `localCiCommand` yet.
+- `Repo-owned local CI candidate exists but localCiCommand is unset.` That means the repo already exposes a likely script candidate, but the supervisor has not opted into it yet. This warning is advisory only. Setup readiness stays unchanged until you configure `localCiCommand`, and codex-supervisor will not run the candidate just because it exists.
+- `Repo-owned local CI contract is configured.` That means the configured command is the active fail-closed gate before PR publication or ready-for-review promotion.
+
 Operator impact: when configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again. Setup/readiness and WebUI guidance should make that visible so operators can tell the difference between a missing contract and a failing configured contract.
 
 Explicit non-goal: `codex-supervisor` does not infer or reconstruct workflow logic from GitHub Actions YAML, other workflow YAML, or changed-file heuristics as a substitute for this contract. If a repo wants a canonical pre-PR local verification command, the repo must expose that command directly.

--- a/docs/operator-dashboard.md
+++ b/docs/operator-dashboard.md
@@ -88,6 +88,12 @@ Beginner rule of thumb:
 - if `Doctor` shows `doctor_check name=github_auth status=fail`, `doctor_check name=codex_cli status=fail`, or `doctor_check name=state_file status=fail`, fix the host or config
 - if `Doctor` shows `doctor_warning kind=config ...`, fix the supervisor config rather than the issue body
 
+Read the local CI posture the same way:
+
+- `No repo-owned local CI contract is configured.` No canonical repo-owned local gate is active, so local CI is not blocking PR publication yet.
+- `Repo-owned local CI candidate exists but localCiCommand is unset.` The repo already defines a likely entrypoint, but codex-supervisor will not run it until `localCiCommand` is configured. This warning is advisory only.
+- `Repo-owned local CI contract is configured.` The configured command is now the active fail-closed gate. When configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again.
+
 ## Current safe command surface
 
 The dashboard currently exposes only the same narrow safe commands that the CLI exposes:
@@ -144,6 +150,14 @@ Practical split:
 1. If `Issue details` is red, repair the issue first.
 2. If `Issue details` is clean but `Doctor` is red or warns, repair host/config/state next.
 3. If both look clean and selection still surprises you, inspect `Status` or run `explain <issue-number>`.
+
+In short: `Issue details` tells you when to fix the issue first, and `Doctor` tells you when to repair host/config/state next.
+
+Use that same split when local CI is involved:
+
+- If `Issue details` is red because `issue-lint` reports missing sections or malformed metadata, fix the GitHub issue body first.
+- If `Issue details` is clean but `Doctor` or setup/readiness shows `Repo-owned local CI candidate exists but localCiCommand is unset.`, decide whether to adopt the repo script by updating supervisor config; this is not an issue-authoring failure.
+- If `Issue details` is clean and the configured local CI gate fails, repair the repo or host until the configured command passes again.
 
 ## Browser smoke suite
 

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -113,6 +113,37 @@ test("getting-started defines the repo-owned local CI contract for pre-PR verifi
   assert.match(content, /ready-for-review promotion stays blocked/i);
 });
 
+test("operator-facing docs explain steady-state local CI posture and remediation flow", async () => {
+  const [gettingStarted, operatorDashboard, configuration] = await Promise.all([
+    readGettingStarted(),
+    fs.readFile(path.join(process.cwd(), "docs", "operator-dashboard.md"), "utf8"),
+    fs.readFile(path.join(process.cwd(), "docs", "configuration.md"), "utf8"),
+  ]);
+
+  for (const content of [gettingStarted, operatorDashboard, configuration]) {
+    assert.match(content, /No repo-owned local CI contract is configured\./);
+    assert.match(
+      content,
+      /Repo-owned local CI candidate exists but localCiCommand is unset\./,
+    );
+    assert.match(content, /This warning is advisory only/i);
+    assert.match(content, /Repo-owned local CI contract is configured\./);
+    assert.match(content, /when configured local CI fails/i);
+    assert.match(content, /PR publication stays blocked/i);
+  }
+
+  assert.match(gettingStarted, /fix the GitHub issue body/i);
+  assert.match(gettingStarted, /fix GitHub auth on the host/i);
+  assert.match(gettingStarted, /fix the supervisor config rather than the issue body/i);
+
+  assert.match(operatorDashboard, /Issue details.*fix the issue first/si);
+  assert.match(operatorDashboard, /Doctor.*repair host\/config\/state next/si);
+
+  assert.match(configuration, /repo script candidate/i);
+  assert.match(configuration, /codex-supervisor will not run it until localCiCommand is configured/i);
+  assert.match(configuration, /preserve backward compatibility by not inventing one/i);
+});
+
 test("getting-started points operators to doctor for the effective orphan cleanup policy", async () => {
   const content = await readGettingStarted();
 


### PR DESCRIPTION
## Summary
- document the steady-state local CI posture after setup across operator-facing docs
- explain how to separate issue-body fixes from supervisor config adoption and repo or host remediation
- add a docs regression to keep the getting-started and README guidance aligned

## Testing
- npx tsx --test src/getting-started-docs.test.ts src/readme-docs.test.ts

Closes #1208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified local CI contract configuration states and their impact on PR publication blocking behavior.
  * Added diagnostic guidance for troubleshooting local CI configuration issues.
  * Documented steady-state behavior expectations for different local CI contract scenarios.

* **Tests**
  * Added comprehensive test coverage verifying consistency of local CI documentation across multiple guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->