### PR TITLE
Advance healthy tracked draft PRs out of draft_pr during run-once progression

### DIFF
--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -169,7 +169,7 @@ test("handleAuthFailure blocks the active issue and preserves failure tracking f
   assert.equal(updated.blocked_reason, "unknown");
 });
 
-test("runOnce dry-run selects an issue and hydrates workspace and PR context before Codex", async () => {
+test("runOnce dry-run selects an issue and hydrates workspace and PR context before tracked draft PR progression", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 91;
   const branch = branchName(fixture.config, issueNumber);
@@ -195,6 +195,12 @@ test("runOnce dry-run selects an issue and hydrates workspace and PR context bef
   let checksCalls = 0;
   let reviewThreadCalls = 0;
   const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, pr.number);
+    return { pr, checks, reviewThreads };
+  };
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [issue],
@@ -227,8 +233,8 @@ test("runOnce dry-run selects an issue and hydrates workspace and PR context bef
   };
 
   const message = await supervisor.runOnce({ dryRun: true });
-  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
   assert.match(message, /state=draft_pr/);
+  assert.doesNotMatch(message, /would invoke Codex/u);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
@@ -366,6 +372,12 @@ test("runOnce converges stale failed tracked PR state before selecting the resum
   });
 
   const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, pr.number);
+    return { pr, checks: [], reviewThreads: [] };
+  };
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [issue],
@@ -401,8 +413,8 @@ test("runOnce converges stale failed tracked PR state before selecting the resum
   };
 
   const message = await supervisor.runOnce({ dryRun: true });
-  assert.match(message, /Dry run: would invoke Codex for issue #366\./);
   assert.match(message, /state=draft_pr/);
+  assert.doesNotMatch(message, /would invoke Codex/u);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
@@ -640,6 +652,12 @@ test("runOnce clears stale failed tracked PR recovery on the same head before co
 
   let getPullRequestCalls = 0;
   const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, pr.number);
+    return { pr, checks: [], reviewThreads: [] };
+  };
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [issue],
@@ -673,8 +691,8 @@ test("runOnce clears stale failed tracked PR recovery on the same head before co
   };
 
   const message = await supervisor.runOnce({ dryRun: true });
-  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
   assert.match(message, /state=draft_pr/);
+  assert.doesNotMatch(message, /would invoke Codex/u);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -573,7 +573,7 @@ test("shouldRunCodex only returns true for actionable supervisor states", () => 
   assert.equal(shouldRunCodex(createRecord({ state: "queued", pr_number: null }), null, [], [], config), true);
   assert.equal(
     shouldRunCodex(createRecord({ state: "draft_pr" }), createPullRequest({ isDraft: true }), checks, reviewThreads, config),
-    true,
+    false,
   );
   assert.equal(
     shouldRunCodex(createRecord({ state: "waiting_ci" }), createPullRequest(), checks, reviewThreads, config),

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -366,7 +366,6 @@ export function shouldRunCodex(
 
   const inferred = inferStateFromPullRequest(config, record, pr, checks, reviewThreads);
   return (
-    inferred === "draft_pr" ||
     inferred === "repairing_ci" ||
     inferred === "resolving_conflict" ||
     inferred === "addressing_review" ||


### PR DESCRIPTION
## Summary
- stop rerunning Codex for tracked healthy draft PRs during run-once progression
- let tracked draft PRs flow into post-turn PR progression instead of staying on the Codex execution path
- update orchestration and lifecycle expectations for the tracked draft PR fast path

Closes #1286

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-readiness.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft pull requests are no longer processed by the automated system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->