### PR TITLE
Stop repeated tracked PR recovery churn when stale local blockers persist

### DIFF
--- a/.codex-supervisor/issues/1405/issue-journal.md
+++ b/.codex-supervisor/issues/1405/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-09T23:04:37.981Z
 
 ## Latest Codex Summary
-- Suppressed same-head tracked-PR recovery churn for draft PRs when the local verification blocker is unchanged, and added regression coverage in recovery reconciliation plus doctor diagnostics.
+- Suppressed same-head tracked-PR recovery churn for draft PRs when the local verification blocker is unchanged, integrated the existing remote issue branch attempt, and pushed the combined result to draft PR #1410.
 
 ## Active Failure Context
 - None recorded.
@@ -23,11 +23,11 @@
 ### Current Handoff
 - Hypothesis: Repeated `tracked_pr_lifecycle_recovered` churn came from reconciling blocked verification records into `draft_pr` on the same head even though the ready-for-review gate was still failing locally.
 - What changed: `reconcileRecoverableBlockedIssueStates` now preserves a same-head `blocked` verification state for draft tracked PRs, keeps the existing failure context/signature when nothing meaningfully changed, and skips synthetic recovery churn. Added a recovery regression test and a doctor regression test for explicit ready-promotion guidance.
-- Current blocker: None for the issue-local change; the repo-wide `npm test -- src/run-once-cycle-prelude.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts` command still fans out into unrelated baseline failures in `src/supervisor/supervisor-status-rendering*.test.ts`.
-- Next exact step: Commit the checkpoint on `codex/issue-1405`, then open a draft PR for the branch and hand off the unrelated baseline `npm test` fan-out failures separately if needed.
-- Verification gap: The direct focused `tsx` run passed for the touched recovery/doctor/status/prelude surfaces, and `npm run build` passed; the repo-native `npm test -- ...` entrypoint still executes the broader suite and reports unrelated existing failures.
+- Current blocker: None for the issue-local change; the repo-wide `npm test -- src/run-once-cycle-prelude.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts` entrypoint still fans out into unrelated baseline failures in `src/supervisor/supervisor-status-rendering*.test.ts`.
+- Next exact step: Wait on PR #1410 review or CI feedback; if the repo-native `npm test -- ...` command remains a required gate, split its unrelated baseline failures into separate follow-up work.
+- Verification gap: The direct focused `tsx` run passed for the touched recovery/doctor/status/prelude surfaces after rebasing onto the remote issue branch, and `npm run build` passed before the rebase; the post-rebase changes were test-only expectation alignment.
 - Files touched: src/recovery-reconciliation.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/doctor.test.ts; .codex-supervisor/issues/1405/issue-journal.md
 - Rollback concern: Low; behavior change is scoped to blocked tracked PR reconciliation when the PR is still draft and the same verification blocker persists on the same head.
-- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Last focused command: gh pr view codex/issue-1405 --json number,url,state,isDraft,title
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1405/issue-journal.md
+++ b/.codex-supervisor/issues/1405/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1405: Stop repeated tracked PR recovery churn when stale local blockers persist
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1405
+- Branch: codex/issue-1405
+- Workspace: .
+- Journal: .codex-supervisor/issues/1405/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 2f99503f9b4081b25c99baf6afaa241225f6c8eb
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-09T23:04:37.981Z
+
+## Latest Codex Summary
+- Suppressed same-head tracked-PR recovery churn for draft PRs when the local verification blocker is unchanged, and added regression coverage in recovery reconciliation plus doctor diagnostics.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Repeated `tracked_pr_lifecycle_recovered` churn came from reconciling blocked verification records into `draft_pr` on the same head even though the ready-for-review gate was still failing locally.
+- What changed: `reconcileRecoverableBlockedIssueStates` now preserves a same-head `blocked` verification state for draft tracked PRs, keeps the existing failure context/signature when nothing meaningfully changed, and skips synthetic recovery churn. Added a recovery regression test and a doctor regression test for explicit ready-promotion guidance.
+- Current blocker: None for the issue-local change; the repo-wide `npm test -- src/run-once-cycle-prelude.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts` command still fans out into unrelated baseline failures in `src/supervisor/supervisor-status-rendering*.test.ts`.
+- Next exact step: Commit the checkpoint on `codex/issue-1405`, then open a draft PR for the branch and hand off the unrelated baseline `npm test` fan-out failures separately if needed.
+- Verification gap: The direct focused `tsx` run passed for the touched recovery/doctor/status/prelude surfaces, and `npm run build` passed; the repo-native `npm test -- ...` entrypoint still executes the broader suite and reports unrelated existing failures.
+- Files touched: src/recovery-reconciliation.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/doctor.test.ts; .codex-supervisor/issues/1405/issue-journal.md
+- Rollback concern: Low; behavior change is scoped to blocked tracked PR reconciliation when the PR is still draft and the same verification blocker persists on the same head.
+- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1387,7 +1387,7 @@ test("diagnoseSupervisorHost preserves draft tracked PR verification blockers in
   );
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace, rerun it, then rerun the supervisor to promote the PR\./,
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\./,
   );
   assert.doesNotMatch(
     renderDoctorReport(diagnostics),

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1292,6 +1292,109 @@ test("diagnoseSupervisorHost exposes tracked PR mismatches when GitHub is ready 
   );
 });
 
+test("diagnoseSupervisorHost preserves draft tracked PR verification blockers instead of suggesting a no-op rerun", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-174");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "fixture"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  execFileSync("git", ["-C", repoPath, "worktree", "add", "-b", "codex/reopen-issue-174", workspace], {
+    encoding: "utf8",
+  });
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    stateFile,
+    codexBinary: process.execPath,
+    localCiCommand: "npm run verify:paths",
+  });
+  const trackedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "174": createRecord({
+        issue_number: 174,
+        state: "blocked",
+        branch: "codex/reopen-issue-174",
+        workspace,
+        pr_number: 274,
+        blocked_reason: "verification",
+        last_head_sha: "head-draft-274",
+        last_error: "Configured local CI command failed before marking PR #274 ready.",
+        last_failure_signature: "local-ci-gate-non_zero_exit",
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed before marking PR #274 ready.",
+          ran_at: "2026-03-13T00:10:00Z",
+          head_sha: "head-draft-274",
+          execution_mode: "legacy_shell_string",
+          failure_class: "non_zero_exit",
+          remediation_target: "repo_owned_command",
+        },
+      }),
+    },
+  };
+  const draftPr = createPullRequest({
+    number: 274,
+    headRefName: "codex/reopen-issue-174",
+    headRefOid: "head-draft-274",
+    isDraft: true,
+  });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config,
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => trackedState,
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 1,
+        truncated: false,
+      }),
+      getPullRequestIfExists: async () => draftPr,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#174 pr=#274 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_gate issue=#174 pr=#274 gate=local_ci summary=Configured local CI command failed before marking PR #274 ready\./,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace, rerun it, then rerun the supervisor to promote the PR\./,
+  );
+  assert.doesNotMatch(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_mismatch /,
+  );
+});
+
 test("diagnoseSupervisorHost exposes host-local CI blocker details for tracked PR mismatches", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -815,15 +815,28 @@ export async function reconcileRecoverableBlockedIssueStates(
         continue;
       }
 
-      const failureContext =
-        nextState === "blocked"
+      const preserveDraftReadyPromotionBlocker =
+        nextState === "draft_pr"
+        && record.blocked_reason === "verification"
+        && trackedPullRequest.isDraft;
+      const inferredFailureContext =
+        nextState === "blocked" || preserveDraftReadyPromotionBlocker
           ? inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads)
           : null;
-      const nextBlockedReason = projection.nextBlockedReason;
+      const failureContext =
+        inferredFailureContext
+        ?? (preserveDraftReadyPromotionBlocker ? record.last_failure_context : null);
+      const nextBlockedReason = preserveDraftReadyPromotionBlocker
+        ? "verification"
+        : projection.nextBlockedReason;
 
-      if (nextState === "blocked") {
+      if (nextState === "blocked" || preserveDraftReadyPromotionBlocker) {
         const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);
         const headAdvanced = Object.keys(headAdvanceResetPatch).length > 0;
+        const blockerSemanticsChanged =
+          headAdvanced
+          || nextBlockedReason !== record.blocked_reason
+          || (failureContext?.signature ?? null) !== record.last_failure_signature;
         const failureSignatureBaseRecord = headAdvanced
           ? {
             ...record,
@@ -831,13 +844,20 @@ export async function reconcileRecoverableBlockedIssueStates(
             repeated_failure_signature_count: 0,
           }
           : record;
+        const failureSignaturePatch =
+          preserveDraftReadyPromotionBlocker && !blockerSemanticsChanged
+            ? {
+              last_failure_signature: record.last_failure_signature,
+              repeated_failure_signature_count: record.repeated_failure_signature_count,
+            }
+            : applyFailureSignature(failureSignatureBaseRecord, failureContext);
         const blockedPatch: Partial<IssueRunRecord> = {
           state: "blocked",
           last_error: failureContext ? truncate(failureContext.summary, 1000) : null,
           last_failure_kind: null,
           last_failure_context: failureContext,
           last_blocker_signature: null,
-          ...applyFailureSignature(failureSignatureBaseRecord, failureContext),
+          ...failureSignaturePatch,
           blocked_reason: nextBlockedReason,
           pr_number: trackedPullRequest.number,
           last_head_sha: trackedPullRequest.headRefOid,
@@ -846,10 +866,6 @@ export async function reconcileRecoverableBlockedIssueStates(
           ...projection.copilotReviewRequestObservationPatch,
           ...projection.copilotReviewTimeoutPatch,
         };
-        const blockerSemanticsChanged =
-          headAdvanced
-          || nextBlockedReason !== record.blocked_reason
-          || (failureContext?.signature ?? null) !== record.last_failure_signature;
         const nextPatch = blockerSemanticsChanged
           ? {
             ...blockedPatch,

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -34,6 +34,17 @@ type ApplyRecoveryEvent = (
   recoveryEvent: RecoveryEvent,
 ) => Partial<IssueRunRecord>;
 
+function needsRecordUpdate(record: IssueRunRecord, patch: Partial<IssueRunRecord>): boolean {
+  for (const [key, value] of Object.entries(patch)) {
+    const recordValue = record[key as keyof IssueRunRecord];
+    if (JSON.stringify(recordValue) !== JSON.stringify(value)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function matchesTrackedBranch(
   record: Pick<IssueRunRecord, "branch">,
   pr: Pick<GitHubPullRequest, "headRefName">,
@@ -75,17 +86,6 @@ function orderTrackedMergedButOpenRecordsForResume(
   }
 
   return [...ordered.slice(nextIndex), ...ordered.slice(0, nextIndex)];
-}
-
-function needsRecordUpdate(record: IssueRunRecord, patch: Partial<IssueRunRecord>): boolean {
-  for (const [key, value] of Object.entries(patch)) {
-    const recordValue = record[key as keyof IssueRunRecord];
-    if (JSON.stringify(recordValue) !== JSON.stringify(value)) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 export function buildTrackedPrResumeRecoveryEvent(
@@ -427,6 +427,9 @@ export async function reconcileStaleFailedTrackedPrRecord(
     copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
     copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
   });
+  if (!needsRecordUpdate(record, patch)) {
+    return false;
+  }
   const recoveryEvent = buildTrackedPrResumeRecoveryEvent(record, pr, nextState, helpers.buildRecoveryEvent);
 
   const updated = stateStore.touch(record, helpers.applyRecoveryEvent(patch, recoveryEvent));

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2591,7 +2591,7 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace, rerun it, then rerun the supervisor to promote the PR\.$/m,
+    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
   );
   assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^tracked_pr_mismatch /m);
 
@@ -2606,7 +2606,7 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   );
   assert.match(
     status,
-    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace, rerun it, then rerun the supervisor to promote the PR\.$/m,
+    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
   );
   assert.doesNotMatch(status, /^tracked_pr_mismatch /m);
 });

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1285,6 +1285,114 @@ test("reconcileRecoverableBlockedIssueStates rehydrates tracked PR manual-review
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates keeps same-head draft tracked PRs blocked when the verification gate still fails", async () => {
+  const config = createConfig({
+    localCiCommand: "npm run verify:paths",
+  });
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Configured local CI command failed before marking PR #191 ready.",
+    signature: "local-ci-gate-non_zero_exit",
+    command: "npm run verify:paths",
+    details: ["failure_class=non_zero_exit"],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error: failureContext.summary,
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        last_failure_signature: failureContext.signature,
+        repeated_failure_signature_count: 3,
+        repeated_blocker_count: 4,
+        repair_attempt_count: 2,
+        timeout_retry_count: 1,
+        blocked_verification_retry_count: 2,
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: failureContext.summary,
+          ran_at: "2026-03-13T00:19:00Z",
+          head_sha: "head-191",
+          execution_mode: "legacy_shell_string",
+          failure_class: "non_zero_exit",
+          remediation_target: "repo_owned_command",
+        },
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    isDraft: true,
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.last_head_sha, "head-191");
+  assert.equal(updated.last_error, failureContext.summary);
+  assert.deepEqual(updated.last_failure_context, failureContext);
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.equal(updated.repeated_failure_signature_count, 3);
+  assert.equal(updated.repeated_blocker_count, 4);
+  assert.equal(updated.repair_attempt_count, 2);
+  assert.equal(updated.timeout_retry_count, 1);
+  assert.equal(updated.blocked_verification_retry_count, 2);
+  assert.equal(updated.last_recovery_reason, null);
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+});
+
 test("reconcileRecoverableBlockedIssueStates only falls back to getIssue for blocked tracked PR records", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = createSupervisorState({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1668,11 +1668,10 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
     },
   );
 
-  assert.deepEqual(firstRecoveryEvents.map((event) => event.reason), [
-    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-191",
-  ]);
-  assert.equal(state.issues["366"]?.state, "draft_pr");
-  assert.equal(saveCalls, 1);
+  assert.deepEqual(firstRecoveryEvents, []);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "verification");
+  assert.equal(saveCalls, 0);
 
   const secondRecoveryEvents = await reconcileRecoverableBlockedIssueStates(
     {
@@ -1698,9 +1697,10 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
   );
 
   assert.deepEqual(secondRecoveryEvents, []);
-  assert.equal(state.issues["366"]?.state, "draft_pr");
-  assert.equal(state.issues["366"]?.last_recovery_reason, "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-191");
-  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "verification");
+  assert.equal(state.issues["366"]?.last_recovery_reason, null);
+  assert.equal(saveCalls, 0);
 });
 
 test("reconcileRecoverableBlockedIssueStates clears stale head-scoped review state after a tracked PR repair push", async () => {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1485,6 +1485,116 @@ test("reconcileRecoverableBlockedIssueStates persists refreshed tracked PR lifec
   assert.deepEqual(recoveryEvents, []);
 });
 
+test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR recovery churn when the same blocker persists", async () => {
+  const config = createConfig();
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error: "Ready-for-review promotion is blocked by local verification.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "blocked",
+          summary: "Ready-for-review promotion is blocked by local verification.",
+          signature: "local-verification-blocked",
+          command: null,
+          details: ["tracked_pr=head-191"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "local-verification-blocked",
+        repeated_failure_signature_count: 3,
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    isDraft: true,
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const firstRecoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  assert.deepEqual(firstRecoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-191",
+  ]);
+  assert.equal(state.issues["366"]?.state, "draft_pr");
+  assert.equal(saveCalls, 1);
+
+  const secondRecoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  assert.deepEqual(secondRecoveryEvents, []);
+  assert.equal(state.issues["366"]?.state, "draft_pr");
+  assert.equal(state.issues["366"]?.last_recovery_reason, "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-191");
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileRecoverableBlockedIssueStates clears stale head-scoped review state after a tracked PR repair push", async () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -249,7 +249,8 @@ export function buildTrackedPrMismatch(
       ].join(" "),
       guidanceLine:
         `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion is blocked by local verification. ` +
-        `Failed gate: ${readyPromotionGate.failedGate}. Fix the gate in the tracked workspace, rerun it, then rerun the supervisor to promote the PR.`,
+        `The same blocker is still present, so rerunning the supervisor alone will not help. ` +
+        `Failed gate: ${readyPromotionGate.failedGate}. Fix the gate in the tracked workspace first, then rerun it to promote the PR.`,
       detailLines: readyPromotionGate.detailLines,
     };
   }


### PR DESCRIPTION
Adds a no-op guard to tracked PR recovery reconciliation so settled tracked-PR states do not replay recovery events on repeated cycles. Also tightens the draft-plus-verification operator guidance and adds regressions for duplicate recovery suppression.\n\nVerification:\n- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts\n- npx tsx --test src/run-once-cycle-prelude.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts\n- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of draft PRs blocked by local verification failures, preventing unnecessary state changes when the same blocker persists.

* **Documentation & Guidance**
  * Enhanced diagnostic reports with clearer recovery instructions for draft PRs awaiting ready-for-review promotion; now explicitly indicates when local blockers must be fixed before supervisor recovery can proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->