### PR TITLE
[codex] Update sticky tracked PR status comment clears

### DIFF
--- a/.codex-supervisor/issues/1418/issue-journal.md
+++ b/.codex-supervisor/issues/1418/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1418: Update sticky tracked-PR status comments on blocker changes and clear them without churn
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1418
+- Branch: codex/issue-1418
+- Workspace: .
+- Journal: .codex-supervisor/issues/1418/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 75e102541398b89a5fa82857270e066c9fbb4931
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T01:28:53.481Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Sticky tracked-PR status comments deduped repeated blocker fingerprints, but there was no same-comment update path when a previously published persistent blocker cleared on the same head.
+- What changed: Added cleared-status publishing for active tracked-PR states in `handlePostTurnPullRequestTransitionsPhase`, keyed by a stable `cleared:<state>` fingerprint so the existing sticky comment updates once on recovery without repeat churn. Added focused tests for clear-on-recovery and no-churn on repeated identical cycles.
+- Current blocker: none
+- Next exact step: Commit the focused implementation and test changes on `codex/issue-1418`.
+- Verification gap: none for the scoped change; targeted suite and issue-listed verification command are green locally.
+- Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1418/issue-journal.md`
+- Rollback concern: Low; behavior only changes when a sticky tracked-PR status comment already exists on the current head and the PR resumes an active state.
+- Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1418/issue-journal.md
+++ b/.codex-supervisor/issues/1418/issue-journal.md
@@ -5,16 +5,25 @@
 - Branch: codex/issue-1418
 - Workspace: .
 - Journal: .codex-supervisor/issues/1418/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 75e102541398b89a5fa82857270e066c9fbb4931
+- Current phase: stabilizing
+- Attempt count: 2 (implementation=2, repair=0)
+- Last head SHA: 8a78ffab8c36a33d7a507f155112027f6a7992ae
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-11T01:28:53.481Z
+- Updated at: 2026-04-11T01:39:40.000Z
 
 ## Latest Codex Summary
-- None yet.
+Updated the tracked-PR sticky status flow in [src/post-turn-pull-request.ts](src/post-turn-pull-request.ts) so a previously published persistent blocker comment is updated once when the blocker clears and the PR resumes an active state. The clear path stores a `cleared:<state>` fingerprint on the current head, so repeated identical cycles do not churn the same comment. Draft suppression stays on its existing dedicated comment path.
+
+Added focused coverage in [src/post-turn-pull-request.test.ts](src/post-turn-pull-request.test.ts) for both behaviors: updating the existing sticky comment when a persistent blocker clears, and not rewriting it again on the next identical cycle. I reran the issue verification commands, pushed `8a78ffa` to `origin/codex/issue-1418`, and opened draft PR [#1423](https://github.com/TommyKammy/codex-supervisor/pull/1423).
+
+Summary: Sticky tracked-PR status comments now update on blocker clear and dedupe repeated cleared-state cycles.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts`; `npm run build`; `git push -u origin codex/issue-1418`
+Next action: Monitor draft PR #1423 and respond to CI or review feedback if it appears.
+Failure signature: none
 
 ## Active Failure Context
 - None recorded.
@@ -22,12 +31,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: Sticky tracked-PR status comments deduped repeated blocker fingerprints, but there was no same-comment update path when a previously published persistent blocker cleared on the same head.
-- What changed: Added cleared-status publishing for active tracked-PR states in `handlePostTurnPullRequestTransitionsPhase`, keyed by a stable `cleared:<state>` fingerprint so the existing sticky comment updates once on recovery without repeat churn. Added focused tests for clear-on-recovery and no-churn on repeated identical cycles.
+- What changed: Added cleared-status publishing for active tracked-PR states in `handlePostTurnPullRequestTransitionsPhase`, keyed by a stable `cleared:<state>` fingerprint so the existing sticky comment updates once on recovery without repeat churn. Added focused tests for clear-on-recovery and no-churn on repeated identical cycles. Pushed the branch and opened draft PR `#1423`.
 - Current blocker: none
-- Next exact step: Commit the focused implementation and test changes on `codex/issue-1418`.
+- Next exact step: Watch PR `#1423` for CI and review feedback; address any failures on `codex/issue-1418`.
 - Verification gap: none for the scoped change; targeted suite and issue-listed verification command are green locally.
 - Files touched: `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`, `.codex-supervisor/issues/1418/issue-journal.md`
 - Rollback concern: Low; behavior only changes when a sticky tracked-PR status comment already exists on the current head and the PR resumes an active state.
-- Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts`
+- Last focused command: `gh pr create --draft --base main --head codex/issue-1418 --title '[codex] Update sticky tracked PR status comment clears' --body-file <tempfile>`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2264,6 +2264,230 @@ test("handlePostTurnPullRequestTransitionsPhase syncs the journal even when pers
   assert.equal(syncJournalCalls, 1);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase updates the sticky tracked PR status comment when a persistent blocker clears", async () => {
+  const config = createConfig();
+  const issue = createIssue({ title: "Clear tracked PR sticky status comment when progress resumes" });
+  const pr = createPullRequest({
+    title: "Tracked PR blocker clears",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        provider_success_observed_at: "2026-04-11T00:00:00.000Z",
+        provider_success_head_sha: pr.headRefOid,
+        merge_readiness_last_evaluated_at: "2026-04-11T00:05:00.000Z",
+        last_host_local_pr_blocker_comment_head_sha: pr.headRefOid,
+        last_host_local_pr_blocker_comment_signature:
+          "merge-state:BLOCKED:MERGEABLE:merge_state=BLOCKED|mergeable=MERGEABLE|check=build:pass:SUCCESS",
+      }),
+    },
+  };
+  const updateCalls: Array<{ commentId: number; body: string }> = [];
+  let addCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => {
+        addCalls += 1;
+      },
+      getExternalReviewSurface: async () => ({
+        reviews: [],
+        issueComments: [
+          {
+            id: "comment-42",
+            databaseId: 42,
+            body: [
+              "Tracked PR head `head-116` remains stopped near merge.",
+              "",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+            ].join("\n"),
+            createdAt: "2026-04-11T00:06:00.000Z",
+            url: "https://example.test/comments/42",
+            viewerDidAuthor: true,
+            author: {
+              login: "codex-supervisor[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      }),
+      updateIssueComment: async (commentId: number, body: string) => {
+        updateCalls.push({ commentId, body });
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "ready_to_merge", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: {
+          provider_success_observed_at: "2026-04-11T00:00:00.000Z",
+          provider_success_head_sha: pr.headRefOid,
+          merge_readiness_last_evaluated_at: "2026-04-11T00:10:00.000Z",
+        },
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "ready_to_merge");
+  assert.equal(addCalls, 0);
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0]?.commentId, 42);
+  assert.match(updateCalls[0]?.body ?? "", /blocker cleared/i);
+  assert.match(updateCalls[0]?.body ?? "", /ready_to_merge/i);
+  assert.match(updateCalls[0]?.body ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase does not churn cleared sticky tracked PR status comments on repeated identical cycles", async () => {
+  const config = createConfig();
+  const issue = createIssue({ title: "Do not churn cleared tracked PR sticky status comments" });
+  const pr = createPullRequest({
+    title: "Tracked PR blocker stays cleared",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const updateCalls: Array<{ commentId: number; body: string }> = [];
+
+  const runScenario = async (state: SupervisorStateFile) =>
+    handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async () => {
+          throw new Error("unexpected addIssueComment call");
+        },
+        getExternalReviewSurface: async () => ({
+          reviews: [],
+          issueComments: [
+            {
+              id: "comment-42",
+              databaseId: 42,
+              body: [
+                "Tracked PR head `head-116` remains stopped near merge.",
+                "",
+                "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+              ].join("\n"),
+              createdAt: "2026-04-11T00:06:00.000Z",
+              url: "https://example.test/comments/42",
+              viewerDidAuthor: true,
+              author: {
+                login: "codex-supervisor[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        }),
+        updateIssueComment: async (commentId: number, body: string) => {
+          updateCalls.push({ commentId, body });
+        },
+      }),
+      context: createPostTurnContext({
+        state,
+        record: state.issues["102"]!,
+        issue,
+        pr,
+        workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      }),
+      derivePullRequestLifecycleSnapshot: (recordForState) =>
+        createLifecycleSnapshot(recordForState, "ready_to_merge", {
+          failureContext: null,
+          mergeLatencyVisibilityPatch: {
+            provider_success_observed_at: "2026-04-11T00:00:00.000Z",
+            provider_success_head_sha: pr.headRefOid,
+            merge_readiness_last_evaluated_at: "2026-04-11T00:10:00.000Z",
+          },
+        }),
+      applyFailureSignature: (_record, failureContext) => ({
+        last_failure_signature: failureContext?.signature ?? null,
+        repeated_failure_signature_count: failureContext ? 1 : 0,
+      }),
+      blockedReasonFromReviewState: () => null,
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+      runLocalCiCommand: async () => undefined,
+      runWorkstationLocalPathGate: async () => ({
+        ok: true,
+        failureContext: null,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [] satisfies ReviewThread[],
+      }),
+    });
+
+  const firstState: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        provider_success_observed_at: "2026-04-11T00:00:00.000Z",
+        provider_success_head_sha: pr.headRefOid,
+        merge_readiness_last_evaluated_at: "2026-04-11T00:05:00.000Z",
+        last_host_local_pr_blocker_comment_head_sha: pr.headRefOid,
+        last_host_local_pr_blocker_comment_signature:
+          "merge-state:BLOCKED:MERGEABLE:merge_state=BLOCKED|mergeable=MERGEABLE|check=build:pass:SUCCESS",
+      }),
+    },
+  };
+
+  const firstResult = await runScenario(firstState);
+  const secondState: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": firstResult.record,
+    },
+  };
+  const secondResult = await runScenario(secondState);
+
+  assert.equal(firstResult.record.last_host_local_pr_blocker_comment_signature, "cleared:ready_to_merge");
+  assert.equal(secondResult.record.last_host_local_pr_blocker_comment_signature, "cleared:ready_to_merge");
+  assert.equal(updateCalls.length, 1);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-issue journals before ready promotion", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -99,6 +99,7 @@ const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
 
 type TrackedPrStatusCommentKind = "status" | "host-local-blocker";
 
@@ -269,6 +270,37 @@ function buildTrackedPrPersistentStatusComment(args: {
     ...args.evidence.map((detail) => `- evidence: ${detail}`),
     `- automatic retry: ${args.automaticRetry}`,
     `- next action: ${args.nextAction}`,
+  ].join("\n");
+}
+
+function isTrackedPrActiveStatusState(state: RunState): boolean {
+  switch (state) {
+    case "local_review":
+    case "local_review_fix":
+    case "stabilizing":
+    case "pr_open":
+    case "repairing_ci":
+    case "resolving_conflict":
+    case "waiting_ci":
+    case "addressing_review":
+    case "ready_to_merge":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function buildTrackedPrClearedStatusComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
+  state: RunState;
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` blocker cleared; progress has resumed.`,
+    "",
+    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED}\``,
+    `- current supervisor state: \`${args.state}\``,
+    "- automatic retry: yes",
+    `- next action: continue the tracked PR workflow for PR #${args.pr.number} from the current active state.`,
   ].join("\n");
 }
 
@@ -591,7 +623,45 @@ async function maybeCommentOnTrackedPrPersistentStatus(args: {
     summarizeChecks: args.summarizeChecks,
   });
   if (!comment) {
-    return args.record;
+    const previouslyPublishedCommentOnCurrentHead =
+      args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+      && args.record.last_host_local_pr_blocker_comment_signature != null;
+    if (!previouslyPublishedCommentOnCurrentHead || !isTrackedPrActiveStatusState(args.record.state)) {
+      return args.record;
+    }
+
+    const blockerSignature = `${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED}:${args.record.state}`;
+    if (args.record.last_host_local_pr_blocker_comment_signature === blockerSignature) {
+      return args.record;
+    }
+
+    try {
+      await publishTrackedPrStatusComment({
+        github: args.github,
+        issueNumber: args.record.issue_number,
+        pr: args.pr,
+        kind: "status",
+        body: buildTrackedPrClearedStatusComment({
+          pr: args.pr,
+          state: args.record.state,
+        }),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `Failed to publish cleared tracked PR status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+      );
+      return args.record;
+    }
+
+    const updatedRecord = args.stateStore.touch(args.record, {
+      last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+      last_host_local_pr_blocker_comment_signature: blockerSignature,
+    });
+    args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(updatedRecord);
+    return updatedRecord;
   }
 
   if (


### PR DESCRIPTION
## Summary
- update the supervisor-owned sticky tracked-PR status comment when a previously published persistent blocker clears and the PR resumes an active state
- store a stable `cleared:<state>` fingerprint on the current head so repeated identical recovery cycles do not rewrite the same comment
- add focused coverage for blocker-clear updates and no-churn repeated cycles

## Why
Persistent blocker comments were already deduplicated for repeated blocker fingerprints, but the same sticky comment was not updated when the blocker cleared on the same head. That left stale operator-facing PR context behind after progress resumed.

## Impact
Tracked PR status comments now stay current across both blocker changes and blocker clear events without creating timeline churn for transient retries or repeated identical cycles.

## Verification
- `npx tsx --test src/post-turn-pull-request.test.ts src/recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated PR status comment handling: when blockers clear, existing comments are now updated instead of creating duplicates, with tracking to prevent unnecessary updates across repeated cycles.

* **Tests**
  * Added test coverage for PR status comment updates when blockers clear and to verify no redundant comments are posted on identical repeated scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->