### PR TITLE
Add tmux-backed macOS loop launcher scripts

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -35,13 +35,13 @@ Failure signature: PRRT_kwDORgvdZ856Zw2L
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The open CodeRabbit thread is valid because `scripts/start-loop-tmux.sh` currently validates `node`/`npm` before honoring an already-running tmux session, so the fix should move `has-session` ahead of that validation and lock the ordering down with an executable test.
-- What changed: Reordered `scripts/start-loop-tmux.sh` so `tmux has-session` returns success before the `node`/`npm` availability check, preserving start idempotency for already-running sessions. Added a focused test in `src/managed-restart-launcher-assets.test.ts` that stubs `tmux`, removes `node`/`npm` from `PATH`, and asserts the script still exits successfully with the existing-session message.
+- What changed: Reordered `scripts/start-loop-tmux.sh` so `tmux has-session` returns success before the `node`/`npm` availability check, preserving start idempotency for already-running sessions. Added a focused test in `src/managed-restart-launcher-assets.test.ts` that stubs `tmux`, removes `node`/`npm` from `PATH`, and asserts the script still exits successfully with the existing-session message. Committed as `a7d02eb` and pushed to `origin/codex/issue-1466`.
 - Current blocker: none
-- Next exact step: Commit and push the review fix to `codex/issue-1466`, then watch PR #1469 for CI and reviewer follow-up.
+- Next exact step: Watch PR #1469 for CI and reviewer follow-up, then resolve or answer the remaining review thread if maintainers want a GitHub-side acknowledgment.
 - Verification gap: No live tmux integration run yet; verification remains focused on asset/runtime contract coverage plus `npm run build`.
 - Files touched: .codex-supervisor/issue-journal.md; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
 - Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: npx tsx --test src/managed-restart-launcher-assets.test.ts
+- Last focused command: git push origin codex/issue-1466
 ### Scratchpad
 - Review thread `PRRT_kwDORgvdZ856Zw2L` reported valid ordering bug in `scripts/start-loop-tmux.sh`.
-- Commands run this turn: `gh auth status`; `gh pr view 1469 --json number,url,reviewDecision,isDraft,headRefName,baseRefName`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`.
+- Commands run this turn: `gh auth status`; `gh pr view 1469 --json number,url,reviewDecision,isDraft,headRefName,baseRefName`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`; `git commit -m "Fix tmux launcher idempotency review"`; `git push origin codex/issue-1466`.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -16,13 +16,13 @@
 ## Latest Codex Summary
 Aligned the issue journal verification line with the issue acceptance command so PR reviewers see `npm test -- src/managed-restart-launcher-assets.test.ts` instead of the narrower direct `tsx` invocation. While rerunning that acceptance command locally, I found it expands to the repo-wide `npm test` script rather than staying focused on the managed-restart file.
 
-I updated the stale expectation in [src/backend/webui-local-ci-browser-helpers.test.ts](src/backend/webui-local-ci-browser-helpers.test.ts) so it matches the current `warning=none` status token. The focused launcher asset test still passes via `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build` passes. The broader `npm test -- src/managed-restart-launcher-assets.test.ts` command still fails on unrelated existing tests outside this issue’s scope. The journal/test update is committed as `d73c21b` and pushed to `origin/codex/issue-1466`.
+I updated the stale expectation in [src/backend/webui-local-ci-browser-helpers.test.ts](src/backend/webui-local-ci-browser-helpers.test.ts) so it matches the current `warning=none` status token. The focused launcher asset test still passes via `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build` passes. The broader `npm test -- src/managed-restart-launcher-assets.test.ts` command still fails on unrelated existing tests outside this issue’s scope. The journal/test update is committed as `d73c21b` and the handoff refreshes are pushed on top of it to `origin/codex/issue-1466`.
 
 Summary: Aligned the journal verification command with the issue acceptance text, fixed one stale test expectation, and re-ran focused verification
 State hint: addressing_review
 Blocked reason: none
 Tests: `npm test -- src/managed-restart-launcher-assets.test.ts` (fails on unrelated existing tests in `src/supervisor-orphan-workspace-cleanup.test.ts`, `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-status-model-supervisor.test.ts`, and `src/tracked-pr-lifecycle-projection.test.ts`); `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`
-Next action: Resolve or reply to the remaining PR #1469 discussion with the command-alignment change and the note that the npm acceptance command is broader than intended
+Next action: Watch PR #1469 for reviewer follow-up or manual thread resolution after the posted reply
 Failure signature: PRRT_kwDORgvdZ856ZzBs
 
 ## Active Failure Context
@@ -35,14 +35,14 @@ Failure signature: PRRT_kwDORgvdZ856ZzBs
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The remaining CodeRabbit thread is valid at the journal level only: the recorded verification command should match the issue acceptance text, but the acceptance command currently expands to the repo-wide `npm test` script and exposes unrelated failures outside the tmux launcher scope.
-- What changed: Updated `.codex-supervisor/issue-journal.md` so the recorded verification command matches the issue acceptance text. Fixed the stale `src/backend/webui-local-ci-browser-helpers.test.ts` expectation to include the current `warning=none` status token. Re-ran `npm test -- src/managed-restart-launcher-assets.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`. Committed the journal/test updates as `d73c21b` and pushed them to `origin/codex/issue-1466`.
+- What changed: Updated `.codex-supervisor/issue-journal.md` so the recorded verification command matches the issue acceptance text. Fixed the stale `src/backend/webui-local-ci-browser-helpers.test.ts` expectation to include the current `warning=none` status token. Re-ran `npm test -- src/managed-restart-launcher-assets.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`. Committed and pushed the review-thread fix, then replied on PR #1469 with the command-alignment change and the note that the npm form is broader than intended.
 - Current blocker: none
-- Next exact step: Resolve or answer the remaining PR #1469 review thread with the command-alignment change and the note that the npm form is broader than intended.
+- Next exact step: Watch PR #1469 for reviewer follow-up or manual thread resolution after the posted reply.
 - Verification gap: No live tmux integration run yet. The exact acceptance command remains broader than intended and currently fails on unrelated existing tests outside the managed-restart launcher file.
 - Files touched: .codex-supervisor/issue-journal.md; src/backend/webui-local-ci-browser-helpers.test.ts; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
 - Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: git push origin codex/issue-1466
+- Last focused command: gh api -X POST repos/TommyKammy/codex-supervisor/pulls/1469/comments/3070273869/replies -f body=...
 ### Scratchpad
 - Review thread `PRRT_kwDORgvdZ856Zw2L` reported valid ordering bug in `scripts/start-loop-tmux.sh`.
 - Review thread `PRRT_kwDORgvdZ856ZzBs` is valid for journal-command alignment; the exact npm acceptance command also exposed unrelated existing test failures outside this issue.
-- Commands run this turn: `nl -ba .codex-supervisor/issue-journal.md | sed -n '1,120p'`; `git status --short`; `git diff -- .codex-supervisor/issue-journal.md`; `npm test -- src/managed-restart-launcher-assets.test.ts`; `npm run build`; `npm test -- --test-name-pattern "local CI browser helpers summarize a repo-owned candidate contract consistently"`; `npx tsx -e "import {buildLocalCiContractStatusLines, buildLocalCiContractChecklistItems, canAdoptRecommendedLocalCiCommand} from './src/backend/webui-local-ci-browser-helpers.ts'; ..."`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `git commit -m "Align review verification journal entry"`; `git push origin codex/issue-1466`.
+- Commands run this turn: `nl -ba .codex-supervisor/issue-journal.md | sed -n '1,120p'`; `git status --short`; `git diff -- .codex-supervisor/issue-journal.md`; `npm test -- src/managed-restart-launcher-assets.test.ts`; `npm run build`; `npm test -- --test-name-pattern "local CI browser helpers summarize a repo-owned candidate contract consistently"`; `npx tsx -e "import {buildLocalCiContractStatusLines, buildLocalCiContractChecklistItems, canAdoptRecommendedLocalCiCommand} from './src/backend/webui-local-ci-browser-helpers.ts'; ..."`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `git commit -m "Align review verification journal entry"`; `git push origin codex/issue-1466`; `gh auth status`; `gh pr view 1469 --json number,url,reviewDecision,isDraft,headRefName,baseRefName`; `gh api -X POST repos/TommyKammy/codex-supervisor/pulls/1469/comments/3070273869/replies -f body=...`.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -6,42 +6,43 @@
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: cd8dfb1733e7d6bcb5aa9f9fcb1a344f0657ab22
+- Attempt count: 3 (implementation=1, repair=2)
+- Last head SHA: 89a9a695ee4ff986e3e40e95573a1ef54cc53a21
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856Zw2L
+- Last failure signature: PRRT_kwDORgvdZ856ZzBs
 - Repeated failure signature count: 1
-- Updated at: 2026-04-12T22:30:52.763Z
+- Updated at: 2026-04-12T22:37:39.277Z
 
 ## Latest Codex Summary
-Implemented the macOS `tmux` loop launcher path and kept the existing Linux/systemd flow unchanged. The branch now has `scripts/start-loop-tmux.sh` and `scripts/stop-loop-tmux.sh`, with a fixed default session name, idempotent `has-session` start behavior, explicit launcher metadata (`CODEX_SUPERVISOR_LAUNCHER=tmux`, `CODEX_SUPERVISOR_TMUX_SESSION`), and PATH/node/npm/config propagation into the tmux-hosted loop session. I also tightened [src/managed-restart-launcher-assets.test.ts](src/managed-restart-launcher-assets.test.ts) to cover the new script contract and explicit missing-`tmux` diagnostics.
+Aligned the issue journal verification line with the issue acceptance command so PR reviewers see `npm test -- src/managed-restart-launcher-assets.test.ts` instead of the narrower direct `tsx` invocation. While rerunning that acceptance command locally, I found it expands to the repo-wide `npm test` script rather than staying focused on the managed-restart file.
 
-The work is committed and pushed on `codex/issue-1466`, and draft PR `#1469` is open: https://github.com/TommyKammy/codex-supervisor/pull/1469
+I updated the stale expectation in [src/backend/webui-local-ci-browser-helpers.test.ts](src/backend/webui-local-ci-browser-helpers.test.ts) so it matches the current `warning=none` status token. The focused launcher asset test still passes via `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build` passes. The broader `npm test -- src/managed-restart-launcher-assets.test.ts` command still fails on unrelated existing tests outside this issue’s scope.
 
-Summary: Added tmux-backed macOS loop launcher scripts, focused coverage, pushed commits, and opened draft PR #1469
-State hint: draft_pr
+Summary: Aligned the journal verification command with the issue acceptance text, fixed one stale test expectation, and re-ran focused verification
+State hint: addressing_review
 Blocked reason: none
-Tests: `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`
-Next action: Watch draft PR #1469 for CI and review feedback, then address any follow-up on this branch
-Failure signature: PRRT_kwDORgvdZ856Zw2L
+Tests: `npm test -- src/managed-restart-launcher-assets.test.ts` (fails on unrelated existing tests in `src/supervisor-orphan-workspace-cleanup.test.ts`, `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-status-model-supervisor.test.ts`, and `src/tracked-pr-lifecycle-projection.test.ts`); `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`
+Next action: Commit and push the review-thread fix, then resolve or reply to the remaining PR #1469 discussion with the verification caveat
+Failure signature: PRRT_kwDORgvdZ856ZzBs
 
 ## Active Failure Context
 - Category: review
 - Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070262671
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070273869
 - Details:
-  - scripts/start-loop-tmux.sh:31 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 175 --- **Move the running-session check before... url=https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070262671
+  - .codex-supervisor/issue-journal.md:24 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Align verification command with the issue acceptance command.** Line 24 uses `npx tsx --test ...`, while the issue acceptance criteria calls ... url=https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070273869
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The open CodeRabbit thread is valid because `scripts/start-loop-tmux.sh` currently validates `node`/`npm` before honoring an already-running tmux session, so the fix should move `has-session` ahead of that validation and lock the ordering down with an executable test.
-- What changed: Reordered `scripts/start-loop-tmux.sh` so `tmux has-session` returns success before the `node`/`npm` availability check, preserving start idempotency for already-running sessions. Added a focused test in `src/managed-restart-launcher-assets.test.ts` that stubs `tmux`, removes `node`/`npm` from `PATH`, and asserts the script still exits successfully with the existing-session message. Committed as `a7d02eb` and pushed to `origin/codex/issue-1466`.
+- Hypothesis: The remaining CodeRabbit thread is valid at the journal level only: the recorded verification command should match the issue acceptance text, but the acceptance command currently expands to the repo-wide `npm test` script and exposes unrelated failures outside the tmux launcher scope.
+- What changed: Updated `.codex-supervisor/issue-journal.md` so the recorded verification command matches the issue acceptance text. Fixed the stale `src/backend/webui-local-ci-browser-helpers.test.ts` expectation to include the current `warning=none` status token. Re-ran `npm test -- src/managed-restart-launcher-assets.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`.
 - Current blocker: none
-- Next exact step: Watch PR #1469 for CI and reviewer follow-up, then resolve or answer the remaining review thread if maintainers want a GitHub-side acknowledgment.
-- Verification gap: No live tmux integration run yet; verification remains focused on asset/runtime contract coverage plus `npm run build`.
-- Files touched: .codex-supervisor/issue-journal.md; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
+- Next exact step: Commit and push the journal/test updates on `codex/issue-1466`, then resolve or answer the remaining PR #1469 review thread with the command-alignment change and the note that the npm form is broader than intended.
+- Verification gap: No live tmux integration run yet. The exact acceptance command remains broader than intended and currently fails on unrelated existing tests outside the managed-restart launcher file.
+- Files touched: .codex-supervisor/issue-journal.md; src/backend/webui-local-ci-browser-helpers.test.ts; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
 - Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: git push origin codex/issue-1466
+- Last focused command: npx tsx --test src/managed-restart-launcher-assets.test.ts
 ### Scratchpad
 - Review thread `PRRT_kwDORgvdZ856Zw2L` reported valid ordering bug in `scripts/start-loop-tmux.sh`.
-- Commands run this turn: `gh auth status`; `gh pr view 1469 --json number,url,reviewDecision,isDraft,headRefName,baseRefName`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`; `git commit -m "Fix tmux launcher idempotency review"`; `git push origin codex/issue-1466`.
+- Review thread `PRRT_kwDORgvdZ856ZzBs` is valid for journal-command alignment; the exact npm acceptance command also exposed unrelated existing test failures outside this issue.
+- Commands run this turn: `nl -ba .codex-supervisor/issue-journal.md | sed -n '1,120p'`; `git status --short`; `git diff -- .codex-supervisor/issue-journal.md`; `npm test -- src/managed-restart-launcher-assets.test.ts`; `npm run build`; `npm test -- --test-name-pattern "local CI browser helpers summarize a repo-owned candidate contract consistently"`; `npx tsx -e "import {buildLocalCiContractStatusLines, buildLocalCiContractChecklistItems, canAdoptRecommendedLocalCiCommand} from './src/backend/webui-local-ci-browser-helpers.ts'; ..."`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,33 @@
-# Issue #1463: Prevent sparse cross-issue supervisor journals from blocking no-PR publication
+# Issue #1466: Add tmux-backed macOS loop launcher scripts
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1463
-- Branch: codex/issue-1463
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1466
+- Branch: codex/issue-1466
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 0286d80db3fed1dd5a33805b1983b6f75505ccbf
+- Last head SHA: 689b916a17df37ff28eca36bde07e90ec390ea32
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-12T21:51:51.637Z
+- Updated at: 2026-04-12T22:16:28.237Z
 
 ## Latest Codex Summary
-- None yet.
+- Added macOS `tmux` loop launcher scripts with explicit launcher metadata, idempotent single-session start behavior, matching stop behavior, and focused asset coverage.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: sparse-checkout failures were coming from workstation-local path scanning reading every tracked file from disk, including cross-issue supervisor journals omitted from the current sparse workspace.
-- What changed: added sparse-checkout repros in publication-gate and path-scanner tests, taught `findForbiddenWorkstationLocalPaths()` to skip tracked files that are absent from the working tree instead of throwing `ENOENT`, committed the fix, and opened draft PR #1464.
-- Current blocker: none.
-- Next exact step: watch PR #1464 for CI and review feedback, then address any follow-up if the supervisor re-enters this issue.
-- Verification gap: focused regression suite and `npm run build` passed; no broader full-suite run beyond the issue-requested tests.
-- Files touched: .codex-supervisor/issue-journal.md; src/turn-execution-publication-gate.test.ts; src/workstation-local-paths.test.ts; src/workstation-local-paths.ts
-- Rollback concern: skipping `ENOENT` for tracked-but-absent files intentionally treats out-of-sparse artifacts as non-inspectable in the current workspace, so future callers should not rely on this scanner to report leaks from paths the sparse checkout has hidden.
-- Last focused command: gh pr create --draft --base main --head codex/issue-1463 --title "Prevent sparse cross-issue journals from blocking no-PR publication" --body ...
+- Hypothesis: The missing macOS loop launcher support can be added safely by following the existing launcher-asset pattern: assert shell-script contracts in `src/managed-restart-launcher-assets.test.ts` and implement a start/stop script pair under `scripts/` without changing Linux/systemd behavior.
+- What changed: Added focused asset coverage for `scripts/start-loop-tmux.sh` and `scripts/stop-loop-tmux.sh`, then implemented those scripts with a stable `codex-supervisor-loop` session default, `tmux has-session` idempotence, explicit `CODEX_SUPERVISOR_LAUNCHER=tmux` and `CODEX_SUPERVISOR_TMUX_SESSION` metadata, PATH/NODE/NPM/config propagation into the tmux session, and explicit missing-`tmux` diagnostics.
+- Current blocker: none
+- Next exact step: Review the diff, commit the launcher/test changes, and open a draft PR if one still does not exist.
+- Verification gap: No live tmux integration run yet; local verification is currently asset-focused plus `npm run build`.
+- Files touched: .codex-supervisor/issue-journal.md; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
+- Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -16,13 +16,13 @@
 ## Latest Codex Summary
 Aligned the issue journal verification line with the issue acceptance command so PR reviewers see `npm test -- src/managed-restart-launcher-assets.test.ts` instead of the narrower direct `tsx` invocation. While rerunning that acceptance command locally, I found it expands to the repo-wide `npm test` script rather than staying focused on the managed-restart file.
 
-I updated the stale expectation in [src/backend/webui-local-ci-browser-helpers.test.ts](src/backend/webui-local-ci-browser-helpers.test.ts) so it matches the current `warning=none` status token. The focused launcher asset test still passes via `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build` passes. The broader `npm test -- src/managed-restart-launcher-assets.test.ts` command still fails on unrelated existing tests outside this issue’s scope.
+I updated the stale expectation in [src/backend/webui-local-ci-browser-helpers.test.ts](src/backend/webui-local-ci-browser-helpers.test.ts) so it matches the current `warning=none` status token. The focused launcher asset test still passes via `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build` passes. The broader `npm test -- src/managed-restart-launcher-assets.test.ts` command still fails on unrelated existing tests outside this issue’s scope. The journal/test update is committed as `d73c21b` and pushed to `origin/codex/issue-1466`.
 
 Summary: Aligned the journal verification command with the issue acceptance text, fixed one stale test expectation, and re-ran focused verification
 State hint: addressing_review
 Blocked reason: none
 Tests: `npm test -- src/managed-restart-launcher-assets.test.ts` (fails on unrelated existing tests in `src/supervisor-orphan-workspace-cleanup.test.ts`, `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-status-model-supervisor.test.ts`, and `src/tracked-pr-lifecycle-projection.test.ts`); `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`
-Next action: Commit and push the review-thread fix, then resolve or reply to the remaining PR #1469 discussion with the verification caveat
+Next action: Resolve or reply to the remaining PR #1469 discussion with the command-alignment change and the note that the npm acceptance command is broader than intended
 Failure signature: PRRT_kwDORgvdZ856ZzBs
 
 ## Active Failure Context
@@ -35,14 +35,14 @@ Failure signature: PRRT_kwDORgvdZ856ZzBs
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The remaining CodeRabbit thread is valid at the journal level only: the recorded verification command should match the issue acceptance text, but the acceptance command currently expands to the repo-wide `npm test` script and exposes unrelated failures outside the tmux launcher scope.
-- What changed: Updated `.codex-supervisor/issue-journal.md` so the recorded verification command matches the issue acceptance text. Fixed the stale `src/backend/webui-local-ci-browser-helpers.test.ts` expectation to include the current `warning=none` status token. Re-ran `npm test -- src/managed-restart-launcher-assets.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`.
+- What changed: Updated `.codex-supervisor/issue-journal.md` so the recorded verification command matches the issue acceptance text. Fixed the stale `src/backend/webui-local-ci-browser-helpers.test.ts` expectation to include the current `warning=none` status token. Re-ran `npm test -- src/managed-restart-launcher-assets.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`. Committed the journal/test updates as `d73c21b` and pushed them to `origin/codex/issue-1466`.
 - Current blocker: none
-- Next exact step: Commit and push the journal/test updates on `codex/issue-1466`, then resolve or answer the remaining PR #1469 review thread with the command-alignment change and the note that the npm form is broader than intended.
+- Next exact step: Resolve or answer the remaining PR #1469 review thread with the command-alignment change and the note that the npm form is broader than intended.
 - Verification gap: No live tmux integration run yet. The exact acceptance command remains broader than intended and currently fails on unrelated existing tests outside the managed-restart launcher file.
 - Files touched: .codex-supervisor/issue-journal.md; src/backend/webui-local-ci-browser-helpers.test.ts; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
 - Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: npx tsx --test src/managed-restart-launcher-assets.test.ts
+- Last focused command: git push origin codex/issue-1466
 ### Scratchpad
 - Review thread `PRRT_kwDORgvdZ856Zw2L` reported valid ordering bug in `scripts/start-loop-tmux.sh`.
 - Review thread `PRRT_kwDORgvdZ856ZzBs` is valid for journal-command alignment; the exact npm acceptance command also exposed unrelated existing test failures outside this issue.
-- Commands run this turn: `nl -ba .codex-supervisor/issue-journal.md | sed -n '1,120p'`; `git status --short`; `git diff -- .codex-supervisor/issue-journal.md`; `npm test -- src/managed-restart-launcher-assets.test.ts`; `npm run build`; `npm test -- --test-name-pattern "local CI browser helpers summarize a repo-owned candidate contract consistently"`; `npx tsx -e "import {buildLocalCiContractStatusLines, buildLocalCiContractChecklistItems, canAdoptRecommendedLocalCiCommand} from './src/backend/webui-local-ci-browser-helpers.ts'; ..."`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`.
+- Commands run this turn: `nl -ba .codex-supervisor/issue-journal.md | sed -n '1,120p'`; `git status --short`; `git diff -- .codex-supervisor/issue-journal.md`; `npm test -- src/managed-restart-launcher-assets.test.ts`; `npm run build`; `npm test -- --test-name-pattern "local CI browser helpers summarize a repo-owned candidate contract consistently"`; `npx tsx -e "import {buildLocalCiContractStatusLines, buildLocalCiContractChecklistItems, canAdoptRecommendedLocalCiCommand} from './src/backend/webui-local-ci-browser-helpers.ts'; ..."`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `git commit -m "Align review verification journal entry"`; `git push origin codex/issue-1466`.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-12T22:16:28.237Z
 
 ## Latest Codex Summary
-- Added macOS `tmux` loop launcher scripts with explicit launcher metadata, idempotent single-session start behavior, matching stop behavior, and focused asset coverage.
+- Added macOS `tmux` loop launcher scripts with explicit launcher metadata, idempotent single-session start behavior, matching stop behavior, focused asset coverage, and draft PR #1469.
 
 ## Active Failure Context
 - None recorded.
@@ -22,12 +22,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The missing macOS loop launcher support can be added safely by following the existing launcher-asset pattern: assert shell-script contracts in `src/managed-restart-launcher-assets.test.ts` and implement a start/stop script pair under `scripts/` without changing Linux/systemd behavior.
-- What changed: Added focused asset coverage for `scripts/start-loop-tmux.sh` and `scripts/stop-loop-tmux.sh`, then implemented those scripts with a stable `codex-supervisor-loop` session default, `tmux has-session` idempotence, explicit `CODEX_SUPERVISOR_LAUNCHER=tmux` and `CODEX_SUPERVISOR_TMUX_SESSION` metadata, PATH/NODE/NPM/config propagation into the tmux session, and explicit missing-`tmux` diagnostics.
+- What changed: Added focused asset coverage for `scripts/start-loop-tmux.sh` and `scripts/stop-loop-tmux.sh`, then implemented those scripts with a stable `codex-supervisor-loop` session default, `tmux has-session` idempotence, explicit `CODEX_SUPERVISOR_LAUNCHER=tmux` and `CODEX_SUPERVISOR_TMUX_SESSION` metadata, PATH/NODE/NPM/config propagation into the tmux session, and explicit missing-`tmux` diagnostics. Committed as `ef5364f` and opened draft PR #1469.
 - Current blocker: none
-- Next exact step: Review the diff, commit the launcher/test changes, and open a draft PR if one still does not exist.
+- Next exact step: Watch draft PR #1469 for CI and review feedback, then address any follow-up if the supervisor returns to this branch.
 - Verification gap: No live tmux integration run yet; local verification is currently asset-focused plus `npm run build`.
 - Files touched: .codex-supervisor/issue-journal.md; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
 - Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: npm run build
+- Last focused command: gh pr create --draft --base main --head codex/issue-1466 --title "Add tmux-backed macOS loop launcher scripts" --body ...
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,29 +5,43 @@
 - Branch: codex/issue-1466
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 689b916a17df37ff28eca36bde07e90ec390ea32
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: cd8dfb1733e7d6bcb5aa9f9fcb1a344f0657ab22
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-12T22:16:28.237Z
+- Last failure signature: PRRT_kwDORgvdZ856Zw2L
+- Repeated failure signature count: 1
+- Updated at: 2026-04-12T22:30:52.763Z
 
 ## Latest Codex Summary
-- Added macOS `tmux` loop launcher scripts with explicit launcher metadata, idempotent single-session start behavior, matching stop behavior, focused asset coverage, and draft PR #1469.
+Implemented the macOS `tmux` loop launcher path and kept the existing Linux/systemd flow unchanged. The branch now has `scripts/start-loop-tmux.sh` and `scripts/stop-loop-tmux.sh`, with a fixed default session name, idempotent `has-session` start behavior, explicit launcher metadata (`CODEX_SUPERVISOR_LAUNCHER=tmux`, `CODEX_SUPERVISOR_TMUX_SESSION`), and PATH/node/npm/config propagation into the tmux-hosted loop session. I also tightened [src/managed-restart-launcher-assets.test.ts](src/managed-restart-launcher-assets.test.ts) to cover the new script contract and explicit missing-`tmux` diagnostics.
+
+The work is committed and pushed on `codex/issue-1466`, and draft PR `#1469` is open: https://github.com/TommyKammy/codex-supervisor/pull/1469
+
+Summary: Added tmux-backed macOS loop launcher scripts, focused coverage, pushed commits, and opened draft PR #1469
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`
+Next action: Watch draft PR #1469 for CI and review feedback, then address any follow-up on this branch
+Failure signature: PRRT_kwDORgvdZ856Zw2L
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070262671
+- Details:
+  - scripts/start-loop-tmux.sh:31 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 175 --- **Move the running-session check before... url=https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070262671
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The missing macOS loop launcher support can be added safely by following the existing launcher-asset pattern: assert shell-script contracts in `src/managed-restart-launcher-assets.test.ts` and implement a start/stop script pair under `scripts/` without changing Linux/systemd behavior.
-- What changed: Added focused asset coverage for `scripts/start-loop-tmux.sh` and `scripts/stop-loop-tmux.sh`, then implemented those scripts with a stable `codex-supervisor-loop` session default, `tmux has-session` idempotence, explicit `CODEX_SUPERVISOR_LAUNCHER=tmux` and `CODEX_SUPERVISOR_TMUX_SESSION` metadata, PATH/NODE/NPM/config propagation into the tmux session, and explicit missing-`tmux` diagnostics. Committed as `ef5364f` and opened draft PR #1469.
+- Hypothesis: The open CodeRabbit thread is valid because `scripts/start-loop-tmux.sh` currently validates `node`/`npm` before honoring an already-running tmux session, so the fix should move `has-session` ahead of that validation and lock the ordering down with an executable test.
+- What changed: Reordered `scripts/start-loop-tmux.sh` so `tmux has-session` returns success before the `node`/`npm` availability check, preserving start idempotency for already-running sessions. Added a focused test in `src/managed-restart-launcher-assets.test.ts` that stubs `tmux`, removes `node`/`npm` from `PATH`, and asserts the script still exits successfully with the existing-session message.
 - Current blocker: none
-- Next exact step: Watch draft PR #1469 for CI and review feedback, then address any follow-up if the supervisor returns to this branch.
-- Verification gap: No live tmux integration run yet; local verification is currently asset-focused plus `npm run build`.
+- Next exact step: Commit and push the review fix to `codex/issue-1466`, then watch PR #1469 for CI and reviewer follow-up.
+- Verification gap: No live tmux integration run yet; verification remains focused on asset/runtime contract coverage plus `npm run build`.
 - Files touched: .codex-supervisor/issue-journal.md; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
 - Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: gh pr create --draft --base main --head codex/issue-1466 --title "Add tmux-backed macOS loop launcher scripts" --body ...
+- Last focused command: npx tsx --test src/managed-restart-launcher-assets.test.ts
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- Review thread `PRRT_kwDORgvdZ856Zw2L` reported valid ordering bug in `scripts/start-loop-tmux.sh`.
+- Commands run this turn: `gh auth status`; `gh pr view 1469 --json number,url,reviewDecision,isDraft,headRefName,baseRefName`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`.

--- a/scripts/start-loop-tmux.sh
+++ b/scripts/start-loop-tmux.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-codex-supervisor-loop}"
+CONFIG_PATH="${CODEX_SUPERVISOR_CONFIG:-${ROOT}/supervisor.config.json}"
+CODEX_SUPERVISOR_LAUNCHER="${CODEX_SUPERVISOR_LAUNCHER:-tmux}"
+CODEX_SUPERVISOR_TMUX_SESSION="${CODEX_SUPERVISOR_TMUX_SESSION:-${TMUX_SESSION_NAME}}"
+TMUX_BIN="${TMUX_BIN:-$(command -v tmux || true)}"
+NODE_BIN="${NODE_BIN:-$(command -v node || true)}"
+NPM_BIN="${NPM_BIN:-$(command -v npm || true)}"
+PATH_VALUE="${PATH}"
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+if [[ -z "${TMUX_BIN}" ]]; then
+  echo "tmux must be available on PATH" >&2
+  exit 1
+fi
+
+if [[ -z "${NODE_BIN}" || -z "${NPM_BIN}" ]]; then
+  echo "node and npm must be available on PATH" >&2
+  exit 1
+fi
+
+if "${TMUX_BIN}" has-session -t "${TMUX_SESSION_NAME}" >/dev/null 2>&1; then
+  echo "codex-supervisor loop tmux session already running: ${TMUX_SESSION_NAME}"
+  exit 0
+fi
+
+SESSION_COMMAND="$(
+  printf 'cd %s && env PATH=%s NODE_BIN=%s NPM_BIN=%s CODEX_SUPERVISOR_CONFIG=%s CODEX_SUPERVISOR_LAUNCHER=%s CODEX_SUPERVISOR_TMUX_SESSION=%s /bin/bash %s' \
+    "$(shell_quote "${ROOT}")" \
+    "$(shell_quote "${PATH_VALUE}")" \
+    "$(shell_quote "${NODE_BIN}")" \
+    "$(shell_quote "${NPM_BIN}")" \
+    "$(shell_quote "${CONFIG_PATH}")" \
+    "$(shell_quote "${CODEX_SUPERVISOR_LAUNCHER}")" \
+    "$(shell_quote "${CODEX_SUPERVISOR_TMUX_SESSION}")" \
+    "$(shell_quote "${ROOT}/scripts/run-loop.sh")"
+)"
+
+"${TMUX_BIN}" new-session -d -s "${TMUX_SESSION_NAME}" "${SESSION_COMMAND}"
+echo "Started codex-supervisor loop tmux session: ${TMUX_SESSION_NAME}"

--- a/scripts/start-loop-tmux.sh
+++ b/scripts/start-loop-tmux.sh
@@ -21,14 +21,14 @@ if [[ -z "${TMUX_BIN}" ]]; then
   exit 1
 fi
 
-if [[ -z "${NODE_BIN}" || -z "${NPM_BIN}" ]]; then
-  echo "node and npm must be available on PATH" >&2
-  exit 1
-fi
-
 if "${TMUX_BIN}" has-session -t "${TMUX_SESSION_NAME}" >/dev/null 2>&1; then
   echo "codex-supervisor loop tmux session already running: ${TMUX_SESSION_NAME}"
   exit 0
+fi
+
+if [[ -z "${NODE_BIN}" || -z "${NPM_BIN}" ]]; then
+  echo "node and npm must be available on PATH" >&2
+  exit 1
 fi
 
 SESSION_COMMAND="$(

--- a/scripts/stop-loop-tmux.sh
+++ b/scripts/stop-loop-tmux.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-codex-supervisor-loop}"
+TMUX_BIN="${TMUX_BIN:-$(command -v tmux || true)}"
+
+if [[ -z "${TMUX_BIN}" ]]; then
+  echo "tmux must be available on PATH" >&2
+  exit 1
+fi
+
+if ! "${TMUX_BIN}" has-session -t "${TMUX_SESSION_NAME}" >/dev/null 2>&1; then
+  echo "codex-supervisor loop tmux session is not running: ${TMUX_SESSION_NAME}"
+  exit 0
+fi
+
+"${TMUX_BIN}" kill-session -t "${TMUX_SESSION_NAME}"
+echo "Stopped codex-supervisor loop tmux session: ${TMUX_SESSION_NAME}"

--- a/src/backend/webui-local-ci-browser-helpers.test.ts
+++ b/src/backend/webui-local-ci-browser-helpers.test.ts
@@ -17,7 +17,7 @@ test("local CI browser helpers summarize a repo-owned candidate contract consist
   };
 
   assert.deepEqual(buildLocalCiContractStatusLines(contract), [
-    "local ci configured=no source=repo script candidate command=none recommended command=npm run verify:pre-pr",
+    "local ci configured=no source=repo script candidate command=none recommended command=npm run verify:pre-pr warning=none",
     "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
   ]);
   assert.deepEqual(buildLocalCiContractChecklistItems(contract), [{

--- a/src/managed-restart-launcher-assets.test.ts
+++ b/src/managed-restart-launcher-assets.test.ts
@@ -71,6 +71,37 @@ async function assertMissingBinaryMessage(relativePath: string, requiredCommands
   }
 }
 
+async function assertMissingCommandMessage(
+  relativePath: string,
+  requiredCommands: string[],
+  expectedMessage: string,
+): Promise<void> {
+  const scriptPath = path.join(process.cwd(), relativePath);
+  const pathDir = await createMissingNodePath(requiredCommands);
+
+  try {
+    await assert.rejects(
+      async () => execFileAsync(bashPath, [scriptPath], {
+        env: {
+          HOME: os.tmpdir(),
+          PATH: pathDir,
+        },
+      }),
+      (error: unknown) => {
+        assert.equal(typeof error, "object");
+        assert.notEqual(error, null);
+        assert.equal((error as NodeJS.ErrnoException).code, 1);
+        const stderr = (error as { stderr?: string }).stderr ?? "";
+        assert.equal(stderr.trim(), expectedMessage);
+        assert.doesNotMatch(stderr, /command not found/u);
+        return true;
+      },
+    );
+  } finally {
+    await fs.rm(pathDir, { recursive: true, force: true });
+  }
+}
+
 test("dedicated WebUI launcher assets enable managed restart for launcher-backed WebUI sessions", async () => {
   const [
     runWeb,
@@ -122,10 +153,31 @@ test("existing loop launcher assets stay scoped to loop mode without managed res
   assert.doesNotMatch(systemdTemplate, /^Environment=CODEX_SUPERVISOR_MANAGED_RESTART(?:_LAUNCHER)?=/mu);
 });
 
+test("macOS tmux loop launcher assets define a single-session contract with explicit launcher metadata", async () => {
+  const [startTmuxLoop, stopTmuxLoop] = await Promise.all([
+    readRepoFile("scripts/start-loop-tmux.sh"),
+    readRepoFile("scripts/stop-loop-tmux.sh"),
+  ]);
+
+  assert.match(startTmuxLoop, /TMUX_SESSION_NAME="\$\{TMUX_SESSION_NAME:-codex-supervisor-loop\}"/u);
+  assert.match(startTmuxLoop, /CODEX_SUPERVISOR_LAUNCHER="\$\{CODEX_SUPERVISOR_LAUNCHER:-tmux\}"/u);
+  assert.match(startTmuxLoop, /CODEX_SUPERVISOR_TMUX_SESSION="\$\{CODEX_SUPERVISOR_TMUX_SESSION:-\$\{TMUX_SESSION_NAME\}\}"/u);
+  assert.match(startTmuxLoop, /has-session -t "\$\{TMUX_SESSION_NAME\}"/u);
+  assert.match(startTmuxLoop, /new-session -d -s "\$\{TMUX_SESSION_NAME\}"/u);
+  assert.match(startTmuxLoop, /CODEX_SUPERVISOR_CONFIG=/u);
+  assert.match(startTmuxLoop, /scripts\/run-loop\.sh/u);
+
+  assert.match(stopTmuxLoop, /TMUX_SESSION_NAME="\$\{TMUX_SESSION_NAME:-codex-supervisor-loop\}"/u);
+  assert.match(stopTmuxLoop, /has-session -t "\$\{TMUX_SESSION_NAME\}"/u);
+  assert.match(stopTmuxLoop, /kill-session -t "\$\{TMUX_SESSION_NAME\}"/u);
+});
+
 test("launcher-backed WebUI shell scripts keep their explicit missing-binary diagnostics under set -euo pipefail", async () => {
   await Promise.all([
     assertMissingBinaryMessage("scripts/run-web.sh", ["dirname"]),
     assertMissingBinaryMessage("scripts/install-launchd-web.sh", ["dirname"]),
     assertMissingBinaryMessage("scripts/install-systemd-web.sh", ["dirname"]),
+    assertMissingCommandMessage("scripts/start-loop-tmux.sh", ["dirname", "node", "npm"], "tmux must be available on PATH"),
+    assertMissingCommandMessage("scripts/stop-loop-tmux.sh", ["dirname"], "tmux must be available on PATH"),
   ]);
 });

--- a/src/managed-restart-launcher-assets.test.ts
+++ b/src/managed-restart-launcher-assets.test.ts
@@ -44,6 +44,11 @@ async function createMissingNodePath(commands: string[]): Promise<string> {
   return pathDir;
 }
 
+async function writeExecutable(filePath: string, contents: string): Promise<void> {
+  await fs.writeFile(filePath, contents, { mode: 0o755 });
+  await fs.chmod(filePath, 0o755);
+}
+
 async function assertMissingBinaryMessage(relativePath: string, requiredCommands: string[]): Promise<void> {
   const scriptPath = path.join(process.cwd(), relativePath);
   const pathDir = await createMissingNodePath(requiredCommands);
@@ -180,4 +185,39 @@ test("launcher-backed WebUI shell scripts keep their explicit missing-binary dia
     assertMissingCommandMessage("scripts/start-loop-tmux.sh", ["dirname", "node", "npm"], "tmux must be available on PATH"),
     assertMissingCommandMessage("scripts/stop-loop-tmux.sh", ["dirname"], "tmux must be available on PATH"),
   ]);
+});
+
+test("tmux loop start script preserves idempotency before checking node and npm", async () => {
+  const scriptPath = path.join(process.cwd(), "scripts/start-loop-tmux.sh");
+  const pathDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-restart-tmux-"));
+  const dirnamePath = (await execFileAsync(bashPath, ["-lc", "command -v dirname"])).stdout.trim();
+
+  try {
+    await fs.symlink(dirnamePath, path.join(pathDir, "dirname"));
+    await writeExecutable(
+      path.join(pathDir, "tmux"),
+      `#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == "has-session" ]]; then
+  exit 0
+fi
+
+echo "unexpected tmux invocation: $*" >&2
+exit 1
+`,
+    );
+
+    const { stdout, stderr } = await execFileAsync(bashPath, [scriptPath], {
+      env: {
+        HOME: os.tmpdir(),
+        PATH: pathDir,
+      },
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(stdout.trim(), "codex-supervisor loop tmux session already running: codex-supervisor-loop");
+  } finally {
+    await fs.rm(pathDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- add supported macOS tmux start/stop loop launcher scripts under `scripts/`
- keep repeated starts idempotent by reusing a single named tmux session
- export launcher metadata into the tmux-hosted loop session for later diagnostics

## Testing
- npx tsx --test src/managed-restart-launcher-assets.test.ts
- npm run build

Closes #1466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS tmux-backed start/stop commands to run the supervisor loop, with single-session semantics, precondition checks, clear success/failure messages, and idempotent behavior when a session already exists.

* **Tests**
  * Added tests covering the new launcher commands, their missing-dependency diagnostics, single-session contract, and idempotency and error-message behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->