### PR TITLE
[codex] Fix release-blocking selection/readiness/explain test drift on main

### DIFF
--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -38,6 +38,7 @@ Parallelizable: No`,
     updatedAt: "2026-03-19T00:00:00Z",
     url: "https://example.test/issues/603",
     state: "OPEN",
+    labels: [],
     ...overrides,
   };
 }

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -29,6 +29,7 @@ Preserve readiness and selection-why summary output.
     updatedAt: "2026-03-19T00:00:00Z",
     url: "https://example.test/issues/604",
     state: "OPEN",
+    labels: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- restore the selection/readiness/explain fixtures so these tests exercise the intended runtime path after label-metadata fail-closed behavior landed
- add explicit `labels: []` to the shared issue fixtures in the affected tests instead of changing supervisor runtime behavior

## Root cause
The current runtime now treats omitted issue labels as degraded metadata and blocks those issues with `metadata:labels_unavailable`. The stale tests were still building fixtures without a `labels` field, so they drifted onto that newer blocker path and no longer covered the selection/readiness/explain behavior they were intended to validate.

## Impact
This keeps the release-blocking tests aligned with current behavior on `main` without changing selection or explain logic.

## Verification
- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts

## Notes
- `npm test` still does not run directly in this worktree because the package script expects `tsx` on `PATH` (`sh: 1: tsx: not found`).
- The broader `npx tsx --test "src/**/*.test.ts"` suite still has unrelated failures outside this issue scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data factories to ensure consistent initialization of mock objects across test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->