### PR TITLE
Bug: reply_and_resolve can resolve stale configured-bot threads but leave tracked PR blocked as stale_review_bot (#1476)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,31 +5,51 @@
 - Branch: codex/issue-1476
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 61e880ba3a0899dbe631a4f92c6a8b158f742e95
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 1eeba93624afb2f8c5c476fc9fc88087b5e3da21
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-13T08:58:18.407Z
+- Last failure signature: PRRT_kwDORgvdZ856etYm|PRRT_kwDORgvdZ856etY6
+- Repeated failure signature count: 1
+- Updated at: 2026-04-13T09:21:48.563Z
 
 ## Latest Codex Summary
-- Added a focused reproducer for same-head `reply_and_resolve` convergence and fixed post-turn tracked PR reconciliation so successful stale configured-bot auto-resolution refreshes GitHub facts before returning.
+Implemented the fix in `src/post-turn-pull-request.ts` and committed it as `1eeba93` (`Refresh tracked PR state after stale bot auto-resolve`).
+
+The change does two things. First, it adds a focused regression in `src/post-turn-pull-request.test.ts` that reproduces the stale same-head `reply_and_resolve` case: unresolved configured-bot threads are auto-resolved, a fresh same-head snapshot clears them, and the tracked record must stop reporting `blocked_reason=stale_review_bot`. Second, it reuses the tracked PR lifecycle projection after successful same-head `reply_and_resolve`, so the supervisor refreshes GitHub facts, updates the persisted tracked state, and re-runs sticky status comment handling against the refreshed snapshot instead of returning the stale blocked record.
+
+Verification passed with:
+`node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads"`
+`node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
+`npm run build`
+
+Summary: Reproduced and fixed same-head `reply_and_resolve` stale-review convergence so tracked PR state refreshes out of `stale_review_bot` after auto-resolution, with regression coverage added.
+State hint: stabilizing
+Blocked reason: none
+Tests: Focused post-turn reproducer; requested 5-file node test suite; `npm run build`
+Next action: Push `codex/issue-1476` and open or update the draft PR if needed.
+Failure signature: PRRT_kwDORgvdZ856etYm|PRRT_kwDORgvdZ856etY6
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1477#discussion_r3071996214
+- Details:
+  - src/post-turn-pull-request.ts:1719 summary=_⚠️ Potential issue_ | _🟡 Minor_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 1047 --- 🏁 Script executed: Repository: TommyK... url=https://github.com/TommyKammy/codex-supervisor/pull/1477#discussion_r3071996214
+  - src/post-turn-pull-request.ts:1718 summary=_⚠️ Potential issue_ | _🟠 Major_ **Always propagate the reconciled snapshot after the extra load.** `applyTrackedPrLifecycleState()` has already persisted `reconciledRecord`, b... url=https://github.com/TommyKammy/codex-supervisor/pull/1477#discussion_r3071996239
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `maybeCommentOnTrackedPrPersistentStatus()` returned immediately after persisting `reply_and_resolve` progress, so the tracked record kept local `blocked_reason=stale_review_bot` even though a fresh same-head GitHub snapshot would already be clear.
-- What changed: Added a focused regression test in `src/post-turn-pull-request.test.ts` that requires a third same-head snapshot after `reply_and_resolve`; extracted tracked PR lifecycle application into `applyTrackedPrLifecycleState()` and reused it after successful same-head `reply_and_resolve` to refresh state and re-run persistent-status commenting on fresh GitHub facts.
+- Hypothesis: the review feedback was correct on two points: the exported handler args still omitted `github.resolveReviewThread`, and the same-head `reply_and_resolve` refresh path only propagated `postReady` and `record` when the stale-review blocker cleared, so callers could observe a pre-refresh record even after `applyTrackedPrLifecycleState()` persisted newer blocked-state facts.
+- What changed: added `resolveReviewThread` to `HandlePostTurnPullRequestTransitionsArgs["github"]`; updated the same-head `shouldRefreshAfterReplyAndResolve` branch in `src/post-turn-pull-request.ts` to always assign the reconciled snapshot and refreshed record before conditionally re-running persistent-status commenting; added a regression in `src/post-turn-pull-request.test.ts` that keeps the PR blocked on a different stale configured-bot thread after refresh and asserts the returned record and review-thread snapshot match the reconciled state.
 - Current blocker: none.
-- Next exact step: commit the verified fix on `codex/issue-1476`.
+- Next exact step: commit the review-thread fixes on `codex/issue-1476` and update PR #1477.
 - Verification gap: none for the requested local scope; targeted suite and build are green.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`.
-- Rollback concern: low to moderate; the new post-auto-resolution refresh is intentionally limited to same-head `reply_and_resolve` stale-review cases, but any future broadening should avoid introducing extra snapshot churn for `reply_only` or already-settled blockers.
-- Last focused command: `npm run build`
+- Rollback concern: low to moderate; the reconciled snapshot is now always returned for same-head `reply_and_resolve` refreshes, so future edits in this area should avoid coupling return-value freshness to whether the blocker clears.
+- Last focused command: `node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
 ### Scratchpad
 - Reproducer command: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads"`
 - Targeted verification: `node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
+- Review-fix verification: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "reply_and_resolve"` and `npm run build`
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,35 @@
-# Issue #1474: Bug: reply_only stale_review_bot incidents can stay permanently runnable after the first auto-reply
+# Issue #1476: Bug: reply_and_resolve can resolve stale configured-bot threads but leave tracked PR blocked as stale_review_bot
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1474
-- Branch: codex/issue-1474
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1476
+- Branch: codex/issue-1476
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 3be9af5e5c8e3a5da236f1c61c23e7fffea72083
+- Last head SHA: 61e880ba3a0899dbe631a4f92c6a8b158f742e95
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-13T07:55:18.086Z
+- Updated at: 2026-04-13T08:58:18.407Z
 
 ## Latest Codex Summary
-- None yet.
+- Added a focused reproducer for same-head `reply_and_resolve` convergence and fixed post-turn tracked PR reconciliation so successful stale configured-bot auto-resolution refreshes GitHub facts before returning.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: stale configured-bot recovery is selected too loosely; the supervisor re-enters `blocked/stale_review_bot` tracked PRs even after `reply_only` already handled the current PR head and stale-review signature.
-- What changed: tightened `shouldAutoRecoverStaleReviewBot` to require an actionable current head/signature, and added focused tests for the suppressed same-head/same-signature recovery case plus explain output.
+- Hypothesis: `maybeCommentOnTrackedPrPersistentStatus()` returned immediately after persisting `reply_and_resolve` progress, so the tracked record kept local `blocked_reason=stale_review_bot` even though a fresh same-head GitHub snapshot would already be clear.
+- What changed: Added a focused regression test in `src/post-turn-pull-request.test.ts` that requires a third same-head snapshot after `reply_and_resolve`; extracted tracked PR lifecycle application into `applyTrackedPrLifecycleState()` and reused it after successful same-head `reply_and_resolve` to refresh state and re-run persistent-status commenting on fresh GitHub facts.
 - Current blocker: none.
-- Next exact step: commit this focused recovery-gate change, then optionally open/update a draft PR.
-- Verification gap: full repo `npm test` still has unrelated pre-existing failures on this branch; focused issue verification passed on the requested stale-review-bot files.
-- Files touched: `src/supervisor/supervisor-execution-policy.ts`, `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`.
-- Rollback concern: low; the gate only suppresses stale-review auto-recovery when persisted state already proves the current head/signature received the stale-bot auto-reply.
-- Last focused command: `node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
+- Next exact step: commit the verified fix on `codex/issue-1476`.
+- Verification gap: none for the requested local scope; targeted suite and build are green.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`.
+- Rollback concern: low to moderate; the new post-auto-resolution refresh is intentionally limited to same-head `reply_and_resolve` stale-review cases, but any future broadening should avoid introducing extra snapshot churn for `reply_only` or already-settled blockers.
+- Last focused command: `npm run build`
 ### Scratchpad
+- Reproducer command: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads"`
+- Targeted verification: `node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2397,6 +2397,131 @@ test("handlePostTurnPullRequestTransitionsPhase replies and resolves stale confi
   assert.equal(resolveCalls.length, 2);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+  });
+  const issue = createIssue({ title: "Clear stale local blocker after reply_and_resolve converges GitHub facts" });
+  const pr = createPullRequest({
+    title: "Tracked PR stale configured-bot blocker self-heals after auto-resolution",
+    number: 117,
+    isDraft: false,
+    headRefOid: "head-117",
+    mergeStateStatus: "CLEAN",
+    currentHeadCiGreenAt: "2026-03-13T02:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-03-13T02:11:00Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "blocked",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        blocked_reason: "stale_review_bot",
+      }),
+    },
+  };
+  const staleBotFailureContext = {
+    ...createFailureContext(
+      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    ),
+    signature: "stalled-bot:thread-1",
+    details: [
+      "reviewer=copilot-pull-request-reviewer file=src/review-a.ts line=42 processed_on_current_head=yes",
+    ],
+    url: "https://example.test/review/1",
+  };
+  const unresolvedReviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      path: "src/review-a.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "This finding is stale on the current head.",
+            createdAt: "2026-03-13T02:05:00Z",
+            url: "https://example.test/pr/117#discussion_r1",
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ] satisfies ReviewThread[];
+  const passingChecks = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }] satisfies PullRequestCheck[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  let loadSnapshotCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => {
+        throw new Error("unexpected addIssueComment call");
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, currentPr, checks, reviewThreads, recordPatch) =>
+      reviewThreads.length === 0
+        ? deriveSupervisorPullRequestLifecycleSnapshot(config, recordForState, currentPr, checks, reviewThreads, recordPatch)
+        : createLifecycleSnapshot(recordForState, "blocked", {
+            failureContext: staleBotFailureContext,
+          }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_recordForState, _currentPr, _checks, reviewThreads) =>
+      reviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads: () => unresolvedReviewThreads,
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      loadSnapshotCalls += 1;
+      return {
+        pr,
+        checks: passingChecks,
+        reviewThreads: loadSnapshotCalls >= 3 ? ([] satisfies ReviewThread[]) : unresolvedReviewThreads,
+      };
+    },
+  });
+
+  assert.deepEqual(
+    replyCalls.map((call) => call.threadId),
+    ["thread-1"],
+  );
+  assert.deepEqual(resolveCalls, ["thread-1"]);
+  assert.equal(loadSnapshotCalls, 3);
+  assert.notEqual(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, null);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resumes reply_and_resolve without duplicating already-posted stale replies", async () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2522,6 +2522,163 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes tracked PR state after
   assert.equal(result.record.blocked_reason, null);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase returns the reconciled snapshot even when stale_review_bot remains blocked after reply_and_resolve", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+  });
+  const issue = createIssue({ title: "Propagate reconciled stale review bot state after reply_and_resolve" });
+  const pr = createPullRequest({
+    title: "Tracked PR stale configured-bot blocker refresh stays blocked on a new thread",
+    number: 118,
+    isDraft: false,
+    headRefOid: "head-118",
+    mergeStateStatus: "CLEAN",
+    currentHeadCiGreenAt: "2026-03-13T02:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-03-13T02:11:00Z",
+  });
+  const initialThread = createReviewThread({
+    id: "thread-1",
+    path: "src/review-a.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "This finding is stale on the current head.",
+          createdAt: "2026-03-13T02:05:00Z",
+          url: "https://example.test/pr/118#discussion_r1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const reconciledThread = createReviewThread({
+    id: "thread-2",
+    path: "src/review-b.ts",
+    line: 84,
+    comments: {
+      nodes: [
+        {
+          id: "comment-2",
+          body: "A different stale finding still remains after the first thread is resolved.",
+          createdAt: "2026-03-13T02:07:00Z",
+          url: "https://example.test/pr/118#discussion_r2",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "blocked",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        blocked_reason: "stale_review_bot",
+      }),
+    },
+  };
+  const initialFailureContext = {
+    ...createFailureContext(
+      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    ),
+    signature: "stalled-bot:thread-1",
+    details: [
+      "reviewer=copilot-pull-request-reviewer file=src/review-a.ts line=42 processed_on_current_head=yes",
+    ],
+    url: "https://example.test/review/118/1",
+  };
+  const reconciledFailureContext = {
+    ...createFailureContext(
+      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    ),
+    signature: "stalled-bot:thread-2",
+    details: [
+      "reviewer=copilot-pull-request-reviewer file=src/review-b.ts line=84 processed_on_current_head=yes",
+    ],
+    url: "https://example.test/review/118/2",
+  };
+  const passingChecks = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }] satisfies PullRequestCheck[];
+  let loadSnapshotCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => {
+        throw new Error("unexpected addIssueComment call");
+      },
+      replyToReviewThread: async () => undefined,
+      resolveReviewThread: async () => undefined,
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, currentPr, checks, reviewThreads, recordPatch) =>
+      reviewThreads.some((thread) => thread.id === "thread-2")
+        ? createLifecycleSnapshot(recordForState, "blocked", {
+            failureContext: reconciledFailureContext,
+          })
+        : reviewThreads.length === 0
+          ? deriveSupervisorPullRequestLifecycleSnapshot(config, recordForState, currentPr, checks, reviewThreads, recordPatch)
+          : createLifecycleSnapshot(recordForState, "blocked", {
+              failureContext: initialFailureContext,
+            }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_recordForState, _currentPr, _checks, reviewThreads) =>
+      reviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads: (_config, reviewThreads) =>
+      reviewThreads.filter(
+        (thread) => thread.comments.nodes[0]?.author?.login === "copilot-pull-request-reviewer",
+      ),
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      loadSnapshotCalls += 1;
+      return {
+        pr,
+        checks: passingChecks,
+        reviewThreads:
+          loadSnapshotCalls >= 3
+            ? ([reconciledThread] satisfies ReviewThread[])
+            : ([initialThread] satisfies ReviewThread[]),
+      };
+    },
+  });
+
+  assert.equal(loadSnapshotCalls, 3);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "stale_review_bot");
+  assert.equal(result.record.last_failure_signature, "stalled-bot:thread-2");
+  assert.equal(result.record.last_failure_context?.url, "https://example.test/review/118/2");
+  assert.deepEqual(
+    result.reviewThreads.map((thread) => thread.id),
+    ["thread-2"],
+  );
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resumes reply_and_resolve without duplicating already-posted stale replies", async () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -1146,6 +1146,108 @@ async function loadOpenPullRequestSnapshot(
   return { pr, checks, reviewThreads };
 }
 
+async function applyTrackedPrLifecycleState(args: {
+  config: SupervisorConfig;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  syncJournal: IssueJournalSync;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  repeatedLocalReviewSignatureCount: number;
+  derivePullRequestLifecycleSnapshot: HandlePostTurnPullRequestTransitionsArgs["derivePullRequestLifecycleSnapshot"];
+  applyFailureSignature: HandlePostTurnPullRequestTransitionsArgs["applyFailureSignature"];
+  blockedReasonFromReviewState: HandlePostTurnPullRequestTransitionsArgs["blockedReasonFromReviewState"];
+  summarizeChecks: HandlePostTurnPullRequestTransitionsArgs["summarizeChecks"];
+  manualReviewThreads: HandlePostTurnPullRequestTransitionsArgs["manualReviewThreads"];
+  configuredBotReviewThreads: HandlePostTurnPullRequestTransitionsArgs["configuredBotReviewThreads"];
+  mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
+}): Promise<{ record: IssueRunRecord; effectiveFailureContext: FailureContext | null }> {
+  const refreshedLifecycle = args.derivePullRequestLifecycleSnapshot(
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+    { repeated_local_review_signature_count: args.repeatedLocalReviewSignatureCount },
+  );
+  const localReviewRepairSummary =
+    refreshedLifecycle.nextState === "local_review_fix"
+      ? localReviewRepairContinuationSummary(args.config, refreshedLifecycle.recordForState, args.pr)
+      : null;
+  const postReadyLocalReviewFailureContext =
+    refreshedLifecycle.nextState === "blocked" &&
+    localReviewRetryLoopStalled(
+      args.config,
+      refreshedLifecycle.recordForState,
+      args.pr,
+      args.checks,
+      args.reviewThreads,
+      args.manualReviewThreads,
+      args.configuredBotReviewThreads,
+      args.summarizeChecks,
+      args.mergeConflictDetected,
+    )
+      ? localReviewStallFailureContext(refreshedLifecycle.recordForState)
+      : refreshedLifecycle.nextState === "blocked" &&
+          localReviewHighSeverityNeedsBlock(args.config, refreshedLifecycle.recordForState, args.pr)
+        ? localReviewFailureContext(refreshedLifecycle.recordForState)
+        : refreshedLifecycle.nextState === "local_review_fix"
+          ? localReviewRepairContinuationFailureContext(args.config, refreshedLifecycle.recordForState, args.pr)
+          : null;
+  const effectiveFailureContext = refreshedLifecycle.failureContext ?? postReadyLocalReviewFailureContext;
+  const updatedRecord = args.stateStore.touch(args.record, {
+    pr_number: args.pr.number,
+    ...refreshedLifecycle.reviewWaitPatch,
+    ...refreshedLifecycle.copilotRequestObservationPatch,
+    merge_readiness_last_evaluated_at: refreshedLifecycle.mergeLatencyVisibilityPatch.merge_readiness_last_evaluated_at,
+    provider_success_head_sha: refreshedLifecycle.mergeLatencyVisibilityPatch.provider_success_head_sha,
+    provider_success_observed_at: refreshedLifecycle.mergeLatencyVisibilityPatch.provider_success_observed_at,
+    ...refreshedLifecycle.copilotTimeoutPatch,
+    state: refreshedLifecycle.nextState,
+    last_head_sha: args.pr.headRefOid,
+    repeated_local_review_signature_count: args.repeatedLocalReviewSignatureCount,
+    last_error:
+      refreshedLifecycle.nextState === "blocked" && effectiveFailureContext
+        ? truncate(effectiveFailureContext.summary, 1000)
+        : localReviewRepairSummary
+          ? truncate(localReviewRepairSummary, 1000)
+          : args.record.last_error,
+    last_failure_context: effectiveFailureContext,
+    ...args.applyFailureSignature(args.record, effectiveFailureContext),
+    blocked_reason:
+      refreshedLifecycle.nextState === "blocked"
+        ? args.blockedReasonFromReviewState(
+            refreshedLifecycle.recordForState,
+            args.pr,
+            args.checks,
+            args.reviewThreads,
+          ) ??
+          ((localReviewRetryLoopStalled(
+            args.config,
+            refreshedLifecycle.recordForState,
+            args.pr,
+            args.checks,
+            args.reviewThreads,
+            args.manualReviewThreads,
+            args.configuredBotReviewThreads,
+            args.summarizeChecks,
+            args.mergeConflictDetected,
+          ) ||
+            localReviewHighSeverityNeedsBlock(args.config, refreshedLifecycle.recordForState, args.pr))
+            ? "verification"
+            : null)
+        : null,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return {
+    record: updatedRecord,
+    effectiveFailureContext,
+  };
+}
+
 export async function handlePostTurnPullRequestTransitionsPhase(
   args: HandlePostTurnPullRequestTransitionsArgs,
 ): Promise<PostTurnPullRequestResult> {
@@ -1507,7 +1609,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     await github.markPullRequestReady(refreshed.pr.number);
   }
 
-  const postReady = await loadOpenPullRequestSnapshotImpl(pr.number);
+  let postReady = await loadOpenPullRequestSnapshotImpl(pr.number);
   const currentHeadLocalReviewTracked =
     record.last_head_sha === postReady.pr.headRefOid && record.local_review_head_sha === postReady.pr.headRefOid;
   const retryLoopCandidate =
@@ -1529,82 +1631,26 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       : !ranLocalReviewThisCycle && currentHeadLocalReviewTracked
         ? 0
         : record.repeated_local_review_signature_count;
-  const refreshedLifecycle = args.derivePullRequestLifecycleSnapshot(
+  let lifecycleResult = await applyTrackedPrLifecycleState({
+    config,
+    stateStore,
+    state,
+    syncJournal,
     record,
-    postReady.pr,
-    postReady.checks,
-    postReady.reviewThreads,
-    { repeated_local_review_signature_count: repeatedLocalReviewSignatureCount },
-  );
-  const localReviewRepairSummary =
-    refreshedLifecycle.nextState === "local_review_fix"
-      ? localReviewRepairContinuationSummary(config, refreshedLifecycle.recordForState, postReady.pr)
-      : null;
-  const postReadyLocalReviewFailureContext =
-    refreshedLifecycle.nextState === "blocked" &&
-    localReviewRetryLoopStalled(
-      config,
-      refreshedLifecycle.recordForState,
-      postReady.pr,
-      postReady.checks,
-      postReady.reviewThreads,
-      args.manualReviewThreads,
-      args.configuredBotReviewThreads,
-      args.summarizeChecks,
-      args.mergeConflictDetected,
-        )
-      ? localReviewStallFailureContext(refreshedLifecycle.recordForState)
-      : refreshedLifecycle.nextState === "blocked" &&
-          localReviewHighSeverityNeedsBlock(config, refreshedLifecycle.recordForState, postReady.pr)
-        ? localReviewFailureContext(refreshedLifecycle.recordForState)
-        : refreshedLifecycle.nextState === "local_review_fix"
-          ? localReviewRepairContinuationFailureContext(config, refreshedLifecycle.recordForState, postReady.pr)
-          : null;
-  const effectiveFailureContext = refreshedLifecycle.failureContext ?? postReadyLocalReviewFailureContext;
-  record = stateStore.touch(record, {
-    pr_number: postReady.pr.number,
-    ...refreshedLifecycle.reviewWaitPatch,
-    ...refreshedLifecycle.copilotRequestObservationPatch,
-    ...refreshedLifecycle.mergeLatencyVisibilityPatch,
-    ...refreshedLifecycle.copilotTimeoutPatch,
-    state: refreshedLifecycle.nextState,
-    last_head_sha: postReady.pr.headRefOid,
-    repeated_local_review_signature_count: repeatedLocalReviewSignatureCount,
-    last_error:
-      refreshedLifecycle.nextState === "blocked" && effectiveFailureContext
-        ? truncate(effectiveFailureContext.summary, 1000)
-        : localReviewRepairSummary
-          ? truncate(localReviewRepairSummary, 1000)
-          : record.last_error,
-    last_failure_context: effectiveFailureContext,
-    ...args.applyFailureSignature(record, effectiveFailureContext),
-    blocked_reason:
-      refreshedLifecycle.nextState === "blocked"
-        ? args.blockedReasonFromReviewState(
-            refreshedLifecycle.recordForState,
-            postReady.pr,
-            postReady.checks,
-            postReady.reviewThreads,
-          ) ??
-          ((localReviewRetryLoopStalled(
-            config,
-            refreshedLifecycle.recordForState,
-            postReady.pr,
-            postReady.checks,
-            postReady.reviewThreads,
-            args.manualReviewThreads,
-            args.configuredBotReviewThreads,
-            args.summarizeChecks,
-            args.mergeConflictDetected,
-          ) ||
-            localReviewHighSeverityNeedsBlock(config, refreshedLifecycle.recordForState, postReady.pr))
-            ? "verification"
-            : null)
-        : null,
+    pr: postReady.pr,
+    checks: postReady.checks,
+    reviewThreads: postReady.reviewThreads,
+    repeatedLocalReviewSignatureCount,
+    derivePullRequestLifecycleSnapshot: args.derivePullRequestLifecycleSnapshot,
+    applyFailureSignature: args.applyFailureSignature,
+    blockedReasonFromReviewState: args.blockedReasonFromReviewState,
+    summarizeChecks: args.summarizeChecks,
+    manualReviewThreads: args.manualReviewThreads,
+    configuredBotReviewThreads: args.configuredBotReviewThreads,
+    mergeConflictDetected: args.mergeConflictDetected,
   });
-  state.issues[String(record.issue_number)] = record;
-  await stateStore.save(state);
-  await syncJournal(record);
+  record = lifecycleResult.record;
+  let effectiveFailureContext = lifecycleResult.effectiveFailureContext;
   record = await maybeCommentOnTrackedPrPersistentStatus({
     github,
     stateStore,
@@ -1619,6 +1665,59 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     failureContext: effectiveFailureContext,
     summarizeChecks: args.summarizeChecks,
   });
+  const staleReviewBotReplySignature =
+    effectiveFailureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
+  const shouldRefreshAfterReplyAndResolve =
+    config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
+    record.state === "blocked" &&
+    record.blocked_reason === "stale_review_bot" &&
+    record.last_stale_review_bot_reply_head_sha === postReady.pr.headRefOid &&
+    record.last_stale_review_bot_reply_signature === staleReviewBotReplySignature;
+  if (shouldRefreshAfterReplyAndResolve) {
+    const reconciled = await loadOpenPullRequestSnapshotImpl(postReady.pr.number);
+    if (reconciled.pr.headRefOid === postReady.pr.headRefOid) {
+      lifecycleResult = await applyTrackedPrLifecycleState({
+        config,
+        stateStore,
+        state,
+        syncJournal,
+        record,
+        pr: reconciled.pr,
+        checks: reconciled.checks,
+        reviewThreads: reconciled.reviewThreads,
+        repeatedLocalReviewSignatureCount: record.repeated_local_review_signature_count,
+        derivePullRequestLifecycleSnapshot: args.derivePullRequestLifecycleSnapshot,
+        applyFailureSignature: args.applyFailureSignature,
+        blockedReasonFromReviewState: args.blockedReasonFromReviewState,
+        summarizeChecks: args.summarizeChecks,
+        manualReviewThreads: args.manualReviewThreads,
+        configuredBotReviewThreads: args.configuredBotReviewThreads,
+        mergeConflictDetected: args.mergeConflictDetected,
+      });
+      const reconciledRecord = lifecycleResult.record;
+      const reconciledBlockedReason =
+        reconciledRecord.state === "blocked" ? reconciledRecord.blocked_reason : null;
+      if (reconciledRecord.state !== "blocked" || reconciledBlockedReason !== "stale_review_bot") {
+        postReady = reconciled;
+        record = reconciledRecord;
+        effectiveFailureContext = lifecycleResult.effectiveFailureContext;
+        record = await maybeCommentOnTrackedPrPersistentStatus({
+          github,
+          stateStore,
+          state,
+          record,
+          pr: postReady.pr,
+          checks: postReady.checks,
+          reviewThreads: postReady.reviewThreads,
+          manualReviewThreadCount: args.manualReviewThreads(config, postReady.reviewThreads).length,
+          syncJournal,
+          config,
+          failureContext: effectiveFailureContext,
+          summarizeChecks: args.summarizeChecks,
+        });
+      }
+    }
+  }
   if (
     record.state === "draft_pr"
     && reviewBotDiagnostics(

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -1095,7 +1095,12 @@ export interface HandlePostTurnPullRequestTransitionsArgs {
     Partial<
       Pick<
         GitHubClient,
-        "createIssue" | "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment" | "replyToReviewThread"
+        | "createIssue"
+        | "addIssueComment"
+        | "getExternalReviewSurface"
+        | "updateIssueComment"
+        | "replyToReviewThread"
+        | "resolveReviewThread"
       >
     >;
   context: PostTurnPullRequestContext;
@@ -1694,13 +1699,11 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         configuredBotReviewThreads: args.configuredBotReviewThreads,
         mergeConflictDetected: args.mergeConflictDetected,
       });
-      const reconciledRecord = lifecycleResult.record;
-      const reconciledBlockedReason =
-        reconciledRecord.state === "blocked" ? reconciledRecord.blocked_reason : null;
-      if (reconciledRecord.state !== "blocked" || reconciledBlockedReason !== "stale_review_bot") {
-        postReady = reconciled;
-        record = reconciledRecord;
-        effectiveFailureContext = lifecycleResult.effectiveFailureContext;
+      postReady = reconciled;
+      record = lifecycleResult.record;
+      effectiveFailureContext = lifecycleResult.effectiveFailureContext;
+      const reconciledBlockedReason = record.state === "blocked" ? record.blocked_reason : null;
+      if (record.state !== "blocked" || reconciledBlockedReason !== "stale_review_bot") {
         record = await maybeCommentOnTrackedPrPersistentStatus({
           github,
           stateStore,


### PR DESCRIPTION
Closes #1476
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the fix in `src/post-turn-pull-request.ts` and committed it as `1eeba93` (`Refresh tracked PR state after stale bot auto-resolve`).

The change does two things. First, it adds a focused regression in `src/post-turn-pull-request.test.ts` that reproduces the stale same-head `reply_and_resolve` case: unresolved configured-bot threads are auto-resolved, a fresh same-head snapshot clears them, and the tracked record must stop reporting `blocked_reason=stale_review_bot`. Second, it reuses the tracked PR lifecycle projection after successful same-head `reply_and_resolve`, so the supervisor refreshes GitHub facts, updates the persisted tracked state, and re-runs sticky status comment handling against the refreshed snapshot instead of returning the stale blocked record.

Verification passed with:
`node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads"`
`node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
`npm run build`

Summary: Reproduced and fixed same-head `reply_and_resolve` stale-review convergence so tracked PR state refreshes out of `stale_review_bot` after auto-resolution, with regression coverage added.
State hint: stabilizing
Blocked reason: no...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation for pull requests using the "reply_and_resolve" stale-review policy so PR status unblocks correctly after stale review threads are resolved.

* **Tests**
  * Added regression tests covering the reply-and-resolve flow and snapshot reconciliation to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->