### PR TITLE
Fix release-blocking PR readiness and recovery regressions

### DIFF
--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { ensureWorkspace } from "../core/workspace";
 import { Supervisor } from "./supervisor";
 import { GitHubIssue, GitHubPullRequest, PullRequestCheck, ReviewThread, SupervisorStateFile } from "../core/types";
 import {
@@ -22,33 +23,32 @@ async function withStubbedDateNow<T>(nowIso: string, run: () => Promise<T>): Pro
   }
 }
 
+function runnableCodexIssueBody(summary: string): string {
+  return `${executionReadyBody(summary)}
+
+Depends on: none
+Execution order: 1 of 1
+Parallelizable: No`;
+}
+
 test("runOnce marks a clean draft PR ready and enables auto-merge after the turn", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 92;
   const branch = branchName(fixture.config, issueNumber);
   const state: SupervisorStateFile = {
-    activeIssueNumber: issueNumber,
-    issues: {
-      [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "stabilizing",
-        branch,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
-        journal_path: null,
-        pr_number: 113,
-        blocked_reason: null,
-      }),
-    },
+    activeIssueNumber: null,
+    issues: {},
   };
   await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 
   const issue: GitHubIssue = {
     number: issueNumber,
     title: "Extract post-turn PR transitions",
-    body: "",
+    body: runnableCodexIssueBody("Extract post-turn PR transitions."),
     createdAt: "2026-03-13T00:00:00Z",
     updatedAt: "2026-03-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
     state: "OPEN",
   };
   const draftPr: GitHubPullRequest = {
@@ -91,7 +91,7 @@ test("runOnce marks a clean draft PR ready and enables auto-merge after the turn
     getIssue: async () => issue,
     resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
       assert.equal(branchName, branch);
-      assert.equal(prNumber, 113);
+      assert.equal(prNumber, null);
       return draftPr;
     },
     getChecks: async (prNumber: number) => {
@@ -147,28 +147,19 @@ test("runOnce waits for Copilot propagation after marking a draft PR ready", asy
     reviewBotLogins: ["copilot-pull-request-reviewer"],
   });
   const state: SupervisorStateFile = {
-    activeIssueNumber: issueNumber,
-    issues: {
-      [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "stabilizing",
-        branch,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
-        journal_path: null,
-        pr_number: 114,
-        blocked_reason: null,
-      }),
-    },
+    activeIssueNumber: null,
+    issues: {},
   };
   await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 
   const issue: GitHubIssue = {
     number: issueNumber,
     title: "Honor the refreshed review-wait snapshot after ready for review",
-    body: "",
+    body: runnableCodexIssueBody("Honor the refreshed review-wait snapshot after ready for review."),
     createdAt: "2026-03-13T00:00:00Z",
     updatedAt: "2026-03-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
     state: "OPEN",
   };
   const draftPr: GitHubPullRequest = {
@@ -212,7 +203,7 @@ test("runOnce waits for Copilot propagation after marking a draft PR ready", asy
     getIssue: async () => issue,
     resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
       assert.equal(branchName, branch);
-      assert.equal(prNumber, 114);
+      assert.equal(prNumber, null);
       return draftPr;
     },
     getChecks: async (prNumber: number) => {
@@ -319,6 +310,7 @@ test("handlePostTurnPullRequestTransitions refreshes PR state after marking read
   let snapshotLoads = 0;
   let syncJournalCalls = 0;
   const supervisor = new Supervisor(fixture.config);
+  await ensureWorkspace(fixture.config, issueNumber, branch);
   (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
     prNumber: number,
   ) => {
@@ -755,10 +747,11 @@ test("runOnce records an observed Copilot request time when GitHub omits the req
   const issue: GitHubIssue = {
     number: issueNumber,
     title: "Persist observed Copilot request time",
-    body: executionReadyBody("Persist observed Copilot request time."),
+    body: runnableCodexIssueBody("Persist observed Copilot request time."),
     createdAt: "2026-03-13T00:00:00Z",
     updatedAt: "2026-03-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
     state: "OPEN",
   };
   const pr: GitHubPullRequest = {

--- a/src/supervisor/supervisor-recovery-failure-flows.test.ts
+++ b/src/supervisor/supervisor-recovery-failure-flows.test.ts
@@ -19,40 +19,32 @@ function issueLockPath(supervisor: Supervisor, issueNumber: number): string {
   }).lockPath("issues", `issue-${issueNumber}`);
 }
 
+function runnableCodexIssueBody(summary: string): string {
+  return `${executionReadyBody(summary)}
+
+Depends on: none
+Execution order: 1 of 1
+Parallelizable: No`;
+}
+
 test("runOnce recovers when post-codex refresh throws after leaving a dirty worktree", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 87;
   const branch = branchName(fixture.config, issueNumber);
   const state: SupervisorStateFile = {
-    activeIssueNumber: issueNumber,
-    issues: {
-      [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "stabilizing",
-        branch,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
-        journal_path: null,
-        attempt_count: 1,
-        implementation_attempt_count: 1,
-        repair_attempt_count: 0,
-        last_error: null,
-        last_failure_kind: null,
-        last_failure_context: null,
-        last_failure_signature: null,
-        repeated_failure_signature_count: 0,
-        blocked_reason: null,
-      }),
-    },
+    activeIssueNumber: null,
+    issues: {},
   };
   await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 
   const issue: GitHubIssue = {
     number: issueNumber,
     title: "Reproduce dirty worktree recovery",
-    body: executionReadyBody("Reproduce dirty worktree recovery."),
+    body: runnableCodexIssueBody("Reproduce dirty worktree recovery."),
     createdAt: "2026-03-13T00:00:00Z",
     updatedAt: "2026-03-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
     state: "OPEN",
   };
 
@@ -65,7 +57,7 @@ test("runOnce recovers when post-codex refresh throws after leaving a dirty work
     getIssue: async () => issue,
     resolvePullRequestForBranch: async () => {
       resolveCalls += 1;
-      if (resolveCalls <= 2) {
+      if (resolveCalls <= 1) {
         return null;
       }
       throw new Error("post-turn refresh blew up");
@@ -93,7 +85,7 @@ test("runOnce recovers when post-codex refresh throws after leaving a dirty work
   assert.equal(record.blocked_reason, null);
   assert.match(record.last_failure_context?.summary ?? "", /Supervisor failed while recovering a Codex turn/);
   assert.deepEqual(record.last_failure_context?.details.slice(0, 4), [
-    "previous_state=stabilizing",
+    "previous_state=reproducing",
     "workspace_dirty=yes",
     `workspace_head=${record.last_head_sha}`,
     "pr_number=none",

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -920,13 +920,16 @@ export class Supervisor {
         localReviewHighSeverityNeedsRetry(this.config, lifecycle.recordForState, currentPr)
           ? localReviewFailureContext(lifecycle.recordForState)
           : null);
+      const staleReadyToMerge = currentPr.headRefOid !== pr.headRefOid && lifecycle.nextState === "ready_to_merge";
 
-      if (lifecycle.nextState !== "ready_to_merge") {
+      if (lifecycle.nextState !== "ready_to_merge" || staleReadyToMerge) {
         nextRecord = this.stateStore.touch(nextRecord, {
           ...lifecyclePatch,
-          state: lifecycle.nextState,
+          state: staleReadyToMerge ? "stabilizing" : lifecycle.nextState,
           last_error:
-            lifecycle.nextState === "blocked" && effectiveFailureContext
+            staleReadyToMerge
+              ? nextRecord.last_error
+              : lifecycle.nextState === "blocked" && effectiveFailureContext
               ? truncate(effectiveFailureContext.summary, 1000)
               : lifecycle.nextState === "local_review_fix" &&
                   localReviewHighSeverityNeedsRetry(this.config, lifecycle.recordForState, currentPr)
@@ -935,7 +938,9 @@ export class Supervisor {
           last_failure_context: effectiveFailureContext,
           ...applyFailureSignature(nextRecord, effectiveFailureContext),
           blocked_reason:
-            lifecycle.nextState === "blocked"
+            staleReadyToMerge
+              ? null
+              : lifecycle.nextState === "blocked"
               ? blockedReasonForLifecycleState(
                   this.config,
                   lifecycle.recordForState,


### PR DESCRIPTION
## Summary
- fix the stale post-turn merge regression when a refreshed PR head changes before auto-merge
- align PR readiness and recovery-flow regressions with current runnable issue and worktree-path behavior
- restore the release-blocking focused supervisor coverage for readiness and recovery flows

## Verification
- npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts
- npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts src/supervisor/supervisor-recovery-failure-flows.test.ts src/supervisor/supervisor-lifecycle.test.ts src/tracked-pr-lifecycle-projection.test.ts src/supervisor/supervisor-diagnostics-issue-lint-readiness.test.ts

## Notes
- local `npm test` still fails in this workspace with `sh: 1: tsx: not found`, even though `npx tsx --test ...` works
- full repo-wide `npx tsx --test "src/**/*.test.ts"` was not claimed here because optional browser-related modules can still make that path noisy in this environment

Closes #1258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of stale pull requests in the merge-ready state. The supervisor now properly reverts to a stabilizing state instead of proceeding with merge operations when the PR head becomes outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->