### PR TITLE
[codex] Extract shared supervisor orchestration test fixtures

### DIFF
--- a/src/orchestration-test-helpers.ts
+++ b/src/orchestration-test-helpers.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { type CodexTurnContext } from "./run-once-turn-execution";
+import {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+  WorkspaceStatus,
+} from "./core/types";
+import {
+  createIssue as createRunOnceIssue,
+  createPullRequest as createRunOncePullRequest,
+  createRecord as createRunOnceRecord,
+} from "./turn-execution-test-helpers";
+import {
+  branchName,
+  createIssue as createSupervisorIssue,
+  createPullRequest as createSupervisorPullRequest,
+  createRecord as createSupervisorRecord,
+} from "./supervisor/supervisor-test-helpers";
+
+export function trackedIssuePaths(workspaceRoot: string, issueNumber: number): {
+  workspacePath: string;
+  journalPath: string;
+} {
+  const workspacePath = path.join(workspaceRoot, `issue-${issueNumber}`);
+  return {
+    workspacePath,
+    journalPath: path.join(workspacePath, ".codex-supervisor", "issue-journal.md"),
+  };
+}
+
+export function createWorkspaceStatus(overrides: Partial<WorkspaceStatus> = {}): WorkspaceStatus {
+  return {
+    branch: "codex/issue-102",
+    headSha: "head-116",
+    hasUncommittedChanges: false,
+    baseAhead: 0,
+    baseBehind: 0,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+    remoteBehind: 0,
+    ...overrides,
+  };
+}
+
+export function createCodexTurnContext(
+  overrides: Omit<Partial<CodexTurnContext>, "workspaceStatus"> & {
+    issueNumber?: number;
+    workspaceRoot?: string;
+    workspaceStatus?: Partial<WorkspaceStatus>;
+  } = {},
+): CodexTurnContext {
+  const issueNumber = overrides.issueNumber ?? overrides.record?.issue_number ?? overrides.issue?.number ?? 102;
+  const workspaceRoot = overrides.workspaceRoot ?? "/tmp/workspaces";
+  const { workspacePath, journalPath } = trackedIssuePaths(workspaceRoot, issueNumber);
+  const record =
+    overrides.record ??
+    createRunOnceRecord({
+      issue_number: issueNumber,
+      workspace: workspacePath,
+      journal_path: journalPath,
+    });
+
+  return {
+    state: overrides.state ?? {
+      activeIssueNumber: issueNumber,
+      issues: {
+        [String(issueNumber)]: record,
+      },
+    },
+    record,
+    issue: overrides.issue ?? createRunOnceIssue({ number: issueNumber }),
+    previousCodexSummary: overrides.previousCodexSummary ?? null,
+    previousError: overrides.previousError ?? null,
+    workspacePath: overrides.workspacePath ?? workspacePath,
+    journalPath: overrides.journalPath ?? journalPath,
+    syncJournal: overrides.syncJournal ?? (async () => undefined),
+    memoryArtifacts: overrides.memoryArtifacts ?? {
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+    },
+    workspaceStatus: createWorkspaceStatus({
+      branch: record.branch,
+      headSha: record.last_head_sha ?? "head-116",
+      ...overrides.workspaceStatus,
+    }),
+    pr:
+      overrides.pr === undefined
+        ? record.pr_number === null
+          ? null
+          : createRunOncePullRequest({
+              number: record.pr_number,
+              headRefName: record.branch,
+              headRefOid: record.last_head_sha ?? "head-116",
+            })
+        : overrides.pr,
+    checks: overrides.checks ?? [],
+    reviewThreads: overrides.reviewThreads ?? [],
+    options: overrides.options ?? { dryRun: false },
+  };
+}
+
+export function createTrackedSupervisorRecord(
+  config: SupervisorConfig,
+  workspaceRoot: string,
+  issueNumber: number,
+  overrides: Partial<IssueRunRecord> = {},
+): IssueRunRecord {
+  const branch = branchName(config, issueNumber);
+  const { workspacePath, journalPath } = trackedIssuePaths(workspaceRoot, issueNumber);
+  return createSupervisorRecord({
+    issue_number: issueNumber,
+    branch,
+    workspace: workspacePath,
+    journal_path: journalPath,
+    ...overrides,
+  });
+}
+
+export async function writeSupervisorState(stateFile: string, state: SupervisorStateFile): Promise<void> {
+  await fs.writeFile(stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+export function createTrackedIssue(
+  issueNumber: number,
+  overrides: Partial<GitHubIssue> = {},
+): GitHubIssue {
+  return createSupervisorIssue({
+    number: issueNumber,
+    ...overrides,
+  });
+}
+
+export function createTrackedPullRequest(
+  config: SupervisorConfig,
+  issueNumber: number,
+  overrides: Partial<GitHubPullRequest> = {},
+): GitHubPullRequest {
+  return createSupervisorPullRequest({
+    headRefName: branchName(config, issueNumber),
+    ...overrides,
+  });
+}
+
+export type { PullRequestCheck, ReviewThread };

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { executeCodexTurnPhase } from "./run-once-turn-execution";
 import { FailureContextCategory, GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorStateFile } from "./core/types";
+import { createCodexTurnContext, createWorkspaceStatus } from "./orchestration-test-helpers";
 import { createConfig, createIssue, createPullRequest, createRecord, createReviewThread } from "./turn-execution-test-helpers";
 import { AgentRunner, AgentTurnRequest } from "./supervisor/agent-runner";
 import { interruptedTurnMarkerPath } from "./interrupted-turn-marker";
@@ -60,6 +61,18 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
   let journalReads = 0;
   let resolveCalls = 0;
   const resolvePurposes: Array<"status" | "action" | undefined> = [];
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    pr: initialPr,
+    checks: [],
+    reviewThreads,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-b",
+    },
+  });
   const result = await executeCodexTurnPhase({
     config,
     stateStore: {
@@ -81,36 +94,7 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
         throw new Error("unexpected getExternalReviewSurface call");
       },
     },
-    context: {
-      state,
-      record: state.issues["102"]!,
-      issue,
-      previousCodexSummary: null,
-      previousError: null,
-      workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
-      syncJournal: async () => undefined,
-      memoryArtifacts: {
-        alwaysReadFiles: [],
-        onDemandFiles: [],
-        contextIndexPath: "/tmp/context-index.md",
-        agentsPath: "/tmp/AGENTS.generated.md",
-      },
-      workspaceStatus: {
-        branch: "codex/issue-102",
-        headSha: "head-b",
-        hasUncommittedChanges: false,
-        baseAhead: 0,
-        baseBehind: 0,
-        remoteBranchExists: true,
-        remoteAhead: 0,
-        remoteBehind: 0,
-      },
-      pr: initialPr,
-      checks: [],
-      reviewThreads,
-      options: { dryRun: false },
-    },
+    context,
     acquireSessionLock: async () => null,
     classifyFailure: () => "command_error",
     buildCodexFailureContext: (category, summary, details) => ({
@@ -150,16 +134,7 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    getWorkspaceStatus: async () => ({
-      branch: "codex/issue-102",
-      headSha: "head-b",
-      hasUncommittedChanges: false,
-      baseAhead: 0,
-      baseBehind: 0,
-      remoteBranchExists: true,
-      remoteAhead: 0,
-      remoteBehind: 0,
-    }),
+    getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b" }),
     pushBranch: async () => {
       throw new Error("unexpected pushBranch call");
     },
@@ -212,6 +187,25 @@ test("executeCodexTurnPhase skips prompt preparation side effects when the sessi
     },
   };
   let syncJournalCalls = 0;
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-a",
+    },
+    pr: createPullRequest({
+      title: "Session-locked review turn",
+      reviewDecision: "CHANGES_REQUESTED",
+      headRefOid: "head-a",
+    }),
+    checks: [],
+    reviewThreads: [createReviewThread()],
+  });
 
   const result = await executeCodexTurnPhase({
     config: createConfig(),
@@ -236,42 +230,7 @@ test("executeCodexTurnPhase skips prompt preparation side effects when the sessi
         throw new Error("unexpected getExternalReviewSurface call");
       },
     },
-    context: {
-      state,
-      record: state.issues["102"]!,
-      issue,
-      previousCodexSummary: null,
-      previousError: null,
-      workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
-      syncJournal: async () => {
-        syncJournalCalls += 1;
-      },
-      memoryArtifacts: {
-        alwaysReadFiles: [],
-        onDemandFiles: [],
-        contextIndexPath: "/tmp/context-index.md",
-        agentsPath: "/tmp/AGENTS.generated.md",
-      },
-      workspaceStatus: {
-        branch: "codex/issue-102",
-        headSha: "head-a",
-        hasUncommittedChanges: false,
-        baseAhead: 0,
-        baseBehind: 0,
-        remoteBranchExists: true,
-        remoteAhead: 0,
-        remoteBehind: 0,
-      },
-      pr: createPullRequest({
-        title: "Session-locked review turn",
-        reviewDecision: "CHANGES_REQUESTED",
-        headRefOid: "head-a",
-      }),
-      checks: [],
-      reviewThreads: [createReviewThread()],
-      options: { dryRun: false },
-    },
+    context,
     acquireSessionLock: async () => ({
       sessionId: "session-102",
       acquired: false,
@@ -331,6 +290,22 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
   };
   let createPullRequestCalls = 0;
   let syncJournalCalls = 0;
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-b",
+      baseAhead: 1,
+    },
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+  });
 
   const result = await executeCodexTurnPhase({
     config: createConfig({ localCiCommand: "npm run ci:local" }),
@@ -350,38 +325,7 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
         throw new Error("unexpected getExternalReviewSurface call");
       },
     },
-    context: {
-      state,
-      record: state.issues["102"]!,
-      issue,
-      previousCodexSummary: null,
-      previousError: null,
-      workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
-      syncJournal: async () => {
-        syncJournalCalls += 1;
-      },
-      memoryArtifacts: {
-        alwaysReadFiles: [],
-        onDemandFiles: [],
-        contextIndexPath: "/tmp/context-index.md",
-        agentsPath: "/tmp/AGENTS.generated.md",
-      },
-      workspaceStatus: {
-        branch: "codex/issue-102",
-        headSha: "head-b",
-        hasUncommittedChanges: false,
-        baseAhead: 1,
-        baseBehind: 0,
-        remoteBranchExists: true,
-        remoteAhead: 0,
-        remoteBehind: 0,
-      },
-      pr: null,
-      checks: [],
-      reviewThreads: [],
-      options: { dryRun: false },
-    },
+    context,
     acquireSessionLock: async () => null,
     classifyFailure: () => "command_error",
     buildCodexFailureContext: (category, summary, details) => ({
@@ -421,16 +365,7 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    getWorkspaceStatus: async () => ({
-      branch: "codex/issue-102",
-      headSha: "head-b",
-      hasUncommittedChanges: false,
-      baseAhead: 1,
-      baseBehind: 0,
-      remoteBranchExists: true,
-      remoteAhead: 0,
-      remoteBehind: 0,
-    }),
+    getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b", baseAhead: 1 }),
     pushBranch: async () => undefined,
     readIssueJournal: (() => {
       let readCount = 0;
@@ -513,6 +448,21 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
   };
   let pushBranchCalls = 0;
   let syncJournalCalls = 0;
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-a",
+    },
+    pr,
+    checks: [],
+    reviewThreads: [],
+  });
 
   const result = await executeCodexTurnPhase({
     config: createConfig({ localCiCommand: "npm run ci:local" }),
@@ -531,38 +481,7 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
         throw new Error("unexpected getExternalReviewSurface call");
       },
     },
-    context: {
-      state,
-      record: state.issues["102"]!,
-      issue,
-      previousCodexSummary: null,
-      previousError: null,
-      workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
-      syncJournal: async () => {
-        syncJournalCalls += 1;
-      },
-      memoryArtifacts: {
-        alwaysReadFiles: [],
-        onDemandFiles: [],
-        contextIndexPath: "/tmp/context-index.md",
-        agentsPath: "/tmp/AGENTS.generated.md",
-      },
-      workspaceStatus: {
-        branch: "codex/issue-102",
-        headSha: "head-a",
-        hasUncommittedChanges: false,
-        baseAhead: 0,
-        baseBehind: 0,
-        remoteBranchExists: true,
-        remoteAhead: 0,
-        remoteBehind: 0,
-      },
-      pr,
-      checks: [],
-      reviewThreads: [],
-      options: { dryRun: false },
-    },
+    context,
     acquireSessionLock: async () => null,
     classifyFailure: () => "command_error",
     buildCodexFailureContext: (category, summary, details) => ({
@@ -602,16 +521,7 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    getWorkspaceStatus: async () => ({
-      branch: "codex/issue-102",
-      headSha: "head-b",
-      hasUncommittedChanges: false,
-      baseAhead: 0,
-      baseBehind: 0,
-      remoteBranchExists: true,
-      remoteAhead: 1,
-      remoteBehind: 0,
-    }),
+    getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b", remoteAhead: 1 }),
     pushBranch: async () => {
       pushBranchCalls += 1;
     },

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -24,6 +24,13 @@ import {
   executionReadyBody,
   git,
 } from "./supervisor-test-helpers";
+import {
+  createTrackedIssue,
+  createTrackedPullRequest,
+  createTrackedSupervisorRecord,
+  trackedIssuePaths,
+  writeSupervisorState,
+} from "../orchestration-test-helpers";
 import { captureIssueJournalFingerprint, interruptedTurnMarkerPath } from "../interrupted-turn-marker";
 
 test("runOnce records timeout bookkeeping when Codex exits non-zero", async () => {
@@ -53,15 +60,11 @@ test("runOnce records timeout bookkeeping when Codex exits non-zero", async () =
     ],
   });
   const issueNumber = 89;
-  const branch = branchName(fixture.config, issueNumber);
   const state: SupervisorStateFile = createSupervisorState({
     activeIssueNumber: issueNumber,
     issues: [
-      createRecord({
-        issue_number: issueNumber,
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
         state: "stabilizing",
-        branch,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         journal_path: null,
         codex_session_id: null,
         timeout_retry_count: 0,
@@ -74,10 +77,9 @@ test("runOnce records timeout bookkeeping when Codex exits non-zero", async () =
       }),
     ],
   });
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
 
-  const issue = createIssue({
-    number: issueNumber,
+  const issue = createTrackedIssue(issueNumber, {
     title: "Capture timeout failure bookkeeping",
   });
 
@@ -171,20 +173,18 @@ test("runOnce dry-run selects an issue and hydrates workspace and PR context bef
   const issueNumber = 91;
   const branch = branchName(fixture.config, issueNumber);
   const state: SupervisorStateFile = createSupervisorState();
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
 
-  const issue = createIssue({
-    number: issueNumber,
+  const issue = createTrackedIssue(issueNumber, {
     title: "Extract supervisor setup helpers",
     body: executionReadyBody("Extract supervisor setup helpers."),
     labels: [],
   });
-  const pr = createPullRequest({
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
     number: 112,
     title: "Draft setup refactor",
     createdAt: "2026-03-13T00:10:00Z",
     isDraft: true,
-    headRefName: branch,
     headRefOid: "head-112",
   });
   const checks: PullRequestCheck[] = [];
@@ -252,28 +252,23 @@ test("runOnce reconciles tracked PR state before reserving a new runnable issue"
   const selectedIssueNumber = 91;
   const unrelatedIssueNumber = 92;
   const selectedBranch = branchName(fixture.config, selectedIssueNumber);
-  const unrelatedBranch = branchName(fixture.config, unrelatedIssueNumber);
   const state: SupervisorStateFile = createSupervisorState({
     issues: [
-      createRecord({
-        issue_number: unrelatedIssueNumber,
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, unrelatedIssueNumber, {
         state: "waiting_ci",
-        branch: unrelatedBranch,
         pr_number: 192,
         codex_session_id: null,
       }),
     ],
   });
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
 
-  const selectedIssue = createIssue({
-    number: selectedIssueNumber,
+  const selectedIssue = createTrackedIssue(selectedIssueNumber, {
     title: "Reserve the next runnable issue before broad reconciliation",
     body: executionReadyBody("Reserve the runnable issue before unrelated reconciliation."),
     labels: [],
   });
-  const unrelatedIssue = createIssue({
-    number: unrelatedIssueNumber,
+  const unrelatedIssue = createTrackedIssue(unrelatedIssueNumber, {
     title: "Slow unrelated reconciliation target",
     body: executionReadyBody("Remain unrelated to the selected runnable issue."),
     createdAt: "2026-03-13T00:05:00Z",
@@ -281,11 +276,10 @@ test("runOnce reconciles tracked PR state before reserving a new runnable issue"
     labels: [],
   });
 
-  const unrelatedPr = createPullRequest({
+  const unrelatedPr = createTrackedPullRequest(fixture.config, unrelatedIssueNumber, {
     number: 192,
     title: "Existing tracked PR",
     createdAt: "2026-03-13T00:03:00Z",
-    headRefName: unrelatedBranch,
     headRefOid: "head-192",
   });
 
@@ -337,10 +331,8 @@ test("runOnce converges stale failed tracked PR state before selecting the resum
   const branch = branchName(fixture.config, issueNumber);
   const state: SupervisorStateFile = createSupervisorState({
     issues: [
-      createRecord({
-        issue_number: issueNumber,
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
         state: "failed",
-        branch,
         pr_number: 191,
         last_head_sha: "head-191",
         last_error: "Stopped after repeated repair attempts.",
@@ -359,18 +351,16 @@ test("runOnce converges stale failed tracked PR state before selecting the resum
       }),
     ],
   });
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
 
-  const issue = createIssue({
-    number: issueNumber,
+  const issue = createTrackedIssue(issueNumber, {
     title: "Converge stale failed tracked PR state",
     body: executionReadyBody("Recover the authoritative tracked PR lifecycle state before selection."),
   });
-  const pr = createPullRequest({
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
     number: 191,
     title: "Recovery implementation",
     isDraft: true,
-    headRefName: branch,
     headRefOid: "head-191",
   });
 
@@ -436,13 +426,9 @@ test("prepareIssueExecutionContext blocks PR publication when configured local C
   fixture.config.localCiCommand = "npm run ci:local";
   const issueNumber = 91;
   const branch = branchName(fixture.config, issueNumber);
-  const record = createRecord({
-    issue_number: issueNumber,
+  const record = createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
     state: "stabilizing",
-    branch,
     pr_number: null,
-    workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
-    journal_path: path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor", "issue-journal.md"),
     blocked_reason: null,
     last_error: null,
     last_failure_kind: null,
@@ -455,8 +441,7 @@ test("prepareIssueExecutionContext blocks PR publication when configured local C
     issues: [record],
   });
 
-  const issue = createIssue({
-    number: issueNumber,
+  const issue = createTrackedIssue(issueNumber, {
     title: "Gate PR publication on local CI",
     body: executionReadyBody("Run configured local CI before opening the PR."),
   });
@@ -534,11 +519,8 @@ test("runOnce reclaims a stale stabilizing issue without carrying mismatched tra
   const state: SupervisorStateFile = createSupervisorState({
     activeIssueNumber: issueNumber,
     issues: [
-      createRecord({
-        issue_number: issueNumber,
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
         state: "stabilizing",
-        branch,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         journal_path: null,
         pr_number: 527,
         codex_session_id: "stale-session",
@@ -547,10 +529,9 @@ test("runOnce reclaims a stale stabilizing issue without carrying mismatched tra
       }),
     ],
   });
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
 
-  const issue = createIssue({
-    number: issueNumber,
+  const issue = createTrackedIssue(issueNumber, {
     title: "Recover stale stabilizing reservation",
     body: executionReadyBody("Recover stale stabilizing reservation."),
   });
@@ -614,12 +595,9 @@ test("runOnce clears stale failed tracked PR recovery on the same head before co
   const branch = branchName(fixture.config, issueNumber);
   const state: SupervisorStateFile = createSupervisorState({
     issues: [
-      createRecord({
-        issue_number: issueNumber,
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
         state: "failed",
-        branch,
         pr_number: 191,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         journal_path: null,
         last_head_sha: "head-191",
         attempt_count: 3,
@@ -641,20 +619,18 @@ test("runOnce clears stale failed tracked PR recovery on the same head before co
       }),
     ],
   });
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
 
-  const issue = createIssue({
-    number: issueNumber,
+  const issue = createTrackedIssue(issueNumber, {
     title: "Recover stale failed tracked PR state through runOnce",
     body: executionReadyBody("Recover stale failed tracked PR state through runOnce."),
     updatedAt: "2026-03-13T00:21:00Z",
     labels: [],
   });
-  const pr = createPullRequest({
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
     number: 191,
     title: "Recovery implementation",
     isDraft: true,
-    headRefName: branch,
     headRefOid: "head-191",
   });
 
@@ -719,29 +695,33 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
   const nextIssueNumber = 92;
   const interruptedBranch = branchName(fixture.config, interruptedIssueNumber);
   const nextBranch = branchName(fixture.config, nextIssueNumber);
-  const interruptedWorkspace = path.join(fixture.workspaceRoot, `issue-${interruptedIssueNumber}`);
-  const interruptedJournalPath = path.join(interruptedWorkspace, ".codex-supervisor", "issue-journal.md");
+  const { workspacePath: interruptedWorkspace, journalPath: interruptedJournalPath } = trackedIssuePaths(
+    fixture.workspaceRoot,
+    interruptedIssueNumber,
+  );
   const state: SupervisorStateFile = {
     activeIssueNumber: interruptedIssueNumber,
     issues: {
-      [String(interruptedIssueNumber)]: createRecord({
-        issue_number: interruptedIssueNumber,
-        state: "implementing",
-        branch: interruptedBranch,
-        workspace: interruptedWorkspace,
-        journal_path: interruptedJournalPath,
-        pr_number: null,
-        codex_session_id: "stale-session",
-        blocked_reason: null,
-        last_error: null,
-        last_failure_context: null,
-        last_failure_signature: null,
-        repeated_failure_signature_count: 0,
-        updated_at: "2026-03-26T00:00:00.000Z",
-      }),
+      [String(interruptedIssueNumber)]: createTrackedSupervisorRecord(
+        fixture.config,
+        fixture.workspaceRoot,
+        interruptedIssueNumber,
+        {
+          state: "implementing",
+          branch: interruptedBranch,
+          pr_number: null,
+          codex_session_id: "stale-session",
+          blocked_reason: null,
+          last_error: null,
+          last_failure_context: null,
+          last_failure_signature: null,
+          repeated_failure_signature_count: 0,
+          updated_at: "2026-03-26T00:00:00.000Z",
+        },
+      ),
     },
   };
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeSupervisorState(fixture.stateFile, state);
   await fs.mkdir(path.dirname(interruptedJournalPath), { recursive: true });
   await fs.writeFile(interruptedJournalPath, "# issue journal\n", "utf8");
   const initialJournalFingerprint = await captureIssueJournalFingerprint(interruptedJournalPath);


### PR DESCRIPTION
## Summary
- extract shared orchestration test helpers for tracked issue paths, persisted supervisor state, and default Codex turn context setup
- replace repeated inline fixture scaffolding in the run-once and supervisor orchestration test suites
- preserve existing scenario assertions and orchestration behavior coverage

## Verification
- npx tsx --test src/run-once-turn-execution.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test helper utilities for orchestration workflows.
  * Refactored existing tests to use the new utilities, reducing code duplication and improving consistency across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->