### PR TITLE
[codex] Fix remaining release-blocking browser smoke regressions

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,32 +5,46 @@
 - Branch: codex/issue-1264
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: cfa082799f7e41b2c4b66e5b6093d7e73b50f6d9
+- Current phase: repairing_ci
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: e64bec8de17b131baea5f1e858c135331ff0c0f6
 - Blocked reason: none
-- Last failure signature: handoff-missing
+- Last failure signature: build (ubuntu-latest):fail
 - Repeated failure signature count: 1
-- Updated at: 2026-03-31T13:34:03.272Z
+- Updated at: 2026-03-31T14:01:33.889Z
 
 ## Latest Codex Summary
-- Reproduced the remaining browser-smoke blocker as harness-level Chrome discovery failure on macOS, taught the smoke harness to resolve local Chrome/Chromium app bundles when `CHROME_BIN` and PATH lookups are absent, added resolver regression coverage, and verified the smoke suite plus `npm run build`.
+Updated [src/backend/webui-dashboard-browser-smoke.test.ts](src/backend/webui-dashboard-browser-smoke.test.ts) so the WebUI smoke harness no longer hard-fails when `CHROME_BIN` is unset on macOS. It now keeps the explicit env override, keeps the existing PATH lookup, and falls back to standard local Chrome/Chromium app-bundle paths under `/Applications` and `$HOME/Applications`. I also added a focused resolver regression test in the same file.
+
+The targeted smoke suite now passes locally without any environment override, `npm run build` passes, and the checkpoint is pushed on `codex/issue-1264` with draft PR #1269 open: https://github.com/TommyKammy/codex-supervisor/pull/1269. CI is currently running on that PR.
+
+Summary: Restored browser smoke execution by fixing Chrome discovery fallback in the smoke harness, verified locally, pushed the branch, and opened draft PR #1269.
+State hint: waiting_ci
+Blocked reason: none
+Tests: `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `npm run build`
+Next action: Watch PR #1269 CI on macOS and Ubuntu, then address any fallout or move the draft toward review once checks finish.
+Failure signature: build (ubuntu-latest):fail
 
 ## Active Failure Context
-- None recorded.
+- Category: checks
+- Summary: PR #1269 has failing checks.
+- Command or source: gh pr checks
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1269
+- Details:
+  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/23800368842/job/69358801268
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the remaining release-blocking browser smoke failures on `main` were not flow regressions inside the dashboard itself; the harness had become too strict about browser discovery and now failed before any smoke flow could execute in macOS worktrees unless `CHROME_BIN` was set manually.
-- What changed: reproduced the blocker locally, confirmed every browser smoke flow passed once `CHROME_BIN` pointed at `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`, then updated `src/backend/webui-dashboard-browser-smoke.test.ts` so `resolveChromeExecutable` trims `CHROME_BIN`, keeps the existing PATH lookup, and falls back to standard macOS Google Chrome/Chromium app-bundle paths under `/Applications` and `$HOME/Applications`. Added a focused resolver regression test covering explicit env override, PATH resolution, and macOS app-bundle fallback. Committed the fix as `38b8027` (`[codex] Fix WebUI browser smoke Chrome discovery`), pushed `codex/issue-1264`, and opened draft PR #1269.
+- Hypothesis: the Ubuntu CI failure is no longer a live browser-smoke regression. The current blocker is `npm run verify:paths`, which rejects workstation-local absolute paths introduced by the new resolver regression test fixture.
+- What changed: inspected PR #1269's failing Actions log with `gh` and the bundled CI inspector, confirmed `build (ubuntu-latest)` failed in `npm run verify:paths`, and reproduced that failure locally. The only remaining findings were macOS workstation-style absolute path literals in `src/backend/webui-dashboard-browser-smoke.test.ts`, so I replaced that fixture `HOME` value with `/tmp/example-home` while keeping the resolver assertions unchanged. Re-ran `npm run verify:paths`, `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`, and `npm run build`; all now pass locally.
 - Current blocker: none.
-- Next exact step: watch draft PR #1269, confirm the macOS and Ubuntu CI jobs pass with the new browser-discovery fallback, and address any review or CI fallout if it appears.
-- Verification gap: local verification covered the targeted browser smoke suite and a full TypeScript build. I did not run the repo-wide `npm test` glob because this issue is scoped to the WebUI smoke harness and the targeted verifier already exercises the affected flows end-to-end in a real browser.
+- Next exact step: commit the focused verify-paths repair, push `codex/issue-1264`, and recheck PR #1269 until the Ubuntu CI job reruns cleanly.
+- Verification gap: local verification covered the repo path-policy check, the targeted browser smoke suite, and a full TypeScript build. I did not run the repo-wide `npm test` glob because this issue is still scoped to the smoke harness plus its supporting test fixture.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/backend/webui-dashboard-browser-smoke.test.ts`.
-- Rollback concern: low. The runtime-facing change is limited to test-harness browser executable discovery, and the added regression test constrains the fallback order.
-- Last focused command: `gh pr view 1269 --json number,url,isDraft,headRefName,baseRefName,mergeStateStatus,statusCheckRollup`
-- What changed this turn: read the required memory files, noticed the journal handoff had stale notes from another issue, verified `codex/issue-1264` was still identical to `main`, reproduced the smoke-suite blocker as missing Chrome discovery without `CHROME_BIN`, patched the harness fallback logic, reran the smoke suite successfully without any environment override, committed the fix, pushed the branch, and opened draft PR #1269.
-- Exact failure reproduced this turn: `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts` failed all five smoke flows immediately with `Error: Set CHROME_BIN to a local Chrome/Chromium executable for the WebUI smoke test.` from `resolveChromeExecutable` before the dashboard fixture loaded.
-- Commands run this turn: `sed -n '1,220p' /Users/tomoakikawada/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1264/AGENTS.generated.md`; `sed -n '1,220p' /Users/tomoakikawada/Dev/codex-supervisor-self/.local/memory/TommyKammy-codex-supervisor/issue-1264/context-index.md`; `sed -n '1,260p' .codex-supervisor/issue-journal.md`; `git branch --show-current && git status --short`; `git log --oneline --decorate -8`; `git diff --stat origin/main...HEAD`; `git diff --name-only origin/main...HEAD`; `rg -n "read-only|safe command|first-run|effective-save|launcher-managed|restart" src/backend/webui-dashboard-browser-smoke.test.ts`; `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `which chromium chromium-browser google-chrome google-chrome-stable chrome || true`; `ls -1 /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome /Applications/Chromium.app/Contents/MacOS/Chromium 2>/dev/null || true`; `fd -HI "(chrome|chromium)$" "$HOME/Library/Caches/ms-playwright" /Applications 2>/dev/null | head -n 40`; `CHROME_BIN='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `sed -n '1,260p' src/backend/webui-dashboard-browser-smoke.test.ts`; `git show 054b8cd -- src/backend/webui-dashboard-browser-smoke.test.ts`; `rg -n "CHROME_BIN|resolveChromeExecutable|chromium.launch|playwright-core" -S src test .`; `cat package.json`; `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `npm run build`; `git status --short`; `git diff -- src/backend/webui-dashboard-browser-smoke.test.ts`; `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true`; `git ls-files --stage .codex-supervisor/issue-journal.md`; `git add src/backend/webui-dashboard-browser-smoke.test.ts .codex-supervisor/issue-journal.md && git commit -m "[codex] Fix WebUI browser smoke Chrome discovery"`; `git push -u origin codex/issue-1264`; `gh pr create --draft --base main --head codex/issue-1264 --title "[codex] Fix remaining release-blocking browser smoke regressions" --body ...`; `git status --short`; `gh pr view 1269 --json number,url,isDraft,headRefName,baseRefName,mergeStateStatus,statusCheckRollup`
+- Rollback concern: low. This turn only changes a regression-test fixture value and the journal handoff; runtime behavior is unchanged.
+- Last focused command: `npm run build`
+- What changed this turn: read the required memory files and the issue journal, used `gh` plus the bundled CI inspector to inspect PR #1269, reproduced the Ubuntu `verify:paths` failure locally, patched the new resolver test fixture to avoid a forbidden workstation-local path literal, and reran the focused local verifiers successfully.
+- Exact failure reproduced this turn: `npm run verify:paths` failed with `Forbidden workstation-local absolute path references found` because the new resolver regression test fixture used a macOS workstation-style absolute home path.
+- Commands run this turn: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `gh auth status`; `git branch --show-current && git status --short && git log --oneline --decorate -5`; `python3 <redacted-local-path> --repo . --pr 1269 --json`; `gh pr checks 1269 --json name,state,bucket,link,startedAt,completedAt,workflow`; `sed -n '1,220p' src/workstation-local-paths.ts`; `nl -ba src/backend/webui-dashboard-browser-smoke.test.ts | sed -n '240,310p'`; `nl -ba .codex-supervisor/issue-journal.md | sed -n '24,44p'`; `npm run verify:paths`; `rg -n "function resolveChromeExecutable|resolveChromeExecutable\\(" src/backend/webui-dashboard-browser-smoke.test.ts`; `sed -n '150,235p' src/backend/webui-dashboard-browser-smoke.test.ts`; `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `npm run build`; `rg -n '<workstation-path-pattern>' .codex-supervisor/issue-journal.md`; `git status --short`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/backend/webui-dashboard-browser-smoke.test.ts
+++ b/src/backend/webui-dashboard-browser-smoke.test.ts
@@ -266,7 +266,7 @@ test("browser smoke resolves Chrome binaries from explicit, PATH, and macOS bund
 
   assert.equal(
     resolveChromeExecutable({
-      env: { HOME: "/Users/example" },
+      env: { HOME: "/tmp/example-home" },
       which: (candidate) => (candidate === "chromium" ? "/usr/local/bin/chromium" : null),
       fileExists: () => false,
     }),
@@ -275,7 +275,7 @@ test("browser smoke resolves Chrome binaries from explicit, PATH, and macOS bund
 
   assert.equal(
     resolveChromeExecutable({
-      env: { HOME: "/Users/example" },
+      env: { HOME: "/tmp/example-home" },
       which: () => null,
       fileExists: (candidate) => candidate === "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     }),


### PR DESCRIPTION
## Summary
- restore browser smoke execution when CHROME_BIN is unset by resolving standard local Chrome/Chromium app bundles
- keep the existing PATH-based discovery order and explicit CHROME_BIN override
- add resolver regression coverage for explicit, PATH, and macOS bundle discovery

## Testing
- npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts
- npm run build

Closes #1264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Chrome/Chromium detection on macOS. The WebUI browser smoke test no longer hard-fails when `CHROME_BIN` is unset and now automatically searches standard macOS application directories.

* **Tests**
  * Added regression test for Chrome binary resolution from multiple sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->