### PR TITLE
[codex] Post deduplicated ready-promotion blocker comments

### DIFF
--- a/.codex-supervisor/issues/1412/issue-journal.md
+++ b/.codex-supervisor/issues/1412/issue-journal.md
@@ -5,18 +5,29 @@
 - Branch: codex/issue-1412
 - Workspace: .
 - Journal: .codex-supervisor/issues/1412/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 895ce344f89239f32df89f9a0ad189ba79dca2d4
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: 421253211507d9f018f19fa9fdff9d536f8c4afa
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T00:52:13.984Z
+- Updated at: 2026-04-10T01:03:39.000Z
 
 ## Latest Codex Summary
-- Reproduced the gap with a focused test: workstation-local path hygiene could block ready promotion without posting the existing deduplicated tracked-PR host-local blocker comment.
-- Fixed the ready-promotion path to reuse `maybeCommentOnTrackedPrHostLocalBlocker(...)` for `workstation_local_path_hygiene`, with concise remediation-first comment text and existing `(head SHA, blocker signature)` dedupe state.
-- Verified with targeted transition/recovery/status tests and `npm run build`.
+Re-verified the existing implementation commit `4212532` (`Post deduped ready-promotion blocker comments`) and prepared the branch for publication. The code change remains scoped to [src/post-turn-pull-request.ts](src/post-turn-pull-request.ts) and [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), where tracked draft PRs now post a concise deduplicated top-level comment when `workstation_local_path_hygiene` blocks ready-for-review promotion.
+
+The comment body is still remediation-first, explains that the PR remains draft because promotion is blocked locally, names the gate, summarizes the first-fix offenders, and states that rerunning the supervisor alone will not clear the blocker. Focused verification passed again on the committed checkpoint.
+
+Verification ran clean:
+`npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+`npm run build`
+
+Summary: Re-verified the deduplicated tracked-PR ready-promotion blocker comment change and prepared the branch for draft PR publication.
+State hint: stabilizing
+Blocked reason: none
+Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
+Next action: Push `codex/issue-1412`, open the draft PR, and leave the manual `npm run verify:paths` smoke test as the remaining validation gap
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
@@ -26,10 +37,10 @@
 - Hypothesis: The tracked ready-promotion blocker comment gap existed because the workstation-local path hygiene gate returned before the tracked PR host-local comment helper was reused on that path.
 - What changed: Added a focused regression test for deduplicated workstation-local path hygiene comments, extended tracked PR blocker comment rendering for `workstation_local_path_hygiene`, and hooked the existing dedupe helper into the actual ready-promotion path hygiene gate.
 - Current blocker: none.
-- Next exact step: Review the diff, then commit the source and journal changes on `codex/issue-1412`.
+- Next exact step: Push `codex/issue-1412` and open the draft PR for review.
 - Verification gap: Manual PR smoke test against a real tracked draft PR blocked by `npm run verify:paths` is still not exercised in this workspace.
 - Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1412/issue-journal.md`.
 - Rollback concern: Low; the change is scoped to tracked draft ready-promotion blocker comments and reuses existing dedupe state fields.
-- Last focused command: `npm run build`
+- Last focused commands: `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1412/issue-journal.md
+++ b/.codex-supervisor/issues/1412/issue-journal.md
@@ -11,10 +11,10 @@
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-10T01:03:39.000Z
+- Updated at: 2026-04-10T01:05:00.000Z
 
 ## Latest Codex Summary
-Re-verified the existing implementation commit `4212532` (`Post deduped ready-promotion blocker comments`) and prepared the branch for publication. The code change remains scoped to [src/post-turn-pull-request.ts](src/post-turn-pull-request.ts) and [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), where tracked draft PRs now post a concise deduplicated top-level comment when `workstation_local_path_hygiene` blocks ready-for-review promotion.
+Re-verified the existing implementation commit `4212532` (`Post deduped ready-promotion blocker comments`), pushed `codex/issue-1412`, and opened draft PR #1413. The code change remains scoped to [src/post-turn-pull-request.ts](src/post-turn-pull-request.ts) and [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), where tracked draft PRs now post a concise deduplicated top-level comment when `workstation_local_path_hygiene` blocks ready-for-review promotion.
 
 The comment body is still remediation-first, explains that the PR remains draft because promotion is blocked locally, names the gate, summarizes the first-fix offenders, and states that rerunning the supervisor alone will not clear the blocker. Focused verification passed again on the committed checkpoint.
 
@@ -22,11 +22,11 @@ Verification ran clean:
 `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
 `npm run build`
 
-Summary: Re-verified the deduplicated tracked-PR ready-promotion blocker comment change and prepared the branch for draft PR publication.
-State hint: stabilizing
+Summary: Re-verified the deduplicated tracked-PR ready-promotion blocker comment change, pushed the branch, and opened draft PR #1413.
+State hint: draft_pr
 Blocked reason: none
 Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
-Next action: Push `codex/issue-1412`, open the draft PR, and leave the manual `npm run verify:paths` smoke test as the remaining validation gap
+Next action: Keep PR #1413 in draft pending manual smoke validation against a real tracked draft PR blocked by `npm run verify:paths`
 Failure signature: none
 
 ## Active Failure Context
@@ -37,7 +37,7 @@ Failure signature: none
 - Hypothesis: The tracked ready-promotion blocker comment gap existed because the workstation-local path hygiene gate returned before the tracked PR host-local comment helper was reused on that path.
 - What changed: Added a focused regression test for deduplicated workstation-local path hygiene comments, extended tracked PR blocker comment rendering for `workstation_local_path_hygiene`, and hooked the existing dedupe helper into the actual ready-promotion path hygiene gate.
 - Current blocker: none.
-- Next exact step: Push `codex/issue-1412` and open the draft PR for review.
+- Next exact step: Run the manual smoke test against PR #1413 or hand off for review if that validation is deferred.
 - Verification gap: Manual PR smoke test against a real tracked draft PR blocked by `npm run verify:paths` is still not exercised in this workspace.
 - Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1412/issue-journal.md`.
 - Rollback concern: Low; the change is scoped to tracked draft ready-promotion blocker comments and reuses existing dedupe state fields.

--- a/.codex-supervisor/issues/1412/issue-journal.md
+++ b/.codex-supervisor/issues/1412/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #1412: Post deduplicated PR comments when tracked ready-promotion is blocked locally
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1412
+- Branch: codex/issue-1412
+- Workspace: .
+- Journal: .codex-supervisor/issues/1412/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 895ce344f89239f32df89f9a0ad189ba79dca2d4
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T00:52:13.984Z
+
+## Latest Codex Summary
+- Reproduced the gap with a focused test: workstation-local path hygiene could block ready promotion without posting the existing deduplicated tracked-PR host-local blocker comment.
+- Fixed the ready-promotion path to reuse `maybeCommentOnTrackedPrHostLocalBlocker(...)` for `workstation_local_path_hygiene`, with concise remediation-first comment text and existing `(head SHA, blocker signature)` dedupe state.
+- Verified with targeted transition/recovery/status tests and `npm run build`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The tracked ready-promotion blocker comment gap existed because the workstation-local path hygiene gate returned before the tracked PR host-local comment helper was reused on that path.
+- What changed: Added a focused regression test for deduplicated workstation-local path hygiene comments, extended tracked PR blocker comment rendering for `workstation_local_path_hygiene`, and hooked the existing dedupe helper into the actual ready-promotion path hygiene gate.
+- Current blocker: none.
+- Next exact step: Review the diff, then commit the source and journal changes on `codex/issue-1412`.
+- Verification gap: Manual PR smoke test against a real tracked draft PR blocked by `npm run verify:paths` is still not exercised in this workspace.
+- Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1412/issue-journal.md`.
+- Rollback concern: Low; the change is scoped to tracked draft ready-promotion blocker comments and reuses existing dedupe state fields.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1412/issue-journal.md
+++ b/.codex-supervisor/issues/1412/issue-journal.md
@@ -5,39 +5,40 @@
 - Branch: codex/issue-1412
 - Workspace: .
 - Journal: .codex-supervisor/issues/1412/issue-journal.md
-- Current phase: stabilizing
-- Attempt count: 2 (implementation=2, repair=0)
-- Last head SHA: 421253211507d9f018f19fa9fdff9d536f8c4afa
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 2412c751b1d0dac7eeb4ebd220b1a9fac067ae55
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-10T01:05:00.000Z
+- Last failure signature: PRRT_kwDORgvdZ856AmTu|PRRT_kwDORgvdZ856AmT3
+- Repeated failure signature count: 1
+- Updated at: 2026-04-10T01:13:39.132Z
 
 ## Latest Codex Summary
-Re-verified the existing implementation commit `4212532` (`Post deduped ready-promotion blocker comments`), pushed `codex/issue-1412`, and opened draft PR #1413. The code change remains scoped to [src/post-turn-pull-request.ts](src/post-turn-pull-request.ts) and [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), where tracked draft PRs now post a concise deduplicated top-level comment when `workstation_local_path_hygiene` blocks ready-for-review promotion.
+Published the checkpoint on `codex/issue-1412` and opened draft PR [#1413](https://github.com/TommyKammy/codex-supervisor/pull/1413). The implementation commit `4212532` adds the tracked ready-promotion blocker comment path in [src/post-turn-pull-request.ts](src/post-turn-pull-request.ts) with the focused regression in [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), and I pushed two small follow-up journal commits so the handoff state is recorded in [.codex-supervisor/issues/1412/issue-journal.md](.codex-supervisor/issues/1412/issue-journal.md).
 
-The comment body is still remediation-first, explains that the PR remains draft because promotion is blocked locally, names the gate, summarizes the first-fix offenders, and states that rerunning the supervisor alone will not clear the blocker. Focused verification passed again on the committed checkpoint.
+Verification passed on the published branch with `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts` and `npm run build`. The remaining gap is the manual smoke test against a real tracked draft PR blocked by `npm run verify:paths`. The only local dirt left is untracked supervisor runtime scratch under `.codex-supervisor/`, which I left untouched.
 
-Verification ran clean:
-`npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
-`npm run build`
-
-Summary: Re-verified the deduplicated tracked-PR ready-promotion blocker comment change, pushed the branch, and opened draft PR #1413.
+Summary: Pushed the ready-promotion blocker comment fix, opened draft PR #1413, and updated the issue journal with the published handoff state
 State hint: draft_pr
 Blocked reason: none
 Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
-Next action: Keep PR #1413 in draft pending manual smoke validation against a real tracked draft PR blocked by `npm run verify:paths`
-Failure signature: none
+Next action: Run the manual smoke test for the `npm run verify:paths` blocked-draft scenario on PR #1413, or hand the draft PR off for review if that validation is deferred
+Failure signature: PRRT_kwDORgvdZ856AmTu|PRRT_kwDORgvdZ856AmT3
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1413#discussion_r3061500943
+- Details:
+  - src/post-turn-pull-request.test.ts:1409 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Reuse the first run’s persisted dedupe state here.** This rerun hand-seeds `last_host_local_pr_blocker_comment_*`, so it would still pass eve... url=https://github.com/TommyKammy/codex-supervisor/pull/1413#discussion_r3061500943
+  - src/post-turn-pull-request.ts:595 summary=_⚠️ Potential issue_ | _🟠 Major_ **Also post the blocker comment on the fail-closed head-mismatch path.** This new hook only covers the `!pathHygieneGate.ok` branch. url=https://github.com/TommyKammy/codex-supervisor/pull/1413#discussion_r3061500954
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The tracked ready-promotion blocker comment gap existed because the workstation-local path hygiene gate returned before the tracked PR host-local comment helper was reused on that path.
-- What changed: Added a focused regression test for deduplicated workstation-local path hygiene comments, extended tracked PR blocker comment rendering for `workstation_local_path_hygiene`, and hooked the existing dedupe helper into the actual ready-promotion path hygiene gate.
+- Hypothesis: The remaining review gaps were real: the fail-closed local/remote head mismatch branch still skipped the tracked PR blocker comment helper, and the dedupe regression test was not proving persisted state because it hand-seeded the comment signature fields.
+- What changed: Reused `maybeCommentOnTrackedPrHostLocalBlocker(...)` on the workstation-local path hygiene head-mismatch return path and tightened the dedupe regression to rerun from `firstResult.record` instead of synthetic dedupe fields.
 - Current blocker: none.
-- Next exact step: Run the manual smoke test against PR #1413 or hand off for review if that validation is deferred.
+- Next exact step: Commit the review fixes on `codex/issue-1412`, push the branch, and leave PR #1413 ready for another review pass.
 - Verification gap: Manual PR smoke test against a real tracked draft PR blocked by `npm run verify:paths` is still not exercised in this workspace.
 - Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1412/issue-journal.md`.
 - Rollback concern: Low; the change is scoped to tracked draft ready-promotion blocker comments and reuses existing dedupe state fields.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1272,6 +1272,143 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion 
   assert.match(result.record.last_failure_context?.details[0] ?? "", /docs\/guide\.md:1/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-local path hygiene blocks tracked ready promotion", async (t) => {
+  const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+
+  const config = createConfig({ localCiCommand: "npm run ci:local" });
+  const issue = createIssue({ title: "Comment on tracked ready-promotion path hygiene blockers" });
+  const draftPr = createPullRequest({
+    title: "Tracked PR path hygiene blocker",
+    isDraft: true,
+    headRefOid: headSha,
+  });
+  const commentBodies: string[] = [];
+
+  const createState = (recordOverrides: Partial<IssueRunRecord> = {}): SupervisorStateFile => ({
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: draftPr.number,
+        last_head_sha: headSha,
+        ...recordOverrides,
+      }),
+    },
+  });
+
+  const runScenario = async (state: SupervisorStateFile) =>
+    handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: {
+        touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+        save: async () => undefined,
+      },
+      github: {
+        getPullRequest: async () => {
+          throw new Error("unexpected getPullRequest call");
+        },
+        getChecks: async () => {
+          throw new Error("unexpected getChecks call");
+        },
+        getUnresolvedReviewThreads: async () => {
+          throw new Error("unexpected getUnresolvedReviewThreads call");
+        },
+        markPullRequestReady: async () => {
+          throw new Error("unexpected markPullRequestReady call");
+        },
+        addIssueComment: async (_prNumber: number, body: string) => {
+          commentBodies.push(body);
+        },
+      },
+      context: {
+        state,
+        record: state.issues["102"]!,
+        issue,
+        workspacePath,
+        syncJournal: async () => undefined,
+        memoryArtifacts: {
+          alwaysReadFiles: [],
+          onDemandFiles: [],
+          contextIndexPath: "/tmp/context-index.md",
+          agentsPath: "/tmp/AGENTS.generated.md",
+        },
+        pr: draftPr,
+        options: { dryRun: false },
+      },
+      derivePullRequestLifecycleSnapshot: (record) => ({
+        recordForState: record,
+        nextState: "draft_pr",
+        failureContext: null,
+        reviewWaitPatch: {},
+        copilotRequestObservationPatch: {},
+        mergeLatencyVisibilityPatch: {
+          provider_success_observed_at: null,
+          provider_success_head_sha: null,
+          merge_readiness_last_evaluated_at: null,
+        },
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: null,
+          copilot_review_timeout_action: null,
+          copilot_review_timeout_reason: null,
+        },
+      }),
+      applyFailureSignature: (_record, failureContext) => ({
+        last_failure_signature: failureContext?.signature ?? null,
+        repeated_failure_signature_count: failureContext ? 1 : 0,
+      }),
+      blockedReasonFromReviewState: () => null,
+      summarizeChecks: () => ({
+        hasPending: false,
+        hasFailing: false,
+      }),
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+      runLocalCiCommand: async () => undefined,
+      runWorkstationLocalPathGate: async () => ({
+        ok: false,
+        failureContext: {
+          ...createFailureContext(
+            "Tracked durable artifacts failed workstation-local path hygiene before marking PR #116 ready. First fix: docs/guide.md (2 matches, unix_home); .codex-supervisor/issues/181/issue-journal.md (1 match, macos_home).",
+          ),
+          signature: "workstation-local-path-hygiene-failed",
+          command: "npm run verify:paths",
+          details: [
+            `docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`,
+            `docs/guide.md:5 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}/tmp"`,
+            `.codex-supervisor/issues/181/issue-journal.md:4 matched /${"Users"}/ via "${SAMPLE_MACOS_WORKSTATION_PATH}"`,
+          ],
+        },
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr: draftPr,
+        checks: [],
+        reviewThreads: [] satisfies ReviewThread[],
+      }),
+    });
+
+  const firstState = createState();
+  const firstResult = await runScenario(firstState);
+  assert.equal(firstResult.record.state, "blocked");
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /still draft because ready-for-review promotion is blocked locally/i);
+  assert.match(commentBodies[0] ?? "", /gate name: `workstation_local_path_hygiene`/i);
+  assert.match(commentBodies[0] ?? "", /First fix: docs\/guide\.md/i);
+  assert.match(commentBodies[0] ?? "", /rerunning the supervisor alone will not help yet/i);
+  assert.doesNotMatch(commentBodies[0] ?? "", /\.codex-supervisor\/issues\/181\/issue-journal\.md:4 matched/);
+
+  const dedupedState = createState({
+    last_host_local_pr_blocker_comment_head_sha: draftPr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: "workstation-local-path-hygiene-failed",
+  });
+  const dedupedResult = await runScenario(dedupedState);
+  assert.equal(dedupedResult.record.state, "blocked");
+  assert.equal(commentBodies.length, 1);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-issue journals before ready promotion", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1394,16 +1394,21 @@ test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-l
   const firstResult = await runScenario(firstState);
   assert.equal(firstResult.record.state, "blocked");
   assert.equal(commentBodies.length, 1);
+  assert.equal(firstResult.record.last_host_local_pr_blocker_comment_head_sha, draftPr.headRefOid);
+  assert.equal(firstResult.record.last_host_local_pr_blocker_comment_signature, "workstation-local-path-hygiene-failed");
   assert.match(commentBodies[0] ?? "", /still draft because ready-for-review promotion is blocked locally/i);
   assert.match(commentBodies[0] ?? "", /gate name: `workstation_local_path_hygiene`/i);
   assert.match(commentBodies[0] ?? "", /First fix: docs\/guide\.md/i);
   assert.match(commentBodies[0] ?? "", /rerunning the supervisor alone will not help yet/i);
   assert.doesNotMatch(commentBodies[0] ?? "", /\.codex-supervisor\/issues\/181\/issue-journal\.md:4 matched/);
 
-  const dedupedState = createState({
-    last_host_local_pr_blocker_comment_head_sha: draftPr.headRefOid,
-    last_host_local_pr_blocker_comment_signature: "workstation-local-path-hygiene-failed",
-  });
+  const dedupedState: SupervisorStateFile = {
+    ...firstState,
+    issues: {
+      ...firstState.issues,
+      "102": firstResult.record,
+    },
+  };
   const dedupedResult = await runScenario(dedupedState);
   assert.equal(dedupedResult.record.state, "blocked");
   assert.equal(commentBodies.length, 1);

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -85,7 +85,10 @@ export interface PullRequestLifecycleSnapshot {
   >;
 }
 
-type HostLocalTrackedPrBlockerGateType = "workspace_preparation" | "local_ci";
+type HostLocalTrackedPrBlockerGateType =
+  | "workspace_preparation"
+  | "local_ci"
+  | "workstation_local_path_hygiene";
 
 const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
 
@@ -126,18 +129,80 @@ function buildTrackedPrHostLocalBlockerComment(args: {
   pr: Pick<GitHubPullRequest, "headRefOid">;
   gateType: HostLocalTrackedPrBlockerGateType;
   blockerSignature: string;
-  failureClass: string;
-  remediationTarget: string;
+  failureClass: string | null;
+  remediationTarget: string | null;
   summary: string;
+  details?: string[] | null;
 }): string {
+  if (args.gateType === "workstation_local_path_hygiene") {
+    return buildTrackedPrReadyPromotionPathHygieneComment(args);
+  }
+
   return [
     `Supervisor host-local ${args.gateType} blocker on tracked PR head \`${args.pr.headRefOid}\`.`,
     "",
     `- gate type: \`${args.gateType}\``,
     `- blocker signature: \`${args.blockerSignature}\``,
-    `- failure class: \`${args.failureClass}\``,
-    `- remediation target: \`${args.remediationTarget}\``,
+    `- failure class: \`${args.failureClass ?? "unknown"}\``,
+    `- remediation target: \`${args.remediationTarget ?? "unknown"}\``,
     `- summary: ${args.summary}`,
+    "",
+    "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
+  ].join("\n");
+}
+
+function summarizeWorkstationLocalPathFirstFix(details: string[] | null | undefined): string | null {
+  if (!details || details.length === 0) {
+    return null;
+  }
+
+  const countsByFile = new Map<string, number>();
+  for (const detail of details) {
+    const match = detail.match(/^-?\s*([^:\s][^:]*)\:\d+\s+matched\b/);
+    if (!match) {
+      continue;
+    }
+    const filePath = match[1]?.trim();
+    if (!filePath) {
+      continue;
+    }
+    countsByFile.set(filePath, (countsByFile.get(filePath) ?? 0) + 1);
+  }
+
+  if (countsByFile.size === 0) {
+    return null;
+  }
+
+  const sortedFiles = [...countsByFile.entries()].sort((left, right) => {
+    if (right[1] !== left[1]) {
+      return right[1] - left[1];
+    }
+    return left[0].localeCompare(right[0]);
+  });
+  const visibleFiles = sortedFiles
+    .slice(0, 3)
+    .map(([filePath, count]) => `${filePath} (${count} match${count === 1 ? "" : "es"})`);
+  const remainingCount = sortedFiles.length - visibleFiles.length;
+  const tail = remainingCount > 0 ? `; +${remainingCount} more file${remainingCount === 1 ? "" : "s"}` : "";
+  return `First fix: ${visibleFiles.join("; ")}${tail}.`;
+}
+
+function buildTrackedPrReadyPromotionPathHygieneComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  blockerSignature: string;
+  summary: string;
+  details?: string[] | null;
+}): string {
+  const firstFix = summarizeWorkstationLocalPathFirstFix(args.details);
+  const conciseSummary = args.summary.replace(/\s+First fix:.*$/i, "").trim();
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
+    "",
+    `- gate name: \`workstation_local_path_hygiene\``,
+    `- blocker signature: \`${args.blockerSignature}\``,
+    `- what failed: ${conciseSummary}`,
+    ...(firstFix ? [`- ${firstFix}`] : []),
+    "- rerunning the supervisor alone will not help yet; fix the tracked workspace artifacts first, then rerun promotion.",
     "",
     "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
   ].join("\n");
@@ -155,6 +220,7 @@ async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
   failureClass: string | null;
   remediationTarget: string | null;
   summary: string | null;
+  details?: string[] | null;
 }): Promise<IssueRunRecord> {
   if (!args.github.addIssueComment) {
     return args.record;
@@ -181,6 +247,7 @@ async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
         failureClass: args.failureClass,
         remediationTarget: args.remediationTarget,
         summary: args.summary,
+        details: args.details,
       }),
     );
   } catch (error) {
@@ -512,6 +579,20 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
+      record = await maybeCommentOnTrackedPrHostLocalBlocker({
+        github,
+        stateStore,
+        state,
+        record,
+        pr: refreshed.pr,
+        syncJournal,
+        gateType: "workstation_local_path_hygiene",
+        blockerSignature: failureContext?.signature ?? null,
+        failureClass: failureContext?.signature ?? null,
+        remediationTarget: "workspace_contents",
+        summary: failureContext?.summary ?? null,
+        details: failureContext?.details,
+      });
       return {
         record,
         pr: refreshed.pr,
@@ -636,6 +717,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         failureClass: workspacePreparationFailureClass(failureContext?.signature),
         remediationTarget: workspacePreparationRemediationTarget(workspacePreparationFailureClass(failureContext?.signature)),
         summary: failureContext?.summary ?? null,
+        details: failureContext?.details,
       });
       return {
         record,
@@ -682,6 +764,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         failureClass: localCiGate.latestResult?.failure_class ?? null,
         remediationTarget: localCiGate.latestResult?.remediation_target ?? null,
         summary: failureContext?.summary ?? localCiGate.latestResult?.summary ?? null,
+        details: failureContext?.details,
       });
       return {
         record,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -803,6 +803,20 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
+      record = await maybeCommentOnTrackedPrHostLocalBlocker({
+        github,
+        stateStore,
+        state,
+        record,
+        pr: refreshed.pr,
+        syncJournal,
+        gateType: "workstation_local_path_hygiene",
+        blockerSignature: failureContext.signature,
+        failureClass: failureContext.signature,
+        remediationTarget: "workspace_contents",
+        summary: failureContext.summary,
+        details: failureContext.details,
+      });
       return {
         record,
         pr: refreshed.pr,


### PR DESCRIPTION
## Summary
- post a tracked PR conversation comment when ready-for-review promotion stays blocked by a host-local verification gate
- extend the existing tracked PR host-local blocker comment path to cover `workstation_local_path_hygiene`
- reuse the existing `(head SHA, blocker signature)` dedupe state so stable reruns do not spam the PR

## Why
Tracked ready-promotion blockers were visible in local `status` and `doctor`, but not in the PR conversation itself. That left reviewers without a direct explanation for why a draft PR stayed draft even when GitHub checks looked fine.

## Validation
- `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npm run build`

## Remaining gap
- manual smoke test with a real tracked draft PR blocked by `npm run verify:paths`

Closes #1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path-hygiene gate now blocks draft→ready promotions and posts a single, deduplicated GitHub comment with guidance and a compact “First fix” list of the most-impacted file paths.

* **Tests**
  * Added coverage for the path-hygiene blocking flow, comment content, and deduplication to prevent duplicate guidance messages.

* **Documentation**
  * Recorded a supervisor journal entry capturing the issue checkpoint, verification steps, and remaining manual smoke-test guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->