### PR TITLE
Stale local verification blockers can keep tracked PRs draft after newer head turns green (#1486)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,46 +1,33 @@
-# Issue #1485: Bug: reviewThreads GraphQL surface can be truncated at 64KB and crash tracked PR reconciliation
+# Issue #1486: Stale local verification blockers can keep tracked PRs draft after newer head turns green
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1485
-- Branch: codex/issue-1485
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1486
+- Branch: codex/issue-1486
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=1, repair=2)
-- Last head SHA: 258a449526b1dcc6dd3ddd59c32c65dc6a80dfbf
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c805fb4cfdbb6fa79fc14795a194f6ac7c0f89be
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856mV3T
-- Repeated failure signature count: 1
-- Updated at: 2026-04-13T17:20:27.000Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T17:40:02.399Z
 
 ## Latest Codex Summary
-No further code changes were needed. I verified the remaining CodeRabbit thread on PR `#1487` still pointed at stale journal text, then aligned the `Current Handoff` note so it no longer says to commit and push after `258a449` was already pushed.
-
-The underlying tracked-PR reconciliation fix remains the previously pushed code change in `258a449`. This turn only updates `.codex-supervisor/issue-journal.md` and pushes a journal-only follow-up so the supervisor handoff matches the live PR state and points the next loop at CI/re-review instead of another nonexistent local commit.
-
-Summary: Aligned the issue journal handoff with the already-pushed PR state and pushed a journal-only follow-up for the remaining review thread.
-State hint: addressing_review
-Blocked reason: none
-Tests: not rerun; journal-only review fix
-Next action: wait for PR #1487 CI/re-review and resolve the remaining thread if GitHub does not auto-clear it.
-Failure signature: PRRT_kwDORgvdZ856mV3T
+- Cleared stale tracked-PR ready-promotion verification blockers on head advance, added a focused reconciliation regression, and updated diagnostics so stale stored blockers are described as stale instead of “still present.”
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074644785
-- Details:
-  - .codex-supervisor/issue-journal.md:27 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Align the “next exact step” note with the already-pushed state.** The journal says commits are already pushed (Line 21) and to wait for CI (L... url=https://github.com/TommyKammy/codex-supervisor/pull/1487#discussion_r3074644785
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the remaining review thread was valid because the journal handoff still said to commit and push even though `258a449` was already on PR `#1487`.
-- What changed: updated the `Next exact step` note in `.codex-supervisor/issue-journal.md` to reflect the already-pushed state, then pushed a journal-only follow-up so the next loop starts at CI/re-review instead of another local commit.
-- Current blocker: none.
-- Next exact step: monitor CI for PR #1487 and address any failing checks or new review feedback.
-- Verification gap: none; this turn only updates supervisor-facing journal text.
-- Files touched: `.codex-supervisor/issue-journal.md`.
-- Rollback concern: low; docs-only journal alignment for review-thread handling.
-- Last focused command: `gh pr view 1487 --json number,state,isDraft,reviewDecision,mergeStateStatus,headRefName,baseRefName,comments,reviews`
+- Hypothesis: `reconcileRecoverableBlockedIssueStates(...)` was preserving `last_failure_context` for draft ready-promotion blockers even when the tracked PR head had advanced and fresh current-head inference returned no blocker.
+- What changed: Guarded draft ready-promotion blocker preservation so old-head verification context only survives when the blocker is still on the same head or there is fresh current-head failure evidence; added a regression that advances from `head-old` to `head-new`; updated tracked-PR mismatch guidance in status/doctor so stale stored blockers are called out as stale.
+- Current blocker: none
+- Next exact step: Commit the tested fix on `codex/issue-1486` and leave the branch ready for PR/update.
+- Verification gap: `src/supervisor/supervisor-diagnostics-explain.test.ts` was not changed because the affected wording is covered through status and doctor paths; no failing explain coverage surfaced during targeted verification.
+- Files touched: `src/recovery-reconciliation.ts`, `src/supervisor/tracked-pr-mismatch.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/doctor.test.ts`
+- Rollback concern: low; the behavioral change is narrowly scoped to draft tracked-PR verification blocker preservation and diagnostic wording when the stored blocker belongs to an older head.
+- Last focused command: `npm run build`
 ### Scratchpad
-- 2026-04-13: Verified PR #1487 still has the single CodeRabbit journal thread open, confirmed the live journal still said "commit and push", then aligned the handoff text before pushing a journal-only follow-up.
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1442,6 +1442,103 @@ test("diagnoseSupervisorHost preserves draft tracked PR verification blockers in
   );
 });
 
+test("diagnoseSupervisorHost marks old-head ready-promotion blockers as stale", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-175");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "fixture"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  execFileSync("git", ["-C", repoPath, "worktree", "add", "-b", "codex/reopen-issue-175", workspace], {
+    encoding: "utf8",
+  });
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    stateFile,
+    codexBinary: process.execPath,
+    localCiCommand: "npm run verify:paths",
+  });
+  const trackedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "175": createRecord({
+        issue_number: 175,
+        state: "blocked",
+        branch: "codex/reopen-issue-175",
+        workspace,
+        pr_number: 275,
+        blocked_reason: "verification",
+        last_head_sha: "head-old-275",
+        last_error: "Configured local CI command failed before marking PR #275 ready.",
+        last_failure_signature: "local-ci-gate-non_zero_exit",
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed before marking PR #275 ready.",
+          ran_at: "2026-03-13T00:10:00Z",
+          head_sha: "head-old-275",
+          execution_mode: "legacy_shell_string",
+          failure_class: "non_zero_exit",
+          remediation_target: "repo_owned_command",
+        },
+      }),
+    },
+  };
+  const draftPr = createPullRequest({
+    number: 275,
+    headRefName: "codex/reopen-issue-175",
+    headRefOid: "head-new-275",
+    isDraft: true,
+    currentHeadCiGreenAt: "2026-03-13T00:12:00Z",
+  });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config,
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => trackedState,
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 1,
+        truncated: false,
+      }),
+      getPullRequestIfExists: async () => draftPr,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#175 pr=#275 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #275 is still draft, but the stored ready-for-review verification blocker is stale relative to the current head\. Run a one-shot supervisor cycle to refresh tracked PR state before assuming the gate still fails\./,
+  );
+  assert.doesNotMatch(renderDoctorReport(diagnostics), /The same blocker is still present/);
+});
+
 test("diagnoseSupervisorHost exposes host-local CI blocker details for tracked PR mismatches", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1053,14 +1053,20 @@ export async function reconcileRecoverableBlockedIssueStates(
         continue;
       }
 
+      const inferredFailureContext =
+        nextState === "blocked"
+        || (
+          nextState === "draft_pr"
+          && record.blocked_reason === "verification"
+          && trackedPullRequest.isDraft
+        )
+          ? inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads)
+          : null;
       const preserveDraftReadyPromotionBlocker =
         nextState === "draft_pr"
         && record.blocked_reason === "verification"
-        && trackedPullRequest.isDraft;
-      const inferredFailureContext =
-        nextState === "blocked" || preserveDraftReadyPromotionBlocker
-          ? inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads)
-          : null;
+        && trackedPullRequest.isDraft
+        && (record.last_head_sha === trackedPullRequest.headRefOid || inferredFailureContext !== null);
       const failureContext =
         inferredFailureContext
         ?? (preserveDraftReadyPromotionBlocker ? record.last_failure_context : null);

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2734,6 +2734,81 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   assert.doesNotMatch(status, /^tracked_pr_mismatch /m);
 });
 
+test("status marks old-head ready-promotion blockers as stale in recovery guidance", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 175;
+  const prNumber = 275;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "verification",
+        last_error: "Configured local CI command failed before marking PR #275 ready.",
+        last_head_sha: "head-old-275",
+        last_failure_signature: "local-ci-gate-non_zero_exit",
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed before marking PR #275 ready.",
+          ran_at: "2026-03-13T00:10:00Z",
+          head_sha: "head-old-275",
+          execution_mode: "legacy_shell_string",
+          failure_class: "non_zero_exit",
+          remediation_target: "repo_owned_command",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked stale draft PR ready gate",
+    body: executionReadyBody("Surface stale draft PR ready-promotion blockers without implying the gate still fails."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-new-275",
+    isDraft: true,
+    currentHeadCiGreenAt: "2026-03-13T00:12:00Z",
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^tracked_pr_ready_promotion_blocked issue=#175 pr=#275 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^recovery_guidance=PR #275 is still draft, but the stored ready-for-review verification blocker is stale relative to the current head\. Run a one-shot supervisor cycle to refresh tracked PR state before assuming the gate still fails\.$/m,
+  );
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /The same blocker is still present/);
+});
+
 test("status surfaces host-local CI blocker details for tracked PR mismatches", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2025,6 +2025,110 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
   assert.equal(saveCalls, 0);
 });
 
+test("reconcileRecoverableBlockedIssueStates clears stale tracked PR ready-promotion blockers after head advance", async () => {
+  const config = createConfig();
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Ready-for-review promotion is blocked by local verification on the previous head.",
+    signature: "local-verification-blocked",
+    command: null,
+    details: [`tracked_pr=${TRACKED_PR_OLD_HEAD}`],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createTrackedPrStaleReviewRecord({
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: TRACKED_PR_NUMBER,
+        last_head_sha: TRACKED_PR_OLD_HEAD,
+        last_error: failureContext.summary,
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        last_failure_signature: failureContext.signature,
+        repeated_failure_signature_count: 3,
+        repeated_blocker_count: 4,
+        repair_attempt_count: 2,
+        timeout_retry_count: 1,
+        blocked_verification_retry_count: 2,
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed on the previous head.",
+          ran_at: "2026-03-13T00:22:00Z",
+          head_sha: TRACKED_PR_OLD_HEAD,
+          execution_mode: "shell",
+          failure_class: "non_zero_exit",
+          remediation_target: "repo_owned_command",
+        },
+      }),
+    ],
+  });
+  const issue = createTrackedPrRecoveryIssue();
+  const pr = createTrackedPrRecoveryPullRequest({
+    headRefOid: TRACKED_PR_NEW_HEAD,
+    isDraft: true,
+    currentHeadCiGreenAt: "2026-03-13T00:24:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "draft_pr");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_head_sha, TRACKED_PR_NEW_HEAD);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.repeated_blocker_count, 0);
+  assert.equal(updated.repair_attempt_count, 0);
+  assert.equal(updated.timeout_retry_count, 0);
+  assert.equal(updated.blocked_verification_retry_count, 0);
+  assert.equal(updated.local_review_head_sha, null);
+  assert.equal(updated.latest_local_ci_result, null);
+  assert.equal(updated.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_head_advanced: resumed issue #366 from blocked to draft_pr after tracked PR #191 advanced from head-old-191 to head-new-191",
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates resumes tracked PR stale configured-bot blockers after reply_and_resolve is enabled", async () => {
   const config = createConfig({
     staleConfiguredBotReviewPolicy: "reply_and_resolve",

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -31,6 +31,13 @@ function isBlockedLikeState(state: RunState): boolean {
   return state === "blocked" || state === "failed";
 }
 
+function blockerMatchesCurrentHead(
+  record: Pick<IssueRunRecord, "last_head_sha">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  return typeof record.last_head_sha === "string" && record.last_head_sha === pr.headRefOid;
+}
+
 function localCiHeadStatus(record: IssueRunRecord, pr: GitHubPullRequest, result: LatestLocalCiResult): "current" | "stale" | "unknown" {
   const currentHeadSha = pr.headRefOid ?? record.last_head_sha ?? null;
   if (result.head_sha === null || currentHeadSha === null) {
@@ -230,6 +237,7 @@ export function buildTrackedPrMismatch(
 
   if (record.state === "blocked" && record.blocked_reason === "verification" && githubState === "draft_pr" && pr.isDraft) {
     const readyPromotionGate = readyPromotionGateSummary(config, record, pr, checks);
+    const blockerIsCurrentHead = blockerMatchesCurrentHead(record, pr);
     return {
       issueNumber: record.issue_number,
       prNumber: pr.number,
@@ -247,10 +255,12 @@ export function buildTrackedPrMismatch(
         `local_blocked_reason=${record.blocked_reason ?? "none"}`,
         `stale_local_blocker=${staleLocalBlocker ? "yes" : "no"}`,
       ].join(" "),
-      guidanceLine:
-        `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion is blocked by local verification. ` +
-        `The same blocker is still present, so rerunning the supervisor alone will not help. ` +
-        `Failed gate: ${readyPromotionGate.failedGate}. Fix the gate in the tracked workspace first, then rerun it to promote the PR.`,
+      guidanceLine: blockerIsCurrentHead
+        ? `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion is blocked by local verification. ` +
+          `The same blocker is still present, so rerunning the supervisor alone will not help. ` +
+          `Failed gate: ${readyPromotionGate.failedGate}. Fix the gate in the tracked workspace first, then rerun it to promote the PR.`
+        : `recovery_guidance=PR #${pr.number} is still draft, but the stored ready-for-review verification blocker is stale relative to the current head. ` +
+          "Run a one-shot supervisor cycle to refresh tracked PR state before assuming the gate still fails.",
       detailLines: readyPromotionGate.detailLines,
     };
   }


### PR DESCRIPTION
Closes #1486
This PR was opened by codex-supervisor.
Latest Codex summary:

Cleared the stale-head ready-promotion blocker path. The reconciliation change in [src/recovery-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1486/src/recovery-reconciliation.ts) now preserves a draft `blocked_reason=verification` only when the blocker is still on the current head or there is fresh current-head failure evidence. That lets a tracked PR converge back to `draft_pr` and drops stale head-scoped blocker artifacts when the PR head advances and the old blocker has gone stale.

I added the focused regression in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1486/src/supervisor/supervisor-recovery-reconciliation.test.ts) for the `head-old` -> `head-new` case, and left the same-head preservation control covered. I also updated tracked-PR mismatch guidance in [src/supervisor/tracked-pr-mismatch.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1486/src/supervisor/tracked-pr-mismatch.ts), with matching status/doctor coverage in [src/supervisor/supervisor-diagnostics-status-selection.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1486/src/supervisor/supervisor-diagnostics-status-selection.test.ts) and [src/doctor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1486/src/doctor.test.ts), so stale stored blockers are described as stale instead of “the same blocker...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of stale verification blockers when PR commits advance; stale blockers are now correctly identified and marked as requiring refresh.

* **Bug Fixes**
  * Fixed false positive blocker detection when tracked PRs advance to new commits; recovery guidance now accurately reflects whether blockers are still relevant.

* **Tests**
  * Added comprehensive test coverage for stale blocker detection and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->