### PR TITLE
Improve tracked-PR self-healing after supervisor downtime

### DIFF
--- a/.codex-supervisor/issues/1443/issue-journal.md
+++ b/.codex-supervisor/issues/1443/issue-journal.md
@@ -5,29 +5,42 @@
 - Branch: codex/issue-1443
 - Workspace: .
 - Journal: .codex-supervisor/issues/1443/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: bc56de43bcb93bbf0eb16c51535434207f10c08c
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 5ee59df82f9dde15fff78b717c8710d909619920
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T22:14:39.190Z
+- Last failure signature: PRRT_kwDORgvdZ856VEIF
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T22:35:00.369Z
 
 ## Latest Codex Summary
-- None yet.
+Implemented the tracked-PR downtime catch-up in the bounded merged/open reconciliation path so open tracked PR records now refresh from authoritative GitHub facts when their projected lifecycle state changed while the supervisor was down. That covers stale active states like `waiting_ci`, `addressing_review`, and transitions into blocked tracked-PR states without waiting for a later babysat loop. I also updated mismatch diagnostics to point operators at a concrete one-shot refresh path: `run-once --dry-run`.
+
+Regression coverage was added for the new `runOnce` behavior and for persisted reconciliation cursor behavior across cycles. I updated the issue journal handoff, committed the checkpoint as `5ee59df` (`Improve tracked PR downtime reconciliation`), pushed `codex/issue-1443`, and opened draft PR #1445: https://github.com/TommyKammy/codex-supervisor/pull/1445
+
+Summary: Added bounded tracked-PR lifecycle refresh for stale open PR states after downtime, updated operator recovery guidance, verified the required suites, committed, pushed, and opened draft PR #1445.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npx tsx --test src/post-turn-pull-request.test.ts`; `npx tsx --test src/supervisor/supervisor-lifecycle.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`; `npx tsx --test --test-name-pattern "runOnce reconciles tracked PR state before reserving a new runnable issue|runOnce refreshes stale waiting_ci tracked PR review state after downtime before stopping on the new blocked state|runOnce keeps tracked PR repair work retryable when the same failure repeats after PR head progress" src/supervisor/supervisor-execution-orchestration.test.ts`; `npm run build`
+Next action: Wait for PR #1445 review/CI and address any follow-up if the tracked-PR recovery path needs adjustment.
+Failure signature: PRRT_kwDORgvdZ856VEIF
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1445#discussion_r3068679266
+- Details:
+  - src/recovery-tracked-pr-reconciliation.ts:286 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Keep the open-PR refresh branch aligned with the stale-failed reconciliation path.** Unlike `reconcileStaleFailedTrackedPrRecord` below, this... url=https://github.com/TommyKammy/codex-supervisor/pull/1445#discussion_r3068679266
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Post-downtime tracked PR state was only self-healing for merged, failed, and some blocked records; open tracked PR records left in active lifecycle states could stay stale until a later full loop action.
-- What changed: Added bounded tracked-PR lifecycle refresh for open PR records in active tracked-PR states during merged/open reconciliation, updated mismatch guidance to point operators at a one-shot `run-once --dry-run` refresh path, and added regression coverage for run-once and reconciliation cursor behavior.
+- Hypothesis: The remaining review gap was narrower than the original downtime bug: open tracked-PR resume reconciliation cleared reconciliation-progress `waitStep` at loop start but did not repopulate it when fresh GitHub facts projected the record into `waiting_ci`.
+- What changed: Mirrored the stale-failed tracked-PR path in merged/open resume reconciliation by threading `inferGitHubWaitStep` into `reconcileTrackedMergedButOpenIssuesInModule`, updating reconciliation progress with the inferred GitHub wait step before applying the recovery patch, and adding a regression that proves an open `pr_open` record refreshed into `waiting_ci` reports `configured_bot_initial_grace_wait`.
 - Current blocker: none
-- Next exact step: Commit the verified checkpoint and, if desired by the supervisor flow, open or update a draft PR for `codex/issue-1443`.
+- Next exact step: Commit and push the review fix to `codex/issue-1443`, then leave PR #1445 ready for re-review.
 - Verification gap: The full `src/supervisor/supervisor-execution-orchestration.test.ts` suite still contains a pre-existing unrelated stale no-PR test failure outside this tracked-PR issue scope; the targeted tracked-PR regressions and the issue's required verification commands passed.
-- Files touched: src/recovery-tracked-pr-reconciliation.ts; src/supervisor/tracked-pr-mismatch.ts; src/supervisor/supervisor-execution-orchestration.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts
-- Rollback concern: The new refresh path is intentionally limited to open tracked PR records whose authoritative GitHub lifecycle state differs from the local active state, to avoid disturbing same-state retry accounting.
-- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
+- Files touched: src/recovery-tracked-pr-reconciliation.ts; src/recovery-reconciliation.ts; src/supervisor/tracked-pr-mismatch.ts; src/supervisor/supervisor-execution-orchestration.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts
+- Rollback concern: The added wait-step projection is intentionally limited to the open tracked-PR resume path and only updates reconciliation progress, so it should not perturb persisted issue state or same-state retry accounting.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1443/issue-journal.md
+++ b/.codex-supervisor/issues/1443/issue-journal.md
@@ -35,12 +35,12 @@ Failure signature: PRRT_kwDORgvdZ856VEIF
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The remaining review gap was narrower than the original downtime bug: open tracked-PR resume reconciliation cleared reconciliation-progress `waitStep` at loop start but did not repopulate it when fresh GitHub facts projected the record into `waiting_ci`.
-- What changed: Mirrored the stale-failed tracked-PR path in merged/open resume reconciliation by threading `inferGitHubWaitStep` into `reconcileTrackedMergedButOpenIssuesInModule`, updating reconciliation progress with the inferred GitHub wait step before applying the recovery patch, and adding a regression that proves an open `pr_open` record refreshed into `waiting_ci` reports `configured_bot_initial_grace_wait`.
+- What changed: Mirrored the stale-failed tracked-PR path in merged/open resume reconciliation by threading `inferGitHubWaitStep` into `reconcileTrackedMergedButOpenIssuesInModule`, updating reconciliation progress with the inferred GitHub wait step before applying the recovery patch, adding a regression that proves an open `pr_open` record refreshed into `waiting_ci` reports `configured_bot_initial_grace_wait`, and pushing the review fix as commit `10f115e` on `codex/issue-1443`.
 - Current blocker: none
-- Next exact step: Commit and push the review fix to `codex/issue-1443`, then leave PR #1445 ready for re-review.
+- Next exact step: Wait for PR #1445 re-review or resolve the thread manually if the operator wants an explicit reply/resolution action.
 - Verification gap: The full `src/supervisor/supervisor-execution-orchestration.test.ts` suite still contains a pre-existing unrelated stale no-PR test failure outside this tracked-PR issue scope; the targeted tracked-PR regressions and the issue's required verification commands passed.
 - Files touched: src/recovery-tracked-pr-reconciliation.ts; src/recovery-reconciliation.ts; src/supervisor/tracked-pr-mismatch.ts; src/supervisor/supervisor-execution-orchestration.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts
 - Rollback concern: The added wait-step projection is intentionally limited to the open tracked-PR resume path and only updates reconciliation progress, so it should not perturb persisted issue state or same-state retry accounting.
-- Last focused command: npm run build
+- Last focused command: git push origin codex/issue-1443
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/1443/issue-journal.md
+++ b/.codex-supervisor/issues/1443/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1443: Improve tracked-PR self-healing after supervisor downtime
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1443
+- Branch: codex/issue-1443
+- Workspace: .
+- Journal: .codex-supervisor/issues/1443/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: bc56de43bcb93bbf0eb16c51535434207f10c08c
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T22:14:39.190Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Post-downtime tracked PR state was only self-healing for merged, failed, and some blocked records; open tracked PR records left in active lifecycle states could stay stale until a later full loop action.
+- What changed: Added bounded tracked-PR lifecycle refresh for open PR records in active tracked-PR states during merged/open reconciliation, updated mismatch guidance to point operators at a one-shot `run-once --dry-run` refresh path, and added regression coverage for run-once and reconciliation cursor behavior.
+- Current blocker: none
+- Next exact step: Commit the verified checkpoint and, if desired by the supervisor flow, open or update a draft PR for `codex/issue-1443`.
+- Verification gap: The full `src/supervisor/supervisor-execution-orchestration.test.ts` suite still contains a pre-existing unrelated stale no-PR test failure outside this tracked-PR issue scope; the targeted tracked-PR regressions and the issue's required verification commands passed.
+- Files touched: src/recovery-tracked-pr-reconciliation.ts; src/supervisor/tracked-pr-mismatch.ts; src/supervisor/supervisor-execution-orchestration.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts
+- Rollback concern: The new refresh path is intentionally limited to open tracked PR records whose authoritative GitHub lifecycle state differs from the local active state, to avoid disturbing same-state retry accounting.
+- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { runCommand } from "./core/command";
 import {
+  inferGitHubWaitStep,
   inferStateFromPullRequest,
 } from "./pull-request-state";
 import {
@@ -548,6 +549,7 @@ export async function reconcileTrackedMergedButOpenIssues(
       buildRecoveryEvent,
       applyRecoveryEvent,
       doneResetPatch,
+      inferGitHubWaitStep,
     },
     updateReconciliationProgress,
     options,

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -16,7 +16,7 @@ import {
 import { syncPostMergeAuditArtifactSafely } from "./supervisor/post-merge-audit-artifact";
 import { buildTrackedPrStaleFailureConvergencePatch } from "./recovery-tracked-pr-support";
 import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
-import { inferStateFromPullRequest } from "./pull-request-state";
+import { inferGitHubWaitStep, inferStateFromPullRequest } from "./pull-request-state";
 import {
   syncCopilotReviewRequestObservation,
   syncCopilotReviewTimeoutState,
@@ -155,6 +155,12 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
     buildRecoveryEvent: BuildRecoveryEvent;
     applyRecoveryEvent: ApplyRecoveryEvent;
     doneResetPatch: typeof import("./recovery-support").doneResetPatch;
+    inferGitHubWaitStep?: (
+      config: SupervisorConfig,
+      record: IssueRunRecord,
+      pr: NonNullable<Awaited<ReturnType<RecoveryGitHubLike["getPullRequestIfExists"]>>>,
+      checks: PullRequestCheck[],
+    ) => string | null;
   },
   updateReconciliationProgress: ((patch: {
     targetIssueNumber?: number | null;
@@ -247,6 +253,13 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
         syncReviewWaitWindow,
         syncCopilotReviewRequestObservation,
         syncCopilotReviewTimeoutState,
+      });
+      const inferredWaitStep =
+        projection.nextState === "waiting_ci"
+          ? (helpers.inferGitHubWaitStep?.(config, projection.recordForState, trackedPullRequest, checks) ?? null)
+          : null;
+      await updateReconciliationProgress?.({
+        waitStep: inferredWaitStep,
       });
       if (projection.shouldSuppressRecovery) {
         continue;
@@ -485,9 +498,7 @@ export async function reconcileStaleFailedTrackedPrRecord(
   const nextState = projection.nextState;
   await updateReconciliationProgress?.({
     waitStep:
-      nextState === "waiting_ci"
-        ? (deps.inferGitHubWaitStep?.(config, projection.recordForState, pr, checks) ?? null)
-        : null,
+      nextState === "waiting_ci" ? (deps.inferGitHubWaitStep?.(config, projection.recordForState, pr, checks) ?? null) : null,
   });
 
   if (projection.shouldSuppressRecovery) {

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -16,6 +16,14 @@ import {
 import { syncPostMergeAuditArtifactSafely } from "./supervisor/post-merge-audit-artifact";
 import { buildTrackedPrStaleFailureConvergencePatch } from "./recovery-tracked-pr-support";
 import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
+import { inferStateFromPullRequest } from "./pull-request-state";
+import {
+  syncCopilotReviewRequestObservation,
+  syncCopilotReviewTimeoutState,
+  syncReviewWaitWindow,
+} from "./pull-request-state-sync";
+import { blockedReasonForLifecycleState, isOpenPullRequest } from "./supervisor/supervisor-lifecycle";
+import { inferFailureContext } from "./supervisor/supervisor-failure-context";
 
 type RecoveryGitHubLike = Pick<
   import("./github").GitHubClient,
@@ -33,6 +41,18 @@ type ApplyRecoveryEvent = (
   patch: Partial<IssueRunRecord>,
   recoveryEvent: RecoveryEvent,
 ) => Partial<IssueRunRecord>;
+
+const TRACKED_PR_LIFECYCLE_REFRESH_STATES = new Set<IssueRunRecord["state"]>([
+  "draft_pr",
+  "local_review",
+  "pr_open",
+  "repairing_ci",
+  "resolving_conflict",
+  "waiting_ci",
+  "addressing_review",
+  "ready_to_merge",
+  "merging",
+]);
 
 function needsRecordUpdate(record: IssueRunRecord, patch: Partial<IssueRunRecord>): boolean {
   for (const [key, value] of Object.entries(patch)) {
@@ -123,7 +143,10 @@ export function buildTrackedPrResumeRecoveryEvent(
 }
 
 export async function reconcileTrackedMergedButOpenIssuesInModule(
-  github: Pick<RecoveryGitHubLike, "closeIssue" | "getIssue" | "getPullRequestIfExists">,
+  github: Pick<
+    RecoveryGitHubLike,
+    "closeIssue" | "getChecks" | "getIssue" | "getPullRequestIfExists" | "getUnresolvedReviewThreads"
+  >,
   stateStore: StateStoreLike,
   state: SupervisorStateFile,
   config: SupervisorConfig,
@@ -203,6 +226,64 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
     }
 
     if (!trackedPullRequest || (!trackedPullRequest.mergedAt && trackedPullRequest.state !== "MERGED")) {
+      if (!trackedPullRequest || !isOpenPullRequest(trackedPullRequest)) {
+        continue;
+      }
+
+      if (!TRACKED_PR_LIFECYCLE_REFRESH_STATES.has(record.state)) {
+        continue;
+      }
+
+      const checks = await github.getChecks(trackedPullRequest.number);
+      const reviewThreads = await github.getUnresolvedReviewThreads(trackedPullRequest.number);
+      const projection = projectTrackedPrLifecycle({
+        config,
+        record,
+        pr: trackedPullRequest,
+        checks,
+        reviewThreads,
+        inferStateFromPullRequest,
+        blockedReasonForLifecycleState,
+        syncReviewWaitWindow,
+        syncCopilotReviewRequestObservation,
+        syncCopilotReviewTimeoutState,
+      });
+      if (projection.shouldSuppressRecovery) {
+        continue;
+      }
+
+      const nextState = projection.nextState;
+      if (nextState === record.state) {
+        continue;
+      }
+      const failureContext =
+        nextState === "blocked"
+          ? inferFailureContext(config, projection.recordForState, trackedPullRequest, checks, reviewThreads)
+          : null;
+      const patch = buildTrackedPrStaleFailureConvergencePatch({
+        record,
+        pr: trackedPullRequest,
+        nextState,
+        failureContext,
+        blockedReason: projection.nextBlockedReason,
+        reviewWaitPatch: projection.reviewWaitPatch,
+        copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
+        copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
+      });
+      if (!needsRecordUpdate(record, patch)) {
+        continue;
+      }
+
+      const recoveryEvent = buildTrackedPrResumeRecoveryEvent(
+        record,
+        trackedPullRequest,
+        nextState,
+        helpers.buildRecoveryEvent,
+      );
+      const updated = stateStore.touch(record, helpers.applyRecoveryEvent(patch, recoveryEvent));
+      state.issues[String(record.issue_number)] = updated;
+      saveNeeded = true;
+      recoveryEvents.push(recoveryEvent);
       continue;
     }
 

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -434,7 +434,7 @@ Expose stale tracked PR mismatch diagnostics.
   );
   assert.match(
     explanation,
-    /^recovery_guidance=Tracked PR facts are fresher than local state; run the supervisor again to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
+    /^recovery_guidance=Tracked PR facts are fresher than local state; run a one-shot supervisor cycle such as `node dist\/index\.js run-once --config \.\.\. --dry-run` to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2504,7 +2504,7 @@ test("status surfaces tracked PR mismatches when GitHub is ready but local state
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^recovery_guidance=Tracked PR facts are fresher than local state; run the supervisor again to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
+    /^recovery_guidance=Tracked PR facts are fresher than local state; run a one-shot supervisor cycle such as `node dist\/index\.js run-once --config \.\.\. --dry-run` to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
   );
 
   const status = await supervisor.status();
@@ -2514,7 +2514,7 @@ test("status surfaces tracked PR mismatches when GitHub is ready but local state
   );
   assert.match(
     status,
-    /^recovery_guidance=Tracked PR facts are fresher than local state; run the supervisor again to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
+    /^recovery_guidance=Tracked PR facts are fresher than local state; run a one-shot supervisor cycle such as `node dist\/index\.js run-once --config \.\.\. --dry-run` to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\.$/m,
   );
 });
 

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -328,7 +328,7 @@ test("runOnce reconciles tracked PR state before reserving a new runnable issue"
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   assert.equal(persisted.activeIssueNumber, selectedIssueNumber);
   assert.equal(persisted.issues[String(selectedIssueNumber)]?.state, "reproducing");
-  assert.equal(persisted.issues[String(unrelatedIssueNumber)]?.state, "waiting_ci");
+  assert.equal(persisted.issues[String(unrelatedIssueNumber)]?.state, "ready_to_merge");
   assert.equal(persisted.issues[String(unrelatedIssueNumber)]?.pr_number, 192);
 });
 
@@ -430,6 +430,101 @@ test("runOnce converges stale failed tracked PR state before selecting the resum
   assert.equal(
     record.last_recovery_reason,
     "tracked_pr_lifecycle_recovered: resumed issue #366 from failed to draft_pr using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(record.last_recovery_at);
+});
+
+test("runOnce refreshes stale waiting_ci tracked PR review state after downtime before stopping on the new blocked state", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 366;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
+        state: "waiting_ci",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        codex_session_id: "thread-366",
+      }),
+    ],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+
+  const issue = createTrackedIssue(issueNumber, {
+    title: "Refresh stale waiting_ci tracked PR state",
+    body: executionReadyBody("Refresh tracked PR lifecycle state from GitHub after downtime."),
+  });
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
+    number: 191,
+    title: "Recovery implementation",
+    isDraft: false,
+    headRefOid: "head-191",
+    reviewDecision: "CHANGES_REQUESTED",
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, pr.number);
+    return {
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [createReviewThread({ id: "thread-191", isResolved: false })],
+    };
+  };
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async (requestedIssueNumber: number) => {
+      assert.equal(requestedIssueNumber, issueNumber);
+      return issue;
+    },
+    resolvePullRequestForBranch: async (requestedBranch: string, prNumber: number | null) => {
+      assert.equal(requestedBranch, branch);
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return [createReviewThread({ id: "thread-191", isResolved: false })];
+    },
+    getPullRequestIfExists: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(
+    message,
+    /recovery issue=#366 reason=tracked_pr_lifecycle_recovered: resumed issue #366 from waiting_ci to blocked using fresh tracked PR #191 facts at head head-191; No matching open issue found\./,
+  );
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(persisted.activeIssueNumber, null);
+  assert.equal(record.state, "blocked");
+  assert.equal(record.blocked_reason, "manual_review");
+  assert.equal(record.pr_number, pr.number);
+  assert.match(record.last_error ?? "", /review/i);
+  assert.ok(record.last_failure_context);
+  assert.equal(
+    record.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from waiting_ci to blocked using fresh tracked PR #191 facts at head head-191",
   );
   assert.ok(record.last_recovery_at);
 });

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3427,10 +3427,13 @@ test("reconcileTrackedMergedButOpenIssues resumes from persisted progress in the
     { maxRecords: 1 },
   );
 
-  assert.deepEqual(firstCycleEvents, []);
+  assert.deepEqual(firstCycleEvents.map((event) => event.reason), [
+    "tracked_pr_head_advanced: resumed issue #366 from waiting_ci to ready_to_merge after tracked PR #191 advanced from abcdef1 to open-head-191",
+  ]);
   assert.deepEqual(prLookups, [191]);
   assert.equal(saveCalls, 1);
-  assert.equal(state.issues["366"]?.state, "waiting_ci");
+  assert.equal(state.issues["366"]?.state, "ready_to_merge");
+  assert.equal(state.issues["366"]?.last_head_sha, "open-head-191");
   assert.equal(state.issues["367"]?.state, "merging");
 
   const secondCycleEvents = await reconcileTrackedMergedButOpenIssues(

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3115,6 +3115,97 @@ test("reconcileTrackedMergedButOpenIssues refreshes open issue snapshots for mer
   ]);
 });
 
+test("reconcileTrackedMergedButOpenIssues reports the inferred wait step when open tracked PR refresh resumes in waiting_ci", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai[bot]"],
+    configuredBotInitialGraceWaitSeconds: 90,
+  });
+  const record = createRecord({
+    issue_number: 366,
+    state: "pr_open",
+    pr_number: 191,
+    last_head_sha: "head-191",
+    branch: "codex/reopen-issue-366",
+    blocked_reason: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "366": record,
+    },
+  };
+  const openPr = createTrackedPrRecoveryPullRequest({
+    headRefOid: "head-191",
+    currentHeadCiGreenAt: "2026-03-16T00:00:00Z",
+  });
+
+  let saveCalls = 0;
+  const progressUpdates: Array<{
+    targetIssueNumber?: number | null;
+    targetPrNumber?: number | null;
+    waitStep?: string | null;
+  }> = [];
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-16T00:00:31Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:00:30Z");
+  try {
+    const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
+      {
+        getPullRequestIfExists: async () => openPr,
+        getIssue: async () => {
+          throw new Error("unexpected getIssue call");
+        },
+        closeIssue: async () => {
+          throw new Error("unexpected closeIssue call");
+        },
+        closePullRequest: async () => {
+          throw new Error("unexpected closePullRequest call");
+        },
+        getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        getMergedPullRequestsClosingIssue: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+      },
+      stateStore,
+      state,
+      config,
+      [createTrackedPrRecoveryIssue()],
+      async (patch) => {
+        progressUpdates.push(patch);
+      },
+    );
+
+    assert.equal(saveCalls, 1);
+    assert.equal(state.issues["366"]?.state, "waiting_ci");
+    assert.deepEqual(progressUpdates, [
+      {
+        targetIssueNumber: 366,
+        targetPrNumber: 191,
+        waitStep: null,
+      },
+      {
+        waitStep: "configured_bot_initial_grace_wait",
+      },
+    ]);
+    assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+      "tracked_pr_lifecycle_recovered: resumed issue #366 from pr_open to waiting_ci using fresh tracked PR #191 facts at head head-191",
+    ]);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("reconcileTrackedMergedButOpenIssues can restrict convergence to the active merging issue", async () => {
   const activeRecord = createRecord({
     issue_number: 366,

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -274,7 +274,7 @@ export function buildTrackedPrMismatch(
       `stale_local_blocker=${staleLocalBlocker ? "yes" : "no"}`,
     ].join(" "),
     guidanceLine:
-      "recovery_guidance=Tracked PR facts are fresher than local state; run the supervisor again to refresh tracked PR state. Explicit requeue is unavailable for tracked PR work.",
+      "recovery_guidance=Tracked PR facts are fresher than local state; run a one-shot supervisor cycle such as `node dist/index.js run-once --config ... --dry-run` to refresh tracked PR state. Explicit requeue is unavailable for tracked PR work.",
     detailLines: buildTrackedPrHostLocalCiDetailLines(config, record, pr, checks),
   };
 }


### PR DESCRIPTION
## Summary
- refresh stale open tracked-PR lifecycle state during bounded merged/open reconciliation when GitHub projects a different lifecycle state
- add focused run-once and reconciliation regression coverage for post-downtime tracked-PR catch-up
- update mismatch diagnostics to point operators at a one-shot `run-once --dry-run` refresh path

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/supervisor/supervisor-lifecycle.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test --test-name-pattern "runOnce reconciles tracked PR state before reserving a new runnable issue|runOnce refreshes stale waiting_ci tracked PR review state after downtime before stopping on the new blocked state|runOnce keeps tracked PR repair work retryable when the same failure repeats after PR head progress" src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling for tracked pull requests that become stale after supervisor downtime by refreshing PR lifecycle state during reconciliation.

* **Documentation**
  * Updated operator guidance to provide specific one-shot supervisor refresh command (`run-once --dry-run`) instead of generic instructions.

* **Tests**
  * Updated test expectations to reflect improved PR state refresh and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->