### PR TITLE
Add tracked PR stale failure recovery regressions

### DIFF
--- a/.codex-supervisor/issues/1212/issue-journal.md
+++ b/.codex-supervisor/issues/1212/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1212: [codex] Converge tracked PR recovery when stale failed local state disagrees with GitHub PR facts
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1212
+- Branch: codex/issue-1212
+- Workspace: .
+- Journal: .codex-supervisor/issues/1212/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d854b7d62f525e548c221a5031f514095846e189
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-03-30T21:43:23.990Z
+
+## Latest Codex Summary
+- Added regression coverage for tracked PR stale-failure recovery converging to persisted non-failed state and aligned explain/status diagnostics. Focused tests and `npm run build` pass in this worktree after installing lockfile dependencies with `npm ci`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The reported `latest_recovery` versus persisted `state=failed` drift was already fixed in reconciliation logic; the gap was missing regression coverage for the same-head `failed -> draft_pr` tracked PR recovery and its operator-facing diagnostics.
+- What changed: Added a focused reconciliation test for same-head `failed -> draft_pr` recovery, plus explain/status regressions asserting the recovered record stays non-failed and no longer emits stale mismatch or `local_state failed` diagnostics.
+- Current blocker: none
+- Next exact step: Commit the test-only checkpoint on `codex/issue-1212`.
+- Verification gap: none for the scoped regression coverage requested in the issue.
+- Files touched: `.codex-supervisor/issues/1212/issue-journal.md`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- Rollback concern: Low; changes are test-only plus journal notes.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -673,3 +673,59 @@ test("explain reuses the recorded recovery reason for a recovered tracked PR iss
     /^latest_recovery issue=#101 at=2026-03-19T00:20:00Z reason=tracked_pr_head_advanced detail=resumed issue #101 from blocked to reproducing after tracked PR #191 advanced from head-old-191 to head-new-191$/m,
   );
 });
+
+test("explain does not report local_state failed after tracked PR recovery resumes the issue in draft_pr", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 102;
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked PR recovery clears stale failed explain diagnostics",
+    body: executionReadyBody("Explain should reflect the resumed tracked PR lifecycle state."),
+    createdAt: "2026-03-18T00:00:00Z",
+    updatedAt: "2026-03-18T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "draft_pr",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 192,
+        last_recovery_reason:
+          "tracked_pr_lifecycle_recovered: resumed issue #102 from failed to draft_pr using fresh tracked PR #192 facts at head head-192",
+        last_recovery_at: "2026-03-19T00:20:00Z",
+        blocked_reason: null,
+        last_error: null,
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^state=draft_pr$/m);
+  assert.match(explanation, /^runnable=yes$/m);
+  assert.match(
+    explanation,
+    /^latest_recovery issue=#102 at=2026-03-19T00:20:00Z reason=tracked_pr_lifecycle_recovered detail=resumed issue #102 from failed to draft_pr using fresh tracked PR #192 facts at head head-192$/m,
+  );
+  assert.doesNotMatch(explanation, /^reason_\d+=local_state failed$/m);
+  assert.doesNotMatch(explanation, /^reason_\d+=blocked_failure /m);
+});

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2321,3 +2321,71 @@ test("status surfaces tracked PR mismatches when GitHub is ready but local state
     /^recovery_guidance=Tracked PR facts are fresher than local state; run the supervisor again to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
   );
 });
+
+test("status does not surface tracked PR mismatch diagnostics after tracked PR recovery persists draft_pr state", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 172;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "draft_pr",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 272,
+        blocked_reason: null,
+        last_error: null,
+        last_head_sha: "head-272",
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        last_recovery_reason:
+          "tracked_pr_lifecycle_recovered: resumed issue #172 from failed to draft_pr using fresh tracked PR #272 facts at head head-272",
+        last_recovery_at: "2026-03-13T00:20:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked PR recovery converged",
+    body: executionReadyBody("Status should reflect the resumed tracked PR lifecycle state."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: 272,
+    headRefName: branch,
+    headRefOid: "head-272",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => draftPr,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^tracked_pr_mismatch /m);
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^recovery_guidance=/m);
+
+  const status = await supervisor.status();
+  assert.doesNotMatch(status, /^tracked_pr_mismatch /m);
+  assert.doesNotMatch(status, /^recovery_guidance=/m);
+  assert.match(
+    status,
+    /^latest_recovery issue=#172 at=2026-03-13T00:20:00Z reason=tracked_pr_lifecycle_recovered detail=resumed issue #172 from failed to draft_pr using fresh tracked PR #272 facts at head head-272$/m,
+  );
+});

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2842,6 +2842,105 @@ test("reconcileStaleFailedIssueStates reclassifies stale failed tracked PRs to b
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileStaleFailedIssueStates clears stale failed tracked PR state when GitHub resumes the issue in draft_pr on the same head", async () => {
+  const config = createConfig();
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error: "Stopped after repeated repair attempts.",
+        last_failure_kind: "codex_failed",
+        last_failure_context: {
+          category: "codex",
+          summary: "Repair budget exhausted while waiting for PR recovery.",
+          signature: "repair-budget-exhausted",
+          command: null,
+          details: ["attempts=3/3"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "repair-budget-exhausted",
+        repeated_failure_signature_count: 3,
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    isDraft: true,
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: () => ({}),
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "draft_pr");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(
+    updated.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from failed to draft_pr using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileStaleFailedIssueStates reclassifies stale failed tracked PRs to blocked verification state", async () => {
   const config = createConfig();
   const failureContext = {


### PR DESCRIPTION
## Summary
- add focused regression coverage for same-head tracked PR stale-failure recovery converging from `failed` to `draft_pr`
- cover explain and status diagnostics so recovered tracked PR issues no longer report stale failed-state guidance

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for tracked PR recovery scenarios, including supervisor diagnostics verification.
  * Added tests verifying recovery state transitions and reconciliation of stale-failure issue records.

* **Documentation**
  * Added issue journal entry documenting operational tracking and recovery context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->