### PR TITLE
Fix reviewThreads JSON truncation during tracked PR reconciliation

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,32 +5,44 @@
 - Branch: codex/issue-1485
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: d3b1ae7e27271c1175a1b4dfb66706d97a3d4487
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 8b509669717bb2359f4aad8f7d23341fb2d111f5
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-13T16:55:38.364Z
+- Last failure signature: PRRT_kwDORgvdZ856mORL
+- Repeated failure signature count: 1
+- Updated at: 2026-04-13T17:11:14.627Z
 
 ## Latest Codex Summary
-- Added focused regressions proving large GraphQL JSON payloads were being locally truncated before JSON parsing in both `reviewThreads` reconciliation and the sibling PR hydrator path.
-- Routed machine-readable GitHub JSON calls in `GitHubReviewSurfaceClient` and `GitHubPullRequestHydrator` through unbounded stdout capture while leaving the command runner default bounded capture unchanged.
-- Verified with focused GitHub tests, command-runner tests, and a full TypeScript build.
-- Committed as `4d7f95a` on `codex/issue-1485`, pushed the branch, and opened draft PR #1487.
+Protected the tracked-PR GitHub JSON fetch paths from local stdout truncation by routing machine-readable `gh` calls through `stdoutCaptureLimitBytes: null` in [github-review-surface.ts](src/github/github-review-surface.ts) and [github-pull-request-hydrator.ts](src/github/github-pull-request-hydrator.ts). That covers the reported `reviewThreads` failure and the sibling PR hydrator GraphQL surface that was exposed to the same 64KB truncation risk.
+
+I added focused regressions in [github.test.ts](src/github/github.test.ts) and [github-pull-request-hydrator.test.ts](src/github/github-pull-request-hydrator.test.ts) that simulate a valid payload larger than the default capture limit and prove the pre-fix truncation behavior. The default bounded stdout behavior in `runCommand` is unchanged, and [command.test.ts](src/core/command.test.ts) still passes.
+
+Committed and pushed on `codex/issue-1485` as `4d7f95a` and `8b50966`. Draft PR is open at https://github.com/TommyKammy/codex-supervisor/pull/1487. The worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/`, which I left untouched.
+
+Summary: Fixed large GraphQL JSON truncation for tracked PR reconciliation, added targeted regressions, pushed branch, and opened draft PR #1487.
+State hint: draft_pr
+Blocked reason: none
+Tests: `node --test --import tsx src/github/github.test.ts`; `node --test --import tsx src/github/github-pull-request-hydrator.test.ts`; `node --test --import tsx src/core/command.test.ts`; `npm run build`
+Next action: Wait for CI on draft PR #1487 and address any reported failures or review feedback.
+Failure signature: PRRT_kwDORgvdZ856mORL
 
 ## Active Failure Context
-- Reproduced pre-fix failure as `reviewthreads-json-truncated-64kb` with: `Failed to parse JSON from gh api graphql reviewThreads pr=443: Bad control character in string literal in JSON at position 32766`.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074602547
+- Details:
+  - src/github/github-review-surface.ts:43 summary=_⚠️ Potential issue_ | _🟠 Major_ **Forwarded options are currently dropped before reaching the hydrator.** `runGhJsonCommand` is correct, but `GitHubPullRequestHydrator` is con... url=https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074602547
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: tracked PR reconciliation was parsing bounded stdout from `gh` as if it were complete JSON; any GraphQL review payload above 64KB would be truncated locally and crash parse.
-- What changed: added large-payload regressions; introduced `runGhJsonCommand(..., { stdoutCaptureLimitBytes: null })` helpers in `src/github/github-review-surface.ts` and `src/github/github-pull-request-hydrator.ts`; moved structural JSON fetches in those files to the unbounded path.
+- Hypothesis: the remaining review thread was valid; `GitHubReviewSurfaceClient` constructed `GitHubPullRequestHydrator` with an adapter that dropped `CommandOptions`, so the hydrator's `stdoutCaptureLimitBytes: null` override never reached `runGhCommand` on the status hydration path.
+- What changed: forwarded `CommandOptions` through the review-surface hydrator adapter in `src/github/github-review-surface.ts` and added a `GitHubClient` regression in `src/github/github.test.ts` that proves `findOpenPullRequest(..., { purpose: "status" })` can hydrate a >64KB GraphQL review summary payload without truncation.
 - Current blocker: none.
-- Next exact step: monitor draft PR #1487 and address CI or review feedback if it appears.
-- Verification gap: none for the requested local scope; GitHub CI has not reported yet in this turn.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-review-surface.ts`, `src/github/github-pull-request-hydrator.ts`, `src/github/github.test.ts`, `src/github/github-pull-request-hydrator.test.ts`.
+- Next exact step: commit and push the review fix to `codex/issue-1485`, then refresh PR #1487 for re-review.
+- Verification gap: none for the local scope after `node --test --import tsx src/github/github.test.ts`, `node --test --import tsx src/github/github-pull-request-hydrator.test.ts`, and `npm run build` passed.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-review-surface.ts`, `src/github/github.test.ts`.
 - Rollback concern: low; scope is limited to machine-readable GitHub JSON callers and preserves bounded capture for human-oriented command output.
-- Last focused command: `gh pr create --repo TommyKammy/codex-supervisor --base main --head codex/issue-1485 --draft ...`
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -17,6 +17,7 @@
 - Added focused regressions proving large GraphQL JSON payloads were being locally truncated before JSON parsing in both `reviewThreads` reconciliation and the sibling PR hydrator path.
 - Routed machine-readable GitHub JSON calls in `GitHubReviewSurfaceClient` and `GitHubPullRequestHydrator` through unbounded stdout capture while leaving the command runner default bounded capture unchanged.
 - Verified with focused GitHub tests, command-runner tests, and a full TypeScript build.
+- Committed as `4d7f95a` on `codex/issue-1485`, pushed the branch, and opened draft PR #1487.
 
 ## Active Failure Context
 - Reproduced pre-fix failure as `reviewthreads-json-truncated-64kb` with: `Failed to parse JSON from gh api graphql reviewThreads pr=443: Bad control character in string literal in JSON at position 32766`.
@@ -26,10 +27,10 @@
 - Hypothesis: tracked PR reconciliation was parsing bounded stdout from `gh` as if it were complete JSON; any GraphQL review payload above 64KB would be truncated locally and crash parse.
 - What changed: added large-payload regressions; introduced `runGhJsonCommand(..., { stdoutCaptureLimitBytes: null })` helpers in `src/github/github-review-surface.ts` and `src/github/github-pull-request-hydrator.ts`; moved structural JSON fetches in those files to the unbounded path.
 - Current blocker: none.
-- Next exact step: commit the fix and, if branch policy still expects early publication, open a draft PR from `codex/issue-1485`.
-- Verification gap: none for the requested local scope; CI has not run yet.
+- Next exact step: monitor draft PR #1487 and address CI or review feedback if it appears.
+- Verification gap: none for the requested local scope; GitHub CI has not reported yet in this turn.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-review-surface.ts`, `src/github/github-pull-request-hydrator.ts`, `src/github/github.test.ts`, `src/github/github-pull-request-hydrator.test.ts`.
 - Rollback concern: low; scope is limited to machine-readable GitHub JSON callers and preserves bounded capture for human-oriented command output.
-- Last focused command: `npm run build`
+- Last focused command: `gh pr create --repo TommyKammy/codex-supervisor --base main --head codex/issue-1485 --draft ...`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,55 +1,35 @@
-# Issue #1476: Bug: reply_and_resolve can resolve stale configured-bot threads but leave tracked PR blocked as stale_review_bot
+# Issue #1485: Bug: reviewThreads GraphQL surface can be truncated at 64KB and crash tracked PR reconciliation
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1476
-- Branch: codex/issue-1476
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1485
+- Branch: codex/issue-1485
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 1eeba93624afb2f8c5c476fc9fc88087b5e3da21
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d3b1ae7e27271c1175a1b4dfb66706d97a3d4487
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856etYm|PRRT_kwDORgvdZ856etY6
-- Repeated failure signature count: 1
-- Updated at: 2026-04-13T09:21:48.563Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T16:55:38.364Z
 
 ## Latest Codex Summary
-Implemented the fix in `src/post-turn-pull-request.ts` and committed it as `1eeba93` (`Refresh tracked PR state after stale bot auto-resolve`).
-
-The change does two things. First, it adds a focused regression in `src/post-turn-pull-request.test.ts` that reproduces the stale same-head `reply_and_resolve` case: unresolved configured-bot threads are auto-resolved, a fresh same-head snapshot clears them, and the tracked record must stop reporting `blocked_reason=stale_review_bot`. Second, it reuses the tracked PR lifecycle projection after successful same-head `reply_and_resolve`, so the supervisor refreshes GitHub facts, updates the persisted tracked state, and re-runs sticky status comment handling against the refreshed snapshot instead of returning the stale blocked record.
-
-Verification passed with:
-`node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads"`
-`node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
-`npm run build`
-
-Summary: Reproduced and fixed same-head `reply_and_resolve` stale-review convergence so tracked PR state refreshes out of `stale_review_bot` after auto-resolution, with regression coverage added.
-State hint: stabilizing
-Blocked reason: none
-Tests: Focused post-turn reproducer; requested 5-file node test suite; `npm run build`
-Next action: Push `codex/issue-1476` and open or update the draft PR if needed.
-Failure signature: PRRT_kwDORgvdZ856etYm|PRRT_kwDORgvdZ856etY6
+- Added focused regressions proving large GraphQL JSON payloads were being locally truncated before JSON parsing in both `reviewThreads` reconciliation and the sibling PR hydrator path.
+- Routed machine-readable GitHub JSON calls in `GitHubReviewSurfaceClient` and `GitHubPullRequestHydrator` through unbounded stdout capture while leaving the command runner default bounded capture unchanged.
+- Verified with focused GitHub tests, command-runner tests, and a full TypeScript build.
 
 ## Active Failure Context
-- Category: review
-- Summary: 2 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1477#discussion_r3071996214
-- Details:
-  - src/post-turn-pull-request.ts:1719 summary=_⚠️ Potential issue_ | _🟡 Minor_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 1047 --- 🏁 Script executed: Repository: TommyK... url=https://github.com/TommyKammy/codex-supervisor/pull/1477#discussion_r3071996214
-  - src/post-turn-pull-request.ts:1718 summary=_⚠️ Potential issue_ | _🟠 Major_ **Always propagate the reconciled snapshot after the extra load.** `applyTrackedPrLifecycleState()` has already persisted `reconciledRecord`, b... url=https://github.com/TommyKammy/codex-supervisor/pull/1477#discussion_r3071996239
+- Reproduced pre-fix failure as `reviewthreads-json-truncated-64kb` with: `Failed to parse JSON from gh api graphql reviewThreads pr=443: Bad control character in string literal in JSON at position 32766`.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the review feedback was correct on two points: the exported handler args still omitted `github.resolveReviewThread`, and the same-head `reply_and_resolve` refresh path only propagated `postReady` and `record` when the stale-review blocker cleared, so callers could observe a pre-refresh record even after `applyTrackedPrLifecycleState()` persisted newer blocked-state facts.
-- What changed: added `resolveReviewThread` to `HandlePostTurnPullRequestTransitionsArgs["github"]`; updated the same-head `shouldRefreshAfterReplyAndResolve` branch in `src/post-turn-pull-request.ts` to always assign the reconciled snapshot and refreshed record before conditionally re-running persistent-status commenting; added a regression in `src/post-turn-pull-request.test.ts` that keeps the PR blocked on a different stale configured-bot thread after refresh and asserts the returned record and review-thread snapshot match the reconciled state.
+- Hypothesis: tracked PR reconciliation was parsing bounded stdout from `gh` as if it were complete JSON; any GraphQL review payload above 64KB would be truncated locally and crash parse.
+- What changed: added large-payload regressions; introduced `runGhJsonCommand(..., { stdoutCaptureLimitBytes: null })` helpers in `src/github/github-review-surface.ts` and `src/github/github-pull-request-hydrator.ts`; moved structural JSON fetches in those files to the unbounded path.
 - Current blocker: none.
-- Next exact step: commit the review-thread fixes on `codex/issue-1476` and update PR #1477.
-- Verification gap: none for the requested local scope; targeted suite and build are green.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/post-turn-pull-request.ts`, `src/post-turn-pull-request.test.ts`.
-- Rollback concern: low to moderate; the reconciled snapshot is now always returned for same-head `reply_and_resolve` refreshes, so future edits in this area should avoid coupling return-value freshness to whether the blocker clears.
-- Last focused command: `node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
+- Next exact step: commit the fix and, if branch policy still expects early publication, open a draft PR from `codex/issue-1485`.
+- Verification gap: none for the requested local scope; CI has not run yet.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-review-surface.ts`, `src/github/github-pull-request-hydrator.ts`, `src/github/github.test.ts`, `src/github/github-pull-request-hydrator.test.ts`.
+- Rollback concern: low; scope is limited to machine-readable GitHub JSON callers and preserves bounded capture for human-oriented command output.
+- Last focused command: `npm run build`
 ### Scratchpad
-- Reproducer command: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "refreshes tracked PR state after reply_and_resolve clears stale configured-bot threads"`
-- Targeted verification: `node --test --import tsx src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
-- Review-fix verification: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "reply_and_resolve"` and `npm run build`
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -6,43 +6,41 @@
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 8b509669717bb2359f4aad8f7d23341fb2d111f5
+- Attempt count: 3 (implementation=1, repair=2)
+- Last head SHA: 258a449526b1dcc6dd3ddd59c32c65dc6a80dfbf
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856mORL
+- Last failure signature: PRRT_kwDORgvdZ856mV3T
 - Repeated failure signature count: 1
-- Updated at: 2026-04-13T17:11:14.627Z
+- Updated at: 2026-04-13T17:19:14.000Z
 
 ## Latest Codex Summary
-Protected the tracked-PR GitHub JSON fetch paths from local stdout truncation by routing machine-readable `gh` calls through `stdoutCaptureLimitBytes: null` in [github-review-surface.ts](src/github/github-review-surface.ts) and [github-pull-request-hydrator.ts](src/github/github-pull-request-hydrator.ts). That covers the reported `reviewThreads` failure and the sibling PR hydrator GraphQL surface that was exposed to the same 64KB truncation risk.
+No further code changes were needed. I verified the remaining CodeRabbit thread on PR `#1487` still pointed at stale journal text, then aligned the `Current Handoff` note so it no longer says to commit and push after `258a449` was already pushed.
 
-I added focused regressions in [github.test.ts](src/github/github.test.ts) and [github-pull-request-hydrator.test.ts](src/github/github-pull-request-hydrator.test.ts) that simulate a valid payload larger than the default capture limit and prove the pre-fix truncation behavior. The default bounded stdout behavior in `runCommand` is unchanged, and [command.test.ts](src/core/command.test.ts) still passes.
+The underlying tracked-PR reconciliation fix remains the previously pushed code change in `258a449`. This turn only updates `.codex-supervisor/issue-journal.md` so the supervisor handoff matches the live PR state and points the next loop at CI/re-review instead of another nonexistent local commit.
 
-Committed and pushed on `codex/issue-1485` as `4d7f95a` and `8b50966`. Draft PR is open at https://github.com/TommyKammy/codex-supervisor/pull/1487. The worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/`, which I left untouched.
-
-Summary: Fixed large GraphQL JSON truncation for tracked PR reconciliation, added targeted regressions, pushed branch, and opened draft PR #1487.
-State hint: draft_pr
+Summary: Aligned the issue journal handoff with the already-pushed PR state so the remaining review thread is addressed without changing code behavior.
+State hint: addressing_review
 Blocked reason: none
-Tests: `node --test --import tsx src/github/github.test.ts`; `node --test --import tsx src/github/github-pull-request-hydrator.test.ts`; `node --test --import tsx src/core/command.test.ts`; `npm run build`
-Next action: Wait for CI on draft PR #1487 and address any reported failures or review feedback.
-Failure signature: PRRT_kwDORgvdZ856mORL
+Tests: not rerun; journal-only review fix
+Next action: push the journal update to `codex/issue-1485`, then wait for PR #1487 CI/re-review and resolve the thread if GitHub does not auto-clear it.
+Failure signature: PRRT_kwDORgvdZ856mV3T
 
 ## Active Failure Context
 - Category: review
 - Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074602547
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074644785
 - Details:
-  - src/github/github-review-surface.ts:43 summary=_⚠️ Potential issue_ | _🟠 Major_ **Forwarded options are currently dropped before reaching the hydrator.** `runGhJsonCommand` is correct, but `GitHubPullRequestHydrator` is con... url=https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074602547
+  - .codex-supervisor/issue-journal.md:27 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Align the “next exact step” note with the already-pushed state.** The journal says commits are already pushed (Line 21) and to wait for CI (L... url=https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074644785
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the remaining review thread was valid; `GitHubReviewSurfaceClient` constructed `GitHubPullRequestHydrator` with an adapter that dropped `CommandOptions`, so the hydrator's `stdoutCaptureLimitBytes: null` override never reached `runGhCommand` on the status hydration path.
-- What changed: forwarded `CommandOptions` through the review-surface hydrator adapter in `src/github/github-review-surface.ts` and added a `GitHubClient` regression in `src/github/github.test.ts` that proves `findOpenPullRequest(..., { purpose: "status" })` can hydrate a >64KB GraphQL review summary payload without truncation.
+- Hypothesis: the remaining review thread was valid because the journal handoff still said to commit and push even though `258a449` was already on PR `#1487`.
+- What changed: updated the `Next exact step` note in `.codex-supervisor/issue-journal.md` to reflect the already-pushed state and direct the next loop to CI/re-review instead of another local commit.
 - Current blocker: none.
-- Next exact step: commit and push the review fix to `codex/issue-1485`, then refresh PR #1487 for re-review.
-- Verification gap: none for the local scope after `node --test --import tsx src/github/github.test.ts`, `node --test --import tsx src/github/github-pull-request-hydrator.test.ts`, and `npm run build` passed.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/github/github-review-surface.ts`, `src/github/github.test.ts`.
-- Rollback concern: low; scope is limited to machine-readable GitHub JSON callers and preserves bounded capture for human-oriented command output.
-- Last focused command: `npm run build`
+- Next exact step: monitor CI for PR #1487 and address any failing checks or new review feedback.
+- Verification gap: none; this turn only updates supervisor-facing journal text.
+- Files touched: `.codex-supervisor/issue-journal.md`.
+- Rollback concern: low; docs-only journal alignment for review-thread handling.
+- Last focused command: `gh pr view 1487 --json number,state,isDraft,reviewDecision,mergeStateStatus,headRefName,baseRefName,comments,reviews`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- 2026-04-13: Verified PR #1487 still has the single CodeRabbit journal thread open, confirmed the live journal still said "commit and push", then aligned the handoff text before pushing a journal-only follow-up.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -11,18 +11,18 @@
 - Blocked reason: none
 - Last failure signature: PRRT_kwDORgvdZ856mV3T
 - Repeated failure signature count: 1
-- Updated at: 2026-04-13T17:19:14.000Z
+- Updated at: 2026-04-13T17:20:27.000Z
 
 ## Latest Codex Summary
 No further code changes were needed. I verified the remaining CodeRabbit thread on PR `#1487` still pointed at stale journal text, then aligned the `Current Handoff` note so it no longer says to commit and push after `258a449` was already pushed.
 
-The underlying tracked-PR reconciliation fix remains the previously pushed code change in `258a449`. This turn only updates `.codex-supervisor/issue-journal.md` so the supervisor handoff matches the live PR state and points the next loop at CI/re-review instead of another nonexistent local commit.
+The underlying tracked-PR reconciliation fix remains the previously pushed code change in `258a449`. This turn only updates `.codex-supervisor/issue-journal.md` and pushes a journal-only follow-up so the supervisor handoff matches the live PR state and points the next loop at CI/re-review instead of another nonexistent local commit.
 
-Summary: Aligned the issue journal handoff with the already-pushed PR state so the remaining review thread is addressed without changing code behavior.
+Summary: Aligned the issue journal handoff with the already-pushed PR state and pushed a journal-only follow-up for the remaining review thread.
 State hint: addressing_review
 Blocked reason: none
 Tests: not rerun; journal-only review fix
-Next action: push the journal update to `codex/issue-1485`, then wait for PR #1487 CI/re-review and resolve the thread if GitHub does not auto-clear it.
+Next action: wait for PR #1487 CI/re-review and resolve the remaining thread if GitHub does not auto-clear it.
 Failure signature: PRRT_kwDORgvdZ856mV3T
 
 ## Active Failure Context
@@ -35,7 +35,7 @@ Failure signature: PRRT_kwDORgvdZ856mV3T
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: the remaining review thread was valid because the journal handoff still said to commit and push even though `258a449` was already on PR `#1487`.
-- What changed: updated the `Next exact step` note in `.codex-supervisor/issue-journal.md` to reflect the already-pushed state and direct the next loop to CI/re-review instead of another local commit.
+- What changed: updated the `Next exact step` note in `.codex-supervisor/issue-journal.md` to reflect the already-pushed state, then pushed a journal-only follow-up so the next loop starts at CI/re-review instead of another local commit.
 - Current blocker: none.
 - Next exact step: monitor CI for PR #1487 and address any failing checks or new review feedback.
 - Verification gap: none; this turn only updates supervisor-facing journal text.

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { GitHubPullRequestHydrator } from "./github-pull-request-hydrator";
 import { GitHubPullRequest, SupervisorConfig } from "../core/types";
 
+const OUTPUT_TRUNCATION_MARKER = "\n...\n";
+
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
     repoPath: "/tmp/repo",
@@ -80,6 +82,17 @@ function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPu
     mergedAt: null,
     ...overrides,
   };
+}
+
+function truncateLikeDefaultStdoutCapture(value: string, limit = 64 * 1024): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  const availableLength = Math.max(limit - OUTPUT_TRUNCATION_MARKER.length, 0);
+  const headLength = Math.ceil(availableLength / 2);
+  const tailLength = Math.floor(availableLength / 2);
+  return `${value.slice(0, headLength)}${OUTPUT_TRUNCATION_MARKER}${tailLength > 0 ? value.slice(-tailLength) : ""}`;
 }
 
 test("GitHubPullRequestHydrator classifies nitpick-only configured-bot top-level changes requests conservatively", async () => {
@@ -1048,4 +1061,67 @@ test("GitHubPullRequestHydrator records the current-head CI-green timestamp from
   assert.match(lifecycleQuery, /isRequired\s*\(pullRequestNumber:\s*\$number\)/);
   assert.match(lifecycleQuery, /CheckRun[\s\S]*completedAt/);
   assert.equal(ciGreenAt, "2026-03-13T02:05:00Z");
+});
+
+test("GitHubPullRequestHydrator hydrates large GraphQL payloads without parsing truncated stdout", async () => {
+  const config = createConfig();
+  const largeBody = "Blocking concern: ".concat("y".repeat(70_000));
+  const payload = JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewRequests: {
+            nodes: [],
+          },
+          reviews: {
+            nodes: [
+              {
+                submittedAt: "2026-04-14T01:02:03Z",
+                state: "CHANGES_REQUESTED",
+                body: largeBody,
+                commit: {
+                  oid: "head-44",
+                },
+                author: {
+                  login: "copilot-pull-request-reviewer",
+                },
+              },
+            ],
+          },
+          comments: {
+            nodes: [],
+          },
+          reviewThreads: {
+            nodes: [],
+          },
+          timelineItems: {
+            nodes: [
+              {
+                __typename: "ReviewRequestedEvent",
+                createdAt: "2026-04-14T01:00:00Z",
+                requestedReviewer: {
+                  login: "copilot-pull-request-reviewer",
+                },
+              },
+            ],
+          },
+          commits: {
+            nodes: [],
+          },
+        },
+      },
+    },
+  });
+
+  const hydrator = new GitHubPullRequestHydrator(config, async (_args, options) => ({
+    exitCode: 0,
+    stdout: options?.stdoutCaptureLimitBytes === null ? payload : truncateLikeDefaultStdoutCapture(payload),
+    stderr: "",
+  }));
+
+  const pr = await hydrator.hydrate(createPullRequest());
+
+  assert.equal(pr?.copilotReviewState, "arrived");
+  assert.equal(pr?.configuredBotTopLevelReviewStrength, "blocking");
+  assert.equal(pr?.configuredBotTopLevelReviewSubmittedAt, "2026-04-14T01:02:03Z");
 });

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -155,6 +155,10 @@ export class GitHubPullRequestHydrator {
     return this.hydrateForStatus(pr);
   }
 
+  private async runGhJsonCommand(args: string[], options: CommandOptions = {}): Promise<CommandResult> {
+    return this.runGhCommand(args, { ...options, stdoutCaptureLimitBytes: null });
+  }
+
   private async fetchConfiguredBotReviewSummary(
     prNumber: number,
     currentHeadOid: string,
@@ -295,7 +299,7 @@ export class GitHubPullRequestHydrator {
       }
     `;
 
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "api",
       "graphql",
       "-f",

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -38,11 +38,15 @@ export class GitHubReviewSurfaceClient {
     );
   }
 
+  private async runGhJsonCommand(args: string[], options: CommandOptions = {}): Promise<CommandResult> {
+    return this.runGhCommand(args, { ...options, stdoutCaptureLimitBytes: null });
+  }
+
   async findOpenPullRequest(
     branch: string,
     options: { purpose?: "status" | "action" } = {},
   ): Promise<GitHubPullRequest | null> {
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "pr",
       "list",
       "--repo",
@@ -64,7 +68,7 @@ export class GitHubReviewSurfaceClient {
     branch: string,
     options: { purpose?: "status" | "action" } = {},
   ): Promise<GitHubPullRequest | null> {
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "pr",
       "list",
       "--repo",
@@ -88,7 +92,7 @@ export class GitHubReviewSurfaceClient {
   }
 
   async getPullRequest(prNumber: number): Promise<GitHubPullRequest> {
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "pr",
       "view",
       String(prNumber),
@@ -105,7 +109,7 @@ export class GitHubReviewSurfaceClient {
     prNumber: number,
     options: { purpose?: "status" | "action" } = {},
   ): Promise<GitHubPullRequest | null> {
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "pr",
       "view",
       String(prNumber),
@@ -183,7 +187,7 @@ export class GitHubReviewSurfaceClient {
       }
     `;
 
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "api",
       "graphql",
       "-f",
@@ -215,7 +219,7 @@ export class GitHubReviewSurfaceClient {
   }
 
   async getChecks(prNumber: number): Promise<PullRequestCheck[]> {
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "pr",
       "checks",
       String(prNumber),
@@ -234,7 +238,7 @@ export class GitHubReviewSurfaceClient {
       }
     }
 
-    const fallback = await this.runGhCommand([
+    const fallback = await this.runGhJsonCommand([
       "pr",
       "view",
       String(prNumber),
@@ -378,7 +382,7 @@ export class GitHubReviewSurfaceClient {
       }
     `;
 
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "api",
       "graphql",
       "-f",
@@ -461,7 +465,7 @@ export class GitHubReviewSurfaceClient {
       }
     `;
 
-    const result = await this.runGhCommand([
+    const result = await this.runGhJsonCommand([
       "api",
       "graphql",
       "-f",

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -33,7 +33,7 @@ export class GitHubReviewSurfaceClient {
   ) {
     this.pullRequestHydrator = new GitHubPullRequestHydrator(
       this.config,
-      (args) => this.runGhCommand(args),
+      (args, options) => this.runGhCommand(args, options),
       this.now,
     );
   }

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -388,6 +388,102 @@ test("GitHubClient fetches unresolved review threads from JSON payloads larger t
   assert.equal(threads[0]?.comments.nodes[0]?.body, largeBody);
 });
 
+test("GitHubClient forwards unbounded stdout capture options through review-surface hydration", async () => {
+  const config = createConfig();
+  const largeBody = "Blocking issue: ".concat("x".repeat(70_000));
+  const prListPayload = JSON.stringify([
+    createPullRequest({
+      number: 443,
+      title: "Large review payload",
+      url: "https://example.test/pull/443",
+      headRefName: "codex/issue-443",
+      headRefOid: "head-443",
+    }),
+  ]);
+  const reviewSummaryPayload = JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewRequests: {
+            nodes: [
+              {
+                requestedReviewer: {
+                  login: "copilot-pull-request-reviewer",
+                },
+              },
+            ],
+          },
+          reviews: {
+            nodes: [
+              {
+                submittedAt: "2026-04-14T01:02:03Z",
+                state: "CHANGES_REQUESTED",
+                body: `Please address these blocking concerns.\n\n${largeBody}`,
+                commit: {
+                  oid: "head-443",
+                },
+                author: {
+                  login: "copilot-pull-request-reviewer",
+                },
+              },
+            ],
+          },
+          comments: {
+            nodes: [],
+          },
+          reviewThreads: {
+            nodes: [],
+          },
+          timelineItems: {
+            nodes: [
+              {
+                __typename: "ReviewRequestedEvent",
+                createdAt: "2026-04-14T01:00:00Z",
+                requestedReviewer: {
+                  login: "copilot-pull-request-reviewer",
+                },
+              },
+            ],
+          },
+          commits: {
+            nodes: [],
+          },
+        },
+      },
+    },
+  });
+
+  const client = new GitHubClient(config, async (_command, args, options) => {
+    if (args[0] === "pr" && args[1] === "list") {
+      return {
+        exitCode: 0,
+        stdout: prListPayload,
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout:
+          options?.stdoutCaptureLimitBytes === null
+            ? reviewSummaryPayload
+            : truncateLikeDefaultStdoutCapture(reviewSummaryPayload),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pullRequest = await client.findOpenPullRequest("codex/issue-443", { purpose: "status" });
+
+  assert.equal(pullRequest?.number, 443);
+  assert.equal(pullRequest?.configuredBotTopLevelReviewStrength, "blocking");
+  assert.equal(pullRequest?.configuredBotTopLevelReviewSubmittedAt, "2026-04-14T01:02:03Z");
+  assert.equal(pullRequest?.copilotReviewState, "arrived");
+});
+
 test("GitHubClient refreshes unresolved review threads when the review surface version changes", async () => {
   const config = createConfig();
   let graphqlCalls = 0;

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -7,6 +7,8 @@ import { GitHubClient } from "./github";
 import { runCommand } from "../core/command";
 import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../core/types";
 
+const OUTPUT_TRUNCATION_MARKER = "\n...\n";
+
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
     repoPath: "/tmp/repo",
@@ -154,6 +156,17 @@ function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPu
     headRefOid: "head-354",
     ...overrides,
   };
+}
+
+function truncateLikeDefaultStdoutCapture(value: string, limit = 64 * 1024): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  const availableLength = Math.max(limit - OUTPUT_TRUNCATION_MARKER.length, 0);
+  const headLength = Math.ceil(availableLength / 2);
+  const tailLength = Math.floor(availableLength / 2);
+  return `${value.slice(0, headLength)}${OUTPUT_TRUNCATION_MARKER}${tailLength > 0 ? value.slice(-tailLength) : ""}`;
 }
 
 test("GitHubClient fetches the newest unresolved review thread comments", async () => {
@@ -317,6 +330,62 @@ test("GitHubClient reuses cached unresolved review threads for same-head status 
   assert.equal(first.length, 1);
   assert.equal(second.length, 1);
   assert.equal(graphqlCalls, 1);
+});
+
+test("GitHubClient fetches unresolved review threads from JSON payloads larger than the default stdout capture limit", async () => {
+  const config = createConfig();
+  const largeBody = "Blocking issue: ".concat("x".repeat(70_000));
+  const payload = JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              {
+                id: "thread-large",
+                isResolved: false,
+                isOutdated: false,
+                path: "src/github/github-review-surface.ts",
+                line: 401,
+                comments: {
+                  nodes: [
+                    {
+                      id: "comment-large",
+                      body: largeBody,
+                      createdAt: "2026-04-14T01:02:03Z",
+                      url: "https://example.test/comments/large",
+                      author: {
+                        login: "copilot-pull-request-reviewer",
+                        __typename: "Bot",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  });
+
+  const client = new GitHubClient(config, async (_command, args, options) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: options?.stdoutCaptureLimitBytes === null ? payload : truncateLikeDefaultStdoutCapture(payload),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const threads = await client.getUnresolvedReviewThreads(443);
+
+  assert.equal(threads.length, 1);
+  assert.equal(threads[0]?.id, "thread-large");
+  assert.equal(threads[0]?.comments.nodes[0]?.body, largeBody);
 });
 
 test("GitHubClient refreshes unresolved review threads when the review surface version changes", async () => {


### PR DESCRIPTION
## Summary
- protect machine-readable GitHub JSON fetches from the default 64KB stdout truncation path
- cover the reported `reviewThreads` host incident with a >64KB regression
- protect the sibling PR hydrator GraphQL fetch that also parses whole JSON payloads

## Testing
- node --test --import tsx src/github/github.test.ts
- node --test --import tsx src/github/github-pull-request-hydrator.test.ts
- node --test --import tsx src/core/command.test.ts
- npm run build

Closes #1485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented truncation of large GitHub GraphQL/PR payloads so pull request reconciliation and review-thread processing remain accurate.

* **Tests**
  * Added tests covering oversized GraphQL payloads and behavior with both truncated and unbounded command output captures.

* **Documentation**
  * Updated supervisor issue journal and working notes to reflect the new failing surface and follow-up steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->