### PR TITLE
Protect already tracked live issue journals from future recommits

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -322,7 +322,7 @@ test("ensureWorkspace bootstraps from the fresh default-branch ref instead of st
 test("ensureWorkspace hides tracked live issue journals while preserving intentional files outside the live path", async () => {
   const config = await createRepositoryFixture();
   const trackedJournalPath = path.join(config.repoPath, ".codex-supervisor", "issues", "811", "issue-journal.md");
-  const trackedFixturePath = path.join(config.repoPath, ".codex-supervisor", "issues", "fixtures", "journal-fixture.md");
+  const trackedFixturePath = path.join(config.repoPath, ".codex-supervisor", "issues", "fixtures", "issue-journal.md");
   const issueNumber = 811;
   const branch = `${config.branchPrefix}${issueNumber}`;
 
@@ -330,17 +330,17 @@ test("ensureWorkspace hides tracked live issue journals while preserving intenti
   await fs.mkdir(path.dirname(trackedFixturePath), { recursive: true });
   await fs.writeFile(trackedJournalPath, "# live journal\n", "utf8");
   await fs.writeFile(trackedFixturePath, "# intentional fixture\n", "utf8");
-  await git(config.repoPath, "add", ".codex-supervisor/issues/811/issue-journal.md", ".codex-supervisor/issues/fixtures/journal-fixture.md");
+  await git(config.repoPath, "add", ".codex-supervisor/issues/811/issue-journal.md", ".codex-supervisor/issues/fixtures/issue-journal.md");
   await git(config.repoPath, "commit", "-m", "Track journal fixture paths");
   await git(config.repoPath, "push", "origin", config.defaultBranch);
 
   const ensured = await ensureWorkspace(config, issueNumber, branch);
 
   await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "811", "issue-journal.md"), "runtime note\n", "utf8");
-  await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "fixtures", "journal-fixture.md"), "tracked fixture note\n", "utf8");
+  await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "fixtures", "issue-journal.md"), "tracked fixture note\n", "utf8");
 
   const workspaceStatus = await gitOutput(ensured.workspacePath, "status", "--short");
-  assert.match(workspaceStatus, /\.codex-supervisor\/issues\/fixtures\/journal-fixture\.md/u);
+  assert.match(workspaceStatus, /\.codex-supervisor\/issues\/fixtures\/issue-journal\.md/u);
   assert.doesNotMatch(workspaceStatus, /\.codex-supervisor\/issues\/811\/issue-journal\.md/u);
 });
 

--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -319,6 +319,31 @@ test("ensureWorkspace bootstraps from the fresh default-branch ref instead of st
   assert.notEqual(branchHeadSha, originDefaultSha);
 });
 
+test("ensureWorkspace hides tracked live issue journals while preserving intentional files outside the live path", async () => {
+  const config = await createRepositoryFixture();
+  const trackedJournalPath = path.join(config.repoPath, ".codex-supervisor", "issues", "811", "issue-journal.md");
+  const trackedFixturePath = path.join(config.repoPath, ".codex-supervisor", "issues", "fixtures", "journal-fixture.md");
+  const issueNumber = 811;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+
+  await fs.mkdir(path.dirname(trackedJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(trackedFixturePath), { recursive: true });
+  await fs.writeFile(trackedJournalPath, "# live journal\n", "utf8");
+  await fs.writeFile(trackedFixturePath, "# intentional fixture\n", "utf8");
+  await git(config.repoPath, "add", ".codex-supervisor/issues/811/issue-journal.md", ".codex-supervisor/issues/fixtures/journal-fixture.md");
+  await git(config.repoPath, "commit", "-m", "Track journal fixture paths");
+  await git(config.repoPath, "push", "origin", config.defaultBranch);
+
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+
+  await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "811", "issue-journal.md"), "runtime note\n", "utf8");
+  await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "fixtures", "journal-fixture.md"), "tracked fixture note\n", "utf8");
+
+  const workspaceStatus = await gitOutput(ensured.workspacePath, "status", "--short");
+  assert.match(workspaceStatus, /\.codex-supervisor\/issues\/fixtures\/journal-fixture\.md/u);
+  assert.doesNotMatch(workspaceStatus, /\.codex-supervisor\/issues\/811\/issue-journal\.md/u);
+});
+
 test("ensureWorkspace ignores similarly suffixed remote-tracking refs when bootstrapping", async () => {
   const config = await createRepositoryFixture();
   const issueNumber = 727;

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -4,7 +4,8 @@ import { runCommand } from "./command";
 import { EnsuredWorkspace, SupervisorConfig, WorkspaceRestoreMetadata, WorkspaceStatus } from "./types";
 import { ensureDir, isValidGitRefName } from "./utils";
 
-const LIVE_ISSUE_JOURNAL_PATH_GLOB = ".codex-supervisor/issues/*/issue-journal.md";
+const LIVE_ISSUE_JOURNAL_PATH_GLOB = ".codex-supervisor/issues/[0-9]*/issue-journal.md";
+const LIVE_ISSUE_JOURNAL_PATH_REGEX = /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/u;
 
 function assertIssueNumber(issueNumber: number): void {
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
@@ -185,7 +186,8 @@ async function protectTrackedLiveIssueJournals(workspacePath: string): Promise<v
   const trackedPaths = trackedPathsResult.stdout
     .split("\0")
     .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => LIVE_ISSUE_JOURNAL_PATH_REGEX.test(entry));
 
   if (trackedPaths.length === 0) {
     return;

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -4,6 +4,8 @@ import { runCommand } from "./command";
 import { EnsuredWorkspace, SupervisorConfig, WorkspaceRestoreMetadata, WorkspaceStatus } from "./types";
 import { ensureDir, isValidGitRefName } from "./utils";
 
+const LIVE_ISSUE_JOURNAL_PATH_GLOB = ".codex-supervisor/issues/*/issue-journal.md";
+
 function assertIssueNumber(issueNumber: number): void {
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
     throw new Error(`Invalid issue number: ${issueNumber}`);
@@ -175,6 +177,23 @@ function buildEnsuredWorkspace(
   };
 }
 
+async function protectTrackedLiveIssueJournals(workspacePath: string): Promise<void> {
+  const trackedPathsResult = await runCommand(
+    "git",
+    ["-C", workspacePath, "ls-files", "-z", "--", LIVE_ISSUE_JOURNAL_PATH_GLOB],
+  );
+  const trackedPaths = trackedPathsResult.stdout
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (trackedPaths.length === 0) {
+    return;
+  }
+
+  await runCommand("git", ["-C", workspacePath, "update-index", "--skip-worktree", "--", ...trackedPaths]);
+}
+
 export function formatWorkspaceRestoreStatusLine(restore: WorkspaceRestoreMetadata): string {
   return `workspace_restore source=${restore.source} ref=${restore.ref}`;
 }
@@ -270,6 +289,7 @@ export async function ensureWorkspace(
 
   if (fs.existsSync(path.join(workspacePath, ".git"))) {
     await assertReusableExistingWorkspace(config, workspacePath, branch);
+    await protectTrackedLiveIssueJournals(workspacePath);
     return buildEnsuredWorkspace(workspacePath, {
       source: "existing_workspace",
       ref: branch,
@@ -282,6 +302,7 @@ export async function ensureWorkspace(
 
   if (await branchExists(config.repoPath, branch)) {
     await runCommand("git", ["-C", config.repoPath, "worktree", "add", workspacePath, branch]);
+    await protectTrackedLiveIssueJournals(workspacePath);
     return buildEnsuredWorkspace(workspacePath, {
       source: "local_branch",
       ref: branch,
@@ -290,6 +311,7 @@ export async function ensureWorkspace(
 
   if (remoteBranchExists) {
     await runCommand("git", ["-C", config.repoPath, "worktree", "add", "-b", branch, workspacePath, `origin/${branch}`]);
+    await protectTrackedLiveIssueJournals(workspacePath);
     return buildEnsuredWorkspace(workspacePath, {
       source: "remote_branch",
       ref: `origin/${branch}`,
@@ -307,6 +329,7 @@ export async function ensureWorkspace(
     workspacePath,
     bootstrapBaseRef,
   ]);
+  await protectTrackedLiveIssueJournals(workspacePath);
 
   return buildEnsuredWorkspace(workspacePath, {
     source: "bootstrap_default_branch",


### PR DESCRIPTION
## Summary
- reapply `git update-index --skip-worktree` for tracked live journals matching `.codex-supervisor/issues/*/issue-journal.md` whenever a workspace is ensured
- keep intentional tracked files outside the live journal path visible to git status
- add a regression test covering both tracked live journals and a non-live fixture file

## Verification
- npx tsx --test src/core/workspace.test.ts
- npm run build

Closes #1448


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracked live issue journal files under the supervisor path are now automatically hidden from workspace status changes while other fixture files remain visible.

* **Tests**
  * Added test coverage verifying workspace initialization hides tracked live issue journals and preserves intentionally placed fixture files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->