### PR TITLE
[codex] Unify tracked PR lifecycle projection across runtime and diagnostics

### DIFF
--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -117,3 +117,62 @@ test("projectTrackedPrLifecycle flags failed projections for suppression", () =>
   assert.equal(projection.nextBlockedReason, null);
   assert.equal(projection.shouldSuppressRecovery, true);
 });
+
+test("projectTrackedPrLifecycle passes the fully patched tracked PR record into lifecycle inference and blocker derivation", () => {
+  const config = createConfig();
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 191,
+    last_head_sha: "head-old-191",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    headRefOid: "head-new-191",
+  });
+
+  let inferredRecord: ReturnType<typeof createRecord> | null = null;
+  let blockedReasonRecord: ReturnType<typeof createRecord> | null = null;
+  const projection = projectTrackedPrLifecycle({
+    config,
+    record,
+    pr,
+    checks: [],
+    reviewThreads: [],
+    syncReviewWaitWindow: () => ({
+      review_wait_started_at: "2026-03-31T00:01:00Z",
+      review_wait_head_sha: "head-new-191",
+    }),
+    syncCopilotReviewRequestObservation: () => ({
+      copilot_review_requested_observed_at: "2026-03-31T00:02:00Z",
+      copilot_review_requested_head_sha: "head-new-191",
+    }),
+    syncCopilotReviewTimeoutState: () => ({
+      copilot_review_timed_out_at: "2026-03-31T00:03:00Z",
+      copilot_review_timeout_action: "continue",
+      copilot_review_timeout_reason: "review pending",
+    }),
+    inferStateFromPullRequest: (_config, recordForState) => {
+      inferredRecord = recordForState;
+      return "blocked";
+    },
+    blockedReasonForLifecycleState: (_config, recordForState) => {
+      blockedReasonRecord = recordForState;
+      return "verification";
+    },
+  });
+
+  assert.equal(inferredRecord, projection.recordForState);
+  assert.equal(blockedReasonRecord, projection.recordForState);
+  assert.equal(projection.recordForState.pr_number, 191);
+  assert.equal(projection.recordForState.last_head_sha, "head-new-191");
+  assert.equal(projection.recordForState.review_wait_started_at, "2026-03-31T00:01:00Z");
+  assert.equal(projection.recordForState.review_wait_head_sha, "head-new-191");
+  assert.equal(projection.recordForState.copilot_review_requested_observed_at, "2026-03-31T00:02:00Z");
+  assert.equal(projection.recordForState.copilot_review_requested_head_sha, "head-new-191");
+  assert.equal(projection.recordForState.copilot_review_timed_out_at, "2026-03-31T00:03:00Z");
+  assert.equal(projection.recordForState.copilot_review_timeout_action, "continue");
+  assert.equal(projection.recordForState.copilot_review_timeout_reason, "review pending");
+  assert.equal(projection.nextState, "blocked");
+  assert.equal(projection.nextBlockedReason, "verification");
+});


### PR DESCRIPTION
## Summary
- add a focused regression test for the shared tracked PR lifecycle projection helper
- lock down the single projected `recordForState` boundary used by lifecycle inference and blocked-reason derivation
- verify the existing refactor still preserves the synchronized review-wait and Copilot observation/timeout patches

## Why
The runtime reconciliation and diagnostics paths now rely on one shared projection helper. This PR hardens that boundary so future lifecycle-field additions cannot drift silently between the two callers.

## Impact
Operator-visible lifecycle behavior is unchanged. The added coverage reduces the risk of divergence in draft, blocked, waiting CI, conflict, and ready-to-merge lifecycle inference.

## Validation
- `npx tsx --test src/tracked-pr-lifecycle-projection.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating the lifecycle projection mechanism, including state inference and blocker derivation verification. Tests ensure proper field synchronization across state transitions, accurate blocker reason determination, and correct behavior with mocked collaborators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->