### PR TITLE
[codex] Reproduce stale failed tracked PR recovery at run-once orchestration level

### DIFF
--- a/.codex-supervisor/issues/1215/issue-journal.md
+++ b/.codex-supervisor/issues/1215/issue-journal.md
@@ -6,28 +6,37 @@
 - Workspace: .
 - Journal: .codex-supervisor/issues/1215/issue-journal.md
 - Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 47f417c79c14ae8491751979a144a85c814a1596
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: db4002b0b4359d161e425a95616a296183efa401
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-03-30T22:09:19.803Z
+- Updated at: 2026-03-30T22:16:08.847Z
 
 ## Latest Codex Summary
-- None yet.
+Kept the committed run-once stale-failed tracked-PR reproducer from `db4002b` and fixed the remaining local verification failure in [supervisor-execution-orchestration.test.ts](src/supervisor/supervisor-execution-orchestration.test.ts) by updating the local-CI blocked-message expectation to include the current remediation-target suffix emitted by the runtime.
+
+After restoring local dependencies with `npm ci`, the full orchestration suite and `npm run build` both pass in this worktree.
+
+Summary: Preserved the stale failed tracked-PR run-once reproducer and repaired the unrelated orchestration assertion so the requested verification passes locally.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`; `npm ci`; `npm run build`
+Next action: Commit the verification-fix follow-up, push `codex/issue-1215`, and open a draft PR for review.
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The missing regression should exercise `Supervisor.runOnce` after stale-failed tracked-PR reconciliation, including the same-cycle continuation path where the issue is immediately reselected.
-- What changed: Added an orchestration-level test that seeds a `failed` tracked PR on the same head, runs `Supervisor.runOnce({ dryRun: true })`, and asserts the persisted record clears `last_error`, `last_failure_context`, and failure-signature fields after recovery to `draft_pr`.
-- Current blocker: None on the focused reproducer; the broader orchestration test file still has a pre-existing assertion mismatch in the local-CI failure message text.
-- Next exact step: Commit the regression checkpoint, then decide whether this issue needs an even closer reproducer for the stale-failed behavior or can hand off to the convergence-fix issue with this guard in place.
-- Verification gap: `src/supervisor/supervisor-execution-orchestration.test.ts` still fails overall because an older test expects the pre-remediation local-CI block message.
+- Hypothesis: The reproduction requirement is now satisfied by the run-once same-head stale-failed tracked-PR test; the only remaining work on this branch was to bring local verification back to green.
+- What changed: Left the `db4002b` reproduction test in place and updated the older local-CI blocked-message assertion so it matches the runtime remediation-target wording.
+- Current blocker: None.
+- Next exact step: Commit the assertion fix and journal update, then push and open the draft PR.
+- Verification gap: None in the requested checks after running `npm ci`.
 - Files touched: `src/supervisor/supervisor-execution-orchestration.test.ts`; `.codex-supervisor/issues/1215/issue-journal.md`
-- Rollback concern: Low; changes only add regression coverage and update the issue journal.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern "stale failed tracked PR recovery on the same head"`
+- Rollback concern: Low; follow-up only updates one stale expectation and journal state.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -417,7 +417,7 @@ test("prepareIssueExecutionContext blocks PR publication when configured local C
 
   assert.equal(
     result,
-    "Issue #91 blocked: Configured local CI command failed before opening a pull request.",
+    "Issue #91 blocked: Configured local CI command failed before opening a pull request. Remediation target: repo-owned command.",
   );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(pushBranchCalls, 0);


### PR DESCRIPTION
## Summary
- add orchestration-level regression coverage for same-head stale failed tracked PR recovery through `Supervisor.runOnce`
- assert the persisted tracked record converges back to `draft_pr` and clears stale failure metadata
- align the older local-CI blocked-message expectation with the current remediation-target wording so the full orchestration suite stays green

## Why
The stale failed tracked PR recovery bug needs a reproducer on the real run-once path, not only helper-level coverage. This branch keeps that reproducer in place and removes an unrelated stale assertion so the requested verification passes cleanly.

## Validation
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`
- `npm run build`

Closes #1215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for error handling and remediation messaging
  * Added test coverage for issue state recovery and PR tracking validation

* **Chores**
  * Added issue tracking documentation for ongoing issue management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->