### PR TITLE
[codex] Update status-rendering test for review_follow_up line

### DIFF
--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -238,6 +238,7 @@ test("formatDetailedStatus renders core lines before appended summaries", () => 
       "pr_state=OPEN draft=no merge_state=CLEAN review_decision=none head_sha=deadbeef",
       "checks=none",
       "review_threads bot_pending=0 bot_unresolved=0 manual=0",
+      "review_follow_up state=inactive remaining=0 head_sha=none actionable=0",
       "handoff_summary=blocked\\nneeds reproduction",
       "local_review_routing generic=inherit->gpt-5-codex(1) specialists=gpt-5-codex(1) verifier=gpt-5-codex",
       "change_classes=backend, docs, tests",


### PR DESCRIPTION
## Summary
- update the stale status-rendering expectation to include the current `review_follow_up` line
- leave runtime detailed status rendering unchanged

## Why
The test snapshot had drifted from the live `formatDetailedStatus` output after the `review_follow_up` line was added to the rendered status.

## Impact
This restores the release-blocking status-rendering test without changing supervisor behavior.

## Root cause
The expectation in `src/supervisor/supervisor-status-rendering.test.ts` still reflected the older output shape.

## Verification
- `npx tsx --test src/supervisor/supervisor-status-rendering.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for status output verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->