### PR TITLE
[codex] Keep local review disabled by default but opinionated when enabled

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,43 +1,35 @@
-# Issue #1312: [codex] Add an opt-in current-head local review gate for tracked codex PRs
+# Issue #1322: [codex] Keep local review disabled by default but opinionated when enabled
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1312
-- Branch: codex/issue-1312
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1322
+- Branch: codex/issue-1322
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: draft_pr
-- Attempt count: 4 (implementation=2, repair=2)
-- Last head SHA: 53a32820443d9b91d9bfd003130dbad54a28977a
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: e5b04812832912bd5796f7aa9013fc00a339cc59
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-06T23:10:42.277Z
+- Updated at: 2026-04-07T01:09:49.465Z
 
 ## Latest Codex Summary
-Adjusted the tracked current-head gate in [pull-request-state.ts](src/pull-request-state.ts) so a stale reviewed head stays in `waiting_ci` while checks on the new head are still pending, instead of falling through the stale-head merge blocker. I also hardened coverage in [post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts) by switching the later-cycle regression to the real supervisor lifecycle path, and added a direct policy assertion in [pull-request-state-policy.test.ts](src/pull-request-state-policy.test.ts). The journal handoff in [issue-journal.md](.codex-supervisor/issue-journal.md) is now consistent with the pushed branch state.
+- Reproduced the default-posture drift with a focused config test: `loadConfig` still defaulted `localReviewPolicy` to `block_ready` even though the shipped starter profiles already recommended `block_merge` with local review disabled. Fixed the parser default in `src/core/config.ts`, added coverage in `src/config.test.ts` for both the runtime defaults and the shipped starter configs, and updated the docs to distinguish the safe disabled-by-default posture from the recommended once-enabled baseline.
 
-Pushed to `origin/codex/issue-1312` at `53a3282`. Verification passed with the focused test suites and `npm run build`. The only remaining local changes are untracked supervisor scratch paths under `.codex-supervisor/`, which I did not touch.
-
-Summary: Fixed the tracked stale-head local-review gate so pending checks keep the PR in `waiting_ci` until a current-head rerun is actually possible, added production-path regression coverage, and synced the issue journal after pushing.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/local-review/index.test.ts src/supervisor/supervisor-pre-merge-evaluation.test.ts src/pull-request-state-policy.test.ts`; `npx tsx --test src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts`; `npm run build`
-Next action: Let PR #1313 run on pushed head `53a3282`, then address any new CI or review feedback if it appears.
-Failure signature: none
+- Focused verification passed with `npx tsx --test src/config.test.ts`, and `npm run build` completed successfully. The change stays scoped to config defaults and docs; local-review runtime behavior was not redesigned.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: when the opt-in tracked current-head gate is enabled, a ready PR whose head advanced during pending CI could still fall into `blocked` before any later-cycle rerun path reopened local review.
-- What changed: `inferStateFromPullRequest` now returns `waiting_ci` while a tracked stale-head rerun is still blocked on pending checks, then promotes that same path back to `local_review` once the current head is actually runnable; the later-cycle post-turn regression now uses the real supervisor lifecycle derivation instead of a synthetic `waiting_ci` stub, and the policy suite has a direct pending-checks assertion for the tracked stale-head case.
-- Current blocker: none; the stale-head pending-check classification is repaired, committed, pushed, and verified locally.
-- Next exact step: wait for PR #1313 CI and review to finish on commit `53a3282`, then address any fresh feedback if it appears.
-- Verification gap: none in the targeted regression area; broader full-suite verification was not run beyond the focused tests and `npm run build`.
-- Files touched: `src/pull-request-state.ts`, `src/pull-request-state-policy.test.ts`, `src/post-turn-pull-request.test.ts`.
-- Rollback concern: low; the new behavior is fully opt-in and defaults to `false`, so existing repos stay on current semantics unless they enable the gate.
-- Last focused command:
-- Last focused commands: `npx tsx --test src/post-turn-pull-request.test.ts src/local-review/index.test.ts src/supervisor/supervisor-pre-merge-evaluation.test.ts src/pull-request-state-policy.test.ts`; `npx tsx --test src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts`; `npm run build`
+- Hypothesis: the only product-default drift is in config parsing and docs wording, not in local-review execution itself.
+- What changed: changed the fallback `localReviewPolicy` default from `block_ready` to `block_merge`; added focused tests for the disabled-by-default plus opinionated-enabled baseline and for starter-profile `localReviewEnabled: false`; updated `docs/local-review.md`, `docs/getting-started.md`, `docs/configuration.md`, and `docs/examples/atlaspm.md` to make the disabled-vs-enabled distinction explicit.
+- Current blocker: none.
+- Next exact step: commit the verified changes on `codex/issue-1322`, then open or update a draft PR if needed.
+- Verification gap: did not run the full test suite beyond `src/config.test.ts` and `npm run build`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/core/config.ts`, `src/config.test.ts`, `docs/configuration.md`, `docs/getting-started.md`, `docs/local-review.md`, `docs/examples/atlaspm.md`.
+- Rollback concern: low; the runtime change is a default-only policy alignment, and local review remains disabled unless operators explicitly enable it.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,12 @@ Review and merge policy:
 - `localReviewArtifactDir`, `localReviewConfidenceThreshold`, `localReviewReviewerThresholds`
 - `mergeMethod`
 
+Local-review default posture:
+
+- shipped starter profiles and default config loading keep `localReviewEnabled: false`
+- once an operator intentionally enables local review, the recommended baseline is `localReviewAutoDetect: true`, `localReviewRoles: []`, `localReviewPolicy: "block_merge"`, `trackedPrCurrentHeadLocalReviewRequired: false`, and `localReviewHighSeverityAction: "blocked"`
+- use `trackedPrCurrentHeadLocalReviewRequired: true` only when your workflow explicitly requires a fresh current-head local review before ready-for-review or merge can continue
+
 Repository-owned local CI policy:
 
 - when a repo exposes a canonical pre-PR entrypoint such as `ci:local` or `verify:pre-pr`, keep that command definition in the managed repo rather than in supervisor inference logic

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -75,11 +75,12 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - If you use GSD for upstream planning, enable `gsdEnabled` and point `gsdPlanningFiles` at `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, and `STATE.md`.
 - Copilot review is expected to start automatically after the PR is marked ready.
 - Leave `boundedRepairModelStrategy` unset unless you explicitly want `repairing_ci` and `addressing_review` turns to use a smaller bounded-repair model such as `gpt-5.4-mini`.
+- The shipped starter profiles keep local review disabled by default. This atlaspm example intentionally shows the recommended once enabled posture.
 - A local review swarm should usually run with `localReviewPolicy: "block_merge"` so it acts as a practical merge gate, with Markdown (`head-<sha>.md`) and JSON (`head-<sha>.json`) artifacts written under the supervisor's `.local/reviews` directory.
 - Leaving `localReviewRoles` empty while `localReviewAutoDetect` is `true` lets the supervisor add repo-specific specialists such as `prisma_postgres_reviewer`, `migration_invariant_reviewer`, `contract_consistency_reviewer`, and workflow-oriented roles like `github_actions_semantics_reviewer`, `workflow_test_reviewer`, and `portability_reviewer` when the repo shape suggests them.
 - `localReviewPolicy: "block_merge"` is the recommended starting point because it allows normal ready-for-review flow while still blocking merge until actionable findings are resolved.
 - Use `block_ready` when you want the swarm to stop draft PRs before `gh pr ready`, and `advisory` when you only want saved findings without merge gating.
-- Set `trackedPrCurrentHeadLocalReviewRequired: true` when tracked codex PRs must always refresh local review on the current head before either ready-for-review or merge can proceed.
+- Keep `trackedPrCurrentHeadLocalReviewRequired: false` for the recommended enabled baseline. Set it to `true` only when tracked codex PRs must always refresh local review on the current head before either ready-for-review or merge can proceed.
 - `localReviewHighSeverityAction: "blocked"` is the safer default for solo operators because verifier-confirmed high-severity findings stop the merge until a human decides the next step.
 - Switch to `localReviewHighSeverityAction: "retry"` when your team explicitly wants the supervisor to start another repair pass automatically after verifier-confirmed high-severity findings.
 - Findings below the configured confidence threshold stay in the raw role reports but are not counted as actionable.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -399,7 +399,7 @@ When should I open a PR?
 Open or update a draft PR as soon as the branch has a coherent checkpoint. The supervisor is designed to publish early rather than waiting for a perfect final state.
 
 When should I enable local review?
-Enable it when you want a committed pre-merge review gate or an additional local advisory pass before CI and external reviews. Use the [Local review reference](./local-review.md) for role selection, thresholds, artifacts, and policy choices.
+Local review is disabled by default in the shipped starter configs. Enable it when you want a committed pre-merge review gate or an additional local advisory pass before CI and external reviews. The recommended once enabled posture is `localReviewAutoDetect: true`, `localReviewRoles: []`, `localReviewPolicy: "block_merge"`, `trackedPrCurrentHeadLocalReviewRequired: false`, and `localReviewHighSeverityAction: "blocked"`. Use the [Local review reference](./local-review.md) for role selection, thresholds, artifacts, and policy choices.
 
 When should orphaned workspaces be cleaned up?
 Treat orphaned `issue-*` worktrees as explicit cleanup work, not as the same thing as delayed cleanup for tracked done workspaces. Use `doctor` to confirm the effective policy: `doctor_orphan_policy mode=explicit_only background_prune=false operator_prune=true grace_hours=... preserved=locked,recent,unsafe_target`. The explicit `prune-orphaned-workspaces` action only preserves orphan candidates marked `locked`, `recent`, or `unsafe_target`; there is no separate manual-keep state. The orphan grace setting only controls when `doctor` and `prune-orphaned-workspaces` consider an orphan old enough to avoid the `recent` state; it does not make `run-once` prune orphan workspaces in the background.

--- a/docs/local-review.md
+++ b/docs/local-review.md
@@ -4,7 +4,9 @@ This guide holds the detailed local-review swarm reference so the landing docs c
 
 ## What local review is for
 
-`codex-supervisor` can run a local review swarm on pull requests before merge. The recommended starting policy is `block_merge`, because it preserves the usual ready-for-review flow while still making the swarm a practical merge gate on the current PR head.
+`codex-supervisor` can run a local review swarm on pull requests before merge. It is disabled by default in shipped starter configs and in default config loading behavior. Once an operator intentionally enables it, the recommended once enabled posture uses `localReviewAutoDetect: true`, `localReviewRoles: []`, `localReviewPolicy: "block_merge"`, `trackedPrCurrentHeadLocalReviewRequired: false`, and `localReviewHighSeverityAction: "blocked"`.
+
+The recommended starting policy is `block_merge`, because it preserves the usual ready-for-review flow while still making the swarm a practical merge gate on the current PR head.
 
 Core behavior:
 
@@ -20,7 +22,8 @@ Policy guidance:
 - `block_merge` is the recommended default: gate merge on ready PRs and re-run on ready PR head updates
 - `block_ready` is stricter earlier in the flow: gate the draft-to-ready transition
 - `advisory` is non-blocking and fits setups that want saved findings without automation gates
-- `trackedPrCurrentHeadLocalReviewRequired: true` makes tracked codex PRs wait for a fresh local review on every head update before ready-for-review or merge can continue
+- `trackedPrCurrentHeadLocalReviewRequired: false` keeps the enabled baseline opinionated without adding a separate freshness gate
+- `trackedPrCurrentHeadLocalReviewRequired: true` is the stricter opt-in mode: tracked codex PRs wait for a fresh local review on every head update before ready-for-review or merge can continue
 
 ## Choosing reviewer roles
 
@@ -38,7 +41,10 @@ Example:
 {
   "localReviewEnabled": true,
   "localReviewAutoDetect": true,
-  "localReviewRoles": []
+  "localReviewRoles": [],
+  "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
+  "localReviewHighSeverityAction": "blocked"
 }
 ```
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -115,6 +115,37 @@ test("loadConfigSummary surfaces the default trust diagnostics posture", async (
   });
 });
 
+test("loadConfig keeps local review disabled by default while using the opinionated enabled posture", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+
+  assert.equal(config.localReviewEnabled, false);
+  assert.equal(config.localReviewAutoDetect, true);
+  assert.deepEqual(config.localReviewRoles, []);
+  assert.equal(config.localReviewPolicy, "block_merge");
+  assert.equal(config.trackedPrCurrentHeadLocalReviewRequired, false);
+  assert.equal(config.localReviewHighSeverityAction, "blocked");
+});
+
 test("loadConfigSummary accepts an explicit safer trust diagnostics posture without warning", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {
@@ -854,6 +885,21 @@ test("shipped example configs recommend block_merge for local review gating", as
   }
 });
 
+test("shipped starter config profiles keep local review disabled until operators opt in", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const examplePaths = [
+    path.join(rootDir, "supervisor.config.example.json"),
+    path.join(rootDir, "supervisor.config.copilot.json"),
+    path.join(rootDir, "supervisor.config.codex.json"),
+    path.join(rootDir, "supervisor.config.coderabbit.json"),
+  ];
+
+  for (const examplePath of examplePaths) {
+    const raw = JSON.parse(await fs.readFile(examplePath, "utf8")) as { localReviewEnabled?: unknown };
+    assert.equal(raw.localReviewEnabled, false, `${path.relative(rootDir, examplePath)} should keep local review disabled by default`);
+  }
+});
+
 test("shipped example configs recommend blocked for high-severity local review findings", async () => {
   const rootDir = path.resolve(__dirname, "..");
   const examplePaths = [
@@ -1061,6 +1107,8 @@ test("getting started links to focused configuration and local review references
   assert.match(gettingStarted, /\[Issue metadata reference\]\(\.\/issue-metadata\.md\)/i);
   assert.match(gettingStarted, /review provider profile/i);
   assert.match(gettingStarted, /provider-specific review settings/i);
+  assert.match(gettingStarted, /disabled by default/i);
+  assert.match(gettingStarted, /recommended once enabled/i);
   assert.doesNotMatch(gettingStarted, /review-bot profile/i);
   assert.doesNotMatch(gettingStarted, /^### Option 1: Auto-detect roles$/m);
   assert.doesNotMatch(gettingStarted, /^### Option 2: Explicit roles$/m);
@@ -1071,6 +1119,8 @@ test("getting started links to focused configuration and local review references
   assert.match(localReview, /^# Local Review Reference$/m);
   assert.match(localReview, /^## Choosing reviewer roles$/m);
   assert.match(localReview, /^## Artifacts, thresholds, and guardrails$/m);
+  assert.match(localReview, /disabled by default/i);
+  assert.match(localReview, /recommended once enabled/i);
 
   assert.match(issueMetadata, /^# Issue Metadata$/m);
   assert.match(issueMetadata, /^## Canonical fields$/m);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -837,7 +837,7 @@ function parseSupervisorConfigDocument(raw: Record<string, unknown>, resolvedPat
     localReviewPolicy:
       typeof raw.localReviewPolicy === "string" && VALID_LOCAL_REVIEW_POLICIES.has(raw.localReviewPolicy as LocalReviewPolicy)
         ? (raw.localReviewPolicy as LocalReviewPolicy)
-        : "block_ready",
+        : "block_merge",
     trackedPrCurrentHeadLocalReviewRequired:
       typeof raw.trackedPrCurrentHeadLocalReviewRequired === "boolean"
         ? raw.trackedPrCurrentHeadLocalReviewRequired


### PR DESCRIPTION
## Summary
- keep local review disabled by default in config loading and shipped starter profiles
- align the enabled default posture around block-merge gating, blocked high-severity handling, auto-detected roles, and no current-head freshness gate
- update docs to distinguish disabled-by-default behavior from the recommended once-enabled baseline

## Why
The shipped starter profiles already described an opinionated enabled posture, but the config loader still defaulted `localReviewPolicy` to `block_ready`. That left product defaults and docs out of sync.

## Testing
- npx tsx --test src/config.test.ts
- npm run build

Refs #1322