### PR TITLE
Refresh README and operator docs flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,61 @@
 # codex-supervisor
 
-Deterministic GitHub issue, PR, CI, and review supervision for `codex exec` and `gh`.
+Keep Codex moving through execution-ready GitHub issues without babysitting every CI run, review thread, or merge step.
 
-`codex-supervisor` keeps the execution loop outside the chat thread: it stores local state, works in per-issue worktrees, and keeps re-reading GitHub before every next action.
-
-Pull-request hydration contract: action-taking supervisor paths must rely on fresh GitHub review facts. Any retained cached hydration data is informational and non-authoritative; it can help diagnostics and operator visibility, but it must not be the authority for review readiness, merge readiness, or similar PR decisions.
+`codex-supervisor` wraps `codex exec` and `gh` in a durable outer loop: it keeps local state, works in per-issue worktrees, re-reads GitHub on each cycle, and requires fresh GitHub PR facts before action-taking review or merge transitions.
 
 Japanese overview: [docs/README.ja.md](./docs/README.ja.md)  
 Japanese getting started: [docs/getting-started.ja.md](./docs/getting-started.ja.md)
+
+## The Problem
+
+Codex CLI is powerful, but long-running execution often breaks at the edges:
+
+- Codex stops mid-task and the next session has to reconstruct context
+- CI fails and nothing automatically picks up the repair loop
+- review feedback arrives after the original session is gone
+- draft PRs, local state, and GitHub state can drift unless something keeps reconciling them
+
+`codex-supervisor` is the outer loop that keeps that work moving. You author execution-ready GitHub issues, and the supervisor keeps re-checking the repo, worktree, PR, CI, and review state needed to advance them safely.
 
 ## What It Is
 
 Use `codex-supervisor` when you want Codex to work through execution-ready GitHub issues in a durable, explicit loop:
 
-- re-read issue, PR, checks, reviews, and mergeability from GitHub
+- re-read issue state on each cycle and require fresh PR review facts before action-taking PR transitions
 - select the next runnable issue instead of trusting chat history
 - run each turn in a dedicated worktree with a persistent issue journal
 - keep moving through draft PR, CI repair, review fixes, and merge
+
+```mermaid
+flowchart LR
+    A["Execution-ready GitHub issues"] --> B["codex-supervisor loop"]
+    B --> C["Per-issue worktree + journal"]
+    C --> D["Draft PR"]
+    D --> E{"Checks and reviews"}
+    E -->|pass| F["Merge-ready PR"]
+    E -->|fail or changes requested| B
+    B -->|select next runnable issue| A
+```
 
 GitHub-authored issue bodies, PR review comments, and related GitHub text are execution inputs, not trusted instructions by default. Treat that GitHub-authored text as part of the supervisor trust boundary and use the autonomous loop only in repos where the operator trusts both the repository and the GitHub authors who can supply that text.
 
 If you want the setup flow, first-run commands, and operator decisions, start with [Getting started](./docs/getting-started.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
+If you need the narrower freshness and durability contracts, use [Architecture](./docs/architecture.md) and [Configuration reference](./docs/configuration.md) instead of treating this README as the full runtime spec.
 
 ## Who It Is For
 
-Best fit:
-
-- solo development or one clearly owned automation lane
-- repos with execution-ready issues and explicit dependency order
-- branch-protected repos with a stable PR and CI workflow
-- teams that want GitHub, not chat memory, to stay the source of truth
-
-Not a fit:
-
-- multi-author repos with frequent overlapping changes
-- backlogs whose priority and dependency order are mostly implicit
-- issue trackers full of discussion prompts instead of executable tasks
-- workflows that expect the supervisor to invent planning or coordination policy
+| Good fit | Not a fit |
+| --- | --- |
+| solo development or one clearly owned automation lane | multi-author repos with frequent overlapping changes |
+| repos with execution-ready issues and explicit dependency order | backlogs whose priority and dependency order are mostly implicit |
+| branch-protected repos with a stable PR and CI workflow | issue trackers full of discussion prompts instead of executable tasks |
+| teams that want GitHub, not chat memory, to stay the source of truth | workflows that expect the supervisor to invent planning or coordination policy |
 
 ## Quick Start
+
+Prerequisites: Node.js 18+, `gh auth status`, and `codex` CLI available from your shell.
 
 1. Install dependencies and build the CLI.
 
@@ -47,14 +63,6 @@ Not a fit:
    npm install
    npm run build
    ```
-
-   For the operator dashboard browser smoke suite, run:
-
-   ```bash
-   npm run test:webui-smoke
-   ```
-
-   The smoke harness launches a local Chrome/Chromium binary through `playwright-core` against an in-process HTTP fixture. If your browser executable is not on a standard `google-chrome`, `google-chrome-stable`, `chromium`, or `chromium-browser` path, set `CHROME_BIN=/path/to/browser`.
 
 2. Create your active config from the base example.
 
@@ -75,7 +83,11 @@ Not a fit:
    ```bash
    node dist/index.js run-once --config /path/to/supervisor.config.json
    node dist/index.js status --config /path/to/supervisor.config.json
-   node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json
+   ```
+
+6. Start the durable loop only after the first pass looks sane.
+
+   ```bash
    node dist/index.js loop --config /path/to/supervisor.config.json
    ```
 
@@ -179,13 +191,16 @@ If `issue-lint` reports missing or malformed metadata, fix the issue body before
 
 Requirements: `gh auth status` must succeed, `codex` CLI must be installed, the managed repository should already have branch protection and CI in place, and the operator should only enable autonomous execution in a trusted repo with trusted GitHub authors. The current Codex runs use `--dangerously-bypass-approvals-and-sandbox`; see [Getting started](./docs/getting-started.md), [Configuration reference](./docs/configuration.md), and [Architecture](./docs/architecture.md) for the execution-safety boundary.
 
-State-file contract: missing JSON state is an empty bootstrap case, but corrupted JSON state is not. Treat corrupted JSON state as a recovery event, not a durable recovery point, until an operator has inspected it and performed an explicit acknowledgement or reset.
+## Operational Boundaries
 
-Workspace restore contract: `ensureWorkspace()` should prefer an existing local issue branch first, then an existing remote issue branch, and only then bootstrap a fresh issue branch from an authoritative fresh default-branch ref such as `origin/<defaultBranch>`. Bootstrapping from the default branch is the fallback path when no existing issue branch can be restored.
+The README is the product overview, not the full runtime spec, but a few safety contracts matter even on a first read:
 
-Workspace cleanup contract: tracked done workspaces and orphaned workspaces are different cases. Tracked done workspace cleanup is the bounded delayed cleanup controlled by the done-workspace settings. An orphaned workspace is an untracked `issue-*` worktree under `workspaceRoot` that no longer has a live state entry; the explicit orphan prune flow only preserves candidates marked `locked`, `recent`, or `unsafe_target`, and abandoned orphan workspaces are only pruned through an explicit operator action rather than an implicit background cleanup. Run `node dist/index.js doctor --config /path/to/supervisor.config.json` and check `doctor_orphan_policy mode=explicit_only ...` when you need to confirm the effective orphan cleanup policy on a real setup.
+- missing JSON state is a normal bootstrap case, but corrupted JSON state is a recovery event that needs operator handling before that state is trusted again
+- corrupted JSON state is not a durable recovery point until the operator completes an explicit acknowledgement or reset
+- workspace restore prefers an existing local issue branch first, then an existing remote issue branch, and only then falls back to a fresh `origin/<defaultBranch>` bootstrap as the fallback path
+- tracked done workspaces and orphaned workspaces are different cleanup cases; orphan workspaces are preserved or pruned through explicit operator-driven orphan cleanup, and the preserve cases are `locked`, `recent`, and `unsafe_target`
 
-Execution metrics durability contract: terminal run summaries are retained under `<dirname(stateFile)>/execution-metrics/run-summaries/`, so worktree cleanup does not remove the aggregation source. Run `node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json` to write the current daily rollup to `<dirname(stateFile)>/execution-metrics/daily-rollups.json`.
+Use [Configuration reference](./docs/configuration.md), [Getting started](./docs/getting-started.md), and [Architecture](./docs/architecture.md) when you need the detailed state, workspace, cleanup, or freshness contracts.
 
 ## Provider Profiles
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,12 +1,22 @@
 # codex-supervisor 日本語ガイド
 
-`codex-supervisor` は、`codex exec` と `gh` を使って GitHub issue、PR、CI、review、merge の進行を継続監督するための deterministic な supervisor です。
+`codex-supervisor` は、execution-ready な GitHub issue を `codex exec` と `gh` で継続実行していくための durable な outer loop です。CI 失敗、review 待ち、draft PR、merge 直前の確認までを、chat thread ではなく GitHub とローカル state を使って追い続けます。
 
 英語版の一次ソースは [README.md](../README.md) です。この文書は、日本語で全体像と入口を把握するための軽い案内として使ってください。人がセットアップと運用手順を確認するときは [docs/getting-started.ja.md](./getting-started.ja.md) から始め、repo に入った AI agent は [docs/agent-instructions.ja.md](./agent-instructions.ja.md) を先に読んでください。
 
+## 何が解決されるか
+
+Codex CLI 単体でも実装は進められますが、長い実行では次のようなところで止まりやすくなります。
+
+- session が切れて、次の実行で context を作り直す必要がある
+- CI が失敗しても、その修復 loop を自動で拾い直せない
+- review や mergeability の変化を、元の session が知らないまま止まる
+
+`codex-supervisor` は、その外側で動く継続 loop です。issue ごとの worktree と journal を維持しながら、毎サイクル GitHub とローカル state を見直して、次に進めるべき runnable issue と PR 状態を選び直します。
+
 ## 何をするツールか
 
-`codex-supervisor` は、長い chat thread を覚え続ける代わりに、毎ターン GitHub とローカル state を読み直して次の行動を決めます。
+`codex-supervisor` は、長い chat thread を覚え続ける代わりに、毎サイクル GitHub とローカル state を読み直して次の行動を決めます。
 
 - issue、PR、checks、review、mergeability を再取得する
 - runnable な issue を readiness-driven に選ぶ
@@ -32,6 +42,12 @@ Not a fit:
 
 ## クイックスタート
 
+前提条件:
+
+- `gh auth status` が通る
+- `codex` CLI が shell から使える
+- Node.js 18+ が入っている
+
 1. 依存関係を入れてビルドします。
 
    ```bash
@@ -52,13 +68,21 @@ Not a fit:
    - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
 
 4. `repoPath`、`repoSlug`、`workspaceRoot`、`codexBinary` などを初回実行前に設定します。`supervisor.config.coderabbit.json` は、customize を必須にするため `repoSlug` に無効な placeholder を入れています。
-5. まず `run-once` と `status` で挙動を確認し、その後 `loop` に切り替えます。
-
-   local operator dashboard を使う時は同じ config で次を実行します。
+5. まず `run-once` と `status` で挙動を確認します。
 
    ```bash
+   node dist/index.js run-once --config /path/to/supervisor.config.json
+   node dist/index.js status --config /path/to/supervisor.config.json
+   ```
+
+6. 問題なければ `loop` と必要に応じて WebUI を起動します。
+
+   ```bash
+   node dist/index.js loop --config /path/to/supervisor.config.json
    node dist/index.js web --config /path/to/supervisor.config.json
    ```
+
+最初の runnable issue は README のテンプレか [docs/issue-metadata.md](./issue-metadata.md) の完成例から書き始めるのが安全です。issue の scheduling metadata が正しいかは、`node dist/index.js issue-lint <issue-number> --config /path/to/supervisor.config.json` で先に確認してください。
 
 より詳しい初回手順、issue の書き方、運用中の判断は [docs/getting-started.ja.md](./getting-started.ja.md) を参照してください。AI agent が repo に入るときの読み順と escalation ルールは [docs/agent-instructions.ja.md](./agent-instructions.ja.md) を参照してください。
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,18 @@ Repository-owned local CI policy:
 - `Repo-owned local CI candidate exists but localCiCommand is unset.` means setup/readiness found a repo script candidate. The source is `repo script candidate`. codex-supervisor will not run it until localCiCommand is configured. This warning is advisory only.
 - `Repo-owned local CI contract is configured.` means the configured command is active and fail-closed. When configured local CI fails, PR publication stays blocked until the command passes again.
 
+`localCiCommand` execution modes:
+
+- structured mode: configure an explicit executable plus argument list. This is the preferred mode because the supervisor runs the declared program directly without shell expansion.
+- explicit shell mode: configure a shell command intentionally when you really need shell grammar such as pipes or compound commands. Treat this as the high-risk escape hatch.
+- legacy shell-string mode: older string configs still work for backward compatibility, but they run through the shell and should be migrated to structured mode when practical.
+
+Operator rule of thumb:
+
+- prefer structured mode for repo-owned commands such as `npm`, `pnpm`, `cargo`, or `make`
+- use explicit shell mode only when the repo contract truly depends on shell syntax
+- if a configured local CI gate fails, inspect whether the failure came from the repo-owned command itself or from missing workspace toolchain prerequisites before changing the issue body
+
 Workspace cleanup:
 
 - `maxDoneWorkspaces`
@@ -127,6 +139,13 @@ Workspace cleanup:
 - `cleanupOrphanedWorkspacesAfterHours`
 
 `maxDoneWorkspaces` and `cleanupDoneWorkspacesAfterHours` apply only to tracked done workspaces. `cleanupOrphanedWorkspacesAfterHours` does not enable background orphan cleanup; it defines the age gate used when `doctor` reports orphan prune candidates and when the operator runs `prune-orphaned-workspaces`. An orphaned workspace is an untracked canonical issue workspace that no longer has a live state entry. The explicit `prune-orphaned-workspaces` path only preserves candidates whose eligibility is `locked`, `recent`, or `unsafe_target`; there is no separate manual-keep marker outside those states. The default orphan grace period is 24 hours, so `cleanupOrphanedWorkspacesAfterHours` keeps recently touched orphan workspaces in the `recent` state until that window expires. When you need to verify the live effective policy, run `doctor` and inspect `doctor_orphan_policy mode=explicit_only background_prune=false operator_prune=true grace_hours=... preserved=locked,recent,unsafe_target`.
+
+Setup config backup posture:
+
+- setup writes now keep a rotating local backup chain instead of overwriting a single `.bak` forever
+- the newest backup still lives at `<configPath>.bak`, and older snapshots rotate to numbered siblings such as `<configPath>.bak.1`
+- treat those backups as local operator rollback aids, not as a substitute for version control or host backups
+- if you automate config edits outside the setup flow, preserve the same expectation that backups are bounded and local rather than an infinite history log
 
 ## Operator Dashboard
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,13 +37,7 @@ For a lightweight pre-PR path-hygiene check that stays independent from `build` 
 npm run verify:paths
 ```
 
-If you want to run the WebUI browser smoke suite locally or in CI, use:
-
-```bash
-npm run test:webui-smoke
-```
-
-That harness uses `playwright-core` with a local Chrome/Chromium executable against an in-process dashboard fixture. Set `CHROME_BIN=/path/to/browser` when the browser is not discoverable as `google-chrome`, `google-chrome-stable`, `chromium`, or `chromium-browser`.
+If you want to run the WebUI browser smoke suite locally or in CI, see the browser requirements in the [Operator dashboard guide](./operator-dashboard.md#browser-smoke-suite).
 
 Current execution-safety rule: GitHub-authored issue bodies, review comments, and similar GitHub text are part of the supervisor trust boundary because they become execution inputs for Codex. The current runtime uses `--dangerously-bypass-approvals-and-sandbox`, so autonomous execution is safe enough to enable only in a trusted repo with trusted authors. If that trust is not present, autonomous execution is not safe for the current posture.
 

--- a/docs/operator-dashboard.md
+++ b/docs/operator-dashboard.md
@@ -94,6 +94,14 @@ Read the local CI posture the same way:
 - `Repo-owned local CI candidate exists but localCiCommand is unset.` The repo already defines a likely entrypoint, but codex-supervisor will not run it until `localCiCommand` is configured. This warning is advisory only.
 - `Repo-owned local CI contract is configured.` The configured command is now the active fail-closed gate. When configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again.
 
+If local CI is configured, remember that the config can now use either:
+
+- structured execution mode for an explicit executable plus arguments
+- explicit shell mode for a deliberately shell-driven command
+- a legacy shell-string config kept only for backward compatibility
+
+Use the [Configuration reference](./configuration.md) when you need to confirm which execution mode is active or when a local CI failure looks like a workspace toolchain problem instead of a repo command failure.
+
 ## Current safe command surface
 
 The dashboard currently exposes only the same narrow safe commands that the CLI exposes:


### PR DESCRIPTION
## Summary
- simplify the README landing flow and move deep runtime detail behind reference docs
- document local CI execution modes and rotating setup backups in operator-facing docs
- sync the Japanese overview with the updated onboarding structure

## Testing
- npx tsx --test src/readme-docs.test.ts src/getting-started-docs.test.ts src/execution-safety-docs.test.ts src/agent-instructions-docs.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README and guides with clearer messaging about execution flow and workflow
  * Added guidance for local CI execution mode configuration options
  * Introduced configuration backup strategy documentation
  * Enhanced quick-start instructions with refined prerequisites and step ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->