### PR TITLE
Fix degraded current-head local review classification

### DIFF
--- a/.codex-supervisor/issues/1347/issue-journal.md
+++ b/.codex-supervisor/issues/1347/issue-journal.md
@@ -1,0 +1,36 @@
+# Issue #1347: Bug: classify degraded current-head local review separately from manual_review_required
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1347
+- Branch: codex/issue-1347
+- Workspace: .
+- Journal: .codex-supervisor/issues/1347/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c7bd069b84b8803d9d381127c8542528cf34be46
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-08T08:11:20.530Z
+
+## Latest Codex Summary
+- Reproduced the tracked current-head regression where a degraded local-review run with no `manual_review_required` residuals still collapsed into `blocked/manual_review`.
+- Fixed manual-review classification to require at least one true manual-review residual, leaving degraded no-manual-residual runs in the verification lane while preserving genuine manual-review blockers.
+- Tightened pre-merge evaluation/status reporting so degraded artifacts surface as `degraded_local_review` instead of looking like unresolved manual-review residuals.
+- Verified with focused tests plus `npm run build`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The regression came from treating `manual_review_blocked` as synonymous with `manual_review_required`, even when the local-review artifact was degraded and `manualReviewCount` was zero.
+- What changed: Updated review-handling and post-turn PR classification to require a real manual-review residual before mapping to `blocked/manual_review`; added regression coverage for the degraded current-head path; updated pre-merge evaluation reporting to emit `reason=degraded_local_review` and `repair=none` for degraded/no-manual-residual artifacts.
+- Current blocker: none.
+- Next exact step: Commit the fix on `codex/issue-1347` and leave the branch ready for PR/update.
+- Verification gap: None in the focused issue scope; the requested targeted suite and build passed locally.
+- Files touched: src/review-handling.ts, src/post-turn-pull-request.ts, src/supervisor/supervisor-pre-merge-evaluation.ts, src/post-turn-pull-request.test.ts, src/pull-request-state-policy.test.ts, src/supervisor/supervisor-pre-merge-evaluation.test.ts
+- Rollback concern: Low. The behavior change is scoped to degraded local-review runs with zero manual-review residuals; genuine manual-review blockers still use `manual_review`.
+- Last focused command: npm run build
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { handlePostTurnPullRequestTransitionsPhase, type PullRequestLifecycleSnapshot } from "./post-turn-pull-request";
 import { IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorStateFile } from "./core/types";
 import { derivePullRequestLifecycleSnapshot as deriveSupervisorPullRequestLifecycleSnapshot } from "./supervisor/supervisor-lifecycle";
-import { inferStateFromPullRequest } from "./pull-request-state";
+import { blockedReasonFromReviewState as resolveBlockedReasonFromReviewState, inferStateFromPullRequest } from "./pull-request-state";
 import { createConfig, createFailureContext, createIssue, createPullRequest, createRecord } from "./turn-execution-test-helpers";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
@@ -1911,12 +1911,7 @@ test("handlePostTurnPullRequestTransitionsPhase routes current-head manual-revie
       repeated_failure_signature_count: 0,
     }),
     blockedReasonFromReviewState: (record, pr, checks, reviewThreads) =>
-      inferStateFromPullRequest(config, record, pr, checks, reviewThreads) === "blocked" &&
-      record.pre_merge_evaluation_outcome === "manual_review_blocked"
-        ? "manual_review"
-        : record.pre_merge_evaluation_outcome === "fix_blocked"
-          ? "verification"
-          : null,
+      resolveBlockedReasonFromReviewState(config, record, pr, checks, reviewThreads),
     summarizeChecks: (checks) => ({
       hasPending: checks.some((check) => check.bucket === "pending"),
       hasFailing: checks.some((check) => check.bucket === "fail"),
@@ -3138,6 +3133,132 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft PRs when local revi
   assert.equal(result.record.blocked_reason, "manual_review");
   assert.equal(result.record.pre_merge_evaluation_outcome, "manual_review_blocked");
   assert.match(result.record.last_error ?? "", /manual/i);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase keeps degraded current-head local review separate from manual-review blockers", async () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+  });
+  const issue = createIssue({ title: "Keep degraded local review out of manual review" });
+  const readyPr = createPullRequest({ title: "Degraded local review gate", isDraft: false, headRefOid: "head-117" });
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        throw new Error("unexpected markPullRequestReady call");
+      },
+    },
+    context: {
+      state: {
+        activeIssueNumber: 103,
+        issues: { "103": createRecord({ state: "pr_open", pr_number: readyPr.number, last_head_sha: "head-117" }) },
+      },
+      record: createRecord({ state: "pr_open", pr_number: readyPr.number, last_head_sha: "head-117" }),
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-103"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: readyPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record, pr, checks, reviewThreads) => ({
+      recordForState: record,
+      nextState: inferStateFromPullRequest(config, record, pr, checks, reviewThreads),
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: (record, pr, checks, reviewThreads) =>
+      resolveBlockedReasonFromReviewState(config, record, pr, checks, reviewThreads),
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalReviewImpl: async () => ({
+      ranAt: "2026-03-24T00:11:00Z",
+      summaryPath: "/tmp/reviews/owner-repo/issue-103/head-117.md",
+      findingsPath: "/tmp/reviews/owner-repo/issue-103/head-117.json",
+      summary: "One local review role failed after surfacing a medium-severity follow-up candidate.",
+      blockerSummary: "degraded local review; inspect the saved artifact",
+      findingsCount: 1,
+      rootCauseCount: 1,
+      maxSeverity: "medium",
+      verifiedFindingsCount: 0,
+      verifiedMaxSeverity: "none",
+      recommendation: "changes_requested",
+      degraded: true,
+      finalEvaluation: {
+        outcome: "manual_review_blocked",
+        residualFindings: [
+          {
+            findingKey: "src/ui/panel.tsx|20|21|retry path|retry path should preserve prior findings.",
+            summary: "Retry path should preserve prior findings.",
+            severity: "medium",
+            category: "correctness",
+            file: "src/ui/panel.tsx",
+            start: 20,
+            end: 21,
+            source: "local_review",
+            resolution: "follow_up_candidate",
+            rationale: "Residual non-high-severity finding is eligible for explicit follow-up instead of blocking merge by itself.",
+          },
+        ],
+        mustFixCount: 0,
+        manualReviewCount: 0,
+        followUpCount: 1,
+      },
+      rawOutput: "raw output",
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: readyPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.local_review_degraded, true);
+  assert.equal(result.record.pre_merge_evaluation_outcome, "manual_review_blocked");
+  assert.equal(result.record.pre_merge_manual_review_count, 0);
+  assert.match(result.record.last_error ?? "", /degraded state/i);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase emits typed review-wait change events", async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -445,6 +445,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           : null;
       const signatureTracking = nextLocalReviewSignatureTracking(record, refreshed.pr.headRefOid, actionableSignature);
       const manualReviewBlocked = localReview.finalEvaluation.outcome === "manual_review_blocked";
+      const manualReviewResidualBlocked = manualReviewBlocked && localReview.finalEvaluation.manualReviewCount > 0;
       const manualReviewNeedsRepair = localReviewManualReviewNeedsRepair(
         config,
         {
@@ -457,7 +458,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       );
 
       record = stateStore.touch(record, {
-        state: manualReviewNeedsRepair ? "local_review_fix" : manualReviewBlocked ? "blocked" : "draft_pr",
+        state: manualReviewNeedsRepair ? "local_review_fix" : manualReviewResidualBlocked ? "blocked" : "draft_pr",
         local_review_head_sha: refreshed.pr.headRefOid,
         local_review_blocker_summary: localReview.blockerSummary,
         local_review_summary_path: localReview.summaryPath,
@@ -480,7 +481,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         external_review_near_match_findings_count: 0,
         external_review_missed_findings_count: 0,
         blocked_reason:
-          manualReviewBlocked && !manualReviewNeedsRepair
+          manualReviewResidualBlocked && !manualReviewNeedsRepair
             ? "manual_review"
             : localReview.recommendation !== "ready" && config.localReviewHighSeverityAction === "blocked" && localReview.verifiedMaxSeverity === "high"
             ? "verification"
@@ -492,7 +493,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
                   ? "Local review completed in a degraded state."
                   : manualReviewNeedsRepair
                     ? `Local review found ${localReview.finalEvaluation.manualReviewCount} unresolved manual-review residual${localReview.finalEvaluation.manualReviewCount === 1 ? "" : "s"} on the current PR head. Codex will continue with a same-PR repair pass before the PR can proceed.`
-                  : manualReviewBlocked
+                  : manualReviewResidualBlocked
                     ? `Local review requires manual verification before the PR can proceed (${localReview.finalEvaluation.manualReviewCount} unresolved manual-review residual${localReview.finalEvaluation.manualReviewCount === 1 ? "" : "s"}).`
                   : localReview.verifiedMaxSeverity === "high" && config.localReviewHighSeverityAction === "retry"
                     ? `Local review found high-severity issues (${localReview.findingsCount} actionable findings across ${localReview.rootCauseCount} root cause(s)). Codex will continue with a repair pass before the PR can proceed.`

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -596,6 +596,27 @@ test("blockedReasonFromReviewState reports manual_review for manual-review-block
   );
 });
 
+test("blockedReasonFromReviewState reports verification for degraded local review without manual-review residuals", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    copilotReviewWaitMinutes: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    local_review_head_sha: "head123",
+    local_review_degraded: true,
+    pre_merge_evaluation_outcome: "manual_review_blocked",
+    pre_merge_manual_review_count: 0,
+    pre_merge_follow_up_count: 1,
+  });
+
+  assert.equal(
+    blockedReasonFromReviewState(config, record, createPullRequest({ headRefOid: "head123" }), [], []),
+    "verification",
+  );
+});
+
 test("inferStateFromPullRequest blocks draft PRs when the current head still needs manual verification", () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -165,6 +165,7 @@ export function localReviewRequiresManualReview(
     config.localReviewPolicy === "block_merge" &&
     record.local_review_head_sha === pr.headRefOid &&
     record.pre_merge_evaluation_outcome === "manual_review_blocked" &&
+    (record.pre_merge_manual_review_count ?? 0) > 0 &&
     !localReviewManualReviewNeedsRepair(config, record, pr)
   );
 }

--- a/src/supervisor/supervisor-pre-merge-evaluation.test.ts
+++ b/src/supervisor/supervisor-pre-merge-evaluation.test.ts
@@ -101,6 +101,61 @@ test("loadPreMergeEvaluationDto marks opted-in current-head manual-review local-
   }
 });
 
+test("loadPreMergeEvaluationDto distinguishes degraded local review from manual-review residuals", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pre-merge-eval-"));
+  const summaryPath = path.join(tempDir, "owner-repo", "issue-58", "local-review-summary.md");
+  const artifactPath = `${summaryPath.slice(0, -3)}.json`;
+
+  try {
+    await fs.mkdir(path.dirname(summaryPath), { recursive: true });
+    await fs.writeFile(
+      artifactPath,
+      JSON.stringify({
+        ranAt: "2026-03-24T00:11:00Z",
+        degraded: true,
+        finalEvaluation: {
+          outcome: "manual_review_blocked",
+          mustFixCount: 0,
+          manualReviewCount: 0,
+          followUpCount: 1,
+        },
+      }),
+      "utf8",
+    );
+
+    const dto = await loadPreMergeEvaluationDto({
+      config: createConfig({
+        localReviewEnabled: true,
+        localReviewPolicy: "block_merge",
+        localReviewArtifactDir: tempDir,
+      }),
+      record: createRecord({
+        state: "blocked",
+        local_review_head_sha: "head-current",
+        local_review_summary_path: summaryPath,
+        local_review_run_at: "2026-03-24T00:11:00Z",
+      }),
+      pr: createPullRequest({ headRefOid: "head-current", isDraft: false }),
+    });
+
+    assert.deepEqual(dto, {
+      status: "blocked",
+      outcome: "manual_review_blocked",
+      repair: "none",
+      reason: "degraded_local_review",
+      headStatus: "current",
+      summaryPath: "owner-repo/issue-58/local-review-summary.md",
+      artifactPath: "owner-repo/issue-58/local-review-summary.json",
+      ranAt: "2026-03-24T00:11:00Z",
+      mustFixCount: 0,
+      manualReviewCount: 0,
+      followUpCount: 1,
+    });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("loadPreMergeEvaluationDto marks current-head fix-blocked local-review residuals as same-PR repair", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pre-merge-eval-"));
   const summaryPath = path.join(tempDir, "owner-repo", "issue-58", "local-review-summary.md");

--- a/src/supervisor/supervisor-pre-merge-evaluation.ts
+++ b/src/supervisor/supervisor-pre-merge-evaluation.ts
@@ -47,6 +47,9 @@ function pendingReason(headStatus: SupervisorPreMergeEvaluationDto["headStatus"]
 }
 
 function blockedReason(artifact: LocalReviewArtifact): string {
+  if (artifact.degraded && artifact.finalEvaluation.manualReviewCount === 0) {
+    return "degraded_local_review";
+  }
   if (artifact.finalEvaluation.outcome === "manual_review_blocked") {
     return `manual_review_residuals=${artifact.finalEvaluation.manualReviewCount}`;
   }
@@ -102,7 +105,7 @@ function repairDisposition(args: {
     ) {
       return "same_pr_manual_review_current_head";
     }
-    return "manual_review_required";
+    return args.artifact.finalEvaluation.manualReviewCount > 0 ? "manual_review_required" : "none";
   }
 
   if (args.headStatus !== "current" || args.record.state !== "local_review_fix") {


### PR DESCRIPTION
## Summary
- keep degraded current-head local review runs out of the `blocked/manual_review` lane unless they contain real manual-review residuals
- preserve genuine manual-review blockers while routing degraded no-manual-residual runs through verification/degraded reporting
- clarify pre-merge evaluation reporting for degraded artifacts

## Testing
- `npx tsx --test src/local-review/final-evaluation.test.ts src/post-turn-pull-request.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-status-review-bot.test.ts`
- `npm run build`

Closes #1347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved classification of degraded local review scenarios in pull requests. These states are now reported with a distinct classification (`degraded_local_review`) instead of being grouped with manual review blocks, providing clearer and more accurate status indicators for PR review states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->