### PR TITLE
Accept reply_and_resolve in staleConfiguredBotReviewPolicy config parsing

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -841,7 +841,7 @@ test("loadConfig accepts explicit stale configured-bot reply_only policy", async
   assert.equal(config.staleConfiguredBotReviewPolicy, "reply_only");
 });
 
-test("loadConfig rejects unsupported explicit stale configured-bot review policies", async (t) => {
+test("loadConfig accepts explicit stale configured-bot reply_and_resolve policy", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -864,17 +864,44 @@ test("loadConfig rejects unsupported explicit stale configured-bot review polici
     "utf8",
   );
 
+  const config = loadConfig(configPath);
+  assert.equal(config.staleConfiguredBotReviewPolicy, "reply_and_resolve");
+});
+
+test("loadConfig rejects unsupported explicit stale configured-bot review policies", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./.local/worktrees",
+      stateBackend: "json",
+      stateFile: "./.local/state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      staleConfiguredBotReviewPolicy: "resolve_only",
+    }),
+    "utf8",
+  );
+
   const summary = loadConfigSummary(configPath);
   assert.equal(summary.status, "invalid_config");
   assert.deepEqual(summary.invalidFields, ["staleConfiguredBotReviewPolicy"]);
   assert.match(
     summary.error ?? "",
-    /Invalid config field: staleConfiguredBotReviewPolicy \(unsupported value: reply_and_resolve; supported values: diagnose_only, reply_only\)/,
+    /Invalid config field: staleConfiguredBotReviewPolicy \(unsupported value: resolve_only; supported values: diagnose_only, reply_only, reply_and_resolve\)/,
   );
 
   assert.throws(
     () => loadConfig(configPath),
-    /Invalid config field: staleConfiguredBotReviewPolicy \(unsupported value: reply_and_resolve; supported values: diagnose_only, reply_only\)/,
+    /Invalid config field: staleConfiguredBotReviewPolicy \(unsupported value: resolve_only; supported values: diagnose_only, reply_only, reply_and_resolve\)/,
   );
 });
 

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -25,7 +25,11 @@ const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untru
 const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
 const VALID_LOCAL_REVIEW_POLICIES = new Set<LocalReviewPolicy>(["advisory", "block_ready", "block_merge"]);
 const VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS = new Set<LocalReviewHighSeverityAction>(["retry", "blocked"]);
-const VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES = new Set<StaleConfiguredBotReviewPolicy>(["diagnose_only", "reply_only"]);
+const VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES = new Set<StaleConfiguredBotReviewPolicy>([
+  "diagnose_only",
+  "reply_only",
+  "reply_and_resolve",
+]);
 const VALID_COPILOT_REVIEW_TIMEOUT_ACTIONS = new Set<CopilotReviewTimeoutAction>(["continue", "block"]);
 const VALID_LOCAL_REVIEW_MINIMUM_SEVERITIES = new Set<LocalReviewReviewerThresholdConfig["minimumSeverity"]>(["low", "medium", "high"]);
 const VALID_RUN_STATES = new Set<RunState>([
@@ -84,7 +88,7 @@ function parseStaleConfiguredBotReviewPolicy(value: unknown): StaleConfiguredBot
   }
 
   throw new Error(
-    `Invalid config field: staleConfiguredBotReviewPolicy (unsupported value: ${String(value)}; supported values: diagnose_only, reply_only)`,
+    `Invalid config field: staleConfiguredBotReviewPolicy (unsupported value: ${String(value)}; supported values: diagnose_only, reply_only, reply_and_resolve)`,
   );
 }
 


### PR DESCRIPTION
## Summary
- accept `reply_and_resolve` in stale configured-bot review policy config parsing
- keep focused config coverage aligned with the shipped policy surface, including unsupported-value rejection
- preserve the existing omitted-value default behavior

Closes #1440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the stale bot review policy configuration to now support `"reply_and_resolve"` as a valid option alongside existing policy settings, giving users greater flexibility in their configuration choices.

* **Tests**
  * Added comprehensive test coverage to validate the newly supported `"reply_and_resolve"` policy option and updated existing validation tests to ensure all supported values and error scenarios are properly tested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->