### PR TITLE
Surface stale configured-bot review blockers in diagnostics and sticky PR comments

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1929,6 +1929,89 @@ test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays
   assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays blocked on stale configured-bot review state near merge", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const issue = createIssue({ title: "Comment on persistent stale configured-bot blockers" });
+  const pr = createPullRequest({
+    title: "Tracked PR stale configured-bot blocker",
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+    mergeStateStatus: "CLEAN",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "blocked",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        blocked_reason: "stale_review_bot",
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+  const staleBotFailureContext = {
+    ...createFailureContext(
+      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    ),
+    signature: "stalled-bot:thread-1",
+    details: ["reviewer=copilot-pull-request-reviewer file=src/review.ts line=42 processed_on_current_head=yes"],
+    url: "https://example.test/review/1",
+  };
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "blocked", {
+        failureContext: staleBotFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "stale_review_bot");
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `stale_review_bot`/i);
+  assert.match(commentBodies[0] ?? "", /configured bot review thread\(s\) remain unresolved/i);
+  assert.match(commentBodies[0] ?? "", /processed_on_current_head=yes/i);
+  assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase comments when merge readiness stays blocked after checks pass", async () => {
   const config = createConfig();
   const issue = createIssue({ title: "Comment on persistent tracked PR merge-readiness mismatches" });

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -97,6 +97,7 @@ const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-ow
 const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT = "stale_review_bot";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
@@ -361,6 +362,24 @@ function derivePersistentTrackedPrStatusComment(args: {
         evidence: compactEvidenceLines(args.failureContext?.details),
         nextAction:
           "Resolve the remaining manual review blocker or complete the required manual verification, then rerun the supervisor.",
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  if (args.record.state === "blocked" && args.record.blocked_reason === "stale_review_bot") {
+    const summary =
+      args.failureContext?.summary
+      ?? "Configured bot review state is stale on the current head and now requires manual attention.";
+    return {
+      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
+        summary,
+        evidence: compactEvidenceLines(args.failureContext?.details),
+        nextAction:
+          "Inspect the stale configured-bot review state on the current head, then rerun the supervisor after the blocker is cleared or explicitly resolved.",
         automaticRetry: "no",
       }),
     };

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -311,6 +311,61 @@ Wait for a human review before proceeding.
   assert.match(explanation, /^reason_2=local_state blocked$/m);
 });
 
+test("explain reports stale configured-bot blockers distinctly from generic manual review", async () => {
+  const fixture = await createSupervisorFixture();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "98": createRecord({
+        issue_number: 98,
+        state: "blocked",
+        branch: branchName(fixture.config, 98),
+        workspace: path.join(fixture.workspaceRoot, "issue-98"),
+        journal_path: null,
+        blocked_reason: "stale_review_bot",
+        last_error: "configured bot review stayed stale on the current head",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const blockedIssue: GitHubIssue = {
+    number: 98,
+    title: "Stale configured bot blocker",
+    body: `## Summary
+Show stale configured-bot review blockers distinctly in explain output.
+
+## Scope
+- surface stale configured-bot review-state as its own blocker class
+
+## Acceptance criteria
+- explain distinguishes stale configured-bot review-state from generic manual review
+
+## Verification
+- npm test -- src/supervisor/supervisor-diagnostics-explain.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/98",
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => blockedIssue,
+    listAllIssues: async () => [blockedIssue],
+    listCandidateIssues: async () => [blockedIssue],
+  };
+
+  const explanation = await supervisor.explain(98);
+
+  assert.match(explanation, /^state=blocked$/m);
+  assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
+  assert.match(explanation, /^runnable=no$/m);
+  assert.match(explanation, /^reason_1=manual_block stale_review_bot$/m);
+  assert.match(explanation, /^reason_2=local_state blocked$/m);
+});
+
 test("explain reports tracked PR mismatches when GitHub is ready but local state is still blocked", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -134,7 +134,11 @@ export function buildNonRunnableLocalStateReasons(record: IssueRunRecord, config
   const reasons: string[] = [];
 
   if (record.state === "blocked") {
-    if (record.blocked_reason === "manual_review" || record.blocked_reason === "manual_pr_closed") {
+    if (
+      record.blocked_reason === "manual_review" ||
+      record.blocked_reason === "manual_pr_closed" ||
+      record.blocked_reason === "stale_review_bot"
+    ) {
       reasons.push(`manual_block ${record.blocked_reason}`);
     } else if (record.blocked_reason === "verification" && !shouldAutoRetryBlockedVerification(record, config)) {
       if (!hasAttemptBudgetRemaining(record, config, "implementation")) {


### PR DESCRIPTION
## Summary
- surface `stale_review_bot` distinctly in explain diagnostics instead of collapsing it into generic blocked state
- publish sticky tracked-PR status comments for persistent stale configured-bot blockers near merge
- cover both paths with focused regression tests

Closes #1430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection and reporting for pull requests blocked due to stale automated bot reviews, with enhanced diagnostic visibility for blocked status.

* **Tests**
  * Added comprehensive test coverage for stale bot review detection, status comment generation, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->