### PR TITLE
[codex] Publish sticky tracked-PR status comments for draft and ready-promotion blockers

### DIFF
--- a/.codex-supervisor/issues/1416/issue-journal.md
+++ b/.codex-supervisor/issues/1416/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1416: Publish sticky tracked-PR status comments for draft and ready-promotion blockers
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1416
+- Branch: codex/issue-1416
+- Workspace: .
+- Journal: .codex-supervisor/issues/1416/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 695431180bca336d8bcf4bac42224ecee67b717e
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T00:01:02.868Z
+
+## Latest Codex Summary
+- Added generic sticky tracked-PR status comment handling so draft-state provider suppression and ready-promotion local blockers share one supervisor-owned comment that updates in place.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The existing implementation only handled host-local ready-promotion blocker comments and never published a sticky tracked-PR status comment for persistent draft-state provider suppression.
+- What changed: Added focused reproducing tests for draft suppression and blocker-class transitions, generalized the tracked-PR sticky comment marker to `kind=status`, added stable reason codes plus next-action/automatic-retry guidance, and reused the same sticky comment across draft suppression and ready-promotion blockers.
+- Current blocker: none
+- Next exact step: Commit the verified implementation checkpoint on `codex/issue-1416`.
+- Verification gap: none for the targeted issue scope; requested test suite and `npm run build` both passed locally.
+- Files touched: src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts
+- Rollback concern: Existing legacy `kind=host-local-blocker` comments are migrated opportunistically by updating either marker kind in place; removing that compatibility path would strand older sticky comments.
+- Last focused command: npm run build
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1416/issue-journal.md
+++ b/.codex-supervisor/issues/1416/issue-journal.md
@@ -5,42 +5,43 @@
 - Branch: codex/issue-1416
 - Workspace: .
 - Journal: .codex-supervisor/issues/1416/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 2753ceff05a151fa2fc9ce85ac3695a53aa40807
+- Current phase: repairing_ci
+- Attempt count: 4 (implementation=2, repair=2)
+- Last head SHA: 48d41ab4228b55e56f0a688148403fb605f4ec07
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856QtdC
-- Repeated failure signature count: 1
-- Updated at: 2026-04-11T00:20:54Z
+- Last failure signature: build (ubuntu-latest):fail
+- Repeated failure signature count: 3
+- Updated at: 2026-04-11T00:25:15.206Z
 
 ## Latest Codex Summary
-I re-checked the live PR review state with the `gh-address-comments` GraphQL helper and confirmed the only unresolved review thread on [#1420](https://github.com/TommyKammy/codex-supervisor/pull/1420) is the missing create-path assertion for the sticky tracked-PR status marker. The comment was valid: the draft-suppression test verified the message body but did not assert the appended `kind=status` marker that later dedupe and update paths depend on.
+I inspected the failing Ubuntu Actions run for PR #1420 and confirmed the breakage is a path-hygiene failure in the tracked issue journal, not a feature regression. Commit `48d41ab` recorded an absolute workstation path in the `Tests:` line of [issue-journal.md](.codex-supervisor/issues/1416/issue-journal.md), which caused `npm run verify:paths` to fail on CI before the build reached TypeScript compilation.
 
-I added that missing assertion in [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), kept production code unchanged, and reran the focused test file successfully.
+I kept the existing local journal sanitization, reran the failing command locally, and verified the branch with the issue's focused test/build commands. Production files under `src/` are unchanged in this repair; the only tracked fix is the journal cleanup needed to unblock CI.
 
-Summary: Added the missing `kind=status` create-path assertion to the draft-suppression test and reverified the modified test file.
-State hint: addressing_review
+Summary: Reproduced the Ubuntu path-hygiene failure, confirmed the local journal already removed the offending absolute path, and reverified the branch so the sanitized journal can be pushed as the CI repair.
+State hint: repairing_ci
 Blocked reason: none
-Tests: `python3 /home/tommy/.codex/plugins/cache/openai-curated/github/fb0a18376bcd9f2604047fbe7459ec5aed70c64b/skills/gh-address-comments/scripts/fetch_comments.py`; `npx tsx --test src/post-turn-pull-request.test.ts`
-Next action: Let the supervisor refresh PR #1420 review state and confirm the automated thread is cleared or outdated on the new head.
-Failure signature: none
+Tests: `python3 <gh-fix-ci>/scripts/inspect_pr_checks.py --repo . --pr 1420 --json`; `npm run verify:paths`; `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
+Next action: Wait for PR #1420 checks to refresh on the repaired branch head and confirm the Ubuntu build clears.
+Failure signature: build (ubuntu-latest):fail
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1420#discussion_r3067219031
+- Category: checks
+- Summary: PR #1420 has failing checks.
+- Command or source: gh pr checks
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1420
 - Details:
-  - src/post-turn-pull-request.test.ts:1727 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Assert the sticky marker on the create path.** This test verifies the suppression body, but it would still pass if freshly added comments sto... url=https://github.com/TommyKammy/codex-supervisor/pull/1420#discussion_r3067219031
+  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/24270141826/job/70873310708
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The remaining automated review feedback is a valid test-coverage gap only; production behavior is already correct, but the create path for draft-suppression comments was not asserting the sticky `kind=status` marker.
-- What changed: Confirmed PR #1420 has one unresolved review thread, added the missing `kind=status` assertion to the draft-suppression test, reran `npx tsx --test src/post-turn-pull-request.test.ts` successfully, and prepared the review-fix checkpoint for PR update.
+- Hypothesis: The only remaining CI blocker is the committed absolute workstation path in the tracked issue journal; once the sanitized journal is pushed, the Ubuntu build should clear.
+- What changed: Inspected the failing GitHub Actions run for PR #1420, confirmed `npm run verify:paths` failed on a committed absolute workstation path in the journal's `Tests:` line from commit `48d41ab`, and verified the current working tree already removes that path.
 - Current blocker: none
-- Next exact step: Push the review-fix checkpoint on `codex/issue-1416`, then let the supervisor re-read PR #1420 review state.
-- Verification gap: none for the targeted review fix; the modified test file passed locally after the assertion was added.
-- Files touched: src/post-turn-pull-request.test.ts; .codex-supervisor/issues/1416/issue-journal.md
+- Next exact step: Push the repaired branch head and recheck PR #1420 checks for a clean Ubuntu build.
+- Verification gap: none for the CI repair; the reproduced failing command and the issue verification commands all pass locally on the sanitized journal.
+- Files touched: .codex-supervisor/issues/1416/issue-journal.md
 - Rollback concern: Existing legacy `kind=host-local-blocker` comments are migrated opportunistically by updating either marker kind in place; removing that compatibility path would strand older sticky comments.
-- Last focused command: npx tsx --test src/post-turn-pull-request.test.ts
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1416/issue-journal.md
+++ b/.codex-supervisor/issues/1416/issue-journal.md
@@ -5,29 +5,42 @@
 - Branch: codex/issue-1416
 - Workspace: .
 - Journal: .codex-supervisor/issues/1416/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 695431180bca336d8bcf4bac42224ecee67b717e
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 2753ceff05a151fa2fc9ce85ac3695a53aa40807
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T00:01:02.868Z
+- Last failure signature: PRRT_kwDORgvdZ856QtdC
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T00:20:54Z
 
 ## Latest Codex Summary
-- Added generic sticky tracked-PR status comment handling so draft-state provider suppression and ready-promotion local blockers share one supervisor-owned comment that updates in place.
+I re-checked the live PR review state with the `gh-address-comments` GraphQL helper and confirmed the only unresolved review thread on [#1420](https://github.com/TommyKammy/codex-supervisor/pull/1420) is the missing create-path assertion for the sticky tracked-PR status marker. The comment was valid: the draft-suppression test verified the message body but did not assert the appended `kind=status` marker that later dedupe and update paths depend on.
+
+I added that missing assertion in [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts), kept production code unchanged, and reran the focused test file successfully.
+
+Summary: Added the missing `kind=status` create-path assertion to the draft-suppression test and reverified the modified test file.
+State hint: addressing_review
+Blocked reason: none
+Tests: `python3 /home/tommy/.codex/plugins/cache/openai-curated/github/fb0a18376bcd9f2604047fbe7459ec5aed70c64b/skills/gh-address-comments/scripts/fetch_comments.py`; `npx tsx --test src/post-turn-pull-request.test.ts`
+Next action: Let the supervisor refresh PR #1420 review state and confirm the automated thread is cleared or outdated on the new head.
+Failure signature: none
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1420#discussion_r3067219031
+- Details:
+  - src/post-turn-pull-request.test.ts:1727 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Assert the sticky marker on the create path.** This test verifies the suppression body, but it would still pass if freshly added comments sto... url=https://github.com/TommyKammy/codex-supervisor/pull/1420#discussion_r3067219031
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The existing implementation only handled host-local ready-promotion blocker comments and never published a sticky tracked-PR status comment for persistent draft-state provider suppression.
-- What changed: Added focused reproducing tests for draft suppression and blocker-class transitions, generalized the tracked-PR sticky comment marker to `kind=status`, added stable reason codes plus next-action/automatic-retry guidance, and reused the same sticky comment across draft suppression and ready-promotion blockers.
+- Hypothesis: The remaining automated review feedback is a valid test-coverage gap only; production behavior is already correct, but the create path for draft-suppression comments was not asserting the sticky `kind=status` marker.
+- What changed: Confirmed PR #1420 has one unresolved review thread, added the missing `kind=status` assertion to the draft-suppression test, reran `npx tsx --test src/post-turn-pull-request.test.ts` successfully, and prepared the review-fix checkpoint for PR update.
 - Current blocker: none
-- Next exact step: Commit the verified implementation checkpoint on `codex/issue-1416`.
-- Verification gap: none for the targeted issue scope; requested test suite and `npm run build` both passed locally.
-- Files touched: src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts
+- Next exact step: Push the review-fix checkpoint on `codex/issue-1416`, then let the supervisor re-read PR #1420 review state.
+- Verification gap: none for the targeted review fix; the modified test file passed locally after the assertion was added.
+- Files touched: src/post-turn-pull-request.test.ts; .codex-supervisor/issues/1416/issue-journal.md
 - Rollback concern: Existing legacy `kind=host-local-blocker` comments are migrated opportunistically by updating either marker kind in place; removing that compatibility path would strand older sticky comments.
-- Last focused command: npm run build
+- Last focused command: npx tsx --test src/post-turn-pull-request.test.ts
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1713,6 +1713,10 @@ test("handlePostTurnPullRequestTransitionsPhase comments once when tracked draft
   assert.match(commentBodies[0] ?? "", /still draft because provider review is intentionally suppressed/i);
   assert.match(commentBodies[0] ?? "", /reason code: `draft_review_provider_suppressed`/i);
   assert.match(commentBodies[0] ?? "", /automatic retry: yes/i);
+  assert.match(
+    commentBodies[0] ?? "",
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/,
+  );
 
   const dedupedState: SupervisorStateFile = {
     ...firstState,

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -966,7 +966,7 @@ test("handlePostTurnPullRequestTransitionsPhase comments once when workspace pre
   assert.equal(result.record.state, "blocked");
   assert.equal(comments.length, 1);
   assert.equal(comments[0]?.prNumber, 116);
-  assert.match(comments[0]?.body ?? "", /host-local workspace_preparation blocker/i);
+  assert.match(comments[0]?.body ?? "", /still draft because ready-for-review promotion is blocked locally/i);
   assert.match(comments[0]?.body ?? "", /head `head-116`/);
   assert.match(comments[0]?.body ?? "", /failure class: `workspace_toolchain_missing`/);
   assert.match(comments[0]?.body ?? "", /remediation target: `workspace_environment`/);
@@ -1210,7 +1210,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
             body: [
               "Supervisor host-local workspace_preparation blocker on tracked PR head `old-head`.",
               "",
-              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
             ].join("\n"),
             createdAt: "2026-03-16T01:00:00Z",
             url: "https://example.test/comments/42",
@@ -1268,7 +1268,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
   assert.equal(updateCalls[0]?.commentId, 42);
   assert.match(
     updateCalls[0]?.body ?? "",
-    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->/,
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/,
   );
   assert.match(updateCalls[0]?.body ?? "", /head `head-116`/);
   assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, draftPr.headRefOid);
@@ -1308,7 +1308,7 @@ test("handlePostTurnPullRequestTransitionsPhase creates a fresh tracked PR block
             body: [
               "Copied marker from a different participant.",
               "",
-              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
             ].join("\n"),
             createdAt: "2026-03-16T01:00:00Z",
             url: "https://example.test/comments/99",
@@ -1366,7 +1366,7 @@ test("handlePostTurnPullRequestTransitionsPhase creates a fresh tracked PR block
   assert.equal(addCalls[0]?.prNumber, draftPr.number);
   assert.match(
     addCalls[0]?.body ?? "",
-    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker -->/,
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/,
   );
   assert.match(addCalls[0]?.body ?? "", /head `head-116`/);
 });
@@ -1620,6 +1620,212 @@ test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-l
   const dedupedResult = await runScenario(dedupedState);
   assert.equal(dedupedResult.record.state, "blocked");
   assert.equal(commentBodies.length, 1);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase comments once when tracked draft PR review is intentionally suppressed", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+  });
+  const issue = createIssue({ title: "Comment when draft suppresses provider review" });
+  const draftPr = createPullRequest({
+    title: "Tracked PR awaiting ready-for-review",
+    isDraft: true,
+    configuredBotDraftSkipAt: "2026-03-16T00:10:00Z",
+    currentHeadCiGreenAt: "2026-03-16T00:08:00Z",
+  });
+  const commentBodies: string[] = [];
+
+  const createState = (recordOverrides: Partial<IssueRunRecord> = {}): SupervisorStateFile => ({
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: draftPr.number,
+        last_head_sha: draftPr.headRefOid,
+        ...recordOverrides,
+      }),
+    },
+  });
+
+  const runScenario = async (state: SupervisorStateFile) =>
+    handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: {
+        touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+        save: async () => undefined,
+      },
+      github: {
+        getPullRequest: async () => {
+          throw new Error("unexpected getPullRequest call");
+        },
+        getChecks: async () => {
+          throw new Error("unexpected getChecks call");
+        },
+        getUnresolvedReviewThreads: async () => {
+          throw new Error("unexpected getUnresolvedReviewThreads call");
+        },
+        markPullRequestReady: async () => {
+          throw new Error("unexpected markPullRequestReady call");
+        },
+        addIssueComment: async (_prNumber: number, body: string) => {
+          commentBodies.push(body);
+        },
+      },
+      context: {
+        state,
+        record: state.issues["102"]!,
+        issue,
+        workspacePath: path.join("/tmp/workspaces", "issue-102"),
+        syncJournal: async () => undefined,
+        memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+        pr: draftPr,
+        options: { dryRun: false },
+      },
+      derivePullRequestLifecycleSnapshot: (record) => createLifecycleSnapshot(record, "draft_pr"),
+      applyFailureSignature: (_record, failureContext) => ({
+        last_failure_signature: failureContext?.signature ?? null,
+        repeated_failure_signature_count: failureContext ? 1 : 0,
+      }),
+      blockedReasonFromReviewState: () => null,
+      summarizeChecks: () => ({
+        hasPending: true,
+        hasFailing: false,
+      }),
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+      runLocalCiCommand: async () => undefined,
+      runWorkstationLocalPathGate: async () => ({
+        ok: true,
+        failureContext: null,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr: draftPr,
+        checks: [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }],
+        reviewThreads: [] satisfies ReviewThread[],
+      }),
+    });
+
+  const firstState = createState();
+  const firstResult = await runScenario(firstState);
+  assert.equal(firstResult.record.state, "draft_pr");
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /still draft because provider review is intentionally suppressed/i);
+  assert.match(commentBodies[0] ?? "", /reason code: `draft_review_provider_suppressed`/i);
+  assert.match(commentBodies[0] ?? "", /automatic retry: yes/i);
+
+  const dedupedState: SupervisorStateFile = {
+    ...firstState,
+    issues: {
+      ...firstState.issues,
+      "102": firstResult.record,
+    },
+  };
+  const dedupedResult = await runScenario(dedupedState);
+  assert.equal(dedupedResult.record.state, "draft_pr");
+  assert.equal(commentBodies.length, 1);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase updates the sticky tracked PR status comment when draft suppression turns into a local promotion blocker", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    localCiCommand: "npm run ci:local",
+  });
+  const issue = createIssue({ title: "Update tracked PR sticky status comment across blocker classes" });
+  const draftPr = createPullRequest({
+    title: "Tracked PR status comment migration",
+    isDraft: true,
+    number: 116,
+    headRefOid: "head-116",
+    configuredBotDraftSkipAt: "2026-03-16T00:10:00Z",
+    currentHeadCiGreenAt: "2026-03-16T00:08:00Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "draft_pr",
+        pr_number: draftPr.number,
+        last_head_sha: draftPr.headRefOid,
+      }),
+    },
+  };
+  const updateCalls: Array<{ commentId: number; body: string }> = [];
+  let addCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => {
+        addCalls += 1;
+      },
+      getExternalReviewSurface: async () => ({
+        reviews: [],
+        issueComments: [
+          {
+            id: "comment-42",
+            databaseId: 42,
+            body: [
+              "Tracked PR head `head-116` is still draft because provider review is intentionally suppressed.",
+              "",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+            ].join("\n"),
+            createdAt: "2026-03-16T01:00:00Z",
+            url: "https://example.test/comments/42",
+            viewerDidAuthor: true,
+            author: {
+              login: "codex-supervisor[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      }),
+      updateIssueComment: async (commentId: number, body: string) => {
+        updateCalls.push({ commentId, body });
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr: draftPr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (record) => createLifecycleSnapshot(record, "draft_pr"),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => {
+      throw Object.assign(new Error("local CI failed"), {
+        stderr: "local CI failed",
+      });
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(addCalls, 0);
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0]?.commentId, 42);
+  assert.match(updateCalls[0]?.body ?? "", /still draft because ready-for-review promotion is blocked locally/i);
+  assert.match(updateCalls[0]?.body ?? "", /reason code: `ready_promotion_blocked_local_ci`/i);
+  assert.match(updateCalls[0]?.body ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-issue journals before ready promotion", async (t) => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -43,6 +43,7 @@ import {
   maybeBuildReviewWaitChangedEvent,
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
+import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
 import { parseIssueMetadata } from "./issue-metadata";
 import { commitAndPushTrackedFiles, getWorkspaceStatus } from "./core/workspace";
 import {
@@ -93,6 +94,9 @@ type HostLocalTrackedPrBlockerGateType =
 
 const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
 const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
+
+type TrackedPrStatusCommentKind = "status" | "host-local-blocker";
 
 function workspacePreparationFailureClass(
   signature: string | null | undefined,
@@ -141,13 +145,16 @@ function buildTrackedPrHostLocalBlockerComment(args: {
   }
 
   return [
-    `Supervisor host-local ${args.gateType} blocker on tracked PR head \`${args.pr.headRefOid}\`.`,
+    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
     "",
+    `- reason code: \`${trackedPrReadyPromotionBlockedReasonCode(args.gateType)}\``,
     `- gate type: \`${args.gateType}\``,
     `- blocker signature: \`${args.blockerSignature}\``,
     `- failure class: \`${args.failureClass ?? "unknown"}\``,
     `- remediation target: \`${args.remediationTarget ?? "unknown"}\``,
     `- summary: ${args.summary}`,
+    "- automatic retry: no",
+    "- next action: fix the tracked workspace blocker, then rerun the supervisor to retry ready-for-review promotion.",
     "",
     "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
   ].join("\n");
@@ -200,31 +207,52 @@ function buildTrackedPrReadyPromotionPathHygieneComment(args: {
   return [
     `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
     "",
+    `- reason code: \`${trackedPrReadyPromotionBlockedReasonCode("workstation_local_path_hygiene")}\``,
     `- gate name: \`workstation_local_path_hygiene\``,
     `- blocker signature: \`${args.blockerSignature}\``,
     `- what failed: ${conciseSummary}`,
     ...(firstFix ? [`- ${firstFix}`] : []),
+    "- automatic retry: no",
     "- rerunning the supervisor alone will not help yet; fix the tracked workspace artifacts first, then rerun promotion.",
     "",
     "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
   ].join("\n");
 }
 
+function trackedPrReadyPromotionBlockedReasonCode(gateType: HostLocalTrackedPrBlockerGateType): string {
+  return `ready_promotion_blocked_${gateType}`;
+}
+
+function buildTrackedPrDraftReviewSuppressedComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because provider review is intentionally suppressed.`,
+    "",
+    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED}\``,
+    "- what is happening: configured provider review stays suppressed until this PR is ready for review.",
+    "- automatic retry: yes",
+    `- next action: keep the tracked workspace moving toward ready-for-review promotion for PR #${args.pr.number}; the supervisor will retry automatically on later cycles.`,
+    "",
+    "GitHub checks may still be pending because external review-provider work does not start while the PR remains draft.",
+  ].join("\n");
+}
+
 function buildTrackedPrStatusCommentMarker(args: {
   issueNumber: number;
   prNumber: number;
-  kind: "host-local-blocker";
+  kind: TrackedPrStatusCommentKind;
 }): string {
   return `<!-- ${TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX} issue=${args.issueNumber} pr=${args.prNumber} kind=${args.kind} -->`;
 }
 
 function findOwnedTrackedPrStatusComment(
   issueComments: IssueComment[],
-  marker: string,
+  markers: string[],
 ): IssueComment | null {
   const matchingComments = issueComments.filter(
     (comment) =>
-      comment.body.includes(marker) &&
+      markers.some((marker) => comment.body.includes(marker)) &&
       comment.viewerDidAuthor === true &&
       typeof comment.databaseId === "number",
   );
@@ -240,7 +268,7 @@ async function publishTrackedPrStatusComment(args: {
   github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
   issueNumber: number;
   pr: GitHubPullRequest;
-  kind: "host-local-blocker";
+  kind: TrackedPrStatusCommentKind;
   body: string;
 }): Promise<void> {
   if (!args.github.addIssueComment) {
@@ -253,6 +281,14 @@ async function publishTrackedPrStatusComment(args: {
     kind: args.kind,
   });
   const bodyWithMarker = `${args.body}\n\n${marker}`;
+  const editableMarkers = [
+    marker,
+    buildTrackedPrStatusCommentMarker({
+      issueNumber: args.issueNumber,
+      prNumber: args.pr.number,
+      kind: args.kind === "status" ? "host-local-blocker" : "status",
+    }),
+  ];
 
   if (args.github.getExternalReviewSurface && args.github.updateIssueComment) {
     const surface = await args.github.getExternalReviewSurface(args.pr.number, {
@@ -260,7 +296,7 @@ async function publishTrackedPrStatusComment(args: {
       headSha: args.pr.headRefOid,
       reviewSurfaceVersion: args.pr.updatedAt,
     });
-    const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, marker);
+    const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, editableMarkers);
     const existingCommentDatabaseId = existingComment?.databaseId;
     if (typeof existingCommentDatabaseId === "number") {
       await args.github.updateIssueComment(existingCommentDatabaseId, bodyWithMarker);
@@ -305,7 +341,7 @@ async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
       github: args.github,
       issueNumber: args.record.issue_number,
       pr: args.pr,
-      kind: "host-local-blocker",
+      kind: "status",
       body: buildTrackedPrHostLocalBlockerComment({
         pr: args.pr,
         gateType: args.gateType,
@@ -327,6 +363,54 @@ async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
   const updatedRecord = args.stateStore.touch(args.record, {
     last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
     last_host_local_pr_blocker_comment_signature: args.blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+async function maybeCommentOnTrackedPrDraftReviewSuppressed(args: {
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  syncJournal: IssueJournalSync;
+}): Promise<IssueRunRecord> {
+  if (!args.github.addIssueComment) {
+    return args.record;
+  }
+
+  const blockerSignature = TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED;
+  if (
+    args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+    && args.record.last_host_local_pr_blocker_comment_signature === blockerSignature
+  ) {
+    return args.record;
+  }
+
+  try {
+    await publishTrackedPrStatusComment({
+      github: args.github,
+      issueNumber: args.record.issue_number,
+      pr: args.pr,
+      kind: "status",
+      body: buildTrackedPrDraftReviewSuppressedComment({
+        pr: args.pr,
+      }),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to publish tracked PR draft suppression status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return args.record;
+  }
+
+  const updatedRecord = args.stateStore.touch(args.record, {
+    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: blockerSignature,
   });
   args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
   await args.stateStore.save(args.state);
@@ -990,6 +1074,25 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   });
   state.issues[String(record.issue_number)] = record;
   await stateStore.save(state);
+  if (
+    record.state === "draft_pr"
+    && reviewBotDiagnostics(
+      config,
+      record,
+      postReady.pr,
+      postReady.reviewThreads,
+      args.configuredBotReviewThreads,
+    ).status === "review_not_expected_while_draft"
+  ) {
+    record = await maybeCommentOnTrackedPrDraftReviewSuppressed({
+      github,
+      stateStore,
+      state,
+      record,
+      pr: postReady.pr,
+      syncJournal,
+    });
+  }
   emitSupervisorEvent(args.emitEvent, maybeBuildReviewWaitChangedEvent(args.context.record, record, postReady.pr.number));
 
   return {


### PR DESCRIPTION
## Summary
- publish a supervisor-owned sticky tracked-PR status comment when a tracked PR remains draft because provider review is intentionally suppressed
- reuse the same sticky comment when a ready-for-review promotion is blocked by local gates such as workstation path hygiene, workspace preparation, or local CI
- preserve compatibility with existing `kind=host-local-blocker` comments so older sticky comments are updated in place instead of duplicating timeline noise

## Why
The supervisor already had deduplicated host-local blocker comments for ready-promotion failures, but persistent draft-state suppression did not surface through the same stable tracked-PR comment path. That left operator-facing blockers split across ad hoc behavior and made repeated loops noisier than necessary.

## Impact
Tracked PRs now keep one stable supervisor-owned status comment for persistent pre-merge blockers before review can proceed. The comment carries a stable reason code, concise evidence, next operator action, and whether automatic retry is expected.

## Validation
- `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npm run build`

Closes #1416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post automatic status comments on draft PRs when provider reviews are suppressed, including retry guidance and next-action messaging
  * Improved status comment content to explicitly state when ready-for-review promotion is blocked locally and how to proceed

* **Tests**
  * Added tests for draft review suppression, status comment deduplication, and transitions from suppressed to locally-blocked states
  * Updated assertions to match the new status comment format
<!-- end of auto-generated comment: release notes by coderabbit.ai -->