### PR TITLE
Bug: blocked stale_review_bot tracked PRs are never revisited after enabling reply_and_resolve (#1472)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,30 +5,43 @@
 - Branch: codex/issue-1472
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 19f21f8eb46774e52e72fee7ff019bcc6419b492
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 1deceebd33cb7cf65586d7879466f4c9b76a3e31
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-13T06:56:25.806Z
+- Last failure signature: PRRT_kwDORgvdZ856c-Kd|PRRT_kwDORgvdZ856c-Kj
+- Repeated failure signature count: 1
+- Updated at: 2026-04-13T07:16:36.528Z
 
 ## Latest Codex Summary
-- Added a stale-review-bot auto-recovery gate so tracked PR records already blocked as `stale_review_bot` become selectable and recoverable again when `staleConfiguredBotReviewPolicy` is `reply_only` or `reply_and_resolve`.
-- Extended supervisor-side coverage for selection eligibility, blocked-state reconciliation, and explain diagnostics to prove the issue reproduces and is fixed without broadening `diagnose_only`.
+Addressed the two automated review threads on top of the original stale-review-bot recovery change. The main fix is in `src/run-once-cycle-prelude.ts`: degraded inventory continuation now still runs tracked blocked-PR reconciliation for `stale_review_bot` records when the configured policy makes them auto-recoverable, via the same `shouldAutoRecoverStaleReviewBot()` predicate used by reconciliation. `src/supervisor/supervisor.ts` now passes that policy-aware predicate into the prelude so the gate stays aligned with the existing recovery rules instead of broadening degraded retries globally.
+
+I also tightened the regression coverage the review asked for. `src/run-once-cycle-prelude.test.ts` now proves degraded continuation invokes blocked tracked-PR reconciliation for an auto-recoverable `stale_review_bot` record, and `src/supervisor/supervisor-recovery-reconciliation.test.ts` normalizes the inherited head-scoped review fields to the current head so the same-head resume test no longer passes through stale-head fixture baggage.
+
+Summary: Fixed the degraded-continuation gate for auto-recoverable `stale_review_bot` tracked PRs, tightened the same-head stale-review regression fixture, and verified the updated branch locally.
+State hint: addressing_review
+Blocked reason: none
+Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
+Next action: Commit and push the review-fix delta to PR `#1473`, then refresh review state for the unresolved automated threads.
+Failure signature: PRRT_kwDORgvdZ856c-Kd|PRRT_kwDORgvdZ856c-Kj
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1473#discussion_r3071387483
+- Details:
+  - src/recovery-reconciliation.ts:1030 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 50384 --- 🏁 Script executed: Repository: Tommy... url=https://github.com/TommyKammy/codex-supervisor/pull/1473#discussion_r3071387483
+  - src/supervisor/supervisor-recovery-reconciliation.test.ts:2052 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Tighten this regression to the intended same-head recovery path.** `createTrackedPrStaleReviewRecord()` still brings along head-scoped review... url=https://github.com/TommyKammy/codex-supervisor/pull/1473#discussion_r3071387489
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: the stale configured-bot reply/resolve handler already works in `post-turn`, but supervisor selection/recovery treated `blocked_reason=stale_review_bot` as a permanent manual block, so already-blocked tracked PR incidents never re-entered that handler after the policy changed.
-- What changed: added `shouldAutoRecoverStaleReviewBot()` in supervisor execution policy, used it in selection eligibility and explain retry-state/manual-block reasoning, and allowed tracked-PR blocked-state reconciliation to revisit `stale_review_bot` records when the policy is `reply_only` or `reply_and_resolve`.
+- What changed this turn: fixed the degraded inventory-refresh prelude gate so it still calls `reconcileRecoverableBlockedIssueStates(..., { onlyTrackedPrStates: true })` for `stale_review_bot` tracked PR records when `shouldAutoRecoverStaleReviewBot(record, config)` is true; passed that predicate from `src/supervisor/supervisor.ts`; added a prelude regression test; normalized same-head stale-review fixture fields in the reconciliation test.
 - Current blocker: none.
-- Next exact step: commit the focused change set and proceed to PR/update flow if requested by the supervisor loop.
+- Next exact step: commit the focused review-fix delta, push `codex/issue-1472`, and let the supervisor/PR loop re-evaluate the remaining review-thread state.
 - Verification gap: full `npm test -- <file>` still pulls unrelated suite-wide failures in this repo, so focused verification used `npx tsx --test` with the exact requested files instead.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-execution-policy.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
+- Files touched this turn: `.codex-supervisor/issue-journal.md`, `src/run-once-cycle-prelude.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
 - Rollback concern: low; the new recovery path is limited to tracked PR records already blocked as `stale_review_bot` and still defers actual reply/resolve safety checks to the existing post-turn stale-bot handler.
-- Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
+- Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,36 +1,34 @@
-# Issue #1467: Document tmux as the supported macOS loop host and fail closed on direct launchd loop install
+# Issue #1472: Bug: blocked stale_review_bot tracked PRs are never revisited after enabling reply_and_resolve
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1467
-- Branch: codex/issue-1467
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1472
+- Branch: codex/issue-1472
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 96fcafd4268ff0fafc4c1eef7d0d8bf5c415b5eb
+- Last head SHA: 19f21f8eb46774e52e72fee7ff019bcc6419b492
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-12T22:50:15.098Z
+- Updated at: 2026-04-13T06:56:25.806Z
 
 ## Latest Codex Summary
-- Reproduced the unsupported macOS direct launchd loop path with a focused launcher-assets regression, then changed `scripts/install-launchd.sh` to fail closed with explicit tmux/WebUI guidance instead of installing a loop LaunchAgent.
-- Updated `README.md`, `docs/getting-started.md`, and `docs/getting-started.ja.md` so macOS loop hosting points to the supported tmux start/stop scripts, while Linux systemd and WebUI launchd guidance remain distinct. Added focused docs assertions and refreshed matching configuration wording required by the existing getting-started doc suite.
-- Verified with `npx tsx --test src/getting-started-docs.test.ts`, `npx tsx --test src/managed-restart-launcher-assets.test.ts`, and `npm run build`.
+- Added a stale-review-bot auto-recovery gate so tracked PR records already blocked as `stale_review_bot` become selectable and recoverable again when `staleConfiguredBotReviewPolicy` is `reply_only` or `reply_and_resolve`.
+- Extended supervisor-side coverage for selection eligibility, blocked-state reconciliation, and explain diagnostics to prove the issue reproduces and is fixed without broadening `diagnose_only`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The macOS loop host should be tmux only; the old direct launchd installer was the unsupported contract that needed to fail closed, while docs needed to state the supported tmux start/stop path explicitly.
-- What changed: Replaced the direct launchd loop installer body with a fail-closed message that points operators to `./scripts/start-loop-tmux.sh`, `./scripts/stop-loop-tmux.sh`, and `./scripts/install-launchd-web.sh`. Updated English and Japanese getting-started docs plus README macOS loop guidance. Added focused regression coverage for the installer behavior and the macOS tmux wording. Added minimal matching phrasing in `docs/configuration.md` so the existing getting-started docs suite remains green.
-- Current blocker: none
-- Next exact step: Commit the checkpoint and leave the branch ready for PR creation or the next supervisor pass.
-- Verification gap: No live manual tmux session launch on macOS host; verification is focused on script behavior, docs wording, and build integrity.
-- Files touched: .codex-supervisor/issue-journal.md; README.md; docs/configuration.md; docs/getting-started.md; docs/getting-started.ja.md; scripts/install-launchd.sh; src/getting-started-docs.test.ts; src/managed-restart-launcher-assets.test.ts; src/readme-docs.test.ts
-- Rollback concern: Low; the change narrows macOS loop installation behavior by failing closed and only adjusts operator docs/tests around the supported tmux path.
-- Last focused command: npm run build
+- Hypothesis: the stale configured-bot reply/resolve handler already works in `post-turn`, but supervisor selection/recovery treated `blocked_reason=stale_review_bot` as a permanent manual block, so already-blocked tracked PR incidents never re-entered that handler after the policy changed.
+- What changed: added `shouldAutoRecoverStaleReviewBot()` in supervisor execution policy, used it in selection eligibility and explain retry-state/manual-block reasoning, and allowed tracked-PR blocked-state reconciliation to revisit `stale_review_bot` records when the policy is `reply_only` or `reply_and_resolve`.
+- Current blocker: none.
+- Next exact step: commit the focused change set and proceed to PR/update flow if requested by the supervisor loop.
+- Verification gap: full `npm test -- <file>` still pulls unrelated suite-wide failures in this repo, so focused verification used `npx tsx --test` with the exact requested files instead.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-execution-policy.ts`, `src/supervisor/supervisor-selection-issue-explain.ts`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
+- Rollback concern: low; the new recovery path is limited to tracked PR records already blocked as `stale_review_bot` and still defers actual reply/resolve safety checks to the existing post-turn stale-bot handler.
+- Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
 ### Scratchpad
-- Focused reproducer that failed before the fix: `npx tsx --test src/managed-restart-launcher-assets.test.ts`
-- Focused verification after the fix: `npx tsx --test src/getting-started-docs.test.ts src/managed-restart-launcher-assets.test.ts src/readme-docs.test.ts`
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -18,11 +18,11 @@ Addressed the two automated review threads on top of the original stale-review-b
 
 I also tightened the regression coverage the review asked for. `src/run-once-cycle-prelude.test.ts` now proves degraded continuation invokes blocked tracked-PR reconciliation for an auto-recoverable `stale_review_bot` record, and `src/supervisor/supervisor-recovery-reconciliation.test.ts` normalizes the inherited head-scoped review fields to the current head so the same-head resume test no longer passes through stale-head fixture baggage.
 
-Summary: Fixed the degraded-continuation gate for auto-recoverable `stale_review_bot` tracked PRs, tightened the same-head stale-review regression fixture, and verified the updated branch locally.
+Summary: Fixed the degraded-continuation gate for auto-recoverable `stale_review_bot` tracked PRs, tightened the same-head stale-review regression fixture, verified locally, and pushed commit `7a36bd2` to PR `#1473`.
 State hint: addressing_review
 Blocked reason: none
 Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
-Next action: Commit and push the review-fix delta to PR `#1473`, then refresh review state for the unresolved automated threads.
+Next action: Refresh PR `#1473` review state and reply or resolve the remaining automated threads if the operator wants GitHub-side thread writes.
 Failure signature: PRRT_kwDORgvdZ856c-Kd|PRRT_kwDORgvdZ856c-Kj
 
 ## Active Failure Context
@@ -38,7 +38,7 @@ Failure signature: PRRT_kwDORgvdZ856c-Kd|PRRT_kwDORgvdZ856c-Kj
 - Hypothesis: the stale configured-bot reply/resolve handler already works in `post-turn`, but supervisor selection/recovery treated `blocked_reason=stale_review_bot` as a permanent manual block, so already-blocked tracked PR incidents never re-entered that handler after the policy changed.
 - What changed this turn: fixed the degraded inventory-refresh prelude gate so it still calls `reconcileRecoverableBlockedIssueStates(..., { onlyTrackedPrStates: true })` for `stale_review_bot` tracked PR records when `shouldAutoRecoverStaleReviewBot(record, config)` is true; passed that predicate from `src/supervisor/supervisor.ts`; added a prelude regression test; normalized same-head stale-review fixture fields in the reconciliation test.
 - Current blocker: none.
-- Next exact step: commit the focused review-fix delta, push `codex/issue-1472`, and let the supervisor/PR loop re-evaluate the remaining review-thread state.
+- Next exact step: let the supervisor/PR loop re-evaluate the remaining review-thread state on pushed commit `7a36bd2`, then decide whether to post GitHub thread replies.
 - Verification gap: full `npm test -- <file>` still pulls unrelated suite-wide failures in this repo, so focused verification used `npx tsx --test` with the exact requested files instead.
 - Files touched this turn: `.codex-supervisor/issue-journal.md`, `src/run-once-cycle-prelude.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
 - Rollback concern: low; the new recovery path is limited to tracked PR records already blocked as `stale_review_bot` and still defers actual reply/resolve safety checks to the existing post-turn stale-bot handler.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -14,6 +14,7 @@ import {
   isOpenPullRequest,
 } from "./supervisor/supervisor-lifecycle";
 import { inferFailureContext } from "./supervisor/supervisor-failure-context";
+import { shouldAutoRecoverStaleReviewBot } from "./supervisor/supervisor-execution-policy";
 import {
   findHighRiskBlockingAmbiguity,
   findParentIssuesReadyToClose,
@@ -1021,7 +1022,12 @@ export async function reconcileRecoverableBlockedIssueStates(
 
     if (
       record.pr_number !== null &&
-      (record.blocked_reason === null || record.blocked_reason === "manual_review" || record.blocked_reason === "verification")
+      (
+        record.blocked_reason === null ||
+        record.blocked_reason === "manual_review" ||
+        record.blocked_reason === "verification" ||
+        shouldAutoRecoverStaleReviewBot(record, config)
+      )
     ) {
       const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);
       if (!trackedPullRequest || !isOpenPullRequestImpl(trackedPullRequest)) {

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -1520,6 +1520,71 @@ test("runOnceCyclePrelude rehydrates blocked tracked PRs during degraded invento
   assert.equal(result.state.issues["77"]?.last_failure_signature, null);
 });
 
+test("runOnceCyclePrelude rehydrates auto-recoverable stale review bot tracked PRs during degraded inventory refresh", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "77": createRecord({
+        issue_number: 77,
+        state: "blocked",
+        pr_number: 170,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: "head-170",
+        last_failure_signature: "stale-configured-bot-review",
+      }),
+    },
+  };
+  const blockedCalls: Array<{
+    loadedState: SupervisorStateFile;
+    loadedIssues: GitHubIssue[];
+    options?: { onlyTrackedPrStates?: boolean };
+  }> = [];
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => {},
+    },
+    carryoverRecoveryEvents: [],
+    shouldReconcileTrackedBlockedRecordDuringDegradedContinuation: (record) =>
+      record.issue_number === 77,
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => {
+      throw new Error("Failed to parse JSON from gh issue list: Unexpected token ] in JSON at position 1");
+    },
+    reserveRunnableIssueSelection: async () => {
+      throw new Error("unexpected reserveRunnableIssueSelection call");
+    },
+    reconcileTrackedMergedButOpenIssues: async () => [],
+    reconcileMergedIssueClosures: async () => {
+      throw new Error("unexpected reconcileMergedIssueClosures call");
+    },
+    reconcileStaleFailedIssueStates: async () => {
+      throw new Error("unexpected reconcileStaleFailedIssueStates call");
+    },
+    reconcileRecoverableBlockedIssueStates: async (loadedState, loadedIssues, options) => {
+      blockedCalls.push({ loadedState, loadedIssues, options });
+      return [];
+    },
+    reconcileParentEpicClosures: async () => {
+      throw new Error("unexpected reconcileParentEpicClosures call");
+    },
+    cleanupExpiredDoneWorkspaces: async () => {
+      throw new Error("unexpected cleanupExpiredDoneWorkspaces call");
+    },
+  });
+
+  assert.ok(!("kind" in result));
+  assert.deepEqual(blockedCalls, [
+    {
+      loadedState: state,
+      loadedIssues: [],
+      options: { onlyTrackedPrStates: true },
+    },
+  ]);
+});
+
 test("runOnceCyclePrelude does not reconcile parent epic closures from tracked issue snapshots when full inventory refresh is malformed", async () => {
   const parentIssue: GitHubIssue = {
     number: 1043,

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -39,6 +39,9 @@ interface RunOnceCyclePreludeArgs {
   emitEvent?: SupervisorEventSink;
   setReconciliationPhase?: (phase: string | null) => Promise<void>;
   setReconciliationProgress?: (progress: ReconciliationProgressUpdate | null) => Promise<void>;
+  shouldReconcileTrackedBlockedRecordDuringDegradedContinuation?: (
+    record: SupervisorStateFile["issues"][string],
+  ) => boolean;
   reconcileStaleActiveIssueReservation: (state: SupervisorStateFile) => Promise<RecoveryEvent[]>;
   reserveRunnableIssueSelection?: (state: SupervisorStateFile) => Promise<boolean>;
   handleAuthFailure: (state: SupervisorStateFile) => Promise<string | null>;
@@ -210,7 +213,12 @@ export async function runOnceCyclePrelude(
       const hasBlockedTrackedPrRecords = Object.values(state.issues).some((record) =>
         record.state === "blocked" &&
         record.pr_number !== null &&
-        (record.blocked_reason === null || record.blocked_reason === "manual_review" || record.blocked_reason === "verification"),
+        (
+          record.blocked_reason === null ||
+          record.blocked_reason === "manual_review" ||
+          record.blocked_reason === "verification" ||
+          args.shouldReconcileTrackedBlockedRecordDuringDegradedContinuation?.(record) === true
+        ),
       );
       if (allowDegradedContinuation && hasBlockedTrackedPrRecords) {
         await setReconciliationPhase("recoverable_blocked_issue_states");

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -449,6 +449,63 @@ Show stale configured-bot review blockers distinctly in explain output.
   assert.match(explanation, /^reason_2=local_state blocked$/m);
 });
 
+test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.staleConfiguredBotReviewPolicy = "reply_and_resolve";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "97": createRecord({
+        issue_number: 97,
+        state: "blocked",
+        branch: branchName(fixture.config, 97),
+        workspace: path.join(fixture.workspaceRoot, "issue-97"),
+        journal_path: null,
+        pr_number: 197,
+        blocked_reason: "stale_review_bot",
+        last_error: "configured bot review stayed stale on the current head",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const blockedIssue: GitHubIssue = {
+    number: 97,
+    title: "Recoverable stale configured bot blocker",
+    body: `## Summary
+Show recoverable stale configured-bot review blockers as runnable when auto-handling is enabled.
+
+## Scope
+- reflect auto-recoverable stale configured-bot blockers in explain output
+
+## Acceptance criteria
+- explain reports the issue as runnable once reply_and_resolve can handle the stale bot review
+
+## Verification
+- npm test -- src/supervisor/supervisor-diagnostics-explain.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: "https://example.test/issues/97",
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => blockedIssue,
+    listAllIssues: async () => [blockedIssue],
+    listCandidateIssues: async () => [blockedIssue],
+  };
+
+  const explanation = await supervisor.explain(97);
+
+  assert.match(explanation, /^state=blocked$/m);
+  assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
+  assert.match(explanation, /^runnable=yes$/m);
+  assert.doesNotMatch(explanation, /^reason_1=manual_block stale_review_bot$/m);
+  assert.match(explanation, /^selection_reason=ready execution_ready=yes depends_on=none execution_order=none predecessors=none retry_state=stale_review_bot_recovery:reply_and_resolve$/m);
+});
+
 test("explain reports tracked PR mismatches when GitHub is ready but local state is still blocked", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -8,6 +8,7 @@ import {
   incrementAttemptCounters,
   isEligibleForSelection,
   isVerificationBlockedMessage,
+  shouldAutoRecoverStaleReviewBot,
   shouldAutoRetryBlockedVerification,
   shouldAutoRetryHandoffMissing,
   shouldEnforceExecutionReady,
@@ -274,6 +275,39 @@ test("isEligibleForSelection retries only terminal states with an allowed retry 
     ),
     false,
   );
+  assert.equal(
+    isEligibleForSelection(
+      createRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 44,
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    isEligibleForSelection(
+      createRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 44,
+      }),
+      createConfig({ staleConfiguredBotReviewPolicy: "reply_only" }),
+    ),
+    true,
+  );
+  assert.equal(
+    isEligibleForSelection(
+      createRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 44,
+      }),
+      createConfig({ staleConfiguredBotReviewPolicy: "reply_and_resolve" }),
+    ),
+    true,
+  );
 });
 
 test("shouldAutoRetryHandoffMissing only retries recoverable blocked handoffs", () => {
@@ -313,4 +347,22 @@ test("shouldAutoRetryHandoffMissing only retries recoverable blocked handoffs", 
     ),
     false,
   );
+});
+
+test("shouldAutoRecoverStaleReviewBot only reopens tracked PR incidents when the policy enables automatic handling", () => {
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "stale_review_bot",
+    pr_number: 44,
+  });
+
+  assert.equal(shouldAutoRecoverStaleReviewBot(record, createConfig()), false);
+  assert.equal(shouldAutoRecoverStaleReviewBot(record, createConfig({ staleConfiguredBotReviewPolicy: "reply_only" })), true);
+  assert.equal(
+    shouldAutoRecoverStaleReviewBot(record, createConfig({ staleConfiguredBotReviewPolicy: "reply_and_resolve" })),
+    true,
+  );
+  assert.equal(shouldAutoRecoverStaleReviewBot(createRecord({ ...record, pr_number: null }), createConfig({
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+  })), false);
 });

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -71,6 +71,16 @@ export function shouldAutoRetryHandoffMissing(record: IssueRunRecord, config: Su
   );
 }
 
+export function shouldAutoRecoverStaleReviewBot(record: IssueRunRecord, config: SupervisorConfig): boolean {
+  return (
+    record.state === "blocked" &&
+    record.blocked_reason === "stale_review_bot" &&
+    record.pr_number !== null &&
+    (config.staleConfiguredBotReviewPolicy === "reply_only" ||
+      config.staleConfiguredBotReviewPolicy === "reply_and_resolve")
+  );
+}
+
 export function shouldEnforceExecutionReady(
   record: Pick<IssueRunRecord, "attempt_count" | "pr_number"> | undefined | null,
 ): boolean {
@@ -102,6 +112,7 @@ export function isEligibleForSelection(record: IssueRunRecord | undefined, confi
   return (
     shouldAutoRetryTimeout(record, config) ||
     shouldAutoRetryBlockedVerification(record, config) ||
-    shouldAutoRetryHandoffMissing(record, config)
+    shouldAutoRetryHandoffMissing(record, config) ||
+    shouldAutoRecoverStaleReviewBot(record, config)
   );
 }

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2037,6 +2037,8 @@ test("reconcileRecoverableBlockedIssueStates resumes tracked PR stale configured
         blocked_reason: "stale_review_bot",
         pr_number: 191,
         last_head_sha: "head-191",
+        local_review_head_sha: "head-191",
+        local_review_summary_path: "/tmp/reviews/issue-366/head-191.md",
         last_error: "Configured bot review stayed stale on the current head.",
         last_failure_kind: null,
         last_failure_context: {
@@ -2049,6 +2051,21 @@ test("reconcileRecoverableBlockedIssueStates resumes tracked PR stale configured
           updated_at: "2026-03-13T00:20:00Z",
         },
         last_failure_signature: "stale-configured-bot-review",
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Local CI passed on the current head.",
+          ran_at: "2026-03-13T00:22:00Z",
+          head_sha: "head-191",
+          execution_mode: "shell",
+          failure_class: null,
+          remediation_target: null,
+        },
+        external_review_head_sha: "head-191",
+        external_review_misses_path: "/tmp/reviews/issue-366/head-191-misses.json",
+        review_follow_up_head_sha: "head-191",
+        last_host_local_pr_blocker_comment_head_sha: "head-191",
+        processed_review_thread_ids: ["thread-1", "thread-1@head-191"],
+        processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
       }),
     ],
   });
@@ -2115,6 +2132,7 @@ test("reconcileRecoverableBlockedIssueStates resumes tracked PR stale configured
   assert.equal(state.issues["366"]?.blocked_reason, "stale_review_bot");
   assert.equal(state.issues["366"]?.pr_number, 191);
   assert.equal(state.issues["366"]?.last_head_sha, "head-191");
+  assert.equal(state.issues["366"]?.last_failure_signature, "stale-configured-bot-review");
   assert.equal(saveCalls, 1);
 });
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2025,6 +2025,99 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
   assert.equal(saveCalls, 0);
 });
 
+test("reconcileRecoverableBlockedIssueStates resumes tracked PR stale configured-bot blockers after reply_and_resolve is enabled", async () => {
+  const config = createConfig({
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createTrackedPrStaleReviewRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error: "Configured bot review stayed stale on the current head.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "blocked",
+          summary: "Configured bot review stayed stale on the current head.",
+          signature: "stale-configured-bot-review",
+          command: null,
+          details: ["tracked_pr=head-191"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "stale-configured-bot-review",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    isDraft: false,
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [createReviewThread()],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "blocked",
+      inferFailureContext: () => ({
+        category: "blocked",
+        summary: "Configured bot review stayed stale on the current head.",
+        signature: "stale-configured-bot-review",
+        command: null,
+        details: ["tracked_pr=head-191"],
+        url: null,
+        updated_at: "2026-03-13T00:20:00Z",
+      }),
+      blockedReasonForLifecycleState: () => "stale_review_bot",
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  assert.equal(recoveryEvents.length, 0);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "stale_review_bot");
+  assert.equal(state.issues["366"]?.pr_number, 191);
+  assert.equal(state.issues["366"]?.last_head_sha, "head-191");
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileRecoverableBlockedIssueStates clears stale head-scoped review state after a tracked PR repair push", async () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -13,6 +13,7 @@ import {
   formatExecutionReadyMissingFields,
   hasAttemptBudgetRemaining,
   isEligibleForSelection,
+  shouldAutoRecoverStaleReviewBot,
   shouldAutoRetryBlockedVerification,
   shouldAutoRetryHandoffMissing,
   shouldEnforceExecutionReady,
@@ -141,7 +142,7 @@ export function buildNonRunnableLocalStateReasons(record: IssueRunRecord, config
     if (
       record.blocked_reason === "manual_review" ||
       record.blocked_reason === "manual_pr_closed" ||
-      record.blocked_reason === "stale_review_bot"
+      (record.blocked_reason === "stale_review_bot" && !shouldAutoRecoverStaleReviewBot(record, config))
     ) {
       reasons.push(`manual_block ${record.blocked_reason}`);
     } else if (record.blocked_reason === "verification" && !shouldAutoRetryBlockedVerification(record, config)) {
@@ -521,6 +522,10 @@ function formatRetryState(record: IssueRunRecord | undefined, config: Supervisor
 
   if (shouldAutoRetryHandoffMissing(record, config)) {
     return "handoff_missing_retry";
+  }
+
+  if (shouldAutoRecoverStaleReviewBot(record, config)) {
+    return `stale_review_bot_recovery:${config.staleConfiguredBotReviewPolicy}`;
   }
 
   return `resume:${record.state}`;

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -92,6 +92,7 @@ import {
   hasAttemptBudgetRemaining,
   incrementAttemptCounters,
   isVerificationBlockedMessage,
+  shouldAutoRecoverStaleReviewBot,
   shouldAutoRetryBlockedVerification,
   shouldAutoRetryHandoffMissing,
 } from "./supervisor-execution-policy";
@@ -1037,6 +1038,8 @@ export class Supervisor {
       stateStore: this.stateStore,
       carryoverRecoveryEvents,
       emitEvent: this.onEvent,
+      shouldReconcileTrackedBlockedRecordDuringDegradedContinuation: (record) =>
+        shouldAutoRecoverStaleReviewBot(record, this.config),
       setReconciliationPhase: (phase) =>
         phase === null
           ? clearCurrentReconciliationPhase(this.config)


### PR DESCRIPTION
Closes #1472
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the re-entry path for tracked PR records blocked as `stale_review_bot` once `staleConfiguredBotReviewPolicy` is switched to `reply_only` or `reply_and_resolve`. The change is in the supervisor-side gating, not the post-turn handler: `src/supervisor/supervisor-execution-policy.ts` now treats those incidents as recoverable only for tracked PRs with an auto-handling policy enabled, `src/recovery-reconciliation.ts` lets blocked tracked PR reconciliation revisit them, and `src/supervisor/supervisor-selection-issue-explain.ts` stops classifying them as a permanent manual block when they are auto-recoverable.

I added focused coverage for all three surfaces the issue called out: selection eligibility, blocked-state reconciliation, and operator diagnostics. The new tests live in `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, and `src/supervisor/supervisor-diagnostics-explain.test.ts`. I also updated the issue journal and committed the checkpoint as `1deceeb` with message `Resume stale review bot blocked tracked PRs`.

Summary: Added stale-review-bot auto-recovery for tracked PRs under `reply_only`/`reply_and_resolve`, updated explain diagnostics, added focused regression tests, and committed the checkpoint.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explai...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tracked PRs blocked by a stale review bot can now be automatically reconsidered when the review policy is `reply_only` or `reply_and_resolve`, improving recovery of degraded inventories.

* **Tests**
  * Added tests covering auto-recovery eligibility, selection behavior, degraded-continuation reconciliation, and related explanations.

* **Documentation**
  * Updated the supervisor issue journal and diagnostic explanations to reflect the new stale-review-bot auto-recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->