### PR TITLE
Bug: latest main still leaves tracked PR #435 blocked as stale_review_bot after run-once despite ready_to_merge GitHub facts (#1480)

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -14,7 +14,7 @@ import {
   isOpenPullRequest,
 } from "./supervisor/supervisor-lifecycle";
 import { inferFailureContext } from "./supervisor/supervisor-failure-context";
-import { shouldAutoRecoverStaleReviewBot } from "./supervisor/supervisor-execution-policy";
+import { shouldReconcileTrackedPrStaleReviewBot } from "./supervisor/supervisor-execution-policy";
 import {
   findHighRiskBlockingAmbiguity,
   findParentIssuesReadyToClose,
@@ -1026,7 +1026,7 @@ export async function reconcileRecoverableBlockedIssueStates(
         record.blocked_reason === null ||
         record.blocked_reason === "manual_review" ||
         record.blocked_reason === "verification" ||
-        shouldAutoRecoverStaleReviewBot(record, config)
+        shouldReconcileTrackedPrStaleReviewBot(record, config)
       )
     ) {
       const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -9,6 +9,7 @@ import {
   isEligibleForSelection,
   isVerificationBlockedMessage,
   shouldAutoRecoverStaleReviewBot,
+  shouldReconcileTrackedPrStaleReviewBot,
   shouldAutoRetryBlockedVerification,
   shouldAutoRetryHandoffMissing,
   shouldEnforceExecutionReady,
@@ -395,4 +396,31 @@ test("shouldAutoRecoverStaleReviewBot suppresses stale configured-bot recovery a
   }), createConfig({
     staleConfiguredBotReviewPolicy: "reply_only",
   })), true);
+});
+
+test("shouldReconcileTrackedPrStaleReviewBot keeps same-head stale configured-bot records eligible for fresh GitHub reprojection", () => {
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "stale_review_bot",
+    pr_number: 44,
+    last_head_sha: "head-44",
+    last_failure_signature: "stalled-bot:thread-1",
+    last_stale_review_bot_reply_head_sha: "head-44",
+    last_stale_review_bot_reply_signature: "stalled-bot:thread-1",
+  });
+
+  assert.equal(
+    shouldReconcileTrackedPrStaleReviewBot(record, createConfig({ staleConfiguredBotReviewPolicy: "reply_and_resolve" })),
+    true,
+  );
+  assert.equal(
+    shouldReconcileTrackedPrStaleReviewBot(record, createConfig({ staleConfiguredBotReviewPolicy: "diagnose_only" })),
+    false,
+  );
+  assert.equal(
+    shouldReconcileTrackedPrStaleReviewBot(createRecord({ ...record, pr_number: null }), createConfig({
+      staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    })),
+    false,
+  );
 });

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -75,6 +75,13 @@ function staleReviewBotRecoverySignature(record: Pick<IssueRunRecord, "last_fail
   return record.last_failure_signature ?? "stale_review_bot";
 }
 
+function hasStaleReviewBotRecoveryPolicy(config: SupervisorConfig): boolean {
+  return (
+    config.staleConfiguredBotReviewPolicy === "reply_only" ||
+    config.staleConfiguredBotReviewPolicy === "reply_and_resolve"
+  );
+}
+
 function canAutoRecoverCurrentStaleReviewBotHead(
   record: Pick<
     IssueRunRecord,
@@ -96,13 +103,15 @@ function canAutoRecoverCurrentStaleReviewBotHead(
 }
 
 export function shouldAutoRecoverStaleReviewBot(record: IssueRunRecord, config: SupervisorConfig): boolean {
+  return shouldReconcileTrackedPrStaleReviewBot(record, config) && canAutoRecoverCurrentStaleReviewBotHead(record);
+}
+
+export function shouldReconcileTrackedPrStaleReviewBot(record: IssueRunRecord, config: SupervisorConfig): boolean {
   return (
     record.state === "blocked" &&
     record.blocked_reason === "stale_review_bot" &&
     record.pr_number !== null &&
-    canAutoRecoverCurrentStaleReviewBotHead(record) &&
-    (config.staleConfiguredBotReviewPolicy === "reply_only" ||
-      config.staleConfiguredBotReviewPolicy === "reply_and_resolve")
+    hasStaleReviewBotRecoveryPolicy(config)
   );
 }
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2136,6 +2136,128 @@ test("reconcileRecoverableBlockedIssueStates resumes tracked PR stale configured
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileRecoverableBlockedIssueStates rehydrates same-head stale configured-bot blockers to ready_to_merge after the current head was already auto-handled", async () => {
+  const config = createConfig({
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createTrackedPrStaleReviewRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        local_review_head_sha: "head-191",
+        local_review_summary_path: "/tmp/reviews/issue-366/head-191.md",
+        last_error: "Configured bot review stayed stale on the current head.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "blocked",
+          summary: "Configured bot review stayed stale on the current head.",
+          signature: "stale-configured-bot-review",
+          command: null,
+          details: ["tracked_pr=head-191"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "stale-configured-bot-review",
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Local CI passed on the current head.",
+          ran_at: "2026-03-13T00:22:00Z",
+          head_sha: "head-191",
+          execution_mode: "shell",
+          failure_class: null,
+          remediation_target: null,
+        },
+        external_review_head_sha: "head-191",
+        external_review_misses_path: "/tmp/reviews/issue-366/head-191-misses.json",
+        review_follow_up_head_sha: "head-191",
+        last_host_local_pr_blocker_comment_head_sha: "head-191",
+        processed_review_thread_ids: ["thread-1", "thread-1@head-191"],
+        processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+        last_stale_review_bot_reply_head_sha: "head-191",
+        last_stale_review_bot_reply_signature: "stale-configured-bot-review",
+        stale_review_bot_reply_progress_keys: ["reply:thread-1@head-191"],
+        stale_review_bot_resolve_progress_keys: ["resolve:thread-1@head-191"],
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    isDraft: false,
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "ready_to_merge",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "ready_to_merge");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.last_stale_review_bot_reply_head_sha, "head-191");
+  assert.equal(updated.last_stale_review_bot_reply_signature, "stale-configured-bot-review");
+  assert.deepEqual(updated.stale_review_bot_reply_progress_keys, ["reply:thread-1@head-191"]);
+  assert.deepEqual(updated.stale_review_bot_resolve_progress_keys, ["resolve:thread-1@head-191"]);
+  assert.equal(
+    updated.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to ready_to_merge using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to ready_to_merge using fresh tracked PR #191 facts at head head-191",
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates clears stale head-scoped review state after a tracked PR repair push", async () => {
   const config = createConfig({
     localReviewEnabled: true,


### PR DESCRIPTION
Closes #1480
This PR was opened by codex-supervisor.
Latest Codex summary:

Separated stale configured-bot handling into two paths. `shouldAutoRecoverStaleReviewBot(...)` still suppresses duplicate same-head reply/resolve work, while new `shouldReconcileTrackedPrStaleReviewBot(...)` keeps `blocked/stale_review_bot` tracked PRs eligible for fresh reconciliation. `reconcileRecoverableBlockedIssueStates(...)` now uses the reconciliation-specific gate, so a same-head record that was already auto-handled can still reproject to `ready_to_merge` when live GitHub facts have converged.

I added focused regressions in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1480/src/supervisor/supervisor-recovery-reconciliation.test.ts) and [src/supervisor/supervisor-execution-policy.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1480/src/supervisor/supervisor-execution-policy.test.ts) to cover the same-head `stale_review_bot -> ready_to_merge` recovery case and to prove duplicate auto-handle suppression still holds. The code change is in [src/recovery-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1480/src/recovery-reconciliation.ts) and [src/supervisor/supervisor-execution-policy.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1480/src/supervisor/supervisor-execution-policy.ts). I also committed the fix as `5ac606b` with message `Fix stale review bot tracked PR recovery`.

Summary: Spl...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced recovery logic for PRs blocked by stale ReviewBot states. The system now better reconciles tracked PRs with configurable recovery policies (reply_only, reply_and_resolve, diagnose_only), enabling automatic state transitions and recovery when conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->