### PR TITLE
[codex] Treat artifact-only stale no-PR branches as already satisfied on main

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #1291: [codex] Separate stale no-PR recovery budget from implementation attempts
+# Issue #1292: [codex] Treat artifact-only stale no-PR branches as already_satisfied_on_main
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1291
-- Branch: codex/issue-1291
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1292
+- Branch: codex/issue-1292
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: dad4210b1b7dd5b4c4b01679fc10a7e85656f96a
+- Last head SHA: a0ff00cf03130a630c6d47f5d3c0a1459b1a3f02
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-03T23:11:34.457Z
+- Updated at: 2026-04-03T23:46:03.089Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,13 +21,13 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The stale no-PR recovery path was still hitting the generic implementation-attempt gate in `resolveRunnableIssueContext`, so a recoverable stale cleanup could fail before its own stale recovery retry budget was exhausted.
-- What changed: Added a regression test for exhausted implementation attempts during queued stale no-PR recovery, added a no-PR helper to detect when stale recovery budget still applies, and skipped the implementation budget gate for that specific queued stale-recovery case so exhaustion diagnostics now end at the stale recovery loop rather than the implementation lane.
+- Hypothesis: Failed no-PR reconciliation was already classifying artifact-only divergence as `already_satisfied_on_main`, but the recovery branch still converted that result into a blocked manual-review outcome instead of done-style convergence.
+- What changed: Updated `reconcileStaleFailedIssueStates` to map failed no-PR `already_satisfied_on_main` results to `doneResetPatch(...)` and `already_satisfied_on_main` recovery events, while leaving `manual_review_required` fail-closed. Tightened regression tests to expect done-state convergence for artifact-only dirty worktrees, artifact-only commits ahead of `origin/main`, and exact-main matches.
 - Current blocker: none
-- Next exact step: Push or open/update the draft PR with the checkpoint commit if the supervisor wants the branch published now.
-- Verification gap: none for the scoped change; requested focused tests and build passed locally.
-- Files touched: .codex-supervisor/issue-journal.md; src/no-pull-request-state.ts; src/no-pull-request-state.test.ts; src/supervisor/supervisor.ts; src/supervisor/supervisor-execution-orchestration.test.ts
-- Rollback concern: The new bypass is intentionally narrow to queued no-PR stale recovery with remaining stale retry budget; if broadened accidentally it could weaken the normal implementation-attempt guardrail for ordinary no-PR work.
-- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts && npm run build
+- Next exact step: Commit the verified reconciliation and test changes on `codex/issue-1292`.
+- Verification gap: none for the requested focused tests and build; unrelated test fixtures still log known execution-metrics chronology warnings without failing.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`
+- Rollback concern: Recovery logs for failed no-PR artifact-only cases now emit done-style `already_satisfied_on_main` reasons instead of blocked `failed_no_pr_already_satisfied` reasons, so any downstream tooling matching the old string would need to tolerate the new outcome.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1375,32 +1375,51 @@ export async function reconcileStaleFailedIssueStates(
       const branchRecovery = await classifyFailedNoPrBranchRecovery({ config, record });
       if (branchRecovery.state !== "recoverable") {
         const branchRecoveryState = branchRecovery.state;
-        const failureContext = buildFailedNoPrBranchFailureContext({
-          record,
-          branchRecoveryState,
-          headSha: branchRecovery.headSha,
-          defaultBranch: config.defaultBranch,
-        });
+        const shouldMarkAlreadySatisfiedOnMain = branchRecoveryState === "already_satisfied_on_main";
+        const failureContext = shouldMarkAlreadySatisfiedOnMain
+          ? null
+          : buildFailedNoPrBranchFailureContext({
+              record,
+              branchRecoveryState,
+              headSha: branchRecovery.headSha,
+              defaultBranch: config.defaultBranch,
+            });
         const recoveryEvent = buildRecoveryEvent(
           record.issue_number,
-          branchRecoveryState === "already_satisfied_on_main"
-            ? `failed_no_pr_already_satisfied: blocked issue #${record.issue_number} after failed no-PR recovery found no meaningful branch changes relative to origin/${config.defaultBranch}`
+          shouldMarkAlreadySatisfiedOnMain
+            ? branchRecovery.headSha === record.last_head_sha
+              ? `already_satisfied_on_main: marked issue #${record.issue_number} done after failed no-PR recovery found no meaningful branch changes`
+              : `already_satisfied_on_main: marked issue #${record.issue_number} done after failed no-PR recovery found only supervisor-owned branch divergence`
             : `failed_no_pr_manual_review: blocked issue #${record.issue_number} after failed no-PR recovery found an unsafe or ambiguous workspace state`,
         );
-        const patch: Partial<IssueRunRecord> = {
-          state: "blocked",
-          pr_number: null,
-          codex_session_id: null,
-          blocked_reason: "manual_review",
-          last_error: truncate(failureContext.summary, 1000),
-          last_failure_kind: null,
-          last_failure_context: failureContext,
-          last_blocker_signature: null,
-          repeated_blocker_count: 0,
-          stale_stabilizing_no_pr_recovery_count: 0,
-          last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
-          ...applyFailureSignature(record, failureContext),
-        };
+        const patch: Partial<IssueRunRecord> = shouldMarkAlreadySatisfiedOnMain
+          ? doneResetPatch({
+              pr_number: null,
+              codex_session_id: null,
+              last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
+            })
+          : (() => {
+              const manualReviewFailureContext = buildFailedNoPrBranchFailureContext({
+                record,
+                branchRecoveryState,
+                headSha: branchRecovery.headSha,
+                defaultBranch: config.defaultBranch,
+              });
+              return {
+                state: "blocked",
+                pr_number: null,
+                codex_session_id: null,
+                blocked_reason: "manual_review",
+                last_error: truncate(manualReviewFailureContext.summary, 1000),
+                last_failure_kind: null,
+                last_failure_context: manualReviewFailureContext,
+                last_blocker_signature: null,
+                repeated_blocker_count: 0,
+                stale_stabilizing_no_pr_recovery_count: 0,
+                last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
+                ...applyFailureSignature(record, manualReviewFailureContext),
+              };
+            })();
         const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
         state.issues[String(record.issue_number)] = updated;
         changed = true;

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2925,7 +2925,7 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates does not requeue failed no-PR issues when only supervisor-local artifacts are dirty", async () => {
+test("reconcileStaleFailedIssueStates converges failed no-PR issues when only supervisor-local artifacts are dirty", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -3029,25 +3029,17 @@ test("reconcileStaleFailedIssueStates does not requeue failed no-PR issues when 
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "blocked");
+  assert.equal(updated.state, "done");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.blocked_reason, null);
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
-  assert.match(updated.last_error ?? "", /no longer differs from origin\/main/i);
-  assert.deepEqual(updated.last_failure_context?.details ?? [], [
-    "state=failed",
-    "tracked_pr=none",
-    "branch_state=already_satisfied_on_main",
-    "default_branch=origin/main",
-    `head_sha=${baseHead}`,
-    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
-  ]);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_error, null);
   assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(
     updated.last_recovery_reason,
-    "failed_no_pr_already_satisfied: blocked issue #366 after failed no-PR recovery found no meaningful branch changes relative to origin/main",
+    "already_satisfied_on_main: marked issue #366 done after failed no-PR recovery found no meaningful branch changes",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
@@ -3161,31 +3153,24 @@ test("reconcileStaleFailedIssueStates treats artifact-only commits ahead of orig
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "blocked");
+  assert.equal(updated.state, "done");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.blocked_reason, null);
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
-  assert.match(updated.last_error ?? "", /no longer differs from origin\/main/i);
-  assert.deepEqual(updated.last_failure_context?.details ?? [], [
-    "state=failed",
-    "tracked_pr=none",
-    "branch_state=already_satisfied_on_main",
-    "default_branch=origin/main",
-    `head_sha=${headSha}`,
-    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
-  ]);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_head_sha, headSha);
   assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(
     updated.last_recovery_reason,
-    "failed_no_pr_already_satisfied: blocked issue #366 after failed no-PR recovery found no meaningful branch changes relative to origin/main",
+    "already_satisfied_on_main: marked issue #366 done after failed no-PR recovery found only supervisor-owned branch divergence",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates blocks failed no-PR issues when the preserved branch is already satisfied on origin/main", async () => {
+test("reconcileStaleFailedIssueStates converges failed no-PR issues when the preserved branch is already satisfied on origin/main", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -3286,25 +3271,17 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues when the preser
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "blocked");
+  assert.equal(updated.state, "done");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.blocked_reason, null);
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
-  assert.match(updated.last_error ?? "", /no longer differs from origin\/main/i);
-  assert.deepEqual(updated.last_failure_context?.details ?? [], [
-    "state=failed",
-    "tracked_pr=none",
-    "branch_state=already_satisfied_on_main",
-    "default_branch=origin/main",
-    `head_sha=${baseHead}`,
-    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
-  ]);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_error, null);
   assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(
     updated.last_recovery_reason,
-    "failed_no_pr_already_satisfied: blocked issue #366 after failed no-PR recovery found no meaningful branch changes relative to origin/main",
+    "already_satisfied_on_main: marked issue #366 done after failed no-PR recovery found no meaningful branch changes",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);


### PR DESCRIPTION
## Summary
- treat stale no-PR branches whose only divergence from `origin/main` is supervisor-owned durable artifacts as already satisfied on main
- keep fail-closed behavior for meaningful non-artifact diffs
- add regression coverage for artifact-only stale reconciliation paths

## Root Cause
The failed no-PR stale recovery path already recognized some artifact-only branch states as `already_satisfied_on_main`, but the recovery mapping converted that result into a blocked/manual-review style outcome instead of a done-style convergence.

## What Changed
- updated stale failed-issue reconciliation so `already_satisfied_on_main` becomes a done reset path for no-PR recovery
- preserved manual-review-required handling for meaningful diffs
- added focused tests for artifact-only dirty worktrees, artifact-only commits ahead of `origin/main`, and exact-main matches

## Validation
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`
- `npm run build`

Closes #1292
