### PR TITLE
[codex] Fetch origin/default branch once per reconciliation pass

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,33 @@
-# Issue #1292: [codex] Treat artifact-only stale no-PR branches as already_satisfied_on_main
+# Issue #1293: [codex] Fetch origin/default branch once per reconciliation pass
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1292
-- Branch: codex/issue-1292
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1293
+- Branch: codex/issue-1293
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: a0ff00cf03130a630c6d47f5d3c0a1459b1a3f02
+- Last head SHA: 7f5f7c9bc1c45fb819c6deaf7ed8e6345472ff1f
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-03T23:46:03.089Z
+- Updated at: 2026-04-04T00:03:35.318Z
 
 ## Latest Codex Summary
-- None yet.
+- Moved failed no-PR default-branch fetches to a shared per-pass boundary inside stale failed reconciliation, added regression coverage for one-fetch-per-pass reuse and shared-fetch fail-closed behavior, and verified with the focused reconciliation suite plus `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Failed no-PR reconciliation was already classifying artifact-only divergence as `already_satisfied_on_main`, but the recovery branch still converted that result into a blocked manual-review outcome instead of done-style convergence.
-- What changed: Updated `reconcileStaleFailedIssueStates` to map failed no-PR `already_satisfied_on_main` results to `doneResetPatch(...)` and `already_satisfied_on_main` recovery events, while leaving `manual_review_required` fail-closed. Tightened regression tests to expect done-state convergence for artifact-only dirty worktrees, artifact-only commits ahead of `origin/main`, and exact-main matches.
+- Hypothesis: `reconcileStaleFailedIssueStates` was re-fetching `origin/<defaultBranch>` once per eligible failed no-PR record because the fetch lived inside `classifyFailedNoPrBranchRecovery`, so multiple stale no-PR records in one pass repeated the same remote fetch.
+- What changed: Added a shared per-pass `ensureOriginDefaultBranchFetched` promise in `reconcileStaleFailedIssueStates`, routed failed no-PR branch classification through that shared fetch, and added focused regression tests for one-fetch-per-pass reuse plus shared-fetch fail-closed behavior.
 - Current blocker: none
-- Next exact step: Commit the verified reconciliation and test changes on `codex/issue-1292`.
-- Verification gap: none for the requested focused tests and build; unrelated test fixtures still log known execution-metrics chronology warnings without failing.
+- Next exact step: Commit the reconciliation/test updates on `codex/issue-1293` and hand back a clean verified checkpoint.
+- Verification gap: none for the requested focused reconciliation coverage and build; the reconciliation test file still emits known execution-metrics chronology warnings in unrelated tests without failing.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`
-- Rollback concern: Recovery logs for failed no-PR artifact-only cases now emit done-style `already_satisfied_on_main` reasons instead of blocked `failed_no_pr_already_satisfied` reasons, so any downstream tooling matching the old string would need to tolerate the new outcome.
+- Rollback concern: Failed no-PR reconciliation now reuses one shared default-branch fetch result per pass, so any future change that expects per-record fetch retries inside the same pass would need an explicit redesign.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -190,6 +190,7 @@ async function classifyFailedNoPrBranchRecovery(args: {
     "repoPath" | "defaultBranch" | "issueJournalRelativePath" | "codexExecTimeoutMinutes" | "workspaceRoot" | "branchPrefix"
   >;
   record: Pick<IssueRunRecord, "issue_number" | "workspace" | "journal_path" | "branch">;
+  ensureOriginDefaultBranchFetched: () => Promise<void>;
 }): Promise<{ state: FailedNoPrBranchRecoveryState; headSha: string | null }> {
   const { config, record } = args;
   if (!isSafeCleanupTarget(config, record.workspace, record.branch) || !fs.existsSync(path.join(record.workspace, ".git"))) {
@@ -227,9 +228,7 @@ async function classifyFailedNoPrBranchRecovery(args: {
       return { state: "manual_review_required", headSha: null };
     }
 
-    await runCommand("git", ["-C", config.repoPath, "fetch", "origin", config.defaultBranch], {
-      timeoutMs: gitProbeTimeoutMs,
-    });
+    await args.ensureOriginDefaultBranchFetched();
     const [headResult, baseAheadResult, baseDiffResult, workspaceStatusResult] = await Promise.all([
       runCommand("git", ["-C", record.workspace, "rev-parse", "HEAD"], {
         timeoutMs: gitProbeTimeoutMs,
@@ -268,6 +267,14 @@ async function classifyFailedNoPrBranchRecovery(args: {
   } catch {
     return { state: "manual_review_required", headSha: null };
   }
+}
+
+async function fetchOriginDefaultBranch(
+  config: Pick<SupervisorConfig, "repoPath" | "defaultBranch" | "codexExecTimeoutMinutes">,
+): Promise<void> {
+  await runCommand("git", ["-C", config.repoPath, "fetch", "origin", config.defaultBranch], {
+    timeoutMs: config.codexExecTimeoutMinutes * 60_000,
+  });
 }
 
 function shouldAutoRecoverFailedNoPr(record: IssueRunRecord, config: SupervisorConfig): boolean {
@@ -1327,6 +1334,9 @@ export async function reconcileStaleFailedIssueStates(
       pr: NonNullable<Awaited<ReturnType<RecoveryGitHubLike["getPullRequestIfExists"]>>>,
     ) => Partial<IssueRunRecord>;
     syncCopilotReviewTimeoutState: typeof syncCopilotReviewTimeoutState;
+    fetchOriginDefaultBranch?: (
+      config: Pick<SupervisorConfig, "repoPath" | "defaultBranch" | "codexExecTimeoutMinutes">
+    ) => Promise<void>;
     inferGitHubWaitStep?: (
       config: SupervisorConfig,
       record: IssueRunRecord,
@@ -1342,6 +1352,11 @@ export async function reconcileStaleFailedIssueStates(
 ): Promise<void> {
   let changed = false;
   const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
+  let failedNoPrFetchPromise: Promise<void> | null = null;
+  const ensureOriginDefaultBranchFetched = (): Promise<void> => {
+    failedNoPrFetchPromise ??= (deps.fetchOriginDefaultBranch ?? fetchOriginDefaultBranch)(config);
+    return failedNoPrFetchPromise;
+  };
 
   for (const record of Object.values(state.issues)) {
     if (record.state !== "failed") {
@@ -1372,7 +1387,11 @@ export async function reconcileStaleFailedIssueStates(
         continue;
       }
 
-      const branchRecovery = await classifyFailedNoPrBranchRecovery({ config, record });
+      const branchRecovery = await classifyFailedNoPrBranchRecovery({
+        config,
+        record,
+        ensureOriginDefaultBranchFetched,
+      });
       if (branchRecovery.state !== "recoverable") {
         const branchRecoveryState = branchRecovery.state;
         const shouldMarkAlreadySatisfiedOnMain = branchRecoveryState === "already_satisfied_on_main";

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2797,6 +2797,290 @@ test("reconcileStaleFailedIssueStates requeues failed no-PR issues when the work
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileStaleFailedIssueStates fetches origin/main once per reconciliation pass for repeated failed no-PR recovery", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspace366 = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const workspace367 = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 367,
+    branch: "codex/reopen-issue-367",
+  });
+
+  const issueDetails = [
+    { issueNumber: 366, workspacePath: workspace366, branch: "codex/reopen-issue-366" },
+    { issueNumber: 367, workspacePath: workspace367, branch: "codex/reopen-issue-367" },
+  ] as const;
+
+  const headShaByIssueNumber = new Map<number, string>();
+  for (const { issueNumber, workspacePath } of issueDetails) {
+    const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+    await fs.mkdir(path.dirname(journalPath), { recursive: true });
+    await fs.writeFile(journalPath, "# local journal\n");
+    await fs.writeFile(path.join(workspacePath, "feature.txt"), `recoverable checkpoint ${issueNumber}\n`);
+    await runCommand("git", ["-C", workspacePath, "add", "feature.txt"]);
+    await runCommand("git", ["-C", workspacePath, "commit", "-m", `recoverable checkpoint ${issueNumber}`]);
+    const headSha = (await runCommand("git", ["-C", workspacePath, "rev-parse", "HEAD"])).stdout.trim();
+    headShaByIssueNumber.set(issueNumber, headSha);
+  }
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: issueDetails.map(({ issueNumber, workspacePath, branch }) =>
+      createRecord({
+        issue_number: issueNumber,
+        state: "failed",
+        branch,
+        workspace: workspacePath,
+        journal_path: path.join(workspacePath, ".codex-supervisor", "issue-journal.md"),
+        pr_number: null,
+        implementation_attempt_count: config.maxImplementationAttemptsPerIssue,
+        last_head_sha: baseHead,
+        last_error: "Selected model is at capacity. Please try a different model.",
+        last_failure_kind: "codex_exit",
+        last_failure_context: {
+          category: "codex",
+          summary: "Selected model is at capacity. Please try a different model.",
+          signature: "provider-capacity",
+          command: null,
+          details: ["provider=codex"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "provider-capacity",
+        repeated_failure_signature_count: 1,
+        codex_session_id: `session-${issueNumber}`,
+      })),
+  });
+  const issues = issueDetails.map(({ issueNumber }) =>
+    createIssue({
+      number: issueNumber,
+      title: `Recover failed no-PR branch ${issueNumber}`,
+      updatedAt: "2026-03-13T00:21:00Z",
+    }));
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  let fetchCalls = 0;
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    issues,
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+      fetchOriginDefaultBranch: async () => {
+        fetchCalls += 1;
+      },
+    },
+  );
+
+  assert.equal(fetchCalls, 1);
+  for (const { issueNumber } of issueDetails) {
+    const updated = state.issues[String(issueNumber)];
+    assert.equal(updated.state, "queued");
+    assert.equal(updated.last_failure_signature, "stale-stabilizing-no-pr-recovery-loop");
+    assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
+    assert.equal(
+      updated.last_recovery_reason,
+      `failed_no_pr_branch_recovery: requeued issue #${issueNumber} from failed to queued after finding a recoverable no-PR branch ahead of origin/main at ${headShaByIssueNumber.get(issueNumber)}`,
+    );
+  }
+  assert.equal(saveCalls, 1);
+});
+
+test("reconcileStaleFailedIssueStates fails closed for all affected no-PR recovery records when the shared fetch fails", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspace366 = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const workspace367 = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 367,
+    branch: "codex/reopen-issue-367",
+  });
+
+  const issueDetails = [
+    { issueNumber: 366, workspacePath: workspace366, branch: "codex/reopen-issue-366" },
+    { issueNumber: 367, workspacePath: workspace367, branch: "codex/reopen-issue-367" },
+  ] as const;
+
+  for (const { issueNumber, workspacePath } of issueDetails) {
+    const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+    await fs.mkdir(path.dirname(journalPath), { recursive: true });
+    await fs.writeFile(journalPath, "# local journal\n");
+    await fs.writeFile(path.join(workspacePath, "feature.txt"), `recoverable checkpoint ${issueNumber}\n`);
+    await runCommand("git", ["-C", workspacePath, "add", "feature.txt"]);
+    await runCommand("git", ["-C", workspacePath, "commit", "-m", `recoverable checkpoint ${issueNumber}`]);
+  }
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: issueDetails.map(({ issueNumber, workspacePath, branch }) =>
+      createRecord({
+        issue_number: issueNumber,
+        state: "failed",
+        branch,
+        workspace: workspacePath,
+        journal_path: path.join(workspacePath, ".codex-supervisor", "issue-journal.md"),
+        pr_number: null,
+        implementation_attempt_count: config.maxImplementationAttemptsPerIssue,
+        last_head_sha: baseHead,
+        last_error: "Selected model is at capacity. Please try a different model.",
+        last_failure_kind: "codex_exit",
+        last_failure_context: {
+          category: "codex",
+          summary: "Selected model is at capacity. Please try a different model.",
+          signature: "provider-capacity",
+          command: null,
+          details: ["provider=codex"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "provider-capacity",
+        repeated_failure_signature_count: 1,
+        codex_session_id: `session-${issueNumber}`,
+      })),
+  });
+  const issues = issueDetails.map(({ issueNumber }) =>
+    createIssue({
+      number: issueNumber,
+      title: `Recover failed no-PR branch ${issueNumber}`,
+      updatedAt: "2026-03-13T00:21:00Z",
+    }));
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  let fetchCalls = 0;
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    issues,
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+      fetchOriginDefaultBranch: async () => {
+        fetchCalls += 1;
+        throw new Error("simulated shared fetch failure");
+      },
+    },
+  );
+
+  assert.equal(fetchCalls, 1);
+  for (const { issueNumber } of issueDetails) {
+    const updated = state.issues[String(issueNumber)];
+    assert.equal(updated.state, "blocked");
+    assert.equal(updated.blocked_reason, "manual_review");
+    assert.equal(updated.last_failure_context?.signature, "failed-no-pr-manual-review-required");
+    assert.deepEqual(updated.last_failure_context?.details ?? [], [
+      "state=failed",
+      "tracked_pr=none",
+      "branch_state=manual_review_required",
+      "default_branch=origin/main",
+      "head_sha=unknown",
+      "operator_action=inspect the preserved workspace and resolve the unsafe or ambiguous branch state before requeueing manually",
+    ]);
+    assert.equal(
+      updated.last_recovery_reason,
+      `failed_no_pr_manual_review: blocked issue #${issueNumber} after failed no-PR recovery found an unsafe or ambiguous workspace state`,
+    );
+  }
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when the workspace branch is ahead but still has non-artifact edits", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({


### PR DESCRIPTION
Closes #1293

## Summary
- fetch  once per stale failed no-PR reconciliation pass instead of once per eligible record
- preserve fail-closed behavior when the shared fetch fails
- add focused regression coverage for fetch reuse and shared-fetch failure handling

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npm run build