### PR TITLE
Add bounded gating for same-PR follow-up repair

### DIFF
--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -553,6 +553,30 @@ test("inferStateFromPullRequest blocks stalled identical high local-review retri
   );
 });
 
+test("inferStateFromPullRequest blocks stalled identical same-PR follow-up repairs", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewFollowUpRepairEnabled: true,
+    sameFailureSignatureRepeatLimit: 3,
+  });
+  const record = createRecord({
+    state: "local_review_fix",
+    pr_number: 44,
+    local_review_head_sha: "head123",
+    local_review_findings_count: 1,
+    local_review_recommendation: "changes_requested",
+    pre_merge_evaluation_outcome: "follow_up_eligible",
+    pre_merge_follow_up_count: 1,
+    repeated_local_review_signature_count: 3,
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, createPullRequest({ isDraft: false }), [], []),
+    "blocked",
+  );
+});
+
 test("blockedReasonFromReviewState reports manual_review for manual-review-blocked local review outcomes", () => {
   const config = createConfig({
     localReviewEnabled: true,
@@ -614,5 +638,78 @@ test("inferStateFromPullRequest does not stall local-review retries when CI adds
   assert.equal(
     inferStateFromPullRequest(config, record, createPullRequest({ isDraft: true }), checks, []),
     "local_review_fix",
+  );
+});
+
+test("inferStateFromPullRequest preserves CI, review-thread, and conflict precedence over same-PR follow-up repair", () => {
+  const baseConfig = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewFollowUpRepairEnabled: true,
+    humanReviewBlocksMerge: true,
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const record = createRecord({
+    state: "local_review_fix",
+    pr_number: 44,
+    local_review_head_sha: "head123",
+    local_review_findings_count: 1,
+    local_review_recommendation: "changes_requested",
+    pre_merge_evaluation_outcome: "follow_up_eligible",
+    pre_merge_follow_up_count: 1,
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(
+      baseConfig,
+      record,
+      createPullRequest({ isDraft: false }),
+      [{ name: "test", state: "FAILURE", bucket: "fail", workflow: "CI" }],
+      [],
+    ),
+    "repairing_ci",
+  );
+
+  assert.equal(
+    inferStateFromPullRequest(
+      baseConfig,
+      record,
+      createPullRequest({ isDraft: false }),
+      passingChecks(),
+      [
+        createReviewThread({
+          comments: {
+            nodes: [
+              {
+                id: "comment-1",
+                body: "Please address this review finding.",
+                createdAt: "2026-03-11T00:00:00Z",
+                url: "https://example.test/pr/44#discussion_r1",
+                author: {
+                  login: "copilot-pull-request-reviewer",
+                  typeName: "Bot",
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    ),
+    "addressing_review",
+  );
+
+  assert.equal(
+    inferStateFromPullRequest(
+      baseConfig,
+      record,
+      createPullRequest({
+        isDraft: false,
+        mergeStateStatus: "DIRTY",
+        mergeable: "CONFLICTING",
+      }),
+      passingChecks(),
+      [],
+    ),
+    "resolving_conflict",
   );
 });

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -833,6 +833,7 @@ export function inferStateFromPullRequest(
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
   const botFollowUpState = configuredBotReviewFollowUpState(record, pr, unresolvedBotThreads);
+  const checkSummary = summarizeChecks(checks);
 
   if (pr.mergedAt || pr.state === "MERGED") {
     return "done";
@@ -881,15 +882,17 @@ export function inferStateFromPullRequest(
     return "local_review_fix";
   }
 
-  if (localReviewFollowUpNeedsRepair(config, record, pr)) {
+  if (
+    localReviewFollowUpNeedsRepair(config, record, pr) &&
+    !checkSummary.hasFailing &&
+    !checkSummary.hasPending &&
+    unresolvedBotThreads.length === 0 &&
+    (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
+    !mergeConflictDetected(pr)
+  ) {
     return "local_review_fix";
   }
 
-  if (localReviewHighSeverityNeedsBlock(config, record, pr)) {
-    return "blocked";
-  }
-
-  const checkSummary = summarizeChecks(checks);
   if (checkSummary.hasFailing) {
     return "repairing_ci";
   }
@@ -903,6 +906,10 @@ export function inferStateFromPullRequest(
   }
 
   if (config.humanReviewBlocksMerge && manualThreads.length > 0) {
+    return "blocked";
+  }
+
+  if (localReviewHighSeverityNeedsBlock(config, record, pr)) {
     return "blocked";
   }
 

--- a/src/review-handling.test.ts
+++ b/src/review-handling.test.ts
@@ -4,6 +4,7 @@ import {
   hasProcessedReviewThread,
   localReviewBlocksMerge,
   localReviewBlocksReady,
+  localReviewFollowUpNeedsRepair,
   localReviewHighSeverityNeedsBlock,
   localReviewHighSeverityNeedsRetry,
   localReviewRetryLoopCandidate,
@@ -276,6 +277,23 @@ test("tracked PR current-head gate blocks ready and merge progression until loca
   assert.equal(localReviewBlocksMerge(config, staleRecord, pr), true);
 });
 
+test("opted-in same-PR follow-up repair blocks ready and merge progression on the current head", () => {
+  const pr = createPullRequest({ isDraft: false, headRefOid: "deadbeef" });
+  const record = createRecord({
+    local_review_head_sha: "deadbeef",
+    pre_merge_evaluation_outcome: "follow_up_eligible",
+    pre_merge_follow_up_count: 2,
+  });
+  const config = createConfig({
+    localReviewPolicy: "block_merge",
+    localReviewFollowUpRepairEnabled: true,
+  });
+
+  assert.equal(localReviewFollowUpNeedsRepair(config, record, pr), true);
+  assert.equal(localReviewBlocksReady(config, record, pr), true);
+  assert.equal(localReviewBlocksMerge(config, record, pr), true);
+});
+
 test("local review high-severity actions distinguish retry from blocked", () => {
   const pr = createPullRequest();
   const record = createRecord({
@@ -329,6 +347,58 @@ test("local review retry loop helpers require a clean path and stall after repea
   const record = createRecord({
     local_review_head_sha: "deadbeef",
     local_review_verified_max_severity: "high",
+    repeated_local_review_signature_count: 2,
+  });
+  const checks: PullRequestCheck[] = [];
+  const reviewThreads: ReviewThread[] = [];
+
+  const manualReviewThreads = () => [];
+  const configuredBotReviewThreads = () => [];
+  const summarizeChecks = () => ({ hasFailing: false, hasPending: false });
+  const mergeConflictDetected = () => false;
+
+  assert.equal(
+    localReviewRetryLoopCandidate(
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    ),
+    true,
+  );
+  assert.equal(
+    localReviewRetryLoopStalled(
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected,
+    ),
+    true,
+  );
+});
+
+test("local review retry loop helpers also stall repeated same-PR follow-up repairs on a clean path", () => {
+  const config = createConfig({
+    localReviewPolicy: "block_merge",
+    localReviewFollowUpRepairEnabled: true,
+    sameFailureSignatureRepeatLimit: 2,
+    humanReviewBlocksMerge: true,
+  });
+  const pr = createPullRequest({ isDraft: false });
+  const record = createRecord({
+    local_review_head_sha: "deadbeef",
+    pre_merge_evaluation_outcome: "follow_up_eligible",
+    pre_merge_follow_up_count: 1,
     repeated_local_review_signature_count: 2,
   });
   const checks: PullRequestCheck[] = [];

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -76,6 +76,7 @@ export function localReviewBlocksReady(
     | "local_review_findings_count"
     | "local_review_recommendation"
     | "pre_merge_evaluation_outcome"
+    | "pre_merge_follow_up_count"
   >,
   pr: GitHubPullRequest,
 ): boolean {
@@ -89,6 +90,10 @@ export function localReviewBlocksReady(
 
   if (config.localReviewPolicy === "block_ready") {
     return record.local_review_head_sha !== pr.headRefOid || localReviewHasActionableFindings(record, pr);
+  }
+
+  if (localReviewFollowUpNeedsRepair(config, record, pr)) {
+    return true;
   }
 
   if (config.localReviewPolicy !== "block_merge") {
@@ -114,6 +119,7 @@ export function localReviewBlocksMerge(
     | "local_review_findings_count"
     | "local_review_recommendation"
     | "pre_merge_evaluation_outcome"
+    | "pre_merge_follow_up_count"
   >,
   pr: GitHubPullRequest,
 ): boolean {
@@ -127,6 +133,10 @@ export function localReviewBlocksMerge(
 
   if (config.localReviewPolicy !== "block_merge") {
     return false;
+  }
+
+  if (localReviewFollowUpNeedsRepair(config, record, pr)) {
+    return true;
   }
 
   if (record.local_review_head_sha !== pr.headRefOid) {
@@ -185,6 +195,8 @@ export function localReviewRetryLoopCandidate(
     IssueRunRecord,
     | "local_review_head_sha"
     | "local_review_verified_max_severity"
+    | "pre_merge_evaluation_outcome"
+    | "pre_merge_follow_up_count"
     | "repeated_local_review_signature_count"
     | "processed_review_thread_ids"
     | "processed_review_thread_fingerprints"
@@ -201,7 +213,7 @@ export function localReviewRetryLoopCandidate(
   const manualThreads = manualReviewThreads(config, reviewThreads);
   const unresolvedBotThreads = configuredBotReviewThreads(config, reviewThreads);
   return (
-    localReviewHighSeverityNeedsRetry(config, record, pr) &&
+    (localReviewHighSeverityNeedsRetry(config, record, pr) || localReviewFollowUpNeedsRepair(config, record, pr)) &&
     !checkSummary.hasFailing &&
     !checkSummary.hasPending &&
     unresolvedBotThreads.length === 0 &&
@@ -216,6 +228,8 @@ export function localReviewRetryLoopStalled(
     IssueRunRecord,
     | "local_review_head_sha"
     | "local_review_verified_max_severity"
+    | "pre_merge_evaluation_outcome"
+    | "pre_merge_follow_up_count"
     | "repeated_local_review_signature_count"
     | "processed_review_thread_ids"
     | "processed_review_thread_fingerprints"


### PR DESCRIPTION
## Summary\n- block ready and merge progression while opted-in same-PR local-review follow-up repair is pending on the current head\n- reuse the shared local-review retry convergence path for same-PR follow-up repair\n- preserve CI, review-thread, and merge-conflict precedence over follow-up repair retries\n\n## Testing\n- npx tsx --test src/review-handling.test.ts\n- npx tsx --test src/pull-request-state-policy.test.ts\n- npx tsx --test src/post-turn-pull-request.test.ts\n- npm run build\n\nCloses #1331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for pull request state inference, review handling, and follow-up repair scenarios including CI failures and merge conflict conditions.

* **Refactor**
  * Improved pull request state computation with enhanced follow-up repair evaluation and better handling of CI failures, merge conflicts, and review thread conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->