### PR TITLE
Keep fix_blocked same-PR repair behind review gates

### DIFF
--- a/.codex-supervisor/issues/1352/issue-journal.md
+++ b/.codex-supervisor/issues/1352/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1352: Bug: keep fix_blocked same-PR repair behind GitHub review gates
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1352
+- Branch: codex/issue-1352
+- Workspace: .
+- Journal: .codex-supervisor/issues/1352/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 589172407e2267af4407d21a155c8cd37ea06da6
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-08T11:34:04.180Z
+
+## Latest Codex Summary
+- Reproduced the retry-lane precedence bug with focused `pull-request-state-policy` regressions, then fixed `localReviewHighSeverityNeedsRetry()` so current-head `fix_blocked` retries stay behind the same GitHub review gates as same-PR repair. Focused tests and `npm run build` now pass.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `inferStateFromPullRequest()` was letting current-head `fix_blocked` records bypass GitHub review gates because the high-severity retry branch ran before the guarded same-PR repair lane.
+- What changed: Added regressions for `fix_blocked` + `localReviewHighSeverityAction=\"retry\"` under `REVIEW_REQUIRED` and `CHANGES_REQUESTED`, added a clean-lane approval regression, and narrowed `localReviewHighSeverityNeedsRetry()` so `fix_blocked` only retries when `reviewDecisionAllowsSamePrRepair(pr)` is true.
+- Current blocker: none
+- Next exact step: Stage the focused code/test changes and create a checkpoint commit on `codex/issue-1352`.
+- Verification gap: none for local focused coverage; targeted tests and full TypeScript build passed.
+- Files touched: `src/pull-request-state-policy.test.ts`, `src/review-handling.test.ts`, `src/review-handling.ts`, `.codex-supervisor/issues/1352/issue-journal.md`
+- Rollback concern: low; change is scoped to the retry eligibility helper and only alters current-head `fix_blocked` behavior when GitHub review is still blocking same-PR repair.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -751,6 +751,91 @@ test("inferStateFromPullRequest keeps current-head fix-blocked residuals blocked
   assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), []), "verification");
 });
 
+test("inferStateFromPullRequest keeps current-head fix-blocked retry residuals blocked when GitHub review is still required", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "retry",
+    humanReviewBlocksMerge: true,
+    copilotReviewWaitMinutes: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    local_review_head_sha: "head123",
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    local_review_verified_max_severity: "high",
+    pre_merge_evaluation_outcome: "fix_blocked",
+    pre_merge_must_fix_count: 2,
+  });
+  const pr = createPullRequest({
+    isDraft: false,
+    headRefOid: "head123",
+    reviewDecision: "REVIEW_REQUIRED",
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), []), "blocked");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), []), "verification");
+});
+
+test("inferStateFromPullRequest keeps current-head fix-blocked retry residuals blocked on aggregate changes requested", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "retry",
+    humanReviewBlocksMerge: true,
+    copilotReviewWaitMinutes: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    local_review_head_sha: "head123",
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    local_review_verified_max_severity: "high",
+    pre_merge_evaluation_outcome: "fix_blocked",
+    pre_merge_must_fix_count: 2,
+  });
+  const pr = createPullRequest({
+    isDraft: false,
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), []), "blocked");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), []), "verification");
+});
+
+test("inferStateFromPullRequest still routes current-head fix-blocked retry residuals into same-PR repair on a clean lane", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "retry",
+    humanReviewBlocksMerge: true,
+    copilotReviewWaitMinutes: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    local_review_head_sha: "head123",
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    local_review_verified_max_severity: "high",
+    pre_merge_evaluation_outcome: "fix_blocked",
+    pre_merge_must_fix_count: 2,
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(
+      config,
+      record,
+      createPullRequest({ isDraft: false, headRefOid: "head123", reviewDecision: "APPROVED" }),
+      passingChecks(),
+      [],
+    ),
+    "local_review_fix",
+  );
+});
+
 test("inferStateFromPullRequest keeps same-PR manual-review residuals blocked when GitHub still requires review", () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/review-handling.test.ts
+++ b/src/review-handling.test.ts
@@ -621,6 +621,25 @@ test("localReviewHighSeverityNeedsRetry only escalates verifier-confirmed high f
   );
 });
 
+test("localReviewHighSeverityNeedsRetry keeps current-head fix-blocked retries behind review gates", () => {
+  const config = createConfig({ localReviewPolicy: "block_merge", localReviewHighSeverityAction: "retry" });
+  const record = createRecord({
+    local_review_head_sha: "deadbeef",
+    local_review_verified_max_severity: "high",
+    pre_merge_evaluation_outcome: "fix_blocked",
+  });
+
+  assert.equal(
+    localReviewHighSeverityNeedsRetry(config, record, createPullRequest({ reviewDecision: "REVIEW_REQUIRED" })),
+    false,
+  );
+  assert.equal(
+    localReviewHighSeverityNeedsRetry(config, record, createPullRequest({ reviewDecision: "CHANGES_REQUESTED" })),
+    false,
+  );
+  assert.equal(localReviewHighSeverityNeedsRetry(config, record, createPullRequest({ reviewDecision: "APPROVED" })), true);
+});
+
 test("local review retry loop helpers require a clean path and stall after repeated identical signatures", () => {
   const config = createConfig({
     localReviewPolicy: "block_ready",

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -193,13 +193,17 @@ export function localReviewDegradedNeedsBlock(
 
 export function localReviewHighSeverityNeedsRetry(
   config: SupervisorConfig,
-  record: Pick<IssueRunRecord, "local_review_head_sha" | "local_review_verified_max_severity">,
-  pr: GitHubPullRequest,
+  record: Pick<
+    IssueRunRecord,
+    "local_review_head_sha" | "local_review_verified_max_severity" | "pre_merge_evaluation_outcome"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid" | "reviewDecision">,
 ): boolean {
   return (
     config.localReviewPolicy !== "advisory" &&
     record.local_review_head_sha === pr.headRefOid &&
     record.local_review_verified_max_severity === "high" &&
+    (record.pre_merge_evaluation_outcome !== "fix_blocked" || reviewDecisionAllowsSamePrRepair(pr)) &&
     config.localReviewHighSeverityAction === "retry"
   );
 }


### PR DESCRIPTION
## Summary
- keep current-head `fix_blocked` retry work behind the existing GitHub review gates
- prevent `localReviewHighSeverityAction: "retry"` from bypassing same-PR repair gating
- add regressions for blocked and clean-lane cases

## Testing
- npx tsx --test src/review-handling.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-pre-merge-evaluation.test.ts
- npm run build

Closes #1352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for pull request review state handling and fix-blocked retry behavior.

* **Bug Fixes**
  * Improved retry decision logic to ensure high-severity findings properly respect GitHub review requirements—retries now only proceed when review approval criteria are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->