### PR TITLE
Prevent sparse cross-issue journals from blocking no-PR publication

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -22,12 +22,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: sparse-checkout failures were coming from workstation-local path scanning reading every tracked file from disk, including cross-issue supervisor journals omitted from the current sparse workspace.
-- What changed: added a sparse-checkout repro in publication-gate and path-scanner tests, then taught `findForbiddenWorkstationLocalPaths()` to skip tracked files that are absent from the working tree instead of throwing `ENOENT`.
+- What changed: added sparse-checkout repros in publication-gate and path-scanner tests, taught `findForbiddenWorkstationLocalPaths()` to skip tracked files that are absent from the working tree instead of throwing `ENOENT`, committed the fix, and opened draft PR #1464.
 - Current blocker: none.
-- Next exact step: stage the scanner, regression tests, and this journal, then commit the sparse-workspace checkpoint on `codex/issue-1463`.
+- Next exact step: watch PR #1464 for CI and review feedback, then address any follow-up if the supervisor re-enters this issue.
 - Verification gap: focused regression suite and `npm run build` passed; no broader full-suite run beyond the issue-requested tests.
 - Files touched: .codex-supervisor/issue-journal.md; src/turn-execution-publication-gate.test.ts; src/workstation-local-paths.test.ts; src/workstation-local-paths.ts
 - Rollback concern: skipping `ENOENT` for tracked-but-absent files intentionally treats out-of-sparse artifacts as non-inspectable in the current workspace, so future callers should not rely on this scanner to report leaks from paths the sparse checkout has hidden.
-- Last focused command: npm run build
+- Last focused command: gh pr create --draft --base main --head codex/issue-1463 --title "Prevent sparse cross-issue journals from blocking no-PR publication" --body ...
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #1460: Stale no-PR recovery reruns Codex instead of resuming draft PR publication for clean checkpoint branches
+# Issue #1463: Prevent sparse cross-issue supervisor journals from blocking no-PR publication
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1460
-- Branch: codex/issue-1460
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1463
+- Branch: codex/issue-1463
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 09bd0ffea7244279e88951a840200e24f9e14ade
+- Last head SHA: 0286d80db3fed1dd5a33805b1983b6f75505ccbf
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-12T10:44:45.661Z
+- Updated at: 2026-04-12T21:51:51.637Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,13 +21,13 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: stale no-PR recovery was rerunning Codex because supervisor-owned issue-journal dirtiness prevented clean checkpoint branches from inferring `draft_pr`, and dry-run still tried to execute the publication path as a Codex turn.
-- What changed: ignored supervisor-owned issue-journal paths when computing workspace dirtiness, taught dry-run checkpoint hydration to stop before mutating GitHub, and added regression coverage for stale no-PR dry-run publication plus the shared lifecycle/preparation helpers.
+- Hypothesis: sparse-checkout failures were coming from workstation-local path scanning reading every tracked file from disk, including cross-issue supervisor journals omitted from the current sparse workspace.
+- What changed: added a sparse-checkout repro in publication-gate and path-scanner tests, then taught `findForbiddenWorkstationLocalPaths()` to skip tracked files that are absent from the working tree instead of throwing `ENOENT`.
 - Current blocker: none.
-- Next exact step: commit the verified fix, then let the supervisor move this issue to the next publication/review phase.
-- Verification gap: full requested file suites and build passed locally; no broader full-suite run beyond the touched file-level regressions.
-- Files touched: .codex-supervisor/issue-journal.md; src/core/git-workspace-helpers.ts; src/core/git-workspace-helpers.test.ts; src/core/workspace.ts; src/run-once-issue-preparation.ts; src/run-once-issue-preparation.test.ts; src/supervisor/supervisor-lifecycle.ts; src/supervisor/supervisor-lifecycle.test.ts; src/supervisor/supervisor-execution-orchestration.test.ts
-- Rollback concern: if supervisor-owned journal paths should ever count as meaningful dirtiness for publication gating, this change would make those worktrees look clean again.
+- Next exact step: stage the scanner, regression tests, and this journal, then commit the sparse-workspace checkpoint on `codex/issue-1463`.
+- Verification gap: focused regression suite and `npm run build` passed; no broader full-suite run beyond the issue-requested tests.
+- Files touched: .codex-supervisor/issue-journal.md; src/turn-execution-publication-gate.test.ts; src/workstation-local-paths.test.ts; src/workstation-local-paths.ts
+- Rollback concern: skipping `ENOENT` for tracked-but-absent files intentionally treats out-of-sparse artifacts as non-inspectable in the current workspace, so future callers should not rely on this scanner to report leaks from paths the sparse checkout has hidden.
 - Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -213,6 +213,106 @@ test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journal
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 
+test("applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitted by sparse checkout", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(
+    otherJournalPath,
+    [
+      "# Issue #181: stale leak",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      `- What changed: reproduced a leak from ${SAMPLE_MACOS_WORKSTATION_PATH}.`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md", ".codex-supervisor/issues/181/issue-journal.md");
+  git(workspacePath, "commit", "-m", "seed sparse cross-issue journal leak");
+
+  git(workspacePath, "sparse-checkout", "init", "--no-cone");
+  await fs.writeFile(
+    path.join(workspacePath, ".git", "info", "sparse-checkout"),
+    ["/README.md", "/.codex-supervisor/issues/102/"].join("\n").concat("\n"),
+    "utf8",
+  );
+  git(workspacePath, "read-tree", "-mu", "HEAD");
+  await assert.rejects(fs.access(otherJournalPath), { code: "ENOENT" });
+
+  let createPullRequestCalls = 0;
+  const issue = createIssue({ title: "Gate sparse cross-issue journal hygiene without blocking publication" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        return createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    runLocalCiCommand: async () => undefined,
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "ready");
+  assert.equal(createPullRequestCalls, 1);
+  assert.equal(result.record.state, "stabilizing");
+  assert.equal(result.record.last_failure_signature, null);
+  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed sparse cross-issue journal leak");
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+});
+
 test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails", async () => {
   const issue = createIssue({ title: "Gate draft PR creation" });
   const state: SupervisorStateFile = {

--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -200,3 +200,59 @@ test("findForbiddenWorkstationLocalPaths classifies mixed-prefix path lists with
     ],
   );
 });
+
+test("findForbiddenWorkstationLocalPaths skips tracked files omitted by sparse checkout", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  const currentJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const otherJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  const visibleDocPath = path.join(repoPath, "docs", "guide.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(visibleDocPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(otherJournalPath, `- What changed: ${buildMacHomePath("alice", "Dev", "private-repo")}\n`, "utf8");
+  await fs.writeFile(visibleDocPath, `Visible leak: ${buildUnixHomePath("alice", "dev", "private-repo")}\n`, "utf8");
+  git(
+    repoPath,
+    "add",
+    ".codex-supervisor/issues/102/issue-journal.md",
+    ".codex-supervisor/issues/181/issue-journal.md",
+    "docs/guide.md",
+  );
+  git(repoPath, "commit", "-m", "seed sparse checkout fixture");
+
+  git(repoPath, "sparse-checkout", "init", "--no-cone");
+  await fs.writeFile(
+    path.join(repoPath, ".git", "info", "sparse-checkout"),
+    ["/README.md", "/docs/", "/.codex-supervisor/issues/102/"].join("\n").concat("\n"),
+    "utf8",
+  );
+  git(repoPath, "read-tree", "-mu", "HEAD");
+
+  await assert.rejects(fs.access(otherJournalPath), { code: "ENOENT" });
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath);
+
+  assert.deepEqual(
+    findings.map((finding) => ({
+      filePath: finding.filePath,
+      line: finding.line,
+      prefix: finding.prefix,
+      reason: finding.reason,
+      match: finding.match,
+    })),
+    [
+      {
+        filePath: "docs/guide.md",
+        line: 1,
+        prefix: "/home/<user>/",
+        reason: "Linux user home directory",
+        match: buildUnixHomePath("alice", "dev", "private-repo"),
+      },
+    ],
+  );
+});

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -207,7 +207,17 @@ export async function findForbiddenWorkstationLocalPaths(
     }
 
     const absolutePath = path.join(workspacePath, filePath);
-    const rawContents = await fs.readFile(absolutePath);
+    let rawContents: Buffer;
+    try {
+      rawContents = await fs.readFile(absolutePath);
+    } catch (error) {
+      const maybeErr = error as NodeJS.ErrnoException;
+      if (maybeErr.code === "ENOENT") {
+        continue;
+      }
+
+      throw error;
+    }
     if (isBinary(rawContents)) {
       continue;
     }


### PR DESCRIPTION
## Summary
- skip tracked files that are outside the current sparse checkout during workstation-local path scans
- add sparse-checkout regressions for the path scanner and no-PR publication gate

## Testing
- npx tsx --test src/turn-execution-publication-gate.test.ts src/run-once-turn-execution.test.ts src/workstation-local-paths.test.ts
- npm run build

Closes #1463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sparse checkout configurations to gracefully skip unavailable tracked files, preventing system failures.

* **Tests**
  * Added comprehensive test coverage for sparse checkout scenarios involving missing tracked files in publication gate and path scanning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->