### PR TITLE
Same-head host-local blockers can be cleared as stale when blocker comment publication fails (#1491)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #1489: Same-head stale verification blockers can stay authoritative when only last_head_sha is current
+# Issue #1491: Same-head host-local blockers can be cleared as stale when blocker comment publication fails
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1489
-- Branch: codex/issue-1489
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1491
+- Branch: codex/issue-1491
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 3221a66cd050ac8eafed054e09c12935541c333d
+- Last head SHA: c531613daa6b57a415ab74d7c6294b11d859b966
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-13T18:33:54.162Z
+- Updated at: 2026-04-13T22:23:19.704Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,13 +21,13 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Same-head draft `blocked/verification` records should only stay authoritative when fresh current-head blocker evidence still exists; `last_head_sha` by itself is insufficient.
-- What changed: Added a shared tracked-PR ready-promotion blocker freshness helper; reconciliation now clears stale same-head verification blockers without fresh evidence, and diagnostics (`status`, `explain`, `doctor`) now use the same rule for stale guidance. Added same-head stale regression coverage plus same-head current-evidence control remains covered.
+- Hypothesis: Same-head host-local ready-promotion blockers were only considered fresh when local CI failed on the current head or a blocker comment had been persisted, so workspace-preparation and workstation-local-path blockers observed on the current head could be down-ranked as stale if comment publication failed.
+- What changed: Added head-scoped `last_observed_host_local_pr_blocker_*` state, recorded it before best-effort blocker comment publication, cleared it after host-local gates pass, taught the ready-promotion freshness helper to trust that observation, and added focused regressions for post-turn, reconciliation, status, explain, and doctor.
 - Current blocker: none
-- Next exact step: Commit the focused reconciliation/diagnostics change set on `codex/issue-1489`.
-- Verification gap: none for the requested focused tests and build.
-- Files touched: `src/tracked-pr-ready-promotion-blocker.ts`, `src/recovery-reconciliation.ts`, `src/supervisor/tracked-pr-mismatch.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/doctor.test.ts`, `.codex-supervisor/issue-journal.md`
-- Rollback concern: If the freshness helper is too strict, same-head blockers that only persist via non-comment/non-local-CI evidence could be cleared early; current tests cover current-head local CI and current-head stale/no-evidence cases.
-- Last focused command: `npm run build`
+- Next exact step: Push the checkpoint commit or open/update the draft PR if the supervisor asks for publication.
+- Verification gap: none for the requested local checks; the broad reconciliation test still emits pre-existing execution-metrics warning logs in fixture scenarios, but the suite passes.
+- Files touched: .codex-supervisor/issue-journal.md; src/core/types.ts; src/core/state-store.ts; src/core/state-store-normalization.ts; src/post-turn-pull-request.ts; src/tracked-pr-ready-promotion-blocker.ts; src/tracked-pr-lifecycle-projection.ts; src/post-turn-pull-request.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts; src/doctor.test.ts; src/supervisor/supervisor-test-helpers.ts; src/turn-execution-test-helpers.ts
+- Rollback concern: The new observed-blocker fields are intentionally sticky across same-head reconciliation until a successful ready-promotion pass clears them; if another caller starts reusing those fields outside ready-promotion freshness checks, same-head stale classification could become too conservative.
+- Last focused command: node --test --import tsx src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,29 +5,42 @@
 - Branch: codex/issue-1491
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: c531613daa6b57a415ab74d7c6294b11d859b966
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 1ebc994164cc74440b4cd9cef7efc9d12b4bacf3
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-13T22:23:19.704Z
+- Last failure signature: PRRT_kwDORgvdZ856qw1j
+- Repeated failure signature count: 1
+- Updated at: 2026-04-13T22:42:53.013Z
 
 ## Latest Codex Summary
-- None yet.
+Recorded current-head host-local blocker observations separately from blocker-comment persistence, then used that observation in same-head ready-promotion freshness checks. That keeps workspace-preparation and workstation-local-path blockers authoritative after comment publication fails, while preserving the stale-path behavior for older records that lack current-head evidence.
+
+The change is in commit `1ebc994` (`Preserve observed same-head host-local blockers`). I added focused regressions for post-turn comment-failure handling plus reconciliation, `status`, `explain`, and `doctor`, and the requested verification passed locally. The only remaining uncommitted items are supervisor-owned transient artifacts under `.codex-supervisor/`.
+
+Summary: Preserved same-head host-local ready-promotion blockers by persisting current-head blocker observations independent of sticky-comment publication, added focused regressions, and committed the fix as `1ebc994`.
+State hint: stabilizing
+Blocked reason: none
+Tests: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "comment posting fails|host-local blocker"`; `node --test --import tsx src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts`; `npm run build`
+Next action: Push commit `1ebc994` and open or update the branch PR if the supervisor requests publication
+Failure signature: PRRT_kwDORgvdZ856qw1j
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1492#discussion_r3076208723
+- Details:
+  - src/post-turn-pull-request.ts:1506 summary=_⚠️ Potential issue_ | _🟠 Major_ **Workstation path-hygiene blockers can still lose fresh evidence on comment failure.** Line 1503 applies observed-blocker persistence for work... url=https://github.com/TommyKammy/codex-supervisor/pull/1492#discussion_r3076208723
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Same-head host-local ready-promotion blockers were only considered fresh when local CI failed on the current head or a blocker comment had been persisted, so workspace-preparation and workstation-local-path blockers observed on the current head could be down-ranked as stale if comment publication failed.
-- What changed: Added head-scoped `last_observed_host_local_pr_blocker_*` state, recorded it before best-effort blocker comment publication, cleared it after host-local gates pass, taught the ready-promotion freshness helper to trust that observation, and added focused regressions for post-turn, reconciliation, status, explain, and doctor.
+- Hypothesis: The follow-up review correctly identified that three `workstation_local_path_hygiene` blocked-state writes still skipped `last_observed_host_local_pr_blocker_*`, so same-head path-hygiene blockers could still look stale when comment publication failed or normalization could not be published.
+- What changed: Added `observedTrackedPrHostLocalBlockerPatch(...)` to the initial path-hygiene failure branch and both normalization-persistence failure branches in `handlePostTurnPullRequestTransitionsPhase`, added a focused `comment posting fails` regression for path-hygiene blockers, and extended the unpublished-normalization regression to assert the current-head observation is persisted.
 - Current blocker: none
-- Next exact step: Push the checkpoint commit or open/update the draft PR if the supervisor asks for publication.
-- Verification gap: none for the requested local checks; the broad reconciliation test still emits pre-existing execution-metrics warning logs in fixture scenarios, but the suite passes.
-- Files touched: .codex-supervisor/issue-journal.md; src/core/types.ts; src/core/state-store.ts; src/core/state-store-normalization.ts; src/post-turn-pull-request.ts; src/tracked-pr-ready-promotion-blocker.ts; src/tracked-pr-lifecycle-projection.ts; src/post-turn-pull-request.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts; src/doctor.test.ts; src/supervisor/supervisor-test-helpers.ts; src/turn-execution-test-helpers.ts
+- Next exact step: Commit the review-fix delta, then push `codex/issue-1491` and update PR #1492 if publication is requested.
+- Verification gap: none for the requested checks; the broader reconciliation suite still logs the same pre-existing execution-metrics chronology warnings in fixture scenarios, but the suite passes.
+- Files touched: .codex-supervisor/issue-journal.md; src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts
 - Rollback concern: The new observed-blocker fields are intentionally sticky across same-head reconciliation until a successful ready-promotion pass clears them; if another caller starts reusing those fields outside ready-promotion freshness checks, same-head stale classification could become too conservative.
-- Last focused command: node --test --import tsx src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -148,6 +148,8 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     last_tracked_pr_progress_snapshot: value.last_tracked_pr_progress_snapshot ?? null,
     last_tracked_pr_progress_summary: value.last_tracked_pr_progress_summary ?? null,
     last_tracked_pr_repeat_failure_decision: value.last_tracked_pr_repeat_failure_decision ?? null,
+    last_observed_host_local_pr_blocker_signature: value.last_observed_host_local_pr_blocker_signature ?? null,
+    last_observed_host_local_pr_blocker_head_sha: value.last_observed_host_local_pr_blocker_head_sha ?? null,
     last_host_local_pr_blocker_comment_signature: value.last_host_local_pr_blocker_comment_signature ?? null,
     last_host_local_pr_blocker_comment_head_sha: value.last_host_local_pr_blocker_comment_head_sha ?? null,
     stale_review_bot_reply_progress_keys: value.stale_review_bot_reply_progress_keys ?? [],

--- a/src/core/state-store.ts
+++ b/src/core/state-store.ts
@@ -204,6 +204,14 @@ export class StateStore {
         hasOwn(patch, "last_blocker_signature") ? patch.last_blocker_signature ?? null : record.last_blocker_signature ?? null,
       last_failure_signature:
         hasOwn(patch, "last_failure_signature") ? patch.last_failure_signature ?? null : record.last_failure_signature ?? null,
+      last_observed_host_local_pr_blocker_signature:
+        hasOwn(patch, "last_observed_host_local_pr_blocker_signature")
+          ? patch.last_observed_host_local_pr_blocker_signature ?? null
+          : record.last_observed_host_local_pr_blocker_signature ?? null,
+      last_observed_host_local_pr_blocker_head_sha:
+        hasOwn(patch, "last_observed_host_local_pr_blocker_head_sha")
+          ? patch.last_observed_host_local_pr_blocker_head_sha ?? null
+          : record.last_observed_host_local_pr_blocker_head_sha ?? null,
       last_host_local_pr_blocker_comment_signature:
         hasOwn(patch, "last_host_local_pr_blocker_comment_signature")
           ? patch.last_host_local_pr_blocker_comment_signature ?? null

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -377,6 +377,8 @@ export interface IssueRunRecord {
   last_tracked_pr_progress_snapshot?: string | null;
   last_tracked_pr_progress_summary?: string | null;
   last_tracked_pr_repeat_failure_decision?: "retry_on_progress" | "stop_no_progress" | null;
+  last_observed_host_local_pr_blocker_signature?: string | null;
+  last_observed_host_local_pr_blocker_head_sha?: string | null;
   last_host_local_pr_blocker_comment_signature?: string | null;
   last_host_local_pr_blocker_comment_head_sha?: string | null;
   last_stale_review_bot_reply_signature?: string | null;

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1646,6 +1646,118 @@ test("diagnoseSupervisorHost marks same-head ready-promotion blockers as stale w
   assert.doesNotMatch(renderDoctorReport(diagnostics), /The same blocker is still present/);
 });
 
+test("diagnoseSupervisorHost keeps same-head host-local ready-promotion blockers current when the current head observation exists without a persisted blocker comment", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-177");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "fixture"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  execFileSync("git", ["-C", repoPath, "worktree", "add", "-b", "codex/reopen-issue-177", workspace], {
+    encoding: "utf8",
+  });
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    stateFile,
+    codexBinary: process.execPath,
+    localCiCommand: "npm run verify:paths",
+  });
+  const trackedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "177": createRecord({
+        issue_number: 177,
+        state: "blocked",
+        branch: "codex/reopen-issue-177",
+        workspace,
+        pr_number: 277,
+        blocked_reason: "verification",
+        last_head_sha: "head-draft-277",
+        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #277 ready.",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_observed_host_local_pr_blocker_head_sha: "head-draft-277",
+        last_observed_host_local_pr_blocker_signature: "workstation-local-path-hygiene-failed",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-277",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:08:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    },
+  };
+  const draftPr = createPullRequest({
+    number: 277,
+    headRefName: "codex/reopen-issue-177",
+    headRefOid: "head-draft-277",
+    isDraft: true,
+  });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config,
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => trackedState,
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 1,
+        truncated: false,
+      }),
+      getPullRequestIfExists: async () => draftPr,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#177 pr=#277 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./,
+  );
+  assert.doesNotMatch(
+    renderDoctorReport(diagnostics),
+    /stored ready-for-review verification blocker is stale relative to the current head/,
+  );
+});
+
 test("diagnoseSupervisorHost exposes host-local CI blocker details for tracked PR mismatches", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1316,6 +1316,104 @@ test("handlePostTurnPullRequestTransitionsPhase records workspace-preparation bl
   assert.equal(result.record.last_host_local_pr_blocker_comment_signature, null);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase records workstation-local path blocker observations when tracked PR comment posting fails", async () => {
+  const config = createConfig({ localCiCommand: "npm run ci:local" });
+  const issue = createIssue({ title: "Best-effort tracked PR path-hygiene blocker comments" });
+  const draftPr = createPullRequest({ title: "Tracked PR path-hygiene blocker", isDraft: true });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+  };
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        throw new Error("unexpected markPullRequestReady call");
+      },
+      addIssueComment: async () => {
+        throw new Error("GitHub comment transport unavailable");
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => {
+      throw new Error("unexpected local CI call");
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: false,
+      failureContext: {
+        ...createFailureContext("Tracked durable artifacts failed workstation-local path hygiene before marking PR #116 ready."),
+        signature: "workstation-local-path-hygiene-failed",
+        details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
+      },
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(result.record.last_host_local_pr_blocker_comment_signature, null);
+  assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, draftPr.headRefOid);
+  assert.equal(
+    result.record.last_observed_host_local_pr_blocker_signature,
+    "workstation-local-path-hygiene-failed",
+  );
+});
+
 test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR host-local blocker comment after restart", async () => {
   const config = createConfig({
     workspacePreparationCommand: "npm ci",
@@ -4713,6 +4811,11 @@ test("handlePostTurnPullRequestTransitionsPhase blocks ready promotion until a l
   assert.match(result.record.last_failure_context?.details[0] ?? "", /local workspace HEAD/);
   assert.ok((result.record.last_failure_context?.details[0] ?? "").includes(localHead));
   assert.ok((result.record.last_failure_context?.details[0] ?? "").includes(remoteHead));
+  assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, remoteHead);
+  assert.equal(
+    result.record.last_observed_host_local_pr_blocker_signature,
+    "workstation-local-path-hygiene-failed",
+  );
 });
 
 test("handlePostTurnPullRequestTransitionsPhase keeps follow-up-eligible residuals advisory by default", async (t) => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1209,6 +1209,111 @@ test("handlePostTurnPullRequestTransitionsPhase keeps blocker state authoritativ
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
   assert.equal(result.record.last_failure_signature, "local-ci-gate-workspace_toolchain_missing");
+  assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, draftPr.headRefOid);
+  assert.equal(
+    result.record.last_observed_host_local_pr_blocker_signature,
+    "local-ci-gate-workspace_toolchain_missing",
+  );
+});
+
+test("handlePostTurnPullRequestTransitionsPhase records workspace-preparation blocker observations when tracked PR comment posting fails", async () => {
+  const config = createConfig({
+    workspacePreparationCommand: "npm ci",
+    localCiCommand: "npm run ci:local",
+  });
+  const issue = createIssue({ title: "Best-effort tracked PR workspace-preparation blocker comments" });
+  const draftPr = createPullRequest({ title: "Tracked PR workspace-preparation blocker", isDraft: true });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+  };
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        throw new Error("unexpected markPullRequestReady call");
+      },
+      addIssueComment: async () => {
+        throw new Error("GitHub comment transport unavailable");
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkspacePreparationCommand: async () => {
+      throw new Error("Command failed: sh -lc +1 args\nexitCode=1\nnpm error missing node_modules");
+    },
+    runLocalCiCommand: async () => {
+      throw new Error("unexpected runLocalCiCommand call");
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "workspace-preparation-gate-non_zero_exit");
+  assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, draftPr.headRefOid);
+  assert.equal(
+    result.record.last_observed_host_local_pr_blocker_signature,
+    "workspace-preparation-gate-non_zero_exit",
+  );
+  assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(result.record.last_host_local_pr_blocker_comment_signature, null);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR host-local blocker comment after restart", async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -1374,6 +1374,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...observedTrackedPrHostLocalBlockerPatch({
+          pr: refreshed.pr,
+          blockerSignature: failureContext?.signature ?? null,
+        }),
       });
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
@@ -1425,6 +1429,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           last_failure_context: failureContext,
           ...args.applyFailureSignature(record, failureContext),
           blocked_reason: "verification",
+          ...observedTrackedPrHostLocalBlockerPatch({
+            pr: refreshed.pr,
+            blockerSignature: failureContext.signature,
+          }),
         });
         state.issues[String(record.issue_number)] = record;
         await stateStore.save(state);
@@ -1450,6 +1458,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           last_failure_context: failureContext,
           ...args.applyFailureSignature(record, failureContext),
           blocked_reason: "verification",
+          ...observedTrackedPrHostLocalBlockerPatch({
+            pr: refreshed.pr,
+            blockerSignature: failureContext.signature,
+          }),
         });
         state.issues[String(record.issue_number)] = record;
         await stateStore.save(state);

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -167,6 +167,16 @@ function buildTrackedPrHostLocalBlockerComment(args: {
   ].join("\n");
 }
 
+function observedTrackedPrHostLocalBlockerPatch(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  blockerSignature: string | null;
+}): Pick<IssueRunRecord, "last_observed_host_local_pr_blocker_signature" | "last_observed_host_local_pr_blocker_head_sha"> {
+  return {
+    last_observed_host_local_pr_blocker_head_sha: args.pr.headRefOid,
+    last_observed_host_local_pr_blocker_signature: args.blockerSignature,
+  };
+}
+
 function summarizeWorkstationLocalPathFirstFix(details: string[] | null | undefined): string | null {
   if (!details || details.length === 0) {
     return null;
@@ -1490,6 +1500,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...observedTrackedPrHostLocalBlockerPatch({
+          pr: refreshed.pr,
+          blockerSignature: failureContext?.signature ?? null,
+        }),
       });
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
@@ -1537,6 +1551,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...observedTrackedPrHostLocalBlockerPatch({
+          pr: refreshed.pr,
+          blockerSignature: failureContext?.signature ?? null,
+        }),
       });
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
@@ -1569,6 +1587,8 @@ export async function handlePostTurnPullRequestTransitionsPhase(
             head_sha: refreshed.pr.headRefOid,
           }
         : null,
+      last_observed_host_local_pr_blocker_signature: null,
+      last_observed_host_local_pr_blocker_head_sha: null,
     });
     state.issues[String(record.issue_number)] = record;
     await stateStore.save(state);
@@ -1588,6 +1608,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
+        ...observedTrackedPrHostLocalBlockerPatch({
+          pr: refreshed.pr,
+          blockerSignature: failureContext.signature,
+        }),
       });
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -726,6 +726,98 @@ test("explain marks same-head ready-promotion blockers as stale when fresh block
   assert.doesNotMatch(explanation, /The same blocker is still present/);
 });
 
+test("explain keeps same-head host-local ready-promotion blockers current when the current head observation exists without a persisted blocker comment", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 177;
+  const prNumber = 277;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "verification",
+        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #277 ready.",
+        last_head_sha: "head-draft-277",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_observed_host_local_pr_blocker_head_sha: "head-draft-277",
+        last_observed_host_local_pr_blocker_signature: "workstation-local-path-hygiene-failed",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-277",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:08:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked current same-head draft PR ready gate",
+    body: executionReadyBody("Explain should surface current same-head ready-promotion blockers when comment publication is unavailable."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-draft-277",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^tracked_pr_ready_promotion_blocked issue=#177 pr=#277 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    explanation,
+    /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
+  );
+  assert.doesNotMatch(
+    explanation,
+    /stored ready-for-review verification blocker is stale relative to the current head/,
+  );
+});
+
 test("explain reports bootstrap repos as not ready for expected CI and review signals", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 181;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2894,6 +2894,96 @@ test("status marks same-head ready-promotion blockers as stale when fresh blocke
   assert.doesNotMatch(report.detailedStatusLines.join("\n"), /The same blocker is still present/);
 });
 
+test("status keeps same-head host-local ready-promotion blockers current when the current head observation exists without a persisted blocker comment", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 177;
+  const prNumber = 277;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "verification",
+        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #277 ready.",
+        last_head_sha: "head-draft-277",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_observed_host_local_pr_blocker_head_sha: "head-draft-277",
+        last_observed_host_local_pr_blocker_signature: "workstation-local-path-hygiene-failed",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-old-277",
+          reviewDecision: null,
+          mergeStateStatus: "CLEAN",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-03-13T00:08:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: null,
+          configuredBotTopLevelReviewSubmittedAt: null,
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: [],
+        }),
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked current same-head draft PR ready gate",
+    body: executionReadyBody("Surface current same-head ready-promotion blockers when comment publication is unavailable."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-draft-277",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^tracked_pr_ready_promotion_blocked issue=#177 pr=#277 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
+  );
+  assert.doesNotMatch(
+    report.detailedStatusLines.join("\n"),
+    /stored ready-for-review verification blocker is stale relative to the current head/,
+  );
+});
+
 test("status surfaces host-local CI blocker details for tracked PR mismatches", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1715,6 +1715,101 @@ test("reconcileRecoverableBlockedIssueStates keeps same-head draft tracked PRs b
   assert.deepEqual(recoveryEvents, []);
 });
 
+test("reconcileRecoverableBlockedIssueStates keeps same-head draft tracked PR host-local blockers blocked when the current head observation exists without a persisted comment", async () => {
+  const config = createConfig({
+    localCiCommand: "npm run verify:paths",
+  });
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #191 ready.",
+    signature: "workstation-local-path-hygiene-failed",
+    command: "npm run verify:paths",
+    details: ["First fix: .codex-supervisor/issue-journal.md (1 match)."],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error: failureContext.summary,
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        last_failure_signature: failureContext.signature,
+        repeated_failure_signature_count: 1,
+        last_observed_host_local_pr_blocker_head_sha: "head-191",
+        last_observed_host_local_pr_blocker_signature: failureContext.signature,
+        latest_local_ci_result: null,
+        last_host_local_pr_blocker_comment_signature: null,
+        last_host_local_pr_blocker_comment_head_sha: null,
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    isDraft: true,
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.last_error, failureContext.summary);
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.equal(updated.last_observed_host_local_pr_blocker_head_sha, "head-191");
+  assert.equal(updated.last_observed_host_local_pr_blocker_signature, failureContext.signature);
+  assert.equal(updated.last_recovery_reason, null);
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+});
+
 test("reconcileRecoverableBlockedIssueStates only falls back to getIssue for blocked tracked PR records", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = createSupervisorState({
@@ -6180,6 +6275,8 @@ test("buildTrackedPrStaleFailureConvergencePatch isolates persisted tracked PR r
     external_review_missed_findings_count: 0,
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
     last_host_local_pr_blocker_comment_head_sha: null,
     processed_review_thread_ids: [],

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -144,6 +144,8 @@ export function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunR
     last_tracked_pr_progress_snapshot: null,
     last_tracked_pr_progress_summary: null,
     last_tracked_pr_repeat_failure_decision: null,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
     last_host_local_pr_blocker_comment_head_sha: null,
     last_stale_review_bot_reply_signature: null,

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -56,6 +56,9 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
   const blockerCommentHeadStale =
     record.last_host_local_pr_blocker_comment_head_sha != null
     && record.last_host_local_pr_blocker_comment_head_sha !== nextHeadSha;
+  const observedHostLocalBlockerHeadStale =
+    record.last_observed_host_local_pr_blocker_head_sha != null
+    && record.last_observed_host_local_pr_blocker_head_sha !== nextHeadSha;
   const localCiHeadStale =
     record.latest_local_ci_result?.head_sha != null
     && record.latest_local_ci_result.head_sha !== nextHeadSha;
@@ -64,6 +67,7 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     || externalReviewHeadStale
     || reviewFollowUpHeadStale
     || blockerCommentHeadStale
+    || observedHostLocalBlockerHeadStale
     || localCiHeadStale;
 
   if ((record.last_head_sha === null || record.last_head_sha === nextHeadSha) && !headScopedStateDiverged) {
@@ -96,6 +100,8 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     external_review_missed_findings_count: 0,
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
     last_host_local_pr_blocker_comment_head_sha: null,
     processed_review_thread_ids: [],

--- a/src/tracked-pr-ready-promotion-blocker.ts
+++ b/src/tracked-pr-ready-promotion-blocker.ts
@@ -4,6 +4,8 @@ export function hasFreshTrackedPrReadyPromotionBlockerEvidence(
   record: Pick<
     IssueRunRecord,
     | "latest_local_ci_result"
+    | "last_observed_host_local_pr_blocker_head_sha"
+    | "last_observed_host_local_pr_blocker_signature"
     | "last_host_local_pr_blocker_comment_head_sha"
     | "last_host_local_pr_blocker_comment_signature"
   >,
@@ -12,6 +14,15 @@ export function hasFreshTrackedPrReadyPromotionBlockerEvidence(
   if (
     record.latest_local_ci_result?.outcome === "failed" &&
     record.latest_local_ci_result.head_sha === pr.headRefOid
+  ) {
+    return true;
+  }
+
+  if (
+    record.last_observed_host_local_pr_blocker_head_sha === pr.headRefOid &&
+    typeof record.last_observed_host_local_pr_blocker_signature === "string" &&
+    record.last_observed_host_local_pr_blocker_signature.length > 0 &&
+    !record.last_observed_host_local_pr_blocker_signature.startsWith("cleared:")
   ) {
     return true;
   }

--- a/src/turn-execution-test-helpers.ts
+++ b/src/turn-execution-test-helpers.ts
@@ -118,6 +118,8 @@ export function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunR
     last_failure_context: null,
     last_blocker_signature: null,
     last_failure_signature: null,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
     last_host_local_pr_blocker_comment_head_sha: null,
     last_stale_review_bot_reply_signature: null,


### PR DESCRIPTION
Closes #1491
This PR was opened by codex-supervisor.
Latest Codex summary:

Recorded current-head host-local blocker observations separately from blocker-comment persistence, then used that observation in same-head ready-promotion freshness checks. That keeps workspace-preparation and workstation-local-path blockers authoritative after comment publication fails, while preserving the stale-path behavior for older records that lack current-head evidence.

The change is in commit `1ebc994` (`Preserve observed same-head host-local blockers`). I added focused regressions for post-turn comment-failure handling plus reconciliation, `status`, `explain`, and `doctor`, and the requested verification passed locally. The only remaining uncommitted items are supervisor-owned transient artifacts under `.codex-supervisor/`.

Summary: Preserved same-head host-local ready-promotion blockers by persisting current-head blocker observations independent of sticky-comment publication, added focused regressions, and committed the fix as `1ebc994`.
State hint: stabilizing
Blocked reason: none
Tests: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "comment posting fails|host-local blocker"`; `node --test --import tsx src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts`; `npm run build`
Failure signature: none
Next action: Push commit `1ebc994` and open or update the branch PR if the supervisor reques...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clearer diagnostics and recovery guidance when PR promotion is blocked by local verification, avoiding false "stale" messages and indicating when rerunning the supervisor alone won't help.
  * More accurate tracking of host-local PR blocker observations so ready-promotion status reflects current local blocker evidence and distinguishes stale vs current blockers.
  * Improved error reporting to explain why local verification gates prevent PR promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->