### PR TITLE
Separate stale configured-bot review blockers from generic manual_review

### DIFF
--- a/.codex-supervisor/issues/1429/issue-journal.md
+++ b/.codex-supervisor/issues/1429/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-11T07:50:30.355Z
 
 ## Latest Codex Summary
-- Added a dedicated `stale_review_bot` blocked reason for stale configured-bot review blockers on the current head, kept mixed/manual review on `manual_review`, and verified the focused review-blocker tests plus `npm run build`.
+- Added a dedicated `stale_review_bot` blocked reason for stale configured-bot review blockers on the current head, kept mixed/manual review on `manual_review`, verified the focused review-blocker tests plus `npm run build`, and opened draft PR #1434 from commit `f0eae38`.
 
 ## Active Failure Context
 - None recorded.
@@ -22,12 +22,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The stale configured-bot path was already distinguishable in failure-context generation, but `blockedReasonFromReviewState` still collapsed it into `manual_review`.
-- What changed: Added `stale_review_bot` to blocked-reason types/validators, introduced `staleConfiguredBotReviewThreads(...)`, routed only clean-lane same-head stale configured-bot blockers to the new reason, preserved mixed human+bot blockers as `manual_review`, and reused lifecycle classification when repeated tracked-PR failures stop on the same stale bot blocker.
+- What changed: Added `stale_review_bot` to blocked-reason types/validators, introduced `staleConfiguredBotReviewThreads(...)`, routed only clean-lane same-head stale configured-bot blockers to the new reason, preserved mixed human+bot blockers as `manual_review`, reused lifecycle classification when repeated tracked-PR failures stop on the same stale bot blocker, committed the change as `f0eae38`, and opened draft PR #1434.
 - Current blocker: none
-- Next exact step: Commit the checkpoint and open a draft PR for branch `codex/issue-1429`.
+- Next exact step: Wait for CI/review on PR #1434 or address any follow-up failures if they appear.
 - Verification gap: Full repo test suite not run; focused issue verification and `npm run build` are green.
 - Files touched: src/core/types.ts; src/review-thread-reporting.ts; src/pull-request-state-policy.ts; src/supervisor/supervisor.ts; src/codex/codex-output-parser.ts; src/supervisor/execution-metrics-schema.ts; src/supervisor/replay-corpus-validation.ts; src/pull-request-state-policy.test.ts; src/review-thread-reporting.test.ts; src/supervisor/supervisor-pr-review-blockers.test.ts
 - Rollback concern: `stale_review_bot` is a new persisted reason code, so any downstream logic that intentionally special-cases only `manual_review` may need explicit expansion if future behavior should treat stale bot blockers identically.
-- Last focused command: `npm run build`
+- Last focused command: `git push -u origin codex/issue-1429 && gh pr create --draft --base main --head codex/issue-1429 ...`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1429/issue-journal.md
+++ b/.codex-supervisor/issues/1429/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1429: Separate stale configured-bot review blockers from generic manual_review
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1429
+- Branch: codex/issue-1429
+- Workspace: .
+- Journal: .codex-supervisor/issues/1429/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: f19c80a5a65b7f1e21b6463cb173ce5ea43fb55f
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T07:50:30.355Z
+
+## Latest Codex Summary
+- Added a dedicated `stale_review_bot` blocked reason for stale configured-bot review blockers on the current head, kept mixed/manual review on `manual_review`, and verified the focused review-blocker tests plus `npm run build`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The stale configured-bot path was already distinguishable in failure-context generation, but `blockedReasonFromReviewState` still collapsed it into `manual_review`.
+- What changed: Added `stale_review_bot` to blocked-reason types/validators, introduced `staleConfiguredBotReviewThreads(...)`, routed only clean-lane same-head stale configured-bot blockers to the new reason, preserved mixed human+bot blockers as `manual_review`, and reused lifecycle classification when repeated tracked-PR failures stop on the same stale bot blocker.
+- Current blocker: none
+- Next exact step: Commit the checkpoint and open a draft PR for branch `codex/issue-1429`.
+- Verification gap: Full repo test suite not run; focused issue verification and `npm run build` are green.
+- Files touched: src/core/types.ts; src/review-thread-reporting.ts; src/pull-request-state-policy.ts; src/supervisor/supervisor.ts; src/codex/codex-output-parser.ts; src/supervisor/execution-metrics-schema.ts; src/supervisor/replay-corpus-validation.ts; src/pull-request-state-policy.test.ts; src/review-thread-reporting.test.ts; src/supervisor/supervisor-pr-review-blockers.test.ts
+- Rollback concern: `stale_review_bot` is a new persisted reason code, so any downstream logic that intentionally special-cases only `manual_review` may need explicit expansion if future behavior should treat stale bot blockers identically.
+- Last focused command: `npm run build`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1429/issue-journal.md
+++ b/.codex-supervisor/issues/1429/issue-journal.md
@@ -5,29 +5,46 @@
 - Branch: codex/issue-1429
 - Workspace: .
 - Journal: .codex-supervisor/issues/1429/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: f19c80a5a65b7f1e21b6463cb173ce5ea43fb55f
+- Current phase: repairing_ci
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: d2efa966dcf7ed287e44ffa6551107e421789ec6
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T07:50:30.355Z
+- Last failure signature: build (ubuntu-latest):fail
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T07:59:31.847Z
 
 ## Latest Codex Summary
-- Added a dedicated `stale_review_bot` blocked reason for stale configured-bot review blockers on the current head, kept mixed/manual review on `manual_review`, verified the focused review-blocker tests plus `npm run build`, and opened draft PR #1434 from commit `f0eae38`.
+Implemented the issue on `codex/issue-1429` and pushed it.
+
+The change introduces a dedicated `stale_review_bot` blocked reason for the narrow stale configured-bot path: all remaining unresolved threads are from configured bot reviewers, they were already processed on the current head, no same-head follow-up remains, and the PR is otherwise on a clean lane. Mixed human+bot review and other conservative blockers still stay on `manual_review`. I added focused coverage in the three requested test files, updated downstream blocked-reason validators, and kept repeated tracked-PR failure escalation from collapsing the new reason back to `manual_review`.
+
+Draft PR: [#1434](https://github.com/TommyKammy/codex-supervisor/pull/1434)  
+Commits: `f0eae38`, `d2efa96`
+
+Summary: Added `stale_review_bot` classification for stale configured-bot review blockers, verified focused tests and build, and opened draft PR #1434.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/pull-request-state-policy.test.ts src/review-thread-reporting.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts`; `npm run build`
+Next action: Wait for CI and draft PR review on #1434, then address any follow-up failures if they appear.
+Failure signature: build (ubuntu-latest):fail
 
 ## Active Failure Context
-- None recorded.
+- Category: checks
+- Summary: PR #1434 has failing checks.
+- Command or source: gh pr checks
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1434
+- Details:
+  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/24278112644/job/70895409882
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The stale configured-bot path was already distinguishable in failure-context generation, but `blockedReasonFromReviewState` still collapsed it into `manual_review`.
-- What changed: Added `stale_review_bot` to blocked-reason types/validators, introduced `staleConfiguredBotReviewThreads(...)`, routed only clean-lane same-head stale configured-bot blockers to the new reason, preserved mixed human+bot blockers as `manual_review`, reused lifecycle classification when repeated tracked-PR failures stop on the same stale bot blocker, committed the change as `f0eae38`, and opened draft PR #1434.
+- Hypothesis: The implementation was correct, but the replay corpus expectation for `review-blocked` issue `#532` still encoded the old `manual_review` blocker and caused CI to fail on `npx tsx src/index.ts replay-corpus`.
+- What changed: Confirmed the GitHub Actions failure from run `24278112644` locally, reproduced `Replay corpus summary: total=9 passed=8 failed=1`, and updated `replay-corpus/cases/review-blocked/expected/replay-result.json` so the expected blocker reason is `stale_review_bot`.
 - Current blocker: none
-- Next exact step: Wait for CI/review on PR #1434 or address any follow-up failures if they appear.
-- Verification gap: Full repo test suite not run; focused issue verification and `npm run build` are green.
-- Files touched: src/core/types.ts; src/review-thread-reporting.ts; src/pull-request-state-policy.ts; src/supervisor/supervisor.ts; src/codex/codex-output-parser.ts; src/supervisor/execution-metrics-schema.ts; src/supervisor/replay-corpus-validation.ts; src/pull-request-state-policy.test.ts; src/review-thread-reporting.test.ts; src/supervisor/supervisor-pr-review-blockers.test.ts
+- Next exact step: Commit the replay-corpus expectation repair, push `codex/issue-1429`, and wait for PR #1434 CI to rerun.
+- Verification gap: Full repo test suite not run; focused issue verification, replay corpus, and `npm run build` are green.
+- Files touched: src/core/types.ts; src/review-thread-reporting.ts; src/pull-request-state-policy.ts; src/supervisor/supervisor.ts; src/codex/codex-output-parser.ts; src/supervisor/execution-metrics-schema.ts; src/supervisor/replay-corpus-validation.ts; src/pull-request-state-policy.test.ts; src/review-thread-reporting.test.ts; src/supervisor/supervisor-pr-review-blockers.test.ts; replay-corpus/cases/review-blocked/expected/replay-result.json
 - Rollback concern: `stale_review_bot` is a new persisted reason code, so any downstream logic that intentionally special-cases only `manual_review` may need explicit expansion if future behavior should treat stale bot blockers identically.
-- Last focused command: `git push -u origin codex/issue-1429 && gh pr create --draft --base main --head codex/issue-1429 ...`
+- Last focused commands: `python3 .../inspect_pr_checks.py --repo . --pr 1434 --json`; `npx tsx src/index.ts replay-corpus`; `npx tsx --test src/pull-request-state-policy.test.ts src/review-thread-reporting.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts`; `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/replay-corpus/cases/review-blocked/expected/replay-result.json
+++ b/replay-corpus/cases/review-blocked/expected/replay-result.json
@@ -1,6 +1,6 @@
 {
   "nextState": "blocked",
   "shouldRunCodex": false,
-  "blockedReason": "manual_review",
+  "blockedReason": "stale_review_bot",
   "failureSignature": "stalled-bot:thread-1"
 }

--- a/src/codex/codex-output-parser.ts
+++ b/src/codex/codex-output-parser.ts
@@ -26,6 +26,7 @@ const SUPPORTED_BLOCKED_REASONS: BlockedReason[] = [
   "permissions",
   "secrets",
   "verification",
+  "stale_review_bot",
   "manual_review",
   "manual_pr_closed",
   "handoff_missing",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -229,6 +229,7 @@ export type BlockedReason =
   | "verification"
   | "review_bot_timeout"
   | "copilot_timeout"
+  | "stale_review_bot"
   | "manual_review"
   | "manual_pr_closed"
   | "handoff_missing"

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -253,6 +253,64 @@ test("inferStateFromPullRequest still blocks a configured-bot thread on non-jour
   ];
 
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), "stale_review_bot");
+});
+
+test("blockedReasonFromReviewState keeps mixed unresolved human and configured-bot review on manual_review", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+  });
+  const pr = createPullRequest({
+    configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "This configured-bot finding is now stale on the current head.",
+            createdAt: "2026-03-13T02:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "coderabbitai[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-2",
+      comments: {
+        nodes: [
+          {
+            id: "comment-2",
+            body: "A human reviewer still needs to confirm this.",
+            createdAt: "2026-03-13T02:06:00Z",
+            url: "https://example.test/pr/44#discussion_r2",
+            author: {
+              login: "reviewer-human",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
   assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), "manual_review");
 });
 

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -20,6 +20,7 @@ import {
   configuredBotReviewThreads,
   manualReviewThreads,
   pendingBotReviewThreads,
+  staleConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
 import {
   BlockedReason,
@@ -726,12 +727,28 @@ export function blockedReasonFromReviewState(
 ): Exclude<BlockedReason, null> | null {
   const manualThreads = manualReviewThreads(config, reviewThreads);
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
+  const staleBotThreads =
+    manualThreads.length === 0 ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads) : [];
+  const checkSummary = summarizeChecks(checks);
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr);
   if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
     return "review_bot_timeout";
   }
 
-  if (manualThreads.length > 0 || unresolvedBotThreads.length > 0) {
+  if (manualThreads.length > 0) {
+    return "manual_review";
+  }
+
+  if (
+    staleBotThreads.length > 0 &&
+    !checkSummary.hasPending &&
+    !checkSummary.hasFailing &&
+    !mergeConflictDetected(pr)
+  ) {
+    return "stale_review_bot";
+  }
+
+  if (unresolvedBotThreads.length > 0) {
     return "manual_review";
   }
 

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { configuredBotReviewThreads, manualReviewThreads } from "./supervisor/supervisor-reporting";
-import { ReviewThread, SupervisorConfig } from "./core/types";
+import { staleConfiguredBotReviewThreads } from "./review-thread-reporting";
+import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -89,4 +90,30 @@ test("configuredBotReviewThreads normalizes configured bot logins before classif
 
   assert.equal(configuredBotReviewThreads(config, [thread]).length, 1);
   assert.equal(manualReviewThreads(config, [thread]).length, 0);
+});
+
+test("staleConfiguredBotReviewThreads requires current-head processing evidence before classifying stale bot blockers", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const pr: Pick<GitHubPullRequest, "headRefOid"> = { headRefOid: "head123" };
+  const record: Pick<
+    IssueRunRecord,
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+    | "last_head_sha"
+    | "review_follow_up_head_sha"
+    | "review_follow_up_remaining"
+  > = {
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+    last_head_sha: "head123",
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+  };
+  const processedThread = createReviewThread();
+  const unprocessedThread = createReviewThread({ id: "thread-2" });
+
+  assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [processedThread]), [processedThread]);
+  assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [unprocessedThread]), []);
 });

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -108,6 +108,35 @@ export function actionableBotReviewThreads(
     : [];
 }
 
+export function staleConfiguredBotReviewThreads(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+    | "last_head_sha"
+    | "review_follow_up_head_sha"
+    | "review_follow_up_remaining"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  if (configuredThreads.length === 0) {
+    return [];
+  }
+
+  if (pendingBotReviewThreads(config, record, pr, configuredThreads).length > 0) {
+    return [];
+  }
+
+  if (configuredBotReviewFollowUpState(record, pr, configuredThreads) === "eligible") {
+    return [];
+  }
+
+  return configuredThreads;
+}
+
 export function buildReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
   if (reviewThreads.length === 0) {
     return null;

--- a/src/supervisor/execution-metrics-schema.ts
+++ b/src/supervisor/execution-metrics-schema.ts
@@ -34,6 +34,7 @@ const FAILURE_METRICS_BLOCKED_REASONS = [
   "verification",
   "review_bot_timeout",
   "copilot_timeout",
+  "stale_review_bot",
   "manual_review",
   "manual_pr_closed",
   "handoff_missing",

--- a/src/supervisor/replay-corpus-validation.ts
+++ b/src/supervisor/replay-corpus-validation.ts
@@ -34,6 +34,7 @@ const BLOCKED_REASONS = [
   "verification",
   "review_bot_timeout",
   "copilot_timeout",
+  "stale_review_bot",
   "manual_review",
   "manual_pr_closed",
   "handoff_missing",

--- a/src/supervisor/supervisor-pr-review-blockers.test.ts
+++ b/src/supervisor/supervisor-pr-review-blockers.test.ts
@@ -133,7 +133,7 @@ test("runOnce reprocesses a configured bot review thread once after a new PR hea
   const record = persisted.issues[String(issueNumber)];
   assert.equal(record.state, "blocked");
   assert.equal(record.last_head_sha, runHeadSha);
-  assert.equal(record.blocked_reason, "manual_review");
+  assert.equal(record.blocked_reason, "stale_review_bot");
   assert.deepEqual(record.processed_review_thread_ids, ["thread-1@head-a", `thread-1@${runHeadSha}`]);
   assert.deepEqual(record.processed_review_thread_fingerprints, ["thread-1@head-a#comment-1", `thread-1@${runHeadSha}#comment-1`]);
   assert.equal(record.last_failure_context?.category, "manual");

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -638,7 +638,9 @@ export class Supervisor {
             last_failure_kind: null,
             last_tracked_pr_progress_summary: trackedPrRepeatFailureDisposition.progressSummary,
             last_tracked_pr_repeat_failure_decision: trackedPrRepeatFailureDisposition.decision,
-            blocked_reason: "manual_review",
+            blocked_reason:
+              blockedReasonForLifecycleState(this.config, lifecycle.recordForState, pr, checks, reviewThreads) ??
+              "manual_review",
           });
           state.issues[String(record.issue_number)] = record;
           state.activeIssueNumber = null;


### PR DESCRIPTION
## Summary
- add a dedicated `stale_review_bot` blocker reason for stale configured-bot review blockers on the current head
- keep unresolved human review and mixed human+bot review on `manual_review`
- preserve conservative blocking when checks are pending/failing or the PR is conflicted

## Verification
- `npx tsx --test src/pull-request-state-policy.test.ts src/review-thread-reporting.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts`
- `npm run build`

Closes #1429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "stale_review_bot" blocked reason to distinguish stale bot reviews from manual review blocking scenarios.
  * Enhanced detection logic to identify and categorize stale configured bot review threads separately.

* **Tests**
  * Added test coverage for the new stale bot review blocking classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->