### PR TITLE
[codex] Detect invalid worktree-incompatible workspacePreparationCommand in setup readiness and doctor

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,53 +1,36 @@
-# Issue #1302: [codex] Auto-redact supervisor-owned durable journal leaks before publication and ready gates
+# Issue #1304: [codex] Detect invalid worktree-incompatible workspacePreparationCommand in setup readiness and doctor
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1302
-- Branch: codex/issue-1302
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1304
+- Branch: codex/issue-1304
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 4 (implementation=2, repair=2)
-- Last head SHA: b013c69b14e398322e426ab4058d487b90d5bc04
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d3b89e5e22167a74ec3049fe4b5472f2041885b3
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ8547rAH|PRRT_kwDORgvdZ8547rAI
-- Repeated failure signature count: 1
-- Updated at: 2026-04-05T22:13:22.044Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-05T23:07:58.287Z
 
 ## Latest Codex Summary
-Reproduced the failing Ubuntu check from the GitHub Actions log and confirmed it was not a code regression in the gate logic. The blocker was the committed supervisor-owned `.codex-supervisor/issue-journal.md`, which still contained a workstation-local home-path reference in tracked durable text, so `npm run verify:paths` failed on Linux.
-
-I sanitized the tracked journal, updated the durable handoff to reflect the repair, committed the fix, and pushed `b013c69` to `codex/issue-1302`. Local `npm run verify:paths` and `npm run build` both pass. PR #1307 has restarted CI; both `build` jobs are currently pending on Actions run `24011370574`.
-
-Summary: Reproduced the failing PR path-hygiene check, removed the committed supervisor-owned journal leak, reran local verification, and pushed the repair to PR #1307.
-State hint: waiting_ci
-Blocked reason: none
-Tests: `npm run verify:paths`; `npm run build`
-Next action: watch PR #1307 CI rerun and inspect the Ubuntu build again only if it still fails
-Failure signature: PRRT_kwDORgvdZ8547rAH|PRRT_kwDORgvdZ8547rAI
+- Reproduced the gap with focused setup-readiness tests: repo-relative `workspacePreparationCommand` helpers under `repoPath` were not validated at all, so readiness stayed green and the field was absent even when the helper was missing or untracked.
+- Added shared worktree-compatibility validation for repo-relative workspace-preparation helpers, surfaced `workspacePreparationCommand` as a setup-readiness field, and wired doctor config warnings to the same diagnosis. Focused tests and build now pass.
 
 ## Active Failure Context
-- Category: review
-- Summary: 2 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1307#discussion_r3037418680
-- Details:
-  - src/workstation-local-path-gate.ts:34 summary=_⚠️ Potential issue_ | _🟠 Major_ **Fail closed when journal normalization throws.** `normalizeCommittedIssueJournal` throws on unreadable journals and atomic write failures (`s... url=https://github.com/TommyKammy/codex-supervisor/pull/1307#discussion_r3037418680
-  - src/workstation-local-path-gate.ts:45 summary=_⚠️ Potential issue_ | _🔴 Critical_ **Persist the journal rewrite before returning `ok`.** After Line 43 rewrites the file in the workspace, Line 44 rescans that modified worki... url=https://github.com/TommyKammy/codex-supervisor/pull/1307#discussion_r3037418681
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the two open CodeRabbit threads were valid follow-up gaps in the auto-redaction gate, not false positives from stale review context.
-- What changed: updated the workstation-local path gate to report rewritten supervisor-owned journals and to fail closed with explicit blocker details when journal normalization throws; added branch persistence for rewritten supervisor-owned journals in the pre-push publication path, draft-PR creation gate, and draft-to-ready gate; updated the ready path to keep the PR in `draft_pr` on the new head after an auto-redaction commit so checks can rerun before readying.
+- Hypothesis: repo-relative workspace preparation helpers need validation against the tracked repo contents before preserved issue worktrees attempt to run them.
+- What changed: added shared validation in `src/core/config.ts` for repo-relative helper paths that are missing or untracked; setup readiness now includes `workspacePreparationCommand` and marks invalid helper cases as blocking config errors; doctor report tests cover the new config-warning text; setup config/fixture helpers were updated for the added readiness field.
 - Current blocker: none.
-- Next exact step: commit the review-thread fix, push `codex/issue-1302`, then re-check PR #1307 for the two unresolved automated review threads.
-- Verification gap: GitHub review threads and PR checks have not been re-read after the local review-fix commit yet.
-- Files touched: src/workstation-local-path-gate.ts, src/core/workspace.ts, src/run-once-turn-execution.ts, src/turn-execution-publication-gate.ts, src/post-turn-pull-request.ts, src/workstation-local-path-detector.test.ts, src/turn-execution-publication-gate.test.ts, src/post-turn-pull-request.test.ts
-- Rollback concern: low; the new persistence path only stages and commits the exact supervisor-owned journal files that the gate itself rewrote.
-- Last focused command: npm run build
+- Next exact step: commit the validated implementation on `codex/issue-1304`, then open or update the draft PR if needed.
+- Verification gap: no broader web UI regression pass yet beyond build and the focused readiness/doctor tests.
+- Files touched: .codex-supervisor/issue-journal.md, src/core/config.ts, src/setup-readiness.ts, src/setup-readiness.test.ts, src/doctor.test.ts, src/setup-config-write.ts, src/setup-config-preview.ts, src/backend/setup-test-fixtures.ts
+- Rollback concern: low; the change is additive and only flags repo-relative workspace-preparation helpers that would be absent from preserved worktrees.
+- Last focused command: npx tsx --test src/setup-readiness.test.ts src/doctor.test.ts
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
-- 2026-04-06: Verified the review fix with `npx tsx --test src/journal.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts src/workstation-local-path-detector.test.ts` and `npm run build`.
-- 2026-04-06: Added a regression proving the gate returns a blocker when supervisor-owned journal normalization throws instead of bubbling the exception.
-- 2026-04-06: Publication and ready-path regressions now use real temp repos with a local bare `origin` so the auto-redaction persistence path exercises commit and push behavior instead of only local rewrites.
-- 2026-04-06: Re-ran `npx tsx --test src/journal.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts` and `npm run build`; both passed before pushing and opening PR #1307.
-- 2026-04-06: Reproduced the failing Ubuntu check by inspecting `gh run view 24011239602 --log-failed`; the only blocker was the committed `.codex-supervisor/issue-journal.md` line that still mentioned a macOS home path.
-- 2026-04-06: Pushed `08b883d` to `codex/issue-1302`; `gh pr checks 1307` now shows both build jobs pending on Actions run `24011353906`.
+- 2026-04-06: Reproduced the issue with new focused tests in `src/setup-readiness.test.ts` before implementation.
+- 2026-04-06: Verified with `npx tsx --test src/setup-readiness.test.ts src/doctor.test.ts` and `npm run build`.

--- a/src/backend/setup-test-fixtures.ts
+++ b/src/backend/setup-test-fixtures.ts
@@ -176,6 +176,18 @@ const DEFAULT_SETUP_FIELD_FIXTURES: Record<SetupReadinessFieldKey, Omit<SetupRea
       valueType: "text",
     },
   },
+  workspacePreparationCommand: {
+    label: "Workspace preparation command",
+    state: "missing",
+    value: null,
+    message: "Workspace preparation command is optional until you opt in to the repo-owned contract.",
+    required: false,
+    metadata: {
+      source: "config",
+      editable: true,
+      valueType: "text",
+    },
+  },
   localCiCommand: {
     label: "Local CI command",
     state: "missing",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import {
   CadenceDiagnosticsSummary,
@@ -30,6 +31,7 @@ export const PREFERRED_ISSUE_JOURNAL_RELATIVE_PATH = ".codex-supervisor/issues/{
 export const MISSING_WORKSPACE_PREPARATION_CONTRACT_WARNING =
   "localCiCommand is configured but workspacePreparationCommand is unset. Configure a repo-owned workspacePreparationCommand so preserved issue worktrees can prepare toolchains before host-local CI runs. GitHub checks can stay green while host-local CI still blocks tracked PR progress.";
 const LOCAL_CI_SCRIPT_CANDIDATES = ["verify:supervisor-pre-pr", "verify:pre-pr", "ci:local"] as const;
+const WORKSPACE_PREPARATION_SCRIPT_RUNNERS = new Set(["bash", "sh", "node", "bun", "deno", "python", "python3", "ruby", "tsx", "ts-node"]);
 const REQUIRED_STRING_CONFIG_FIELDS = [
   "repoPath",
   "repoSlug",
@@ -160,6 +162,161 @@ export function displayLocalCiCommand(command: LocalCiCommandConfig | undefined)
   }
 
   return command.command.trim() || null;
+}
+
+function stripWrappingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function tokenizeCommand(command: string): string[] {
+  return command.match(/"[^"]*"|'[^']*'|\S+/g)?.map(stripWrappingQuotes) ?? [];
+}
+
+function isRepoRelativePathToken(token: string | undefined): token is string {
+  if (typeof token !== "string") {
+    return false;
+  }
+
+  const trimmed = token.trim();
+  if (trimmed === "" || trimmed.startsWith("-") || path.isAbsolute(trimmed)) {
+    return false;
+  }
+
+  return trimmed.startsWith("./") || trimmed.startsWith("../") || /[\\/]/.test(trimmed);
+}
+
+function firstRepoRelativeScriptArg(args: string[] | undefined): string | null {
+  if (!Array.isArray(args)) {
+    return null;
+  }
+
+  for (const arg of args) {
+    if (arg.startsWith("-")) {
+      continue;
+    }
+
+    if (isRepoRelativePathToken(arg)) {
+      return arg;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+function extractRepoRelativeWorkspacePreparationHelper(
+  command: LocalCiCommandConfig | undefined,
+): { commandText: string; repoRelativePath: string } | null {
+  const commandText = displayLocalCiCommand(command);
+  if (commandText === null) {
+    return null;
+  }
+
+  if (!command) {
+    return null;
+  }
+
+  if (typeof command === "string") {
+    const tokens = tokenizeCommand(commandText);
+    const firstToken = tokens[0];
+    if (isRepoRelativePathToken(firstToken)) {
+      return { commandText, repoRelativePath: firstToken };
+    }
+
+    if (WORKSPACE_PREPARATION_SCRIPT_RUNNERS.has(firstToken ?? "")) {
+      const scriptArg = firstRepoRelativeScriptArg(tokens.slice(1));
+      if (scriptArg !== null) {
+        return { commandText, repoRelativePath: scriptArg };
+      }
+    }
+
+    return null;
+  }
+
+  if (command.mode === "structured") {
+    if (isRepoRelativePathToken(command.executable)) {
+      return { commandText, repoRelativePath: command.executable };
+    }
+
+    if (WORKSPACE_PREPARATION_SCRIPT_RUNNERS.has(command.executable)) {
+      const scriptArg = firstRepoRelativeScriptArg(command.args);
+      if (scriptArg !== null) {
+        return { commandText, repoRelativePath: scriptArg };
+      }
+    }
+
+    return null;
+  }
+
+  const tokens = tokenizeCommand(command.command);
+  const firstToken = tokens[0];
+  if (isRepoRelativePathToken(firstToken)) {
+    return { commandText, repoRelativePath: firstToken };
+  }
+
+  if (WORKSPACE_PREPARATION_SCRIPT_RUNNERS.has(firstToken ?? "")) {
+    const scriptArg = firstRepoRelativeScriptArg(tokens.slice(1));
+    if (scriptArg !== null) {
+      return { commandText, repoRelativePath: scriptArg };
+    }
+  }
+
+  return null;
+}
+
+export function validateWorkspacePreparationCommandForWorktrees(
+  config: Pick<SupervisorConfig, "workspacePreparationCommand"> & { repoPath?: string },
+): string | null {
+  const workspacePreparationCommand = config.workspacePreparationCommand;
+  if (!workspacePreparationCommand) {
+    return null;
+  }
+
+  const helper = extractRepoRelativeWorkspacePreparationHelper(workspacePreparationCommand);
+  if (helper === null || typeof config.repoPath !== "string" || config.repoPath.trim() === "") {
+    return null;
+  }
+
+  const resolvedHelperPath = path.resolve(config.repoPath, helper.repoRelativePath);
+  const relativeToRepo = path.relative(config.repoPath, resolvedHelperPath);
+  if (
+    relativeToRepo === "" ||
+    relativeToRepo.startsWith("..") ||
+    path.isAbsolute(relativeToRepo)
+  ) {
+    return `workspacePreparationCommand points at ${helper.repoRelativePath}, but that path does not resolve to a file inside repoPath. Move the helper into the repository and commit it, or switch to a worktree-compatible repo-owned command.`;
+  }
+
+  try {
+    const stats = fs.statSync(resolvedHelperPath);
+    if (!stats.isFile()) {
+      return `workspacePreparationCommand points at ${helper.repoRelativePath}, but that path does not resolve to a file inside repoPath. Move the helper into the repository and commit it, or switch to a worktree-compatible repo-owned command.`;
+    }
+  } catch {
+    return `workspacePreparationCommand points at ${helper.repoRelativePath}, but that path does not resolve to a file inside repoPath. Move the helper into the repository and commit it, or switch to a worktree-compatible repo-owned command.`;
+  }
+
+  const repoRelativePathForGit = relativeToRepo.split(path.sep).join("/");
+  const trackedCheck = spawnSync("git", ["-C", config.repoPath, "ls-files", "--error-unmatch", "--", repoRelativePathForGit], {
+    encoding: "utf8",
+  });
+  if (trackedCheck.status === 0) {
+    return null;
+  }
+
+  if (trackedCheck.status === 1) {
+    return `workspacePreparationCommand points at ${helper.repoRelativePath}, but that path resolves to an untracked helper. Commit the helper so preserved issue worktrees inherit it, or switch to a tracked repo-owned command.`;
+  }
+
+  return null;
 }
 
 function assertString(value: unknown, label: string): string {
@@ -405,7 +562,7 @@ export function summarizeLocalCiContract(
 }
 
 export function summarizeWorkspacePreparationContract(
-  config: Pick<SupervisorConfig, "workspacePreparationCommand" | "localCiCommand">,
+  config: Pick<SupervisorConfig, "workspacePreparationCommand" | "localCiCommand"> & { repoPath?: string },
 ): WorkspacePreparationContractSummary {
   const command = displayLocalCiCommand(config.workspacePreparationCommand);
   const warning = buildMissingWorkspacePreparationContractWarning(config);
@@ -415,7 +572,7 @@ export function summarizeWorkspacePreparationContract(
       command,
       source: "config",
       summary: "Repo-owned workspace preparation contract is configured.",
-      warning: null,
+      warning: validateWorkspacePreparationCommandForWorktrees(config),
     };
   }
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -336,6 +336,7 @@ test("diagnoseSetupReadiness returns typed first-run setup state distinct from d
       ["stateFile", "configured", "config", true, "file_path"],
       ["codexBinary", "configured", "config", true, "executable_path"],
       ["branchPrefix", "configured", "config", true, "text"],
+      ["workspacePreparationCommand", "missing", "config", true, "text"],
       ["localCiCommand", "missing", "config", true, "text"],
       ["reviewProvider", "missing", "config", true, "review_provider"],
     ],
@@ -911,6 +912,84 @@ test("renderDoctorReport warns when localCiCommand is configured without workspa
 
   assert.equal(report.includes(`doctor_warning kind=config detail=${MISSING_WORKSPACE_PREPARATION_CONTRACT_WARNING}`), true);
   assert.equal(report.split(MISSING_WORKSPACE_PREPARATION_CONTRACT_WARNING).length - 1, 1);
+});
+
+test("renderDoctorReport warns when workspacePreparationCommand points at a missing repo-relative helper", () => {
+  const warning =
+    "workspacePreparationCommand points at ./scripts/prepare-workspace.sh, but that path does not resolve to a file inside repoPath. Move the helper into the repository and commit it, or switch to a worktree-compatible repo-owned command.";
+  const report = renderDoctorReport({
+    overallStatus: "pass",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+      configWarning: null,
+    },
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    workspacePreparationContract: {
+      configured: true,
+      command: "./scripts/prepare-workspace.sh",
+      source: "config",
+      summary: "Repo-owned workspace preparation contract is configured.",
+      warning,
+    },
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: null,
+      source: "config",
+      summary: "No repo-owned local CI contract is configured.",
+    },
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  assert.equal(report.includes(`doctor_warning kind=config detail=${warning}`), true);
+});
+
+test("renderDoctorReport warns when workspacePreparationCommand points at an untracked repo-relative helper", () => {
+  const warning =
+    "workspacePreparationCommand points at ./scripts/prepare-workspace.sh, but that path resolves to an untracked helper. Commit the helper so preserved issue worktrees inherit it, or switch to a tracked repo-owned command.";
+  const report = renderDoctorReport({
+    overallStatus: "pass",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+      configWarning: null,
+    },
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    workspacePreparationContract: {
+      configured: true,
+      command: "./scripts/prepare-workspace.sh",
+      source: "config",
+      summary: "Repo-owned workspace preparation contract is configured.",
+      warning,
+    },
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: null,
+      source: "config",
+      summary: "No repo-owned local CI contract is configured.",
+    },
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  assert.equal(report.includes(`doctor_warning kind=config detail=${warning}`), true);
 });
 
 test("renderDoctorReport surfaces absent local CI posture when no repo-owned contract exists", () => {

--- a/src/setup-config-preview.ts
+++ b/src/setup-config-preview.ts
@@ -7,7 +7,7 @@ import type { SetupReadinessFieldKey } from "./setup-readiness";
 export type SetupConfigPreviewSelectableReviewProviderProfile = Exclude<ReviewProviderProfileId, "custom">;
 export type SetupConfigPreviewSource = "existing_config" | "scaffold_default" | "selected_review_provider_profile";
 export type SetupConfigPreviewFieldState = "unchanged" | "suggested";
-type SetupConfigPreviewFieldKey = Exclude<SetupReadinessFieldKey, "localCiCommand">;
+type SetupConfigPreviewFieldKey = Exclude<SetupReadinessFieldKey, "localCiCommand" | "workspacePreparationCommand">;
 
 export interface SetupConfigPreviewSupportedProfile {
   id: SetupConfigPreviewSelectableReviewProviderProfile;

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -14,6 +14,7 @@ export interface SetupConfigChanges {
   stateFile?: string;
   codexBinary?: string;
   branchPrefix?: string;
+  workspacePreparationCommand?: string | null;
   localCiCommand?: string | null;
   reviewProvider?: SetupConfigPreviewSelectableReviewProviderProfile;
 }
@@ -43,6 +44,7 @@ const CONFIGURABLE_FIELDS: SetupReadinessFieldKey[] = [
   "stateFile",
   "codexBinary",
   "branchPrefix",
+  "workspacePreparationCommand",
   "localCiCommand",
   "reviewProvider",
 ];
@@ -135,6 +137,9 @@ function normalizeSetupChanges(changes: unknown): SetupConfigChanges {
   if ("branchPrefix" in raw) {
     normalized.branchPrefix = assertGitRef(raw.branchPrefix, "branchPrefix");
   }
+  if ("workspacePreparationCommand" in raw) {
+    normalized.workspacePreparationCommand = normalizeLocalCiCommand(raw.workspacePreparationCommand);
+  }
   if ("localCiCommand" in raw) {
     normalized.localCiCommand = normalizeLocalCiCommand(raw.localCiCommand);
   }
@@ -200,6 +205,13 @@ function applySetupChanges(document: Record<string, unknown>, changes: SetupConf
   if (changes.branchPrefix !== undefined) {
     nextDocument.branchPrefix = changes.branchPrefix;
   }
+  if ("workspacePreparationCommand" in changes) {
+    if (changes.workspacePreparationCommand === null) {
+      delete nextDocument.workspacePreparationCommand;
+    } else {
+      nextDocument.workspacePreparationCommand = changes.workspacePreparationCommand;
+    }
+  }
   if ("localCiCommand" in changes) {
     if (changes.localCiCommand === null) {
       delete nextDocument.localCiCommand;
@@ -252,6 +264,14 @@ function currentSemanticFieldValue(args: {
     return displayStringValue(existingDocument.localCiCommand);
   }
 
+  if (field === "workspacePreparationCommand") {
+    if (resolvedConfig !== null) {
+      return displayLocalCiCommand(resolvedConfig.workspacePreparationCommand);
+    }
+
+    return displayStringValue(existingDocument.workspacePreparationCommand);
+  }
+
   if (resolvedConfig !== null) {
     return displayStringValue(resolvedConfig[field]);
   }
@@ -275,6 +295,8 @@ function nextSemanticFieldValue(field: SetupReadinessFieldKey, changes: SetupCon
       return changes.codexBinary ?? null;
     case "branchPrefix":
       return changes.branchPrefix ?? null;
+    case "workspacePreparationCommand":
+      return changes.workspacePreparationCommand ?? null;
     case "localCiCommand":
       return changes.localCiCommand ?? null;
     case "reviewProvider":

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { diagnoseSetupReadiness } from "./setup-readiness";
+
+async function createTrackedRepo(root: string): Promise<string> {
+  const repoPath = path.join(root, "repo");
+  await fs.mkdir(repoPath, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "# fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "seed"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+
+  return repoPath;
+}
+
+function buildConfigDocument(args: {
+  repoPath: string;
+  workspaceRoot: string;
+  stateFile: string;
+  workspacePreparationCommand: unknown;
+}): Record<string, unknown> {
+  return {
+    repoPath: args.repoPath,
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: args.workspaceRoot,
+    stateFile: args.stateFile,
+    codexBinary: process.execPath,
+    branchPrefix: "codex/issue-",
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    workspacePreparationCommand: args.workspacePreparationCommand,
+  };
+}
+
+test("diagnoseSetupReadiness marks a repo-relative missing workspace preparation helper invalid", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: "./scripts/prepare-workspace.sh",
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "invalid");
+  const field = summary.fields.find((entry) => entry.key === "workspacePreparationCommand");
+  assert.equal(field?.state, "invalid");
+  assert.match(field?.message ?? "", /does not resolve to a file inside repoPath/i);
+  assert.match(field?.message ?? "", /move the helper into the repository and commit it/i);
+});
+
+test("diagnoseSetupReadiness marks an untracked repo-relative workspace preparation helper invalid", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(path.join(repoPath, "scripts"), { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(path.join(repoPath, "scripts", "prepare-workspace.sh"), "#!/bin/sh\nexit 0\n", "utf8");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: "./scripts/prepare-workspace.sh",
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "invalid");
+  const field = summary.fields.find((entry) => entry.key === "workspacePreparationCommand");
+  assert.equal(field?.state, "invalid");
+  assert.match(field?.message ?? "", /resolves to an untracked helper/i);
+  assert.match(field?.message ?? "", /commit the helper/i);
+});
+
+test("diagnoseSetupReadiness keeps a tracked repo-owned workspace preparation helper configured", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(path.join(repoPath, "scripts"), { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(path.join(repoPath, "scripts", "prepare-workspace.sh"), "#!/bin/sh\nexit 0\n", "utf8");
+  execFileSync("git", ["add", "scripts/prepare-workspace.sh"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "add workspace helper"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: "./scripts/prepare-workspace.sh",
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.overallStatus, "configured");
+  const field = summary.fields.find((entry) => entry.key === "workspacePreparationCommand");
+  assert.equal(field?.state, "configured");
+  assert.equal(field?.value, "./scripts/prepare-workspace.sh");
+  assert.match(field?.message ?? "", /workspace preparation command is configured/i);
+});

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -7,6 +7,7 @@ import {
   resolveConfigPath,
   summarizeLocalCiContract,
   summarizeTrustDiagnostics,
+  validateWorkspacePreparationCommandForWorktrees,
 } from "./core/config";
 import type { LocalCiContractSummary, TrustDiagnosticsSummary } from "./core/types";
 import { diagnoseSupervisorHost, type DoctorCheck, type DoctorCheckStatus } from "./doctor";
@@ -22,6 +23,7 @@ export type SetupReadinessFieldKey =
   | "stateFile"
   | "codexBinary"
   | "branchPrefix"
+  | "workspacePreparationCommand"
   | "localCiCommand"
   | "reviewProvider";
 
@@ -120,6 +122,7 @@ const SETUP_FIELD_DEFINITIONS: Array<{
   { key: "stateFile", label: "State file", required: true },
   { key: "codexBinary", label: "Codex binary", required: true },
   { key: "branchPrefix", label: "Branch prefix", required: true },
+  { key: "workspacePreparationCommand", label: "Workspace preparation command", required: false },
   { key: "localCiCommand", label: "Local CI command", required: false },
 ];
 
@@ -131,6 +134,7 @@ const SETUP_FIELD_METADATA: Record<SetupReadinessFieldKey, SetupReadinessFieldMe
   stateFile: { source: "config", editable: true, valueType: "file_path" },
   codexBinary: { source: "config", editable: true, valueType: "executable_path" },
   branchPrefix: { source: "config", editable: true, valueType: "text" },
+  workspacePreparationCommand: { source: "config", editable: true, valueType: "text" },
   localCiCommand: { source: "config", editable: true, valueType: "text" },
   reviewProvider: { source: "config", editable: true, valueType: "review_provider" },
 };
@@ -174,7 +178,19 @@ function tryNormalizeLocalCiCommand(value: unknown): ReturnType<typeof normalize
   }
 }
 
-function buildFieldMessage(field: SetupReadinessField): string {
+function buildFieldMessage(field: SetupReadinessField, workspacePreparationWarning: string | null): string {
+  if (field.key === "workspacePreparationCommand") {
+    if (workspacePreparationWarning !== null && field.state === "invalid") {
+      return workspacePreparationWarning;
+    }
+
+    if (field.state === "configured") {
+      return "Workspace preparation command is configured.";
+    }
+
+    return "Workspace preparation command is optional until you opt in to the repo-owned contract.";
+  }
+
   if (field.key === "localCiCommand") {
     if (field.state === "configured") {
       return "Local CI command is configured.";
@@ -201,12 +217,15 @@ function buildFieldMessage(field: SetupReadinessField): string {
 function buildConfigFields(args: {
   rawConfig: RawConfigDocument;
   configSummary: ReturnType<typeof loadConfigSummary>;
+  workspacePreparationWarning: string | null;
 }): SetupReadinessField[] {
-  const { rawConfig, configSummary } = args;
+  const { rawConfig, configSummary, workspacePreparationWarning } = args;
   const resolvedConfig = configSummary.config;
   const fields = SETUP_FIELD_DEFINITIONS.map(({ key, label, required }) => {
     const resolvedValue = resolvedConfig !== null ? displayValue(resolvedConfig[key]) : displayValue(rawConfig?.[key]);
-    const state: SetupFieldState = configSummary.missingRequiredFields.includes(key)
+    const state: SetupFieldState = key === "workspacePreparationCommand" && workspacePreparationWarning !== null
+      ? "invalid"
+      : configSummary.missingRequiredFields.includes(key)
       ? "missing"
       : configSummary.invalidFields.includes(key)
         ? "invalid"
@@ -224,7 +243,7 @@ function buildConfigFields(args: {
     };
     return {
       ...field,
-      message: buildFieldMessage(field),
+      message: buildFieldMessage(field, workspacePreparationWarning),
     };
   });
 
@@ -410,18 +429,6 @@ export async function diagnoseSetupReadiness(
   const configPath = resolveConfigPath(args.configPath);
   const rawConfig = readRawConfigDocument(configPath);
   const rawConfigDocument = rawConfig ?? {};
-  const fields = buildConfigFields({
-    rawConfig,
-    configSummary,
-  });
-  const hostDiagnostics = configSummary.config
-    ? await diagnoseSupervisorHost({
-      config: configSummary.config,
-      authStatus: args.authStatus,
-    })
-    : null;
-  const hostReadiness = buildHostReadiness(hostDiagnostics?.checks ?? null, hostDiagnostics?.overallStatus ?? null);
-  const blockers = buildBlockers({ fields, hostReadiness });
   const fallbackRepoPath =
     typeof rawConfigDocument.repoPath === "string" && rawConfigDocument.repoPath.trim() !== ""
       ? path.resolve(path.dirname(configPath), rawConfigDocument.repoPath)
@@ -431,6 +438,20 @@ export async function diagnoseSetupReadiness(
     workspacePreparationCommand: tryNormalizeLocalCiCommand(rawConfigDocument.workspacePreparationCommand),
     repoPath: fallbackRepoPath,
   };
+  const workspacePreparationWarning = validateWorkspacePreparationCommandForWorktrees(localCiContractConfig);
+  const fields = buildConfigFields({
+    rawConfig,
+    configSummary,
+    workspacePreparationWarning,
+  });
+  const hostDiagnostics = configSummary.config
+    ? await diagnoseSupervisorHost({
+      config: configSummary.config,
+      authStatus: args.authStatus,
+    })
+    : null;
+  const hostReadiness = buildHostReadiness(hostDiagnostics?.checks ?? null, hostDiagnostics?.overallStatus ?? null);
+  const blockers = buildBlockers({ fields, hostReadiness });
 
   return {
     kind: "setup_readiness",


### PR DESCRIPTION
## Summary
- validate repo-relative `workspacePreparationCommand` helpers against tracked repo contents before preserved issue worktrees try to run them
- report missing or untracked repo-relative helpers as blocking setup-readiness config errors
- surface the same diagnosis in doctor with operator-facing repair guidance and regression coverage

## Verification
- npx tsx --test src/setup-readiness.test.ts src/doctor.test.ts
- npm run build

Closes #1304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for workspace preparation commands in worktrees to ensure helper scripts are properly tracked in git
  * Workspace preparation command status now included in setup readiness diagnostics
  * Doctor tool enhanced to surface workspace preparation command validation warnings

* **Tests**
  * Added comprehensive test coverage for workspace preparation command validation and diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->