### PR TITLE
Harden interrupted-turn handoff recovery

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -129,7 +129,8 @@ type DurableTurnUpdateEvidence =
   | "record_updated_at_advanced"
   | "journal_unchanged"
   | "journal_missing"
-  | "record_updated_at_stale";
+  | "record_updated_at_stale"
+  | "progress_unverifiable";
 
 async function detectDurableTurnUpdateSince(
   record: Pick<IssueRunRecord, "journal_path" | "updated_at">,
@@ -153,7 +154,7 @@ async function detectDurableTurnUpdateSince(
   if (record.journal_path && Number.isFinite(startedAtMs)) {
     try {
       const journalStats = await fs.promises.stat(record.journal_path);
-      if (journalStats.mtimeMs >= startedAtMs) {
+      if (journalStats.mtimeMs > startedAtMs) {
         return { hasDurableUpdate: true, evidence: "journal_mtime_advanced" };
       }
       return { hasDurableUpdate: false, evidence: "journal_unchanged" };
@@ -167,10 +168,10 @@ async function detectDurableTurnUpdateSince(
 
   const updatedAtMs = Date.parse(record.updated_at);
   if (!Number.isFinite(updatedAtMs) || !Number.isFinite(startedAtMs)) {
-    return { hasDurableUpdate: false, evidence: "record_updated_at_stale" };
+    return { hasDurableUpdate: false, evidence: "progress_unverifiable" };
   }
 
-  return updatedAtMs >= startedAtMs
+  return updatedAtMs > startedAtMs
     ? { hasDurableUpdate: true, evidence: "record_updated_at_advanced" }
     : { hasDurableUpdate: false, evidence: "record_updated_at_stale" };
 }
@@ -1301,7 +1302,7 @@ export async function reconcileStaleActiveIssueReservation(args: {
       command: null,
       details: [
         `started_at=${interruptedTurnMarker.startedAt}`,
-        `durable_progress_evidence=${interruptedTurnUpdate?.evidence ?? "record_updated_at_stale"}`,
+        `durable_progress_evidence=${interruptedTurnUpdate?.evidence ?? "progress_unverifiable"}`,
         "Update the Codex Working Notes section before ending the turn.",
       ],
       url: null,

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -176,6 +176,15 @@ async function detectDurableTurnUpdateSince(
     : { hasDurableUpdate: false, evidence: "record_updated_at_stale" };
 }
 
+function appendInterruptedTurnEvidence(
+  reason: string,
+  interruptedTurnUpdate: { evidence: DurableTurnUpdateEvidence } | null,
+): string {
+  return interruptedTurnUpdate
+    ? `${reason}; durable_progress_evidence=${interruptedTurnUpdate.evidence}`
+    : reason;
+}
+
 function trackedMergedButOpenLastProcessedIssueNumber(state: SupervisorStateFile): number | null {
   return state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number ?? null;
 }
@@ -1310,7 +1319,10 @@ export async function reconcileStaleActiveIssueReservation(args: {
     };
     const recoveryEvent = buildRecoveryEvent(
       record.issue_number,
-      `interrupted_turn_recovery: blocked issue #${record.issue_number} after an in-progress Codex turn ended without a durable handoff`,
+      appendInterruptedTurnEvidence(
+        `interrupted_turn_recovery: blocked issue #${record.issue_number} after an in-progress Codex turn ended without a durable handoff`,
+        interruptedTurnUpdate,
+      ),
     );
     const patch: Partial<IssueRunRecord> = {
       state: "blocked",
@@ -1391,13 +1403,16 @@ export async function reconcileStaleActiveIssueReservation(args: {
 
   const recoveryEvent = buildRecoveryEvent(
     record.issue_number,
-    shouldMarkAlreadySatisfiedOnMain
-      ? `stale_stabilizing_no_pr_manual_review: blocked issue #${record.issue_number} after stale stabilizing recovery found an open issue with no authoritative completion signal`
-      : shouldStopRepeatedStaleNoPrLoop
-      ? `stale_state_manual_stop: blocked issue #${record.issue_number} after repeated stale stabilizing recovery without a tracked PR`
-      : shouldRequeueStabilizing
-      ? `stale_state_cleanup: requeued stabilizing issue #${record.issue_number} after ${missingLockReason}`
-      : `stale_state_cleanup: cleared stale active reservation after ${missingLockReason}`,
+    appendInterruptedTurnEvidence(
+      shouldMarkAlreadySatisfiedOnMain
+        ? `stale_stabilizing_no_pr_manual_review: blocked issue #${record.issue_number} after stale stabilizing recovery found an open issue with no authoritative completion signal`
+        : shouldStopRepeatedStaleNoPrLoop
+        ? `stale_state_manual_stop: blocked issue #${record.issue_number} after repeated stale stabilizing recovery without a tracked PR`
+        : shouldRequeueStabilizing
+        ? `stale_state_cleanup: requeued stabilizing issue #${record.issue_number} after ${missingLockReason}`
+        : `stale_state_cleanup: cleared stale active reservation after ${missingLockReason}`,
+      interruptedTurnUpdate,
+    ),
   );
   const patch: Partial<IssueRunRecord> = shouldMarkAlreadySatisfiedOnMain
     ? {

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -123,29 +123,56 @@ function needsRecordUpdate(record: IssueRunRecord, patch: Partial<IssueRunRecord
   return false;
 }
 
-async function hasDurableTurnUpdateSince(
+type DurableTurnUpdateEvidence =
+  | "journal_changed"
+  | "journal_mtime_advanced"
+  | "record_updated_at_advanced"
+  | "journal_unchanged"
+  | "journal_missing"
+  | "record_updated_at_stale";
+
+async function detectDurableTurnUpdateSince(
   record: Pick<IssueRunRecord, "journal_path" | "updated_at">,
   marker: {
     startedAt: string;
     journalFingerprint: import("./interrupted-turn-marker").InterruptedTurnMarker["journalFingerprint"];
   },
-): Promise<boolean> {
+): Promise<{ hasDurableUpdate: boolean; evidence: DurableTurnUpdateEvidence }> {
   if (record.journal_path && marker.journalFingerprint) {
     const currentJournalFingerprint = await captureIssueJournalFingerprint(record.journal_path);
     if (!currentJournalFingerprint.exists) {
-      return false;
+      return { hasDurableUpdate: false, evidence: "journal_missing" };
     }
 
-    return !sameIssueJournalFingerprint(currentJournalFingerprint, marker.journalFingerprint);
+    return sameIssueJournalFingerprint(currentJournalFingerprint, marker.journalFingerprint)
+      ? { hasDurableUpdate: false, evidence: "journal_unchanged" }
+      : { hasDurableUpdate: true, evidence: "journal_changed" };
+  }
+
+  const startedAtMs = Date.parse(marker.startedAt);
+  if (record.journal_path && Number.isFinite(startedAtMs)) {
+    try {
+      const journalStats = await fs.promises.stat(record.journal_path);
+      if (journalStats.mtimeMs >= startedAtMs) {
+        return { hasDurableUpdate: true, evidence: "journal_mtime_advanced" };
+      }
+      return { hasDurableUpdate: false, evidence: "journal_unchanged" };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { hasDurableUpdate: false, evidence: "journal_missing" };
+      }
+      throw error;
+    }
   }
 
   const updatedAtMs = Date.parse(record.updated_at);
-  const startedAtMs = Date.parse(marker.startedAt);
   if (!Number.isFinite(updatedAtMs) || !Number.isFinite(startedAtMs)) {
-    return false;
+    return { hasDurableUpdate: false, evidence: "record_updated_at_stale" };
   }
 
-  return updatedAtMs >= startedAtMs;
+  return updatedAtMs >= startedAtMs
+    ? { hasDurableUpdate: true, evidence: "record_updated_at_advanced" }
+    : { hasDurableUpdate: false, evidence: "record_updated_at_stale" };
 }
 
 function trackedMergedButOpenLastProcessedIssueNumber(state: SupervisorStateFile): number | null {
@@ -1258,10 +1285,14 @@ export async function reconcileStaleActiveIssueReservation(args: {
   }
 
   const interruptedTurnMarker = await readInterruptedTurnMarker(record.workspace);
+  const interruptedTurnUpdate =
+    interruptedTurnMarker && interruptedTurnMarker.issueNumber === record.issue_number
+      ? await detectDurableTurnUpdateSince(record, interruptedTurnMarker)
+      : null;
   if (
     interruptedTurnMarker &&
     interruptedTurnMarker.issueNumber === record.issue_number &&
-    !(await hasDurableTurnUpdateSince(record, interruptedTurnMarker))
+    !interruptedTurnUpdate?.hasDurableUpdate
   ) {
     const failureContext = {
       category: "blocked" as const,
@@ -1270,6 +1301,7 @@ export async function reconcileStaleActiveIssueReservation(args: {
       command: null,
       details: [
         `started_at=${interruptedTurnMarker.startedAt}`,
+        `durable_progress_evidence=${interruptedTurnUpdate?.evidence ?? "record_updated_at_stale"}`,
         "Update the Codex Working Notes section before ending the turn.",
       ],
       url: null,

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1245,10 +1245,9 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
     interruptedRecord.last_error ?? "",
     /Codex started a turn for issue #91 but no durable handoff was recorded before the process exited\./,
   );
-  assert.match(
-    interruptedRecord.last_failure_context?.details?.join("\n") ?? "",
-    /durable_progress_evidence=journal_unchanged|durable_progress_evidence=record_updated_at_stale/,
-  );
+  const failureDetails = interruptedRecord.last_failure_context?.details?.join("\n") ?? "";
+  assert.match(failureDetails, /durable_progress_evidence=journal_unchanged/);
+  assert.doesNotMatch(failureDetails, /durable_progress_evidence=record_updated_at_stale/);
   await assert.rejects(fs.access(interruptedTurnMarkerPath(interruptedWorkspace)));
 });
 

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1245,6 +1245,10 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
     interruptedRecord.last_error ?? "",
     /Codex started a turn for issue #91 but no durable handoff was recorded before the process exited\./,
   );
+  assert.match(
+    interruptedRecord.last_failure_context?.details?.join("\n") ?? "",
+    /durable_progress_evidence=journal_unchanged|durable_progress_evidence=record_updated_at_stale/,
+  );
   await assert.rejects(fs.access(interruptedTurnMarkerPath(interruptedWorkspace)));
 });
 

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1746,18 +1746,24 @@ test("runOnce converges a stale no-PR issue to done when only supervisor-owned w
   const message = await supervisor.runOnce({ dryRun: false });
   assert.match(
     message,
-    /recovery issue=#92 reason=already_satisfied_on_main: marked issue #92 done after stale stabilizing recovery found no meaningful branch changes/,
+    /recovery issue=#92 reason=stale_stabilizing_no_pr_manual_review: blocked issue #92 after stale stabilizing recovery found an open issue with no authoritative completion signal; No matching open issue found\./,
   );
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)]!;
   assert.equal(persisted.activeIssueNumber, null);
-  assert.equal(record.state, "done");
+  assert.equal(record.state, "blocked");
   assert.equal(record.pr_number, null);
   assert.equal(record.codex_session_id, null);
-  assert.equal(record.blocked_reason, null);
-  assert.equal(record.last_error, null);
-  assert.equal(record.last_failure_context, null);
+  assert.equal(record.blocked_reason, "manual_review");
+  assert.match(record.last_error ?? "", /stale stabilizing recovery without authoritative completion evidence/);
+  assert.deepEqual(record.last_failure_context?.details ?? [], [
+    "state=stabilizing",
+    "tracked_pr=none",
+    "github_issue_state=OPEN",
+    "completion_evidence=missing",
+    "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
+  ]);
   assert.equal(record.last_failure_signature, null);
   assert.equal(record.repeated_failure_signature_count, 0);
   assert.equal(record.stale_stabilizing_no_pr_recovery_count, 0);

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1370,6 +1370,7 @@ test("runOnce clears a stale interrupted-turn marker when the journal changed af
   assert.equal(interruptedRecord.codex_session_id, null);
   assert.equal(interruptedRecord.blocked_reason, null);
   assert.equal(interruptedRecord.last_error, null);
+  assert.match(interruptedRecord.last_recovery_reason ?? "", /durable_progress_evidence=journal_changed/);
   await assert.rejects(fs.access(interruptedTurnMarkerPath(interruptedWorkspace)));
 });
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2360,6 +2360,142 @@ test("reconcileStaleActiveIssueReservation does not block interrupted turns when
   await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
 });
 
+test("reconcileStaleActiveIssueReservation blocks interrupted turns when the canonical journal mtime only matches start time", async () => {
+  const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-interrupted-journal-"));
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "366", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# issue journal\n", "utf8");
+  await fs.writeFile(
+    path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json"),
+    `${JSON.stringify({
+      issueNumber: 366,
+      state: "addressing_review",
+      startedAt: "2026-03-26T00:05:00.000Z",
+      journalFingerprint: null,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  const startTime = new Date("2026-03-26T00:05:00.000Z");
+  await fs.utimes(journalPath, startTime, startTime);
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 366,
+    issues: {
+      "366": createRecord({
+        issue_number: 366,
+        state: "addressing_review",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        codex_session_id: "session-366",
+        updated_at: "2026-03-26T00:05:00.000Z",
+      }),
+    },
+  };
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...record,
+        ...patch,
+        updated_at: "2026-03-26T00:10:00.000Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleActiveIssueReservation({
+    stateStore,
+    state,
+    issueLockPath: (issueNumber) => path.join(lockRoot, "locks", "issues", String(issueNumber)),
+    sessionLockPath: (sessionId) => path.join(lockRoot, "locks", "sessions", String(sessionId)),
+  });
+
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "handoff_missing");
+  assert.equal(state.issues["366"]?.codex_session_id, null);
+  assert.match(
+    state.issues["366"]?.last_failure_context?.details?.join("\n") ?? "",
+    /durable_progress_evidence=journal_unchanged/,
+  );
+  assert.equal(saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+  assert.match(
+    formatRecoveryLog(recoveryEvents) ?? "",
+    /recovery issue=#366 reason=interrupted_turn_recovery: blocked issue #366 after an in-progress Codex turn ended without a durable handoff/,
+  );
+  await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
+});
+
+test("reconcileStaleActiveIssueReservation reports interrupted-turn progress as unverifiable when timestamps cannot be compared", async () => {
+  const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-interrupted-journal-"));
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "366", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# issue journal\n", "utf8");
+  await fs.writeFile(
+    path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json"),
+    `${JSON.stringify({
+      issueNumber: 366,
+      state: "addressing_review",
+      startedAt: "not-a-timestamp",
+      journalFingerprint: null,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 366,
+    issues: {
+      "366": createRecord({
+        issue_number: 366,
+        state: "addressing_review",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        codex_session_id: "session-366",
+        updated_at: "2026-03-26T00:05:00.000Z",
+      }),
+    },
+  };
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...record,
+        ...patch,
+        updated_at: "2026-03-26T00:10:00.000Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleActiveIssueReservation({
+    stateStore,
+    state,
+    issueLockPath: (issueNumber) => path.join(lockRoot, "locks", "issues", String(issueNumber)),
+    sessionLockPath: (sessionId) => path.join(lockRoot, "locks", "sessions", String(sessionId)),
+  });
+
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "handoff_missing");
+  assert.equal(state.issues["366"]?.codex_session_id, null);
+  assert.match(
+    state.issues["366"]?.last_failure_context?.details?.join("\n") ?? "",
+    /durable_progress_evidence=progress_unverifiable/,
+  );
+  assert.equal(saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+  await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
+});
+
 test("reconcileStaleActiveIssueReservation requeues a stale stabilizing issue without a tracked PR", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2290,6 +2290,76 @@ test("reconcileStaleActiveIssueReservation clears a stale reservation and emits 
   );
 });
 
+test("reconcileStaleActiveIssueReservation does not block interrupted turns when the canonical journal mtime advanced after start", async () => {
+  const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-interrupted-journal-"));
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "366", "issue-journal.md");
+  const trackedFilePath = path.join(workspacePath, "src", "service.ts");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.mkdir(path.dirname(trackedFilePath), { recursive: true });
+  await fs.writeFile(journalPath, "# issue journal\n", "utf8");
+  await fs.writeFile(trackedFilePath, "export const repair = 1;\n", "utf8");
+  await fs.writeFile(
+    path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json"),
+    `${JSON.stringify({
+      issueNumber: 366,
+      state: "addressing_review",
+      startedAt: "2026-03-26T00:05:00.000Z",
+      journalFingerprint: null,
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  const afterStart = new Date("2026-03-26T00:06:00.000Z");
+  await fs.utimes(journalPath, afterStart, afterStart);
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 366,
+    issues: {
+      "366": createRecord({
+        issue_number: 366,
+        state: "addressing_review",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        codex_session_id: "session-366",
+        updated_at: "2026-03-26T00:00:00.000Z",
+      }),
+    },
+  };
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...record,
+        ...patch,
+        updated_at: "2026-03-26T00:10:00.000Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleActiveIssueReservation({
+    stateStore,
+    state,
+    issueLockPath: (issueNumber) => path.join(lockRoot, "locks", "issues", String(issueNumber)),
+    sessionLockPath: (sessionId) => path.join(lockRoot, "locks", "sessions", String(sessionId)),
+  });
+
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["366"]?.state, "addressing_review");
+  assert.equal(state.issues["366"]?.blocked_reason, null);
+  assert.equal(state.issues["366"]?.codex_session_id, null);
+  assert.equal(saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+  assert.match(
+    formatRecoveryLog(recoveryEvents) ?? "",
+    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
+  );
+  await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
+});
+
 test("reconcileStaleActiveIssueReservation requeues a stale stabilizing issue without a tracked PR", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2351,11 +2351,15 @@ test("reconcileStaleActiveIssueReservation does not block interrupted turns when
   assert.equal(state.issues["366"]?.state, "addressing_review");
   assert.equal(state.issues["366"]?.blocked_reason, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
+  assert.match(
+    state.issues["366"]?.last_recovery_reason ?? "",
+    /durable_progress_evidence=journal_mtime_advanced/,
+  );
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
+    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing; durable_progress_evidence=journal_mtime_advanced/,
   );
   await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
 });


### PR DESCRIPTION
## Summary
- prefer canonical journal evidence over `record.updated_at` when reconciling interrupted turns
- record which durable-progress evidence path drove the recovery decision
- align the stale no-PR orchestration expectation with current manual-review behavior for open issues

## Testing
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
- npx tsx --test src/turn-execution-failure-helpers.test.ts
- npm run build

Closes #1452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Durable-progress detection now returns structured evidence (changed/unchanged/missing/journal-mtime-advanced/progress-unverifiable/record-updated) for clearer diagnostics and strict comparison of update timestamps.
  * Recovery events and failure details now include durable-progress evidence and surface manual-review blocking when authoritative completion evidence is missing.

* **Tests**
  * Expanded interrupted-turn recovery tests to cover journal mtime changes, exact-match/unverifiable timestamps, and revised recovery outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->