### PR TITLE
Route opted-in follow_up_eligible residuals into same-PR local_review_fix

### DIFF
--- a/.codex-supervisor/issues/1330/issue-journal.md
+++ b/.codex-supervisor/issues/1330/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1330: Route opted-in follow_up_eligible residuals into same-PR local_review_fix
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1330
+- Branch: codex/issue-1330
+- Workspace: .
+- Journal: .codex-supervisor/issues/1330/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 0c755117a29d61b72b201f9358956613f6864ccd
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-07T12:24:02.665Z
+
+## Latest Codex Summary
+- Added focused regression coverage for opted-in `follow_up_eligible` residuals and routed current-head same-PR repair opt-ins into `local_review_fix` without rewriting the saved pre-merge outcome or creating residual follow-up issues.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `localReviewFollowUpRepairEnabled` was parsed but never used in PR state inference, so opted-in `follow_up_eligible` results kept flowing to `ready_to_merge`.
+- What changed: Added `localReviewFollowUpNeedsRepair` in `src/review-handling.ts`, routed it to `local_review_fix` from `inferStateFromPullRequest`, and added focused tests in `src/pull-request-state-policy.test.ts` and `src/post-turn-pull-request.test.ts`.
+- Current blocker: none.
+- Next exact step: Commit the verified routing change on `codex/issue-1330`.
+- Verification gap: none for the requested scope; named tests and build are passing.
+- Files touched: `src/review-handling.ts`, `src/pull-request-state.ts`, `src/pull-request-state-policy.test.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1330/issue-journal.md`.
+- Rollback concern: Low; routing only changes current-head `follow_up_eligible` behavior when `localReviewFollowUpRepairEnabled` is explicitly enabled.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { handlePostTurnPullRequestTransitionsPhase, type PullRequestLifecycleSnapshot } from "./post-turn-pull-request";
 import { IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorStateFile } from "./core/types";
 import { derivePullRequestLifecycleSnapshot as deriveSupervisorPullRequestLifecycleSnapshot } from "./supervisor/supervisor-lifecycle";
+import { inferStateFromPullRequest } from "./pull-request-state";
 import { createConfig, createFailureContext, createIssue, createPullRequest, createRecord } from "./turn-execution-test-helpers";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
@@ -1676,6 +1677,154 @@ Parallelizable: No
   assert.doesNotMatch(createdIssues[0]?.body ?? "", /Execution order:\s*1 of 1/);
   assert.match(createdIssues[0]?.body ?? "", /Source issue: #102/);
   assert.equal(readyCalls, 1);
+  assert.equal(result.record.pre_merge_evaluation_outcome, "follow_up_eligible");
+});
+
+test("handlePostTurnPullRequestTransitionsPhase routes opted-in follow-up-eligible current-head residuals into local_review_fix without creating issues", async (t) => {
+  const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewFollowUpRepairEnabled: true,
+  });
+  const issue = createIssue({
+    title: "Repair bounded residuals in the same PR",
+  });
+  const readyPr = createPullRequest({
+    title: "Keep residual repair in the tracked PR",
+    isDraft: false,
+    headRefName: "codex/issue-102",
+    headRefOid: headSha,
+  });
+  let createIssueCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      createIssue: async () => {
+        createIssueCalls += 1;
+        throw new Error("unexpected createIssue call");
+      },
+      markPullRequestReady: async () => {
+        throw new Error("unexpected markPullRequestReady call");
+      },
+    },
+    context: {
+      state: {
+        activeIssueNumber: 102,
+        issues: { "102": createRecord({ state: "pr_open", pr_number: readyPr.number, last_head_sha: headSha }) },
+      },
+      record: createRecord({ state: "pr_open", pr_number: readyPr.number, last_head_sha: headSha }),
+      issue,
+      workspacePath,
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: readyPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record, pr, checks, reviewThreads) => ({
+      recordForState: record,
+      nextState: inferStateFromPullRequest(config, record, pr, checks, reviewThreads),
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: (record, pr, checks, reviewThreads) =>
+      record.pre_merge_evaluation_outcome === "manual_review_blocked"
+        ? "manual_review"
+        : record.pre_merge_evaluation_outcome === "fix_blocked"
+          ? "verification"
+          : null,
+    summarizeChecks: (checks) => ({
+      hasPending: checks.some((check) => check.bucket === "pending"),
+      hasFailing: checks.some((check) => check.bucket === "fail"),
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runLocalReviewImpl: async () => ({
+      ranAt: "2026-03-24T00:11:00Z",
+      summaryPath: "/tmp/reviews/owner-repo/issue-102/head-116.md",
+      findingsPath: "/tmp/reviews/owner-repo/issue-102/head-116.json",
+      summary: "Local review found a bounded medium-severity residual.",
+      blockerSummary: "medium src/example.ts:20-21 This still needs follow-up.",
+      findingsCount: 1,
+      rootCauseCount: 1,
+      maxSeverity: "medium",
+      verifiedFindingsCount: 0,
+      verifiedMaxSeverity: "none",
+      recommendation: "changes_requested",
+      degraded: false,
+      finalEvaluation: {
+        outcome: "follow_up_eligible",
+        residualFindings: [
+          {
+            findingKey: "src/example.ts|20|21|medium issue|this still needs follow-up.",
+            summary: "This still needs follow-up.",
+            severity: "medium",
+            category: "tests",
+            file: "src/example.ts",
+            start: 20,
+            end: 21,
+            source: "local_review",
+            resolution: "follow_up_candidate",
+            rationale: "Residual non-high-severity finding is eligible for explicit follow-up instead of blocking merge by itself.",
+          },
+        ],
+        mustFixCount: 0,
+        manualReviewCount: 0,
+        followUpCount: 1,
+      },
+      rawOutput: "raw output",
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: readyPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(createIssueCalls, 0);
+  assert.equal(result.record.state, "local_review_fix");
   assert.equal(result.record.pre_merge_evaluation_outcome, "follow_up_eligible");
 });
 

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -412,6 +412,25 @@ test("inferStateFromPullRequest covers local review policy gating combinations",
       expected: "local_review_fix",
     },
     {
+      name: "same-PR follow-up repair escalates follow-up-eligible current-head residuals into local_review_fix",
+      config: {
+        localReviewEnabled: true,
+        localReviewPolicy: "block_merge",
+        localReviewFollowUpRepairEnabled: true,
+        copilotReviewWaitMinutes: 0,
+      },
+      record: {
+        state: "pr_open",
+        local_review_head_sha: "head123",
+        local_review_findings_count: 2,
+        local_review_recommendation: "changes_requested",
+        pre_merge_evaluation_outcome: "follow_up_eligible",
+        pre_merge_follow_up_count: 2,
+      },
+      pr: { isDraft: false, headRefOid: "head123" },
+      expected: "local_review_fix",
+    },
+    {
       name: "blocked escalates verifier-confirmed high severity findings to blocked",
       config: {
         localReviewEnabled: true,

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -1,4 +1,5 @@
 import {
+  localReviewFollowUpNeedsRepair,
   localReviewBlocksMerge,
   localReviewHighSeverityNeedsBlock,
   localReviewHighSeverityNeedsRetry,
@@ -877,6 +878,10 @@ export function inferStateFromPullRequest(
   }
 
   if (localReviewHighSeverityNeedsRetry(config, record, pr)) {
+    return "local_review_fix";
+  }
+
+  if (localReviewFollowUpNeedsRepair(config, record, pr)) {
     return "local_review_fix";
   }
 

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -166,6 +166,19 @@ export function localReviewHighSeverityNeedsRetry(
   );
 }
 
+export function localReviewFollowUpNeedsRepair(
+  config: SupervisorConfig,
+  record: Pick<IssueRunRecord, "local_review_head_sha" | "pre_merge_evaluation_outcome" | "pre_merge_follow_up_count">,
+  pr: GitHubPullRequest,
+): boolean {
+  return (
+    config.localReviewFollowUpRepairEnabled === true &&
+    record.local_review_head_sha === pr.headRefOid &&
+    record.pre_merge_evaluation_outcome === "follow_up_eligible" &&
+    (record.pre_merge_follow_up_count ?? 0) > 0
+  );
+}
+
 export function localReviewRetryLoopCandidate(
   config: SupervisorConfig,
   record: Pick<


### PR DESCRIPTION
## Summary
- route opted-in current-head `follow_up_eligible` local-review residuals into `local_review_fix` for the same tracked PR
- preserve saved local-review and pre-merge outcomes as `follow_up_eligible`
- suppress residual follow-up issue creation on the same-PR repair path

## Testing
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts
- npm run build

Closes #1330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests marked as follow-up eligible now route to local review fix state when follow-up repair is enabled in configuration.

* **Tests**
  * Added comprehensive test coverage for the new follow-up repair routing logic and policy combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->