### PR TITLE
[codex] Publish sticky tracked-PR status comments for persistent merge-stage blockers

### DIFF
--- a/.codex-supervisor/issues/1417/issue-journal.md
+++ b/.codex-supervisor/issues/1417/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1417: Publish sticky tracked-PR status comments for persistent merge-stage blockers
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1417
+- Branch: codex/issue-1417
+- Workspace: .
+- Journal: .codex-supervisor/issues/1417/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 767cb70fe938dfcc6ddb5f2afc738fac3f8eb564
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T00:33:44.650Z
+
+## Latest Codex Summary
+- Added focused post-turn coverage for persistent merge-stage tracked-PR sticky comments and implemented non-draft sticky comment publication for persistent manual-review, tracked lifecycle mismatch, and merge-readiness mismatch states.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The existing sticky tracked-PR comment path only covers draft-stage blockers, so persistent merge-stage blockers like manual review and merge-readiness mismatch never surface on the PR timeline.
+- What changed: Added two focused reproducing tests in `src/post-turn-pull-request.test.ts`, then extended `src/post-turn-pull-request.ts` to publish/update the same sticky `kind=status` comment for non-draft persistent manual-review blockers, tracked lifecycle mismatches, and merge-readiness mismatches after post-turn lifecycle refresh.
+- Current blocker: none
+- Next exact step: Commit the verified post-turn sticky-comment change set on `codex/issue-1417`.
+- Verification gap: No dedicated coverage yet for a same-head tracked lifecycle mismatch comment body beyond the shared mismatch-derived helper path.
+- Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1417/issue-journal.md`
+- Rollback concern: The implementation reuses `last_host_local_pr_blocker_comment_*` dedupe fields for broader sticky-status comments, so reverting should restore the older draft/host-local-only publication behavior if comment churn appears.
+- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1417/issue-journal.md
+++ b/.codex-supervisor/issues/1417/issue-journal.md
@@ -5,29 +5,51 @@
 - Branch: codex/issue-1417
 - Workspace: .
 - Journal: .codex-supervisor/issues/1417/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 767cb70fe938dfcc6ddb5f2afc738fac3f8eb564
+- Current phase: addressing_review
+- Attempt count: 5 (implementation=2, repair=3)
+- Last head SHA: e8ffcbf31a885804f885a250b2551b179079730f
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T00:33:44.650Z
+- Last failure signature: PRRT_kwDORgvdZ856Q64P|PRRT_kwDORgvdZ856Q64R
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T01:13:47.047Z
 
 ## Latest Codex Summary
-- Added focused post-turn coverage for persistent merge-stage tracked-PR sticky comments and implemented non-draft sticky comment publication for persistent manual-review, tracked lifecycle mismatch, and merge-readiness mismatch states.
+Fetched the live PR review threads with the GitHub review-thread workflow and confirmed both unresolved CodeRabbit comments were still valid on `e8ffcbf31a885804f885a250b2551b179079730f`. In [src/post-turn-pull-request.ts#L275](src/post-turn-pull-request.ts#L275) I changed the required-check mismatch evidence builder to sort the full check set deterministically, kept the sticky comment body compact with a local slice, and now build the dedupe signature from the full sorted fingerprint so reorder-only check churn does not republish while changes outside the displayed prefix still do. In [src/post-turn-pull-request.ts#L316](src/post-turn-pull-request.ts#L316) I added a merge-stage persistence gate based on the existing `provider_success_*` and `merge_readiness_last_evaluated_at` fields so lifecycle-mismatch and `mergeStateStatus === "BLOCKED"` comments do not publish on the first clean-check settle observation.
+
+I added focused regressions in [src/post-turn-pull-request.test.ts#L121](src/post-turn-pull-request.test.ts#L121), [src/post-turn-pull-request.test.ts#L1919](src/post-turn-pull-request.test.ts#L1919), [src/post-turn-pull-request.test.ts#L1998](src/post-turn-pull-request.test.ts#L1998), and [src/post-turn-pull-request.test.ts#L2065](src/post-turn-pull-request.test.ts#L2065) to cover the persisted merge-stage signal, first-observation suppression, full-signature republish on hidden-check changes, and reorder stability. Verification passed locally with the focused file, the broader issue test set, and `npm run build`. I have not replied to or resolved review threads on GitHub because you did not ask for GitHub write actions.
+
+Summary: Fixed the two live merge-stage sticky-comment review regressions locally, added regression coverage, and refreshed the issue journal.
+State hint: addressing_review
+Blocked reason: none
+Tests: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`; `npm run build`
+Next action: Commit and push the local review-thread fixes on `codex/issue-1417`, then watch PR #1421 for refreshed CodeRabbit/CI results.
+Failure signature: PRRT_kwDORgvdZ856Q64P|PRRT_kwDORgvdZ856Q64R
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain on the remote PR head; both are fixed locally and pending commit/push.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1421#discussion_r3067289084
+- Details:
+  - src/post-turn-pull-request.ts:283 summary=_⚠️ Potential issue_ | _🟠 Major_ **Use a full, deterministic check fingerprint for the dedupe signature.** `buildRequiredCheckMismatchEvidence()` truncates to four entries, and... url=https://github.com/TommyKammy/codex-supervisor/pull/1421#discussion_r3067289084
+  - src/post-turn-pull-request.ts:362 summary=_⚠️ Potential issue_ | _🟠 Major_ **Gate merge-stage sticky comments on a persistence signal.** This helper posts a “persistent” near-merge blocker comment on the first clean-ch... url=https://github.com/TommyKammy/codex-supervisor/pull/1421#discussion_r3067289087
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The existing sticky tracked-PR comment path only covers draft-stage blockers, so persistent merge-stage blockers like manual review and merge-readiness mismatch never surface on the PR timeline.
-- What changed: Added two focused reproducing tests in `src/post-turn-pull-request.test.ts`, then extended `src/post-turn-pull-request.ts` to publish/update the same sticky `kind=status` comment for non-draft persistent manual-review blockers, tracked lifecycle mismatches, and merge-readiness mismatches after post-turn lifecycle refresh.
+- Hypothesis: CodeRabbit's two remaining review complaints were both valid on `e8ffcbf`: required-check mismatch dedupe still used a truncated unsorted fingerprint, and merge-stage lifecycle/blocker comments still published on the first clean-check observation instead of waiting for a persisted merge-stage signal.
+- What changed: Reworked `buildRequiredCheckMismatchEvidence(...)` to return a full sorted check fingerprint, used the full fingerprint for `blockerSignature` while keeping the comment body compact, added `hasPersistentTrackedPrMergeStageSignal(...)` to require a persisted merge-stage signal before lifecycle-mismatch or `BLOCKED` merge-stage comments, and added focused regression coverage for first-observation suppression plus full-signature republish/reorder behavior.
 - Current blocker: none
-- Next exact step: Commit the verified post-turn sticky-comment change set on `codex/issue-1417`.
-- Verification gap: No dedicated coverage yet for a same-head tracked lifecycle mismatch comment body beyond the shared mismatch-derived helper path.
+- Next exact step: Commit the local fixes, push `codex/issue-1417`, and refresh PR #1421 review-thread state to confirm `PRRT_kwDORgvdZ856Q64P` and `PRRT_kwDORgvdZ856Q64R` go outdated or resolve on the new head.
+- Verification gap: None locally after the focused test file, the broader issue verification set, and `npm run build`; only refreshed remote review/CI remains.
 - Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1417/issue-journal.md`
 - Rollback concern: The implementation reuses `last_host_local_pr_blocker_comment_*` dedupe fields for broader sticky-status comments, so reverting should restore the older draft/host-local-only publication behavior if comment churn appears.
 - Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-11: `fetch_comments.py` on PR #1421 confirmed `PRRT_kwDORgvdZ856Q64P` and `PRRT_kwDORgvdZ856Q64R` are the only unresolved non-outdated review threads on head `e8ffcbf31a885804f885a250b2551b179079730f`.
+- 2026-04-11: Local review fix adds a persisted merge-stage gate using `provider_success_*` plus `merge_readiness_last_evaluated_at !== provider_success_observed_at` so the first clean-check settle observation stays quiet.
+- 2026-04-11: Verification after the live-thread fix: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`; `npm run build`
+- 2026-04-11: Live review-thread fetch via `fetch_comments.py` confirmed unresolved thread `PRRT_kwDORgvdZ856Q04I` still targets `src/post-turn-pull-request.ts` and only asks to remove the unused `mergeability_mismatch` constant.
+- 2026-04-11: Verification run after the edit: `npx tsx --test src/post-turn-pull-request.test.ts`; `npm run build`
+- 2026-04-11: After pushing `e278784`, `fetch_comments.py` reported no unresolved non-outdated review threads on PR #1421; CI restarted on the new head and is pending.
+- 2026-04-11: Focused review-fix verification on `e8ffcbf`: `npx tsx --test src/post-turn-pull-request.test.ts`; `npm run build`
+- 2026-04-11: After pushing `e8ffcbf`, `fetch_comments.py` showed CodeRabbit thread `PRRT_kwDORgvdZ856Q3ej` outdated on the new head; thread `PRRT_kwDORgvdZ856Q3el` still appears unresolved/non-outdated even though the requested `syncJournal(record)` call is now present before `maybeCommentOnTrackedPrPersistentStatus(...)`.

--- a/.codex-supervisor/issues/1417/issue-journal.md
+++ b/.codex-supervisor/issues/1417/issue-journal.md
@@ -7,44 +7,41 @@
 - Journal: .codex-supervisor/issues/1417/issue-journal.md
 - Current phase: addressing_review
 - Attempt count: 5 (implementation=2, repair=3)
-- Last head SHA: e8ffcbf31a885804f885a250b2551b179079730f
+- Last head SHA: 410b3a456a4f814ebb797767260146b490f57f29
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856Q64P|PRRT_kwDORgvdZ856Q64R
-- Repeated failure signature count: 1
-- Updated at: 2026-04-11T01:13:47.047Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T01:15:14.834Z
 
 ## Latest Codex Summary
-Fetched the live PR review threads with the GitHub review-thread workflow and confirmed both unresolved CodeRabbit comments were still valid on `e8ffcbf31a885804f885a250b2551b179079730f`. In [src/post-turn-pull-request.ts#L275](src/post-turn-pull-request.ts#L275) I changed the required-check mismatch evidence builder to sort the full check set deterministically, kept the sticky comment body compact with a local slice, and now build the dedupe signature from the full sorted fingerprint so reorder-only check churn does not republish while changes outside the displayed prefix still do. In [src/post-turn-pull-request.ts#L316](src/post-turn-pull-request.ts#L316) I added a merge-stage persistence gate based on the existing `provider_success_*` and `merge_readiness_last_evaluated_at` fields so lifecycle-mismatch and `mergeStateStatus === "BLOCKED"` comments do not publish on the first clean-check settle observation.
+Fetched the live PR review threads with the GitHub review-thread workflow, confirmed both unresolved CodeRabbit comments were valid on `e8ffcbf31a885804f885a250b2551b179079730f`, and fixed them in [src/post-turn-pull-request.ts#L275](src/post-turn-pull-request.ts#L275) and [src/post-turn-pull-request.ts#L316](src/post-turn-pull-request.ts#L316). Required-check mismatch signatures now use the full sorted check fingerprint while the sticky comment body stays compact, and lifecycle-mismatch / `mergeStateStatus === "BLOCKED"` comments now require a persisted merge-stage signal derived from the existing `provider_success_*` plus `merge_readiness_last_evaluated_at` fields so first-observation settle windows stay quiet.
 
-I added focused regressions in [src/post-turn-pull-request.test.ts#L121](src/post-turn-pull-request.test.ts#L121), [src/post-turn-pull-request.test.ts#L1919](src/post-turn-pull-request.test.ts#L1919), [src/post-turn-pull-request.test.ts#L1998](src/post-turn-pull-request.test.ts#L1998), and [src/post-turn-pull-request.test.ts#L2065](src/post-turn-pull-request.test.ts#L2065) to cover the persisted merge-stage signal, first-observation suppression, full-signature republish on hidden-check changes, and reorder stability. Verification passed locally with the focused file, the broader issue test set, and `npm run build`. I have not replied to or resolved review threads on GitHub because you did not ask for GitHub write actions.
+I added focused regressions in [src/post-turn-pull-request.test.ts#L121](src/post-turn-pull-request.test.ts#L121), [src/post-turn-pull-request.test.ts#L1919](src/post-turn-pull-request.test.ts#L1919), [src/post-turn-pull-request.test.ts#L1998](src/post-turn-pull-request.test.ts#L1998), and [src/post-turn-pull-request.test.ts#L2065](src/post-turn-pull-request.test.ts#L2065), then verified with the focused file, the broader issue test set, and `npm run build`. I committed and pushed the fix as `410b3a4`; a fresh `fetch_comments.py` run shows both targeted CodeRabbit threads are now resolved on the new head. CodeRabbit also posted a top-level rate-limit notice on the PR conversation, and `gh pr view` currently reports `mergeStateStatus=UNSTABLE` while checks settle on the pushed head.
 
-Summary: Fixed the two live merge-stage sticky-comment review regressions locally, added regression coverage, and refreshed the issue journal.
+Summary: Fixed the live merge-stage sticky-comment review regressions, added regression coverage, pushed `410b3a4`, and confirmed the targeted review threads resolved on the new head.
 State hint: addressing_review
 Blocked reason: none
 Tests: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`; `npm run build`
-Next action: Commit and push the local review-thread fixes on `codex/issue-1417`, then watch PR #1421 for refreshed CodeRabbit/CI results.
-Failure signature: PRRT_kwDORgvdZ856Q64P|PRRT_kwDORgvdZ856Q64R
+Next action: Watch PR #1421 on head `410b3a456a4f814ebb797767260146b490f57f29` for refreshed CI after the new push; review threads are resolved, so only follow up if new review feedback or failing checks appear.
+Failure signature: none
 
 ## Active Failure Context
-- Category: review
-- Summary: 2 unresolved automated review thread(s) remain on the remote PR head; both are fixed locally and pending commit/push.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1421#discussion_r3067289084
-- Details:
-  - src/post-turn-pull-request.ts:283 summary=_⚠️ Potential issue_ | _🟠 Major_ **Use a full, deterministic check fingerprint for the dedupe signature.** `buildRequiredCheckMismatchEvidence()` truncates to four entries, and... url=https://github.com/TommyKammy/codex-supervisor/pull/1421#discussion_r3067289084
-  - src/post-turn-pull-request.ts:362 summary=_⚠️ Potential issue_ | _🟠 Major_ **Gate merge-stage sticky comments on a persistence signal.** This helper posts a “persistent” near-merge blocker comment on the first clean-ch... url=https://github.com/TommyKammy/codex-supervisor/pull/1421#discussion_r3067289087
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: CodeRabbit's two remaining review complaints were both valid on `e8ffcbf`: required-check mismatch dedupe still used a truncated unsorted fingerprint, and merge-stage lifecycle/blocker comments still published on the first clean-check observation instead of waiting for a persisted merge-stage signal.
-- What changed: Reworked `buildRequiredCheckMismatchEvidence(...)` to return a full sorted check fingerprint, used the full fingerprint for `blockerSignature` while keeping the comment body compact, added `hasPersistentTrackedPrMergeStageSignal(...)` to require a persisted merge-stage signal before lifecycle-mismatch or `BLOCKED` merge-stage comments, and added focused regression coverage for first-observation suppression plus full-signature republish/reorder behavior.
+- Hypothesis: CodeRabbit's two remaining review complaints were both valid on `e8ffcbf`, and the existing `provider_success_*` plus merge-readiness timestamps were sufficient to express the required persistence gate without adding new record schema.
+- What changed: Reworked `buildRequiredCheckMismatchEvidence(...)` to return a full sorted check fingerprint, used the full fingerprint for `blockerSignature` while keeping the comment body compact, added `hasPersistentTrackedPrMergeStageSignal(...)` to require a persisted merge-stage signal before lifecycle-mismatch or `BLOCKED` merge-stage comments, added focused regression coverage for first-observation suppression plus full-signature republish/reorder behavior, committed the result as `410b3a4`, and pushed `codex/issue-1417`.
 - Current blocker: none
-- Next exact step: Commit the local fixes, push `codex/issue-1417`, and refresh PR #1421 review-thread state to confirm `PRRT_kwDORgvdZ856Q64P` and `PRRT_kwDORgvdZ856Q64R` go outdated or resolve on the new head.
-- Verification gap: None locally after the focused test file, the broader issue verification set, and `npm run build`; only refreshed remote review/CI remains.
+- Next exact step: Watch PR #1421 on head `410b3a456a4f814ebb797767260146b490f57f29` for CI completion and only take further action if new review feedback or failing checks appear.
+- Verification gap: None locally after the focused test file, the broader issue verification set, `npm run build`, and the post-push review-thread refresh; only fresh CI remains.
 - Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1417/issue-journal.md`
 - Rollback concern: The implementation reuses `last_host_local_pr_blocker_comment_*` dedupe fields for broader sticky-status comments, so reverting should restore the older draft/host-local-only publication behavior if comment churn appears.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`
+- Last focused command: `python3 /home/tommy/.codex/plugins/cache/openai-curated/github/fb0a18376bcd9f2604047fbe7459ec5aed70c64b/skills/gh-address-comments/scripts/fetch_comments.py`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-11: After pushing `410b3a4`, `fetch_comments.py` showed `PRRT_kwDORgvdZ856Q64P` outdated/resolved and `PRRT_kwDORgvdZ856Q64R` resolved on the new head; no unresolved review threads remain.
+- 2026-04-11: `gh pr view 1421 --json headRefOid,mergeStateStatus,reviewDecision,url` reports head `410b3a456a4f814ebb797767260146b490f57f29` with `mergeStateStatus=UNSTABLE` while checks re-evaluate.
 - 2026-04-11: `fetch_comments.py` on PR #1421 confirmed `PRRT_kwDORgvdZ856Q64P` and `PRRT_kwDORgvdZ856Q64R` are the only unresolved non-outdated review threads on head `e8ffcbf31a885804f885a250b2551b179079730f`.
 - 2026-04-11: Local review fix adds a persisted merge-stage gate using `provider_success_*` plus `merge_readiness_last_evaluated_at !== provider_success_observed_at` so the first clean-check settle observation stays quiet.
 - 2026-04-11: Verification after the live-thread fix: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`; `npm run build`

--- a/.codex-supervisor/issues/1417/issue-journal.md
+++ b/.codex-supervisor/issues/1417/issue-journal.md
@@ -5,41 +5,48 @@
 - Branch: codex/issue-1417
 - Workspace: .
 - Journal: .codex-supervisor/issues/1417/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 5 (implementation=2, repair=3)
-- Last head SHA: 410b3a456a4f814ebb797767260146b490f57f29
+- Current phase: repairing_ci
+- Attempt count: 6 (implementation=2, repair=4)
+- Last head SHA: 0353ba62a7f7118bac8c3a6fe9801c92f44ea154
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T01:15:14.834Z
+- Last failure signature: build (ubuntu-latest):fail
+- Repeated failure signature count: 3
+- Updated at: 2026-04-11T01:19:42.266Z
 
 ## Latest Codex Summary
-Fetched the live PR review threads with the GitHub review-thread workflow, confirmed both unresolved CodeRabbit comments were valid on `e8ffcbf31a885804f885a250b2551b179079730f`, and fixed them in [src/post-turn-pull-request.ts#L275](src/post-turn-pull-request.ts#L275) and [src/post-turn-pull-request.ts#L316](src/post-turn-pull-request.ts#L316). Required-check mismatch signatures now use the full sorted check fingerprint while the sticky comment body stays compact, and lifecycle-mismatch / `mergeStateStatus === "BLOCKED"` comments now require a persisted merge-stage signal derived from the existing `provider_success_*` plus `merge_readiness_last_evaluated_at` fields so first-observation settle windows stay quiet.
+Repaired the failing Ubuntu CI gate for PR #1421 by removing the committed workstation-local skill-cache path from [.codex-supervisor/issues/1417/issue-journal.md](.codex-supervisor/issues/1417/issue-journal.md). The feature code from the prior turn remains unchanged; this turn only publishes the already-redacted journal content that `npm run verify:paths` requires on Linux.
 
-I added focused regressions in [src/post-turn-pull-request.test.ts#L121](src/post-turn-pull-request.test.ts#L121), [src/post-turn-pull-request.test.ts#L1919](src/post-turn-pull-request.test.ts#L1919), [src/post-turn-pull-request.test.ts#L1998](src/post-turn-pull-request.test.ts#L1998), and [src/post-turn-pull-request.test.ts#L2065](src/post-turn-pull-request.test.ts#L2065), then verified with the focused file, the broader issue test set, and `npm run build`. I committed and pushed the fix as `410b3a4`; a fresh `fetch_comments.py` run shows both targeted CodeRabbit threads are now resolved on the new head. CodeRabbit also posted a top-level rate-limit notice on the PR conversation, and `gh pr view` currently reports `mergeStateStatus=UNSTABLE` while checks settle on the pushed head.
+`gh run view 24271286569 --log-failed` showed the exact failure in `npm run verify:paths`, pointing at the tracked journal entry that still mentioned an absolute home-directory skill path on head `0353ba62a7f7118bac8c3a6fe9801c92f44ea154`. Local verification now passes with `npm run verify:paths` and `npm run build`, so the remaining step is pushing the journal-only repair and waiting for refreshed CI on the PR.
 
-Summary: Fixed the live merge-stage sticky-comment review regressions, added regression coverage, pushed `410b3a4`, and confirmed the targeted review threads resolved on the new head.
-State hint: addressing_review
+Summary: Repaired the tracked journal path that broke Ubuntu `verify:paths`; the feature code is unchanged and local verification now passes.
+State hint: repairing_ci
 Blocked reason: none
-Tests: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`; `npm run build`
-Next action: Watch PR #1421 on head `410b3a456a4f814ebb797767260146b490f57f29` for refreshed CI after the new push; review threads are resolved, so only follow up if new review feedback or failing checks appear.
-Failure signature: none
+Tests: `npm run verify:paths`; `npm run build`
+Next action: Push the journal-only repair to `codex/issue-1417`, then watch PR #1421 for refreshed CI and only re-enter if a new failure appears.
+Failure signature: build (ubuntu-latest):fail
 
 ## Active Failure Context
-- None recorded.
+- Category: checks
+- Summary: PR #1421 has failing checks.
+- Command or source: gh pr checks
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1421
+- Details:
+  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/24271286569/job/70876664664
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: CodeRabbit's two remaining review complaints were both valid on `e8ffcbf`, and the existing `provider_success_*` plus merge-readiness timestamps were sufficient to express the required persistence gate without adding new record schema.
-- What changed: Reworked `buildRequiredCheckMismatchEvidence(...)` to return a full sorted check fingerprint, used the full fingerprint for `blockerSignature` while keeping the comment body compact, added `hasPersistentTrackedPrMergeStageSignal(...)` to require a persisted merge-stage signal before lifecycle-mismatch or `BLOCKED` merge-stage comments, added focused regression coverage for first-observation suppression plus full-signature republish/reorder behavior, committed the result as `410b3a4`, and pushed `codex/issue-1417`.
+- Hypothesis: The failing Ubuntu CI job is not a code regression; `npm run verify:paths` is rejecting a committed absolute workstation path that remained in the tracked issue journal on head `0353ba62a7f7118bac8c3a6fe9801c92f44ea154`.
+- What changed: The worktree journal already redacted the recorded skill-script path to `python3 <redacted-local-path>`, which removes the forbidden absolute skill-cache reference that broke `verify:paths`; this turn is validating and publishing that journal-only repair.
 - Current blocker: none
-- Next exact step: Watch PR #1421 on head `410b3a456a4f814ebb797767260146b490f57f29` for CI completion and only take further action if new review feedback or failing checks appear.
-- Verification gap: None locally after the focused test file, the broader issue verification set, `npm run build`, and the post-push review-thread refresh; only fresh CI remains.
-- Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1417/issue-journal.md`
+- Next exact step: Push the journal-only path redaction on `codex/issue-1417`, then watch PR #1421 for the refreshed CI result and only re-enter if a new failure appears.
+- Verification gap: Fresh remote CI is still needed after the journal-only repair is pushed.
+- Files touched: `.codex-supervisor/issues/1417/issue-journal.md`
 - Rollback concern: The implementation reuses `last_host_local_pr_blocker_comment_*` dedupe fields for broader sticky-status comments, so reverting should restore the older draft/host-local-only publication behavior if comment churn appears.
-- Last focused command: `python3 /home/tommy/.codex/plugins/cache/openai-curated/github/fb0a18376bcd9f2604047fbe7459ec5aed70c64b/skills/gh-address-comments/scripts/fetch_comments.py`
+- Last focused command: `gh run view 24271286569 --log-failed`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-11: `gh run view 24271286569 --log-failed` shows Ubuntu CI failed in `npm run verify:paths` because `.codex-supervisor/issues/1417/issue-journal.md` still contained an absolute skill-cache script path on the committed PR head.
+- 2026-04-11: Local `npm run verify:paths` passes once the journal uses `python3 <redacted-local-path>` instead of the absolute workstation path.
 - 2026-04-11: After pushing `410b3a4`, `fetch_comments.py` showed `PRRT_kwDORgvdZ856Q64P` outdated/resolved and `PRRT_kwDORgvdZ856Q64R` resolved on the new head; no unresolved review threads remain.
 - 2026-04-11: `gh pr view 1421 --json headRefOid,mergeStateStatus,reviewDecision,url` reports head `410b3a456a4f814ebb797767260146b490f57f29` with `mergeStateStatus=UNSTABLE` while checks re-evaluate.
 - 2026-04-11: `fetch_comments.py` on PR #1421 confirmed `PRRT_kwDORgvdZ856Q64P` and `PRRT_kwDORgvdZ856Q64R` are the only unresolved non-outdated review threads on head `e8ffcbf31a885804f885a250b2551b179079730f`.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1832,6 +1832,159 @@ test("handlePostTurnPullRequestTransitionsPhase updates the sticky tracked PR st
   assert.match(updateCalls[0]?.body ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays blocked on persistent manual review near merge", async () => {
+  const config = createConfig({
+    humanReviewBlocksMerge: true,
+  });
+  const issue = createIssue({ title: "Comment on persistent tracked PR manual-review blockers" });
+  const pr = createPullRequest({
+    title: "Tracked PR manual-review blocker",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "CLEAN",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "pr_open",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+  const manualReviewFailureContext = {
+    ...createFailureContext("1 unresolved manual or unconfigured review thread(s) require human attention."),
+    signature: "manual:thread-1",
+    details: [
+      "src/review.ts:42 reviewer=human-reviewer summary=Please verify this behavior in a live environment. url=https://example.test/review/1",
+    ],
+    url: "https://example.test/review/1",
+  };
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "blocked", {
+        failureContext: manualReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => "manual_review",
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "manual_review");
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `manual_review`/i);
+  assert.match(commentBodies[0] ?? "", /require human attention/i);
+  assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase comments when merge readiness stays blocked after checks pass", async () => {
+  const config = createConfig();
+  const issue = createIssue({ title: "Comment on persistent tracked PR merge-readiness mismatches" });
+  const pr = createPullRequest({
+    title: "Tracked PR merge-readiness blocker",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "pr_open", {
+        failureContext: null,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "pr_open");
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `required_check_mismatch`/i);
+  assert.match(commentBodies[0] ?? "", /merge_state=BLOCKED/i);
+  assert.match(commentBodies[0] ?? "", /Inspect required checks and branch protection/i);
+  assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-issue journals before ready promotion", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -436,7 +436,7 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
   assert.equal(readyCalls, 1);
   assert.equal(localCiCalls, 1);
   assert.equal(snapshotLoads, 2);
-  assert.equal(syncJournalCalls, 1);
+  assert.equal(syncJournalCalls, 2);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when configured local CI fails", async () => {
@@ -1983,6 +1983,168 @@ test("handlePostTurnPullRequestTransitionsPhase comments when merge readiness st
   assert.match(commentBodies[0] ?? "", /merge_state=BLOCKED/i);
   assert.match(commentBodies[0] ?? "", /Inspect required checks and branch protection/i);
   assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase republishes merge-readiness blocker comment when required-check evidence changes on the same head", async () => {
+  const config = createConfig();
+  const issue = createIssue({ title: "Refresh merge-readiness blocker comment when required checks change" });
+  const pr = createPullRequest({
+    title: "Tracked PR merge-readiness blocker",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const commentBodies: string[] = [];
+
+  const runScenario = async (state: SupervisorStateFile, checks: PullRequestCheck[]) =>
+    handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (_prNumber: number, body: string) => {
+          commentBodies.push(body);
+        },
+      }),
+      context: createPostTurnContext({
+        state,
+        record: state.issues["102"]!,
+        issue,
+        pr,
+        workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      }),
+      derivePullRequestLifecycleSnapshot: (recordForState) =>
+        createLifecycleSnapshot(recordForState, "pr_open", {
+          failureContext: null,
+        }),
+      applyFailureSignature: (_record, failureContext) => ({
+        last_failure_signature: failureContext?.signature ?? null,
+        repeated_failure_signature_count: failureContext ? 1 : 0,
+      }),
+      blockedReasonFromReviewState: () => null,
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+      runLocalCiCommand: async () => undefined,
+      runWorkstationLocalPathGate: async () => ({
+        ok: true,
+        failureContext: null,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks,
+        reviewThreads: [] satisfies ReviewThread[],
+      }),
+    });
+
+  const firstState: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const firstChecks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const firstResult = await runScenario(firstState, firstChecks);
+
+  const secondState: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": firstResult.record,
+    },
+  };
+  const secondChecks: PullRequestCheck[] = [{ name: "lint", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const secondResult = await runScenario(secondState, secondChecks);
+
+  assert.equal(commentBodies.length, 2);
+  assert.notEqual(
+    firstResult.record.last_host_local_pr_blocker_comment_signature,
+    secondResult.record.last_host_local_pr_blocker_comment_signature,
+  );
+  assert.match(commentBodies[0] ?? "", /check=build:pass:SUCCESS/);
+  assert.match(commentBodies[1] ?? "", /check=lint:pass:SUCCESS/);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase syncs the journal even when persistent status commenting is skipped", async () => {
+  const config = createConfig();
+  const issue = createIssue({ title: "Sync journal before persistent status comment no-op" });
+  const pr = createPullRequest({
+    title: "Tracked PR without persistent blocker comment",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: "old-head",
+      }),
+    },
+  };
+
+  let saveCalls = 0;
+  let syncJournalCalls = 0;
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    github: createDefaultGithub(),
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => {
+        syncJournalCalls += 1;
+      },
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "pr_open", {
+        failureContext: null,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "pr_open");
+  assert.equal(saveCalls, 1);
+  assert.equal(syncJournalCalls, 1);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-issue journals before ready promotion", async (t) => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -130,6 +130,22 @@ function summarizeChecks(checks: PullRequestCheck[]) {
   };
 }
 
+function createPersistentMergeStagePatch(headSha: string) {
+  return {
+    provider_success_observed_at: "2026-04-11T00:00:00.000Z",
+    provider_success_head_sha: headSha,
+    merge_readiness_last_evaluated_at: "2026-04-11T00:05:00.000Z",
+  };
+}
+
+function createInitialMergeStageObservationPatch(headSha: string) {
+  return {
+    provider_success_observed_at: "2026-04-11T00:00:00.000Z",
+    provider_success_head_sha: headSha,
+    merge_readiness_last_evaluated_at: "2026-04-11T00:00:00.000Z",
+  };
+}
+
 function createPostTurnContext({
   issue,
   pr,
@@ -1955,6 +1971,7 @@ test("handlePostTurnPullRequestTransitionsPhase comments when merge readiness st
     derivePullRequestLifecycleSnapshot: (recordForState) =>
       createLifecycleSnapshot(recordForState, "pr_open", {
         failureContext: null,
+        mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(pr.headRefOid),
       }),
     applyFailureSignature: (_record, failureContext) => ({
       last_failure_signature: failureContext?.signature ?? null,
@@ -1985,7 +2002,76 @@ test("handlePostTurnPullRequestTransitionsPhase comments when merge readiness st
   assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
 });
 
-test("handlePostTurnPullRequestTransitionsPhase republishes merge-readiness blocker comment when required-check evidence changes on the same head", async () => {
+test("handlePostTurnPullRequestTransitionsPhase skips merge-stage sticky comments on the first clean-check observation", async () => {
+  const config = createConfig();
+  const issue = createIssue({ title: "Suppress first-observation merge-stage blocker comment" });
+  const pr = createPullRequest({
+    title: "Tracked PR merge-readiness blocker",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "pr_open", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: createInitialMergeStageObservationPatch(pr.headRefOid),
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "pr_open");
+  assert.equal(commentBodies.length, 0);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase republishes merge-readiness blocker comment when full required-check evidence changes on the same head", async () => {
   const config = createConfig();
   const issue = createIssue({ title: "Refresh merge-readiness blocker comment when required checks change" });
   const pr = createPullRequest({
@@ -2017,6 +2103,7 @@ test("handlePostTurnPullRequestTransitionsPhase republishes merge-readiness bloc
       derivePullRequestLifecycleSnapshot: (recordForState) =>
         createLifecycleSnapshot(recordForState, "pr_open", {
           failureContext: null,
+          mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(pr.headRefOid),
         }),
       applyFailureSignature: (_record, failureContext) => ({
         last_failure_signature: failureContext?.signature ?? null,
@@ -2047,10 +2134,15 @@ test("handlePostTurnPullRequestTransitionsPhase republishes merge-readiness bloc
         state: "waiting_ci",
         pr_number: pr.number,
         last_head_sha: pr.headRefOid,
+        ...createPersistentMergeStagePatch(pr.headRefOid),
       }),
     },
   };
-  const firstChecks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const firstChecks: PullRequestCheck[] = [
+    { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "lint", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "unit", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+  ];
   const firstResult = await runScenario(firstState, firstChecks);
 
   const secondState: SupervisorStateFile = {
@@ -2059,16 +2151,41 @@ test("handlePostTurnPullRequestTransitionsPhase republishes merge-readiness bloc
       "102": firstResult.record,
     },
   };
-  const secondChecks: PullRequestCheck[] = [{ name: "lint", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const secondChecks: PullRequestCheck[] = [
+    { name: "unit", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "typecheck", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+  ];
   const secondResult = await runScenario(secondState, secondChecks);
+
+  const thirdState: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": secondResult.record,
+    },
+  };
+  const thirdChecks: PullRequestCheck[] = [
+    { name: "typecheck", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    { name: "unit", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+  ];
+  const thirdResult = await runScenario(thirdState, thirdChecks);
 
   assert.equal(commentBodies.length, 2);
   assert.notEqual(
     firstResult.record.last_host_local_pr_blocker_comment_signature,
     secondResult.record.last_host_local_pr_blocker_comment_signature,
   );
+  assert.equal(
+    secondResult.record.last_host_local_pr_blocker_comment_signature,
+    thirdResult.record.last_host_local_pr_blocker_comment_signature,
+  );
   assert.match(commentBodies[0] ?? "", /check=build:pass:SUCCESS/);
-  assert.match(commentBodies[1] ?? "", /check=lint:pass:SUCCESS/);
+  assert.match(commentBodies[0] ?? "", /check=lint:pass:SUCCESS/);
+  assert.doesNotMatch(commentBodies[0] ?? "", /check=unit:pass:SUCCESS/);
+  assert.match(commentBodies[1] ?? "", /check=build:pass:SUCCESS/);
+  assert.match(commentBodies[1] ?? "", /check=typecheck:pass:SUCCESS/);
+  assert.doesNotMatch(commentBodies[1] ?? "", /check=unit:pass:SUCCESS/);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase syncs the journal even when persistent status commenting is skipped", async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -272,6 +272,17 @@ function buildTrackedPrPersistentStatusComment(args: {
   ].join("\n");
 }
 
+function buildRequiredCheckMismatchEvidence(args: {
+  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable">;
+  checks: PullRequestCheck[];
+}): string[] {
+  return [
+    `merge_state=${args.pr.mergeStateStatus}`,
+    `mergeable=${args.pr.mergeable ?? "unknown"}`,
+    ...args.checks.map((check) => `check=${check.name}:${check.bucket}:${check.state}`),
+  ].slice(0, 4);
+}
+
 function derivePersistentTrackedPrStatusComment(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -329,18 +340,18 @@ function derivePersistentTrackedPrStatusComment(args: {
   }
 
   if (args.pr.mergeStateStatus === "BLOCKED") {
+    const evidence = buildRequiredCheckMismatchEvidence({
+      pr: args.pr,
+      checks: args.checks,
+    });
     return {
-      blockerSignature: `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}`,
+      blockerSignature: `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}:${evidence.join("|")}`,
       body: buildTrackedPrPersistentStatusComment({
         pr: args.pr,
         reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH,
         summary:
           "GitHub is not merge-ready even though the tracked PR has no failing or pending checks on the current head.",
-        evidence: [
-          `merge_state=${args.pr.mergeStateStatus}`,
-          `mergeable=${args.pr.mergeable ?? "unknown"}`,
-          ...args.checks.map((check) => `check=${check.name}:${check.bucket}:${check.state}`),
-        ].slice(0, 4),
+        evidence,
         nextAction:
           "Inspect required checks and branch protection for this PR, then rerun the supervisor after GitHub reports the PR as merge-ready.",
         automaticRetry: "no",
@@ -1250,6 +1261,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   });
   state.issues[String(record.issue_number)] = record;
   await stateStore.save(state);
+  await syncJournal(record);
   record = await maybeCommentOnTrackedPrPersistentStatus({
     github,
     stateStore,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -43,6 +43,7 @@ import {
   maybeBuildReviewWaitChangedEvent,
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
+import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
 import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
 import { parseIssueMetadata } from "./issue-metadata";
 import { commitAndPushTrackedFiles, getWorkspaceStatus } from "./core/workspace";
@@ -95,6 +96,10 @@ type HostLocalTrackedPrBlockerGateType =
 const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
 const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MERGEABILITY_MISMATCH = "mergeability_mismatch";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
 
 type TrackedPrStatusCommentKind = "status" | "host-local-blocker";
 
@@ -236,6 +241,115 @@ function buildTrackedPrDraftReviewSuppressedComment(args: {
     "",
     "GitHub checks may still be pending because external review-provider work does not start while the PR remains draft.",
   ].join("\n");
+}
+
+function compactEvidenceLines(details: string[] | null | undefined, limit = 3): string[] {
+  if (!details || details.length === 0) {
+    return [];
+  }
+
+  return details
+    .map((detail) => detail.replace(/\s+/g, " ").trim())
+    .filter((detail) => detail.length > 0)
+    .slice(0, limit);
+}
+
+function buildTrackedPrPersistentStatusComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
+  reasonCode: string;
+  summary: string;
+  evidence: string[];
+  nextAction: string;
+  automaticRetry: "yes" | "no";
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` remains stopped near merge.`,
+    "",
+    `- reason code: \`${args.reasonCode}\``,
+    `- summary: ${args.summary}`,
+    ...args.evidence.map((detail) => `- evidence: ${detail}`),
+    `- automatic retry: ${args.automaticRetry}`,
+    `- next action: ${args.nextAction}`,
+  ].join("\n");
+}
+
+function derivePersistentTrackedPrStatusComment(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  failureContext: FailureContext | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+}): { blockerSignature: string; body: string } | null {
+  if (args.pr.isDraft) {
+    return null;
+  }
+
+  const checkSummary = args.summarizeChecks(args.checks);
+  if (checkSummary.hasPending || checkSummary.hasFailing) {
+    return null;
+  }
+
+  if (args.record.state === "blocked" && args.record.blocked_reason === "manual_review") {
+    const summary =
+      args.failureContext?.summary ?? "Unresolved manual or unconfigured review feedback still requires human attention.";
+    return {
+      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
+        summary,
+        evidence: compactEvidenceLines(args.failureContext?.details),
+        nextAction:
+          "Resolve the remaining manual review blocker or complete the required manual verification, then rerun the supervisor.",
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  const mismatch = buildTrackedPrMismatch(
+    args.config,
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+  );
+  if (mismatch) {
+    return {
+      blockerSignature: mismatch.summaryLine,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH,
+        summary: mismatch.summaryLine,
+        evidence: mismatch.detailLines,
+        nextAction: mismatch.guidanceLine.replace(/^recovery_guidance=/, ""),
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  if (args.pr.mergeStateStatus === "BLOCKED") {
+    return {
+      blockerSignature: `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}`,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH,
+        summary:
+          "GitHub is not merge-ready even though the tracked PR has no failing or pending checks on the current head.",
+        evidence: [
+          `merge_state=${args.pr.mergeStateStatus}`,
+          `mergeable=${args.pr.mergeable ?? "unknown"}`,
+          ...args.checks.map((check) => `check=${check.name}:${check.bucket}:${check.state}`),
+        ].slice(0, 4),
+        nextAction:
+          "Inspect required checks and branch protection for this PR, then rerun the supervisor after GitHub reports the PR as merge-ready.",
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  return null;
 }
 
 function buildTrackedPrStatusCommentMarker(args: {
@@ -411,6 +525,69 @@ async function maybeCommentOnTrackedPrDraftReviewSuppressed(args: {
   const updatedRecord = args.stateStore.touch(args.record, {
     last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
     last_host_local_pr_blocker_comment_signature: blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+async function maybeCommentOnTrackedPrPersistentStatus(args: {
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  syncJournal: IssueJournalSync;
+  config: SupervisorConfig;
+  failureContext: FailureContext | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+}): Promise<IssueRunRecord> {
+  if (!args.github.addIssueComment) {
+    return args.record;
+  }
+
+  const comment = derivePersistentTrackedPrStatusComment({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+    failureContext: args.failureContext,
+    summarizeChecks: args.summarizeChecks,
+  });
+  if (!comment) {
+    return args.record;
+  }
+
+  if (
+    args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+    && args.record.last_host_local_pr_blocker_comment_signature === comment.blockerSignature
+  ) {
+    return args.record;
+  }
+
+  try {
+    await publishTrackedPrStatusComment({
+      github: args.github,
+      issueNumber: args.record.issue_number,
+      pr: args.pr,
+      kind: "status",
+      body: comment.body,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to publish tracked PR merge-stage status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return args.record;
+  }
+
+  const updatedRecord = args.stateStore.touch(args.record, {
+    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: comment.blockerSignature,
   });
   args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
   await args.stateStore.save(args.state);
@@ -1074,6 +1251,19 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   });
   state.issues[String(record.issue_number)] = record;
   await stateStore.save(state);
+  record = await maybeCommentOnTrackedPrPersistentStatus({
+    github,
+    stateStore,
+    state,
+    record,
+    pr: postReady.pr,
+    checks: postReady.checks,
+    reviewThreads: postReady.reviewThreads,
+    syncJournal,
+    config,
+    failureContext: effectiveFailureContext,
+    summarizeChecks: args.summarizeChecks,
+  });
   if (
     record.state === "draft_pr"
     && reviewBotDiagnostics(

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -276,11 +276,27 @@ function buildRequiredCheckMismatchEvidence(args: {
   pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable">;
   checks: PullRequestCheck[];
 }): string[] {
+  const sortedChecks = [...args.checks]
+    .map((check) => `check=${check.name}:${check.bucket}:${check.state}`)
+    .sort();
+
   return [
     `merge_state=${args.pr.mergeStateStatus}`,
     `mergeable=${args.pr.mergeable ?? "unknown"}`,
-    ...args.checks.map((check) => `check=${check.name}:${check.bucket}:${check.state}`),
-  ].slice(0, 4);
+    ...sortedChecks,
+  ];
+}
+
+function hasPersistentTrackedPrMergeStageSignal(args: {
+  record: Pick<IssueRunRecord, "merge_readiness_last_evaluated_at" | "provider_success_head_sha" | "provider_success_observed_at">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+}): boolean {
+  return Boolean(
+    args.record.provider_success_observed_at &&
+      args.record.merge_readiness_last_evaluated_at &&
+      args.record.provider_success_head_sha === args.pr.headRefOid &&
+      args.record.merge_readiness_last_evaluated_at !== args.record.provider_success_observed_at,
+  );
 }
 
 function derivePersistentTrackedPrStatusComment(args: {
@@ -318,6 +334,10 @@ function derivePersistentTrackedPrStatusComment(args: {
     };
   }
 
+  if (!hasPersistentTrackedPrMergeStageSignal({ record: args.record, pr: args.pr })) {
+    return null;
+  }
+
   const mismatch = buildTrackedPrMismatch(
     args.config,
     args.record,
@@ -340,12 +360,14 @@ function derivePersistentTrackedPrStatusComment(args: {
   }
 
   if (args.pr.mergeStateStatus === "BLOCKED") {
-    const evidence = buildRequiredCheckMismatchEvidence({
+    const fullEvidence = buildRequiredCheckMismatchEvidence({
       pr: args.pr,
       checks: args.checks,
     });
+    const evidence = fullEvidence.slice(0, 4);
     return {
-      blockerSignature: `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}:${evidence.join("|")}`,
+      blockerSignature:
+        `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}:${fullEvidence.join("|")}`,
       body: buildTrackedPrPersistentStatusComment({
         pr: args.pr,
         reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -98,7 +98,6 @@ const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-sta
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MERGEABILITY_MISMATCH = "mergeability_mismatch";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
 
 type TrackedPrStatusCommentKind = "status" | "host-local-blocker";


### PR DESCRIPTION
## Summary
- extend the supervisor-owned sticky tracked-PR `kind=status` comment path beyond draft-only blockers
- publish or update the same sticky comment when a tracked PR stays blocked near merge on persistent manual review, mergeability mismatch, required-check mismatch, or tracked lifecycle mismatch
- reuse existing diagnostics and failure-context evidence so the PR timeline carries the same operator-facing reason and next action without inventing parallel wording

## Why
Persistent merge-stage blockers were visible in local status and doctor output, but they were not mirrored onto the tracked PR timeline. That left operators without a durable PR-side explanation when the supervisor stopped making forward progress near merge.

## Validation
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts`
- `npm run build`

Closes #1417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic sticky tracked-PR status comments for persistent merge-stage blockers (manual-review and merge-readiness mismatches), with deduplication and guidance; subsequent evidence changes may post updated blocker comments.

* **Tests**
  * Added tests verifying single persistent status comment for blocked scenarios, updated-comment behavior when evidence changes, and journal sync calls.

* **Documentation**
  * Added a supervisor issue journal entry documenting tracking metadata, failure context, and working notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->