### PR TITLE
[codex] Do not mark open failed no-PR issues done based only on zero branch diff

### DIFF
--- a/src/recovery-no-pr-reconciliation.ts
+++ b/src/recovery-no-pr-reconciliation.ts
@@ -7,7 +7,6 @@ import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
 import {
   buildFailedNoPrBranchFailureContext,
   classifyFailedNoPrBranchRecovery,
-  doneResetPatch,
   shouldAutoRecoverFailedNoPr,
 } from "./recovery-support";
 import { STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE } from "./no-pull-request-state";
@@ -60,43 +59,33 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     isSafeCleanupTarget,
   });
   if (branchRecovery.state !== "recoverable") {
-    const shouldMarkAlreadySatisfiedOnMain = branchRecovery.state === "already_satisfied_on_main";
+    const branchRecoveryReason = branchRecovery.state === "already_satisfied_on_main"
+      ? `failed_no_pr_manual_review: blocked issue #${record.issue_number} after failed no-PR recovery found an open issue with no authoritative completion signal`
+      : `failed_no_pr_manual_review: blocked issue #${record.issue_number} after failed no-PR recovery found an unsafe or ambiguous workspace state`;
     const recoveryEvent = buildRecoveryEvent(
       record.issue_number,
-      shouldMarkAlreadySatisfiedOnMain
-        ? branchRecovery.headSha === record.last_head_sha
-          ? `already_satisfied_on_main: marked issue #${record.issue_number} done after failed no-PR recovery found no meaningful branch changes`
-          : `already_satisfied_on_main: marked issue #${record.issue_number} done after failed no-PR recovery found only supervisor-owned branch divergence`
-        : `failed_no_pr_manual_review: blocked issue #${record.issue_number} after failed no-PR recovery found an unsafe or ambiguous workspace state`,
+      branchRecoveryReason,
     );
-    const patch: Partial<IssueRunRecord> = shouldMarkAlreadySatisfiedOnMain
-      ? doneResetPatch({
-          pr_number: null,
-          codex_session_id: null,
-          last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
-        })
-      : (() => {
-          const manualReviewFailureContext = buildFailedNoPrBranchFailureContext({
-            record,
-            branchRecoveryState: branchRecovery.state,
-            headSha: branchRecovery.headSha,
-            defaultBranch: config.defaultBranch,
-          });
-          return {
-            state: "blocked",
-            pr_number: null,
-            codex_session_id: null,
-            blocked_reason: "manual_review",
-            last_error: truncate(manualReviewFailureContext.summary, 1000),
-            last_failure_kind: null,
-            last_failure_context: manualReviewFailureContext,
-            last_blocker_signature: null,
-            repeated_blocker_count: 0,
-            stale_stabilizing_no_pr_recovery_count: 0,
-            last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
-            ...applyFailureSignature(record, manualReviewFailureContext),
-          };
-        })();
+    const manualReviewFailureContext = buildFailedNoPrBranchFailureContext({
+      record,
+      branchRecoveryState: branchRecovery.state,
+      headSha: branchRecovery.headSha,
+      defaultBranch: config.defaultBranch,
+    });
+    const patch: Partial<IssueRunRecord> = {
+      state: "blocked",
+      pr_number: null,
+      codex_session_id: null,
+      blocked_reason: "manual_review",
+      last_error: truncate(manualReviewFailureContext.summary, 1000),
+      last_failure_kind: null,
+      last_failure_context: manualReviewFailureContext,
+      last_blocker_signature: null,
+      repeated_blocker_count: 0,
+      stale_stabilizing_no_pr_recovery_count: 0,
+      last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
+      ...applyFailureSignature(record, manualReviewFailureContext),
+    };
     const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
     state.issues[String(record.issue_number)] = updated;
     return true;

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3977,7 +3977,7 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates converges failed no-PR issues when only supervisor-local artifacts are dirty", async () => {
+test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when only supervisor-local artifacts are dirty on an open issue", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -4081,23 +4081,31 @@ test("reconcileStaleFailedIssueStates converges failed no-PR issues when only su
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "done");
+  assert.equal(updated.state, "blocked");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.blocked_reason, "manual_review");
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context, null);
-  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.match(updated.last_error ?? "", /confirm whether the implementation already landed elsewhere/i);
+  assert.deepEqual(updated.last_failure_context?.details ?? [], [
+    "state=failed",
+    "tracked_pr=none",
+    "branch_state=already_satisfied_on_main",
+    "default_branch=origin/main",
+    `head_sha=${updated.last_head_sha ?? "unknown"}`,
+    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
+  ]);
   assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(
     updated.last_recovery_reason,
-    "already_satisfied_on_main: marked issue #366 done after failed no-PR recovery found no meaningful branch changes",
+    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates treats artifact-only commits ahead of origin/main as already satisfied", async () => {
+test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when only supervisor-local artifact commits remain on an open issue", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -4205,24 +4213,32 @@ test("reconcileStaleFailedIssueStates treats artifact-only commits ahead of orig
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "done");
+  assert.equal(updated.state, "blocked");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.blocked_reason, "manual_review");
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context, null);
-  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.match(updated.last_error ?? "", /confirm whether the implementation already landed elsewhere/i);
   assert.equal(updated.last_head_sha, headSha);
+  assert.deepEqual(updated.last_failure_context?.details ?? [], [
+    "state=failed",
+    "tracked_pr=none",
+    "branch_state=already_satisfied_on_main",
+    "default_branch=origin/main",
+    `head_sha=${headSha}`,
+    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
+  ]);
   assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(
     updated.last_recovery_reason,
-    "already_satisfied_on_main: marked issue #366 done after failed no-PR recovery found only supervisor-owned branch divergence",
+    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates converges failed no-PR issues when the preserved branch is already satisfied on origin/main", async () => {
+test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when an open no-PR issue has no meaningful branch diff", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -4323,17 +4339,25 @@ test("reconcileStaleFailedIssueStates converges failed no-PR issues when the pre
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "done");
+  assert.equal(updated.state, "blocked");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.blocked_reason, "manual_review");
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context, null);
-  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.match(updated.last_error ?? "", /confirm whether the implementation already landed elsewhere/i);
+  assert.deepEqual(updated.last_failure_context?.details ?? [], [
+    "state=failed",
+    "tracked_pr=none",
+    "branch_state=already_satisfied_on_main",
+    "default_branch=origin/main",
+    `head_sha=${updated.last_head_sha ?? "unknown"}`,
+    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
+  ]);
   assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(
     updated.last_recovery_reason,
-    "already_satisfied_on_main: marked issue #366 done after failed no-PR recovery found no meaningful branch changes",
+    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);


### PR DESCRIPTION
## Summary
- block failed no-PR reconciliation from marking an OPEN GitHub issue locally `done` based only on zero meaningful branch diff
- preserve an explicit `blocked` `manual_review` recovery outcome when there is no positive completion evidence
- add regression coverage for artifact-only local state and true zero-diff branches

## Root cause
The stale failed no-PR reconciliation path treated `already_satisfied_on_main` as sufficient proof to reset local state to `done` for OPEN issues with no PR. In the incident behind #1422, the preserved branch matched `origin/main`, but there was no authoritative evidence that the requested implementation had landed elsewhere.

## Validation
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts --test-name-pattern "open no-PR issue has no meaningful branch diff"`
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts --test-name-pattern "failed no-PR issues"`
- `npx tsx --test src/recovery-support.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-issue-selection.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized failed issue reconciliation logic to consistently block for manual review when resolution evidence is insufficient, replacing variable resolution paths with unified handling for improved workflow predictability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->