### PR TITLE
[codex] Converge authoritative tracked PR state after stale failed recovery

### DIFF
--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -1270,6 +1270,86 @@ test("runOnceCyclePrelude rehydrates stale failed tracked PRs during degraded in
   assert.equal(result.state.issues["77"]?.last_failure_signature, null);
 });
 
+test("runOnceCyclePrelude rehydrates an active stale failed tracked PR during degraded inventory refresh", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 77,
+    issues: {
+      "77": createRecord({
+        issue_number: 77,
+        state: "failed",
+        pr_number: 170,
+        last_head_sha: "head-old-170",
+        last_failure_signature: "repair-budget-exhausted",
+        repeated_failure_signature_count: 3,
+        blocked_reason: null,
+        last_error: "Stopped after repeated repair attempts.",
+        last_failure_kind: "codex_failed",
+      }),
+    },
+  };
+  const staleFailedCalls: Array<{
+    loadedState: SupervisorStateFile;
+    loadedIssues: GitHubIssue[];
+  }> = [];
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => undefined,
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => {
+      throw new Error("Failed to parse JSON from gh issue list: Unexpected token ] in JSON at position 1");
+    },
+    reserveRunnableIssueSelection: async () => {
+      throw new Error("unexpected reserveRunnableIssueSelection call");
+    },
+    reconcileTrackedMergedButOpenIssues: async () => [],
+    reconcileMergedIssueClosures: async () => {
+      throw new Error("unexpected reconcileMergedIssueClosures call");
+    },
+    reconcileStaleFailedIssueStates: async (loadedState, loadedIssues) => {
+      staleFailedCalls.push({ loadedState, loadedIssues });
+      loadedState.issues["77"] = {
+        ...loadedState.issues["77"]!,
+        state: "draft_pr",
+        last_error: null,
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        last_recovery_reason:
+          "tracked_pr_lifecycle_recovered: resumed issue #77 from failed to draft_pr using fresh tracked PR #170 facts at head head-old-170",
+      };
+    },
+    reconcileRecoverableBlockedIssueStates: async () => {
+      throw new Error("unexpected reconcileRecoverableBlockedIssueStates call");
+    },
+    reconcileParentEpicClosures: async () => {
+      throw new Error("unexpected reconcileParentEpicClosures call");
+    },
+    cleanupExpiredDoneWorkspaces: async () => {
+      throw new Error("unexpected cleanupExpiredDoneWorkspaces call");
+    },
+  });
+
+  assert.ok(!("kind" in result));
+  assert.deepEqual(staleFailedCalls, [
+    {
+      loadedState: state,
+      loadedIssues: [],
+    },
+  ]);
+  assert.equal(result.state.issues["77"]?.state, "draft_pr");
+  assert.equal(result.state.issues["77"]?.last_error, null);
+  assert.equal(result.state.issues["77"]?.last_failure_kind, null);
+  assert.equal(result.state.issues["77"]?.last_failure_context, null);
+  assert.equal(result.state.issues["77"]?.last_failure_signature, null);
+  assert.equal(result.state.issues["77"]?.repeated_failure_signature_count, 0);
+});
+
 test("runOnceCyclePrelude rehydrates blocked tracked PRs during degraded inventory refresh", async () => {
   const state: SupervisorStateFile = {
     activeIssueNumber: null,

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -197,12 +197,11 @@ export async function runOnceCyclePrelude(
         emitRecoveryEvents(activeMergedEvents);
       }
 
-      const hasNonActiveFailedTrackedPrRecords = Object.values(state.issues).some((record) =>
+      const hasFailedTrackedPrRecords = Object.values(state.issues).some((record) =>
         record.state === "failed"
-          && record.pr_number !== null
-          && record.issue_number !== state.activeIssueNumber,
+          && record.pr_number !== null,
       );
-      if (allowDegradedContinuation && hasNonActiveFailedTrackedPrRecords) {
+      if (allowDegradedContinuation && hasFailedTrackedPrRecords) {
         await setReconciliationPhase("stale_failed_issue_states");
         await args.reconcileStaleFailedIssueStates(state, [], updateReconciliationProgress);
       }

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -331,6 +331,106 @@ test("runOnce reconciles tracked PR state before reserving a new runnable issue"
   assert.equal(persisted.issues[String(unrelatedIssueNumber)]?.pr_number, 192);
 });
 
+test("runOnce converges stale failed tracked PR state before selecting the resumed issue", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 366;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: issueNumber,
+        state: "failed",
+        branch,
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error: "Stopped after repeated repair attempts.",
+        last_failure_kind: "codex_failed",
+        last_failure_context: {
+          category: "codex",
+          summary: "Repair budget exhausted while waiting for PR recovery.",
+          signature: "repair-budget-exhausted",
+          command: null,
+          details: ["attempts=3/3"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "repair-budget-exhausted",
+        repeated_failure_signature_count: 3,
+      }),
+    ],
+  });
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Converge stale failed tracked PR state",
+    body: executionReadyBody("Recover the authoritative tracked PR lifecycle state before selection."),
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    isDraft: true,
+    headRefName: branch,
+    headRefOid: "head-191",
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async (requestedIssueNumber: number) => {
+      assert.equal(requestedIssueNumber, issueNumber);
+      return issue;
+    },
+    resolvePullRequestForBranch: async (requestedBranch: string, prNumber: number | null) => {
+      assert.equal(requestedBranch, branch);
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return [];
+    },
+    getPullRequestIfExists: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /Dry run: would invoke Codex for issue #366\./);
+  assert.match(message, /state=draft_pr/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(persisted.activeIssueNumber, issueNumber);
+  assert.equal(record.state, "draft_pr");
+  assert.equal(record.pr_number, pr.number);
+  assert.ok(record.last_head_sha);
+  assert.equal(record.last_error, null);
+  assert.equal(record.last_failure_kind, null);
+  assert.equal(record.last_failure_context, null);
+  assert.equal(record.last_failure_signature, null);
+  assert.equal(record.repeated_failure_signature_count, 0);
+  assert.equal(
+    record.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from failed to draft_pr using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(record.last_recovery_at);
+});
+
 test("prepareIssueExecutionContext blocks PR publication when configured local CI fails before draft PR creation", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.localCiCommand = "npm run ci:local";
@@ -417,7 +517,7 @@ test("prepareIssueExecutionContext blocks PR publication when configured local C
 
   assert.equal(
     result,
-    "Issue #91 blocked: Configured local CI command failed before opening a pull request.",
+    "Issue #91 blocked: Configured local CI command failed before opening a pull request. Remediation target: repo-owned command.",
   );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(pushBranchCalls, 0);


### PR DESCRIPTION
## Summary
- converge stale failed tracked-PR recovery during degraded inventory refresh even when the failed record is the active issue
- persist the resumed authoritative lifecycle state so run-once and loop diagnostics stop reporting a stale `local_state:failed` mismatch
- add regressions covering degraded prelude recovery and end-to-end run-once state convergence

## Why
A tracked issue could remain authoritatively `failed` after fresh GitHub PR facts had already resumed it, because degraded reconciliation skipped the active failed tracked-PR record.

## Impact
- run-once and loop recovery now converge the persisted issue record to the resumed non-failed state
- stale failure fields are cleared when tracked PR recovery resumes the issue lifecycle
- diagnostics no longer keep reporting the issue as blocked by a stale local failed state after recovery

## Verification
- `npx tsx --test src/run-once-turn-execution.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npm run build`

Closes #1216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recovery mechanism for active failed issues during degraded inventory refresh operations. Issues in failed state now properly transition to draft state with error fields cleared and recovery metadata recorded.

* **Tests**
  * Added comprehensive test coverage for stale failed issue state recovery during degraded scenarios and supervisor execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->