### PR TITLE
[codex] Separate stale no-PR recovery budget from implementation attempts

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,47 +1,33 @@
-# Issue #1275: Improve diagnostics when a tracked PR is waiting on CI/review signals the repo cannot produce yet
+# Issue #1291: [codex] Separate stale no-PR recovery budget from implementation attempts
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1275
-- Branch: codex/issue-1275
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1291
+- Branch: codex/issue-1291
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 4 (implementation=1, repair=2)
-- Last head SHA: 509204d98265bdd26596e55c3e681441a5ce6b51
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: dad4210b1b7dd5b4c4b01679fc10a7e85656f96a
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ854uTZo|PRRT_kwDORgvdZ854uTZp
-- Repeated failure signature count: 1
-- Updated at: 2026-04-03T21:24:18.812Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-03T23:11:34.457Z
 
 ## Latest Codex Summary
-Patched the readiness diagnostic in [supervisor-status-review-bot.ts](src/supervisor/supervisor-status-review-bot.ts) so configured-bot top-level reviews now count as external review signals, and aggregate status keeps any `repo_not_configured` CI/review gap visible unless there is an actual blocking CI failure or review finding. I added focused regressions in [supervisor-status-review-bot.test.ts](src/supervisor/supervisor-status-review-bot.test.ts) for both review comments.
-
-Verification passed with `npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts` and `npm run build`. I updated the issue journal and pushed commit `509204d` to `codex/issue-1275` for PR #1288.
-
-Summary: Fixed review-bot readiness diagnostics and pushed the review-thread patch to PR #1288.
-State hint: addressing_review
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`; `npm run build`
-Next action: Monitor PR #1288 for refreshed CI/CodeRabbit results and resolve any remaining review follow-up if new feedback appears.
-Failure signature: PRRT_kwDORgvdZ854uTZo|PRRT_kwDORgvdZ854uTZp
+- None yet.
 
 ## Active Failure Context
-- Category: review
-- Summary: 2 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1288#discussion_r3032943000
-- Details:
-  - .codex-supervisor/issue-journal.md:45 summary=_⚠️ Potential issue_ | _🟠 Major_ **Track or address the documented edge case.** The rollback concern identifies a real diagnostic accuracy gap: repos using external CI systems ... url=https://github.com/TommyKammy/codex-supervisor/pull/1288#discussion_r3032943000
-  - src/supervisor/supervisor-status-review-bot.test.ts:283 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Register temp-dir cleanup immediately after creation.** On Line 278, cleanup is registered only after extra awaited setup calls. url=https://github.com/TommyKammy/codex-supervisor/pull/1288#discussion_r3032943002
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The tracked-PR diagnostics only classified "missing provider signal" and "checks=none", so bootstrap repos with no workflows/check runs were being reported like a PR-specific wait instead of a repo capability mismatch.
-- What changed: Addressed the remaining review follow-up by moving the temp-directory cleanup registration to immediately after `fs.mkdtemp(...)` in `supervisor-status-review-bot.test.ts`, and documented the workflow-presence heuristic in `externalSignalReadinessDiagnostics()` with a TODO that calls out external CI and GitHub App checks. Added a focused regression showing emitted external checks already override missing local workflow files, then pushed commit `4641127` to `codex/issue-1275`.
+- Hypothesis: The stale no-PR recovery path was still hitting the generic implementation-attempt gate in `resolveRunnableIssueContext`, so a recoverable stale cleanup could fail before its own stale recovery retry budget was exhausted.
+- What changed: Added a regression test for exhausted implementation attempts during queued stale no-PR recovery, added a no-PR helper to detect when stale recovery budget still applies, and skipped the implementation budget gate for that specific queued stale-recovery case so exhaustion diagnostics now end at the stale recovery loop rather than the implementation lane.
 - Current blocker: none
-- Next exact step: Wait for PR #1288 CI and CodeRabbit to finish on commit `4641127`, then leave the remaining test-thread resolution to the operator unless explicitly asked to write on GitHub.
-- Verification gap: none for the requested focused suite and TypeScript build.
-- Files touched: .codex-supervisor/issue-journal.md; src/supervisor/supervisor-status-review-bot.test.ts; src/supervisor/supervisor-status-review-bot.ts
-- Rollback concern: Bootstrap-stage repos that rely on external CI before any check run is observed can still be inferred as `repo_not_configured` because workflow absence is only a local heuristic; the new TODO documents that gap without changing gating behavior.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`; `npm run build`; `gh pr view 1288 --repo TommyKammy/codex-supervisor --json headRefOid,updatedAt,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,url`
+- Next exact step: Push or open/update the draft PR with the checkpoint commit if the supervisor wants the branch published now.
+- Verification gap: none for the scoped change; requested focused tests and build passed locally.
+- Files touched: .codex-supervisor/issue-journal.md; src/no-pull-request-state.ts; src/no-pull-request-state.test.ts; src/supervisor/supervisor.ts; src/supervisor/supervisor-execution-orchestration.test.ts
+- Rollback concern: The new bypass is intentionally narrow to queued no-PR stale recovery with remaining stale retry budget; if broadened accidentally it could weaken the normal implementation-attempt guardrail for ordinary no-PR work.
+- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts && npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/no-pull-request-state.test.ts
+++ b/src/no-pull-request-state.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   inferStateWithoutPullRequest,
+  hasStaleStabilizingNoPrRecoveryBudgetRemaining,
   STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
   shouldPreserveNoPrFailureTracking,
   shouldPreserveStaleStabilizingNoPrRecoveryTracking,
@@ -218,6 +219,45 @@ test("shouldPreserveStaleStabilizingNoPrRecoveryTracking only keeps stale stabil
         last_failure_signature: "stale-stabilizing-no-pr-recovery-loop",
       }),
       "stabilizing",
+    ),
+    false,
+  );
+});
+
+test("hasStaleStabilizingNoPrRecoveryBudgetRemaining only unlocks queued stale no-PR retries below the repeat limit", () => {
+  assert.equal(
+    hasStaleStabilizingNoPrRecoveryBudgetRemaining(
+      createRecord({
+        state: "queued",
+        pr_number: null,
+        last_failure_signature: STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
+        stale_stabilizing_no_pr_recovery_count: 2,
+      }),
+      { sameFailureSignatureRepeatLimit: 3 },
+    ),
+    true,
+  );
+  assert.equal(
+    hasStaleStabilizingNoPrRecoveryBudgetRemaining(
+      createRecord({
+        state: "queued",
+        pr_number: null,
+        last_failure_signature: STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
+        stale_stabilizing_no_pr_recovery_count: 3,
+      }),
+      { sameFailureSignatureRepeatLimit: 3 },
+    ),
+    false,
+  );
+  assert.equal(
+    hasStaleStabilizingNoPrRecoveryBudgetRemaining(
+      createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        last_failure_signature: STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE,
+        stale_stabilizing_no_pr_recovery_count: 2,
+      }),
+      { sameFailureSignatureRepeatLimit: 3 },
     ),
     false,
   );

--- a/src/no-pull-request-state.ts
+++ b/src/no-pull-request-state.ts
@@ -91,6 +91,29 @@ export function buildStaleStabilizingNoPrRecoveryWarningLine(
   ].join(" ");
 }
 
+export function hasStaleStabilizingNoPrRecoveryBudgetRemaining(
+  record: Pick<
+    IssueRunRecord,
+    | "pr_number"
+    | "state"
+    | "last_failure_signature"
+    | "repeated_failure_signature_count"
+    | "stale_stabilizing_no_pr_recovery_count"
+  >,
+  config: Pick<SupervisorConfig, "sameFailureSignatureRepeatLimit">,
+): boolean {
+  if (record.pr_number !== null || record.state !== "queued") {
+    return false;
+  }
+
+  const repeatedCount = getStaleStabilizingNoPrRecoveryCount(record);
+  if (repeatedCount <= 0) {
+    return false;
+  }
+
+  return repeatedCount < Math.max(config.sameFailureSignatureRepeatLimit, 1);
+}
+
 export function inferStateWithoutPullRequest(
   record: IssueRunRecord,
   workspaceStatus: WorkspaceStatus,

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1295,6 +1295,137 @@ test("runOnce preserves stale no-PR recovery tracking across a successful no-PR 
   );
 });
 
+test("runOnce lets queued stale no-PR recovery use its own retry budget after implementation attempts are exhausted", async () => {
+  const fixture = await createSupervisorFixture({
+    codexScriptLines: [
+      "#!/bin/sh",
+      "set -eu",
+      'out=""',
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      '    -o) out="$2"; shift 2 ;;',
+      '    *) shift ;;',
+      '  esac',
+      "done",
+      'printf \'{"type":"thread.started","thread_id":"thread-stale-no-pr-budget"}\\n\'',
+      "cat <<'EOF' > \"$out\"",
+      "Summary: continued stale stabilizing recovery without opening a PR",
+      "State hint: stabilizing",
+      "Blocked reason: none",
+      "Tests: not run",
+      "Failure signature: none",
+      "Next action: continue the no-PR recovery path",
+      "EOF",
+      "printf '\\n- What changed: completed another successful no-PR recovery turn.\\n' >> .codex-supervisor/issue-journal.md",
+      "printf 'dirty recovery state\\n' >> stale-no-pr.txt",
+      "exit 0",
+      "",
+    ],
+  });
+  fixture.config.maxImplementationAttemptsPerIssue = 2;
+  const issueNumber = 93;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "stabilizing",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: null,
+        codex_session_id: "stale-session",
+        attempt_count: 2,
+        implementation_attempt_count: 2,
+        last_error:
+          "Issue #93 re-entered stale stabilizing recovery without a tracked PR; the supervisor will retry while the repeat count remains below 3.",
+        last_failure_context: {
+          category: "blocked",
+          summary:
+            "Issue #93 re-entered stale stabilizing recovery without a tracked PR; the supervisor will retry while the repeat count remains below 3.",
+          signature: "stale-stabilizing-no-pr-recovery-loop",
+          command: null,
+          details: [
+            "state=stabilizing",
+            "tracked_pr=none",
+            "branch_state=recoverable",
+            "repeat_count=1/3",
+            "operator_action=confirm whether the implementation already landed elsewhere or retarget the tracked issue manually",
+          ],
+          url: null,
+          updated_at: "2026-03-13T00:00:00.000Z",
+        },
+        last_failure_signature: "stale-stabilizing-no-pr-recovery-loop",
+        repeated_failure_signature_count: 0,
+        stale_stabilizing_no_pr_recovery_count: 1,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Separate stale recovery budget from implementation attempts",
+    body: executionReadyBody("Separate stale recovery budget from implementation attempts."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const firstMessage = await supervisor.runOnce({ dryRun: false });
+  assert.match(
+    firstMessage,
+    /recovery issue=#93 reason=stale_state_cleanup: requeued stabilizing issue #93 after issue lock and session lock were missing/,
+  );
+
+  const firstPersisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const firstRecord = firstPersisted.issues[String(issueNumber)]!;
+  assert.equal(firstPersisted.activeIssueNumber, issueNumber);
+  assert.equal(firstRecord.state, "stabilizing");
+  assert.equal(firstRecord.pr_number, null);
+  assert.equal(firstRecord.codex_session_id, "thread-stale-no-pr-budget");
+  assert.equal(firstRecord.stale_stabilizing_no_pr_recovery_count, 2);
+  assert.equal(firstRecord.implementation_attempt_count, 3);
+  assert.doesNotMatch(firstRecord.last_error ?? "", /Reached max implementation Codex attempts/);
+
+  const secondMessage = await supervisor.runOnce({ dryRun: false });
+  assert.match(
+    secondMessage,
+    /recovery issue=#93 reason=stale_state_manual_stop: blocked issue #93 after repeated stale stabilizing recovery without a tracked PR/,
+  );
+
+  const secondPersisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const secondRecord = secondPersisted.issues[String(issueNumber)]!;
+  assert.equal(secondPersisted.activeIssueNumber, null);
+  assert.equal(secondRecord.state, "blocked");
+  assert.equal(secondRecord.blocked_reason, "manual_review");
+  assert.match(secondRecord.last_error ?? "", /manual intervention is required/i);
+  assert.doesNotMatch(secondRecord.last_error ?? "", /implementation Codex attempts/);
+  assert.equal(secondRecord.stale_stabilizing_no_pr_recovery_count, 3);
+});
+
 test("runOnce converges a stale no-PR issue to done when only supervisor-owned worktree artifacts differ from origin/main", async () => {
   const fixture = await createSupervisorFixture({
     codexScriptLines: [

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -27,7 +27,10 @@ import {
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,
 } from "../pull-request-state";
-import { inferStateWithoutPullRequest } from "../no-pull-request-state";
+import {
+  hasStaleStabilizingNoPrRecoveryBudgetRemaining,
+  inferStateWithoutPullRequest,
+} from "../no-pull-request-state";
 import {
   hasProcessedReviewThread,
   localReviewBlocksReady,
@@ -587,7 +590,10 @@ export class Supervisor {
 
     let { record, issue, issueLock } = runnableIssue;
     const budgetLaneBeforeWorkspace = attemptLane(record, null);
-    if (!hasAttemptBudgetRemaining(record, this.config, budgetLaneBeforeWorkspace)) {
+    const staleNoPrRecoveryBudgetApplies =
+      budgetLaneBeforeWorkspace === "implementation"
+      && hasStaleStabilizingNoPrRecoveryBudgetRemaining(record, this.config);
+    if (!staleNoPrRecoveryBudgetApplies && !hasAttemptBudgetRemaining(record, this.config, budgetLaneBeforeWorkspace)) {
       try {
         const used = attemptsUsedForLane(record, budgetLaneBeforeWorkspace);
         const max = attemptBudgetForLane(this.config, budgetLaneBeforeWorkspace);


### PR DESCRIPTION
## Summary
- separate stale no-PR recovery retry budgeting from the generic implementation-attempt gate
- allow queued stale no-PR recovery to continue while its dedicated recovery budget remains, even after implementation attempts are exhausted
- add regression coverage proving stale recovery now terminates with stale-recovery diagnostics instead of implementation-exhaustion diagnostics

## Why
The stale no-PR recovery path was still treated as ordinary implementation work at the pre-workspace budget gate. That meant a recoverable stale cleanup loop could stop early with implementation-attempt exhaustion before its own stale recovery retry budget was used.

## Impact
Operators can now distinguish between actual implementation exhaustion and stale no-PR recovery exhaustion, while the existing implementation-attempt safeguard remains intact for real Codex execution work.

## Validation
- `npx tsx --test src/no-pull-request-state.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`
- `npm run build`

Refs #1291


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recovery mechanism for issues without pull requests, enabling additional automatic retry attempts after standard implementation retries are exhausted before escalating to manual review.

* **Tests**
  * Added test coverage for the new recovery mechanism and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->