### PR TITLE
#1457 Surface blocked partial-work incidents in selection output

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,54 +1,33 @@
-# Issue #1456: Surface preserved partial-work incidents in status and explain
+# Issue #1457: Make loop and readiness output distinguish blocked partial-work incidents from an empty backlog
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1456
-- Branch: codex/issue-1456
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1457
+- Branch: codex/issue-1457
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: repairing_ci
-- Attempt count: 6 (implementation=2, repair=2)
-- Last head SHA: 0311e0d4b3be4df5b9b1dc109dadde72464d1f47
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 3543601c2d50626981344525537a130d94ce8448
 - Blocked reason: none
-- Last failure signature: build (ubuntu-latest):fail
-- Repeated failure signature count: 3
-- Updated at: 2026-04-12T07:37:07.876Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T07:46:14.238Z
 
 ## Latest Codex Summary
-Reproduced the failing `build (ubuntu-latest)` check for PR `#1459` via the GitHub Actions log and confirmed the root cause is still the tracked `.codex-supervisor/issue-journal.md` at `HEAD`: lines 45-46 in the committed file still mention a workstation-local absolute path to the comment-fetch helper, which trips `npm run verify:paths` on Ubuntu.
-
-The working copy already had the portable redaction in place, so I verified the intended fix locally with `npm run verify:paths`, which now passes. This turn packages that tracked journal repair for push so CI can rerun against the sanitized command history.
-
-Summary: Reproduced the Ubuntu CI failure to a stale workstation-local path leak in the committed issue journal and verified the local redaction with `npm run verify:paths`
-State hint: repairing_ci
-Blocked reason: none
-Tests: `npm run verify:paths`
-Next action: Commit and push the journal-only path-redaction repair on `codex/issue-1456`, then recheck PR #1459 checks
-Failure signature: build (ubuntu-latest):fail
+- Reused the persisted `preserved_partial_work=yes` failure-context signal to surface blocked manual-review partial-work incidents in readiness/selection output and the no-runnable run-once message.
 
 ## Active Failure Context
-- Category: checks
-- Summary: PR #1459 has failing checks.
-- Command or source: gh pr checks
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1459
-- Details:
-  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/24301520330/job/70955609165
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The only active CI failure is the stale committed journal content on `0311e0d`; once the already-redacted working-copy journal is pushed, `verify:paths` should stop failing and the PR should return to waiting on fresh checks.
-- What changed: Reproduced the failing Actions check with the bundled `inspect_pr_checks.py` helper, compared `HEAD` versus the working copy for `.codex-supervisor/issue-journal.md`, confirmed the committed file still carried a workstation-local absolute helper path while the working tree had portable placeholders, and reran `npm run verify:paths` locally against the repaired working copy.
-- Current blocker: The fix is only local until the sanitized journal diff is committed and pushed to PR #1459.
-- Next exact step: Commit the repaired `.codex-supervisor/issue-journal.md`, push `codex/issue-1456`, then re-read PR #1459 check status on the new head.
-- Verification gap: This turn reran the failing path verifier only; I did not rerun the broader focused test/build suite because the repair is journal-only and does not touch runtime code.
-- Files touched: .codex-supervisor/issue-journal.md
-- Rollback concern: Low; this turn only refreshes tracked supervisor handoff metadata and does not alter the implemented preserved-partial-work behavior.
-- Last focused command: `npm run verify:paths`
-- Last focused commands: `gh auth status`; `python3 <skill-path>/inspect_pr_checks.py --repo . --pr 1459 --json`; `git show HEAD:.codex-supervisor/issue-journal.md | sed -n '40,55p'`; `sed -n '40,55p' .codex-supervisor/issue-journal.md`; `npm run verify:paths`
+- Hypothesis: The queue looked empty because readiness and run-once fallback messaging collapsed `manual_review + preserved_partial_work` into generic `no_runnable_issue` / `No matching open issue found`.
+- What changed: Added a shared helper that finds the latest blocked manual-review record with preserved partial work from `last_failure_context.details`; readiness now appends `blocked_partial_work ...`, `status --why` emits `selection_reason=blocked_partial_work_manual_review issue=#...`, and run-once no-runnable messaging now names the blocked issue instead of pretending the backlog is empty.
+- Current blocker: None in the issue-specific paths. Repo baseline still has unrelated failing tests outside this issue scope.
+- Next exact step: Commit the checkpoint on `codex/issue-1457`; open/update a draft PR if requested by the supervisor flow.
+- Verification gap: The exact `npm test -- <file>` commands still invoke unrelated repo-wide failures in this branch; issue-specific verification passed via direct `npx tsx --test ...` runs, and `npm run build` passed.
+- Files touched: `.codex-supervisor/issue-journal.md`; `src/supervisor/supervisor-preserved-partial-work.ts`; `src/supervisor/supervisor-selection-readiness-summary.ts`; `src/supervisor/supervisor-selection-readiness-summary.test.ts`; `src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `src/run-once-issue-selection.ts`; `src/run-once-issue-selection.test.ts`.
+- Rollback concern: Low. The new blocked-partial-work signal is only surfaced when the latest preserved partial-work incident is also a candidate issue blocked by `local_state:blocked`, so empty backlog and unrelated blocked states keep the prior `no_runnable_issue` behavior.
+- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
 ### Scratchpad
-- 2026-04-12: Reproduced `build (ubuntu-latest)` to `npm run verify:paths`; the failure is still the committed workstation-local helper-path reference in `.codex-supervisor/issue-journal.md`, while the working copy already carries the redacted portable form and passes the verifier locally.
-- 2026-04-12: Pushed `0311e0d` for the journal metadata repair; PR #1459 now has zero unresolved review threads and fresh CI/CodeRabbit runs on the new head.
-- 2026-04-12: Verified the two remaining unresolved PR threads are both journal-only comments on `.codex-supervisor/issue-journal.md`; no runtime code path was identified that would have produced the stale snapshot now in the branch.
-- 2026-04-12: Pushed journal-only follow-up commit `f917711`; PR #1459 now shows fresh pending CI/check runs on the refreshed checkpoint.
-- 2026-04-12: Confirmed the only remaining unresolved review thread was the stale journal checkpoint itself; refreshed the tracked metadata to `pr_open` after verifying PR #1459 is clean and green.
-- 2026-04-12: Addressed PRRT_kwDORgvdZ856WZIX by excluding `??` entries from failed no-PR `preservedTrackedFiles`; untracked-only work still yields `manual_review_required` but no longer advertises preserved tracked partial work.
-- 2026-04-12: Posted follow-up on PR #1459 via `gh api` because the GitHub app lacked permission to reply to the inline comment, then resolved the review thread directly with GraphQL.
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,54 @@
-# Issue #1457: Make loop and readiness output distinguish blocked partial-work incidents from an empty backlog
+# Issue #1456: Surface preserved partial-work incidents in status and explain
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1457
-- Branch: codex/issue-1457
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1456
+- Branch: codex/issue-1456
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 3543601c2d50626981344525537a130d94ce8448
+- Current phase: repairing_ci
+- Attempt count: 6 (implementation=2, repair=2)
+- Last head SHA: 0311e0d4b3be4df5b9b1dc109dadde72464d1f47
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-12T07:46:14.238Z
+- Last failure signature: build (ubuntu-latest):fail
+- Repeated failure signature count: 3
+- Updated at: 2026-04-12T07:37:07.876Z
 
 ## Latest Codex Summary
-- Reused the persisted `preserved_partial_work=yes` failure-context signal to surface blocked manual-review partial-work incidents in readiness/selection output and the no-runnable run-once message.
+Reproduced the failing `build (ubuntu-latest)` check for PR `#1459` via the GitHub Actions log and confirmed the root cause is still the tracked `.codex-supervisor/issue-journal.md` at `HEAD`: lines 45-46 in the committed file still mention a workstation-local absolute path to the comment-fetch helper, which trips `npm run verify:paths` on Ubuntu.
+
+The working copy already had the portable redaction in place, so I verified the intended fix locally with `npm run verify:paths`, which now passes. This turn packages that tracked journal repair for push so CI can rerun against the sanitized command history.
+
+Summary: Reproduced the Ubuntu CI failure to a stale workstation-local path leak in the committed issue journal and verified the local redaction with `npm run verify:paths`
+State hint: repairing_ci
+Blocked reason: none
+Tests: `npm run verify:paths`
+Next action: Commit and push the journal-only path-redaction repair on `codex/issue-1456`, then recheck PR #1459 checks
+Failure signature: build (ubuntu-latest):fail
 
 ## Active Failure Context
-- None recorded.
+- Category: checks
+- Summary: PR #1459 has failing checks.
+- Command or source: gh pr checks
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1459
+- Details:
+  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/24301520330/job/70955609165
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The queue looked empty because readiness and run-once fallback messaging collapsed `manual_review + preserved_partial_work` into generic `no_runnable_issue` / `No matching open issue found`.
-- What changed: Added a shared helper that finds the latest blocked manual-review record with preserved partial work from `last_failure_context.details`; readiness now appends `blocked_partial_work ...`, `status --why` emits `selection_reason=blocked_partial_work_manual_review issue=#...`, and run-once no-runnable messaging now names the blocked issue instead of pretending the backlog is empty.
-- Current blocker: None in the issue-specific paths. Repo baseline still has unrelated failing tests outside this issue scope.
-- Next exact step: Commit the checkpoint on `codex/issue-1457`; open/update a draft PR if requested by the supervisor flow.
-- Verification gap: The exact `npm test -- <file>` commands still invoke unrelated repo-wide failures in this branch; issue-specific verification passed via direct `npx tsx --test ...` runs, and `npm run build` passed.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/supervisor/supervisor-preserved-partial-work.ts`; `src/supervisor/supervisor-selection-readiness-summary.ts`; `src/supervisor/supervisor-selection-readiness-summary.test.ts`; `src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `src/run-once-issue-selection.ts`; `src/run-once-issue-selection.test.ts`.
-- Rollback concern: Low. The new blocked-partial-work signal is only surfaced when the latest preserved partial-work incident is also a candidate issue blocked by `local_state:blocked`, so empty backlog and unrelated blocked states keep the prior `no_runnable_issue` behavior.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- Hypothesis: The only active CI failure is the stale committed journal content on `0311e0d`; once the already-redacted working-copy journal is pushed, `verify:paths` should stop failing and the PR should return to waiting on fresh checks.
+- What changed: Reproduced the failing Actions check with the bundled `inspect_pr_checks.py` helper, compared `HEAD` versus the working copy for `.codex-supervisor/issue-journal.md`, confirmed the committed file still carried a workstation-local absolute helper path while the working tree had portable placeholders, and reran `npm run verify:paths` locally against the repaired working copy.
+- Current blocker: The fix is only local until the sanitized journal diff is committed and pushed to PR #1459.
+- Next exact step: Commit the repaired `.codex-supervisor/issue-journal.md`, push `codex/issue-1456`, then re-read PR #1459 check status on the new head.
+- Verification gap: This turn reran the failing path verifier only; I did not rerun the broader focused test/build suite because the repair is journal-only and does not touch runtime code.
+- Files touched: .codex-supervisor/issue-journal.md
+- Rollback concern: Low; this turn only refreshes tracked supervisor handoff metadata and does not alter the implemented preserved-partial-work behavior.
+- Last focused command: `npm run verify:paths`
+- Last focused commands: `gh auth status`; `python3 <skill-path>/inspect_pr_checks.py --repo . --pr 1459 --json`; `git show HEAD:.codex-supervisor/issue-journal.md | sed -n '40,55p'`; `sed -n '40,55p' .codex-supervisor/issue-journal.md`; `npm run verify:paths`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-12: Reproduced `build (ubuntu-latest)` to `npm run verify:paths`; the failure is still the committed workstation-local helper-path reference in `.codex-supervisor/issue-journal.md`, while the working copy already carries the redacted portable form and passes the verifier locally.
+- 2026-04-12: Pushed `0311e0d` for the journal metadata repair; PR #1459 now has zero unresolved review threads and fresh CI/CodeRabbit runs on the new head.
+- 2026-04-12: Verified the two remaining unresolved PR threads are both journal-only comments on `.codex-supervisor/issue-journal.md`; no runtime code path was identified that would have produced the stale snapshot now in the branch.
+- 2026-04-12: Pushed journal-only follow-up commit `f917711`; PR #1459 now shows fresh pending CI/check runs on the refreshed checkpoint.
+- 2026-04-12: Confirmed the only remaining unresolved review thread was the stale journal checkpoint itself; refreshed the tracked metadata to `pr_open` after verifying PR #1459 is clean and green.
+- 2026-04-12: Addressed PRRT_kwDORgvdZ856WZIX by excluding `??` entries from failed no-PR `preservedTrackedFiles`; untracked-only work still yields `manual_review_required` but no longer advertises preserved tracked partial work.
+- 2026-04-12: Posted follow-up on PR #1459 via `gh api` because the GitHub app lacked permission to reply to the inline comment, then resolved the review thread directly with GraphQL.

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { resolveRunnableIssueContext } from "./run-once-issue-selection";
+import {
+  formatNoRunnableIssueFoundMessage,
+  resolveRunnableIssueContext,
+} from "./run-once-issue-selection";
 import { GitHubIssue, IssueRunRecord, SupervisorConfig, SupervisorStateFile } from "./core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -252,6 +255,42 @@ test("resolveRunnableIssueContext keeps the acquired lock attached to a ready is
   assert.equal(state.activeIssueNumber, 92);
   assert.equal(state.issues["92"]?.issue_number, 92);
   assert.equal(savedStates.length, 1);
+});
+
+test("formatNoRunnableIssueFoundMessage distinguishes blocked preserved partial work from an empty backlog", () => {
+  const genericState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  assert.equal(formatNoRunnableIssueFoundMessage(genericState), "No matching open issue found.");
+
+  const blockedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "145": createRecord(145, {
+        state: "blocked",
+        blocked_reason: "manual_review",
+        updated_at: "2026-04-12T00:10:00Z",
+        last_failure_context: {
+          category: "manual",
+          summary: "Issue #145 needs manual review because preserved partial work is waiting in the workspace.",
+          signature: "manual-review-preserved-partial-work",
+          command: null,
+          details: [
+            "preserved_partial_work=yes",
+            "tracked_files=feature.txt|src/workflow.ts",
+          ],
+          url: "https://example.test/issues/145",
+          updated_at: "2026-04-12T00:10:00Z",
+        },
+      }),
+    },
+  };
+
+  assert.equal(
+    formatNoRunnableIssueFoundMessage(blockedState),
+    "No runnable issue is available. Latest blocked issue #145 is waiting on manual review with preserved partial work.",
+  );
 });
 
 test("resolveRunnableIssueContext blocks safer-mode autonomous execution without the trusted-input label", async () => {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -43,6 +43,7 @@ import {
   emitSupervisorEvent,
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
+import { findLatestBlockedPreservedPartialWorkIncident } from "./supervisor/supervisor-preserved-partial-work";
 
 export interface ReadyIssueContext {
   kind: "ready";
@@ -100,6 +101,20 @@ interface ReserveRunnableIssueSelectionArgs {
 type DegradedDependencyCheckResult =
   | { kind: "ready" }
   | { kind: "blocked"; reason: string };
+
+export function formatNoRunnableIssueFoundMessage(
+  state: Pick<SupervisorStateFile, "issues">,
+): string {
+  const blockedPartialWorkIncident = findLatestBlockedPreservedPartialWorkIncident(state);
+  if (blockedPartialWorkIncident === null) {
+    return "No matching open issue found.";
+  }
+
+  return [
+    "No runnable issue is available.",
+    `Latest blocked issue #${blockedPartialWorkIncident.record.issue_number} is waiting on manual review with preserved partial work.`,
+  ].join(" ");
+}
 
 function canContinueActiveIssueDuringInventoryDegradation(state: SupervisorStateFile): boolean {
   return canProceedWithDegradedContinuationAfterInventoryRefreshFailure({
@@ -365,7 +380,7 @@ async function selectIssueRecord(
     if (!record) {
       state.activeIssueNumber = null;
       await stateStore.save(state);
-      return "No matching open issue found.";
+      return formatNoRunnableIssueFoundMessage(state);
     }
 
     return {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1541,6 +1541,84 @@ Decide whether to keep the current production auth token flow or replace it befo
   );
 });
 
+test("status distinguishes blocked preserved partial work from an empty backlog", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 145;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        updated_at: "2026-04-12T00:10:00Z",
+        last_failure_context: {
+          category: "manual",
+          summary: "Issue #145 needs manual review because the workspace preserves partial work.",
+          signature: "manual-review-preserved-partial-work",
+          command: null,
+          details: [
+            "preserved_partial_work=yes",
+            "tracked_files=feature.txt|src/workflow.ts",
+          ],
+          url: "https://example.test/issues/145",
+          updated_at: "2026-04-12T00:10:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const blockedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Manual review for preserved partial work",
+    body: executionReadyBody(
+      "Keep the preserved worktree available until the operator manually reviews the partial work.",
+    ),
+    createdAt: "2026-04-12T00:00:00Z",
+    updatedAt: "2026-04-12T00:00:00Z",
+    url: "https://example.test/issues/145",
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [blockedIssue],
+    listAllIssues: async () => [blockedIssue],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport({ why: true });
+  assert.match(report.readinessLines.join("\n"), /^runnable_issues=none$/m);
+  assert.match(report.readinessLines.join("\n"), /^blocked_issues=#145 blocked_by=local_state:blocked$/m);
+  assert.match(
+    report.readinessLines.join("\n"),
+    /^blocked_partial_work issue=#145 blocked_reason=manual_review partial_work=preserved tracked_files=feature\.txt\|src\/workflow\.ts$/m,
+  );
+  assert.deepEqual(report.whyLines, [
+    "selected_issue=none",
+    "selection_reason=blocked_partial_work_manual_review issue=#145",
+    "blocked_partial_work issue=#145 blocked_reason=manual_review partial_work=preserved tracked_files=feature.txt|src/workflow.ts",
+  ]);
+
+  const status = await supervisor.status({ why: true });
+  assert.match(status, /^No active issue\.$/m);
+  assert.match(status, /^selection_reason=blocked_partial_work_manual_review issue=#145$/m);
+  assert.match(
+    status,
+    /^blocked_partial_work issue=#145 blocked_reason=manual_review partial_work=preserved tracked_files=feature\.txt\|src\/workflow\.ts$/m,
+  );
+});
+
 test("status makes safer-mode trust gating explicit while allowing trusted-input issues", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-preserved-partial-work.ts
+++ b/src/supervisor/supervisor-preserved-partial-work.ts
@@ -1,4 +1,9 @@
-import type { IssueRunRecord } from "../core/types";
+import type { IssueRunRecord, SupervisorStateFile } from "../core/types";
+
+export interface PreservedPartialWorkIncident {
+  record: IssueRunRecord;
+  partialWorkSummary: string;
+}
 
 export function summarizePreservedPartialWork(
   failureContext: Pick<NonNullable<IssueRunRecord["last_failure_context"]>, "details"> | null | undefined,
@@ -28,4 +33,39 @@ export function summarizePreservedPartialWork(
     : trackedFileCount
       ? `partial_work=preserved tracked_file_count=${trackedFileCount}`
       : "partial_work=preserved";
+}
+
+export function findLatestBlockedPreservedPartialWorkIncident(
+  state: Pick<SupervisorStateFile, "issues">,
+): PreservedPartialWorkIncident | null {
+  let latest: PreservedPartialWorkIncident | null = null;
+
+  for (const record of Object.values(state.issues)) {
+    if (record.state !== "blocked" || record.blocked_reason !== "manual_review") {
+      continue;
+    }
+
+    const partialWorkSummary = summarizePreservedPartialWork(record.last_failure_context);
+    if (partialWorkSummary === null) {
+      continue;
+    }
+
+    if (latest === null || record.updated_at.localeCompare(latest.record.updated_at) > 0) {
+      latest = {
+        record,
+        partialWorkSummary,
+      };
+    }
+  }
+
+  return latest;
+}
+
+export function formatBlockedPreservedPartialWorkLine(incident: PreservedPartialWorkIncident): string {
+  return [
+    "blocked_partial_work",
+    `issue=#${incident.record.issue_number}`,
+    `blocked_reason=${incident.record.blocked_reason ?? "none"}`,
+    incident.partialWorkSummary,
+  ].join(" ");
 }

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -333,6 +333,88 @@ Execution order: 3 of 3`,
   ]);
 });
 
+test("buildReadinessSummary and buildSelectionWhySummary distinguish blocked preserved partial work from an empty backlog", async () => {
+  const config = createConfig();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "145": createRecord({
+        issue_number: 145,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        updated_at: "2026-04-12T00:10:00Z",
+        last_failure_context: {
+          category: "manual",
+          summary: "Issue #145 needs manual review because the preserved workspace contains partial work.",
+          signature: "manual-review-preserved-partial-work",
+          command: null,
+          details: [
+            "preserved_partial_work=yes",
+            "tracked_files=feature.txt|src/workflow.ts",
+          ],
+          url: "https://example.test/issues/145",
+          updated_at: "2026-04-12T00:10:00Z",
+        },
+      }),
+    },
+  };
+  const blockedIssue = createIssue({
+    number: 145,
+    title: "Manual review for preserved partial work",
+    body: `## Summary
+Hold the preserved workspace for manual review.
+
+## Scope
+- keep the preserved worktree available for operator inspection
+
+## Acceptance criteria
+- selection output stays explicit about the manual-review hold
+
+## Verification
+- npm test -- src/supervisor/supervisor-selection-readiness-summary.test.ts`,
+  });
+
+  const readinessSummary = await buildReadinessSummary(
+    {
+      listCandidateIssues: async () => [blockedIssue],
+      listAllIssues: async () => [blockedIssue],
+    },
+    config,
+    state,
+  );
+
+  assert.deepEqual(readinessSummary, {
+    runnableIssues: [],
+    blockedIssues: [
+      {
+        issueNumber: 145,
+        title: "Manual review for preserved partial work",
+        blockedBy: "local_state:blocked",
+      },
+    ],
+    readinessLines: [
+      "runnable_issues=none",
+      "blocked_issues=#145 blocked_by=local_state:blocked",
+      "blocked_partial_work issue=#145 blocked_reason=manual_review partial_work=preserved tracked_files=feature.txt|src/workflow.ts",
+    ],
+  });
+
+  const whyLines = await buildSelectionWhySummary(
+    {
+      listCandidateIssues: async () => [blockedIssue],
+      listAllIssues: async () => [blockedIssue],
+    },
+    config,
+    state,
+  );
+
+  assert.deepEqual(whyLines, [
+    "selected_issue=none",
+    "selection_reason=blocked_partial_work_manual_review issue=#145",
+    "blocked_partial_work issue=#145 blocked_reason=manual_review partial_work=preserved tracked_files=feature.txt|src/workflow.ts",
+  ]);
+});
+
 test("buildReadinessSummary keeps downstream siblings blocked while predecessor final evaluation is unresolved", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -29,6 +29,10 @@ import {
   formatInventoryRefreshStatusLine,
   formatLastSuccessfulInventorySnapshotStatusLine,
 } from "../inventory-refresh-state";
+import {
+  findLatestBlockedPreservedPartialWorkIncident,
+  formatBlockedPreservedPartialWorkLine,
+} from "./supervisor-preserved-partial-work";
 
 type ReadinessSummaryGitHub =
   Pick<GitHubClient, "listAllIssues" | "listCandidateIssues">
@@ -252,6 +256,18 @@ function buildReadinessSummaryFromIssues(
     });
   }
 
+  const blockedPartialWorkIncident =
+    runnableIssues.length === 0 ? findLatestBlockedPreservedPartialWorkIncident(state) : null;
+  const surfacedBlockedPartialWorkIncident =
+    blockedPartialWorkIncident &&
+      blockedIssues.some(
+        (issue) =>
+          issue.issueNumber === blockedPartialWorkIncident.record.issue_number &&
+          issue.blockedBy === "local_state:blocked",
+      )
+      ? blockedPartialWorkIncident
+      : null;
+
   return {
     runnableIssues,
     blockedIssues,
@@ -260,6 +276,9 @@ function buildReadinessSummaryFromIssues(
       ...(candidateDiscoveryWarningLine === null ? [] : [candidateDiscoveryWarningLine]),
       `runnable_issues=${runnableIssues.length > 0 ? runnableIssues.map((issue) => `#${issue.issueNumber} ready=${issue.readiness}`).join(",") : "none"}`,
       `blocked_issues=${blockedIssues.length > 0 ? blockedIssues.map((issue) => `#${issue.issueNumber} blocked_by=${issue.blockedBy}`).join("; ") : "none"}`,
+      ...(surfacedBlockedPartialWorkIncident === null
+        ? []
+        : [formatBlockedPreservedPartialWorkLine(surfacedBlockedPartialWorkIncident)]),
     ],
   };
 }
@@ -277,9 +296,14 @@ export async function buildSelectionWhySummary(
   }
 
   const summary = await buildSelectionSummary(github, config, state);
+  const blockedPartialWorkIncident =
+    summary.selectedIssueNumber === null && summary.selectionReason?.startsWith("blocked_partial_work_manual_review")
+      ? findLatestBlockedPreservedPartialWorkIncident(state)
+      : null;
   return [
     summary.selectedIssueNumber === null ? "selected_issue=none" : `selected_issue=#${summary.selectedIssueNumber}`,
     `selection_reason=${summary.selectionReason ?? "no_runnable_issue"}`,
+    ...(blockedPartialWorkIncident === null ? [] : [formatBlockedPreservedPartialWorkLine(blockedPartialWorkIncident)]),
   ];
 }
 
@@ -297,6 +321,8 @@ export async function buildSelectionSummary(
 
   const candidateIssues = await github.listCandidateIssues();
   const issues = await github.listAllIssues();
+  const blockedPartialWorkIncident = findLatestBlockedPreservedPartialWorkIncident(state);
+  let blockedPartialWorkBlocked = false;
 
   for (const issue of candidateIssues) {
     if (config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix))) {
@@ -330,6 +356,9 @@ export async function buildSelectionSummary(
       !isEligibleForSelection(existing, config) &&
       !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
     ) {
+      if (blockedPartialWorkIncident?.record.issue_number === issue.number) {
+        blockedPartialWorkBlocked = true;
+      }
       continue;
     }
 
@@ -341,7 +370,10 @@ export async function buildSelectionSummary(
 
   return {
     selectedIssueNumber: null,
-    selectionReason: "no_runnable_issue",
+    selectionReason:
+      blockedPartialWorkIncident === null || !blockedPartialWorkBlocked
+        ? "no_runnable_issue"
+        : `blocked_partial_work_manual_review issue=#${blockedPartialWorkIncident.record.issue_number}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- surface blocked preserved-partial-work incidents in readiness and `status --why`
- make the no-runnable `run-once` fallback say when the latest blocked issue is waiting on manual review with preserved partial work
- keep empty-backlog and unrelated blocked cases on the previous generic messaging path

## Testing
- `npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npx tsx --test src/run-once-issue-selection.test.ts`
- `npm run build`

Closes #1457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced status reporting to detect and display blocked issues with preserved partial work awaiting manual review.
  * Improved messaging when no runnable issues are available, showing specific details about blocking reasons and preserved work.

* **Tests**
  * Added comprehensive test coverage for blocked partial work detection and formatting in status selection and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->