### PR TITLE
[codex] Fail closed on ambiguous-owner supervisor locks

### DIFF
--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -832,6 +832,90 @@ test("statusReport exposes typed loop runtime state from the host runtime marker
   assert.match(report.loopRuntime?.startedAt ?? "", /^\d{4}-\d{2}-\d{2}T/u);
 });
 
+test("acquireSupervisorLock fails closed on ambiguous-owner run locks", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const lockPath = path.resolve(path.dirname(fixture.stateFile), "locks", "supervisor", "run.lock");
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(
+    lockPath,
+    `${JSON.stringify({
+      pid: 999_999,
+      label: "supervisor-loop",
+      acquired_at: "2026-03-20T00:00:00.000Z",
+      host: "other-host",
+      owner: "other-user",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const supervisor = new Supervisor(fixture.config);
+  const lock = await supervisor.acquireSupervisorLock("run-once");
+
+  assert.equal(lock.acquired, false);
+  assert.match(lock.reason ?? "", /ambiguous owner/i);
+  assert.deepEqual(JSON.parse(await fs.readFile(lockPath, "utf8")), {
+    pid: 999_999,
+    label: "supervisor-loop",
+    acquired_at: "2026-03-20T00:00:00.000Z",
+    host: "other-host",
+    owner: "other-user",
+  });
+});
+
+test("acquireLoopRuntimeLock fails closed on ambiguous-owner loop runtime locks and keeps diagnostics visible", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const lockPath = path.resolve(path.dirname(fixture.stateFile), "locks", "supervisor", "loop-runtime.lock");
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(
+    lockPath,
+    `${JSON.stringify({
+      pid: 999_999,
+      label: "supervisor-loop-runtime",
+      acquired_at: "2026-03-20T00:00:00.000Z",
+      host: "other-host",
+      owner: "other-user",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const lock = await supervisor.acquireLoopRuntimeLock();
+
+  assert.equal(lock.acquired, false);
+  assert.match(lock.reason ?? "", /ambiguous owner/i);
+  assert.deepEqual(JSON.parse(await fs.readFile(lockPath, "utf8")), {
+    pid: 999_999,
+    label: "supervisor-loop-runtime",
+    acquired_at: "2026-03-20T00:00:00.000Z",
+    host: "other-host",
+    owner: "other-user",
+  });
+
+  const report = await supervisor.statusReport();
+  assert.deepEqual(report.loopRuntime, {
+    state: "unknown",
+    pid: 999_999,
+    startedAt: "2026-03-20T00:00:00.000Z",
+    detail: "supervisor-loop-runtime",
+  });
+});
+
 test("statusReport exposes typed active-issue and selection summary fields alongside legacy lines", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -15,9 +15,7 @@ export function supervisorLoopRuntimeLockPath(stateFile: string): string {
 }
 
 export async function acquireSupervisorLoopRuntimeLock(stateFile: string): Promise<LockHandle> {
-  return acquireFileLock(supervisorLoopRuntimeLockPath(stateFile), LOOP_RUNTIME_LOCK_LABEL, {
-    allowAmbiguousOwnerCleanup: true,
-  });
+  return acquireFileLock(supervisorLoopRuntimeLockPath(stateFile), LOOP_RUNTIME_LOCK_LABEL);
 }
 
 export async function inspectSupervisorLoopRuntimeLock(stateFile: string): Promise<ExistingLockState> {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -985,9 +985,7 @@ export class Supervisor {
   }
 
   async acquireSupervisorLock(label: "loop" | "run-once"): Promise<LockHandle> {
-    const lock = await acquireFileLock(this.lockPath("supervisor", "run"), `supervisor-${label}`, {
-      allowAmbiguousOwnerCleanup: true,
-    });
+    const lock = await acquireFileLock(this.lockPath("supervisor", "run"), `supervisor-${label}`);
     if (lock.acquired) {
       return lock;
     }


### PR DESCRIPTION
## Summary
- fail closed when supervisor run-lock acquisition encounters an `ambiguous_owner` lock
- fail closed when loop-runtime lock acquisition encounters an `ambiguous_owner` lock
- preserve operator-visible diagnostics instead of implicitly reclaiming the lock

## Testing
- npx tsx --test src/lock.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Closes #1240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for supervisor lock acquisition failures when lock metadata contains ambiguous owner information.

* **Bug Fixes**
  * Updated supervisor lock acquisition to fail safely and deny access when encountering ambiguous lock metadata, removing automatic recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->