### PR TITLE
Reconsider stale local state when issue definitions change

### DIFF
--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -136,6 +136,8 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     stale_stabilizing_no_pr_recovery_count: value.stale_stabilizing_no_pr_recovery_count ?? 0,
     last_recovery_reason: value.last_recovery_reason ?? null,
     last_recovery_at: value.last_recovery_at ?? null,
+    issue_definition_fingerprint: value.issue_definition_fingerprint ?? null,
+    issue_definition_updated_at: value.issue_definition_updated_at ?? null,
     last_failure_kind: value.last_failure_kind ?? null,
     last_failure_context: value.last_failure_context ?? null,
     last_runtime_error: value.last_runtime_error ?? null,

--- a/src/core/state-store.ts
+++ b/src/core/state-store.ts
@@ -188,6 +188,14 @@ export class StateStore {
         hasOwn(patch, "last_recovery_reason") ? patch.last_recovery_reason ?? null : record.last_recovery_reason ?? null,
       last_recovery_at:
         hasOwn(patch, "last_recovery_at") ? patch.last_recovery_at ?? null : record.last_recovery_at ?? null,
+      issue_definition_fingerprint:
+        hasOwn(patch, "issue_definition_fingerprint")
+          ? patch.issue_definition_fingerprint ?? null
+          : record.issue_definition_fingerprint ?? null,
+      issue_definition_updated_at:
+        hasOwn(patch, "issue_definition_updated_at")
+          ? patch.issue_definition_updated_at ?? null
+          : record.issue_definition_updated_at ?? null,
       last_failure_kind:
         hasOwn(patch, "last_failure_kind") ? patch.last_failure_kind ?? null : record.last_failure_kind ?? null,
       last_failure_context:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -361,6 +361,8 @@ export interface IssueRunRecord {
   last_codex_summary: string | null;
   last_recovery_reason: string | null;
   last_recovery_at: string | null;
+  issue_definition_fingerprint?: string | null;
+  issue_definition_updated_at?: string | null;
   last_error: string | null;
   last_failure_kind: FailureKind;
   last_failure_context: FailureContext | null;

--- a/src/issue-definition-freshness.ts
+++ b/src/issue-definition-freshness.ts
@@ -1,0 +1,135 @@
+import crypto from "node:crypto";
+import { type GitHubIssue, type IssueRunRecord } from "./core/types";
+import {
+  findHighRiskBlockingAmbiguity,
+  lintExecutionReadyIssueBody,
+  parseIssueMetadata,
+} from "./issue-metadata";
+
+function normalizeInlineText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function normalizeMultilineText(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) {
+        return "";
+      }
+
+      const normalizedBullet = trimmed.replace(/^(?:[-*]|\d+\.)\s+/, "- ");
+      return normalizedBullet.replace(/\s+/g, " ");
+    })
+    .reduce<string[]>((lines, line) => {
+      if (line.length === 0 && lines[lines.length - 1] === "") {
+        return lines;
+      }
+
+      lines.push(line);
+      return lines;
+    }, [])
+    .join("\n")
+    .trim();
+}
+
+function extractMarkdownSection(body: string, title: string): string | null {
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const headingPattern = new RegExp(`^\\s*##\\s*${title}\\s*$`, "i");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!headingPattern.test(lines[index])) {
+      continue;
+    }
+
+    const sectionLines: string[] = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (/^\s*##\s+\S/.test(lines[cursor])) {
+        break;
+      }
+
+      sectionLines.push(lines[cursor]);
+    }
+
+    const normalized = normalizeMultilineText(sectionLines.join("\n"));
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  return null;
+}
+
+function normalizedLabels(issue: Pick<GitHubIssue, "labels">): string[] | null {
+  if (issue.labels === undefined) {
+    return null;
+  }
+
+  return issue.labels
+    .map((label) => normalizeInlineText(label.name).toLowerCase())
+    .filter(Boolean)
+    .sort();
+}
+
+export function buildIssueDefinitionFingerprint(
+  issue: Pick<GitHubIssue, "title" | "body" | "labels">,
+): string {
+  const metadata = parseIssueMetadata({
+    number: 0,
+    title: issue.title,
+    body: issue.body,
+    labels: issue.labels ?? [],
+    createdAt: "",
+    updatedAt: "",
+    url: "",
+    state: "OPEN",
+  });
+  const readiness = lintExecutionReadyIssueBody({
+    title: issue.title,
+    body: issue.body,
+    labels: issue.labels ?? [],
+  });
+  const clarificationBlock = findHighRiskBlockingAmbiguity(issue);
+  const normalizedDefinition = {
+    title: normalizeInlineText(issue.title),
+    labels: normalizedLabels(issue),
+    sections: {
+      summary: extractMarkdownSection(issue.body, "Summary"),
+      scope: extractMarkdownSection(issue.body, "Scope"),
+      acceptanceCriteria: extractMarkdownSection(issue.body, "Acceptance criteria"),
+      verification: extractMarkdownSection(issue.body, "Verification"),
+    },
+    metadata: {
+      parentIssueNumber: metadata.parentIssueNumber,
+      executionOrderIndex: metadata.executionOrderIndex,
+      executionOrderTotal: metadata.executionOrderTotal,
+      dependsOn: [...metadata.dependsOn].sort((left, right) => left - right),
+      parallelGroup: metadata.parallelGroup ? normalizeInlineText(metadata.parallelGroup) : null,
+      touches: [...metadata.touches].map(normalizeInlineText).sort(),
+    },
+    readiness: {
+      missingRequired: [...readiness.missingRequired].sort(),
+      missingRecommended: [...readiness.missingRecommended].sort(),
+      riskyChangeClasses: [...readiness.riskyChangeClasses].sort(),
+      approvedRiskyChangeClasses: [...readiness.approvedRiskyChangeClasses].sort(),
+    },
+    clarification: clarificationBlock
+      ? {
+          ambiguityClasses: [...clarificationBlock.ambiguityClasses].sort(),
+          riskyChangeClasses: [...clarificationBlock.riskyChangeClasses].sort(),
+          reason: normalizeInlineText(clarificationBlock.reason),
+        }
+      : null,
+  };
+
+  return crypto.createHash("sha256").update(JSON.stringify(normalizedDefinition)).digest("hex");
+}
+
+export function issueDefinitionFreshnessPatch(
+  issue: Pick<GitHubIssue, "title" | "body" | "labels" | "updatedAt">,
+): Pick<IssueRunRecord, "issue_definition_fingerprint" | "issue_definition_updated_at"> {
+  return {
+    issue_definition_fingerprint: buildIssueDefinitionFingerprint(issue),
+    issue_definition_updated_at: issue.updatedAt,
+  };
+}

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -612,6 +612,7 @@ export async function reconcileStaleFailedIssueStates(
   }) => Promise<void>) | null = null,
 ): Promise<void> {
   let changed = false;
+  const issuesByNumber = new Map(issues.map((issue) => [issue.number, issue]));
   const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
   let failedNoPrFetchPromise: Promise<void> | null = null;
   const ensureOriginDefaultBranchFetched = (): Promise<void> => {
@@ -630,21 +631,49 @@ export async function reconcileStaleFailedIssueStates(
       waitStep: null,
     });
 
-    let issueState = issueStateByNumber.get(record.issue_number) ?? null;
-    if (!issueStateByNumber.has(record.issue_number)) {
+    let issue = issuesByNumber.get(record.issue_number);
+    if (!issue) {
       try {
-        issueState = (await github.getIssue(record.issue_number)).state ?? null;
+        issue = await github.getIssue(record.issue_number);
       } catch {
-        issueState = null;
+        issue = undefined;
       }
-      issueStateByNumber.set(record.issue_number, issueState);
+      if (issue) {
+        issuesByNumber.set(record.issue_number, issue);
+      }
     }
+    const issueState = issue?.state ?? null;
+    issueStateByNumber.set(record.issue_number, issueState);
 
     if (issueState !== "OPEN") {
       continue;
     }
 
     if (record.pr_number === null) {
+      if (issue && shouldReconsiderGenericNoPrIssueDefinitionChange(record, issue)) {
+        const recoveryEvent = buildRecoveryEvent(
+          record.issue_number,
+          `github_issue_definition_changed: requeued issue #${record.issue_number} after a material GitHub issue definition change invalidated the stale no-PR ${record.state} state`,
+        );
+        const updated = stateStore.touch(record, {
+          state: "queued",
+          blocked_reason: null,
+          last_error: null,
+          last_failure_kind: null,
+          last_failure_context: null,
+          last_blocker_signature: null,
+          last_failure_signature: null,
+          repeated_failure_signature_count: 0,
+          stale_stabilizing_no_pr_recovery_count: 0,
+          codex_session_id: null,
+          ...issueDefinitionFreshnessPatch(issue),
+          ...applyRecoveryEvent({}, recoveryEvent),
+        });
+        state.issues[String(record.issue_number)] = updated;
+        changed = true;
+        continue;
+      }
+
       if (await reconcileStaleFailedNoPrRecord({
         github,
         stateStore,

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -19,6 +19,7 @@ import {
   hasAvailableIssueLabels,
   lintExecutionReadyIssueBody,
 } from "./issue-metadata";
+import { buildIssueDefinitionFingerprint, issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { inspectFileLock } from "./core/lock";
 import { RecoveryEvent } from "./run-once-cycle-prelude";
 import { StateStore } from "./core/state-store";
@@ -242,6 +243,53 @@ function shouldReconsiderBlockedNoPrStaleManualStop(
     localStopObservedAtMs !== null &&
     issueUpdatedAtMs > localStopObservedAtMs
   );
+}
+
+function shouldReconsiderGenericNoPrIssueDefinitionChange(
+  record: Pick<
+    IssueRunRecord,
+    | "state"
+    | "blocked_reason"
+    | "pr_number"
+    | "issue_definition_fingerprint"
+    | "last_failure_context"
+    | "last_recovery_at"
+    | "updated_at"
+  >,
+  issue: Pick<GitHubIssue, "title" | "body" | "labels" | "updatedAt">,
+): boolean {
+  if (record.pr_number !== null) {
+    return false;
+  }
+
+  if (record.state !== "blocked" && record.state !== "failed") {
+    return false;
+  }
+
+  if (record.state === "blocked" && (
+    record.blocked_reason === "requirements"
+    || record.blocked_reason === "clarification"
+    || record.blocked_reason === "permissions"
+    || record.blocked_reason === "secrets"
+  )) {
+    return false;
+  }
+
+  if (!record.issue_definition_fingerprint) {
+    return false;
+  }
+
+  const issueUpdatedAtMs = Date.parse(issue.updatedAt);
+  const localStopObservedAtMs = latestFiniteTimestamp(
+    record.last_failure_context?.updated_at,
+    record.last_recovery_at,
+    record.updated_at,
+  );
+  if (!Number.isFinite(issueUpdatedAtMs) || localStopObservedAtMs === null || issueUpdatedAtMs <= localStopObservedAtMs) {
+    return false;
+  }
+
+  return buildIssueDefinitionFingerprint(issue) !== record.issue_definition_fingerprint;
 }
 
 export function applyRecoveryEvent(
@@ -822,6 +870,31 @@ export async function reconcileRecoverableBlockedIssueStates(
         repeated_failure_signature_count: 0,
         stale_stabilizing_no_pr_recovery_count: 0,
         codex_session_id: null,
+        ...applyRecoveryEvent({}, recoveryEvent),
+      });
+      state.issues[String(record.issue_number)] = updated;
+      changed = true;
+      recoveryEvents.push(recoveryEvent);
+      continue;
+    }
+
+    if (shouldReconsiderGenericNoPrIssueDefinitionChange(record, issue)) {
+      const recoveryEvent = buildRecoveryEvent(
+        record.issue_number,
+        `github_issue_definition_changed: requeued issue #${record.issue_number} after a material GitHub issue definition change invalidated the stale no-PR ${record.state} state`,
+      );
+      const updated = stateStore.touch(record, {
+        state: "queued",
+        blocked_reason: null,
+        last_error: null,
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_blocker_signature: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        stale_stabilizing_no_pr_recovery_count: 0,
+        codex_session_id: null,
+        ...issueDefinitionFreshnessPatch(issue),
         ...applyRecoveryEvent({}, recoveryEvent),
       });
       state.issues[String(record.issue_number)] = updated;

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { GitHubClient } from "./github";
 import { canProceedWithDegradedContinuationAfterInventoryRefreshFailure } from "./inventory-refresh-state";
+import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import {
   findBlockingIssue,
   findHighRiskBlockingAmbiguity,
@@ -501,6 +502,7 @@ export async function resolveRunnableIssueContext(
         last_failure_context: failureContext,
         ...applyFailureSignature(record, failureContext),
         blocked_reason: "requirements",
+        ...issueDefinitionFreshnessPatch(issue),
       });
       state.issues[String(blockedRecord.issue_number)] = blockedRecord;
       state.activeIssueNumber = null;
@@ -540,6 +542,7 @@ export async function resolveRunnableIssueContext(
           last_failure_context: failureContext,
           ...applyFailureSignature(record, failureContext),
           blocked_reason: "requirements",
+          ...issueDefinitionFreshnessPatch(issue),
         });
         state.issues[String(blockedRecord.issue_number)] = blockedRecord;
         state.activeIssueNumber = null;
@@ -575,6 +578,7 @@ export async function resolveRunnableIssueContext(
         last_failure_context: failureContext,
         ...applyFailureSignature(record, failureContext),
         blocked_reason: "clarification",
+        ...issueDefinitionFreshnessPatch(issue),
       });
       state.issues[String(blockedRecord.issue_number)] = blockedRecord;
       state.activeIssueNumber = null;
@@ -605,6 +609,7 @@ export async function resolveRunnableIssueContext(
         last_failure_context: failureContext,
         ...applyFailureSignature(record, failureContext),
         blocked_reason: "permissions",
+        ...issueDefinitionFreshnessPatch(issue),
       });
       state.issues[String(blockedRecord.issue_number)] = blockedRecord;
       state.activeIssueNumber = null;
@@ -634,6 +639,7 @@ export async function resolveRunnableIssueContext(
         last_failure_context: failureContext,
         ...applyFailureSignature(record, failureContext),
         blocked_reason: "requirements",
+        ...issueDefinitionFreshnessPatch(issue),
       });
       state.issues[String(blockedRecord.issue_number)] = blockedRecord;
       state.activeIssueNumber = null;

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -59,6 +59,7 @@ import {
   clearInterruptedTurnMarker,
   writeInterruptedTurnMarker,
 } from "./interrupted-turn-marker";
+import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate";
 
 export {
@@ -470,6 +471,7 @@ export async function executeCodexTurnPhase(
             last_failure_context: failureContext,
             ...args.applyFailureSignature(record, failureContext),
             blocked_reason: "verification",
+            ...issueDefinitionFreshnessPatch(issue),
           });
           state.issues[String(record.issue_number)] = record;
           await stateStore.save(state);
@@ -512,6 +514,7 @@ export async function executeCodexTurnPhase(
               last_failure_context: failureContext,
               ...args.applyFailureSignature(record, failureContext),
               blocked_reason: "verification",
+              ...issueDefinitionFreshnessPatch(issue),
             });
             state.issues[String(record.issue_number)] = record;
             await stateStore.save(state);
@@ -642,6 +645,9 @@ export async function executeCodexTurnPhase(
             ? args.blockedReasonFromReviewState(postRunSnapshot?.recordForState ?? record, pr, checks, reviewThreads)
             : null,
         state: postRunState,
+        ...((pr === null && (postRunState === "blocked" || postRunState === "failed"))
+          ? issueDefinitionFreshnessPatch(issue)
+          : {}),
       });
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { runCommand } from "../core/command";
 import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorStateFile } from "../core/types";
+import { buildIssueDefinitionFingerprint } from "../issue-definition-freshness";
 import {
   buildTrackedPrStaleFailureConvergencePatch,
   formatRecoveryLog,
@@ -1076,6 +1077,193 @@ test("reconcileRecoverableBlockedIssueStates keeps stale no-PR manual-review sto
   assert.equal(saveCalls, 0);
   assert.deepEqual(recoveryEvents, []);
   assert.deepEqual(state.issues["366"], original);
+});
+
+test("reconcileRecoverableBlockedIssueStates requeues additional no-PR blocked verification stops when the issue definition changes materially", async () => {
+  const config = createConfig();
+  const originalIssue = createIssue({
+    number: 366,
+    body: executionReadyBody("Add recovery coverage for changed issue definitions."),
+    updatedAt: "2026-03-13T00:20:00Z",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: null,
+        codex_session_id: null,
+        last_error: "Verification failed against a stale issue definition.",
+        last_failure_kind: "command_error",
+        last_failure_context: {
+          category: "review",
+          summary: "Verification failed against the stale issue definition.",
+          signature: "verify-failed",
+          command: "npm test",
+          details: ["suite=supervisor", "assertion=stale-acceptance-criteria"],
+          url: "https://example.test/issues/366",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "verify-failed",
+        repeated_failure_signature_count: 2,
+        issue_definition_fingerprint: buildIssueDefinitionFingerprint(originalIssue),
+        issue_definition_updated_at: originalIssue.updatedAt,
+        last_recovery_reason: "verification_stop: blocked issue #366 after local verification failed",
+        last_recovery_at: "2026-03-13T00:20:00Z",
+        updated_at: "2026-03-13T00:20:00Z",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    body: originalIssue.body
+      .replace(
+        "- supervisor treats this issue as runnable",
+        "- supervisor requeues stale no-PR blocked verification stops when the issue definition changes materially",
+      ),
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "queued");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(
+    updated.last_recovery_reason,
+    "github_issue_definition_changed: requeued issue #366 after a material GitHub issue definition change invalidated the stale no-PR blocked state",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "github_issue_definition_changed: requeued issue #366 after a material GitHub issue definition change invalidated the stale no-PR blocked state",
+  ]);
+});
+
+test("reconcileRecoverableBlockedIssueStates ignores cosmetic-only issue edits for additional no-PR blocked verification stops", async () => {
+  const config = createConfig();
+  const originalIssue = createIssue({
+    number: 366,
+    body: executionReadyBody("Add recovery coverage for changed issue definitions."),
+    updatedAt: "2026-03-13T00:20:00Z",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: null,
+        codex_session_id: null,
+        last_error: "Verification failed against a stale issue definition.",
+        last_failure_kind: "command_error",
+        last_failure_context: {
+          category: "review",
+          summary: "Verification failed against the stale issue definition.",
+          signature: "verify-failed",
+          command: "npm test",
+          details: ["suite=supervisor", "assertion=stale-acceptance-criteria"],
+          url: "https://example.test/issues/366",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "verify-failed",
+        repeated_failure_signature_count: 2,
+        issue_definition_fingerprint: buildIssueDefinitionFingerprint(originalIssue),
+        issue_definition_updated_at: originalIssue.updatedAt,
+        updated_at: "2026-03-13T00:20:00Z",
+      }),
+    ],
+  });
+  const cosmeticallyEditedIssue = createIssue({
+    ...originalIssue,
+    body: originalIssue.body
+      .replace("## Scope\n- keep the test fixture execution-ready", "## Scope\n\n- keep the test fixture execution-ready   ")
+      .replace("## Verification\n- npm test -- src/supervisor.test.ts", "## Verification\n\n-   npm test -- src/supervisor.test.ts"),
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+    },
+    stateStore,
+    state,
+    config,
+    [cosmeticallyEditedIssue],
+    {
+      shouldAutoRetryHandoffMissing,
+    },
+  );
+
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+  assert.equal(state.issues["366"]?.state, "blocked");
 });
 
 test("reconcileStaleDoneIssueStates downgrades stale open no-PR done records to manual review", async () => {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2718,6 +2718,120 @@ test("reconcileMergedIssueClosures clears a stale active issue pointer even when
   assert.deepEqual(state.issues["366"], original);
 });
 
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues when the issue definition changes materially", async () => {
+  const config = createConfig();
+  const originalIssue = createIssue({
+    number: 366,
+    body: executionReadyBody("Refresh stale failed no-PR issues after issue-definition changes."),
+    updatedAt: "2026-03-13T00:20:00Z",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        pr_number: null,
+        codex_session_id: null,
+        last_error: "Codex failed against a stale issue definition.",
+        last_failure_kind: "codex_exit",
+        last_failure_context: {
+          category: "codex",
+          summary: "Codex failed against the stale issue definition.",
+          signature: "codex-failed",
+          command: "codex exec",
+          details: ["state=failed", "tracked_pr=none"],
+          url: "https://example.test/issues/366",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "codex-failed",
+        repeated_failure_signature_count: 2,
+        stale_stabilizing_no_pr_recovery_count: 1,
+        issue_definition_fingerprint: buildIssueDefinitionFingerprint(originalIssue),
+        issue_definition_updated_at: originalIssue.updatedAt,
+        last_recovery_reason: "codex_failed: failed issue #366 after codex exited non-zero",
+        last_recovery_at: "2026-03-13T00:20:00Z",
+        updated_at: "2026-03-13T00:20:00Z",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    body: originalIssue.body.replace(
+      "- supervisor treats this issue as runnable",
+      "- supervisor requeues stale failed no-PR issues when the issue definition changes materially",
+    ),
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getIssue: async () => issue,
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getMergedPullRequestsClosingIssue: async () => {
+        throw new Error("unexpected getMergedPullRequestsClosingIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "queued");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(
+    updated.last_recovery_reason,
+    "github_issue_definition_changed: requeued issue #366 after a material GitHub issue definition change invalidated the stale no-PR failed state",
+  );
+  assert.equal(updated.issue_definition_fingerprint, buildIssueDefinitionFingerprint(issue));
+  assert.equal(updated.issue_definition_updated_at, issue.updatedAt);
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileParentEpicClosures clears a stale active issue pointer even when the parent record already matches the done patch", async () => {
   const original = createRecord({
     issue_number: 123,

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -122,6 +122,8 @@ export function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunR
     last_codex_summary: null,
     last_recovery_reason: null,
     last_recovery_at: null,
+    issue_definition_fingerprint: null,
+    issue_definition_updated_at: null,
     last_error: "Codex completed without updating the issue journal for issue #366.",
     last_failure_kind: null,
     last_failure_context: {

--- a/src/turn-execution-failure-helpers.test.ts
+++ b/src/turn-execution-failure-helpers.test.ts
@@ -205,3 +205,58 @@ test("persistCodexTurnExitFailure preserves timeout summaries from bounded Codex
   assert.match(updated.last_failure_context?.details[0] ?? "", /Command timed out after 1800000ms: codex exec/);
   assert.match(updated.last_failure_context?.details[0] ?? "", /\n\.\.\.\n/);
 });
+
+test("persistCodexTurnExitFailure skips issue-definition freshness when labels are unavailable", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 105,
+    issues: {
+      "105": createRecord({
+        issue_number: 105,
+        state: "stabilizing",
+        pr_number: null,
+        issue_definition_fingerprint: "existing-fingerprint",
+        issue_definition_updated_at: "2026-03-24T02:59:00Z",
+      }),
+    },
+  };
+
+  const updated = await persistCodexTurnExitFailure({
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-24T03:15:00Z" }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["105"]!,
+    issue: {
+      createdAt: "2026-03-24T03:00:00Z",
+      title: "Partial issue snapshot",
+      body: "## Summary\nPartial payload\n",
+      updatedAt: "2026-03-24T03:10:00Z",
+    },
+    syncJournal: async () => undefined,
+    issueNumber: 105,
+    codexResult: {
+      lastMessage: "Summary: codex failed",
+      stderr: "boom",
+      stdout: "",
+    },
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-24T03:15:00Z",
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: "codex-exit",
+      repeated_failure_signature_count: 1,
+    }),
+  });
+
+  assert.equal(updated.state, "failed");
+  assert.equal(updated.issue_definition_fingerprint, "existing-fingerprint");
+  assert.equal(updated.issue_definition_updated_at, "2026-03-24T02:59:00Z");
+});

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -1,15 +1,18 @@
 import { StateStore } from "./core/state-store";
 import { CodexTurnResult, FailureContext, GitHubIssue, IssueRunRecord, SupervisorStateFile } from "./core/types";
+import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { truncate, truncatePreservingStartAndEnd } from "./core/utils";
 import { syncExecutionMetricsRunSummarySafely } from "./supervisor/execution-metrics-run-summary";
 
 type TurnExecutionFailureStateStore = Pick<StateStore, "save" | "touch">;
+type IssueDefinitionAwareIssue = Pick<GitHubIssue, "createdAt">
+  & Partial<Pick<GitHubIssue, "title" | "body" | "labels" | "updatedAt">>;
 
 interface PersistTurnExecutionFailureArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
-  issue: Pick<GitHubIssue, "createdAt">;
+  issue: IssueDefinitionAwareIssue;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   error: unknown;
@@ -30,7 +33,7 @@ interface PersistCodexExitFailureArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
-  issue: Pick<GitHubIssue, "createdAt">;
+  issue: IssueDefinitionAwareIssue;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   codexResult: Pick<CodexTurnResult, "lastMessage" | "stderr" | "stdout">;
@@ -51,7 +54,7 @@ interface PersistMissingJournalHandoffArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
-  issue: Pick<GitHubIssue, "createdAt">;
+  issue: IssueDefinitionAwareIssue;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   buildCodexFailureContext: (
@@ -70,7 +73,7 @@ interface PersistHintedCodexTurnStateArgs {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
-  issue: Pick<GitHubIssue, "createdAt">;
+  issue: IssueDefinitionAwareIssue;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   issueNumber: number;
   lastMessage: string;
@@ -123,12 +126,33 @@ async function persistTurnFailurePatch(args: {
   stateStore: TurnExecutionFailureStateStore;
   state: SupervisorStateFile;
   record: IssueRunRecord;
-  issue: Pick<GitHubIssue, "createdAt">;
+  issue: IssueDefinitionAwareIssue;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   patch: Partial<IssueRunRecord>;
   retentionRootPath?: string;
 }): Promise<IssueRunRecord> {
-  const updated = args.stateStore.touch(args.record, args.patch);
+  let issueDefinitionPatch: ReturnType<typeof issueDefinitionFreshnessPatch> | null = null;
+  if (
+    typeof args.issue.title === "string"
+    && typeof args.issue.body === "string"
+    && typeof args.issue.updatedAt === "string"
+  ) {
+    issueDefinitionPatch = issueDefinitionFreshnessPatch({
+      title: args.issue.title,
+      body: args.issue.body,
+      labels: args.issue.labels,
+      updatedAt: args.issue.updatedAt,
+    });
+  }
+  const effectivePatch = (args.patch.state === "blocked" || args.patch.state === "failed")
+    && ((args.patch.pr_number ?? args.record.pr_number) === null)
+    && issueDefinitionPatch
+    ? {
+        ...args.patch,
+        ...issueDefinitionPatch,
+      }
+    : args.patch;
+  const updated = args.stateStore.touch(args.record, effectivePatch);
   args.state.issues[String(args.record.issue_number)] = updated;
   await args.stateStore.save(args.state);
   await syncExecutionMetricsRunSummarySafely({

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -135,6 +135,7 @@ async function persistTurnFailurePatch(args: {
   if (
     typeof args.issue.title === "string"
     && typeof args.issue.body === "string"
+    && Array.isArray(args.issue.labels)
     && typeof args.issue.updatedAt === "string"
   ) {
     issueDefinitionPatch = issueDefinitionFreshnessPatch({

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -13,6 +13,7 @@ import {
   WorkspaceStatus,
 } from "./core/types";
 import { truncate } from "./core/utils";
+import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import {
   buildWorkstationLocalPathFailureContext,
   runWorkstationLocalPathGate,
@@ -103,6 +104,7 @@ export async function applyCodexTurnPublicationGate(args: {
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...issueDefinitionFreshnessPatch(args.issue),
       });
       args.state.issues[String(record.issue_number)] = record;
       await args.stateStore.save(args.state);
@@ -142,6 +144,7 @@ export async function applyCodexTurnPublicationGate(args: {
           last_failure_context: failureContext,
           ...args.applyFailureSignature(record, failureContext),
           blocked_reason: "verification",
+          ...issueDefinitionFreshnessPatch(args.issue),
         });
         args.state.issues[String(record.issue_number)] = record;
         await args.stateStore.save(args.state);
@@ -175,6 +178,7 @@ export async function applyCodexTurnPublicationGate(args: {
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...issueDefinitionFreshnessPatch(args.issue),
       });
       args.state.issues[String(record.issue_number)] = record;
       await args.stateStore.save(args.state);
@@ -211,6 +215,7 @@ export async function applyCodexTurnPublicationGate(args: {
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...issueDefinitionFreshnessPatch(args.issue),
       });
       args.state.issues[String(record.issue_number)] = record;
       await args.stateStore.save(args.state);


### PR DESCRIPTION
## Summary
- generalize no-PR stale-state reconsideration beyond the existing targeted heuristics
- persist a normalized issue-definition fingerprint plus authoritative issue update timestamp on no-PR blocked/failed stop records
- requeue stale no-PR stop states only when the authoritative issue definition changed materially after the local stop, while ignoring cosmetic-only edits

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/turn-execution-failure-helpers.test.ts
- npm run build

Closes #1427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces deterministic issue-definition fingerprints and freshness metadata; these are persisted on relevant issue run records and updated when issues change.
* **Bug Fixes**
  * Records blocked/failed with no PR are automatically reconsidered and requeued when the GitHub issue definition materially changes, clearing stale failure state.
* **Tests**
  * Added unit and integration tests covering material vs. cosmetic issue edits and recovery/requeue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->