### PR TITLE
Preserve runtime context for no-PR manual review recovery

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,33 @@
-# Issue #1326: [codex] Document local-review follow-up issue creation as an opt-in flag
+# Issue #1454: Preserve original runtime failure context across no-PR manual-review recovery
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1326
-- Branch: codex/issue-1326
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1454
+- Branch: codex/issue-1454
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: ff02ebdde0ebb65d975c0138514acb28f17a53c3
+- Last head SHA: 1f70eca4fc7d3691c7506fe116a78147172c0748
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-07T03:11:37.023Z
+- Updated at: 2026-04-12T06:37:39.674Z
 
 ## Latest Codex Summary
-- Added explicit `localReviewFollowUpIssueCreationEnabled: false` coverage to shipped example configs and documented the flag as an opt-in local-review setting in the config and local-review docs.
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The runtime default already existed; the missing discoverability gap was that shipped example configs and operator-facing docs did not surface `localReviewFollowUpIssueCreationEnabled` as an explicit opt-in flag.
-- What changed: Added a focused `src/config.test.ts` assertion that all shipped example configs carry `localReviewFollowUpIssueCreationEnabled: false`; updated starter/example JSON configs plus `docs/configuration.md`, `docs/local-review.md`, `docs/getting-started.md`, and `docs/examples/atlaspm.md` to document the explicit false default and opt-in behavior.
+- Hypothesis: Failed no-PR reconciliation was replacing `last_failure_*` with a generic manual-review blocker, and older failed records without populated `last_runtime_*` lost the original `codex_exit` context entirely. `explain` also only surfaced the blocker summary.
+- What changed: Added a fallback snapshot in `src/recovery-no-pr-reconciliation.ts` so failed no-PR manual-review reconciliation copies the pre-reconciliation runtime failure into `last_runtime_*` when those fields are empty before replacing `last_failure_*`. Extended `src/supervisor/supervisor-selection-issue-explain.ts` to emit `runtime_failure_kind` and `runtime_failure_summary`. Added regression coverage in the recovery reconciliation and explain test files.
 - Current blocker: none
-- Next exact step: Commit the verified docs/example-config change set on `codex/issue-1326` and proceed to PR/draft PR handling if requested by the supervisor loop.
-- Verification gap: none for the scoped docs/example-config change; focused test and full build both passed locally.
-- Files touched: src/config.test.ts; supervisor.config.example.json; supervisor.config.copilot.json; supervisor.config.codex.json; supervisor.config.coderabbit.json; docs/examples/atlaspm.supervisor.config.example.json; docs/configuration.md; docs/local-review.md; docs/getting-started.md; docs/examples/atlaspm.md
-- Rollback concern: low; changes are limited to docs/example-config discoverability plus a focused regression test.
-- Last focused command: npm run build
+- Next exact step: Commit the checkpoint on `codex/issue-1454`, then open or update a draft PR if needed by the supervisor loop.
+- Verification gap: `npm test -- ...` still expands to the broader suite and hits an unrelated existing failure in `local CI browser helpers summarize a repo-owned candidate contract consistently`; isolated `npx tsx --test` runs for the touched test files passed, and `npm run build` passed.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-no-pr-reconciliation.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`
+- Rollback concern: low; change is scoped to failed no-PR manual-review reconciliation and explain rendering, but reverting would again hide original runtime failure details for older failed records that lack `last_runtime_*`.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-no-pr-reconciliation.ts
+++ b/src/recovery-no-pr-reconciliation.ts
@@ -13,6 +13,30 @@ import { STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE } from "./no-pull-request-st
 
 type StateStoreLike = Pick<StateStore, "touch">;
 
+function preserveOriginalRuntimeFailureContext(record: IssueRunRecord): Partial<IssueRunRecord> {
+  if (
+    record.last_runtime_error !== null && record.last_runtime_error !== undefined
+    || record.last_runtime_failure_kind !== null && record.last_runtime_failure_kind !== undefined
+    || record.last_runtime_failure_context !== null && record.last_runtime_failure_context !== undefined
+  ) {
+    return {};
+  }
+
+  if (
+    record.last_error === null
+    && record.last_failure_kind === null
+    && record.last_failure_context === null
+  ) {
+    return {};
+  }
+
+  return {
+    last_runtime_error: record.last_error,
+    last_runtime_failure_kind: record.last_failure_kind,
+    last_runtime_failure_context: record.last_failure_context,
+  };
+}
+
 export async function reconcileStaleFailedNoPrRecord(args: {
   github: Pick<import("./github").GitHubClient, "getIssue">;
   stateStore: StateStoreLike;
@@ -84,6 +108,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
       repeated_blocker_count: 0,
       stale_stabilizing_no_pr_recovery_count: 0,
       last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
+      ...preserveOriginalRuntimeFailureContext(record),
       ...applyFailureSignature(record, manualReviewFailureContext),
     };
     const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -311,6 +311,85 @@ Wait for a human review before proceeding.
   assert.match(explanation, /^reason_2=local_state blocked$/m);
 });
 
+test("explain preserves original runtime failure context for no-PR manual-review recovery", async () => {
+  const fixture = await createSupervisorFixture();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "99": createRecord({
+        issue_number: 99,
+        state: "blocked",
+        branch: branchName(fixture.config, 99),
+        workspace: path.join(fixture.workspaceRoot, "issue-99"),
+        journal_path: null,
+        blocked_reason: "manual_review",
+        last_error: "Issue #99 cannot be reconciled automatically because the preserved no-PR branch is not safe for automatic recovery.",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Issue #99 cannot be reconciled automatically because the preserved no-PR branch is not safe for automatic recovery.",
+          signature: "failed-no-pr-manual-review-required",
+          command: null,
+          details: [
+            "state=failed",
+            "tracked_pr=none",
+            "branch_state=manual_review_required",
+          ],
+          url: null,
+          updated_at: "2026-03-13T00:25:00Z",
+        },
+        last_runtime_error: "Selected model is at capacity. Please try a different model.",
+        last_runtime_failure_kind: "codex_exit",
+        last_runtime_failure_context: {
+          category: "codex",
+          summary: "Selected model is at capacity. Please try a different model.",
+          signature: "provider-capacity",
+          command: null,
+          details: ["provider=codex"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const blockedIssue: GitHubIssue = {
+    number: 99,
+    title: "Preserve runtime failure context after no-PR manual review recovery",
+    body: `## Summary
+Keep the original runtime failure visible after no-PR manual-review recovery.
+
+## Scope
+- preserve runtime failure diagnostics alongside the manual-review blocker
+
+## Acceptance criteria
+- explain shows both the manual-review blocker and the original runtime failure summary
+
+## Verification
+- npm test -- src/supervisor/supervisor-diagnostics-explain.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/99",
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => blockedIssue,
+    listAllIssues: async () => [blockedIssue],
+    listCandidateIssues: async () => [blockedIssue],
+  };
+
+  const explanation = await supervisor.explain(99);
+
+  assert.match(explanation, /^state=blocked$/m);
+  assert.match(explanation, /^blocked_reason=manual_review$/m);
+  assert.match(explanation, /^failure_summary=Issue #99 cannot be reconciled automatically because the preserved no-PR branch is not safe for automatic recovery\.$/m);
+  assert.match(explanation, /^runtime_failure_kind=codex_exit$/m);
+  assert.match(explanation, /^runtime_failure_summary=Selected model is at capacity\. Please try a different model\.$/m);
+});
+
 test("explain reports stale configured-bot blockers distinctly from generic manual review", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -4640,6 +4640,17 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
     },
     last_failure_signature: "provider-capacity",
     repeated_failure_signature_count: 1,
+    last_runtime_error: "Selected model is at capacity. Please try a different model.",
+    last_runtime_failure_kind: "codex_exit",
+    last_runtime_failure_context: {
+      category: "codex",
+      summary: "Selected model is at capacity. Please try a different model.",
+      signature: "provider-capacity",
+      command: null,
+      details: ["provider=codex"],
+      url: null,
+      updated_at: "2026-03-13T00:20:00Z",
+    },
     codex_session_id: "session-366",
   });
   const state: SupervisorStateFile = createSupervisorState({
@@ -4709,6 +4720,11 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   assert.equal(updated.blocked_reason, "manual_review");
   assert.equal(updated.last_failure_kind, null);
   assert.equal(updated.last_failure_context?.signature, "failed-no-pr-manual-review-required");
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.equal(updated.last_runtime_error, "Selected model is at capacity. Please try a different model.");
+  assert.equal(updated.last_runtime_failure_context?.category, "codex");
+  assert.equal(updated.last_runtime_failure_context?.summary, "Selected model is at capacity. Please try a different model.");
+  assert.equal(updated.last_runtime_failure_context?.signature, "provider-capacity");
   assert.match(updated.last_error ?? "", /not safe for automatic recovery/i);
   assert.deepEqual(updated.last_failure_context?.details ?? [], [
     "state=failed",
@@ -4724,6 +4740,123 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
     "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an unsafe or ambiguous workspace state",
   );
   assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
+test("reconcileStaleFailedIssueStates snapshots the original runtime failure when no-PR manual review replaces failure context", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+  await fs.writeFile(path.join(workspacePath, "feature.txt"), "recoverable checkpoint\n");
+  await runCommand("git", ["-C", workspacePath, "add", "feature.txt"]);
+  await runCommand("git", ["-C", workspacePath, "commit", "-m", "recoverable checkpoint"]);
+  await fs.writeFile(path.join(workspacePath, "feature.txt"), "recoverable checkpoint\nextra dirty edit\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+  });
+  const originalFailureContext = {
+    category: "codex" as const,
+    summary: "Selected model is at capacity. Please try a different model.",
+    signature: "provider-capacity",
+    command: null,
+    details: ["provider=codex"],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: originalFailureContext.summary,
+        last_failure_kind: "codex_exit",
+        last_failure_context: originalFailureContext,
+        last_failure_signature: "provider-capacity",
+        repeated_failure_signature_count: 1,
+        last_runtime_error: null,
+        last_runtime_failure_kind: null,
+        last_runtime_failure_context: null,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Preserve runtime failure snapshot for failed no-PR manual review",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-manual-review-required");
+  assert.equal(updated.last_runtime_error, originalFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.deepEqual(updated.last_runtime_failure_context, originalFailureContext);
   assert.equal(saveCalls, 1);
 });
 

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -80,6 +80,8 @@ export interface SupervisorExplainDto {
   reasons: string[];
   lastError: string | null;
   failureSummary: string | null;
+  runtimeFailureKind?: IssueRunRecord["last_runtime_failure_kind"] | null;
+  runtimeFailureSummary?: string | null;
 }
 
 async function buildExplainChangeRiskSummary(args: {
@@ -377,6 +379,8 @@ export async function buildIssueExplainDto(
     reasons,
     lastError: record?.last_error ?? null,
     failureSummary: record?.last_failure_context?.summary ?? null,
+    runtimeFailureKind: record?.last_runtime_failure_kind ?? null,
+    runtimeFailureSummary: record?.last_runtime_failure_context?.summary ?? null,
   };
 }
 
@@ -420,6 +424,12 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
   }
   if (dto.failureSummary) {
     lines.push(`failure_summary=${dto.failureSummary}`);
+  }
+  if (dto.runtimeFailureKind) {
+    lines.push(`runtime_failure_kind=${dto.runtimeFailureKind}`);
+  }
+  if (dto.runtimeFailureSummary) {
+    lines.push(`runtime_failure_summary=${dto.runtimeFailureSummary}`);
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- preserve the original runtime failure snapshot when failed no-PR recovery reclassifies an issue to manual review
- surface the preserved runtime failure kind and summary in `supervisor explain`
- add regressions for both reconciliation and explain output

## Verification
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`
- `npm run build`

## Notes
- `npm test -- ...` still expands to the broader suite in this repo and hits an unrelated existing failure in `local CI browser helpers summarize a repo-owned candidate contract consistently`; the touched suites passed in isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced recovery process to preserve original runtime failure context during manual-review recovery, ensuring pre-recovery failure details remain accessible for troubleshooting.

* **Enhancements**
  * Diagnostic output now displays runtime failure kind and summary information alongside recovery status, providing clearer visibility into root causes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->