### PR TITLE
[codex] preserve same-PR repair continuation summary in failure context

### DIFF
--- a/.codex-supervisor/issues/1353/issue-journal.md
+++ b/.codex-supervisor/issues/1353/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1353: Bug: preserve same-PR repair continuation summary in failure context
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1353
+- Branch: codex/issue-1353
+- Workspace: .
+- Journal: .codex-supervisor/issues/1353/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: cc21c5d169df9eca56d1f59d583bd696b853586a
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-08T11:52:43.127Z
+
+## Latest Codex Summary
+- Preserved same-PR repair continuation summaries in exported failure context, added focused regression coverage for fix-blocked/manual-review continuation summaries and the null lane, and verified with targeted tests plus a full build.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `localReviewRepairContinuationFailureContext()` was rebuilding a generic local-review failure summary even when `localReviewRepairContinuationSummary()` had already produced a continuation-specific same-PR repair message.
+- What changed: Updated the helper to preserve the continuation summary while keeping the existing failure signature/details, and added focused regressions for current-head `fix_blocked`, current-head `manual_review_blocked`, and the no-lane null case.
+- Current blocker: none
+- Next exact step: Commit the verified patch on `codex/issue-1353` and leave the branch ready for PR/draft PR handling.
+- Verification gap: none for the requested local scope; targeted tests and `npm run build` passed.
+- Files touched: `src/review-handling.ts`, `src/review-handling.test.ts`, `.codex-supervisor/issues/1353/issue-journal.md`
+- Rollback concern: low; change only affects operator-facing failure-context summary selection for same-PR continuation lanes.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/review-handling.test.ts
+++ b/src/review-handling.test.ts
@@ -278,6 +278,32 @@ test("localReviewRepairContinuationSummary prefers same-PR manual-review repair 
 
   assert.match(summary ?? "", /2 unresolved manual-review residuals on the current PR head/i);
   assert.match(summary ?? "", /same-PR repair pass/i);
+  assert.equal(failureContext?.summary, summary);
+  assert.equal(failureContext?.signature, "local-review:medium:none:1:0:clean");
+});
+
+test("localReviewRepairContinuationFailureContext preserves current-head fix-blocked repair messaging", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+  });
+  const record = createRecord({
+    local_review_head_sha: "deadbeef",
+    pre_merge_evaluation_outcome: "fix_blocked",
+    pre_merge_must_fix_count: 1,
+    local_review_findings_count: 2,
+    local_review_root_cause_count: 1,
+    local_review_max_severity: "medium",
+    local_review_verified_findings_count: 0,
+    local_review_verified_max_severity: "none",
+  });
+
+  const summary = localReviewRepairContinuationSummary(config, record, createPullRequest());
+  const failureContext = localReviewRepairContinuationFailureContext(config, record, createPullRequest());
+
+  assert.match(summary ?? "", /1 unresolved must-fix residual on the current PR head/i);
+  assert.match(summary ?? "", /same-PR repair pass/i);
+  assert.equal(failureContext?.summary, summary);
   assert.equal(failureContext?.signature, "local-review:medium:none:1:0:clean");
 });
 
@@ -300,6 +326,27 @@ test("localReviewRepairContinuationSummary falls back to the high-severity retry
     localReviewRepairContinuationSummary(config, record, createPullRequest()),
     localReviewFailureSummary(record),
   );
+});
+
+test("localReviewRepairContinuationFailureContext returns null when no continuation repair lane applies", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewManualReviewRepairEnabled: true,
+  });
+  const record = createRecord({
+    local_review_head_sha: "head-old",
+    pre_merge_evaluation_outcome: "manual_review_blocked",
+    pre_merge_manual_review_count: 2,
+    local_review_findings_count: 3,
+    local_review_root_cause_count: 1,
+    local_review_max_severity: "medium",
+    local_review_verified_findings_count: 0,
+    local_review_verified_max_severity: "none",
+  });
+
+  assert.equal(localReviewRepairContinuationSummary(config, record, createPullRequest()), null);
+  assert.equal(localReviewRepairContinuationFailureContext(config, record, createPullRequest()), null);
 });
 
 test("block_ready keeps stale local reviews blocking the ready transition", () => {

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -470,7 +470,15 @@ export function localReviewRepairContinuationFailureContext(
   >,
   pr: GitHubPullRequest,
 ): FailureContext | null {
-  return localReviewRepairContinuationSummary(config, record, pr) ? localReviewFailureContext(record) : null;
+  const continuationSummary = localReviewRepairContinuationSummary(config, record, pr);
+  if (!continuationSummary) {
+    return null;
+  }
+
+  return {
+    ...localReviewFailureContext(record),
+    summary: continuationSummary,
+  };
 }
 
 export function localReviewStallFailureContext(


### PR DESCRIPTION
## Summary
- preserve the continuation-specific same-PR repair summary in exported failure context
- keep the existing failure signature and details unchanged
- add focused regression coverage for current-head repair continuation lanes

## Root cause
`localReviewRepairContinuationFailureContext()` rebuilt a generic local-review blocker summary even when `localReviewRepairContinuationSummary()` had already produced a more specific same-PR repair continuation message.

## Impact
Operator-facing journal, handoff, and cleanup surfaces now keep the same-PR repair continuation wording for current-head `fix_blocked` and `manual_review_blocked` lanes instead of falling back to the generic blocker summary.

## Verification
- `npx tsx --test src/review-handling.test.ts src/supervisor/supervisor-execution-cleanup.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved failure context handling for same-PR repair continuations to ensure accurate summary preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->