### PR TITLE
Fix tracked PR recovery repair budget convergence

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,50 +1,33 @@
-# Issue #1264: [codex] Fix remaining release-blocking browser smoke regressions
+# Issue #1277: Tracked PR recovery can remain stuck in failed local state after fresh PR head is observed
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1264
-- Branch: codex/issue-1264
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1277
+- Branch: codex/issue-1277
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: repairing_ci
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: e64bec8de17b131baea5f1e858c135331ff0c0f6
+- Current phase: stabilizing
+- Attempt count: 7 (implementation=7, repair=0)
+- Last head SHA: 1358cf5e5e3ab84902fb7ec77411ed6aec1a183f
 - Blocked reason: none
-- Last failure signature: build (ubuntu-latest):fail
-- Repeated failure signature count: 1
-- Updated at: 2026-03-31T14:01:33.889Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-01T23:40:21.729Z
 
 ## Latest Codex Summary
-Updated [src/backend/webui-dashboard-browser-smoke.test.ts](src/backend/webui-dashboard-browser-smoke.test.ts) so the WebUI smoke harness no longer hard-fails when `CHROME_BIN` is unset on macOS. It now keeps the explicit env override, keeps the existing PATH lookup, and falls back to standard local Chrome/Chromium app-bundle paths under `/Applications` and `$HOME/Applications`. I also added a focused resolver regression test in the same file.
-
-The targeted smoke suite now passes locally without any environment override, `npm run build` passes, and the checkpoint is pushed on `codex/issue-1264` with draft PR #1269 open: https://github.com/TommyKammy/codex-supervisor/pull/1269. CI is currently running on that PR.
-
-Summary: Restored browser smoke execution by fixing Chrome discovery fallback in the smoke harness, verified locally, pushed the branch, and opened draft PR #1269.
-State hint: waiting_ci
-Blocked reason: none
-Tests: `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `npm run build`
-Next action: Watch PR #1269 CI on macOS and Ubuntu, then address any fallout or move the draft toward review once checks finish.
-Failure signature: build (ubuntu-latest):fail
+- Reset tracked-PR recovery convergence to clear exhausted repair-lane counters when fresh GitHub PR facts resume the issue, and added same-head `failed -> addressing_review` regression coverage through reconciliation, runOnce, explain, and status paths.
 
 ## Active Failure Context
-- Category: checks
-- Summary: PR #1269 has failing checks.
-- Command or source: gh pr checks
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1269
-- Details:
-  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/23800368842/job/69358801268
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the Ubuntu CI failure is no longer a live browser-smoke regression. The current blocker is `npm run verify:paths`, which rejects workstation-local absolute paths introduced by the new resolver regression test fixture.
-- What changed: inspected PR #1269's failing Actions log with `gh` and the bundled CI inspector, confirmed `build (ubuntu-latest)` failed in `npm run verify:paths`, and reproduced that failure locally. The only remaining findings were macOS workstation-style absolute path literals in `src/backend/webui-dashboard-browser-smoke.test.ts`, so I replaced that fixture `HOME` value with `/tmp/example-home` while keeping the resolver assertions unchanged. Re-ran `npm run verify:paths`, `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`, and `npm run build`; all now pass locally.
+- Hypothesis: same-cycle selection was reasserting `failed` after tracked-PR recovery because the stale exhausted `repair_attempt_count` survived recovery into the resumed `addressing_review` state.
+- What changed: `buildTrackedPrStaleFailureConvergencePatch` now resets `repair_attempt_count` alongside the existing stale-failure cleanup, and regression coverage now exercises same-head `failed -> addressing_review` recovery in reconciliation, `runOnce`, `explain`, and `status`.
 - Current blocker: none.
-- Next exact step: commit the focused verify-paths repair, push `codex/issue-1264`, and recheck PR #1269 until the Ubuntu CI job reruns cleanly.
-- Verification gap: local verification covered the repo path-policy check, the targeted browser smoke suite, and a full TypeScript build. I did not run the repo-wide `npm test` glob because this issue is still scoped to the smoke harness plus its supporting test fixture.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/backend/webui-dashboard-browser-smoke.test.ts`.
-- Rollback concern: low. This turn only changes a regression-test fixture value and the journal handoff; runtime behavior is unchanged.
-- Last focused command: `npm run build`
-- What changed this turn: read the required memory files and the issue journal, used `gh` plus the bundled CI inspector to inspect PR #1269, reproduced the Ubuntu `verify:paths` failure locally, patched the new resolver test fixture to avoid a forbidden workstation-local path literal, and reran the focused local verifiers successfully.
-- Exact failure reproduced this turn: `npm run verify:paths` failed with `Forbidden workstation-local absolute path references found` because the new resolver regression test fixture used a macOS workstation-style absolute home path.
-- Commands run this turn: `sed -n '1,220p' <redacted-local-path>`; `sed -n '1,320p' .codex-supervisor/issue-journal.md`; `gh auth status`; `git branch --show-current && git status --short && git log --oneline --decorate -5`; `python3 <redacted-local-path> --repo . --pr 1269 --json`; `gh pr checks 1269 --json name,state,bucket,link,startedAt,completedAt,workflow`; `sed -n '1,220p' src/workstation-local-paths.ts`; `nl -ba src/backend/webui-dashboard-browser-smoke.test.ts | sed -n '240,310p'`; `nl -ba .codex-supervisor/issue-journal.md | sed -n '24,44p'`; `npm run verify:paths`; `rg -n "function resolveChromeExecutable|resolveChromeExecutable\\(" src/backend/webui-dashboard-browser-smoke.test.ts`; `sed -n '150,235p' src/backend/webui-dashboard-browser-smoke.test.ts`; `npx tsx --test src/backend/webui-dashboard-browser-smoke.test.ts`; `npm run build`; `rg -n '<workstation-path-pattern>' .codex-supervisor/issue-journal.md`; `git status --short`
+- Next exact step: review the diff, then push `codex/issue-1277` and open/update the draft PR if requested.
+- Verification gap: none on the requested local test/build surface.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-execution-orchestration.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`.
+- Rollback concern: low; the runtime change is limited to tracked-PR stale-failure convergence and only resets the repair lane when fresh PR facts are accepted.
+- Last focused command: `npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -730,6 +730,7 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
     ...applyFailureSignature(record, failureContext),
     blocked_reason: nextState === "blocked" ? blockedReason : null,
     repeated_blocker_count: 0,
+    repair_attempt_count: 0,
     timeout_retry_count: 0,
     blocked_verification_retry_count: 0,
     pr_number: pr.number,

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -729,3 +729,61 @@ test("explain does not report local_state failed after tracked PR recovery resum
   assert.doesNotMatch(explanation, /^reason_\d+=local_state failed$/m);
   assert.doesNotMatch(explanation, /^reason_\d+=blocked_failure /m);
 });
+
+test("explain does not report local_state failed after tracked PR recovery resumes the issue in addressing_review", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["copilot-pull-request-reviewer"];
+  const issueNumber = 103;
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked PR recovery clears stale failed review diagnostics",
+    body: executionReadyBody("Explain should reflect the resumed tracked PR review lifecycle state."),
+    createdAt: "2026-03-18T00:00:00Z",
+    updatedAt: "2026-03-18T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 193,
+        last_head_sha: "head-193",
+        blocked_reason: null,
+        last_error: null,
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        last_recovery_reason:
+          "tracked_pr_lifecycle_recovered: resumed issue #103 from failed to addressing_review using fresh tracked PR #193 facts at head head-193",
+        last_recovery_at: "2026-03-19T00:20:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^state=addressing_review$/m);
+  assert.match(explanation, /^runnable=yes$/m);
+  assert.match(
+    explanation,
+    /^latest_recovery issue=#103 at=2026-03-19T00:20:00Z reason=tracked_pr_lifecycle_recovered detail=resumed issue #103 from failed to addressing_review using fresh tracked PR #193 facts at head head-193$/m,
+  );
+  assert.doesNotMatch(explanation, /^reason_\d+=local_state failed$/m);
+  assert.doesNotMatch(explanation, /^reason_\d+=blocked_failure /m);
+});

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2647,3 +2647,73 @@ test("status does not surface tracked PR mismatch diagnostics after tracked PR r
     /^latest_recovery issue=#172 at=2026-03-13T00:20:00Z reason=tracked_pr_lifecycle_recovered detail=resumed issue #172 from failed to draft_pr using fresh tracked PR #272 facts at head head-272$/m,
   );
 });
+
+test("status does not surface tracked PR mismatch diagnostics after tracked PR recovery persists addressing_review state", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["copilot-pull-request-reviewer"];
+  const issueNumber = 173;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 273,
+        blocked_reason: null,
+        last_error: null,
+        last_head_sha: "head-273",
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        last_recovery_reason:
+          "tracked_pr_lifecycle_recovered: resumed issue #173 from failed to addressing_review using fresh tracked PR #273 facts at head head-273",
+        last_recovery_at: "2026-03-13T00:20:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked PR review recovery converged",
+    body: executionReadyBody("Status should reflect the resumed tracked PR review lifecycle state."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const reviewPr = createPullRequest({
+    number: 273,
+    headRefName: branch,
+    headRefOid: "head-273",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => reviewPr,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^tracked_pr_mismatch /m);
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^recovery_guidance=/m);
+
+  const status = await supervisor.status();
+  assert.doesNotMatch(status, /^tracked_pr_mismatch /m);
+  assert.doesNotMatch(status, /^recovery_guidance=/m);
+  assert.match(
+    status,
+    /^latest_recovery issue=#173 at=2026-03-13T00:20:00Z reason=tracked_pr_lifecycle_recovered detail=resumed issue #173 from failed to addressing_review using fresh tracked PR #273 facts at head head-273$/m,
+  );
+});

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -19,6 +19,7 @@ import {
   createIssue,
   createPullRequest,
   createRecord,
+  createReviewThread,
   createSupervisorState,
   createSupervisorFixture,
   executionReadyBody,
@@ -688,6 +689,111 @@ test("runOnce clears stale failed tracked PR recovery on the same head before co
   assert.equal(
     record.last_recovery_reason,
     "tracked_pr_lifecycle_recovered: resumed issue #91 from failed to draft_pr using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(record.last_recovery_at);
+});
+
+test("runOnce does not re-fail recovered tracked PR review work on the same head after repair budget exhaustion", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.maxRepairAttemptsPerIssue = 2;
+  fixture.config.reviewBotLogins = ["copilot-pull-request-reviewer"];
+  const issueNumber = 91;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
+        state: "failed",
+        pr_number: 191,
+        journal_path: null,
+        last_head_sha: "head-191",
+        attempt_count: 3,
+        implementation_attempt_count: 1,
+        repair_attempt_count: 2,
+        last_error: "Stopped after repeated repair attempts.",
+        last_failure_kind: "command_error",
+        last_failure_context: {
+          category: "codex",
+          summary: "Repair budget exhausted while waiting for PR recovery.",
+          signature: "repair-budget-exhausted",
+          command: null,
+          details: ["attempts=2/2"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "repair-budget-exhausted",
+        repeated_failure_signature_count: 3,
+      }),
+    ],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+
+  const issue = createTrackedIssue(issueNumber, {
+    title: "Recover stale failed tracked PR review state through runOnce",
+    body: executionReadyBody("Recover stale failed tracked PR review state through runOnce."),
+    updatedAt: "2026-03-13T00:21:00Z",
+    labels: [],
+  });
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
+    number: 191,
+    title: "Recovery implementation",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-191",
+  });
+  const reviewThreads = [createReviewThread()];
+
+  let getPullRequestCalls = 0;
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      assert.equal(branchName, branch);
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return reviewThreads;
+    },
+    getPullRequestIfExists: async (prNumber: number) => {
+      getPullRequestCalls += 1;
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
+  assert.match(message, /state=addressing_review/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(persisted.activeIssueNumber, issueNumber);
+  assert.equal(getPullRequestCalls, 2);
+  assert.equal(record.state, "addressing_review");
+  assert.equal(record.repair_attempt_count, 0);
+  assert.equal(record.last_error, null);
+  assert.equal(record.last_failure_kind, null);
+  assert.match(record.last_failure_context?.summary ?? "", /unresolved automated review thread/);
+  assert.equal(record.last_failure_signature, "thread-1");
+  assert.equal(record.repeated_failure_signature_count, 1);
+  assert.equal(
+    record.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #91 from failed to addressing_review using fresh tracked PR #191 facts at head head-191",
   );
   assert.ok(record.last_recovery_at);
 });

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2813,6 +2813,7 @@ test("buildTrackedPrStaleFailureConvergencePatch isolates persisted tracked PR r
     repeated_failure_signature_count: 3,
     blocked_reason: "verification",
     repeated_blocker_count: 0,
+    repair_attempt_count: 0,
     timeout_retry_count: 0,
     blocked_verification_retry_count: 0,
     pr_number: 191,
@@ -3024,6 +3025,113 @@ test("reconcileStaleFailedIssueStates clears stale failed tracked PR state when 
   assert.equal(
     updated.last_recovery_reason,
     "tracked_pr_lifecycle_recovered: resumed issue #366 from failed to draft_pr using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
+test("reconcileStaleFailedIssueStates resets repair attempts when GitHub resumes the issue in addressing_review on the same head", async () => {
+  const config = createConfig({
+    maxRepairAttemptsPerIssue: 2,
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        attempt_count: 3,
+        implementation_attempt_count: 1,
+        repair_attempt_count: 2,
+        last_error: "Stopped after repeated repair attempts.",
+        last_failure_kind: "codex_failed",
+        last_failure_context: {
+          category: "codex",
+          summary: "Repair budget exhausted while waiting for PR recovery.",
+          signature: "repair-budget-exhausted",
+          command: null,
+          details: ["attempts=2/2"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "repair-budget-exhausted",
+        repeated_failure_signature_count: 3,
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+  });
+  const reviewThreads = [createReviewThread()];
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => reviewThreads,
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "addressing_review");
+  assert.equal(updated.repair_attempt_count, 0);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(
+    updated.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from failed to addressing_review using fresh tracked PR #191 facts at head head-191",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);


### PR DESCRIPTION
Closes #1277

## Summary
- reset stale repair-attempt state when tracked PR recovery accepts fresher PR facts
- add regression coverage for the Ubuntu/AegisOps-shaped failed-to-addressing_review convergence path
- keep diagnostics aligned so recovered tracked PR state no longer remains authoritatively failed without a current blocker

## Verification
- npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recovery state transitions to properly reset internal attempt counters when tracked issues resume from failed states, ensuring clean state normalization.

* **Tests**
  * Added comprehensive regression test coverage for issue recovery and reconciliation, validating correct state transitions, diagnostic accuracy, and proper recovery handling across multiple execution pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->