### PR TITLE
[codex] Fix remaining release-blocking snapshot, orchestration, and docs expectation drift

### DIFF
--- a/src/supervisor/supervisor-agent-runner.test.ts
+++ b/src/supervisor/supervisor-agent-runner.test.ts
@@ -14,6 +14,7 @@ test("runOnce routes supervisor turn execution through an injected agent runner"
     number: issueNumber,
     title: "Use the shared agent runner for supervisor turns",
     body: executionReadyBody("Use the shared agent runner for supervisor turns."),
+    labels: [],
     createdAt: "2026-03-13T00:00:00Z",
     updatedAt: "2026-03-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,

--- a/src/supervisor/supervisor-cycle-snapshot.test.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.test.ts
@@ -238,6 +238,7 @@ test("buildSupervisorCycleDecisionSnapshot keeps the decision inputs narrow and 
     summary: "Configured local CI command passed before opening a pull request.",
     ran_at: "2026-03-16T10:02:30Z",
     head_sha: "head-407",
+    execution_mode: "legacy_shell_string",
     failure_class: null,
     remediation_target: null,
   });
@@ -284,6 +285,7 @@ test("writeSupervisorCycleDecisionSnapshot serializes one cycle into the workspa
     summary: "Configured local CI command passed before opening a pull request.",
     ran_at: "2026-03-16T10:02:30Z",
     head_sha: "head-407",
+    execution_mode: "legacy_shell_string",
     failure_class: null,
     remediation_target: null,
   });

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -509,7 +509,10 @@ test("prepareIssueExecutionContext blocks PR publication when configured local C
   assert.equal(state.issues[String(issueNumber)]?.state, "blocked");
   assert.equal(state.issues[String(issueNumber)]?.blocked_reason, "verification");
   assert.equal(state.issues[String(issueNumber)]?.last_failure_signature, "local-ci-gate-non_zero_exit");
-  assert.match(state.issues[String(issueNumber)]?.last_failure_context?.details[0] ?? "", /local ci failed/);
+  assert.equal(
+    state.issues[String(issueNumber)]?.last_failure_context?.details.some((detail) => /local ci failed/.test(detail)),
+    true,
+  );
 });
 
 test("runOnce reclaims a stale stabilizing issue without carrying mismatched tracked PR context", async () => {

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -222,6 +222,12 @@ ${summary}
 ## Scope
 - keep the test fixture execution-ready
 
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+
 ## Acceptance criteria
 - supervisor treats this issue as runnable
 


### PR DESCRIPTION
## Summary
- align supervisor expectation tests with the current hardening behavior on `main`
- restore execution-ready standalone issue metadata in the shared test fixture
- update snapshot and orchestration assertions to tolerate the current local-CI execution-mode and detail ordering

## Root cause
Recent supervisor hardening changed the intended execution-ready issue metadata and local-CI reporting details. A few tests still asserted the older fixture shape or brittle output ordering, so the release-blocking suite drifted from the runtime behavior.

## What changed
- add standalone scheduling metadata to `executionReadyBody` in the shared supervisor test helper
- provide `labels: []` in the agent-runner fixture so selection evaluates the current policy path
- update the cycle snapshot expectation to include the current local-CI `execution_mode`
- make the orchestration failure assertion search detail lines instead of assuming a fixed first-line position

## Validation
- `npx tsx --test src/supervisor/supervisor-agent-runner.test.ts src/supervisor/supervisor-cycle-snapshot.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/readme-docs.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and expectations to reflect changes in data structures, including issue labels and execution mode tracking.
  * Enhanced test helper utilities to include dependency and execution order metadata in test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->