### PR TITLE
Reject unsupported staleConfiguredBotReviewPolicy values instead of silently falling back

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -841,7 +841,7 @@ test("loadConfig accepts explicit stale configured-bot reply_only policy", async
   assert.equal(config.staleConfiguredBotReviewPolicy, "reply_only");
 });
 
-test("loadConfig accepts explicit stale configured-bot reply_and_resolve policy", async (t) => {
+test("loadConfig rejects unsupported explicit stale configured-bot review policies", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -864,8 +864,18 @@ test("loadConfig accepts explicit stale configured-bot reply_and_resolve policy"
     "utf8",
   );
 
-  const config = loadConfig(configPath);
-  assert.equal(config.staleConfiguredBotReviewPolicy, "reply_and_resolve");
+  const summary = loadConfigSummary(configPath);
+  assert.equal(summary.status, "invalid_config");
+  assert.deepEqual(summary.invalidFields, ["staleConfiguredBotReviewPolicy"]);
+  assert.match(
+    summary.error ?? "",
+    /Invalid config field: staleConfiguredBotReviewPolicy \(unsupported value: reply_and_resolve; supported values: diagnose_only, reply_only\)/,
+  );
+
+  assert.throws(
+    () => loadConfig(configPath),
+    /Invalid config field: staleConfiguredBotReviewPolicy \(unsupported value: reply_and_resolve; supported values: diagnose_only, reply_only\)/,
+  );
 });
 
 test("loadConfig accepts an explicit mergeCriticalRecheckSeconds override", async (t) => {

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -25,11 +25,7 @@ const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untru
 const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
 const VALID_LOCAL_REVIEW_POLICIES = new Set<LocalReviewPolicy>(["advisory", "block_ready", "block_merge"]);
 const VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS = new Set<LocalReviewHighSeverityAction>(["retry", "blocked"]);
-const VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES = new Set<StaleConfiguredBotReviewPolicy>([
-  "diagnose_only",
-  "reply_only",
-  "reply_and_resolve",
-]);
+const VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES = new Set<StaleConfiguredBotReviewPolicy>(["diagnose_only", "reply_only"]);
 const VALID_COPILOT_REVIEW_TIMEOUT_ACTIONS = new Set<CopilotReviewTimeoutAction>(["continue", "block"]);
 const VALID_LOCAL_REVIEW_MINIMUM_SEVERITIES = new Set<LocalReviewReviewerThresholdConfig["minimumSeverity"]>(["low", "medium", "high"]);
 const VALID_RUN_STATES = new Set<RunState>([
@@ -73,6 +69,23 @@ function normalizeStringArray(value: unknown, fieldName: string): string[] {
 
     return entry;
   });
+}
+
+function parseStaleConfiguredBotReviewPolicy(value: unknown): StaleConfiguredBotReviewPolicy {
+  if (typeof value === "undefined") {
+    return "diagnose_only";
+  }
+
+  if (
+    typeof value === "string" &&
+    VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES.has(value as StaleConfiguredBotReviewPolicy)
+  ) {
+    return value as StaleConfiguredBotReviewPolicy;
+  }
+
+  throw new Error(
+    `Invalid config field: staleConfiguredBotReviewPolicy (unsupported value: ${String(value)}; supported values: diagnose_only, reply_only)`,
+  );
 }
 
 export function normalizeLocalCiCommand(value: unknown): LocalCiCommandConfig | undefined {
@@ -366,13 +379,7 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
       VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS.has(raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
         ? (raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
         : "blocked",
-    staleConfiguredBotReviewPolicy:
-      typeof raw.staleConfiguredBotReviewPolicy === "string" &&
-      VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES.has(
-        raw.staleConfiguredBotReviewPolicy as StaleConfiguredBotReviewPolicy,
-      )
-        ? (raw.staleConfiguredBotReviewPolicy as StaleConfiguredBotReviewPolicy)
-        : "diagnose_only",
+    staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)
       ? raw.reviewBotLogins
           .filter((value): value is string => typeof value === "string" && value.trim() !== "")


### PR DESCRIPTION
## Summary
- reject unsupported explicit `staleConfiguredBotReviewPolicy` values instead of silently coercing them to `diagnose_only`
- preserve the default `diagnose_only` behavior when the field is omitted
- add focused config coverage for supported and unsupported explicit values

## Testing
- npx tsx --test src/config.test.ts
- npm run build

Closes #1437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now enforces stricter rules and produces clear error messages for unsupported values instead of silently using defaults.
  * Removed support for one previously-allowed configuration option; only two options are now supported.

* **Tests**
  * Updated test cases to verify stricter configuration validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->