### PR TITLE
[codex] Distinguish workspace toolchain-missing local CI failures from repo command failures

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -86,8 +86,16 @@ export interface LocalCiContractSummary {
 }
 
 export type LocalCiResultOutcome = "passed" | "failed" | "not_configured";
-export type LocalCiFailureClass = "missing_command" | "non_zero_exit" | "unset_contract";
-export type LocalCiRemediationTarget = "issue_body" | "repo_owned_command" | "supervisor_config";
+export type LocalCiFailureClass =
+  | "missing_command"
+  | "workspace_toolchain_missing"
+  | "non_zero_exit"
+  | "unset_contract";
+export type LocalCiRemediationTarget =
+  | "issue_body"
+  | "repo_owned_command"
+  | "supervisor_config"
+  | "workspace_environment";
 
 export interface LatestLocalCiResult {
   outcome: LocalCiResultOutcome;

--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -114,6 +114,33 @@ test("runLocalCiGate classifies a missing configured entrypoint as supervisor-co
   assert.equal(result.latestResult?.remediation_target, "supervisor_config");
 });
 
+test("runLocalCiGate classifies missing workspace toolchains separately from repo-owned command failures", async () => {
+  const failure = Object.assign(
+    new Error("Command failed: sh -lc +1 args\nexitCode=1\ntsc is not installed in this workspace"),
+    {
+      stderr: "tsc is not installed in this workspace",
+    },
+  );
+
+  const result = await runLocalCiGate({
+    config: { localCiCommand: "npm run ci:local" },
+    workspacePath: "/tmp/workspaces/issue-102",
+    gateLabel: "before marking PR #116 ready",
+    runLocalCiCommand: async () => {
+      throw failure;
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.failureContext?.signature, "local-ci-gate-workspace_toolchain_missing");
+  assert.equal(
+    result.failureContext?.summary,
+    "Configured local CI command could not run before marking PR #116 ready because the workspace toolchain is unavailable. Remediation target: workspace environment.",
+  );
+  assert.equal(result.latestResult?.failure_class, "workspace_toolchain_missing");
+  assert.equal(result.latestResult?.remediation_target, "workspace_environment");
+});
+
 test("runLocalCiGate preserves stdout and stderr details from command failures", async () => {
   const failure = Object.assign(new Error("Command failed: sh -lc +1 args\nexitCode=1"), {
     stdout: "lint summary\n1 file checked",

--- a/src/local-ci.ts
+++ b/src/local-ci.ts
@@ -92,18 +92,43 @@ function isMissingCommandError(error: unknown, command: string): boolean {
   });
 }
 
+function isMissingWorkspaceToolchainError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const commandError = error as ErrorWithOutput;
+  const lines = [error.message, commandError.stderr, commandError.stdout]
+    .filter((value): value is string => typeof value === "string")
+    .flatMap((value) => value.split(/\r?\n/))
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+
+  return lines.some((line) => /\bis not installed in this workspace\b/i.test(line));
+}
+
 function localCiFailureSignature(failureClass: Exclude<LocalCiFailureClass, "unset_contract">): string {
   return `local-ci-gate-${failureClass}`;
 }
 
 function classifyLocalCiFailure(error: unknown, command: string): Exclude<LocalCiFailureClass, "unset_contract"> {
-  return isMissingCommandError(error, command) ? "missing_command" : "non_zero_exit";
+  if (isMissingCommandError(error, command)) {
+    return "missing_command";
+  }
+
+  if (isMissingWorkspaceToolchainError(error)) {
+    return "workspace_toolchain_missing";
+  }
+
+  return "non_zero_exit";
 }
 
 function remediationTargetForFailureClass(failureClass: LocalCiFailureClass): LocalCiRemediationTarget {
   switch (failureClass) {
     case "missing_command":
       return "supervisor_config";
+    case "workspace_toolchain_missing":
+      return "workspace_environment";
     case "non_zero_exit":
       return "repo_owned_command";
     case "unset_contract":
@@ -127,6 +152,14 @@ function buildSummary(args: {
           `Configured local CI command is unavailable ${args.gateLabel}. Remediation target: supervisor config.`,
           1000,
         ) ?? "Configured local CI command is unavailable. Remediation target: supervisor config."
+      );
+    case "workspace_toolchain_missing":
+      return (
+        truncate(
+          `Configured local CI command could not run ${args.gateLabel} because the workspace toolchain is unavailable. Remediation target: workspace environment.`,
+          1000,
+        ) ??
+        "Configured local CI command could not run because the workspace toolchain is unavailable. Remediation target: workspace environment."
       );
     case "non_zero_exit":
       return (

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -230,6 +230,113 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion 
   );
 });
 
+test("handlePostTurnPullRequestTransitionsPhase reports workspace toolchain failures as workspace-environment remediation", async () => {
+  const config = createConfig({ localCiCommand: "npm run ci:local" });
+  const issue = createIssue({ title: "Gate ready promotion on missing workspace toolchain" });
+  const draftPr = createPullRequest({ title: "Gate ready promotion", isDraft: true });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+  };
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        throw new Error("unexpected markPullRequestReady call");
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => {
+      throw Object.assign(new Error("Command failed: sh -lc +1 args\nexitCode=1\ntsc is not installed in this workspace"), {
+        stderr: "tsc is not installed in this workspace",
+      });
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "local-ci-gate-workspace_toolchain_missing");
+  assert.deepEqual(result.record.latest_local_ci_result, {
+    outcome: "failed",
+    summary:
+      "Configured local CI command could not run before marking PR #116 ready because the workspace toolchain is unavailable. Remediation target: workspace environment.",
+    ran_at: result.record.latest_local_ci_result?.ran_at ?? "",
+    head_sha: draftPr.headRefOid,
+    failure_class: "workspace_toolchain_missing",
+    remediation_target: "workspace_environment",
+  });
+  assert.match(
+    result.record.last_error ?? "",
+    /Configured local CI command could not run before marking PR #116 ready because the workspace toolchain is unavailable\. Remediation target: workspace environment\./,
+  );
+});
+
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workstation-local path hygiene fails", async () => {
   const config = createConfig({ localCiCommand: "npm run ci:local" });
   const issue = createIssue({ title: "Gate ready promotion on path hygiene" });

--- a/src/supervisor/supervisor-operator-activity-context.ts
+++ b/src/supervisor/supervisor-operator-activity-context.ts
@@ -86,6 +86,7 @@ function isLocalCiBlockingFailureSignature(signature: string | null): boolean {
   return (
     signature === "local-ci-gate-failed" ||
     signature === "local-ci-gate-missing_command" ||
+    signature === "local-ci-gate-workspace_toolchain_missing" ||
     signature === "local-ci-gate-non_zero_exit"
   );
 }


### PR DESCRIPTION
## Summary
- classify explicit workspace toolchain bootstrap failures as local-CI workspace-environment problems instead of repo-owned command failures
- keep the local-CI gate fail-closed while improving remediation targeting and operator messaging

## Why
- operators need to tell whether a failure means the repo command is broken or the workspace cannot execute the expected toolchain entrypoint at all
- the observed `tsc is not installed in this workspace` mode was being folded into the generic repo-owned-command bucket

## Validation
- npx tsx --test src/local-ci.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-operator-activity-context.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and classification of missing workspace toolchain errors.
  * Implemented targeted remediation guidance for workspace environment issues.
  * Enhanced failure reporting to distinguish workspace toolchain problems from other error types, helping users identify and resolve issues more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->