### PR TITLE
Same-head stale verification blockers can stay authoritative when only last_head_sha is current (#1489)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,33 @@
-# Issue #1486: Stale local verification blockers can keep tracked PRs draft after newer head turns green
+# Issue #1489: Same-head stale verification blockers can stay authoritative when only last_head_sha is current
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1486
-- Branch: codex/issue-1486
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1489
+- Branch: codex/issue-1489
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: c805fb4cfdbb6fa79fc14795a194f6ac7c0f89be
+- Last head SHA: 3221a66cd050ac8eafed054e09c12935541c333d
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-13T17:40:02.399Z
+- Updated at: 2026-04-13T18:33:54.162Z
 
 ## Latest Codex Summary
-- Cleared stale tracked-PR ready-promotion verification blockers on head advance, added a focused reconciliation regression, and updated diagnostics so stale stored blockers are described as stale instead of “still present.”
+- None yet.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `reconcileRecoverableBlockedIssueStates(...)` was preserving `last_failure_context` for draft ready-promotion blockers even when the tracked PR head had advanced and fresh current-head inference returned no blocker.
-- What changed: Guarded draft ready-promotion blocker preservation so old-head verification context only survives when the blocker is still on the same head or there is fresh current-head failure evidence; added a regression that advances from `head-old` to `head-new`; updated tracked-PR mismatch guidance in status/doctor so stale stored blockers are called out as stale.
+- Hypothesis: Same-head draft `blocked/verification` records should only stay authoritative when fresh current-head blocker evidence still exists; `last_head_sha` by itself is insufficient.
+- What changed: Added a shared tracked-PR ready-promotion blocker freshness helper; reconciliation now clears stale same-head verification blockers without fresh evidence, and diagnostics (`status`, `explain`, `doctor`) now use the same rule for stale guidance. Added same-head stale regression coverage plus same-head current-evidence control remains covered.
 - Current blocker: none
-- Next exact step: Commit the tested fix on `codex/issue-1486` and leave the branch ready for PR/update.
-- Verification gap: `src/supervisor/supervisor-diagnostics-explain.test.ts` was not changed because the affected wording is covered through status and doctor paths; no failing explain coverage surfaced during targeted verification.
-- Files touched: `src/recovery-reconciliation.ts`, `src/supervisor/tracked-pr-mismatch.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/doctor.test.ts`
-- Rollback concern: low; the behavioral change is narrowly scoped to draft tracked-PR verification blocker preservation and diagnostic wording when the stored blocker belongs to an older head.
+- Next exact step: Commit the focused reconciliation/diagnostics change set on `codex/issue-1489`.
+- Verification gap: none for the requested focused tests and build.
+- Files touched: `src/tracked-pr-ready-promotion-blocker.ts`, `src/recovery-reconciliation.ts`, `src/supervisor/tracked-pr-mismatch.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/doctor.test.ts`, `.codex-supervisor/issue-journal.md`
+- Rollback concern: If the freshness helper is too strict, same-head blockers that only persist via non-comment/non-local-CI evidence could be cleared early; current tests cover current-head local CI and current-head stale/no-evidence cases.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1539,6 +1539,113 @@ test("diagnoseSupervisorHost marks old-head ready-promotion blockers as stale", 
   assert.doesNotMatch(renderDoctorReport(diagnostics), /The same blocker is still present/);
 });
 
+test("diagnoseSupervisorHost marks same-head ready-promotion blockers as stale when fresh blocker evidence is absent", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-176");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "fixture"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  execFileSync("git", ["-C", repoPath, "worktree", "add", "-b", "codex/reopen-issue-176", workspace], {
+    encoding: "utf8",
+  });
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    stateFile,
+    codexBinary: process.execPath,
+    localCiCommand: "npm run verify:paths",
+  });
+  const trackedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "176": createRecord({
+        issue_number: 176,
+        state: "blocked",
+        branch: "codex/reopen-issue-176",
+        workspace,
+        pr_number: 276,
+        blocked_reason: "verification",
+        last_head_sha: "head-draft-276",
+        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #276 ready.",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-276",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:08:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    },
+  };
+  const draftPr = createPullRequest({
+    number: 276,
+    headRefName: "codex/reopen-issue-176",
+    headRefOid: "head-draft-276",
+    isDraft: true,
+  });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config,
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => trackedState,
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 1,
+        truncated: false,
+      }),
+      getPullRequestIfExists: async () => draftPr,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#176 pr=#276 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #276 is still draft, but the stored ready-for-review verification blocker is stale relative to the current head\. Run a one-shot supervisor cycle to refresh tracked PR state before assuming the gate still fails\./,
+  );
+  assert.doesNotMatch(renderDoctorReport(diagnostics), /The same blocker is still present/);
+});
+
 test("diagnoseSupervisorHost exposes host-local CI blocker details for tracked PR mismatches", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -71,6 +71,7 @@ import {
 } from "./interrupted-turn-marker";
 import { mergeConflictDetected } from "./supervisor/supervisor-status-rendering";
 import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
+import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "./tracked-pr-ready-promotion-blocker";
 
 const OWNER_GUARDED_ACTIVE_STATES = new Set<RunState>([
   "planning",
@@ -1066,7 +1067,10 @@ export async function reconcileRecoverableBlockedIssueStates(
         nextState === "draft_pr"
         && record.blocked_reason === "verification"
         && trackedPullRequest.isDraft
-        && (record.last_head_sha === trackedPullRequest.headRefOid || inferredFailureContext !== null);
+        && (
+          inferredFailureContext !== null ||
+          hasFreshTrackedPrReadyPromotionBlockerEvidence(record, trackedPullRequest)
+        );
       const failureContext =
         inferredFailureContext
         ?? (preserveDraftReadyPromotionBlocker ? record.last_failure_context : null);

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -639,6 +639,93 @@ Expose stale tracked PR mismatch diagnostics.
   );
 });
 
+test("explain marks same-head ready-promotion blockers as stale when fresh blocker evidence is absent", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 176;
+  const prNumber = 276;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "verification",
+        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #276 ready.",
+        last_head_sha: "head-draft-276",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-276",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:08:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked stale same-head draft PR ready gate",
+    body: executionReadyBody("Explain should surface stale same-head ready-promotion blockers."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-draft-276",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^tracked_pr_ready_promotion_blocked issue=#176 pr=#276 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    explanation,
+    /^recovery_guidance=PR #276 is still draft, but the stored ready-for-review verification blocker is stale relative to the current head\. Run a one-shot supervisor cycle to refresh tracked PR state before assuming the gate still fails\.$/m,
+  );
+  assert.doesNotMatch(explanation, /The same blocker is still present/);
+});
+
 test("explain reports bootstrap repos as not ready for expected CI and review signals", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 181;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2809,6 +2809,91 @@ test("status marks old-head ready-promotion blockers as stale in recovery guidan
   assert.doesNotMatch(report.detailedStatusLines.join("\n"), /The same blocker is still present/);
 });
 
+test("status marks same-head ready-promotion blockers as stale when fresh blocker evidence is absent", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 176;
+  const prNumber = 276;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "verification",
+        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #276 ready.",
+        last_head_sha: "head-draft-276",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-276",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:08:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked stale same-head draft PR ready gate",
+    body: executionReadyBody("Surface stale same-head ready-promotion blockers without implying the gate still fails."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-draft-276",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^tracked_pr_ready_promotion_blocked issue=#176 pr=#276 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^recovery_guidance=PR #276 is still draft, but the stored ready-for-review verification blocker is stale relative to the current head\. Run a one-shot supervisor cycle to refresh tracked PR state before assuming the gate still fails\.$/m,
+  );
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /The same blocker is still present/);
+});
+
 test("status surfaces host-local CI blocker details for tracked PR mismatches", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1915,7 +1915,7 @@ test("reconcileRecoverableBlockedIssueStates persists refreshed tracked PR lifec
   assert.deepEqual(recoveryEvents, []);
 });
 
-test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR recovery churn when the same blocker persists", async () => {
+test("reconcileRecoverableBlockedIssueStates clears stale same-head tracked PR ready-promotion blockers without fresh evidence", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = createSupervisorState({
     issues: [
@@ -1937,6 +1937,29 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
         },
         last_failure_signature: "local-verification-blocked",
         repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-191",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:18:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        last_recovery_reason:
+          "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-old-191",
+        last_recovery_at: "2026-03-13T00:18:00Z",
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
       }),
     ],
   });
@@ -1967,7 +1990,7 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
     },
   };
 
-  const firstRecoveryEvents = await reconcileRecoverableBlockedIssueStates(
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
     {
       getPullRequestIfExists: async () => pr,
       getIssue: async () => issue,
@@ -1990,39 +2013,26 @@ test("reconcileRecoverableBlockedIssueStates suppresses duplicate tracked PR rec
     },
   );
 
-  assert.deepEqual(firstRecoveryEvents, []);
-  assert.equal(state.issues["366"]?.state, "blocked");
-  assert.equal(state.issues["366"]?.blocked_reason, "verification");
-  assert.equal(saveCalls, 0);
-
-  const secondRecoveryEvents = await reconcileRecoverableBlockedIssueStates(
-    {
-      getPullRequestIfExists: async () => pr,
-      getIssue: async () => issue,
-      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-      getUnresolvedReviewThreads: async () => [],
-    },
-    stateStore,
-    state,
-    config,
-    [issue],
-    {
-      shouldAutoRetryHandoffMissing,
-      inferStateFromPullRequest: () => "draft_pr",
-      inferFailureContext: () => null,
-      blockedReasonForLifecycleState: () => null,
-      isOpenPullRequest,
-      syncReviewWaitWindow: () => ({}),
-      syncCopilotReviewRequestObservation: () => ({}),
-      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
-    },
+  const updated = state.issues["366"];
+  assert.equal(updated?.state, "draft_pr");
+  assert.equal(updated?.blocked_reason, null);
+  assert.equal(updated?.last_error, null);
+  assert.equal(updated?.last_failure_context, null);
+  assert.equal(updated?.last_failure_signature, null);
+  assert.equal(updated?.repeated_failure_signature_count, 0);
+  assert.equal(updated?.repeated_blocker_count, 0);
+  assert.equal(updated?.repair_attempt_count, 0);
+  assert.equal(updated?.timeout_retry_count, 0);
+  assert.equal(updated?.blocked_verification_retry_count, 0);
+  assert.equal(updated?.last_head_sha, "head-191");
+  assert.equal(
+    updated?.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-191",
   );
-
-  assert.deepEqual(secondRecoveryEvents, []);
-  assert.equal(state.issues["366"]?.state, "blocked");
-  assert.equal(state.issues["366"]?.blocked_reason, "verification");
-  assert.equal(state.issues["366"]?.last_recovery_reason, null);
-  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to draft_pr using fresh tracked PR #191 facts at head head-191",
+  ]);
+  assert.equal(saveCalls, 1);
 });
 
 test("reconcileRecoverableBlockedIssueStates clears stale tracked PR ready-promotion blockers after head advance", async () => {

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -13,6 +13,7 @@ import {
   displayLocalCiCommand,
 } from "../core/config";
 import { projectTrackedPrLifecycle } from "../tracked-pr-lifecycle-projection";
+import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "../tracked-pr-ready-promotion-blocker";
 
 export interface TrackedPrMismatch {
   issueNumber: number;
@@ -29,13 +30,6 @@ export interface TrackedPrMismatch {
 
 function isBlockedLikeState(state: RunState): boolean {
   return state === "blocked" || state === "failed";
-}
-
-function blockerMatchesCurrentHead(
-  record: Pick<IssueRunRecord, "last_head_sha">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-): boolean {
-  return typeof record.last_head_sha === "string" && record.last_head_sha === pr.headRefOid;
 }
 
 function localCiHeadStatus(record: IssueRunRecord, pr: GitHubPullRequest, result: LatestLocalCiResult): "current" | "stale" | "unknown" {
@@ -237,7 +231,7 @@ export function buildTrackedPrMismatch(
 
   if (record.state === "blocked" && record.blocked_reason === "verification" && githubState === "draft_pr" && pr.isDraft) {
     const readyPromotionGate = readyPromotionGateSummary(config, record, pr, checks);
-    const blockerIsCurrentHead = blockerMatchesCurrentHead(record, pr);
+    const blockerHasFreshCurrentHeadEvidence = hasFreshTrackedPrReadyPromotionBlockerEvidence(record, pr);
     return {
       issueNumber: record.issue_number,
       prNumber: pr.number,
@@ -255,7 +249,7 @@ export function buildTrackedPrMismatch(
         `local_blocked_reason=${record.blocked_reason ?? "none"}`,
         `stale_local_blocker=${staleLocalBlocker ? "yes" : "no"}`,
       ].join(" "),
-      guidanceLine: blockerIsCurrentHead
+      guidanceLine: blockerHasFreshCurrentHeadEvidence
         ? `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion is blocked by local verification. ` +
           `The same blocker is still present, so rerunning the supervisor alone will not help. ` +
           `Failed gate: ${readyPromotionGate.failedGate}. Fix the gate in the tracked workspace first, then rerun it to promote the PR.`

--- a/src/tracked-pr-ready-promotion-blocker.ts
+++ b/src/tracked-pr-ready-promotion-blocker.ts
@@ -1,0 +1,25 @@
+import type { GitHubPullRequest, IssueRunRecord } from "./core/types";
+
+export function hasFreshTrackedPrReadyPromotionBlockerEvidence(
+  record: Pick<
+    IssueRunRecord,
+    | "latest_local_ci_result"
+    | "last_host_local_pr_blocker_comment_head_sha"
+    | "last_host_local_pr_blocker_comment_signature"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  if (
+    record.latest_local_ci_result?.outcome === "failed" &&
+    record.latest_local_ci_result.head_sha === pr.headRefOid
+  ) {
+    return true;
+  }
+
+  return (
+    record.last_host_local_pr_blocker_comment_head_sha === pr.headRefOid &&
+    typeof record.last_host_local_pr_blocker_comment_signature === "string" &&
+    record.last_host_local_pr_blocker_comment_signature.length > 0 &&
+    !record.last_host_local_pr_blocker_comment_signature.startsWith("cleared:")
+  );
+}


### PR DESCRIPTION
Closes #1489
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed `00be6af` to tighten same-head tracked PR blocker freshness. The change replaces the old `last_head_sha`-only preservation rule with a shared freshness check: a draft `blocked/verification` record now stays authoritative only when there is fresh current-head blocker evidence, currently either a failed current-head local CI result or a current-head blocker comment signature. That same rule now drives reconciliation and diagnostics, so stale same-head blockers recover back to `draft_pr`, and `status` / `explain` / `doctor` no longer pair `stale_local_blocker=yes` with “The same blocker is still present”.

I added a focused same-head stale regression in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1489/src/supervisor/supervisor-recovery-reconciliation.test.ts), plus matching stale-guidance coverage in [src/supervisor/supervisor-diagnostics-status-selection.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1489/src/supervisor/supervisor-diagnostics-status-selection.test.ts), [src/supervisor/supervisor-diagnostics-explain.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1489/src/supervisor/supervisor-diagnostics-explain.test.ts), and [src/doctor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1489/src/doctor.test.ts). The same-head control case with fresh evidence remains covered ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and handling of stale PR verification blockers when fresh blocker evidence is absent at the current PR head.
  * Enhanced diagnostics tools (status, explain, doctor) to accurately flag and report stale blockers with recovery guidance.
  * Added automatic recovery mechanism from incorrectly blocked states when stale blockers are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->