### PR TITLE
Bug: same-head reply_and_resolve refresh can leave stale_review_bot status comments missing or stale (#1478)

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2522,7 +2522,7 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes tracked PR state after
   assert.equal(result.record.blocked_reason, null);
 });
 
-test("handlePostTurnPullRequestTransitionsPhase returns the reconciled snapshot even when stale_review_bot remains blocked after reply_and_resolve", async () => {
+test("handlePostTurnPullRequestTransitionsPhase refreshes the sticky stale-review status comment when same-head reply_and_resolve remains blocked on a different signature", async () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],
     staleConfiguredBotReviewPolicy: "reply_and_resolve",
@@ -2584,6 +2584,8 @@ test("handlePostTurnPullRequestTransitionsPhase returns the reconciled snapshot 
         pr_number: pr.number,
         last_head_sha: pr.headRefOid,
         blocked_reason: "stale_review_bot",
+        last_host_local_pr_blocker_comment_head_sha: pr.headRefOid,
+        last_host_local_pr_blocker_comment_signature: "stalled-bot:thread-1",
       }),
     },
   };
@@ -2608,6 +2610,7 @@ test("handlePostTurnPullRequestTransitionsPhase returns the reconciled snapshot 
     url: "https://example.test/review/118/2",
   };
   const passingChecks = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }] satisfies PullRequestCheck[];
+  const updateCalls: Array<{ commentId: number; body: string }> = [];
   let loadSnapshotCalls = 0;
 
   const result = await handlePostTurnPullRequestTransitionsPhase({
@@ -2616,6 +2619,30 @@ test("handlePostTurnPullRequestTransitionsPhase returns the reconciled snapshot 
     github: createDefaultGithub({
       addIssueComment: async () => {
         throw new Error("unexpected addIssueComment call");
+      },
+      getExternalReviewSurface: async () => ({
+        reviews: [],
+        issueComments: [
+          {
+            id: "comment-118",
+            databaseId: 118,
+            body: [
+              "Tracked PR head `head-118` remains blocked on stale configured-bot review state.",
+              "",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=118 kind=status -->",
+            ].join("\n"),
+            createdAt: "2026-03-13T02:08:00Z",
+            url: "https://example.test/comments/118",
+            viewerDidAuthor: true,
+            author: {
+              login: "codex-supervisor[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      }),
+      updateIssueComment: async (commentId: number, body: string) => {
+        updateCalls.push({ commentId, body });
       },
       replyToReviewThread: async () => undefined,
       resolveReviewThread: async () => undefined,
@@ -2673,6 +2700,12 @@ test("handlePostTurnPullRequestTransitionsPhase returns the reconciled snapshot 
   assert.equal(result.record.blocked_reason, "stale_review_bot");
   assert.equal(result.record.last_failure_signature, "stalled-bot:thread-2");
   assert.equal(result.record.last_failure_context?.url, "https://example.test/review/118/2");
+  assert.equal(result.record.last_host_local_pr_blocker_comment_signature, "stalled-bot:thread-2");
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0]?.commentId, 118);
+  assert.match(updateCalls[0]?.body ?? "", /reason code: `stale_review_bot`/i);
+  assert.match(updateCalls[0]?.body ?? "", /src\/review-b\.ts line=84/i);
+  assert.match(updateCalls[0]?.body ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=118 kind=status -->/);
   assert.deepEqual(
     result.reviewThreads.map((thread) => thread.id),
     ["thread-2"],

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -819,6 +819,7 @@ async function maybeCommentOnTrackedPrPersistentStatus(args: {
   config: SupervisorConfig;
   failureContext: FailureContext | null;
   summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  skipAutoHandleStaleConfiguredBotReview?: boolean;
 }): Promise<IssueRunRecord> {
   const comment = derivePersistentTrackedPrStatusComment({
     config: args.config,
@@ -831,6 +832,7 @@ async function maybeCommentOnTrackedPrPersistentStatus(args: {
   });
 
   const canAutoHandleStaleConfiguredBotReview =
+    !args.skipAutoHandleStaleConfiguredBotReview &&
     args.record.state === "blocked" &&
     args.record.blocked_reason === "stale_review_bot" &&
     comment &&
@@ -1703,7 +1705,12 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       record = lifecycleResult.record;
       effectiveFailureContext = lifecycleResult.effectiveFailureContext;
       const reconciledBlockedReason = record.state === "blocked" ? record.blocked_reason : null;
-      if (record.state !== "blocked" || reconciledBlockedReason !== "stale_review_bot") {
+      if (
+        record.state !== "blocked"
+        || reconciledBlockedReason !== "stale_review_bot"
+        || record.last_host_local_pr_blocker_comment_signature
+          !== (effectiveFailureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT)
+      ) {
         record = await maybeCommentOnTrackedPrPersistentStatus({
           github,
           stateStore,
@@ -1717,6 +1724,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           config,
           failureContext: effectiveFailureContext,
           summarizeChecks: args.summarizeChecks,
+          skipAutoHandleStaleConfiguredBotReview: true,
         });
       }
     }


### PR DESCRIPTION
Closes #1478
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the focused fix for #1478 in commit `919d053` (`Refresh stale-review sticky comment after reconcile`).

The change does two things: it adds a regression covering same-head `reply_and_resolve` when the reconciled `stale_review_bot` signature changes, and it updates the post-reconcile path in [src/post-turn-pull-request.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1478/src/post-turn-pull-request.ts) so the sticky tracked-PR status comment is refreshed for the new blocker without recursively auto-replying again in that refresh pass. The regression lives in [src/post-turn-pull-request.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1478/src/post-turn-pull-request.test.ts). I also updated the local issue journal as requested; that file is gitignored, so it remains a local supervisor artifact rather than part of the commit.

Summary: Fixed same-head `reply_and_resolve` reconciliation so changed `stale_review_bot` signatures refresh the persistent tracked-PR status comment; added a focused regression and committed the code as `919d053`.
State hint: draft_pr
Blocked reason: none
Tests: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "reply_and_resolve"`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for commit `919d053` and continue normal review flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of status comment refresh behavior when PR blocking reasons change, preventing unnecessary re-publication of status comments when the failure signature remains unchanged.
  * Fixed potential duplicate automated actions during status comment reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->