### PR TITLE
[codex] Add request-size limits to WebUI JSON body parsing

### DIFF
--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -1597,6 +1597,67 @@ test("createSupervisorHttpServer rejects malformed setup config write requests b
   assert.deepEqual(setupConfigUpdateCalls, []);
 });
 
+test("createSupervisorHttpServer preserves the malformed JSON error contract for setup config writes", async (t) => {
+  const setupConfigUpdateCalls: Array<unknown> = [];
+  const server = createSupervisorHttpServer({
+    service: createStubService({ setupConfigUpdateCalls }),
+    mutationAuth: testMutationAuth,
+  });
+  t.after(async () => {
+    await closeServer(server);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.on("error", reject);
+  });
+
+  const response = await readJson({
+    server,
+    path: "/api/setup-config",
+    method: "POST",
+    headers: mutationAuthHeaders(server, { "Content-Type": "application/json" }),
+    body: "{\"changes\":",
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, { error: "Request body must be valid JSON." });
+  assert.deepEqual(setupConfigUpdateCalls, []);
+});
+
+test("createSupervisorHttpServer rejects oversized setup config write requests before calling the service", async (t) => {
+  const setupConfigUpdateCalls: Array<unknown> = [];
+  const server = createSupervisorHttpServer({
+    service: createStubService({ setupConfigUpdateCalls }),
+    mutationAuth: testMutationAuth,
+  });
+  t.after(async () => {
+    await closeServer(server);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.on("error", reject);
+  });
+
+  const response = await readJson({
+    server,
+    path: "/api/setup-config",
+    method: "POST",
+    headers: mutationAuthHeaders(server, { "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      changes: {
+        reviewProvider: "codex",
+        notes: "x".repeat(1024 * 1024),
+      },
+    }),
+  });
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(response.body, { error: "Request body exceeds the maximum JSON size." });
+  assert.deepEqual(setupConfigUpdateCalls, []);
+});
+
 test("createSupervisorHttpServer serves a dashboard shell with only the safe operator command actions", async (t) => {
   const server = createSupervisorHttpServer({
     service: createStubService(),

--- a/src/backend/supervisor-http-server.ts
+++ b/src/backend/supervisor-http-server.ts
@@ -60,6 +60,8 @@ interface SseClientConnection {
   heartbeat: NodeJS.Timeout;
 }
 
+const MAX_JSON_BODY_BYTES = 256 * 1024;
+
 export function createSupervisorHttpServer(options: CreateSupervisorHttpServerOptions): http.Server {
   const events = new SupervisorSseEventStream(options.service, {
     heartbeatIntervalMs: options.heartbeatIntervalMs ?? 15_000,
@@ -421,9 +423,19 @@ function parseLastEventId(value: string | string[] | undefined): number | null {
 }
 
 async function readJsonBody(request: http.IncomingMessage): Promise<unknown> {
+  const contentLength = readContentLengthHeader(request.headers["content-length"]);
+  if (contentLength !== null && contentLength > MAX_JSON_BODY_BYTES) {
+    throw new HttpRequestError(413, "Request body exceeds the maximum JSON size.");
+  }
+
   let payload = "";
+  let payloadBytes = 0;
   request.setEncoding("utf8");
   for await (const chunk of request) {
+    payloadBytes += Buffer.byteLength(chunk);
+    if (payloadBytes > MAX_JSON_BODY_BYTES) {
+      throw new HttpRequestError(413, "Request body exceeds the maximum JSON size.");
+    }
     payload += chunk;
   }
 
@@ -436,6 +448,19 @@ async function readJsonBody(request: http.IncomingMessage): Promise<unknown> {
   } catch {
     throw new HttpRequestError(400, "Request body must be valid JSON.");
   }
+}
+
+function readContentLengthHeader(value: string | string[] | undefined): number | null {
+  const header = readSingleHeaderValue(value);
+  if (!header) {
+    return null;
+  }
+
+  const contentLength = Number.parseInt(header, 10);
+  if (!Number.isFinite(contentLength) || contentLength < 0) {
+    return null;
+  }
+  return contentLength;
 }
 
 function readPositiveInteger(body: unknown, fieldName: string): number | null {


### PR DESCRIPTION
## Summary
- add a hard 256 KiB limit to WebUI JSON request body parsing
- reject oversized JSON bodies with HTTP 413 before mutation handlers run
- preserve the existing malformed JSON 400 contract with explicit regression coverage

## Root cause
The WebUI HTTP server buffered JSON mutation request bodies without any size bound, so oversized local requests could be read fully into memory before parse or rejection.

## Verification
- `npx tsx --test src/backend/supervisor-http-server.test.ts`
- `npm run build`

Closes #1241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request body size validation now enforced (256 KiB limit) with appropriate error responses for oversized payloads
  * Enhanced JSON format validation with specific error responses for malformed input

* **Tests**
  * Added coverage for oversized request and malformed JSON validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->