### PR TITLE
[codex] Add repo-owned workspace preparation contract for local CI

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -355,6 +355,33 @@ test("loadConfig accepts a structured repo-owned local CI command", async (t) =>
   });
 });
 
+test("loadConfig exposes an optional repo-owned workspace preparation command", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      workspacePreparationCommand: "npm ci",
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+
+  assert.equal(config.workspacePreparationCommand, "npm ci");
+});
+
 test("loadConfig falls back to the default candidate discovery fetch window for invalid values", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -17,6 +17,7 @@ import {
   SupervisorConfig,
   TrustDiagnosticsSummary,
   TrustMode,
+  WorkspacePreparationContractSummary,
 } from "./types";
 import { DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH } from "./journal";
 import { mapConfiguredReviewProviders } from "./review-providers";
@@ -397,6 +398,27 @@ export function summarizeLocalCiContract(
   };
 }
 
+export function summarizeWorkspacePreparationContract(
+  config: Pick<SupervisorConfig, "workspacePreparationCommand">,
+): WorkspacePreparationContractSummary {
+  const command = displayLocalCiCommand(config.workspacePreparationCommand);
+  if (command !== null) {
+    return {
+      configured: true,
+      command,
+      source: "config",
+      summary: "Repo-owned workspace preparation contract is configured.",
+    };
+  }
+
+  return {
+    configured: false,
+    command: null,
+    source: "config",
+    summary: "No repo-owned workspace preparation contract is configured.",
+  };
+}
+
 function findRepoOwnedLocalCiCandidate(repoPath: string | undefined): string | null {
   if (typeof repoPath !== "string" || repoPath.trim() === "") {
     return null;
@@ -621,6 +643,7 @@ function parseSupervisorConfigDocument(raw: Record<string, unknown>, resolvedPat
         : 6000,
     issueLabel: typeof raw.issueLabel === "string" ? raw.issueLabel : undefined,
     issueSearch: typeof raw.issueSearch === "string" ? raw.issueSearch : undefined,
+    workspacePreparationCommand: normalizeLocalCiCommand(raw.workspacePreparationCommand),
     localCiCommand: normalizeLocalCiCommand(raw.localCiCommand),
     candidateDiscoveryFetchWindow:
       typeof raw.candidateDiscoveryFetchWindow === "number" &&

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -85,6 +85,13 @@ export interface LocalCiContractSummary {
   summary: string;
 }
 
+export interface WorkspacePreparationContractSummary {
+  configured: boolean;
+  command: string | null;
+  source: "config";
+  summary: string;
+}
+
 export interface StructuredLocalCiCommandConfig {
   mode: "structured";
   executable: string;
@@ -165,6 +172,7 @@ export interface SupervisorConfig {
   issueJournalMaxChars: number;
   issueLabel?: string;
   issueSearch?: string;
+  workspacePreparationCommand?: LocalCiCommandConfig;
   localCiCommand?: LocalCiCommandConfig;
   candidateDiscoveryFetchWindow?: number;
   skipTitlePrefixes: string[];

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -617,6 +617,12 @@ test("renderDoctorReport surfaces merge-critical recheck cadence visibility", ()
     candidateDiscoveryWarning: null,
     orphanPolicySummary:
       "doctor_orphan_policy mode=explicit_only background_prune=false operator_prune=true grace_hours=24 preserved=locked,recent,unsafe_target",
+    workspacePreparationContract: {
+      configured: true,
+      command: "npm ci",
+      source: "config",
+      summary: "Repo-owned workspace preparation contract is configured.",
+    },
     localCiContract: {
       configured: true,
       command: "npm run ci:local",
@@ -633,7 +639,50 @@ test("renderDoctorReport surfaces merge-critical recheck cadence visibility", ()
     report,
     /doctor_orphan_policy mode=explicit_only background_prune=false operator_prune=true grace_hours=24 preserved=locked,recent,unsafe_target/,
   );
+  assert.match(
+    report,
+    /doctor_workspace_preparation configured=true source=config command=npm ci summary=Repo-owned workspace preparation contract is configured\./,
+  );
   assert.match(report, /doctor_local_ci configured=true source=config command=npm run ci:local summary=Repo-owned local CI contract is configured\./);
+});
+
+test("renderDoctorReport surfaces absent workspace preparation posture when no repo-owned contract exists", () => {
+  const report = renderDoctorReport({
+    overallStatus: "pass",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+      configWarning: null,
+    },
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    workspacePreparationContract: {
+      configured: false,
+      command: null,
+      source: "config",
+      summary: "No repo-owned workspace preparation contract is configured.",
+    },
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: null,
+      source: "config",
+      summary: "No repo-owned local CI contract is configured.",
+    },
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  assert.match(
+    report,
+    /doctor_workspace_preparation configured=false source=config command=none summary=No repo-owned workspace preparation contract is configured\./,
+  );
 });
 
 test("renderDoctorReport surfaces advisory local CI posture when a repo-owned candidate exists", () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -3,7 +3,14 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { GitHubClient } from "./github";
 import { runCommand } from "./core/command";
-import { summarizeCadenceDiagnostics, summarizeLocalCiContract, summarizeTrustDiagnostics, type ConfigLoadSummary, loadConfigSummary } from "./core/config";
+import {
+  summarizeCadenceDiagnostics,
+  summarizeLocalCiContract,
+  summarizeTrustDiagnostics,
+  summarizeWorkspacePreparationContract,
+  type ConfigLoadSummary,
+  loadConfigSummary,
+} from "./core/config";
 import { parseJson } from "./core/utils";
 import {
   type CandidateDiscoveryDiagnostics,
@@ -14,6 +21,7 @@ import {
   type SupervisorConfig,
   type SupervisorStateFile,
   type TrustDiagnosticsSummary,
+  type WorkspacePreparationContractSummary,
 } from "./core/types";
 import { inspectOrphanedWorkspacePruneCandidates } from "./recovery-reconciliation";
 import {
@@ -40,6 +48,7 @@ export interface DoctorDiagnostics {
   candidateDiscoverySummary: string;
   candidateDiscoveryWarning: string | null;
   orphanPolicySummary?: string;
+  workspacePreparationContract?: WorkspacePreparationContractSummary;
   localCiContract?: LocalCiContractSummary;
 }
 
@@ -560,6 +569,7 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     candidateDiscoverySummary: formatCandidateDiscoveryBehaviorLine(args.config, "doctor_candidate_discovery"),
     candidateDiscoveryWarning,
     orphanPolicySummary: formatOrphanPolicySummary(args.config),
+    workspacePreparationContract: summarizeWorkspacePreparationContract(args.config),
     localCiContract: summarizeLocalCiContract(args.config),
   };
 }
@@ -620,6 +630,9 @@ export async function diagnoseBootstrapReadiness(
 }
 
 export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
+  const workspacePreparationContract =
+    diagnostics.workspacePreparationContract
+    ?? summarizeWorkspacePreparationContract({ workspacePreparationCommand: undefined });
   const localCiContract = diagnostics.localCiContract ?? summarizeLocalCiContract({ localCiCommand: undefined, repoPath: undefined });
   const mergeCriticalRecheckSeconds =
     diagnostics.cadenceDiagnostics.mergeCriticalRecheckSeconds === null
@@ -634,6 +647,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     `doctor_cadence poll_interval_seconds=${diagnostics.cadenceDiagnostics.pollIntervalSeconds} merge_critical_recheck_seconds=${mergeCriticalRecheckSeconds} merge_critical_effective_seconds=${diagnostics.cadenceDiagnostics.mergeCriticalEffectiveSeconds} enabled=${diagnostics.cadenceDiagnostics.mergeCriticalRecheckEnabled}`,
     diagnostics.candidateDiscoverySummary,
     ...(diagnostics.orphanPolicySummary ? [diagnostics.orphanPolicySummary] : []),
+    `doctor_workspace_preparation configured=${workspacePreparationContract.configured} source=${workspacePreparationContract.source} command=${sanitizeDoctorValue(workspacePreparationContract.command ?? "none")} summary=${sanitizeDoctorValue(workspacePreparationContract.summary)}`,
     `doctor_local_ci configured=${localCiContract.configured} source=${localCiContract.source} command=${sanitizeDoctorValue(localCiContract.command ?? "none")} summary=${sanitizeDoctorValue(localCiContract.summary)}`,
     ...trustWarnings.map((warning) => renderDoctorWarningLine(warning, sanitizeDoctorValue)),
     ...(candidateDiscoveryWarning === null ? [] : [renderDoctorWarningLine(candidateDiscoveryWarning, sanitizeDoctorValue)]),

--- a/src/local-ci.ts
+++ b/src/local-ci.ts
@@ -19,6 +19,11 @@ export interface LocalCiGateResult {
   latestResult: LatestLocalCiResult | null;
 }
 
+export interface WorkspacePreparationGateResult {
+  ok: boolean;
+  failureContext: FailureContext | null;
+}
+
 interface ResolvedLocalCiCommand {
   config: LocalCiCommandConfig;
   displayCommand: string;
@@ -182,6 +187,12 @@ function remediationTargetForFailureClass(failureClass: LocalCiFailureClass): Lo
   }
 }
 
+function workspacePreparationFailureSignature(
+  failureClass: Exclude<LocalCiFailureClass, "unset_contract">,
+): string {
+  return `workspace-preparation-gate-${failureClass}`;
+}
+
 function buildSummary(args: {
   failureClass: LocalCiFailureClass | null;
   gateLabel: string;
@@ -261,6 +272,36 @@ function buildFailureDetails(error: unknown, executionMode: LocalCiExecutionMode
     renderFailureOutput("stdout", outputError?.stdout),
     renderFailureOutput("stderr", outputError?.stderr),
   ].filter((detail): detail is string => detail !== null);
+}
+
+function buildWorkspacePreparationSummary(args: {
+  failureClass: Exclude<LocalCiFailureClass, "unset_contract">;
+  gateLabel: string;
+}): string {
+  switch (args.failureClass) {
+    case "missing_command":
+      return (
+        truncate(
+          `Configured workspace preparation command is unavailable ${args.gateLabel}. Remediation target: workspace environment.`,
+          1000,
+        ) ?? "Configured workspace preparation command is unavailable. Remediation target: workspace environment."
+      );
+    case "workspace_toolchain_missing":
+      return (
+        truncate(
+          `Configured workspace preparation command could not run ${args.gateLabel} because the workspace toolchain is unavailable. Remediation target: workspace environment.`,
+          1000,
+        ) ??
+        "Configured workspace preparation command could not run because the workspace toolchain is unavailable. Remediation target: workspace environment."
+      );
+    case "non_zero_exit":
+      return (
+        truncate(
+          `Configured workspace preparation command failed ${args.gateLabel}. Remediation target: workspace environment.`,
+          1000,
+        ) ?? "Configured workspace preparation command failed. Remediation target: workspace environment."
+      );
+  }
 }
 
 export async function executeLocalCiCommand(command: ResolvedLocalCiCommand | LocalCiCommandConfig, workspacePath: string): Promise<void> {
@@ -355,6 +396,44 @@ export async function runLocalCiGate(args: {
         execution_mode: command.executionMode,
         failure_class: failureClass,
         remediation_target: remediationTargetForFailureClass(failureClass),
+      },
+    };
+  }
+}
+
+export async function runWorkspacePreparationGate(args: {
+  config: Pick<SupervisorConfig, "workspacePreparationCommand">;
+  workspacePath: string;
+  gateLabel: string;
+  runWorkspacePreparationCommand?: LocalCiCommandRunner;
+}): Promise<WorkspacePreparationGateResult> {
+  const command = resolveLocalCiCommand(args.config.workspacePreparationCommand);
+  if (!command) {
+    return {
+      ok: true,
+      failureContext: null,
+    };
+  }
+
+  try {
+    await (args.runWorkspacePreparationCommand ?? executeLocalCiCommand)(command, args.workspacePath);
+    return {
+      ok: true,
+      failureContext: null,
+    };
+  } catch (error) {
+    const failureClass = classifyLocalCiFailure(error, command.displayCommand);
+    const summary = buildWorkspacePreparationSummary({ failureClass, gateLabel: args.gateLabel });
+    return {
+      ok: false,
+      failureContext: {
+        category: "blocked",
+        summary,
+        signature: workspacePreparationFailureSignature(failureClass),
+        command: command.displayCommand,
+        details: buildFailureDetails(error, command.executionMode),
+        url: null,
+        updated_at: nowIso(),
       },
     };
   }

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -232,6 +232,211 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion 
   );
 });
 
+test("handlePostTurnPullRequestTransitionsPhase runs workspace preparation before local CI", async () => {
+  const config = createConfig({
+    workspacePreparationCommand: "npm ci",
+    localCiCommand: "npm run ci:local",
+  });
+  const issue = createIssue({ title: "Prepare workspace before ready promotion" });
+  const draftPr = createPullRequest({ title: "Prepare before ready", isDraft: true });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+  };
+  const callOrder: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => undefined,
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkspacePreparationCommand: async (command, cwd) => {
+      callOrder.push(`prepare:${command.displayCommand}:${cwd}`);
+    },
+    runLocalCiCommand: async (command, cwd) => {
+      callOrder.push(`local-ci:${command.displayCommand}:${cwd}`);
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "draft_pr");
+  assert.deepEqual(callOrder, [
+    "prepare:npm ci:/tmp/workspaces/issue-102",
+    "local-ci:npm run ci:local:/tmp/workspaces/issue-102",
+  ]);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workspace preparation fails", async () => {
+  const config = createConfig({
+    workspacePreparationCommand: "npm ci",
+    localCiCommand: "npm run ci:local",
+  });
+  const issue = createIssue({ title: "Gate ready promotion on workspace preparation" });
+  const draftPr = createPullRequest({ title: "Gate ready promotion", isDraft: true });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+  };
+  let readyCalls = 0;
+  let localCiCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        readyCalls += 1;
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkspacePreparationCommand: async () => {
+      throw new Error("Command failed: sh -lc +1 args\nexitCode=1\nnpm error missing node_modules");
+    },
+    runLocalCiCommand: async () => {
+      localCiCalls += 1;
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(readyCalls, 0);
+  assert.equal(localCiCalls, 0);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "workspace-preparation-gate-non_zero_exit");
+  assert.match(
+    result.record.last_error ?? "",
+    /Configured workspace preparation command failed before marking PR #116 ready\. Remediation target: workspace environment\./,
+  );
+});
+
 test("handlePostTurnPullRequestTransitionsPhase reports workspace toolchain failures as workspace-environment remediation", async () => {
   const config = createConfig({ localCiCommand: "npm run ci:local" });
   const issue = createIssue({ title: "Gate ready promotion on missing workspace toolchain" });

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -32,7 +32,7 @@ import {
   SupervisorStateFile,
 } from "./core/types";
 import { nowIso, truncate } from "./core/utils";
-import { runLocalCiGate, type LocalCiCommandRunner } from "./local-ci";
+import { runLocalCiGate, runWorkspacePreparationGate, type LocalCiCommandRunner } from "./local-ci";
 import {
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
@@ -234,6 +234,7 @@ export interface HandlePostTurnPullRequestTransitionsArgs {
   manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
   mergeConflictDetected: (pr: GitHubPullRequest) => boolean;
   runLocalReviewImpl?: typeof runLocalReview;
+  runWorkspacePreparationCommand?: LocalCiCommandRunner;
   runLocalCiCommand?: LocalCiCommandRunner;
   runWorkstationLocalPathGate?: (args: { workspacePath: string; gateLabel: string }) => Promise<WorkstationLocalPathGateResult>;
   emitEvent?: SupervisorEventSink;
@@ -420,6 +421,33 @@ export async function handlePostTurnPullRequestTransitionsPhase(
             ?? `Tracked durable artifacts failed workstation-local path hygiene before marking PR #${refreshed.pr.number} ready.`,
           1000,
         ),
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        ...args.applyFailureSignature(record, failureContext),
+        blocked_reason: "verification",
+      });
+      state.issues[String(record.issue_number)] = record;
+      await stateStore.save(state);
+      await syncJournal(record);
+      return {
+        record,
+        pr: refreshed.pr,
+        checks: refreshed.checks,
+        reviewThreads: refreshed.reviewThreads,
+      };
+    }
+
+    const workspacePreparationGate = await runWorkspacePreparationGate({
+      config,
+      workspacePath,
+      gateLabel: `before marking PR #${refreshed.pr.number} ready`,
+      runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
+    });
+    if (!workspacePreparationGate.ok) {
+      const failureContext = workspacePreparationGate.failureContext;
+      record = stateStore.touch(record, {
+        state: "blocked",
+        last_error: truncate(failureContext?.summary, 1000),
         last_failure_kind: null,
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -168,6 +168,146 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails
   assert.equal(createPullRequestCalls, 0);
 });
 
+test("applyCodexTurnPublicationGate runs workspace preparation before local CI", async () => {
+  const issue = createIssue({ title: "Prepare workspace before local CI" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  const callOrder: string[] = [];
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      workspacePreparationCommand: "npm ci",
+      localCiCommand: "npm run ci:local",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath: "/tmp/workspaces/issue-102",
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-102",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" }),
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runWorkspacePreparationCommand: async (command, cwd) => {
+      callOrder.push(`prepare:${command.displayCommand}:${cwd}`);
+    },
+    runLocalCiCommand: async (command, cwd) => {
+      callOrder.push(`local-ci:${command.displayCommand}:${cwd}`);
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "ready");
+  assert.deepEqual(callOrder, [
+    "prepare:npm ci:/tmp/workspaces/issue-102",
+    "local-ci:npm run ci:local:/tmp/workspaces/issue-102",
+  ]);
+});
+
+test("applyCodexTurnPublicationGate blocks draft PR creation when workspace preparation fails", async () => {
+  const issue = createIssue({ title: "Gate draft PR creation on workspace preparation" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  let runLocalCiCalls = 0;
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      workspacePreparationCommand: "npm ci",
+      localCiCommand: "npm run ci:local",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath: "/tmp/workspaces/issue-102",
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-102",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runWorkspacePreparationCommand: async () => {
+      throw new Error("Command failed: sh -lc +1 args\nexitCode=1\nnpm error missing node_modules");
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.message, "Workspace preparation blocked pull request creation for issue #102.");
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "workspace-preparation-gate-non_zero_exit");
+  assert.match(result.record.last_error ?? "", /workspace environment/i);
+  assert.equal(runLocalCiCalls, 0);
+});
+
 test("applyCodexTurnPublicationGate opens a draft PR after the gate passes", async () => {
   const issue = createIssue({ title: "Open draft PR" });
   const draftPr = createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -1,5 +1,5 @@
 import { GitHubClient } from "./github";
-import { runLocalCiGate, type LocalCiCommandRunner } from "./local-ci";
+import { runLocalCiGate, runWorkspacePreparationGate, type LocalCiCommandRunner } from "./local-ci";
 import { StateStore } from "./core/state-store";
 import {
   FailureContext,
@@ -44,7 +44,7 @@ export type CodexTurnPublicationGateResult =
   | CodexTurnPublicationGateReadyResult;
 
 export async function applyCodexTurnPublicationGate(args: {
-  config: Pick<SupervisorConfig, "draftPrAfterAttempt" | "localCiCommand">;
+  config: Pick<SupervisorConfig, "draftPrAfterAttempt" | "workspacePreparationCommand" | "localCiCommand">;
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
   record: IssueRunRecord;
@@ -60,6 +60,7 @@ export async function applyCodexTurnPublicationGate(args: {
     record: IssueRunRecord,
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  runWorkspacePreparationCommand?: LocalCiCommandRunner;
   runLocalCiCommand?: LocalCiCommandRunner;
   runWorkstationLocalPathGate?: (args: {
     workspacePath: string;
@@ -102,6 +103,36 @@ export async function applyCodexTurnPublicationGate(args: {
       return {
         kind: "blocked",
         message: `Workstation-local path hygiene blocked pull request creation for issue #${record.issue_number}.`,
+        record,
+        pr: null,
+        checks: [],
+        reviewThreads: [],
+      };
+    }
+
+    const workspacePreparationGate = await runWorkspacePreparationGate({
+      config: args.config,
+      workspacePath: args.workspacePath,
+      gateLabel: "before opening a pull request",
+      runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
+    });
+    if (!workspacePreparationGate.ok) {
+      const failureContext = workspacePreparationGate.failureContext;
+      record = args.stateStore.touch(record, {
+        state: "blocked",
+        last_error: truncate(failureContext?.summary, 1000),
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        ...args.applyFailureSignature(record, failureContext),
+        blocked_reason: "verification",
+      });
+      args.state.issues[String(record.issue_number)] = record;
+      await args.stateStore.save(args.state);
+      await args.syncExecutionMetricsRunSummary(record);
+      await args.syncJournal(record);
+      return {
+        kind: "blocked",
+        message: `Workspace preparation blocked pull request creation for issue #${record.issue_number}.`,
         record,
         pr: null,
         checks: [],

--- a/src/turn-execution-test-helpers.ts
+++ b/src/turn-execution-test-helpers.ts
@@ -44,6 +44,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     candidateDiscoveryFetchWindow: 100,
     skipTitlePrefixes: [],
     branchPrefix: "codex/issue-",
+    workspacePreparationCommand: undefined,
     pollIntervalSeconds: 60,
     copilotReviewWaitMinutes: 10,
     copilotReviewTimeoutAction: "continue",

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -67,6 +67,7 @@
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
+  "workspacePreparationCommand": "",
   "localCiCommand": "",
   "skipTitlePrefixes": ["Epic:"],
   "branchPrefix": "codex/issue-",


### PR DESCRIPTION
## Summary
- add an explicit `workspacePreparationCommand` config contract for repo-owned workspace setup before local CI
- run workspace preparation before the existing local CI gate in both draft PR publication and draft-to-ready promotion flows
- surface workspace preparation posture separately in doctor output and keep the behavior opt-in

## Why
Preserved issue worktrees can be missing repo-local toolchain prerequisites even when the repo defines a canonical preparation step. The supervisor previously jumped straight to `localCiCommand`, which made local CI failures ambiguous and prevented repos from declaring the setup contract they expect before CI runs.

## Impact
- repos can opt into a dedicated workspace preparation step without changing `localCiCommand`
- workspace-preparation failures fail closed and are reported as workspace-environment remediation
- when no preparation command is configured, existing behavior is unchanged

## Validation
- `npm ci`
- `npx tsx --test src/config.test.ts src/local-ci.test.ts src/turn-execution-publication-gate.test.ts src/post-turn-pull-request.test.ts src/doctor.test.ts`
- `npx tsx --test src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts src/doctor.test.ts`
- `npm run build`