### PR TITLE
Clarify same-PR local review repair surfaces

### DIFF
--- a/.codex-supervisor/issues/1332/issue-journal.md
+++ b/.codex-supervisor/issues/1332/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1332: Clarify prompt and status surfaces for same-PR local-review follow-up repair
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1332
+- Branch: codex/issue-1332
+- Workspace: .
+- Journal: .codex-supervisor/issues/1332/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 0fc40256f52a8fd558a29e2c804c9d0bd13254ef
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-07T13:00:07.255Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `local_review_fix` was hiding whether the repair pass came from same-PR `follow_up_eligible` residuals or a high-severity retry, so prompt and operator status surfaces needed an explicit repair-intent marker without changing the saved pre-merge outcome.
+- What changed: Added prompt-side `repairIntent` wording for local-review repair context, annotated turn-prep repair context from the live record, extended pre-merge evaluation rendering with `repair=...`, and tightened focused tests for prompt, explain, active-status snapshot, and status-summary output.
+- Current blocker: none.
+- Next exact step: Commit the verified checkpoint on `codex/issue-1332`.
+- Verification gap: none for the scoped prompt/status change; targeted tests and `npm run build` passed locally.
+- Files touched: `src/codex/codex-prompt.ts`, `src/codex/codex-prompt.test.ts`, `src/supervisor/supervisor-pre-merge-evaluation.ts`, `src/supervisor/supervisor-selection-issue-explain.test.ts`, `src/supervisor/supervisor-selection-status-active-status.test.ts`, `src/supervisor/supervisor-status-rendering-supervisor.test.ts`, `src/turn-execution-orchestration.ts`, `src/turn-execution-orchestration.test.ts`.
+- Rollback concern: low; changes are additive wording/metadata surfaces and test coverage around existing follow-up repair routing.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -92,6 +92,7 @@ test("buildCodexPrompt suppresses stale handoff next actions during local_review
 ### Scratchpad
 - Keep this section short.`,
     localReviewRepairContext: {
+      repairIntent: "high_severity_retry",
       summaryPath: "/tmp/reviews/issue-46/head-deadbeef.md",
       findingsPath: "/tmp/reviews/issue-46/head-deadbeef.json",
       relevantFiles: ["src/codex.ts"],
@@ -409,6 +410,7 @@ test("buildCodexPrompt emphasizes compressed local-review root causes during loc
     journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
     failureContext,
     localReviewRepairContext: {
+      repairIntent: "high_severity_retry",
       summaryPath: "/tmp/reviews/issue-46/head-deadbeef.md",
       findingsPath: "/tmp/reviews/issue-46/head-deadbeef.json",
       relevantFiles: ["src/supervisor.ts", "src/codex.ts"],
@@ -453,7 +455,8 @@ test("buildCodexPrompt emphasizes compressed local-review root causes during loc
   });
 
   assert.match(prompt, /Supervisor state: local_review_fix/);
-  assert.match(prompt, /blocking the PR or merge/);
+  assert.match(prompt, /driving the current repair pass/);
+  assert.match(prompt, /Repair intent: high-severity retry on the current PR head\./);
   assert.match(prompt, /Relevant files to inspect first:/);
   assert.match(prompt, /src\/supervisor\.ts/);
   assert.match(prompt, /State inference sends local-review retries/);
@@ -461,6 +464,42 @@ test("buildCodexPrompt emphasizes compressed local-review root causes during loc
   assert.match(prompt, /Repair retries can loop through the wrong state\./);
   assert.match(prompt, /Committed verifier guardrails:/);
   assert.match(prompt, /Re-check retry mode state handoff/);
+});
+
+test("buildCodexPrompt distinguishes same-PR follow-up repair from blocking retry flows", () => {
+  const prompt = buildCodexPrompt({
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "local_review_fix" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+    localReviewRepairContext: {
+      repairIntent: "same_pr_follow_up",
+      summaryPath: "/tmp/reviews/issue-46/head-deadbeef.md",
+      findingsPath: "/tmp/reviews/issue-46/head-deadbeef.json",
+      relevantFiles: ["src/codex.ts"],
+      rootCauses: [
+        {
+          severity: "medium",
+          summary: "Prompt wording should identify same-PR follow-up repair without implying fix_blocked.",
+          file: "src/codex.ts",
+          lines: "1-200",
+        },
+      ],
+      priorMissPatterns: [],
+      verifierGuardrails: [],
+    },
+  });
+
+  assert.match(prompt, /Repair intent: same-PR follow-up repair on the current PR head\./);
+  assert.match(prompt, /saved follow_up_eligible result/);
+  assert.doesNotMatch(prompt, /manual-review flow/);
 });
 
 test("buildCodexPrompt suppresses flat next-action bullet lists during local_review_fix", () => {

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -22,6 +22,7 @@ import type {
 } from "../supervisor/agent-runner";
 
 export interface LocalReviewRepairContext {
+  repairIntent?: "same_pr_follow_up" | "high_severity_retry" | "unspecified";
   summaryPath: string;
   findingsPath: string | null;
   relevantFiles: string[];
@@ -64,7 +65,7 @@ function phaseGuidance(state: RunState): string[] {
 
   if (state === "local_review_fix") {
     return [
-      "- Focus only on the active local-review root causes blocking the PR or merge.",
+      "- Focus only on the active local-review root causes driving the current repair pass.",
       "- Make the smallest code change that resolves the current root cause and avoid checkpoint-maintenance work.",
     ];
   }
@@ -327,6 +328,11 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
           "Active local-review repair context:",
           ...(input.localReviewRepairContext
             ? [
+                input.localReviewRepairContext.repairIntent === "same_pr_follow_up"
+                  ? "- Repair intent: same-PR follow-up repair on the current PR head. Keep operator-facing summaries aligned with the saved follow_up_eligible result until a fresh local review says otherwise."
+                  : input.localReviewRepairContext.repairIntent === "high_severity_retry"
+                    ? "- Repair intent: high-severity retry on the current PR head. This is not a same-PR follow-up repair or a manual-review flow."
+                    : "- Repair intent: local-review repair context loaded; determine from the saved artifacts whether this is a same-PR follow-up or a blocking retry.",
                 `- Summary artifact: ${input.localReviewRepairContext.summaryPath}`,
                 input.localReviewRepairContext.findingsPath
                   ? `- Findings artifact: ${input.localReviewRepairContext.findingsPath}`

--- a/src/supervisor/supervisor-pre-merge-evaluation.ts
+++ b/src/supervisor/supervisor-pre-merge-evaluation.ts
@@ -7,6 +7,7 @@ import { displayRelativeArtifactPath, localReviewHeadStatus, localReviewIsGating
 export interface SupervisorPreMergeEvaluationDto {
   status: "pending" | "passed" | "blocked" | "follow_up_eligible";
   outcome: LocalReviewArtifact["finalEvaluation"]["outcome"] | null;
+  repair?: "none" | "same_pr_follow_up_current_head" | "high_severity_retry_current_head" | "manual_review_required";
   reason: string;
   headStatus: "none" | "current" | "stale" | "unknown";
   summaryPath: string | null;
@@ -67,10 +68,47 @@ function outcomeReason(artifact: LocalReviewArtifact): string {
   }
 }
 
+function repairDisposition(args: {
+  config: Pick<SupervisorConfig, "localReviewFollowUpRepairEnabled" | "localReviewHighSeverityAction">;
+  record: Pick<IssueRunRecord, "state" | "pre_merge_follow_up_count">;
+  headStatus: SupervisorPreMergeEvaluationDto["headStatus"];
+  artifact: LocalReviewArtifact | null;
+}): SupervisorPreMergeEvaluationDto["repair"] {
+  if (!args.artifact) {
+    return "none";
+  }
+
+  if (args.artifact.finalEvaluation.outcome === "manual_review_blocked") {
+    return "manual_review_required";
+  }
+
+  if (args.headStatus !== "current" || args.record.state !== "local_review_fix") {
+    return "none";
+  }
+
+  if (
+    args.artifact.finalEvaluation.outcome === "follow_up_eligible" &&
+    args.config.localReviewFollowUpRepairEnabled === true &&
+    (args.record.pre_merge_follow_up_count ?? args.artifact.finalEvaluation.followUpCount) > 0
+  ) {
+    return "same_pr_follow_up_current_head";
+  }
+
+  if (
+    args.artifact.finalEvaluation.outcome === "fix_blocked" &&
+    args.config.localReviewHighSeverityAction === "retry"
+  ) {
+    return "high_severity_retry_current_head";
+  }
+
+  return "none";
+}
+
 export async function loadPreMergeEvaluationDto(args: {
   config: SupervisorConfig;
   record: Pick<
     IssueRunRecord,
+    | "state"
     | "local_review_summary_path"
     | "local_review_run_at"
     | "local_review_head_sha"
@@ -92,6 +130,7 @@ export async function loadPreMergeEvaluationDto(args: {
     return {
       status: "pending",
       outcome: null,
+      repair: "none",
       reason: pending,
       headStatus,
       summaryPath,
@@ -115,6 +154,7 @@ export async function loadPreMergeEvaluationDto(args: {
     return {
       status: "pending",
       outcome: null,
+      repair: "none",
       reason: "awaiting_final_evaluation_artifact",
       headStatus,
       summaryPath,
@@ -129,6 +169,12 @@ export async function loadPreMergeEvaluationDto(args: {
   return {
     status: outcomeStatus(artifact.finalEvaluation.outcome),
     outcome: artifact.finalEvaluation.outcome,
+    repair: repairDisposition({
+      config: args.config,
+      record: args.record,
+      headStatus,
+      artifact,
+    }),
     reason: outcomeReason(artifact),
     headStatus,
     summaryPath,
@@ -151,6 +197,7 @@ export function formatPreMergeEvaluationStatusLine(
     "pre_merge_evaluation",
     `status=${evaluation.status}`,
     `outcome=${evaluation.outcome ?? "none"}`,
+    `repair=${evaluation.repair ?? "none"}`,
     `head=${evaluation.headStatus}`,
     `must_fix=${evaluation.mustFixCount}`,
     `manual_review=${evaluation.manualReviewCount}`,

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -546,12 +546,14 @@ test("buildIssueExplainSummary surfaces follow-up-eligible pre-merge evaluation 
     issues: {
       [String(issueNumber)]: createRecord({
         issue_number: issueNumber,
-        state: "ready_to_merge",
+        state: "local_review_fix",
         branch: branchName(fixture.config, issueNumber),
         workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         local_review_summary_path: summaryPath,
         local_review_head_sha: "head-609",
         local_review_run_at: "2026-03-24T00:11:00Z",
+        pre_merge_evaluation_outcome: "follow_up_eligible",
+        pre_merge_follow_up_count: 1,
       }),
     },
   };
@@ -560,6 +562,7 @@ test("buildIssueExplainSummary surfaces follow-up-eligible pre-merge evaluation 
     stateFile: fixture.stateFile,
     repoPath: fixture.repoPath,
     localReviewArtifactDir: path.join(fixture.workspaceRoot, "reviews"),
+    localReviewFollowUpRepairEnabled: true,
   });
 
   const dto = await buildIssueExplainDto(
@@ -589,6 +592,7 @@ test("buildIssueExplainSummary surfaces follow-up-eligible pre-merge evaluation 
   assert.deepEqual(dto.activityContext?.preMergeEvaluation, {
     status: "follow_up_eligible",
     outcome: "follow_up_eligible",
+    repair: "same_pr_follow_up_current_head",
     reason: "follow_up_candidates=1",
     headStatus: "current",
     summaryPath: "owner-repo/issue-609/head-609.md",
@@ -600,6 +604,6 @@ test("buildIssueExplainSummary surfaces follow-up-eligible pre-merge evaluation 
   });
   assert.match(
     renderIssueExplainDto(dto),
-    /^pre_merge_evaluation status=follow_up_eligible outcome=follow_up_eligible head=current must_fix=0 manual_review=0 follow_up=1 reason=follow_up_candidates=1 ran_at=2026-03-24T00:11:00Z summary_path=owner-repo\/issue-609\/head-609\.md artifact_path=owner-repo\/issue-609\/head-609\.json$/m,
+    /^pre_merge_evaluation status=follow_up_eligible outcome=follow_up_eligible repair=same_pr_follow_up_current_head head=current must_fix=0 manual_review=0 follow_up=1 reason=follow_up_candidates=1 ran_at=2026-03-24T00:11:00Z summary_path=owner-repo\/issue-609\/head-609\.md artifact_path=owner-repo\/issue-609\/head-609\.json$/m,
   );
 });

--- a/src/supervisor/supervisor-selection-status-active-status.test.ts
+++ b/src/supervisor/supervisor-selection-status-active-status.test.ts
@@ -429,12 +429,18 @@ test("loadActiveIssueStatusSnapshot exposes typed pre-merge final evaluation con
     });
 
     const snapshot = await loadActiveIssueStatusSnapshot({
-      config: createConfig({ localReviewArtifactDir: path.join(tempDir, "reviews") }),
+      config: createConfig({
+        localReviewArtifactDir: path.join(tempDir, "reviews"),
+        localReviewFollowUpRepairEnabled: true,
+      }),
       activeRecord: createRecord({
+        state: "local_review_fix",
         workspace,
         local_review_summary_path: summaryPath,
         local_review_head_sha: "deadbeef",
         local_review_run_at: "2026-03-24T00:11:00Z",
+        pre_merge_evaluation_outcome: "follow_up_eligible",
+        pre_merge_follow_up_count: 1,
       }),
       github: {
         async getIssue() {
@@ -457,6 +463,7 @@ test("loadActiveIssueStatusSnapshot exposes typed pre-merge final evaluation con
     assert.deepEqual(snapshot.activityContext?.preMergeEvaluation, {
       status: "follow_up_eligible",
       outcome: "follow_up_eligible",
+      repair: "same_pr_follow_up_current_head",
       reason: "follow_up_candidates=1",
       headStatus: "current",
       summaryPath: "owner-repo/issue-58/head-deadbeef.md",

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
+import { buildDetailedStatusSummaryLines } from "./supervisor-status-model";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig } from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -269,6 +270,57 @@ test("formatDetailedStatus shows configured-bot same-head follow-up eligibility 
     reviewThreads,
   });
   assert.match(exhaustedStatus, /review_follow_up state=exhausted remaining=0 head_sha=deadbeef actionable=0/);
+});
+
+test("buildDetailedStatusSummaryLines surfaces same-PR follow-up repair without changing the saved outcome", () => {
+  const statusLines = buildDetailedStatusSummaryLines({
+    config: createConfig({ localReviewFollowUpRepairEnabled: true }),
+    activeRecord: createRecord({
+      state: "local_review_fix",
+      local_review_summary_path: "/tmp/reviews/owner-repo/issue-366/head-deadbeef.md",
+    }),
+    activityContext: {
+      handoffSummary: null,
+      localReviewRoutingSummary: null,
+      changeClassesSummary: null,
+      verificationPolicySummary: null,
+      durableGuardrailSummary: null,
+      externalReviewFollowUpSummary: null,
+      preMergeEvaluation: {
+        status: "follow_up_eligible",
+        outcome: "follow_up_eligible",
+        repair: "same_pr_follow_up_current_head",
+        reason: "follow_up_candidates=1",
+        headStatus: "current",
+        summaryPath: "owner-repo/issue-366/head-deadbeef.md",
+        artifactPath: "owner-repo/issue-366/head-deadbeef.json",
+        ranAt: "2026-03-24T00:11:00Z",
+        mustFixCount: 0,
+        manualReviewCount: 0,
+        followUpCount: 1,
+      },
+      localCiStatus: null,
+      latestRecovery: null,
+      retryContext: {
+        timeoutRetryCount: 0,
+        blockedVerificationRetryCount: 0,
+        repeatedBlockerCount: 0,
+        repeatedFailureSignatureCount: 0,
+        lastFailureSignature: null,
+      },
+      repeatedRecovery: null,
+      recentPhaseChanges: [],
+      localReviewSummaryPath: "owner-repo/issue-366/head-deadbeef.md",
+      externalReviewMissesPath: null,
+      reviewWaits: [],
+    },
+  });
+
+  assert.ok(
+    statusLines.includes(
+      "pre_merge_evaluation status=follow_up_eligible outcome=follow_up_eligible repair=same_pr_follow_up_current_head head=current must_fix=0 manual_review=0 follow_up=1 reason=follow_up_candidates=1 ran_at=2026-03-24T00:11:00Z summary_path=owner-repo/issue-366/head-deadbeef.md artifact_path=owner-repo/issue-366/head-deadbeef.json",
+    ),
+  );
 });
 
 test("formatDetailedStatus marks stalled local-review repair loops explicitly", () => {

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -230,6 +230,8 @@ test("prepareCodexTurnPrompt loads local-review repair context for local_review_
       "102": createRecord({
         state: "local_review_fix",
         local_review_summary_path: summaryPath,
+        pre_merge_evaluation_outcome: "follow_up_eligible",
+        pre_merge_follow_up_count: 1,
         last_failure_context: createFailureContext("Active local-review blocker."),
       }),
     },
@@ -237,7 +239,7 @@ test("prepareCodexTurnPrompt loads local-review repair context for local_review_
 
   try {
     const prepared = await prepareCodexTurnPrompt({
-      config: createConfig(),
+      config: createConfig({ localReviewFollowUpRepairEnabled: true }),
       stateStore: {
         touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
         save: async () => undefined,
@@ -277,6 +279,7 @@ test("prepareCodexTurnPrompt loads local-review repair context for local_review_
     }
     const prompt = buildCodexPrompt(prepared.turnContext);
     assert.match(prompt, /Active local-review repair context:/);
+    assert.match(prompt, /Repair intent: same-PR follow-up repair on the current PR head\./);
     assert.match(prompt, /Permission guard retry path is fragile/);
     assert.match(prompt, /file=src\/auth\.ts lines=40-44/);
   } finally {

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -127,7 +127,22 @@ export async function prepareCodexTurnPrompt(args: {
   });
   const localReviewRepairContext =
     args.record.state === "local_review_fix"
-      ? await loadLocalReviewRepairContext(args.record.local_review_summary_path, args.workspacePath)
+      ? await loadLocalReviewRepairContext(args.record.local_review_summary_path, args.workspacePath).then((context) =>
+          context
+            ? {
+                ...context,
+                repairIntent:
+                  args.record.pre_merge_evaluation_outcome === "follow_up_eligible" &&
+                    (args.record.pre_merge_follow_up_count ?? 0) > 0 &&
+                    args.config.localReviewFollowUpRepairEnabled === true
+                    ? ("same_pr_follow_up" as const)
+                    : args.record.pre_merge_evaluation_outcome === "fix_blocked" &&
+                        args.config.localReviewHighSeverityAction === "retry"
+                      ? ("high_severity_retry" as const)
+                      : ("unspecified" as const),
+              }
+            : null,
+        )
       : null;
 
   let externalReviewMissContext: ExternalReviewMissContext | null = null;


### PR DESCRIPTION
## Summary
- clarify `local_review_fix` prompt wording for same-PR follow-up repair versus high-severity retry
- surface a `repair=` marker in pre-merge status/explain output while preserving saved `follow_up_eligible` outcomes
- tighten focused tests around prompt, active status, explain output, and turn prep

## Testing
- `npx tsx --test src/codex/codex-prompt.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced repair operation tracking with distinct intent types (same-PR follow-up vs. high-severity retry) for clearer operational context.
  * Improved pre-merge evaluation status display to include repair disposition information.
  * Refined prompt guidance to better direct focus toward specific repair scenarios.

* **Tests**
  * Updated test coverage to validate new repair intent and disposition functionality across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->