### PR TITLE
Stale no-PR recovery reruns Codex instead of resuming draft PR publication for clean checkpoint branches (#1460)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,54 +1,33 @@
-# Issue #1456: Surface preserved partial-work incidents in status and explain
+# Issue #1460: Stale no-PR recovery reruns Codex instead of resuming draft PR publication for clean checkpoint branches
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1456
-- Branch: codex/issue-1456
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1460
+- Branch: codex/issue-1460
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: repairing_ci
-- Attempt count: 6 (implementation=2, repair=2)
-- Last head SHA: 0311e0d4b3be4df5b9b1dc109dadde72464d1f47
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 09bd0ffea7244279e88951a840200e24f9e14ade
 - Blocked reason: none
-- Last failure signature: build (ubuntu-latest):fail
-- Repeated failure signature count: 3
-- Updated at: 2026-04-12T07:37:07.876Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T10:44:45.661Z
 
 ## Latest Codex Summary
-Reproduced the failing `build (ubuntu-latest)` check for PR `#1459` via the GitHub Actions log and confirmed the root cause is still the tracked `.codex-supervisor/issue-journal.md` at `HEAD`: lines 45-46 in the committed file still mention a workstation-local absolute path to the comment-fetch helper, which trips `npm run verify:paths` on Ubuntu.
-
-The working copy already had the portable redaction in place, so I verified the intended fix locally with `npm run verify:paths`, which now passes. This turn packages that tracked journal repair for push so CI can rerun against the sanitized command history.
-
-Summary: Reproduced the Ubuntu CI failure to a stale workstation-local path leak in the committed issue journal and verified the local redaction with `npm run verify:paths`
-State hint: repairing_ci
-Blocked reason: none
-Tests: `npm run verify:paths`
-Next action: Commit and push the journal-only path-redaction repair on `codex/issue-1456`, then recheck PR #1459 checks
-Failure signature: build (ubuntu-latest):fail
+- None yet.
 
 ## Active Failure Context
-- Category: checks
-- Summary: PR #1459 has failing checks.
-- Command or source: gh pr checks
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1459
-- Details:
-  - build (ubuntu-latest) (fail/FAILURE) https://github.com/TommyKammy/codex-supervisor/actions/runs/24301520330/job/70955609165
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The only active CI failure is the stale committed journal content on `0311e0d`; once the already-redacted working-copy journal is pushed, `verify:paths` should stop failing and the PR should return to waiting on fresh checks.
-- What changed: Reproduced the failing Actions check with the bundled `inspect_pr_checks.py` helper, compared `HEAD` versus the working copy for `.codex-supervisor/issue-journal.md`, confirmed the committed file still carried a workstation-local absolute helper path while the working tree had portable placeholders, and reran `npm run verify:paths` locally against the repaired working copy.
-- Current blocker: The fix is only local until the sanitized journal diff is committed and pushed to PR #1459.
-- Next exact step: Commit the repaired `.codex-supervisor/issue-journal.md`, push `codex/issue-1456`, then re-read PR #1459 check status on the new head.
-- Verification gap: This turn reran the failing path verifier only; I did not rerun the broader focused test/build suite because the repair is journal-only and does not touch runtime code.
-- Files touched: .codex-supervisor/issue-journal.md
-- Rollback concern: Low; this turn only refreshes tracked supervisor handoff metadata and does not alter the implemented preserved-partial-work behavior.
-- Last focused command: `npm run verify:paths`
-- Last focused commands: `gh auth status`; `python3 <skill-path>/inspect_pr_checks.py --repo . --pr 1459 --json`; `git show HEAD:.codex-supervisor/issue-journal.md | sed -n '40,55p'`; `sed -n '40,55p' .codex-supervisor/issue-journal.md`; `npm run verify:paths`
+- Hypothesis: stale no-PR recovery was rerunning Codex because supervisor-owned issue-journal dirtiness prevented clean checkpoint branches from inferring `draft_pr`, and dry-run still tried to execute the publication path as a Codex turn.
+- What changed: ignored supervisor-owned issue-journal paths when computing workspace dirtiness, taught dry-run checkpoint hydration to stop before mutating GitHub, and added regression coverage for stale no-PR dry-run publication plus the shared lifecycle/preparation helpers.
+- Current blocker: none.
+- Next exact step: commit the verified fix, then let the supervisor move this issue to the next publication/review phase.
+- Verification gap: full requested file suites and build passed locally; no broader full-suite run beyond the touched file-level regressions.
+- Files touched: .codex-supervisor/issue-journal.md; src/core/git-workspace-helpers.ts; src/core/git-workspace-helpers.test.ts; src/core/workspace.ts; src/run-once-issue-preparation.ts; src/run-once-issue-preparation.test.ts; src/supervisor/supervisor-lifecycle.ts; src/supervisor/supervisor-lifecycle.test.ts; src/supervisor/supervisor-execution-orchestration.test.ts
+- Rollback concern: if supervisor-owned journal paths should ever count as meaningful dirtiness for publication gating, this change would make those worktrees look clean again.
+- Last focused command: npm run build
 ### Scratchpad
-- 2026-04-12: Reproduced `build (ubuntu-latest)` to `npm run verify:paths`; the failure is still the committed workstation-local helper-path reference in `.codex-supervisor/issue-journal.md`, while the working copy already carries the redacted portable form and passes the verifier locally.
-- 2026-04-12: Pushed `0311e0d` for the journal metadata repair; PR #1459 now has zero unresolved review threads and fresh CI/CodeRabbit runs on the new head.
-- 2026-04-12: Verified the two remaining unresolved PR threads are both journal-only comments on `.codex-supervisor/issue-journal.md`; no runtime code path was identified that would have produced the stale snapshot now in the branch.
-- 2026-04-12: Pushed journal-only follow-up commit `f917711`; PR #1459 now shows fresh pending CI/check runs on the refreshed checkpoint.
-- 2026-04-12: Confirmed the only remaining unresolved review thread was the stale journal checkpoint itself; refreshed the tracked metadata to `pr_open` after verifying PR #1459 is clean and green.
-- 2026-04-12: Addressed PRRT_kwDORgvdZ856WZIX by excluding `??` entries from failed no-PR `preservedTrackedFiles`; untracked-only work still yields `manual_review_required` but no longer advertises preserved tracked partial work.
-- 2026-04-12: Posted follow-up on PR #1459 via `gh api` because the GitHub app lacked permission to reply to the inline comment, then resolved the review thread directly with GraphQL.
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/core/git-workspace-helpers.test.ts
+++ b/src/core/git-workspace-helpers.test.ts
@@ -41,6 +41,8 @@ test("isIgnoredSupervisorArtifactPath matches supervisor-owned artifacts and pre
     isIgnoredSupervisorArtifactPath(".codex-supervisor/issues/1359/issue-journal.md", ".codex-supervisor/issues/1359/issue-journal.md"),
     true,
   );
+  assert.equal(isIgnoredSupervisorArtifactPath(".codex-supervisor/issue-journal.md"), true);
+  assert.equal(isIgnoredSupervisorArtifactPath(".codex-supervisor/issues/2468/issue-journal.md"), true);
   assert.equal(isIgnoredSupervisorArtifactPath("src/user-change.ts", ".codex-supervisor/issues/1359/issue-journal.md"), false);
 });
 

--- a/src/core/git-workspace-helpers.ts
+++ b/src/core/git-workspace-helpers.ts
@@ -6,11 +6,15 @@ export type GitStatusPorcelainV1Entry = {
   paths: string[];
 };
 
+const ISSUE_JOURNAL_RELATIVE_PATH_REGEX = /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/u;
+
 export function isIgnoredSupervisorArtifactPath(
   relativePath: string,
-  journalRelativePath: string,
+  journalRelativePath?: string,
 ): boolean {
   return relativePath === journalRelativePath
+    || relativePath === ".codex-supervisor/issue-journal.md"
+    || ISSUE_JOURNAL_RELATIVE_PATH_REGEX.test(relativePath)
     || relativePath === ".codex-supervisor/turn-in-progress.json"
     || relativePath === ".codex-supervisor/replay"
     || relativePath.startsWith(".codex-supervisor/replay/")

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { runCommand } from "./command";
+import { isIgnoredSupervisorArtifactPath, parseGitStatusPorcelainV1Paths } from "./git-workspace-helpers";
 import { EnsuredWorkspace, SupervisorConfig, WorkspaceRestoreMetadata, WorkspaceStatus } from "./types";
 import { ensureDir, isValidGitRefName } from "./utils";
 
@@ -349,7 +350,7 @@ export async function getWorkspaceStatus(
   const [headResult, branchResult, statusResult, baseResult, remoteExistsResult] = await Promise.all([
     runCommand("git", ["-C", workspacePath, "rev-parse", "HEAD"]),
     runCommand("git", ["-C", workspacePath, "rev-parse", "--abbrev-ref", "HEAD"]),
-    runCommand("git", ["-C", workspacePath, "status", "--short"]),
+    runCommand("git", ["-C", workspacePath, "status", "--porcelain=v1", "-z", "--untracked-files=all"]),
     runCommand("git", ["-C", workspacePath, "rev-list", "--left-right", "--count", `${defaultBranchRef}...HEAD`]),
     runCommand(
       "git",
@@ -382,10 +383,13 @@ export async function getWorkspaceStatus(
       .map((value) => Number(value));
   }
 
+  const hasMeaningfulUncommittedChanges = parseGitStatusPorcelainV1Paths(statusResult.stdout)
+    .some((paths) => paths.some((relativePath) => !isIgnoredSupervisorArtifactPath(relativePath)));
+
   return {
     branch: branchResult.stdout.trim(),
     headSha: headResult.stdout.trim(),
-    hasUncommittedChanges: statusResult.stdout.trim().length > 0,
+    hasUncommittedChanges: hasMeaningfulUncommittedChanges,
     baseAhead: baseAhead || 0,
     baseBehind: baseBehind || 0,
     remoteBranchExists,

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -872,6 +872,67 @@ test("prepareIssueExecutionContext creates a draft PR after checkpointed workspa
   ]);
 });
 
+test("prepareIssueExecutionContext leaves checkpointed dry-run publication as a draft_pr transition without creating a PR", async () => {
+  const record = createRecord({
+    implementation_attempt_count: 2,
+    state: "stabilizing",
+  });
+  const state = createState(record);
+  const issue = createIssue();
+  const workspaceStatus = createWorkspaceStatus({
+    baseAhead: 2,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+  });
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: createConfig({ draftPrAfterAttempt: 1 }),
+    stateStore: {
+      touch(currentRecord, patch) {
+        return { ...currentRecord, ...patch };
+      },
+      async save() {},
+    },
+    state,
+    record,
+    issue,
+    options: { dryRun: true },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async () => {},
+    syncMemoryArtifacts: async () => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => workspaceStatus,
+    pushBranch: async () => {
+      throw new Error("unexpected pushBranch call");
+    },
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected runWorkstationLocalPathGate call");
+    },
+  });
+
+  assert.equal(typeof result, "object");
+  assert.ok(result && !isRestartRunOnce(result) && typeof result !== "string");
+  assert.equal(result.pr, null);
+  assert.deepEqual(result.checks, []);
+  assert.deepEqual(result.reviewThreads, []);
+});
+
 test("prepareIssueExecutionContext blocks publication when tracked durable artifacts fail workstation-local path hygiene", async (t) => {
   const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "prepare-issue-path-hygiene-"));
   t.after(async () => {

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -466,6 +466,16 @@ async function hydratePullRequestContext(
     !nextWorkspaceStatus.hasUncommittedChanges &&
     args.record.implementation_attempt_count >= args.config.draftPrAfterAttempt
   ) {
+    if (args.options.dryRun) {
+      return {
+        record,
+        pr: null,
+        checks: [],
+        reviewThreads: [],
+        workspaceStatus: nextWorkspaceStatus,
+      };
+    }
+
     const pathHygieneBlocked = await blockPublicationForPathHygieneFailure();
     if (pathHygieneBlocked) {
       return pathHygieneBlocked;

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1511,6 +1511,114 @@ test("runOnce preserves stale no-PR recovery tracking across a successful no-PR 
   );
 });
 
+test("runOnce dry-run resumes stale no-PR recovery into draft PR publication for a clean checkpoint branch", async () => {
+  const fixture = await createSupervisorFixture({
+    codexScriptLines: [
+      "#!/bin/sh",
+      "set -eu",
+      "echo unexpected codex invocation >&2",
+      "exit 99",
+      "",
+    ],
+  });
+  const issueNumber = 91;
+  const branch = branchName(fixture.config, issueNumber);
+  const workspace = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
+
+  git(["-C", fixture.repoPath, "checkout", "-b", branch]);
+  await fs.writeFile(path.join(fixture.repoPath, "feature.txt"), "recoverable checkpoint\n", "utf8");
+  git(["-C", fixture.repoPath, "add", "feature.txt"]);
+  git(["-C", fixture.repoPath, "commit", "-m", "recoverable checkpoint"]);
+  git(["-C", fixture.repoPath, "checkout", "main"]);
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "stabilizing",
+        branch,
+        workspace,
+        journal_path: path.join(workspace, ".codex-supervisor", "issue-journal.md"),
+        pr_number: null,
+        codex_session_id: "stale-session",
+        implementation_attempt_count: 2,
+        last_error:
+          "Issue #91 re-entered stale stabilizing recovery without a tracked PR; the supervisor will retry while the repeat count remains below 3.",
+        last_failure_context: {
+          category: "blocked",
+          summary:
+            "Issue #91 re-entered stale stabilizing recovery without a tracked PR; the supervisor will retry while the repeat count remains below 3.",
+          signature: "stale-stabilizing-no-pr-recovery-loop",
+          command: null,
+          details: [
+            "state=stabilizing",
+            "tracked_pr=none",
+            "branch_state=recoverable",
+            "repeat_count=1/3",
+            "operator_action=confirm whether the implementation already landed elsewhere or retarget the tracked issue manually",
+          ],
+          url: null,
+          updated_at: "2026-03-13T00:00:00.000Z",
+        },
+        last_failure_signature: "stale-stabilizing-no-pr-recovery-loop",
+        repeated_failure_signature_count: 1,
+        stale_stabilizing_no_pr_recovery_count: 1,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Resume stale no-PR publication from a clean checkpoint",
+    body: executionReadyBody("Resume stale no-PR publication from a clean checkpoint."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      assert.equal(branchName, branch);
+      assert.equal(prNumber, null);
+      return null;
+    },
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(
+    message,
+    /recovery issue=#91 reason=stale_state_cleanup: requeued stabilizing issue #91 after issue lock and session lock were missing/,
+  );
+  assert.match(message, /state=draft_pr/);
+  assert.doesNotMatch(message, /would invoke Codex/u);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)]!;
+  assert.equal(persisted.activeIssueNumber, issueNumber);
+  assert.equal(record.state, "draft_pr");
+  assert.equal(record.pr_number, null);
+  assert.equal(record.codex_session_id, null);
+});
+
 test("runOnce lets queued stale no-PR recovery use its own retry budget after implementation attempts are exhausted", async () => {
   const fixture = await createSupervisorFixture({
     codexScriptLines: [

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -571,6 +571,7 @@ test("shouldRunCodex only returns true for actionable supervisor states", () => 
   const reviewThreads: ReviewThread[] = [];
 
   assert.equal(shouldRunCodex(createRecord({ state: "queued", pr_number: null }), null, [], [], config), true);
+  assert.equal(shouldRunCodex(createRecord({ state: "draft_pr", pr_number: null }), null, [], [], config), false);
   assert.equal(
     shouldRunCodex(createRecord({ state: "draft_pr" }), createPullRequest({ isDraft: true }), checks, reviewThreads, config),
     false,

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -363,7 +363,7 @@ export function shouldRunCodex(
   config: SupervisorConfig,
 ): boolean {
   if (!pr) {
-    return true;
+    return record.state !== "draft_pr";
   }
 
   const inferred = inferStateFromPullRequest(config, record, pr, checks, reviewThreads);


### PR DESCRIPTION
Closes #1460
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the stale no-PR recovery fix in commit `66c3ca7` (`Resume no-PR draft publication after stale recovery`).

The change does three things: it ignores supervisor-owned issue-journal artifacts when deciding whether a checkpoint branch is meaningfully dirty, it prevents `prepareIssueExecutionContext` from opening a draft PR during `--dry-run` while still surfacing publication as the next state, and it stops `shouldRunCodex` from scheduling another Codex turn once a no-PR issue has already been inferred as `draft_pr`. I also added focused regression coverage for the stale recovery dry-run path, the dry-run preparation path, and the shared workspace/lifecycle helpers.

Verification passed locally with:
- `npx tsx --test src/core/git-workspace-helpers.test.ts`
- `npx tsx --test src/no-pull-request-state.test.ts`
- `npx tsx --test src/run-once-issue-preparation.test.ts`
- `npx tsx --test src/run-once-turn-execution.test.ts`
- `npx tsx --test src/supervisor/supervisor-lifecycle.test.ts --test-name-pattern="shouldRunCodex only returns true for actionable supervisor states"`
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern="runOnce dry-run resumes stale no-PR recovery into draft PR publication for a clean checkpoint branch"`
- `npm run build`

Summary: Fixed stale no-PR recovery so clean checkpoint branches resume draft-PR publication instead of rerunning Codex, and added focused regression coverage.
State hint: draft_pr
Block...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive detection of uncommitted changes by properly filtering supervisor-managed artifact paths in git workspace status.
  * Corrected dry-run mode behavior to skip pull request creation during draft PR state transitions.

* **Tests**
  * Added comprehensive test coverage for dry-run mode workflows and draft PR state management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->