### PR TITLE
Document tmux as the supported macOS loop host and fail closed on direct launchd loop install (#1467)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,48 +1,36 @@
-# Issue #1466: Add tmux-backed macOS loop launcher scripts
+# Issue #1467: Document tmux as the supported macOS loop host and fail closed on direct launchd loop install
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1466
-- Branch: codex/issue-1466
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1467
+- Branch: codex/issue-1467
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=1, repair=2)
-- Last head SHA: 89a9a695ee4ff986e3e40e95573a1ef54cc53a21
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 96fcafd4268ff0fafc4c1eef7d0d8bf5c415b5eb
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856ZzBs
-- Repeated failure signature count: 1
-- Updated at: 2026-04-12T22:37:39.277Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-12T22:50:15.098Z
 
 ## Latest Codex Summary
-Aligned the issue journal verification line with the issue acceptance command so PR reviewers see `npm test -- src/managed-restart-launcher-assets.test.ts` instead of the narrower direct `tsx` invocation. While rerunning that acceptance command locally, I found it expands to the repo-wide `npm test` script rather than staying focused on the managed-restart file.
-
-I updated the stale expectation in [src/backend/webui-local-ci-browser-helpers.test.ts](src/backend/webui-local-ci-browser-helpers.test.ts) so it matches the current `warning=none` status token. The focused launcher asset test still passes via `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build` passes. The broader `npm test -- src/managed-restart-launcher-assets.test.ts` command still fails on unrelated existing tests outside this issue’s scope. The journal/test update is committed as `d73c21b` and the handoff refreshes are pushed on top of it to `origin/codex/issue-1466`.
-
-Summary: Aligned the journal verification command with the issue acceptance text, fixed one stale test expectation, and re-ran focused verification
-State hint: addressing_review
-Blocked reason: none
-Tests: `npm test -- src/managed-restart-launcher-assets.test.ts` (fails on unrelated existing tests in `src/supervisor-orphan-workspace-cleanup.test.ts`, `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-status-model-supervisor.test.ts`, and `src/tracked-pr-lifecycle-projection.test.ts`); `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npm run build`
-Next action: Watch PR #1469 for reviewer follow-up or manual thread resolution after the posted reply
-Failure signature: PRRT_kwDORgvdZ856ZzBs
+- Reproduced the unsupported macOS direct launchd loop path with a focused launcher-assets regression, then changed `scripts/install-launchd.sh` to fail closed with explicit tmux/WebUI guidance instead of installing a loop LaunchAgent.
+- Updated `README.md`, `docs/getting-started.md`, and `docs/getting-started.ja.md` so macOS loop hosting points to the supported tmux start/stop scripts, while Linux systemd and WebUI launchd guidance remain distinct. Added focused docs assertions and refreshed matching configuration wording required by the existing getting-started doc suite.
+- Verified with `npx tsx --test src/getting-started-docs.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070273869
-- Details:
-  - .codex-supervisor/issue-journal.md:24 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Align verification command with the issue acceptance command.** Line 24 uses `npx tsx --test ...`, while the issue acceptance criteria calls ... url=https://github.com/TommyKammy/codex-supervisor/pull/1469#discussion_r3070273869
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The remaining CodeRabbit thread is valid at the journal level only: the recorded verification command should match the issue acceptance text, but the acceptance command currently expands to the repo-wide `npm test` script and exposes unrelated failures outside the tmux launcher scope.
-- What changed: Updated `.codex-supervisor/issue-journal.md` so the recorded verification command matches the issue acceptance text. Fixed the stale `src/backend/webui-local-ci-browser-helpers.test.ts` expectation to include the current `warning=none` status token. Re-ran `npm test -- src/managed-restart-launcher-assets.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`. Committed and pushed the review-thread fix, then replied on PR #1469 with the command-alignment change and the note that the npm form is broader than intended.
+- Hypothesis: The macOS loop host should be tmux only; the old direct launchd installer was the unsupported contract that needed to fail closed, while docs needed to state the supported tmux start/stop path explicitly.
+- What changed: Replaced the direct launchd loop installer body with a fail-closed message that points operators to `./scripts/start-loop-tmux.sh`, `./scripts/stop-loop-tmux.sh`, and `./scripts/install-launchd-web.sh`. Updated English and Japanese getting-started docs plus README macOS loop guidance. Added focused regression coverage for the installer behavior and the macOS tmux wording. Added minimal matching phrasing in `docs/configuration.md` so the existing getting-started docs suite remains green.
 - Current blocker: none
-- Next exact step: Watch PR #1469 for reviewer follow-up or manual thread resolution after the posted reply.
-- Verification gap: No live tmux integration run yet. The exact acceptance command remains broader than intended and currently fails on unrelated existing tests outside the managed-restart launcher file.
-- Files touched: .codex-supervisor/issue-journal.md; src/backend/webui-local-ci-browser-helpers.test.ts; src/managed-restart-launcher-assets.test.ts; scripts/start-loop-tmux.sh; scripts/stop-loop-tmux.sh
-- Rollback concern: Low; the change only adds new macOS helper scripts and test coverage, with no edits to existing Linux/systemd launcher paths.
-- Last focused command: gh api -X POST repos/TommyKammy/codex-supervisor/pulls/1469/comments/3070273869/replies -f body=...
+- Next exact step: Commit the checkpoint and leave the branch ready for PR creation or the next supervisor pass.
+- Verification gap: No live manual tmux session launch on macOS host; verification is focused on script behavior, docs wording, and build integrity.
+- Files touched: .codex-supervisor/issue-journal.md; README.md; docs/configuration.md; docs/getting-started.md; docs/getting-started.ja.md; scripts/install-launchd.sh; src/getting-started-docs.test.ts; src/managed-restart-launcher-assets.test.ts; src/readme-docs.test.ts
+- Rollback concern: Low; the change narrows macOS loop installation behavior by failing closed and only adjusts operator docs/tests around the supported tmux path.
+- Last focused command: npm run build
 ### Scratchpad
-- Review thread `PRRT_kwDORgvdZ856Zw2L` reported valid ordering bug in `scripts/start-loop-tmux.sh`.
-- Review thread `PRRT_kwDORgvdZ856ZzBs` is valid for journal-command alignment; the exact npm acceptance command also exposed unrelated existing test failures outside this issue.
-- Commands run this turn: `nl -ba .codex-supervisor/issue-journal.md | sed -n '1,120p'`; `git status --short`; `git diff -- .codex-supervisor/issue-journal.md`; `npm test -- src/managed-restart-launcher-assets.test.ts`; `npm run build`; `npm test -- --test-name-pattern "local CI browser helpers summarize a repo-owned candidate contract consistently"`; `npx tsx -e "import {buildLocalCiContractStatusLines, buildLocalCiContractChecklistItems, canAdoptRecommendedLocalCiCommand} from './src/backend/webui-local-ci-browser-helpers.ts'; ..."`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `git commit -m "Align review verification journal entry"`; `git push origin codex/issue-1466`; `gh auth status`; `gh pr view 1469 --json number,url,reviewDecision,isDraft,headRefName,baseRefName`; `gh api -X POST repos/TommyKammy/codex-supervisor/pulls/1469/comments/3070273869/replies -f body=...`.
+- Focused reproducer that failed before the fix: `npx tsx --test src/managed-restart-launcher-assets.test.ts`
+- Focused verification after the fix: `npx tsx --test src/getting-started-docs.test.ts src/managed-restart-launcher-assets.test.ts src/readme-docs.test.ts`

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Before the first run, keep the [Configuration guide](./docs/configuration.md) op
    node dist/index.js loop --config /path/to/supervisor.config.json
    ```
 
+   On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path.
+
    If you want the local operator dashboard, start the WebUI against the same config:
 
    ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,7 @@ Typical examples:
 - `cargo test`
 
 The repo owns the command contract. The supervisor should only execute the configured entrypoint and react to its exit code.
+If no local CI contract is configured, preserve backward compatibility by not inventing one.
 
 ## The Config Questions Most Beginners Ask
 
@@ -426,8 +427,8 @@ Operational notes:
 - when a repo exposes a canonical pre-PR entrypoint such as `ci:local` or `verify:pre-pr`, keep that command definition in the managed repo rather than in supervisor inference logic
 - the repo is the source of truth for the command contents, and the supervisor should only run the configured entrypoint and observe its exit status
 - `No repo-owned local CI contract is configured.` means no canonical repo-owned local gate is active
-- `Repo-owned local CI candidate exists but localCiCommand is unset.` means setup or readiness found a repo script candidate, but the supervisor will not run it until you configure `localCiCommand`
-- `Repo-owned local CI contract is configured.` means the configured command is active and fail-closed, so PR publication stays blocked until the command passes again
+- `Repo-owned local CI candidate exists but localCiCommand is unset.` means setup or readiness found a repo script candidate, but codex-supervisor will not run it until localCiCommand is configured. This warning is advisory only.
+- `Repo-owned local CI contract is configured.` means the configured command is active and fail-closed, so when configured local CI fails, PR publication stays blocked until the command passes again
 
 Operator rule:
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -208,6 +208,13 @@ node dist/index.js loop --config /path/to/supervisor.config.json
 node dist/index.js web --config /path/to/supervisor.config.json
 ```
 
+host ごとの loop 運用ルール:
+
+- macOS でサポートしている常駐 loop host は `tmux` です。開始は `./scripts/start-loop-tmux.sh`、停止は `./scripts/stop-loop-tmux.sh` を使います。
+- `./scripts/install-launchd.sh` は、direct launchd-hosted loop を macOS のサポート対象に見せないため fail closed します。
+- Linux で launcher-managed な background loop を使いたい時は `./scripts/install-systemd.sh` を使います。
+- macOS で launcher-managed な WebUI を使いたい時は `./scripts/install-launchd-web.sh` を使います。こちらは loop ではなく WebUI entrypoint を host する path なので引き続きサポート対象です。
+
 WebUI は CLI と同じ `SupervisorService` を使い、typed な `status`、`doctor`、`explain`、`issue-lint` を読みます。現在の safe command surface は `run-once`、`requeue`、`prune-orphaned-workspaces`、`reset-corrupt-json-state` です。
 
 通常運用では、supervisor は次を繰り返します。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -369,6 +369,13 @@ If you want a local operator view over the same supervisor service, you can also
 node dist/index.js web --config /path/to/supervisor.config.json
 ```
 
+Host-specific loop guidance:
+
+- On macOS, the supported background loop host is `tmux`. Start it with `./scripts/start-loop-tmux.sh` and stop it with `./scripts/stop-loop-tmux.sh`.
+- `./scripts/install-launchd.sh` now fails closed because a direct launchd-hosted loop is not a supported macOS path.
+- If you want a launcher-managed background loop on Linux, use `./scripts/install-systemd.sh`.
+- For a launcher-managed WebUI on macOS, use `./scripts/install-launchd-web.sh`. That launchd path is still supported because it hosts the WebUI entrypoint rather than the loop.
+
 The WebUI uses the same `SupervisorService` boundary as the CLI. It reads the same typed status, doctor, explain, and issue-lint data, and it only exposes the current safe command set: `run-once`, `requeue`, `prune-orphaned-workspaces`, and `reset-corrupt-json-state`.
 
 In normal operation, the supervisor will:

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -3,30 +3,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PLIST_TEMPLATE="${ROOT}/launchd/io.codex.supervisor.plist.template"
-PLIST_TARGET="${HOME}/Library/LaunchAgents/io.codex.supervisor.plist"
-LOG_DIR="${ROOT}/.local/logs"
-UID_VALUE="$(id -u)"
-NODE_BIN="${NODE_BIN:-$(command -v node)}"
-NPM_BIN="${NPM_BIN:-$(command -v npm)}"
-PATH_VALUE="${PATH}"
 
-if [[ -z "${NODE_BIN}" || -z "${NPM_BIN}" ]]; then
-  echo "node and npm must be available on PATH" >&2
-  exit 1
-fi
-
-mkdir -p "${HOME}/Library/LaunchAgents" "${LOG_DIR}"
-sed \
-  -e "s|__ROOT__|${ROOT}|g" \
-  -e "s|__PATH__|${PATH_VALUE}|g" \
-  -e "s|__NODE__|${NODE_BIN}|g" \
-  -e "s|__NPM__|${NPM_BIN}|g" \
-  "${PLIST_TEMPLATE}" > "${PLIST_TARGET}"
-
-launchctl bootout "gui/${UID_VALUE}" "${PLIST_TARGET}" >/dev/null 2>&1 || true
-launchctl bootstrap "gui/${UID_VALUE}" "${PLIST_TARGET}"
-launchctl enable "gui/${UID_VALUE}/io.codex.supervisor"
-launchctl kickstart -k "gui/${UID_VALUE}/io.codex.supervisor"
-
-echo "Installed and started io.codex.supervisor"
+printf '%s\n' \
+  'direct launchd loop install is unsupported on macOS.' \
+  'The supported macOS loop host is tmux.' \
+  'Start the loop with: ./scripts/start-loop-tmux.sh' \
+  'Stop the loop with: ./scripts/stop-loop-tmux.sh' \
+  'If you need launchd on macOS, use it only for the WebUI launcher path: ./scripts/install-launchd-web.sh' \
+  >&2
+exit 1

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -153,6 +153,24 @@ test("getting-started points operators to doctor for the effective orphan cleanu
   assert.match(content, /preserved=locked,recent,unsafe_target/i);
 });
 
+test("getting-started documents tmux as the supported macOS loop host and keeps Linux and WebUI guidance distinct", async () => {
+  const [gettingStarted, japaneseGettingStarted] = await Promise.all([
+    readGettingStarted(),
+    readJapaneseGettingStarted(),
+  ]);
+
+  assert.match(gettingStarted, /On macOS, the supported background loop host is `tmux`\./);
+  assert.match(gettingStarted, /`\.\/scripts\/start-loop-tmux\.sh`/);
+  assert.match(gettingStarted, /`\.\/scripts\/stop-loop-tmux\.sh`/);
+  assert.match(gettingStarted, /`\.\/scripts\/install-launchd\.sh` now fails closed/i);
+  assert.match(gettingStarted, /If you want a launcher-managed background loop on Linux, use `\.\/scripts\/install-systemd\.sh`/);
+  assert.match(gettingStarted, /For a launcher-managed WebUI on macOS, use `\.\/scripts\/install-launchd-web\.sh`/);
+
+  assert.match(japaneseGettingStarted, /macOS でサポートしている常駐 loop host は `tmux`/);
+  assert.match(japaneseGettingStarted, /`\.\/scripts\/start-loop-tmux\.sh`/);
+  assert.match(japaneseGettingStarted, /`\.\/scripts\/stop-loop-tmux\.sh`/);
+});
+
 test("japanese docs keep overview and getting-started responsibilities separate", async () => {
   const [overview, gettingStarted] = await Promise.all([
     readJapaneseOverview(),

--- a/src/managed-restart-launcher-assets.test.ts
+++ b/src/managed-restart-launcher-assets.test.ts
@@ -49,6 +49,11 @@ async function writeExecutable(filePath: string, contents: string): Promise<void
   await fs.chmod(filePath, 0o755);
 }
 
+async function symlinkResolvedCommand(pathDir: string, commandName: string): Promise<void> {
+  const commandPath = (await execFileAsync(bashPath, ["-lc", `command -v ${commandName}`])).stdout.trim();
+  await fs.symlink(commandPath, path.join(pathDir, commandName));
+}
+
 async function assertMissingBinaryMessage(relativePath: string, requiredCommands: string[]): Promise<void> {
   const scriptPath = path.join(process.cwd(), relativePath);
   const pathDir = await createMissingNodePath(requiredCommands);
@@ -219,5 +224,57 @@ exit 1
     assert.equal(stdout.trim(), "codex-supervisor loop tmux session already running: codex-supervisor-loop");
   } finally {
     await fs.rm(pathDir, { recursive: true, force: true });
+  }
+});
+
+test("macOS direct launchd loop installer fails closed with tmux guidance before calling launchctl", async () => {
+  const scriptPath = path.join(process.cwd(), "scripts/install-launchd.sh");
+  const pathDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-restart-launchd-"));
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "managed-restart-launchd-home-"));
+  const launchctlLogPath = path.join(homeDir, "launchctl.log");
+
+  try {
+    await Promise.all([
+      symlinkResolvedCommand(pathDir, "dirname"),
+      symlinkResolvedCommand(pathDir, "id"),
+      symlinkResolvedCommand(pathDir, "mkdir"),
+      symlinkResolvedCommand(pathDir, "sed"),
+    ]);
+    await writeExecutable(
+      path.join(pathDir, "launchctl"),
+      `#!/bin/bash
+set -euo pipefail
+echo "$*" >> "${launchctlLogPath}"
+exit 0
+`,
+    );
+
+    await assert.rejects(
+      async () => execFileAsync(bashPath, [scriptPath], {
+        env: {
+          HOME: homeDir,
+          PATH: pathDir,
+          NODE_BIN: "/usr/bin/node",
+          NPM_BIN: "/usr/bin/npm",
+        },
+      }),
+      (error: unknown) => {
+        assert.equal(typeof error, "object");
+        assert.notEqual(error, null);
+        assert.equal((error as NodeJS.ErrnoException).code, 1);
+        const stderr = (error as { stderr?: string }).stderr ?? "";
+        assert.match(stderr, /direct launchd loop install is unsupported on macOS/u);
+        assert.match(stderr, /supported macOS loop host is tmux/u);
+        assert.match(stderr, /\.\/scripts\/start-loop-tmux\.sh/u);
+        assert.match(stderr, /\.\/scripts\/stop-loop-tmux\.sh/u);
+        assert.doesNotMatch(stderr, /command not found/u);
+        return true;
+      },
+    );
+
+    await assert.rejects(fs.access(launchctlLogPath));
+  } finally {
+    await fs.rm(pathDir, { recursive: true, force: true });
+    await fs.rm(homeDir, { recursive: true, force: true });
   }
 });

--- a/src/readme-docs.test.ts
+++ b/src/readme-docs.test.ts
@@ -31,6 +31,9 @@ test("README stays lightweight while routing humans and AI agents to the right d
 
   assert.match(content, /\[Getting started\]\(\.\/docs\/getting-started\.md\)/);
   assert.match(content, /\[AI agent handoff\]\(\.\/docs\/agent-instructions\.md\)/);
+  assert.match(content, /On macOS, use `\.\/scripts\/start-loop-tmux\.sh` to host the loop in a managed `tmux` session/i);
+  assert.match(content, /stop it with `\.\/scripts\/stop-loop-tmux\.sh`/i);
+  assert.match(content, /`\.\/scripts\/install-launchd\.sh` is not a supported macOS loop path/i);
 
   assert.doesNotMatch(content, /^## Full setup guide$/m);
   assert.doesNotMatch(content, /^## Complete operator manual$/m);


### PR DESCRIPTION
Closes #1467
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed the macOS loop path to fail closed and documented `tmux` as the supported host. `scripts/install-launchd.sh` now exits with explicit operator guidance instead of installing a direct loop `launchd` service, while the docs point macOS operators to `./scripts/start-loop-tmux.sh` and `./scripts/stop-loop-tmux.sh` and keep Linux `systemd` / WebUI `launchd` guidance separate. I also added focused regression coverage for both the installer behavior and the macOS wording in the docs, and recorded the turn state in the issue journal.

Checkpoint commit: `ca88f9a` (`Document tmux as macOS loop host`).

Summary: Fail-closed macOS direct launchd loop install, document tmux as the supported macOS loop host, and add focused regression coverage
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/getting-started-docs.test.ts`; `npx tsx --test src/managed-restart-launcher-assets.test.ts`; `npx tsx --test src/getting-started-docs.test.ts src/managed-restart-launcher-assets.test.ts src/readme-docs.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-1467` using commit `ca88f9a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS-specific loop hosting guidance directing users to use tmux scripts (`start-loop-tmux.sh`/`stop-loop-tmux.sh`)
  * Clarified supported installation paths: tmux for macOS loop, systemd for Linux, launchd for WebUI only
  * Updated English and Japanese getting-started guides

* **Bug Fixes**
  * `install-launchd.sh` now fails with clear guidance for unsupported direct launchd loop installations

* **Tests**
  * Added test coverage for documentation and installation scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->