### PR TITLE
[codex] Rotate setup config backups instead of overwriting one .bak

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1029,6 +1029,79 @@ test("updateSetupConfig preserves unrelated fields, writes a backup, and refresh
   assert.equal(result.readiness.providerPosture.profile, "codex");
 });
 
+test("updateSetupConfig rotates multiple backups across consecutive writes with bounded retention", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-rotate-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        repoPath: ".",
+        repoSlug: "owner/repo",
+        defaultBranch: "main",
+        workspaceRoot: "./worktrees",
+        stateFile: "./state.json",
+        codexBinary: "codex",
+        branchPrefix: "codex/issue-",
+        reviewBotLogins: [],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const firstResult = await updateSetupConfig({
+    configPath,
+    changes: {
+      reviewProvider: "codex",
+    },
+  });
+  const secondResult = await updateSetupConfig({
+    configPath,
+    changes: {
+      branchPrefix: "codex/task-",
+    },
+  });
+  for (let index = 0; index < 6; index += 1) {
+    await updateSetupConfig({
+      configPath,
+      changes: {
+        defaultBranch: `main-${index}`,
+      },
+    });
+  }
+
+  assert.ok(firstResult.backupPath);
+  assert.ok(secondResult.backupPath);
+  assert.equal(firstResult.backupPath, secondResult.backupPath);
+
+  const backupPaths = (await fs.readdir(tempDir))
+    .filter((entry) => entry.startsWith("supervisor.config.json.bak"))
+    .sort()
+    .map((entry) => path.join(tempDir, entry));
+
+  assert.deepEqual(backupPaths, [
+    path.join(tempDir, "supervisor.config.json.bak"),
+    path.join(tempDir, "supervisor.config.json.bak.1"),
+    path.join(tempDir, "supervisor.config.json.bak.2"),
+    path.join(tempDir, "supervisor.config.json.bak.3"),
+    path.join(tempDir, "supervisor.config.json.bak.4"),
+  ]);
+
+  const secondBackupDocument = JSON.parse(await fs.readFile(secondResult.backupPath, "utf8")) as Record<string, unknown>;
+  const oldestRetainedBackup = JSON.parse(
+    await fs.readFile(path.join(tempDir, "supervisor.config.json.bak.4"), "utf8"),
+  ) as Record<string, unknown>;
+
+  assert.deepEqual(secondBackupDocument.reviewBotLogins, ["chatgpt-codex-connector"]);
+  assert.equal(secondBackupDocument.defaultBranch, "main-4");
+  assert.equal(oldestRetainedBackup.defaultBranch, "main-0");
+});
+
 test("updateSetupConfig reports no restart requirement when a typed setup write is a no-op", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-noop-"));
   t.after(async () => {

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -55,6 +55,7 @@ const REVIEW_PROVIDER_LOGIN_MAP: Record<SetupConfigPreviewSelectableReviewProvid
   codex: ["chatgpt-codex-connector"],
   coderabbit: ["coderabbitai", "coderabbitai[bot]"],
 };
+const SETUP_CONFIG_BACKUP_RETENTION = 5;
 
 function assertNonEmptyString(value: unknown, fieldName: string): string {
   if (typeof value !== "string" || value.trim() === "") {
@@ -289,6 +290,25 @@ function determineRestartTriggeredFields(args: {
   });
 }
 
+async function rotateSetupConfigBackups(backupPath: string): Promise<void> {
+  for (let index = SETUP_CONFIG_BACKUP_RETENTION - 1; index >= 1; index -= 1) {
+    const destinationPath = `${backupPath}.${index}`;
+    if (index === SETUP_CONFIG_BACKUP_RETENTION - 1) {
+      await fs.rm(destinationPath, { force: true });
+    }
+
+    const sourcePath = index === 1 ? backupPath : `${backupPath}.${index - 1}`;
+    try {
+      await fs.rename(sourcePath, destinationPath);
+    } catch (error) {
+      const maybeErr = error as NodeJS.ErrnoException;
+      if (maybeErr.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+}
+
 export async function updateSetupConfig(args: UpdateSetupConfigArgs): Promise<SetupConfigUpdateResult> {
   const configPath = resolveConfigPath(args.configPath);
   const changes = normalizeSetupChanges(args.changes);
@@ -305,6 +325,7 @@ export async function updateSetupConfig(args: UpdateSetupConfigArgs): Promise<Se
   if (existing.rawContents !== null) {
     backupPath = `${configPath}.bak`;
     await fs.mkdir(path.dirname(backupPath), { recursive: true });
+    await rotateSetupConfigBackups(backupPath);
     await fs.writeFile(backupPath, existing.rawContents, "utf8");
   }
 


### PR DESCRIPTION
## Summary
- rotate setup-owned config backups instead of overwriting a single `${configPath}.bak`
- preserve the latest backup path contract while keeping bounded history for rollback
- add regression coverage for consecutive writes and retention behavior

## Why
Setup config updates were overwriting one backup slot on every write, so earlier rollback points were lost after repeated updates.

## Impact
Operators keep multiple recent setup-config rollback points without changing the existing setup write flow or readiness refresh behavior.

## Verification
- `npx tsx --test src/config.test.ts`
- `npm run build`

Closes #1242.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic backup rotation policy that maintains up to 5 historical backup files of configuration changes.

* **Tests**
  * Added test verifying backup rotation across multiple consecutive writes, confirming proper retention count, file ordering, and content preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->