### PR TITLE
[codex] Add sticky tracked-PR status comment publisher abstraction

### DIFF
--- a/.codex-supervisor/issues/1415/issue-journal.md
+++ b/.codex-supervisor/issues/1415/issue-journal.md
@@ -5,29 +5,43 @@
 - Branch: codex/issue-1415
 - Workspace: .
 - Journal: .codex-supervisor/issues/1415/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 98401144e24d6551e0c9fc38210c6538f539ac56
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 0735f41c63a1e8b31932bb0fa461d416e0bbc968
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-10T23:36:07.682Z
+- Last failure signature: PRRT_kwDORgvdZ856QkMo|PRRT_kwDORgvdZ856QkMt
+- Repeated failure signature count: 1
+- Updated at: 2026-04-10T23:49:51.845Z
 
 ## Latest Codex Summary
-- Added sticky tracked-PR host-local blocker comment publishing with deterministic marker lookup and GitHub comment updates, plus focused regression tests for restart-safe reuse.
+Addressed both open CodeRabbit findings on PR [#1419](https://github.com/TommyKammy/codex-supervisor/pull/1419) without widening scope. The tracked-PR sticky comment update path now uses a REST-compatible issue-comment `databaseId` from the GraphQL review surface, and owned-comment reuse now requires `viewerDidAuthor` so a copied marker on someone else's comment falls back to posting a fresh supervisor-owned sticky comment instead of attempting an unauthorized update.
+
+Focused verification passed cleanly after the review fix: `npx tsx --test src/github/github.test.ts src/post-turn-pull-request.test.ts` and `npm run build`. I also added regression coverage for both the numeric update path and the uneditable-marker fallback before updating this journal.
+
+Summary: Fixed the tracked-PR sticky comment review findings by using comment database IDs and editable-only ownership checks
+State hint: addressing_review
+Blocked reason: none
+Tests: `npx tsx --test src/github/github.test.ts src/post-turn-pull-request.test.ts`; `npm run build`
+Next action: commit the review fix, push `codex/issue-1415`, and update PR #1419 for another review pass
+Failure signature: PRRT_kwDORgvdZ856QkMo|PRRT_kwDORgvdZ856QkMt
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1419#discussion_r3067169661
+- Details:
+  - src/github/github-mutations.ts:143 summary=_⚠️ Potential issue_ | _🔴 Critical_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 3906 --- **Query `databaseId` for PR issue c... url=https://github.com/TommyKammy/codex-supervisor/pull/1419#discussion_r3067169661
+  - src/post-turn-pull-request.ts:231 summary=_⚠️ Potential issue_ | _🟠 Major_ **Don't treat marker-only matches as "owned" comments.** `findOwnedTrackedPrStatusComment()` matches any PR conversation comment that contains ... url=https://github.com/TommyKammy/codex-supervisor/pull/1419#discussion_r3067169666
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Duplicate tracked-PR blocker comments were caused by a create-only GitHub path plus local dedupe fields that do not survive process restarts.
-- What changed: Added `GitHubClient.updateIssueComment()` and REST PATCH support; post-turn tracked-PR blocker publishing now appends a deterministic hidden marker, searches PR conversation comments for an owned match, updates that comment when found, and only creates a new comment when no owned comment exists. Added focused tests for the mutation path and restart-safe update behavior.
+- Hypothesis: The remaining review blockers were real. The restart-safe sticky-comment update path was using GraphQL node IDs against a REST PATCH endpoint, and marker-only matching could select comments the current actor could not edit.
+- What changed: Extended the PR comment review surface to include `databaseId` and `viewerDidAuthor`, changed `GitHubClient.updateIssueComment()` to require the numeric database ID, and tightened tracked-PR sticky comment reuse so only editable marked comments are reused. Added a regression test for update-via-databaseId and another for the fallback create path when a marker exists on an uneditable comment.
 - Current blocker: none.
-- Next exact step: review the diff, commit the checkpoint, and continue with any follow-on sticky publisher abstraction cleanup if needed.
+- Next exact step: commit and push the review fix, then refresh PR #1419 so the unresolved automated threads can be re-evaluated.
 - Verification gap: none for the scoped issue verification; broader full-suite coverage not run this turn.
 - Files touched: src/github/github.ts; src/github/github-mutations.ts; src/github/github.test.ts; src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts
 - Rollback concern: The marker format now defines ownership for tracked PR host-local blocker comments; changing it later would strand older sticky comments unless migration or fallback matching is added.
 - Last focused command: `npm run build`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-11: Focused commands run for the review fix: `npx tsx --test src/github/github.test.ts src/post-turn-pull-request.test.ts`; `npm run build`

--- a/.codex-supervisor/issues/1415/issue-journal.md
+++ b/.codex-supervisor/issues/1415/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1415: Add sticky tracked-PR status comment publisher abstraction
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1415
+- Branch: codex/issue-1415
+- Workspace: .
+- Journal: .codex-supervisor/issues/1415/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 98401144e24d6551e0c9fc38210c6538f539ac56
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-10T23:36:07.682Z
+
+## Latest Codex Summary
+- Added sticky tracked-PR host-local blocker comment publishing with deterministic marker lookup and GitHub comment updates, plus focused regression tests for restart-safe reuse.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Duplicate tracked-PR blocker comments were caused by a create-only GitHub path plus local dedupe fields that do not survive process restarts.
+- What changed: Added `GitHubClient.updateIssueComment()` and REST PATCH support; post-turn tracked-PR blocker publishing now appends a deterministic hidden marker, searches PR conversation comments for an owned match, updates that comment when found, and only creates a new comment when no owned comment exists. Added focused tests for the mutation path and restart-safe update behavior.
+- Current blocker: none.
+- Next exact step: review the diff, commit the checkpoint, and continue with any follow-on sticky publisher abstraction cleanup if needed.
+- Verification gap: none for the scoped issue verification; broader full-suite coverage not run this turn.
+- Files touched: src/github/github.ts; src/github/github-mutations.ts; src/github/github.test.ts; src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts
+- Rollback concern: The marker format now defines ownership for tracked PR host-local blocker comments; changing it later would strand older sticky comments unless migration or fallback matching is added.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -480,10 +480,12 @@ export interface PullRequestReview {
 
 export interface IssueComment {
   id: string;
+  databaseId?: number | null;
   body: string;
   createdAt: string;
   url: string | null;
   author: ExternalReviewActor | null;
+  viewerDidAuthor?: boolean | null;
 }
 
 export interface WorkspaceStatus {

--- a/src/github/github-mutations.ts
+++ b/src/github/github-mutations.ts
@@ -131,11 +131,11 @@ export class GitHubMutationClient {
     ]);
   }
 
-  async updateIssueComment(commentId: string, body: string): Promise<void> {
+  async updateIssueComment(commentDatabaseId: number, body: string): Promise<void> {
     const { owner, repo } = this.repoOwnerAndName();
     await this.runGhCommand([
       "api",
-      `repos/${owner}/${repo}/issues/comments/${commentId}`,
+      `repos/${owner}/${repo}/issues/comments/${commentDatabaseId}`,
       "--method",
       "PATCH",
       "-f",

--- a/src/github/github-mutations.ts
+++ b/src/github/github-mutations.ts
@@ -131,6 +131,18 @@ export class GitHubMutationClient {
     ]);
   }
 
+  async updateIssueComment(commentId: string, body: string): Promise<void> {
+    const { owner, repo } = this.repoOwnerAndName();
+    await this.runGhCommand([
+      "api",
+      `repos/${owner}/${repo}/issues/comments/${commentId}`,
+      "--method",
+      "PATCH",
+      "-f",
+      `body=${body}`,
+    ]);
+  }
+
   async closeIssue(issueNumber: number, comment?: string): Promise<void> {
     const args = [
       "issue",

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -445,9 +445,11 @@ export class GitHubReviewSurfaceClient {
             comments(last: 100) {
               nodes {
                 id
+                databaseId
                 body
                 createdAt
                 url
+                viewerDidAuthor
                 author {
                   login
                   __typename
@@ -492,9 +494,11 @@ export class GitHubReviewSurfaceClient {
             comments?: {
               nodes?: Array<{
                 id?: string | null;
+                databaseId?: number | null;
                 body?: string | null;
                 createdAt?: string | null;
                 url?: string | null;
+                viewerDidAuthor?: boolean | null;
                 author?: {
                   login?: string | null;
                   __typename?: string | null;
@@ -534,9 +538,11 @@ export class GitHubReviewSurfaceClient {
             ? [
                 {
                   id: comment.id,
+                  databaseId: comment.databaseId ?? null,
                   body: comment.body ?? "",
                   createdAt: comment.createdAt ?? "",
                   url: comment.url ?? null,
+                  viewerDidAuthor: comment.viewerDidAuthor ?? null,
                   author: comment.author
                     ? {
                         login: comment.author.login ?? null,

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -358,9 +358,11 @@ test("GitHubClient reuses cached external review surface for same-head status re
                   nodes: [
                     {
                       id: "comment-1",
+                      databaseId: 1001,
                       body: "Top-level follow-up.",
                       createdAt: "2026-03-13T02:25:00Z",
                       url: "https://example.test/comments/1",
+                      viewerDidAuthor: true,
                       author: {
                         login: "copilot-pull-request-reviewer",
                         __typename: "Bot",
@@ -446,11 +448,11 @@ test("GitHubClient updates an existing issue comment", async () => {
     };
   });
 
-  await client.updateIssueComment("comment-123", "Updated sticky status body");
+  await client.updateIssueComment(123, "Updated sticky status body");
 
   assert.deepEqual(capturedArgs, [
     "api",
-    "repos/owner/repo/issues/comments/comment-123",
+    "repos/owner/repo/issues/comments/123",
     "--method",
     "PATCH",
     "-f",

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -434,6 +434,30 @@ test("GitHubClient refreshes external review surface for action reads even on th
   assert.equal(graphqlCalls, 2);
 });
 
+test("GitHubClient updates an existing issue comment", async () => {
+  const config = createConfig();
+  let capturedArgs: string[] | null = null;
+  const client = new GitHubClient(config, async (_command, args) => {
+    capturedArgs = args;
+    return {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    };
+  });
+
+  await client.updateIssueComment("comment-123", "Updated sticky status body");
+
+  assert.deepEqual(capturedArgs, [
+    "api",
+    "repos/owner/repo/issues/comments/comment-123",
+    "--method",
+    "PATCH",
+    "-f",
+    "body=Updated sticky status body",
+  ]);
+});
+
 test("GitHubClient fetches REST and GraphQL rate-limit telemetry from a single rate_limit response", async () => {
   const config = createConfig();
   const client = new GitHubClient(config, async (_command, args) => {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -168,8 +168,8 @@ export class GitHubClient {
     return this.mutations.addIssueComment(issueNumber, body);
   }
 
-  async updateIssueComment(commentId: string, body: string): Promise<void> {
-    return this.mutations.updateIssueComment(commentId, body);
+  async updateIssueComment(commentDatabaseId: number, body: string): Promise<void> {
+    return this.mutations.updateIssueComment(commentDatabaseId, body);
   }
 
   async closeIssue(issueNumber: number, comment?: string): Promise<void> {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -168,6 +168,10 @@ export class GitHubClient {
     return this.mutations.addIssueComment(issueNumber, body);
   }
 
+  async updateIssueComment(commentId: string, body: string): Promise<void> {
+    return this.mutations.updateIssueComment(commentId, body);
+  }
+
   async closeIssue(issueNumber: number, comment?: string): Promise<void> {
     return this.mutations.closeIssue(issueNumber, comment);
   }

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -61,7 +61,17 @@ function createNoopStateStore() {
 
 function createDefaultGithub(
   overrides: Partial<
-    Pick<GitHubClient, "getPullRequest" | "getChecks" | "getUnresolvedReviewThreads" | "markPullRequestReady" | "createIssue" | "addIssueComment">
+    Pick<
+      GitHubClient,
+      | "getPullRequest"
+      | "getChecks"
+      | "getUnresolvedReviewThreads"
+      | "markPullRequestReady"
+      | "createIssue"
+      | "addIssueComment"
+      | "getExternalReviewSurface"
+      | "updateIssueComment"
+    >
   > = {},
 ) {
   return {
@@ -76,6 +86,13 @@ function createDefaultGithub(
     },
     markPullRequestReady: async () => {
       throw new Error("unexpected markPullRequestReady call");
+    },
+    getExternalReviewSurface: async () => ({
+      reviews: [],
+      issueComments: [],
+    }),
+    updateIssueComment: async () => {
+      throw new Error("unexpected updateIssueComment call");
     },
     ...overrides,
   };
@@ -1161,6 +1178,102 @@ test("handlePostTurnPullRequestTransitionsPhase keeps blocker state authoritativ
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
   assert.equal(result.record.last_failure_signature, "local-ci-gate-workspace_toolchain_missing");
+});
+
+test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR host-local blocker comment after restart", async () => {
+  const config = createConfig({
+    workspacePreparationCommand: "npm ci",
+    localCiCommand: "npm run ci:local",
+  });
+  const issue = createIssue({ title: "Update tracked PR host-local blocker comment" });
+  const draftPr = createPullRequest({ title: "Tracked PR host-local blocker", isDraft: true, number: 116, headRefOid: "head-116" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ issue_number: 102, state: "draft_pr", pr_number: draftPr.number }) },
+  };
+  const updateCalls: Array<{ commentId: string; body: string }> = [];
+  let addCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => {
+        addCalls += 1;
+      },
+      getExternalReviewSurface: async () => ({
+        reviews: [],
+        issueComments: [
+          {
+            id: "comment-42",
+            body: [
+              "Supervisor host-local workspace_preparation blocker on tracked PR head `old-head`.",
+              "",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->",
+            ].join("\n"),
+            createdAt: "2026-03-16T01:00:00Z",
+            url: "https://example.test/comments/42",
+            author: {
+              login: "codex-supervisor[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      }),
+      updateIssueComment: async (commentId: string, body: string) => {
+        updateCalls.push({ commentId, body });
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr: draftPr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (record) => createLifecycleSnapshot(record, "draft_pr"),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkspacePreparationCommand: async () => {
+      throw Object.assign(new Error("workspace toolchain is not installed in this workspace"), {
+        stderr: "workspace toolchain is not installed in this workspace",
+      });
+    },
+    runLocalCiCommand: async () => {
+      throw new Error("unexpected local CI call");
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(addCalls, 0);
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0]?.commentId, "comment-42");
+  assert.match(
+    updateCalls[0]?.body ?? "",
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->/,
+  );
+  assert.match(updateCalls[0]?.body ?? "", /head `head-116`/);
+  assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, draftPr.headRefOid);
+  assert.equal(
+    result.record.last_host_local_pr_blocker_comment_signature,
+    "workspace-preparation-gate-workspace_toolchain_missing",
+  );
 });
 
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workstation-local path hygiene fails", async () => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1191,7 +1191,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
     activeIssueNumber: 102,
     issues: { "102": createRecord({ issue_number: 102, state: "draft_pr", pr_number: draftPr.number }) },
   };
-  const updateCalls: Array<{ commentId: string; body: string }> = [];
+  const updateCalls: Array<{ commentId: number; body: string }> = [];
   let addCalls = 0;
 
   const result = await handlePostTurnPullRequestTransitionsPhase({
@@ -1206,6 +1206,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
         issueComments: [
           {
             id: "comment-42",
+            databaseId: 42,
             body: [
               "Supervisor host-local workspace_preparation blocker on tracked PR head `old-head`.",
               "",
@@ -1213,6 +1214,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
             ].join("\n"),
             createdAt: "2026-03-16T01:00:00Z",
             url: "https://example.test/comments/42",
+            viewerDidAuthor: true,
             author: {
               login: "codex-supervisor[bot]",
               typeName: "Bot",
@@ -1220,7 +1222,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
           },
         ],
       }),
-      updateIssueComment: async (commentId: string, body: string) => {
+      updateIssueComment: async (commentId: number, body: string) => {
         updateCalls.push({ commentId, body });
       },
     }),
@@ -1263,7 +1265,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
   assert.equal(result.record.state, "blocked");
   assert.equal(addCalls, 0);
   assert.equal(updateCalls.length, 1);
-  assert.equal(updateCalls[0]?.commentId, "comment-42");
+  assert.equal(updateCalls[0]?.commentId, 42);
   assert.match(
     updateCalls[0]?.body ?? "",
     /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->/,
@@ -1274,6 +1276,99 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
     result.record.last_host_local_pr_blocker_comment_signature,
     "workspace-preparation-gate-workspace_toolchain_missing",
   );
+});
+
+test("handlePostTurnPullRequestTransitionsPhase creates a fresh tracked PR blocker comment when marker match is not editable", async () => {
+  const config = createConfig({
+    workspacePreparationCommand: "npm ci",
+    localCiCommand: "npm run ci:local",
+  });
+  const issue = createIssue({ title: "Replace uneditable tracked PR host-local blocker comment" });
+  const draftPr = createPullRequest({ title: "Tracked PR host-local blocker", isDraft: true, number: 116, headRefOid: "head-116" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ issue_number: 102, state: "draft_pr", pr_number: draftPr.number }) },
+  };
+  const addCalls: Array<{ prNumber: number; body: string }> = [];
+  let updateCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (prNumber: number, body: string) => {
+        addCalls.push({ prNumber, body });
+      },
+      getExternalReviewSurface: async () => ({
+        reviews: [],
+        issueComments: [
+          {
+            id: "comment-99",
+            databaseId: 99,
+            body: [
+              "Copied marker from a different participant.",
+              "",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->",
+            ].join("\n"),
+            createdAt: "2026-03-16T01:00:00Z",
+            url: "https://example.test/comments/99",
+            viewerDidAuthor: false,
+            author: {
+              login: "someone-else",
+              typeName: "User",
+            },
+          },
+        ],
+      }),
+      updateIssueComment: async () => {
+        updateCalls += 1;
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr: draftPr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (record) => createLifecycleSnapshot(record, "draft_pr"),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkspacePreparationCommand: async () => {
+      throw Object.assign(new Error("workspace toolchain is not installed in this workspace"), {
+        stderr: "workspace toolchain is not installed in this workspace",
+      });
+    },
+    runLocalCiCommand: async () => {
+      throw new Error("unexpected local CI call");
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(updateCalls, 0);
+  assert.equal(addCalls.length, 1);
+  assert.equal(addCalls[0]?.prNumber, draftPr.number);
+  assert.match(
+    addCalls[0]?.body ?? "",
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->/,
+  );
+  assert.match(addCalls[0]?.body ?? "", /head `head-116`/);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workstation-local path hygiene fails", async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -21,6 +21,7 @@ import { StateStore } from "./core/state-store";
 import {
   FailureContext,
   GitHubIssue,
+  IssueComment,
   GitHubPullRequest,
   IssueRunRecord,
   LatestLocalCiResult,
@@ -91,6 +92,7 @@ type HostLocalTrackedPrBlockerGateType =
   | "workstation_local_path_hygiene";
 
 const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
+const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
 
 function workspacePreparationFailureClass(
   signature: string | null | undefined,
@@ -208,8 +210,63 @@ function buildTrackedPrReadyPromotionPathHygieneComment(args: {
   ].join("\n");
 }
 
+function buildTrackedPrStatusCommentMarker(args: {
+  issueNumber: number;
+  prNumber: number;
+  kind: "host-local-blocker";
+}): string {
+  return `<!-- ${TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX} issue=${args.issueNumber} pr=${args.prNumber} kind=${args.kind} -->`;
+}
+
+function findOwnedTrackedPrStatusComment(
+  issueComments: IssueComment[],
+  marker: string,
+): IssueComment | null {
+  const matchingComments = issueComments.filter((comment) => comment.body.includes(marker));
+  if (matchingComments.length === 0) {
+    return null;
+  }
+
+  matchingComments.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  return matchingComments[0] ?? null;
+}
+
+async function publishTrackedPrStatusComment(args: {
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
+  issueNumber: number;
+  pr: GitHubPullRequest;
+  kind: "host-local-blocker";
+  body: string;
+}): Promise<void> {
+  if (!args.github.addIssueComment) {
+    return;
+  }
+
+  const marker = buildTrackedPrStatusCommentMarker({
+    issueNumber: args.issueNumber,
+    prNumber: args.pr.number,
+    kind: args.kind,
+  });
+  const bodyWithMarker = `${args.body}\n\n${marker}`;
+
+  if (args.github.getExternalReviewSurface && args.github.updateIssueComment) {
+    const surface = await args.github.getExternalReviewSurface(args.pr.number, {
+      purpose: "action",
+      headSha: args.pr.headRefOid,
+      reviewSurfaceVersion: args.pr.updatedAt,
+    });
+    const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, marker);
+    if (existingComment) {
+      await args.github.updateIssueComment(existingComment.id, bodyWithMarker);
+      return;
+    }
+  }
+
+  await args.github.addIssueComment(args.pr.number, bodyWithMarker);
+}
+
 async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
-  github: Partial<Pick<GitHubClient, "addIssueComment">>;
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
   record: IssueRunRecord;
@@ -238,9 +295,12 @@ async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
   }
 
   try {
-    await args.github.addIssueComment(
-      args.pr.number,
-      buildTrackedPrHostLocalBlockerComment({
+    await publishTrackedPrStatusComment({
+      github: args.github,
+      issueNumber: args.record.issue_number,
+      pr: args.pr,
+      kind: "host-local-blocker",
+      body: buildTrackedPrHostLocalBlockerComment({
         pr: args.pr,
         gateType: args.gateType,
         blockerSignature: args.blockerSignature,
@@ -249,11 +309,11 @@ async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
         summary: args.summary,
         details: args.details,
       }),
-    );
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(
-      `Failed to post tracked PR host-local blocker comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+      `Failed to publish tracked PR host-local blocker comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
     );
     return args.record;
   }

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -222,7 +222,12 @@ function findOwnedTrackedPrStatusComment(
   issueComments: IssueComment[],
   marker: string,
 ): IssueComment | null {
-  const matchingComments = issueComments.filter((comment) => comment.body.includes(marker));
+  const matchingComments = issueComments.filter(
+    (comment) =>
+      comment.body.includes(marker) &&
+      comment.viewerDidAuthor === true &&
+      typeof comment.databaseId === "number",
+  );
   if (matchingComments.length === 0) {
     return null;
   }
@@ -256,8 +261,9 @@ async function publishTrackedPrStatusComment(args: {
       reviewSurfaceVersion: args.pr.updatedAt,
     });
     const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, marker);
-    if (existingComment) {
-      await args.github.updateIssueComment(existingComment.id, bodyWithMarker);
+    const existingCommentDatabaseId = existingComment?.databaseId;
+    if (typeof existingCommentDatabaseId === "number") {
+      await args.github.updateIssueComment(existingCommentDatabaseId, bodyWithMarker);
       return;
     }
   }


### PR DESCRIPTION
## Summary
- add a supervisor-owned sticky tracked-PR status comment path instead of create-only ad hoc publishing
- append deterministic ownership metadata so the same PR conversation comment can be found across loop iterations and restarts
- support updating an existing PR conversation comment through the GitHub mutation layer

## Why
Tracked PR blocker comments were create-only, so restart-safe reuse was not possible and duplicate status comments could accumulate over time. This change makes comment publication sticky and best-effort while keeping authoritative local blocker state unchanged if GitHub transport fails.

## Impact
- tracked PR status publication can reuse a single owned PR conversation comment
- GitHub comment mutations now include issue comment updates
- focused regression coverage protects restart-safe comment ownership and update behavior

## Verification
- `npx tsx --test src/github/github.test.ts src/post-turn-pull-request.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish-or-update tracked PR status comments using a marker: reuses an owned comment when editable, otherwise creates a new supervisor-owned comment; appends marker and PR head SHA.

* **Tests**
  * Expanded tests covering update-vs-create behavior after restart, editable-owner updates, and uneditable fallback.

* **Documentation**
  * Added an issue journal entry describing snapshot, behavior changes, verification notes, and next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->