### PR TITLE
Bug: degraded tracked-PR recovery still suppresses same-head stale_review_bot reconciliation (#1482)

### DIFF
--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import { GitHubIssue, SupervisorStateFile } from "./core/types";
 import { GitHubInventoryRefreshError } from "./github";
 import { RecoveryEvent, runOnceCyclePrelude } from "./run-once-cycle-prelude";
-import { createRecord } from "./supervisor/supervisor-test-helpers";
+import {
+  shouldAutoRecoverStaleReviewBot,
+  shouldReconcileTrackedPrStaleReviewBot,
+} from "./supervisor/supervisor-execution-policy";
+import { createConfig, createRecord } from "./supervisor/supervisor-test-helpers";
 
 test("runOnceCyclePrelude loads state and aggregates recovery setup events in order", async () => {
   const state: SupervisorStateFile = {
@@ -1520,7 +1524,8 @@ test("runOnceCyclePrelude rehydrates blocked tracked PRs during degraded invento
   assert.equal(result.state.issues["77"]?.last_failure_signature, null);
 });
 
-test("runOnceCyclePrelude rehydrates auto-recoverable stale review bot tracked PRs during degraded inventory refresh", async () => {
+test("runOnceCyclePrelude rehydrates same-head stale review bot tracked PRs during degraded inventory refresh even after auto-handle dedupe is recorded", async () => {
+  const config = createConfig({ staleConfiguredBotReviewPolicy: "reply_and_resolve" });
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
     issues: {
@@ -1531,6 +1536,8 @@ test("runOnceCyclePrelude rehydrates auto-recoverable stale review bot tracked P
         blocked_reason: "stale_review_bot",
         last_head_sha: "head-170",
         last_failure_signature: "stale-configured-bot-review",
+        last_stale_review_bot_reply_head_sha: "head-170",
+        last_stale_review_bot_reply_signature: "stale-configured-bot-review",
       }),
     },
   };
@@ -1540,6 +1547,9 @@ test("runOnceCyclePrelude rehydrates auto-recoverable stale review bot tracked P
     options?: { onlyTrackedPrStates?: boolean };
   }> = [];
 
+  assert.equal(shouldAutoRecoverStaleReviewBot(state.issues["77"]!, config), false);
+  assert.equal(shouldReconcileTrackedPrStaleReviewBot(state.issues["77"]!, config), true);
+
   const result = await runOnceCyclePrelude({
     stateStore: {
       load: async () => state,
@@ -1547,7 +1557,7 @@ test("runOnceCyclePrelude rehydrates auto-recoverable stale review bot tracked P
     },
     carryoverRecoveryEvents: [],
     shouldReconcileTrackedBlockedRecordDuringDegradedContinuation: (record) =>
-      record.issue_number === 77,
+      shouldReconcileTrackedPrStaleReviewBot(record, config),
     reconcileStaleActiveIssueReservation: async () => [],
     handleAuthFailure: async () => null,
     listAllIssues: async () => {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -93,6 +93,7 @@ import {
   incrementAttemptCounters,
   isVerificationBlockedMessage,
   shouldAutoRecoverStaleReviewBot,
+  shouldReconcileTrackedPrStaleReviewBot,
   shouldAutoRetryBlockedVerification,
   shouldAutoRetryHandoffMissing,
 } from "./supervisor-execution-policy";
@@ -1039,7 +1040,7 @@ export class Supervisor {
       carryoverRecoveryEvents,
       emitEvent: this.onEvent,
       shouldReconcileTrackedBlockedRecordDuringDegradedContinuation: (record) =>
-        shouldAutoRecoverStaleReviewBot(record, this.config),
+        shouldReconcileTrackedPrStaleReviewBot(record, this.config),
       setReconciliationPhase: (phase) =>
         phase === null
           ? clearCurrentReconciliationPhase(this.config)


### PR DESCRIPTION
Closes #1482
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed the degraded continuation wiring so tracked PR reconciliation uses `shouldReconcileTrackedPrStaleReviewBot` instead of the stricter auto-handle predicate. That preserves same-head/signature stale-review dedupe for replies/resolves, but no longer suppresses fresh lifecycle reprojection during degraded recovery. I also tightened `src/run-once-cycle-prelude.test.ts` with a focused regression that proves the same record is ineligible for auto-handle reopening while still eligible for degraded reconciliation.

Verified with the targeted tests and a full build, then committed the code change as `cb45a5f` (`Fix degraded stale-review reconciliation gating`). I also updated the issue journal working notes. The only remaining untracked files are supervisor-local artifacts under `.codex-supervisor/`, which I left alone.

Summary: Fixed degraded stale-review reconciliation gating, added a focused same-head regression, verified with targeted tests and `npm run build`, and committed as `cb45a5f`.
State hint: draft_pr
Blocked reason: none
Tests: `node --test --import tsx src/run-once-cycle-prelude.test.ts --test-name-pattern "degraded continuation|stale review"`; `node --test --import tsx src/supervisor/supervisor-execution-policy.test.ts --test-name-pattern "stale configured-bot"`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR from `codex/issue-1482` so the verified checkpoint can enter review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test scenarios for stale review bot pull request handling and reconciliation.

* **Chores**
  * Refactored reconciliation logic for pull request handling during degraded continuation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->