### PR TITLE
Surface loop host mode and warn when macOS loop is not running under tmux (#1468)

### DIFF
--- a/src/backend/restartable-webui-shell-service.test.ts
+++ b/src/backend/restartable-webui-shell-service.test.ts
@@ -18,6 +18,7 @@ function createStatusDto(label: string, why: boolean): SupervisorStatusDto {
     candidateDiscovery: null,
     loopRuntime: {
       state: "off",
+      hostMode: "unknown",
       pid: null,
       startedAt: null,
       detail: null,
@@ -96,6 +97,14 @@ function createStubService(args?: {
     },
     candidateDiscoverySummary: "candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+    loopRuntime: {
+      state: "off",
+      hostMode: "unknown",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    loopHostWarning: null,
   };
   const setupReadinessReport: SetupReadinessReport = {
     kind: "setup_readiness",

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -297,6 +297,14 @@ function createStubService(args?: {
     },
     candidateDiscoverySummary: "candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+    loopRuntime: {
+      state: "off",
+      hostMode: "unknown",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    loopHostWarning: null,
   };
   const setupReadinessReport: SetupReadinessReport = args?.setupReadinessReport ?? createSetupReadinessReport();
   const setupConfigPreview: SetupConfigPreview = args?.setupConfigPreview ?? createSetupConfigPreview();
@@ -337,6 +345,7 @@ function createStubService(args?: {
         },
         loopRuntime: {
           state: "off",
+          hostMode: "unknown",
           pid: null,
           startedAt: null,
           detail: null,
@@ -555,6 +564,7 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
     },
     loopRuntime: {
       state: "off",
+      hostMode: "unknown",
       pid: null,
       startedAt: null,
       detail: null,
@@ -600,6 +610,14 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
     },
     candidateDiscoverySummary: "candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+    loopRuntime: {
+      state: "off",
+      hostMode: "unknown",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    loopHostWarning: null,
   });
 
   const postMergeAuditSummaryResponse = await readJson({ server, path: "/api/post-merge-audits/summary" });

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -40,6 +40,7 @@ export interface DashboardCandidateDiscoveryLike {
 
 export interface DashboardLoopRuntimeLike {
   state?: "running" | "off" | "unknown" | null;
+  hostMode?: "tmux" | "direct" | "unknown" | null;
   pid?: number | null;
   startedAt?: string | null;
   detail?: string | null;

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -441,11 +441,11 @@ export function renderDashboardBrowserScript(): string {
       }
 
       function readLoopBadgeLabel(status) {
-        const loopRuntime = describeLoopRuntime(status && status.loopRuntime);
-        if (loopRuntime.chipLabel === "loop running") {
+        const loopRuntime = status && status.loopRuntime;
+        if (loopRuntime && loopRuntime.state === "running") {
           return "Loop mode: running";
         }
-        if (loopRuntime.chipLabel === "loop off") {
+        if (loopRuntime && loopRuntime.state === "off") {
           return "Loop mode: off";
         }
         return "Loop mode: unknown";

--- a/src/backend/webui-dashboard-browser-smoke.test.ts
+++ b/src/backend/webui-dashboard-browser-smoke.test.ts
@@ -63,6 +63,14 @@ function createStubService(args?: { pruneCalls?: number[] }): SupervisorService 
     },
     candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+    loopRuntime: {
+      state: "off",
+      hostMode: "unknown",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    loopHostWarning: null,
   };
 
   return {
@@ -77,6 +85,7 @@ function createStubService(args?: { pruneCalls?: number[] }): SupervisorService 
       candidateDiscovery: null,
       loopRuntime: {
         state: "off",
+        hostMode: "unknown",
         pid: null,
         startedAt: null,
         detail: null,
@@ -376,6 +385,14 @@ function createFirstRunSetupService(args: {
     },
     candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+    loopRuntime: {
+      state: "off",
+      hostMode: "unknown",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    loopHostWarning: null,
   };
 
   let readiness: SetupReadinessReport = {
@@ -472,6 +489,7 @@ function createFirstRunSetupService(args: {
       candidateDiscovery: null,
       loopRuntime: {
         state: "off",
+        hostMode: "unknown",
         pid: null,
         startedAt: null,
         detail: null,

--- a/src/backend/webui-dashboard-browser-view-model.test.ts
+++ b/src/backend/webui-dashboard-browser-view-model.test.ts
@@ -51,12 +51,19 @@ test("buildWorkflowSteps surfaces recover as the current step when only blocked 
   );
 });
 
-test("describeLoopRuntime summarizes running, off, and unknown states", () => {
-  assert.deepEqual(describeLoopRuntime({ state: "running" }), {
-    modeBadge: "Mode: web + loop running",
-    summary: "Loop mode is running on this host",
-    chipLabel: "loop running",
+test("describeLoopRuntime summarizes running, off, and unknown states with host mode detail", () => {
+  assert.deepEqual(describeLoopRuntime({ state: "running", hostMode: "tmux" }), {
+    modeBadge: "Mode: web + loop running (tmux)",
+    summary: "Loop mode is running on this host via tmux",
+    chipLabel: "loop running via tmux",
     chipTone: "ok",
+  });
+
+  assert.deepEqual(describeLoopRuntime({ state: "running", hostMode: "direct" }), {
+    modeBadge: "Mode: web + loop running (direct)",
+    summary: "Loop mode is running on this host directly",
+    chipLabel: "loop running directly",
+    chipTone: "warn",
   });
 
   assert.deepEqual(describeLoopRuntime({ state: "off" }), {

--- a/src/backend/webui-dashboard-browser-view-model.ts
+++ b/src/backend/webui-dashboard-browser-view-model.ts
@@ -11,7 +11,7 @@ export interface DashboardLoopRuntimeSummary {
   modeBadge: string;
   summary: string;
   chipLabel: string;
-  chipTone: "ok" | "info";
+  chipTone: "ok" | "warn" | "info";
 }
 
 function formatIssueRef(issueNumber: number | null | undefined): string {
@@ -149,12 +149,24 @@ export function formatRefreshTime(timestamp: string | null): string {
 
 export function describeLoopRuntime(loopRuntime: DashboardLoopRuntimeLike | null | undefined): DashboardLoopRuntimeSummary {
   const runtimeState = typeof loopRuntime?.state === "string" ? loopRuntime.state : "unknown";
+  const hostMode = typeof loopRuntime?.hostMode === "string" ? loopRuntime.hostMode : "unknown";
   if (runtimeState === "running") {
+    if (hostMode === "tmux") {
+      return {
+        modeBadge: "Mode: web + loop running (tmux)",
+        summary: "Loop mode is running on this host via tmux",
+        chipLabel: "loop running via tmux",
+        chipTone: "ok",
+      };
+    }
+
     return {
-      modeBadge: "Mode: web + loop running",
-      summary: "Loop mode is running on this host",
-      chipLabel: "loop running",
-      chipTone: "ok",
+      modeBadge: `Mode: web + loop running (${hostMode})`,
+      summary: hostMode === "direct"
+        ? "Loop mode is running on this host directly"
+        : "Loop mode is running on this host with unknown host metadata",
+      chipLabel: hostMode === "direct" ? "loop running directly" : "loop running with unknown host",
+      chipTone: "warn",
     };
   }
   if (runtimeState === "off") {

--- a/src/backend/webui-dashboard-test-fixtures.ts
+++ b/src/backend/webui-dashboard-test-fixtures.ts
@@ -370,6 +370,7 @@ export function createDashboardStatusFixture(args: {
   } | null;
   loopRuntime?: {
     state: "running" | "off" | "unknown";
+    hostMode?: "tmux" | "direct" | "unknown";
     pid: number | null;
     startedAt: string | null;
     detail: string | null;
@@ -398,6 +399,9 @@ export function createDashboardStatusFixture(args: {
     observedMatchingOpenIssues: number | null;
     warning: string | null;
   } | null;
+  warning?: {
+    message: string;
+  } | null;
 } = {}) {
   const selectedIssueNumber = args.selectedIssueNumber ?? null;
   const includeWhyLines = args.includeWhyLines ?? true;
@@ -413,12 +417,13 @@ export function createDashboardStatusFixture(args: {
     loopRuntime:
       args.loopRuntime ?? {
         state: "off",
+        hostMode: "unknown",
         pid: null,
         startedAt: null,
         detail: null,
       },
     reconciliationPhase: null,
-    warning: null,
+    warning: args.warning ?? null,
     detailedStatusLines: args.detailedStatusLines ?? [],
     readinessLines: [],
     whyLines: includeWhyLines

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -324,6 +324,7 @@ test("dashboard does not claim loop mode is off while typed runtime status repor
         selectedIssueNumber: 42,
         loopRuntime: {
           state: "running",
+          hostMode: "tmux",
           pid: 4242,
           startedAt: "2026-03-25T00:00:00.000Z",
           detail: "pid 4242",
@@ -339,8 +340,39 @@ test("dashboard does not claim loop mode is off while typed runtime status repor
   assert.ok(loopStateSummary);
 
   assert.match(loopModeBadge.textContent, /loop running/u);
+  assert.match(loopModeBadge.textContent, /tmux/u);
   assert.doesNotMatch(loopModeBadge.textContent, /loop off/u);
-  assert.match(loopStateSummary.textContent, /Loop mode is running on this host/u);
+  assert.match(loopStateSummary.textContent, /Loop mode is running on this host via tmux/u);
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
+test("dashboard warns when a macOS loop is reported as running directly instead of through tmux", async () => {
+  const harness = createDashboardHarness([
+    ...dashboardServer.page({
+      status: createStatus({
+        loopRuntime: {
+          state: "running",
+          hostMode: "direct",
+          pid: 4242,
+          startedAt: "2026-03-25T00:00:00.000Z",
+          detail: "pid 4242",
+        },
+        warning: {
+          message:
+            "macOS loop runtime is active outside tmux. Restart it with ./scripts/start-loop-tmux.sh and stop unsupported direct hosts before relying on steady-state automation.",
+        },
+      }),
+    }),
+  ]);
+  await harness.flush();
+
+  const loopModeBadge = harness.document.getElementById("loop-mode-badge");
+  const overviewWarning = harness.document.getElementById("overview-warning");
+  assert.ok(loopModeBadge);
+  assert.ok(overviewWarning);
+
+  assert.match(loopModeBadge.textContent ?? "", /direct/u);
+  assert.match(overviewWarning.textContent ?? "", /outside tmux/u);
   assert.equal(harness.remainingFetches.length, 0);
 });
 
@@ -350,6 +382,7 @@ test("dashboard renders the loop-off presentation only when typed runtime status
       status: createStatus({
         loopRuntime: {
           state: "off",
+          hostMode: "unknown",
           pid: null,
           startedAt: null,
           detail: null,

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -26,6 +26,7 @@ function createStatusDto(overrides: Partial<SupervisorStatusDto> = {}): Supervis
     candidateDiscovery: null,
     loopRuntime: {
       state: "off",
+      hostMode: "unknown",
       pid: null,
       startedAt: null,
       detail: null,

--- a/src/core/lock.ts
+++ b/src/core/lock.ts
@@ -9,6 +9,7 @@ interface LockPayload {
   acquired_at: string;
   host?: string;
   owner?: string;
+  launcher?: string;
 }
 
 export interface ExistingLockState {
@@ -37,6 +38,11 @@ function currentLockOwner(): string {
   }
 
   return process.env.USER ?? process.env.USERNAME ?? "unknown";
+}
+
+function currentLauncher(): string | undefined {
+  const launcher = process.env.CODEX_SUPERVISOR_LAUNCHER?.trim();
+  return launcher ? launcher : undefined;
 }
 
 function isPidAlive(pid: number): boolean {
@@ -116,6 +122,7 @@ export async function acquireFileLock(
         acquired_at: nowIso(),
         host: os.hostname(),
         owner: currentLockOwner(),
+        launcher: currentLauncher(),
       };
       await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, "utf8");
       await handle.close();

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -101,6 +101,14 @@ test("renderDoctorReport only warns for the legacy shared issue journal path", (
     },
     candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
     candidateDiscoveryWarning: null,
+    loopRuntime: {
+      state: "off" as const,
+      hostMode: "unknown" as const,
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    loopHostWarning: null,
     trustDiagnostics: {
       trustMode: "untrusted_or_mixed" as const,
       executionSafetyMode: "operator_gated" as const,
@@ -124,6 +132,45 @@ test("renderDoctorReport only warns for the legacy shared issue journal path", (
       },
     }),
     /doctor_warning kind=config/,
+  );
+});
+
+test("renderDoctorReport includes loop host diagnostics and macOS tmux drift warnings", () => {
+  const report = renderDoctorReport({
+    overallStatus: "warn",
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    trustDiagnostics: {
+      trustMode: "untrusted_or_mixed",
+      executionSafetyMode: "operator_gated",
+      warning: null,
+      configWarning: null,
+    },
+    loopRuntime: {
+      state: "running",
+      hostMode: "direct",
+      pid: 4242,
+      startedAt: "2026-03-25T00:00:00.000Z",
+      detail: "supervisor-loop-runtime",
+    },
+    loopHostWarning:
+      "macOS loop runtime is active outside tmux. Restart it with ./scripts/start-loop-tmux.sh and stop unsupported direct hosts before relying on steady-state automation.",
+  });
+
+  assert.match(
+    report,
+    /doctor_loop_runtime state=running host_mode=direct pid=4242 started_at=2026-03-25T00:00:00.000Z detail=supervisor-loop-runtime/,
+  );
+  assert.match(
+    report,
+    /doctor_warning kind=loop_host detail=macOS loop runtime is active outside tmux\. Restart it with \.\/scripts\/start-loop-tmux\.sh and stop unsupported direct hosts before relying on steady-state automation\./,
   );
 });
 
@@ -1288,7 +1335,7 @@ test("diagnoseSupervisorHost exposes tracked PR mismatches when GitHub is ready 
   );
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=recovery_guidance=Tracked PR facts are fresher than local state; run the supervisor again to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\./,
+    /doctor_detail name=worktrees detail=recovery_guidance=Tracked PR facts are fresher than local state; run a one-shot supervisor cycle such as `node dist\/index\.js run-once --config \.\.\. --dry-run` to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\./,
   );
 });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -25,6 +25,11 @@ import {
 } from "./core/types";
 import { inspectOrphanedWorkspacePruneCandidates } from "./recovery-reconciliation";
 import {
+  buildMacOsLoopHostWarning,
+  readSupervisorLoopRuntime,
+  type SupervisorLoopRuntimeDto,
+} from "./supervisor/supervisor-loop-runtime-state";
+import {
   formatCandidateDiscoveryBehaviorLine,
   formatCandidateDiscoveryWarningDetail,
 } from "./supervisor/supervisor-selection-readiness-summary";
@@ -47,6 +52,8 @@ export interface DoctorDiagnostics {
   cadenceDiagnostics: CadenceDiagnosticsSummary;
   candidateDiscoverySummary: string;
   candidateDiscoveryWarning: string | null;
+  loopRuntime?: SupervisorLoopRuntimeDto;
+  loopHostWarning?: string | null;
   orphanPolicySummary?: string;
   workspacePreparationContract?: WorkspacePreparationContractSummary;
   localCiContract?: LocalCiContractSummary;
@@ -559,6 +566,7 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     diagnoseStateFile(args.config),
     diagnoseWorktrees(args.config, loadState, github),
   ]);
+  const loopRuntime = await readSupervisorLoopRuntime(args.config.stateFile);
   const candidateDiscoveryWarning = formatCandidateDiscoveryWarningDetail(
     await github.getCandidateDiscoveryDiagnostics().catch(() => null),
   );
@@ -570,6 +578,8 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     cadenceDiagnostics: summarizeCadenceDiagnostics(args.config),
     candidateDiscoverySummary: formatCandidateDiscoveryBehaviorLine(args.config, "doctor_candidate_discovery"),
     candidateDiscoveryWarning,
+    loopRuntime,
+    loopHostWarning: buildMacOsLoopHostWarning(loopRuntime),
     orphanPolicySummary: formatOrphanPolicySummary(args.config),
     workspacePreparationContract: summarizeWorkspacePreparationContract(args.config),
     localCiContract: summarizeLocalCiContract(args.config),
@@ -644,6 +654,14 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
       : String(diagnostics.cadenceDiagnostics.mergeCriticalRecheckSeconds);
   const trustWarnings = buildTrustAndConfigWarnings(diagnostics.trustDiagnostics);
   const candidateDiscoveryWarning = buildWarning("candidate_discovery", diagnostics.candidateDiscoveryWarning);
+  const loopHostWarning = buildWarning("loop_host", diagnostics.loopHostWarning ?? null);
+  const loopRuntime = diagnostics.loopRuntime ?? {
+    state: "off" as const,
+    hostMode: "unknown" as const,
+    pid: null,
+    startedAt: null,
+    detail: null,
+  };
   const workspacePreparationWarning = workspacePreparationContract.warning ?? localCiContract.warning ?? null;
   const configWarnings = workspacePreparationWarning === null ? [] : [renderDoctorWarningLine(buildWarning("config", workspacePreparationWarning)!, sanitizeDoctorValue)];
 
@@ -652,11 +670,13 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     `doctor_posture trust_mode=${diagnostics.trustDiagnostics.trustMode} execution_safety_mode=${diagnostics.trustDiagnostics.executionSafetyMode}`,
     `doctor_cadence poll_interval_seconds=${diagnostics.cadenceDiagnostics.pollIntervalSeconds} merge_critical_recheck_seconds=${mergeCriticalRecheckSeconds} merge_critical_effective_seconds=${diagnostics.cadenceDiagnostics.mergeCriticalEffectiveSeconds} enabled=${diagnostics.cadenceDiagnostics.mergeCriticalRecheckEnabled}`,
     diagnostics.candidateDiscoverySummary,
+    `doctor_loop_runtime state=${loopRuntime.state} host_mode=${loopRuntime.hostMode} pid=${loopRuntime.pid === null ? "none" : String(loopRuntime.pid)} started_at=${loopRuntime.startedAt ?? "none"} detail=${sanitizeDoctorValue(loopRuntime.detail ?? "none")}`,
     ...(diagnostics.orphanPolicySummary ? [diagnostics.orphanPolicySummary] : []),
     `doctor_workspace_preparation configured=${workspacePreparationContract.configured} source=${workspacePreparationContract.source} command=${sanitizeDoctorValue(workspacePreparationContract.command ?? "none")} summary=${sanitizeDoctorValue(workspacePreparationContract.summary)}`,
     `doctor_local_ci configured=${localCiContract.configured} source=${localCiContract.source} command=${sanitizeDoctorValue(localCiContract.command ?? "none")} summary=${sanitizeDoctorValue(localCiContract.summary)}`,
     ...trustWarnings.map((warning) => renderDoctorWarningLine(warning, sanitizeDoctorValue)),
     ...configWarnings,
+    ...(loopHostWarning === null ? [] : [renderDoctorWarningLine(loopHostWarning, sanitizeDoctorValue)]),
     ...(candidateDiscoveryWarning === null ? [] : [renderDoctorWarningLine(candidateDiscoveryWarning, sanitizeDoctorValue)]),
     ...diagnostics.checks.map(
       (check) =>

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -250,6 +250,36 @@ test("renderSupervisorStatusDto appends canonical github rate-limit lines from d
   assert.match(status, /^github_rate_limit resource=graphql status=exhausted remaining=0 limit=5000 reset_at=2026-03-27T00:15:00.000Z$/m);
 });
 
+test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
+  const status = renderSupervisorStatusDto({
+    gsdSummary: null,
+    candidateDiscovery: null,
+    loopRuntime: {
+      state: "running",
+      hostMode: "direct\nlegacy" as unknown as "direct",
+      pid: 4242,
+      startedAt: "2026-03-27T00:15:00.000Z\nlegacy",
+      detail: "supervisor-loop-runtime",
+    },
+    activeIssue: null,
+    selectionSummary: null,
+    trackedIssues: [],
+    runnableIssues: [],
+    blockedIssues: [],
+    detailedStatusLines: [],
+    reconciliationPhase: null,
+    reconciliationWarning: null,
+    readinessLines: [],
+    whyLines: [],
+    warning: null,
+  });
+
+  assert.match(
+    status,
+    /^loop_runtime state=running host_mode=direct\\nlegacy pid=4242 started_at=2026-03-27T00:15:00.000Z\\nlegacy detail=supervisor-loop-runtime$/m,
+  );
+});
+
 test("status omits execution-safety warnings when the trust posture does not require one", async (t) => {
   const fixture = await createSupervisorFixture();
   fixture.config.trustMode = "untrusted_or_mixed";
@@ -892,7 +922,7 @@ test("statusReport exposes typed loop runtime state from the host runtime marker
 
   assert.deepEqual(report.loopRuntime, {
     state: "running",
-    hostMode: "direct",
+    hostMode: "unknown",
     pid: process.pid,
     startedAt: report.loopRuntime?.startedAt ?? null,
     detail: "supervisor-loop-runtime",
@@ -900,7 +930,7 @@ test("statusReport exposes typed loop runtime state from the host runtime marker
   assert.match(report.loopRuntime?.startedAt ?? "", /^\d{4}-\d{2}-\d{2}T/u);
 
   const status = await supervisor.status();
-  assert.match(status, /^loop_runtime state=running host_mode=direct pid=\d+ started_at=\d{4}-\d{2}-\d{2}T.* detail=supervisor-loop-runtime$/m);
+  assert.match(status, /^loop_runtime state=running host_mode=unknown pid=\d+ started_at=\d{4}-\d{2}-\d{2}T.* detail=supervisor-loop-runtime$/m);
 });
 
 test("acquireSupervisorLock fails closed on ambiguous-owner run locks", async (t) => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -228,6 +228,7 @@ test("renderSupervisorStatusDto appends canonical github rate-limit lines from d
     candidateDiscovery: null,
     loopRuntime: {
       state: "off",
+      hostMode: "unknown",
       pid: null,
       startedAt: null,
       detail: null,
@@ -862,6 +863,15 @@ test("statusReport exposes typed loop runtime state from the host runtime marker
   t.after(async () => {
     await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
   });
+  const previousLauncher = process.env.CODEX_SUPERVISOR_LAUNCHER;
+  delete process.env.CODEX_SUPERVISOR_LAUNCHER;
+  t.after(() => {
+    if (previousLauncher === undefined) {
+      delete process.env.CODEX_SUPERVISOR_LAUNCHER;
+      return;
+    }
+    process.env.CODEX_SUPERVISOR_LAUNCHER = previousLauncher;
+  });
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
@@ -882,11 +892,15 @@ test("statusReport exposes typed loop runtime state from the host runtime marker
 
   assert.deepEqual(report.loopRuntime, {
     state: "running",
+    hostMode: "direct",
     pid: process.pid,
     startedAt: report.loopRuntime?.startedAt ?? null,
     detail: "supervisor-loop-runtime",
   });
   assert.match(report.loopRuntime?.startedAt ?? "", /^\d{4}-\d{2}-\d{2}T/u);
+
+  const status = await supervisor.status();
+  assert.match(status, /^loop_runtime state=running host_mode=direct pid=\d+ started_at=\d{4}-\d{2}-\d{2}T.* detail=supervisor-loop-runtime$/m);
 });
 
 test("acquireSupervisorLock fails closed on ambiguous-owner run locks", async (t) => {
@@ -967,6 +981,7 @@ test("acquireLoopRuntimeLock fails closed on ambiguous-owner loop runtime locks 
   const report = await supervisor.statusReport();
   assert.deepEqual(report.loopRuntime, {
     state: "unknown",
+    hostMode: "unknown",
     pid: 999_999,
     startedAt: "2026-03-20T00:00:00.000Z",
     detail: "supervisor-loop-runtime",

--- a/src/supervisor/supervisor-loop-runtime-state.test.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  buildMacOsLoopHostWarning,
+  readSupervisorLoopRuntime,
+  supervisorLoopRuntimeLockPath,
+} from "./supervisor-loop-runtime-state";
+
+test("legacy live loop locks without launcher metadata stay unknown and avoid macOS direct-host warnings", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-loop-runtime-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const stateFile = path.join(root, "state.json");
+  const lockPath = supervisorLoopRuntimeLockPath(stateFile);
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(
+    lockPath,
+    `${JSON.stringify({
+      pid: process.pid,
+      label: "supervisor-loop-runtime",
+      acquired_at: "2026-03-25T00:00:00.000Z",
+      host: "fixture-host",
+      owner: "fixture-owner",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const runtime = await readSupervisorLoopRuntime(stateFile);
+
+  assert.deepEqual(runtime, {
+    state: "running",
+    hostMode: "unknown",
+    pid: process.pid,
+    startedAt: "2026-03-25T00:00:00.000Z",
+    detail: "supervisor-loop-runtime",
+  });
+  assert.equal(buildMacOsLoopHostWarning(runtime, "darwin"), null);
+});

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -41,7 +41,7 @@ function normalizeLoopHostModeFromLauncher(
 
 function inferLoopHostMode(runtimeLock: ExistingLockState): SupervisorLoopHostMode {
   if (runtimeLock.status === "live") {
-    return normalizeLoopHostModeFromLauncher(runtimeLock.payload?.launcher, "direct");
+    return normalizeLoopHostModeFromLauncher(runtimeLock.payload?.launcher, "unknown");
   }
   if (runtimeLock.status === "ambiguous_owner") {
     return normalizeLoopHostModeFromLauncher(runtimeLock.payload?.launcher, "unknown");
@@ -53,7 +53,7 @@ export function buildMacOsLoopHostWarning(
   loopRuntime: Pick<SupervisorLoopRuntimeDto, "state" | "hostMode">,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
-  if (platform !== "darwin" || loopRuntime.state !== "running" || loopRuntime.hostMode === "tmux") {
+  if (platform !== "darwin" || loopRuntime.state !== "running" || loopRuntime.hostMode !== "direct") {
     return null;
   }
 

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -1,8 +1,11 @@
 import path from "node:path";
 import { acquireFileLock, inspectFileLock, type ExistingLockState, type LockHandle } from "../core/lock";
 
+export type SupervisorLoopHostMode = "tmux" | "direct" | "unknown";
+
 export interface SupervisorLoopRuntimeDto {
   state: "running" | "off" | "unknown";
+  hostMode: SupervisorLoopHostMode;
   pid: number | null;
   startedAt: string | null;
   detail: string | null;
@@ -22,11 +25,47 @@ export async function inspectSupervisorLoopRuntimeLock(stateFile: string): Promi
   return inspectFileLock(supervisorLoopRuntimeLockPath(stateFile));
 }
 
+function normalizeLoopHostModeFromLauncher(
+  launcher: string | null | undefined,
+  fallback: SupervisorLoopHostMode,
+): SupervisorLoopHostMode {
+  const normalized = launcher?.trim().toLowerCase();
+  if (!normalized) {
+    return fallback;
+  }
+  if (normalized === "tmux") {
+    return "tmux";
+  }
+  return "direct";
+}
+
+function inferLoopHostMode(runtimeLock: ExistingLockState): SupervisorLoopHostMode {
+  if (runtimeLock.status === "live") {
+    return normalizeLoopHostModeFromLauncher(runtimeLock.payload?.launcher, "direct");
+  }
+  if (runtimeLock.status === "ambiguous_owner") {
+    return normalizeLoopHostModeFromLauncher(runtimeLock.payload?.launcher, "unknown");
+  }
+  return "unknown";
+}
+
+export function buildMacOsLoopHostWarning(
+  loopRuntime: Pick<SupervisorLoopRuntimeDto, "state" | "hostMode">,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (platform !== "darwin" || loopRuntime.state !== "running" || loopRuntime.hostMode === "tmux") {
+    return null;
+  }
+
+  return "macOS loop runtime is active outside tmux. Restart it with ./scripts/start-loop-tmux.sh and stop unsupported direct hosts before relying on steady-state automation.";
+}
+
 export async function readSupervisorLoopRuntime(stateFile: string): Promise<SupervisorLoopRuntimeDto> {
   const runtimeLock = await inspectSupervisorLoopRuntimeLock(stateFile);
   if (runtimeLock.status === "live") {
     return {
       state: "running",
+      hostMode: inferLoopHostMode(runtimeLock),
       pid: runtimeLock.payload?.pid ?? null,
       startedAt: runtimeLock.payload?.acquired_at ?? null,
       detail: runtimeLock.payload?.label ?? LOOP_RUNTIME_LOCK_LABEL,
@@ -36,6 +75,7 @@ export async function readSupervisorLoopRuntime(stateFile: string): Promise<Supe
   if (runtimeLock.status === "ambiguous_owner") {
     return {
       state: "unknown",
+      hostMode: inferLoopHostMode(runtimeLock),
       pid: runtimeLock.payload?.pid ?? null,
       startedAt: runtimeLock.payload?.acquired_at ?? null,
       detail: runtimeLock.payload?.label ?? LOOP_RUNTIME_LOCK_LABEL,
@@ -44,6 +84,7 @@ export async function readSupervisorLoopRuntime(stateFile: string): Promise<Supe
 
   return {
     state: "off",
+    hostMode: "unknown",
     pid: null,
     startedAt: null,
     detail: null,

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -32,7 +32,7 @@ import {
   type SupervisorStatusDto,
 } from "./supervisor-status-report";
 import { buildTrackedPrMismatch } from "./tracked-pr-mismatch";
-import { readSupervisorLoopRuntime } from "./supervisor-loop-runtime-state";
+import { buildMacOsLoopHostWarning, readSupervisorLoopRuntime } from "./supervisor-loop-runtime-state";
 import { loadActiveIssueStatusSnapshot } from "./supervisor-selection-active-status";
 import {
   buildCandidateDiscoverySummary,
@@ -162,6 +162,7 @@ export async function buildSupervisorStatusReport(args: {
   const candidateDiscoverySummary = formatCandidateDiscoveryBehaviorLine(config);
   const localCiContract = summarizeLocalCiContract(config);
   const loopRuntime = await readSupervisorLoopRuntime(config.stateFile);
+  const loopHostWarning = buildMacOsLoopHostWarning(loopRuntime);
   const gsdSummary = await describeGsdIntegration(config);
   const statusRecords = summarizeSupervisorStatusRecords(state);
   const trackedIssues = buildTrackedIssueDtos(state);
@@ -266,22 +267,19 @@ export async function buildSupervisorStatusReport(args: {
         reconciliationWarning,
         readinessLines: readinessSummary?.readinessLines ?? [],
         whyLines,
-        warning: inventoryRefreshWarning
+        warning: loopHostWarning || inventoryRefreshWarning || githubRateLimitStatus.githubRateLimitWarning
           ? {
-            kind: "readiness",
+            kind: loopHostWarning ? "status" : "readiness",
             message: truncate(
               sanitizeStatusValue(
-                [inventoryRefreshWarning, githubRateLimitStatus.githubRateLimitWarning].filter(Boolean).join(" | "),
+                [loopHostWarning, inventoryRefreshWarning, githubRateLimitStatus.githubRateLimitWarning]
+                  .filter(Boolean)
+                  .join(" | "),
               ),
               200,
             ) ?? "",
           }
-          : githubRateLimitStatus.githubRateLimitWarning
-            ? {
-              kind: "readiness",
-              message: truncate(sanitizeStatusValue(githubRateLimitStatus.githubRateLimitWarning), 200) ?? "",
-            }
-            : null,
+          : null,
       };
     }
 
@@ -325,7 +323,12 @@ export async function buildSupervisorStatusReport(args: {
         reconciliationWarning,
         readinessLines: readinessSummary.readinessLines,
         whyLines,
-        warning: null,
+        warning: loopHostWarning
+          ? {
+            kind: "status",
+            message: truncate(sanitizeStatusValue(loopHostWarning), 200) ?? "",
+          }
+          : null,
       };
     } catch (error) {
       const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
@@ -360,9 +363,11 @@ export async function buildSupervisorStatusReport(args: {
         readinessLines: [],
         whyLines: [],
         warning: {
-          kind: "readiness",
+          kind: loopHostWarning ? "status" : "readiness",
           message: truncate(
-            sanitizeStatusValue([message, githubRateLimitStatus.githubRateLimitWarning].filter(Boolean).join(" | ")),
+            sanitizeStatusValue(
+              [loopHostWarning, message, githubRateLimitStatus.githubRateLimitWarning].filter(Boolean).join(" | "),
+            ),
             200,
           ) ?? "",
         },
@@ -445,11 +450,13 @@ export async function buildSupervisorStatusReport(args: {
     readinessLines: [],
     whyLines: [],
     warning: activeStatus.warningMessage || inventoryRefreshWarning
+      || loopHostWarning
       ? {
         kind: "status",
         message: truncate(
           sanitizeStatusValue(
             [
+              loopHostWarning,
               activeStatus.warningMessage,
               inventoryRefreshWarning,
               githubRateLimitStatus.githubRateLimitWarning,

--- a/src/supervisor/supervisor-service.test.ts
+++ b/src/supervisor/supervisor-service.test.ts
@@ -205,6 +205,7 @@ test("createSupervisorService preserves typed operator observability fields on s
     candidateDiscovery: null,
     loopRuntime: {
       state: "off",
+      hostMode: "unknown",
       pid: null,
       startedAt: null,
       detail: null,

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -85,9 +85,9 @@ export function renderLoopRuntimeLine(loopRuntime: SupervisorLoopRuntimeDto): st
   return [
     "loop_runtime",
     `state=${loopRuntime.state}`,
-    `host_mode=${loopRuntime.hostMode}`,
+    `host_mode=${sanitizeStatusValue(loopRuntime.hostMode)}`,
     `pid=${loopRuntime.pid === null ? "none" : String(loopRuntime.pid)}`,
-    `started_at=${loopRuntime.startedAt ?? "none"}`,
+    `started_at=${sanitizeStatusValue(loopRuntime.startedAt ?? "none")}`,
     `detail=${sanitizeStatusValue(loopRuntime.detail ?? "none")}`,
   ].join(" ");
 }

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -81,6 +81,17 @@ export function renderGitHubRateLimitLine(resource: "rest" | "graphql", budget: 
   return `github_rate_limit resource=${resource} status=${budget.state} remaining=${budget.remaining} limit=${budget.limit} reset_at=${budget.resetAt}`;
 }
 
+export function renderLoopRuntimeLine(loopRuntime: SupervisorLoopRuntimeDto): string {
+  return [
+    "loop_runtime",
+    `state=${loopRuntime.state}`,
+    `host_mode=${loopRuntime.hostMode}`,
+    `pid=${loopRuntime.pid === null ? "none" : String(loopRuntime.pid)}`,
+    `started_at=${loopRuntime.startedAt ?? "none"}`,
+    `detail=${sanitizeStatusValue(loopRuntime.detail ?? "none")}`,
+  ].join(" ");
+}
+
 export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
   const localCiContract = dto.localCiContract ?? {
     configured: false,
@@ -117,6 +128,7 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
   const lines = [
     ...dto.detailedStatusLines,
     ...githubRateLimitLines,
+    renderLoopRuntimeLine(dto.loopRuntime),
     `trust_mode=${trustDiagnostics.trustMode}`,
     `execution_safety_mode=${trustDiagnostics.executionSafetyMode}`,
     ...trustWarnings.map((warning) => renderStatusWarningLine(warning, sanitizeStatusValue)),


### PR DESCRIPTION
Closes #1468
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the loop-host reporting path end to end and committed it as `d8c24d5` (`Surface loop host mode in status and doctor`).

The main changes are:
- loop runtime now carries typed `hostMode` metadata derived from the runtime lock payload, with launcher capture persisted when the lock is acquired
- `status` and `doctor` now render explicit loop runtime lines and surface a macOS warning when a running loop is not hosted by `tmux`
- the dashboard now distinguishes `tmux` from direct hosts instead of flattening everything to generic “running”, and the related JSON/test fixtures were updated

Verification completed with:
- `npx tsx --test src/doctor.test.ts`
- `npx tsx --test src/backend/supervisor-http-server.test.ts`
- `npx tsx --test src/backend/webui-dashboard-browser-view-model.test.ts src/backend/webui-dashboard.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts`
- `npm run build`

There are still local-only journal/supervisor artifacts left unstaged in `.codex-supervisor/`; the code changes themselves are committed.

Summary: Added typed loop host mode reporting, surfaced it through status/doctor/dashboard, and added the macOS non-tmux warning path; committed as `d8c24d5`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/backend/supervisor-http-server.test.ts`; `npx tsx --test src/backend/webui-dashboard-browser-view-model.test.ts src/backend/webui-dashboard.test.ts...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and surface supervisor loop host mode (tmux, direct, unknown) and macOS host warnings.

* **Improvements**
  * Add loop runtime and host-mode details to diagnostics, dashboard, status reports, and doctor output.
  * Dashboard badges, summaries and warning indicators now reflect host mode.

* **Tests**
  * Updated and added tests/fixtures to cover host-mode reporting and macOS warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->