### PR TITLE
Reconsider stale open no-PR done records

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -41,7 +41,9 @@ import {
 } from "./no-pull-request-state";
 import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
 import {
+  buildUnsafeNoPrDoneFailureContext,
   doneResetPatch,
+  hasUnsafeNoPrDoneRecoveryReason,
   sanitizeRecoveryReason,
 } from "./recovery-support";
 import { reconcileStaleFailedNoPrRecord } from "./recovery-no-pr-reconciliation";
@@ -633,6 +635,73 @@ export async function reconcileStaleFailedIssueStates(
   }
 }
 
+export async function reconcileStaleDoneIssueStates(
+  github: Pick<RecoveryGitHubLike, "getIssue">,
+  stateStore: StateStoreLike,
+  state: SupervisorStateFile,
+  issues: GitHubIssue[],
+): Promise<RecoveryEvent[]> {
+  let changed = false;
+  const recoveryEvents: RecoveryEvent[] = [];
+  const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
+
+  for (const record of Object.values(state.issues)) {
+    if (record.state !== "done" || !hasUnsafeNoPrDoneRecoveryReason(record)) {
+      continue;
+    }
+
+    let issueState = issueStateByNumber.get(record.issue_number) ?? null;
+    if (!issueStateByNumber.has(record.issue_number)) {
+      try {
+        issueState = (await github.getIssue(record.issue_number)).state ?? null;
+      } catch {
+        issueState = null;
+      }
+      issueStateByNumber.set(record.issue_number, issueState);
+    }
+
+    if (issueState !== "OPEN") {
+      continue;
+    }
+
+    const failureContext = buildUnsafeNoPrDoneFailureContext({
+      issueNumber: record.issue_number,
+      detail: "The stale no-PR done record was downgraded to manual review so the supervisor does not treat the issue as complete.",
+    });
+    const recoveryEvent = buildRecoveryEvent(
+      record.issue_number,
+      `stale_done_manual_review: blocked issue #${record.issue_number} after reconsidering an open no-PR done record with no authoritative completion signal`,
+    );
+    const updated = stateStore.touch(
+      record,
+      applyRecoveryEvent({
+        state: "blocked",
+        blocked_reason: "manual_review",
+        codex_session_id: null,
+        last_error: truncate(failureContext.summary, 1000),
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        last_blocker_signature: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        stale_stabilizing_no_pr_recovery_count: 0,
+      }, recoveryEvent),
+    );
+    state.issues[String(record.issue_number)] = updated;
+    if (state.activeIssueNumber === record.issue_number) {
+      state.activeIssueNumber = null;
+    }
+    changed = true;
+    recoveryEvents.push(recoveryEvent);
+  }
+
+  if (changed) {
+    await stateStore.save(state);
+  }
+
+  return recoveryEvents;
+}
+
 export async function reconcileRecoverableBlockedIssueStates(
   github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">,
   stateStore: StateStoreLike,
@@ -1152,10 +1221,17 @@ export async function reconcileStaleActiveIssueReservation(args: {
       }
     : null;
 
+  const staleNoPrManualReviewContext = shouldMarkAlreadySatisfiedOnMain
+    ? buildUnsafeNoPrDoneFailureContext({
+        issueNumber: record.issue_number,
+        detail: "Stale stabilizing recovery found no meaningful branch changes, so the supervisor cannot treat the open issue as complete without authoritative completion evidence.",
+      })
+    : null;
+
   const recoveryEvent = buildRecoveryEvent(
     record.issue_number,
     shouldMarkAlreadySatisfiedOnMain
-      ? `already_satisfied_on_main: marked issue #${record.issue_number} done after stale stabilizing recovery found no meaningful branch changes`
+      ? `stale_stabilizing_no_pr_manual_review: blocked issue #${record.issue_number} after stale stabilizing recovery found an open issue with no authoritative completion signal`
       : shouldStopRepeatedStaleNoPrLoop
       ? `stale_state_manual_stop: blocked issue #${record.issue_number} after repeated stale stabilizing recovery without a tracked PR`
       : shouldRequeueStabilizing
@@ -1163,10 +1239,19 @@ export async function reconcileStaleActiveIssueReservation(args: {
       : `stale_state_cleanup: cleared stale active reservation after ${missingLockReason}`,
   );
   const patch: Partial<IssueRunRecord> = shouldMarkAlreadySatisfiedOnMain
-    ? doneResetPatch({
+    ? {
+        state: "blocked",
         pr_number: null,
         codex_session_id: null,
-      })
+        blocked_reason: "manual_review",
+        last_error: truncate(staleNoPrManualReviewContext?.summary ?? "", 1000),
+        last_failure_kind: null,
+        last_failure_context: staleNoPrManualReviewContext,
+        last_blocker_signature: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        stale_stabilizing_no_pr_recovery_count: 0,
+      }
     : {
         state: shouldStopRepeatedStaleNoPrLoop ? "blocked" : shouldRequeueStabilizing ? "queued" : record.state,
         pr_number: shouldRequeueStabilizing ? null : record.pr_number,

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -41,9 +41,9 @@ import {
 } from "./no-pull-request-state";
 import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
 import {
-  buildUnsafeNoPrDoneFailureContext,
+  buildUnsafeNoPrFailureContext,
   doneResetPatch,
-  hasUnsafeNoPrDoneRecoveryReason,
+  shouldReconsiderNoPrDoneRecord,
   sanitizeRecoveryReason,
 } from "./recovery-support";
 import { reconcileStaleFailedNoPrRecord } from "./recovery-no-pr-reconciliation";
@@ -645,33 +645,12 @@ export async function reconcileStaleDoneIssueStates(
   const recoveryEvents: RecoveryEvent[] = [];
   const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
 
-  for (const record of Object.values(state.issues)) {
-    if (record.state !== "done" || !hasUnsafeNoPrDoneRecoveryReason(record)) {
-      continue;
-    }
-
-    let issueState = issueStateByNumber.get(record.issue_number) ?? null;
-    if (!issueStateByNumber.has(record.issue_number)) {
-      try {
-        issueState = (await github.getIssue(record.issue_number)).state ?? null;
-      } catch {
-        issueState = null;
-      }
-      issueStateByNumber.set(record.issue_number, issueState);
-    }
-
-    if (issueState !== "OPEN") {
-      continue;
-    }
-
-    const failureContext = buildUnsafeNoPrDoneFailureContext({
-      issueNumber: record.issue_number,
-      detail: "The stale no-PR done record was downgraded to manual review so the supervisor does not treat the issue as complete.",
-    });
-    const recoveryEvent = buildRecoveryEvent(
-      record.issue_number,
-      `stale_done_manual_review: blocked issue #${record.issue_number} after reconsidering an open no-PR done record with no authoritative completion signal`,
-    );
+  const downgradeToManualReview = (
+    record: IssueRunRecord,
+    failureContext: NonNullable<IssueRunRecord["last_failure_context"]>,
+    reason: string,
+  ): void => {
+    const recoveryEvent = buildRecoveryEvent(record.issue_number, reason);
     const updated = stateStore.touch(
       record,
       applyRecoveryEvent({
@@ -693,6 +672,49 @@ export async function reconcileStaleDoneIssueStates(
     }
     changed = true;
     recoveryEvents.push(recoveryEvent);
+  };
+
+  for (const record of Object.values(state.issues)) {
+    if (record.state !== "done" || !shouldReconsiderNoPrDoneRecord(record)) {
+      continue;
+    }
+
+    let issueState = issueStateByNumber.get(record.issue_number) ?? null;
+    if (!issueStateByNumber.has(record.issue_number)) {
+      try {
+        issueState = (await github.getIssue(record.issue_number)).state ?? null;
+      } catch {
+        const failureContext = buildUnsafeNoPrFailureContext({
+          issueNumber: record.issue_number,
+          localState: "done",
+          githubIssueState: "UNKNOWN",
+          detail: "The stale no-PR done record was downgraded to manual review because GitHub revalidation failed and the supervisor cannot safely preserve a terminal local state.",
+        });
+        downgradeToManualReview(
+          record,
+          failureContext,
+          `stale_done_revalidation_failed_manual_review: blocked issue #${record.issue_number} after GitHub revalidation failed for a no-PR done record with no authoritative completion signal`,
+        );
+        continue;
+      }
+      issueStateByNumber.set(record.issue_number, issueState);
+    }
+
+    if (issueState !== "OPEN") {
+      continue;
+    }
+
+    const failureContext = buildUnsafeNoPrFailureContext({
+      issueNumber: record.issue_number,
+      localState: "done",
+      githubIssueState: "OPEN",
+      detail: "The stale no-PR done record was downgraded to manual review so the supervisor does not treat the issue as complete.",
+    });
+    downgradeToManualReview(
+      record,
+      failureContext,
+      `stale_done_manual_review: blocked issue #${record.issue_number} after reconsidering an open no-PR done record with no authoritative completion signal`,
+    );
   }
 
   if (changed) {
@@ -1222,8 +1244,10 @@ export async function reconcileStaleActiveIssueReservation(args: {
     : null;
 
   const staleNoPrManualReviewContext = shouldMarkAlreadySatisfiedOnMain
-    ? buildUnsafeNoPrDoneFailureContext({
+    ? buildUnsafeNoPrFailureContext({
         issueNumber: record.issue_number,
+        localState: "stabilizing",
+        githubIssueState: "OPEN",
         detail: "Stale stabilizing recovery found no meaningful branch changes, so the supervisor cannot treat the open issue as complete without authoritative completion evidence.",
       })
     : null;

--- a/src/recovery-support.ts
+++ b/src/recovery-support.ts
@@ -15,46 +15,38 @@ type FailedNoPrBranchRecoveryState = "recoverable" | "already_satisfied_on_main"
 
 const FAILED_NO_PR_ALREADY_SATISFIED_SIGNATURE = "failed-no-pr-already-satisfied-on-main";
 const FAILED_NO_PR_MANUAL_REVIEW_SIGNATURE = "failed-no-pr-manual-review-required";
+const UNSAFE_NO_PR_REVALIDATION_SIGNATURE = "unsafe-no-pr-revalidation-failed";
 
-function normalizeRecoveryReason(reason: string | null | undefined): string {
-  return (reason ?? "").toLowerCase();
-}
-
-export function hasUnsafeNoPrDoneRecoveryReason(
-  record: Pick<IssueRunRecord, "pr_number" | "last_recovery_reason">,
+export function shouldReconsiderNoPrDoneRecord(
+  record: Pick<IssueRunRecord, "pr_number">,
 ): boolean {
-  if (record.pr_number !== null) {
-    return false;
-  }
-
-  const reason = normalizeRecoveryReason(record.last_recovery_reason);
-  if (!reason.includes("no meaningful branch changes")) {
-    return false;
-  }
-
-  return (
-    reason.includes("already_satisfied_on_main") ||
-    reason.includes("failed no-pr recovery") ||
-    reason.includes("failed no pr recovery") ||
-    reason.includes("failed no-pr zero-diff") ||
-    reason.includes("failed no pr zero-diff") ||
-    reason.includes("stale stabilizing recovery")
-  );
+  return record.pr_number === null;
 }
 
-export function buildUnsafeNoPrDoneFailureContext(args: {
+export function buildUnsafeNoPrFailureContext(args: {
   issueNumber: number;
+  localState: "done" | "stabilizing";
+  githubIssueState: "OPEN" | "UNKNOWN";
   detail: string;
 }): NonNullable<IssueRunRecord["last_failure_context"]> {
+  const localStateSummary = args.localState === "done"
+    ? `Issue #${args.issueNumber} is locally marked done without authoritative completion evidence`
+    : `Issue #${args.issueNumber} is in stale stabilizing recovery without authoritative completion evidence`;
+  const githubStateSummary = args.githubIssueState === "OPEN"
+    ? "but GitHub still reports the issue as open."
+    : "and GitHub revalidation could not confirm the current issue state.";
+
   return {
     category: "blocked",
-    summary: `Issue #${args.issueNumber} is locally marked done without authoritative completion evidence, but GitHub still reports the issue as open. ${args.detail}`,
-    signature: FAILED_NO_PR_ALREADY_SATISFIED_SIGNATURE,
+    summary: `${localStateSummary}, ${githubStateSummary} ${args.detail}`,
+    signature: args.githubIssueState === "OPEN"
+      ? FAILED_NO_PR_ALREADY_SATISFIED_SIGNATURE
+      : UNSAFE_NO_PR_REVALIDATION_SIGNATURE,
     command: null,
     details: [
-      "state=done",
+      `state=${args.localState}`,
       "tracked_pr=none",
-      "github_issue_state=OPEN",
+      `github_issue_state=${args.githubIssueState}`,
       "completion_evidence=missing",
       "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
     ],

--- a/src/recovery-support.ts
+++ b/src/recovery-support.ts
@@ -16,6 +16,53 @@ type FailedNoPrBranchRecoveryState = "recoverable" | "already_satisfied_on_main"
 const FAILED_NO_PR_ALREADY_SATISFIED_SIGNATURE = "failed-no-pr-already-satisfied-on-main";
 const FAILED_NO_PR_MANUAL_REVIEW_SIGNATURE = "failed-no-pr-manual-review-required";
 
+function normalizeRecoveryReason(reason: string | null | undefined): string {
+  return (reason ?? "").toLowerCase();
+}
+
+export function hasUnsafeNoPrDoneRecoveryReason(
+  record: Pick<IssueRunRecord, "pr_number" | "last_recovery_reason">,
+): boolean {
+  if (record.pr_number !== null) {
+    return false;
+  }
+
+  const reason = normalizeRecoveryReason(record.last_recovery_reason);
+  if (!reason.includes("no meaningful branch changes")) {
+    return false;
+  }
+
+  return (
+    reason.includes("already_satisfied_on_main") ||
+    reason.includes("failed no-pr recovery") ||
+    reason.includes("failed no pr recovery") ||
+    reason.includes("failed no-pr zero-diff") ||
+    reason.includes("failed no pr zero-diff") ||
+    reason.includes("stale stabilizing recovery")
+  );
+}
+
+export function buildUnsafeNoPrDoneFailureContext(args: {
+  issueNumber: number;
+  detail: string;
+}): NonNullable<IssueRunRecord["last_failure_context"]> {
+  return {
+    category: "blocked",
+    summary: `Issue #${args.issueNumber} is locally marked done without authoritative completion evidence, but GitHub still reports the issue as open. ${args.detail}`,
+    signature: FAILED_NO_PR_ALREADY_SATISFIED_SIGNATURE,
+    command: null,
+    details: [
+      "state=done",
+      "tracked_pr=none",
+      "github_issue_state=OPEN",
+      "completion_evidence=missing",
+      "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
+    ],
+    url: null,
+    updated_at: nowIso(),
+  };
+}
+
 export function sanitizeRecoveryReason(reason: string): string {
   return reason.replace(/\r?\n/g, "\\n");
 }

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -279,6 +279,99 @@ test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving select
   ]);
 });
 
+test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a new issue", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "77": createRecord({
+        issue_number: 77,
+        state: "done",
+        pr_number: null,
+        blocked_reason: null,
+        codex_session_id: null,
+        last_recovery_reason:
+          "already_satisfied_on_main: marked issue #77 done after failed no-PR recovery found no meaningful branch changes",
+      }),
+    },
+  };
+  const issues: GitHubIssue[] = [
+    {
+      number: 77,
+      title: "Stale done issue",
+      body: "",
+      createdAt: "2026-03-26T00:00:00Z",
+      updatedAt: "2026-03-26T00:00:00Z",
+      url: "https://example.test/issues/77",
+      state: "OPEN",
+    },
+  ];
+  const calls: string[] = [];
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => {
+        calls.push("save");
+      },
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => issues,
+    reserveRunnableIssueSelection: async (loadedState) => {
+      calls.push(`reserve:${loadedState.issues["77"]?.state}`);
+      return false;
+    },
+    reconcileTrackedMergedButOpenIssues: async () => {
+      calls.push("tracked_merged");
+      return [];
+    },
+    reconcileMergedIssueClosures: async () => {
+      calls.push("merged_closures");
+      return [];
+    },
+    reconcileStaleFailedIssueStates: async () => {
+      calls.push("stale_failed");
+    },
+    reconcileStaleDoneIssueStates: async (loadedState, loadedIssues) => {
+      calls.push("stale_done");
+      assert.equal(loadedState, state);
+      assert.equal(loadedIssues, issues);
+      loadedState.issues["77"] = {
+        ...loadedState.issues["77"]!,
+        state: "blocked",
+        blocked_reason: "manual_review",
+      };
+      return [];
+    },
+    reconcileRecoverableBlockedIssueStates: async () => {
+      calls.push("recoverable_blocked");
+      return [];
+    },
+    reconcileParentEpicClosures: async () => {
+      calls.push("parent_epics");
+    },
+    cleanupExpiredDoneWorkspaces: async () => {
+      calls.push("cleanup");
+      return [];
+    },
+  });
+
+  assert.ok(!("kind" in result));
+  assert.deepEqual(calls, [
+    "save",
+    "tracked_merged",
+    "merged_closures",
+    "stale_failed",
+    "stale_done",
+    "recoverable_blocked",
+    "reserve:blocked",
+    "recoverable_blocked",
+    "parent_epics",
+    "cleanup",
+  ]);
+});
+
 test("runOnceCyclePrelude reconciles tracked PR-open issues before reserving a new issue", async () => {
   const state: SupervisorStateFile = {
     activeIssueNumber: null,

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -59,6 +59,10 @@ interface RunOnceCyclePreludeArgs {
     issues: GitHubIssue[],
     updateReconciliationProgress: (patch: ReconciliationProgressPatch) => Promise<void>,
   ) => Promise<void>;
+  reconcileStaleDoneIssueStates?: (
+    state: SupervisorStateFile,
+    issues: GitHubIssue[],
+  ) => Promise<RecoveryEvent[]>;
   reconcileRecoverableBlockedIssueStates: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
@@ -267,6 +271,13 @@ export async function runOnceCyclePrelude(
 
     await setReconciliationPhase("stale_failed_issue_states");
     await args.reconcileStaleFailedIssueStates(state, issues, updateReconciliationProgress);
+
+    if (args.reconcileStaleDoneIssueStates) {
+      await setReconciliationPhase("stale_done_issue_states");
+      const staleDoneEvents = await args.reconcileStaleDoneIssueStates(state, issues);
+      recoveryEvents.push(...staleDoneEvents);
+      emitRecoveryEvents(staleDoneEvents);
+    }
 
     await setReconciliationPhase("recoverable_blocked_issue_states");
     const recoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues, {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1091,8 +1091,7 @@ test("reconcileStaleDoneIssueStates downgrades stale open no-PR done records to 
     last_failure_signature: null,
     last_blocker_signature: null,
     repeated_failure_signature_count: 0,
-    last_recovery_reason:
-      "already_satisfied_on_main: marked issue #366 done after stale stabilizing recovery found no meaningful branch changes",
+    last_recovery_reason: null,
   });
   const state: SupervisorStateFile = createSupervisorState({
     issues: [record],
@@ -1135,10 +1134,80 @@ test("reconcileStaleDoneIssueStates downgrades stale open no-PR done records to 
   assert.equal(state.issues["366"]?.state, "blocked");
   assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
   assert.match(state.issues["366"]?.last_error ?? "", /locally marked done without authoritative completion evidence/);
+  assert.deepEqual(state.issues["366"]?.last_failure_context?.details ?? [], [
+    "state=done",
+    "tracked_pr=none",
+    "github_issue_state=OPEN",
+    "completion_evidence=missing",
+    "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
+  ]);
   assert.equal(recoveryEvents.length, 1);
   assert.equal(
     recoveryEvents[0]?.reason,
     "stale_done_manual_review: blocked issue #366 after reconsidering an open no-PR done record with no authoritative completion signal",
+  );
+});
+
+test("reconcileStaleDoneIssueStates downgrades suspicious no-PR done records when GitHub revalidation fails", async () => {
+  const record = createRecord({
+    issue_number: 366,
+    state: "done",
+    pr_number: null,
+    codex_session_id: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+    last_blocker_signature: null,
+    repeated_failure_signature_count: 0,
+    last_recovery_reason: null,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [record],
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:22:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleDoneIssueStates(
+    {
+      getIssue: async (issueNumber: number) => {
+        assert.equal(issueNumber, 366);
+        throw new Error("GitHub unavailable");
+      },
+    },
+    stateStore,
+    state,
+    [],
+  );
+
+  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
+  assert.match(state.issues["366"]?.last_error ?? "", /GitHub revalidation could not confirm the current issue state/);
+  assert.deepEqual(state.issues["366"]?.last_failure_context?.details ?? [], [
+    "state=done",
+    "tracked_pr=none",
+    "github_issue_state=UNKNOWN",
+    "completion_evidence=missing",
+    "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
+  ]);
+  assert.equal(recoveryEvents.length, 1);
+  assert.equal(
+    recoveryEvents[0]?.reason,
+    "stale_done_revalidation_failed_manual_review: blocked issue #366 after GitHub revalidation failed for a no-PR done record with no authoritative completion signal",
   );
 });
 
@@ -2358,10 +2427,17 @@ test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stal
   assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
   assert.match(
     state.issues["366"]?.last_error ?? "",
-    /locally marked done without authoritative completion evidence/,
+    /stale stabilizing recovery without authoritative completion evidence/,
   );
   assert.equal(state.issues["366"]?.last_failure_kind, null);
   assert.equal(state.issues["366"]?.last_failure_context?.category, "blocked");
+  assert.deepEqual(state.issues["366"]?.last_failure_context?.details ?? [], [
+    "state=stabilizing",
+    "tracked_pr=none",
+    "github_issue_state=OPEN",
+    "completion_evidence=missing",
+    "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
+  ]);
   assert.equal(state.issues["366"]?.last_failure_signature, null);
   assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
   assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 0);

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -13,6 +13,7 @@ import {
   reconcileParentEpicClosures,
   reconcileRecoverableBlockedIssueStates,
   reconcileStaleFailedIssueStates,
+  reconcileStaleDoneIssueStates,
   reconcileStaleActiveIssueReservation,
   reconcileTrackedMergedButOpenIssues,
 } from "../recovery-reconciliation";
@@ -1075,6 +1076,70 @@ test("reconcileRecoverableBlockedIssueStates keeps stale no-PR manual-review sto
   assert.equal(saveCalls, 0);
   assert.deepEqual(recoveryEvents, []);
   assert.deepEqual(state.issues["366"], original);
+});
+
+test("reconcileStaleDoneIssueStates downgrades stale open no-PR done records to manual review", async () => {
+  const record = createRecord({
+    issue_number: 366,
+    state: "done",
+    pr_number: null,
+    codex_session_id: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+    last_blocker_signature: null,
+    repeated_failure_signature_count: 0,
+    last_recovery_reason:
+      "already_satisfied_on_main: marked issue #366 done after stale stabilizing recovery found no meaningful branch changes",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [record],
+  });
+  const issues = [
+    createIssue({
+      number: 366,
+      updatedAt: "2026-03-13T00:21:00Z",
+      state: "OPEN",
+    }),
+  ];
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:22:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleDoneIssueStates(
+    {
+      getIssue: async (issueNumber: number) => {
+        assert.equal(issueNumber, 366);
+        return issues[0]!;
+      },
+    },
+    stateStore,
+    state,
+    issues,
+  );
+
+  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
+  assert.match(state.issues["366"]?.last_error ?? "", /locally marked done without authoritative completion evidence/);
+  assert.equal(recoveryEvents.length, 1);
+  assert.equal(
+    recoveryEvents[0]?.reason,
+    "stale_done_manual_review: blocked issue #366 after reconsidering an open no-PR done record with no authoritative completion signal",
+  );
 });
 
 test("reconcileRecoverableBlockedIssueStates clears stale same-head review-thread blockers after GitHub reports them resolved", async () => {
@@ -2241,7 +2306,7 @@ test("reconcileStaleActiveIssueReservation blocks a repeated stale stabilizing n
   );
 });
 
-test("reconcileStaleActiveIssueReservation converges already-satisfied-on-main stale stabilizing no-PR recovery to done", async () => {
+test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stale stabilizing no-PR recovery for manual review", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -2287,13 +2352,16 @@ test("reconcileStaleActiveIssueReservation converges already-satisfied-on-main s
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "done");
+  assert.equal(state.issues["366"]?.state, "blocked");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
-  assert.equal(state.issues["366"]?.blocked_reason, null);
-  assert.equal(state.issues["366"]?.last_error, null);
+  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
+  assert.match(
+    state.issues["366"]?.last_error ?? "",
+    /locally marked done without authoritative completion evidence/,
+  );
   assert.equal(state.issues["366"]?.last_failure_kind, null);
-  assert.equal(state.issues["366"]?.last_failure_context, null);
+  assert.equal(state.issues["366"]?.last_failure_context?.category, "blocked");
   assert.equal(state.issues["366"]?.last_failure_signature, null);
   assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
   assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 0);
@@ -2301,7 +2369,7 @@ test("reconcileStaleActiveIssueReservation converges already-satisfied-on-main s
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=already_satisfied_on_main: marked issue #366 done after stale stabilizing recovery found no meaningful branch changes/,
+    /recovery issue=#366 reason=stale_stabilizing_no_pr_manual_review: blocked issue #366 after stale stabilizing recovery found an open issue with no authoritative completion signal/,
   );
 });
 

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -12,6 +12,7 @@ import {
   reconcileParentEpicClosures,
   reconcileRecoverableBlockedIssueStates,
   reconcileStaleActiveIssueReservation,
+  reconcileStaleDoneIssueStates,
   reconcileStaleFailedIssueStates,
   reconcileTrackedMergedButOpenIssues,
 } from "../recovery-reconciliation";
@@ -1086,6 +1087,8 @@ export class Supervisor {
           syncCopilotReviewTimeoutState,
           inferGitHubWaitStep,
         }, updateReconciliationProgress),
+      reconcileStaleDoneIssueStates: (state, issues) =>
+        reconcileStaleDoneIssueStates(this.github, this.stateStore, state, issues),
       reconcileRecoverableBlockedIssueStates: (state, issues, options) =>
         reconcileRecoverableBlockedIssueStates(this.github, this.stateStore, state, this.config, issues, {
           shouldAutoRetryHandoffMissing,


### PR DESCRIPTION
## Summary
- downgrade stale open no-PR `done` records that only have historical zero-diff recovery evidence
- block the remaining stale stabilizing `already_satisfied_on_main` no-PR convergence path behind manual review
- add regression coverage for stale-`done` reconsideration before selection

## Testing
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts
- npm run build

Closes #1425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically re-flag issues marked "done" without PR evidence as blocked for manual review; emits recovery events and records failure context.
* **Improvements**
  * Consistent handling and messaging for stale/no-PR recovery paths, including clearer failure context and updated recovery reason text.
* **Tests**
  * Added coverage exercising the stale-done no-PR reconciliation and updated related reconciliation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->