### PR TITLE
Fix issue-journal fixture path coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ dist/
 .DS_Store
 .local/
 .codex-supervisor/issue-journal.md
-.codex-supervisor/issues/*/issue-journal.md
+.codex-supervisor/issues/[0-9]*/issue-journal.md
 supervisor.config.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 .local/
 .codex-supervisor/issue-journal.md
 .codex-supervisor/issues/[0-9]*/issue-journal.md
+!.codex-supervisor/issues/*[!0-9]*/issue-journal.md
 supervisor.config.json

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1320,8 +1320,10 @@ test("repo gitignore ignores workstation noise and live issue journals without h
   await fs.copyFile(path.join(rootDir, ".gitignore"), path.join(tempDir, ".gitignore"));
   await fs.writeFile(path.join(tempDir, ".DS_Store"), "", "utf8");
   await fs.mkdir(path.join(tempDir, ".codex-supervisor", "issues", "1443"), { recursive: true });
+  await fs.mkdir(path.join(tempDir, ".codex-supervisor", "issues", "1443abc"), { recursive: true });
   await fs.mkdir(path.join(tempDir, ".codex-supervisor", "issues", "fixtures"), { recursive: true });
   await fs.writeFile(path.join(tempDir, ".codex-supervisor", "issues", "1443", "issue-journal.md"), "", "utf8");
+  await fs.writeFile(path.join(tempDir, ".codex-supervisor", "issues", "1443abc", "issue-journal.md"), "", "utf8");
   await fs.writeFile(path.join(tempDir, ".codex-supervisor", "issues", "fixtures", "issue-journal.md"), "", "utf8");
   await fs.writeFile(path.join(tempDir, "supervisor.config.coderabbit.json"), "{}", "utf8");
 
@@ -1341,6 +1343,20 @@ test("repo gitignore ignores workstation noise and live issue journals without h
     encoding: "utf8",
   }).trim();
   assert.equal(ignoredJournalPath, ".codex-supervisor/issues/1443/issue-journal.md");
+
+  const nonNumericIssueLikeExitCode = (() => {
+    try {
+      execFileSync("git", ["check-ignore", ".codex-supervisor/issues/1443abc/issue-journal.md"], {
+        cwd: tempDir,
+        stdio: "ignore",
+      });
+      return 0;
+    } catch (error) {
+      const exitCode = (error as NodeJS.ErrnoException & { status?: number }).status;
+      return typeof exitCode === "number" ? exitCode : -1;
+    }
+  })();
+  assert.equal(nonNumericIssueLikeExitCode, 1);
 
   const coderabbitExitCode = (() => {
     try {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1322,7 +1322,7 @@ test("repo gitignore ignores workstation noise and live issue journals without h
   await fs.mkdir(path.join(tempDir, ".codex-supervisor", "issues", "1443"), { recursive: true });
   await fs.mkdir(path.join(tempDir, ".codex-supervisor", "issues", "fixtures"), { recursive: true });
   await fs.writeFile(path.join(tempDir, ".codex-supervisor", "issues", "1443", "issue-journal.md"), "", "utf8");
-  await fs.writeFile(path.join(tempDir, ".codex-supervisor", "issues", "fixtures", "journal-fixture.md"), "", "utf8");
+  await fs.writeFile(path.join(tempDir, ".codex-supervisor", "issues", "fixtures", "issue-journal.md"), "", "utf8");
   await fs.writeFile(path.join(tempDir, "supervisor.config.coderabbit.json"), "{}", "utf8");
 
   execFileSync("git", ["init"], {
@@ -1358,7 +1358,7 @@ test("repo gitignore ignores workstation noise and live issue journals without h
 
   const fixtureExitCode = (() => {
     try {
-      execFileSync("git", ["check-ignore", ".codex-supervisor/issues/fixtures/journal-fixture.md"], {
+      execFileSync("git", ["check-ignore", ".codex-supervisor/issues/fixtures/issue-journal.md"], {
         cwd: tempDir,
         stdio: "ignore",
       });

--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -319,27 +319,42 @@ test("ensureWorkspace bootstraps from the fresh default-branch ref instead of st
   assert.notEqual(branchHeadSha, originDefaultSha);
 });
 
-test("ensureWorkspace hides tracked live issue journals while preserving intentional files outside the live path", async () => {
+test("ensureWorkspace hides tracked live issue journals while preserving intentional files outside the numeric live path", async () => {
   const config = await createRepositoryFixture();
   const trackedJournalPath = path.join(config.repoPath, ".codex-supervisor", "issues", "811", "issue-journal.md");
+  const trackedIssueLikeFixturePath = path.join(config.repoPath, ".codex-supervisor", "issues", "811abc", "issue-journal.md");
   const trackedFixturePath = path.join(config.repoPath, ".codex-supervisor", "issues", "fixtures", "issue-journal.md");
   const issueNumber = 811;
   const branch = `${config.branchPrefix}${issueNumber}`;
 
   await fs.mkdir(path.dirname(trackedJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(trackedIssueLikeFixturePath), { recursive: true });
   await fs.mkdir(path.dirname(trackedFixturePath), { recursive: true });
   await fs.writeFile(trackedJournalPath, "# live journal\n", "utf8");
+  await fs.writeFile(trackedIssueLikeFixturePath, "# numeric-looking fixture\n", "utf8");
   await fs.writeFile(trackedFixturePath, "# intentional fixture\n", "utf8");
-  await git(config.repoPath, "add", ".codex-supervisor/issues/811/issue-journal.md", ".codex-supervisor/issues/fixtures/issue-journal.md");
+  await git(
+    config.repoPath,
+    "add",
+    ".codex-supervisor/issues/811/issue-journal.md",
+    ".codex-supervisor/issues/811abc/issue-journal.md",
+    ".codex-supervisor/issues/fixtures/issue-journal.md",
+  );
   await git(config.repoPath, "commit", "-m", "Track journal fixture paths");
   await git(config.repoPath, "push", "origin", config.defaultBranch);
 
   const ensured = await ensureWorkspace(config, issueNumber, branch);
 
   await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "811", "issue-journal.md"), "runtime note\n", "utf8");
+  await fs.appendFile(
+    path.join(ensured.workspacePath, ".codex-supervisor", "issues", "811abc", "issue-journal.md"),
+    "tracked issue-like fixture note\n",
+    "utf8",
+  );
   await fs.appendFile(path.join(ensured.workspacePath, ".codex-supervisor", "issues", "fixtures", "issue-journal.md"), "tracked fixture note\n", "utf8");
 
   const workspaceStatus = await gitOutput(ensured.workspacePath, "status", "--short");
+  assert.match(workspaceStatus, /\.codex-supervisor\/issues\/811abc\/issue-journal\.md/u);
   assert.match(workspaceStatus, /\.codex-supervisor\/issues\/fixtures\/issue-journal\.md/u);
   assert.doesNotMatch(workspaceStatus, /\.codex-supervisor\/issues\/811\/issue-journal\.md/u);
 });


### PR DESCRIPTION
## Summary
- cover the canonical fixture path .codex-supervisor/issues/fixtures/issue-journal.md in the gitignore regression test
- narrow the live journal ignore rule to numeric issue directories only so intentional fixtures remain versionable

## Testing
- npx tsx --test --test-name-pattern "repo gitignore ignores workstation noise and live issue journals without hiding intentional files" src/config.test.ts
- npm run build
- direct git check-ignore probe confirming live numeric journals stay ignored while fixture paths remain versionable

Closes #1449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened repository ignore rules to only exclude issue journals inside numeric supervisor directories while allowing similarly named files in non-numeric paths.
* **Tests**
  * Updated and extended test fixtures and assertions to validate the refined ignore behavior, ensuring numeric-only ignore patterns exclude intended files and do not hide intentional non-numeric journals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->