### PR TITLE
Comment on GitHub issues when execution-ready metadata is missing (#1442)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,29 +5,45 @@
 - Branch: codex/issue-1442
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 23413175a88824ea9f1b3b81ba83b97d1df66eb5
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: c4a690b5b9df9f0b928af9706176cc6bd9772573
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T01:09:30.422Z
+- Last failure signature: PRRT_kwDORgvdZ856sDWV|PRRT_kwDORgvdZ856sDWX|PRRT_kwDORgvdZ856sDWb|PRRT_kwDORgvdZ856sDWe
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T01:40:55.000Z
 
 ## Latest Codex Summary
-- Added machine-managed requirements-blocker issue comments for execution-ready metadata failures, updated issue-lint repair guidance to the canonical `## Execution order` form, and clear the sticky blocker comment when metadata becomes execution-ready again.
+Addressed the active review threads on top of `c4a690b` by tightening sticky-comment ownership matching, narrowing sequenced-child repair guidance to the canonical predecessor-dependency shape, making blocker-comment sync best-effort on restart paths, and paginating issue comment reads so older sticky comments remain discoverable.
+
+I intentionally did not broad-brush paginate every PR comment surface mentioned by CodeRabbit. The concrete regression here was issue-comment lookup for machine-managed sticky comments; widening the patch to unrelated review-thread and PR top-level comment surfaces would have exceeded the issue scope without evidence of a behavior break in those paths. Focused tests covering the new guidance, null-`databaseId` dedupe, best-effort warning path, issue-comment pagination, recovery clearing, and `npm run build` are green.
+
+Summary: Addressed review feedback for sticky comment dedupe, sequenced-child guidance, best-effort sync, and issue-comment pagination.
+State hint: addressing_review
+Blocked reason: none
+Tests: `npx tsx --test src/run-once-issue-selection.test.ts src/github/github.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
+Next action: Commit the review-fix checkpoint, then push/update PR #1495 for re-review.
+Failure signature: none
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 4 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667581
+- Details:
+  - src/github/github-review-surface.ts:588 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 529 --- 🏁 Script executed: Repository: TommyKa... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667581
+  - src/requirements-blocker-issue-comment.ts:33 summary=_⚠️ Potential issue_ | _🟠 Major_ **Don't require `databaseId` just to recognize the sticky comment.** `IssueComment.databaseId` is nullable in `src/core/types.ts`, and `fetchIs... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667585
+  - src/requirements-blocker-issue-comment.ts:61 summary=_⚠️ Potential issue_ | _🟠 Major_ **Fix the sequenced-child `Depends on:` guidance.** This template currently tells sequenced children to keep `Depends on: none`, which is the w... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667590
+  - src/run-once-issue-selection.ts:568 summary=_⚠️ Potential issue_ | _🟠 Major_ **Treat requirements-blocker comment sync as best-effort to avoid restart-path failures.** If this external call fails, the function throws aft... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667593
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Requirements-blocked issues were only updating local state/journal; the supervisor had no owned GitHub issue-comment surface for actionable metadata blockers, and issue-lint guidance still suggested the legacy single-line `Execution order:` form.
-- What changed: Added `src/requirements-blocker-issue-comment.ts`; wired requirements blocker comment publish/update into `resolveRunnableIssueContext`; wired comment clearing into `reconcileRecoverableBlockedIssueStates`; added GitHub issue-comment GraphQL reads via `getIssueComments`; refactored issue-lint DTO creation to share logic and updated repair guidance to the canonical `## Execution order` section wording.
+- Hypothesis: The remaining automated review findings were a mix of one real dedupe bug (`databaseId` nullable), one real resilience gap (comment sync on restart path), one guidance wording gap for sequenced children, and one overly broad pagination suggestion whose concrete regression surface was older issue comments rather than every PR comment feed.
+- What changed: Removed the `databaseId` requirement from sticky-comment recognition in `src/requirements-blocker-issue-comment.ts`; updated sequenced-child repair text to prefer `Depends on: #<previous-issue-number>` when earlier sequence work truly blocks execution while still allowing `Depends on: none`; wrapped requirements-blocker comment sync in a best-effort warning helper in `src/run-once-issue-selection.ts`; paginated `fetchIssueComments` in `src/github/github-review-surface.ts`; added focused tests in `src/run-once-issue-selection.test.ts` and `src/github/github.test.ts`.
 - Current blocker: none
-- Next exact step: Review the final diff, commit the checkpoint on `codex/issue-1442`, and leave the branch ready for PR/draft PR handling.
-- Verification gap: No full suite run yet; focused coverage for guidance, publish/dedupe/update, clear-on-recovery, and `npm run build` are green.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/requirements-blocker-issue-comment.ts`, `src/run-once-issue-selection.ts`, `src/recovery-reconciliation.ts`, `src/github/github-review-surface.ts`, `src/github/github.ts`, `src/supervisor/supervisor-selection-issue-lint.ts`, related focused tests.
-- Rollback concern: Low to moderate; behavior change is limited to requirements-blocked issue comment publication/clearance and issue-lint repair text, but GitHub issue-comment lookup now depends on a new GraphQL issue comments path.
-- Last focused command: `npm run build`
+- Next exact step: Commit the current diff and update PR #1495 so GitHub can re-evaluate the addressed review threads.
+- Verification gap: No broader full-suite rerun beyond the focused areas touched in this repair pass.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/requirements-blocker-issue-comment.ts`, `src/run-once-issue-selection.ts`, `src/github/github-review-surface.ts`, `src/run-once-issue-selection.test.ts`, `src/github/github.test.ts`.
+- Rollback concern: Low; the runtime changes are narrowly scoped to issue-comment lookup, blocker-comment ownership/guidance, and restart-path error handling.
+- Last focused command: `npx tsx --test src/run-once-issue-selection.test.ts src/github/github.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,46 +1,33 @@
-# Issue #1491: Same-head host-local blockers can be cleared as stale when blocker comment publication fails
+# Issue #1442: Comment on GitHub issues when execution-ready metadata is missing
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1491
-- Branch: codex/issue-1491
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1442
+- Branch: codex/issue-1442
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 1ebc994164cc74440b4cd9cef7efc9d12b4bacf3
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 23413175a88824ea9f1b3b81ba83b97d1df66eb5
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856qw1j
-- Repeated failure signature count: 1
-- Updated at: 2026-04-13T22:42:53.013Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T01:09:30.422Z
 
 ## Latest Codex Summary
-Recorded current-head host-local blocker observations separately from blocker-comment persistence, then used that observation in same-head ready-promotion freshness checks. That keeps workspace-preparation and workstation-local-path blockers authoritative after comment publication fails, while preserving the stale-path behavior for older records that lack current-head evidence.
-
-The change is in commit `1ebc994` (`Preserve observed same-head host-local blockers`). I added focused regressions for post-turn comment-failure handling plus reconciliation, `status`, `explain`, and `doctor`, and the requested verification passed locally. The only remaining uncommitted items are supervisor-owned transient artifacts under `.codex-supervisor/`.
-
-Summary: Preserved same-head host-local ready-promotion blockers by persisting current-head blocker observations independent of sticky-comment publication, added focused regressions, and committed the fix as `1ebc994`.
-State hint: stabilizing
-Blocked reason: none
-Tests: `node --test --import tsx src/post-turn-pull-request.test.ts --test-name-pattern "comment posting fails|host-local blocker"`; `node --test --import tsx src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts`; `npm run build`
-Next action: Push commit `1ebc994` and open or update the branch PR if the supervisor requests publication
-Failure signature: PRRT_kwDORgvdZ856qw1j
+- Added machine-managed requirements-blocker issue comments for execution-ready metadata failures, updated issue-lint repair guidance to the canonical `## Execution order` form, and clear the sticky blocker comment when metadata becomes execution-ready again.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1492#discussion_r3076208723
-- Details:
-  - src/post-turn-pull-request.ts:1506 summary=_⚠️ Potential issue_ | _🟠 Major_ **Workstation path-hygiene blockers can still lose fresh evidence on comment failure.** Line 1503 applies observed-blocker persistence for work... url=https://github.com/TommyKammy/codex-supervisor/pull/1492#discussion_r3076208723
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The follow-up review correctly identified that three `workstation_local_path_hygiene` blocked-state writes still skipped `last_observed_host_local_pr_blocker_*`, so same-head path-hygiene blockers could still look stale when comment publication failed or normalization could not be published.
-- What changed: Added `observedTrackedPrHostLocalBlockerPatch(...)` to the initial path-hygiene failure branch and both normalization-persistence failure branches in `handlePostTurnPullRequestTransitionsPhase`, added a focused `comment posting fails` regression for path-hygiene blockers, and extended the unpublished-normalization regression to assert the current-head observation is persisted.
+- Hypothesis: Requirements-blocked issues were only updating local state/journal; the supervisor had no owned GitHub issue-comment surface for actionable metadata blockers, and issue-lint guidance still suggested the legacy single-line `Execution order:` form.
+- What changed: Added `src/requirements-blocker-issue-comment.ts`; wired requirements blocker comment publish/update into `resolveRunnableIssueContext`; wired comment clearing into `reconcileRecoverableBlockedIssueStates`; added GitHub issue-comment GraphQL reads via `getIssueComments`; refactored issue-lint DTO creation to share logic and updated repair guidance to the canonical `## Execution order` section wording.
 - Current blocker: none
-- Next exact step: Commit the review-fix delta, then push `codex/issue-1491` and update PR #1492 if publication is requested.
-- Verification gap: none for the requested checks; the broader reconciliation suite still logs the same pre-existing execution-metrics chronology warnings in fixture scenarios, but the suite passes.
-- Files touched: .codex-supervisor/issue-journal.md; src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts
-- Rollback concern: The new observed-blocker fields are intentionally sticky across same-head reconciliation until a successful ready-promotion pass clears them; if another caller starts reusing those fields outside ready-promotion freshness checks, same-head stale classification could become too conservative.
-- Last focused command: npm run build
+- Next exact step: Review the final diff, commit the checkpoint on `codex/issue-1442`, and leave the branch ready for PR/draft PR handling.
+- Verification gap: No full suite run yet; focused coverage for guidance, publish/dedupe/update, clear-on-recovery, and `npm run build` are green.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/requirements-blocker-issue-comment.ts`, `src/run-once-issue-selection.ts`, `src/recovery-reconciliation.ts`, `src/github/github-review-surface.ts`, `src/github/github.ts`, `src/supervisor/supervisor-selection-issue-lint.ts`, related focused tests.
+- Rollback concern: Low to moderate; behavior change is limited to requirements-blocked issue comment publication/clearance and issue-lint repair text, but GitHub issue-comment lookup now depends on a new GraphQL issue comments path.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -581,83 +581,136 @@ export class GitHubReviewSurfaceClient {
 
   private async fetchIssueComments(issueNumber: number): Promise<IssueComment[]> {
     const { owner, repo } = this.repoOwnerAndName();
-    const query = `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          issue(number: $number) {
-            comments(last: 100) {
-              nodes {
-                id
-                databaseId
-                body
-                createdAt
-                url
-                viewerDidAuthor
-                author {
-                  login
-                  __typename
+    const comments: IssueComment[] = [];
+    let cursor: string | null = null;
+
+    while (true) {
+      const query = cursor === null
+        ? `
+          query($owner: String!, $repo: String!, $number: Int!) {
+            repository(owner: $owner, name: $repo) {
+              issue(number: $number) {
+                comments(first: 100) {
+                  nodes {
+                    id
+                    databaseId
+                    body
+                    createdAt
+                    url
+                    viewerDidAuthor
+                    author {
+                      login
+                      __typename
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
                 }
               }
             }
           }
-        }
-      }
-    `;
-
-    const result = await this.runGhJsonCommand([
-      "api",
-      "graphql",
-      "-f",
-      `query=${query}`,
-      "-F",
-      `owner=${owner}`,
-      "-F",
-      `repo=${repo}`,
-      "-F",
-      `number=${issueNumber}`,
-    ]);
-
-    const payload = parseJson<{
-      data?: {
-        repository?: {
-          issue?: {
-            comments?: {
-              nodes?: Array<{
-                id?: string | null;
-                databaseId?: number | null;
-                body?: string | null;
-                createdAt?: string | null;
-                url?: string | null;
-                viewerDidAuthor?: boolean | null;
-                author?: {
-                  login?: string | null;
-                  __typename?: string | null;
-                } | null;
-              }>;
-            };
-          } | null;
-        };
-      };
-    }>(result.stdout, `gh api graphql issue comments issue=${issueNumber}`);
-
-    return payload.data?.repository?.issue?.comments?.nodes?.flatMap((comment) =>
-      comment?.id
-        ? [{
-          id: comment.id,
-          databaseId: comment.databaseId ?? null,
-          body: comment.body ?? "",
-          createdAt: comment.createdAt ?? "",
-          url: comment.url ?? null,
-          viewerDidAuthor: comment.viewerDidAuthor ?? null,
-          author: comment.author
-            ? {
-              login: comment.author.login ?? null,
-              typeName: comment.author.__typename ?? null,
+        `
+        : `
+          query($owner: String!, $repo: String!, $number: Int!, $cursor: String!) {
+            repository(owner: $owner, name: $repo) {
+              issue(number: $number) {
+                comments(first: 100, after: $cursor) {
+                  nodes {
+                    id
+                    databaseId
+                    body
+                    createdAt
+                    url
+                    viewerDidAuthor
+                    author {
+                      login
+                      __typename
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
             }
-            : null,
-        }]
-        : []
-    ) ?? [];
+          }
+        `;
+      const args = [
+        "api",
+        "graphql",
+        "-f",
+        `query=${query}`,
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `repo=${repo}`,
+        "-F",
+        `number=${issueNumber}`,
+      ];
+      if (cursor !== null) {
+        args.push("-F", `cursor=${cursor}`);
+      }
+
+      const result = await this.runGhJsonCommand(args);
+      const payload = parseJson<{
+        data?: {
+          repository?: {
+            issue?: {
+              comments?: {
+                nodes?: Array<{
+                  id?: string | null;
+                  databaseId?: number | null;
+                  body?: string | null;
+                  createdAt?: string | null;
+                  url?: string | null;
+                  viewerDidAuthor?: boolean | null;
+                  author?: {
+                    login?: string | null;
+                    __typename?: string | null;
+                  } | null;
+                }>;
+                pageInfo?: {
+                  hasNextPage?: boolean | null;
+                  endCursor?: string | null;
+                } | null;
+              };
+            } | null;
+          };
+        };
+      }>(result.stdout, `gh api graphql issue comments issue=${issueNumber}`);
+
+      const connection = payload.data?.repository?.issue?.comments;
+      comments.push(...(connection?.nodes?.flatMap((comment) =>
+        comment?.id
+          ? [{
+            id: comment.id,
+            databaseId: comment.databaseId ?? null,
+            body: comment.body ?? "",
+            createdAt: comment.createdAt ?? "",
+            url: comment.url ?? null,
+            viewerDidAuthor: comment.viewerDidAuthor ?? null,
+            author: comment.author
+              ? {
+                login: comment.author.login ?? null,
+                typeName: comment.author.__typename ?? null,
+              }
+              : null,
+          }]
+          : []
+      ) ?? []));
+
+      const pageInfo = connection?.pageInfo;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) {
+        break;
+      }
+
+      cursor = pageInfo.endCursor;
+    }
+
+    return comments;
   }
 
   private async hydratePullRequestForStatus(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -22,6 +22,11 @@ export interface PullRequestReviewSurfaceOptions {
   reviewSurfaceVersion?: string | null;
 }
 
+export interface IssueCommentSurfaceOptions {
+  purpose?: "status" | "action";
+  issueVersion?: string | null;
+}
+
 export class GitHubReviewSurfaceClient {
   private readonly pullRequestHydrator: GitHubPullRequestHydrator;
   private readonly pullRequestGraphqlSurfaceCache = new Map<string, Promise<unknown>>();
@@ -286,6 +291,20 @@ export class GitHubReviewSurfaceClient {
       prNumber,
       options,
       () => this.fetchExternalReviewSurface(prNumber),
+    );
+  }
+
+  async getIssueComments(
+    issueNumber: number,
+    options: IssueCommentSurfaceOptions = {},
+  ): Promise<IssueComment[]> {
+    if (options.purpose !== "status" || !options.issueVersion) {
+      return this.fetchIssueComments(issueNumber);
+    }
+
+    return this.getCachedPullRequestGraphqlSurface(
+      `issue-comments:${issueNumber}:${options.issueVersion}`,
+      () => this.fetchIssueComments(issueNumber),
     );
   }
 
@@ -558,6 +577,87 @@ export class GitHubReviewSurfaceClient {
             : [],
         ) ?? [],
     };
+  }
+
+  private async fetchIssueComments(issueNumber: number): Promise<IssueComment[]> {
+    const { owner, repo } = this.repoOwnerAndName();
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          issue(number: $number) {
+            comments(last: 100) {
+              nodes {
+                id
+                databaseId
+                body
+                createdAt
+                url
+                viewerDidAuthor
+                author {
+                  login
+                  __typename
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await this.runGhJsonCommand([
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `repo=${repo}`,
+      "-F",
+      `number=${issueNumber}`,
+    ]);
+
+    const payload = parseJson<{
+      data?: {
+        repository?: {
+          issue?: {
+            comments?: {
+              nodes?: Array<{
+                id?: string | null;
+                databaseId?: number | null;
+                body?: string | null;
+                createdAt?: string | null;
+                url?: string | null;
+                viewerDidAuthor?: boolean | null;
+                author?: {
+                  login?: string | null;
+                  __typename?: string | null;
+                } | null;
+              }>;
+            };
+          } | null;
+        };
+      };
+    }>(result.stdout, `gh api graphql issue comments issue=${issueNumber}`);
+
+    return payload.data?.repository?.issue?.comments?.nodes?.flatMap((comment) =>
+      comment?.id
+        ? [{
+          id: comment.id,
+          databaseId: comment.databaseId ?? null,
+          body: comment.body ?? "",
+          createdAt: comment.createdAt ?? "",
+          url: comment.url ?? null,
+          viewerDidAuthor: comment.viewerDidAuthor ?? null,
+          author: comment.author
+            ? {
+              login: comment.author.login ?? null,
+              typeName: comment.author.__typename ?? null,
+            }
+            : null,
+        }]
+        : []
+    ) ?? [];
   }
 
   private async hydratePullRequestForStatus(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -633,6 +633,83 @@ test("GitHubClient refreshes external review surface for action reads even on th
   assert.equal(graphqlCalls, 2);
 });
 
+test("GitHubClient paginates issue comments so older machine-managed comments stay visible", async () => {
+  const config = createConfig();
+  const queries: string[] = [];
+  let graphqlCalls = 0;
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      graphqlCalls += 1;
+      queries.push(args.find((arg) => arg.startsWith("query=")) ?? "");
+      const cursor = args.find((arg) => arg.startsWith("cursor=")) ?? null;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                comments: cursor === null
+                  ? {
+                    nodes: [
+                      {
+                        id: "comment-1",
+                        databaseId: 1001,
+                        body: "oldest visible sticky comment",
+                        createdAt: "2026-03-13T02:20:00Z",
+                        url: "https://example.test/issues/44#issuecomment-1001",
+                        viewerDidAuthor: true,
+                        author: {
+                          login: "codex-supervisor",
+                          __typename: "Bot",
+                        },
+                      },
+                    ],
+                    pageInfo: {
+                      hasNextPage: true,
+                      endCursor: "cursor-1",
+                    },
+                  }
+                  : {
+                    nodes: [
+                      {
+                        id: "comment-2",
+                        databaseId: 1002,
+                        body: "newer operator comment",
+                        createdAt: "2026-03-13T02:21:00Z",
+                        url: "https://example.test/issues/44#issuecomment-1002",
+                        viewerDidAuthor: false,
+                        author: {
+                          login: "octocat",
+                          __typename: "User",
+                        },
+                      },
+                    ],
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null,
+                    },
+                  },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const comments = await client.getIssueComments(44, { purpose: "action" });
+
+  assert.equal(graphqlCalls, 2);
+  assert.equal(comments.length, 2);
+  assert.equal(comments[0]?.id, "comment-1");
+  assert.equal(comments[1]?.id, "comment-2");
+  assert.match(queries[0] ?? "", /comments\(first: 100\)/);
+  assert.match(queries[1] ?? "", /comments\(first: 100, after: \$cursor\)/);
+});
+
 test("GitHubClient updates an existing issue comment", async () => {
   const config = createConfig();
   let capturedArgs: string[] | null = null;

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -13,7 +13,11 @@ import {
 import { CommandOptions, runCommand } from "../core/command";
 import { GitHubInventoryClient, GitHubInventoryRefreshError, ListAllIssuesOptions } from "./github-inventory";
 import { GitHubMutationClient } from "./github-mutations";
-import { GitHubReviewSurfaceClient, PullRequestReviewSurfaceOptions } from "./github-review-surface";
+import {
+  GitHubReviewSurfaceClient,
+  IssueCommentSurfaceOptions,
+  PullRequestReviewSurfaceOptions,
+} from "./github-review-surface";
 import { GitHubTransport, isGitHubRateLimitFailure } from "./github-transport";
 
 export { isTransientGitHubCommandFailure } from "./github-transport";
@@ -203,5 +207,12 @@ export class GitHubClient {
     issueComments: IssueComment[];
   }> {
     return this.reviewSurface.getExternalReviewSurface(prNumber, options);
+  }
+
+  async getIssueComments(
+    issueNumber: number,
+    options: IssueCommentSurfaceOptions = {},
+  ): Promise<IssueComment[]> {
+    return this.reviewSurface.getIssueComments(issueNumber, options);
   }
 }

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -72,6 +72,7 @@ import {
 import { mergeConflictDetected } from "./supervisor/supervisor-status-rendering";
 import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "./tracked-pr-ready-promotion-blocker";
+import { clearRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
 
 const OWNER_GUARDED_ACTIVE_STATES = new Set<RunState>([
   "planning",
@@ -97,7 +98,7 @@ type RecoveryGitHubLike = Pick<
   | "getMergedPullRequestsClosingIssue"
   | "getPullRequestIfExists"
   | "getUnresolvedReviewThreads"
->;
+> & Partial<Pick<import("./github").GitHubClient, "getIssueComments" | "updateIssueComment">>;
 
 async function fetchOriginDefaultBranch(
   config: Pick<SupervisorConfig, "repoPath" | "defaultBranch" | "codexExecTimeoutMinutes">,
@@ -843,7 +844,8 @@ export async function reconcileStaleDoneIssueStates(
 }
 
 export async function reconcileRecoverableBlockedIssueStates(
-  github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">,
+  github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">
+    & Partial<Pick<RecoveryGitHubLike, "getIssueComments" | "updateIssueComment">>,
   stateStore: StateStoreLike,
   state: SupervisorStateFile,
   config: SupervisorConfig,
@@ -1182,6 +1184,7 @@ export async function reconcileRecoverableBlockedIssueStates(
       });
       state.issues[String(record.issue_number)] = updated;
       changed = true;
+      await clearRequirementsBlockerIssueComment(github, record.issue_number, issue.updatedAt);
       recoveryEvents.push(recoveryEvent);
       continue;
     }

--- a/src/requirements-blocker-issue-comment.ts
+++ b/src/requirements-blocker-issue-comment.ts
@@ -22,8 +22,7 @@ function findOwnedRequirementsBlockerComment(
   const matchingComments = issueComments.filter(
     (comment) =>
       comment.body.includes(marker) &&
-      comment.viewerDidAuthor === true &&
-      typeof comment.databaseId === "number",
+      comment.viewerDidAuthor === true,
   );
   if (matchingComments.length === 0) {
     return null;
@@ -52,7 +51,7 @@ function buildCanonicalRepairSection(issue: GitHubIssue): string[] {
     return [
       "Canonical sequenced-child repair:",
       "- add `Part of: #<number>` only when this issue truly belongs to a parent epic or tracked sequence",
-      "- keep `Depends on: none` unless another issue truly blocks execution",
+      "- add `Depends on: #<previous-issue-number>` when earlier sequence work must land first; otherwise use `Depends on: none`",
       "- keep `Parallelizable: No` unless parallel execution is confirmed safe",
       "```md",
       "## Execution order",

--- a/src/requirements-blocker-issue-comment.ts
+++ b/src/requirements-blocker-issue-comment.ts
@@ -1,0 +1,171 @@
+import { GitHubClient } from "./github";
+import { GitHubIssue, IssueComment } from "./core/types";
+import { parseIssueMetadata } from "./issue-metadata";
+import { createIssueLintDto } from "./supervisor/supervisor-selection-issue-lint";
+
+const REQUIREMENTS_BLOCKER_COMMENT_MARKER_PREFIX = "codex-supervisor:requirements-blocker-comment";
+
+type RequirementsBlockerIssueCommentGitHub = Partial<Pick<
+  GitHubClient,
+  "addIssueComment" | "getIssueComments" | "updateIssueComment"
+>>;
+
+function buildRequirementsBlockerCommentMarker(issueNumber: number): string {
+  return `<!-- ${REQUIREMENTS_BLOCKER_COMMENT_MARKER_PREFIX} issue=${issueNumber} -->`;
+}
+
+function findOwnedRequirementsBlockerComment(
+  issueComments: IssueComment[],
+  issueNumber: number,
+): IssueComment | null {
+  const marker = buildRequirementsBlockerCommentMarker(issueNumber);
+  const matchingComments = issueComments.filter(
+    (comment) =>
+      comment.body.includes(marker) &&
+      comment.viewerDidAuthor === true &&
+      typeof comment.databaseId === "number",
+  );
+  if (matchingComments.length === 0) {
+    return null;
+  }
+
+  matchingComments.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  return matchingComments[0] ?? null;
+}
+
+function quoteItems(items: string[]): string {
+  return items.map((item) => `\`${item}\``).join(", ");
+}
+
+function buildCanonicalRepairSection(issue: GitHubIssue): string[] {
+  const metadata = parseIssueMetadata(issue);
+  const executionOrderIndex = metadata.executionOrderIndex;
+  const executionOrderTotal = metadata.executionOrderTotal;
+  const isSequencedChild =
+    metadata.parentIssueNumber !== null ||
+    (executionOrderIndex !== null && executionOrderTotal !== null && executionOrderTotal > 1);
+
+  if (isSequencedChild) {
+    const executionOrder = executionOrderIndex !== null && executionOrderTotal !== null
+      ? `${executionOrderIndex} of ${executionOrderTotal}`
+      : "N of M";
+    return [
+      "Canonical sequenced-child repair:",
+      "- add `Part of: #<number>` only when this issue truly belongs to a parent epic or tracked sequence",
+      "- keep `Depends on: none` unless another issue truly blocks execution",
+      "- keep `Parallelizable: No` unless parallel execution is confirmed safe",
+      "```md",
+      "## Execution order",
+      executionOrder,
+      "```",
+    ];
+  }
+
+  return [
+    "Canonical standalone repair:",
+    "- omit `Part of:`",
+    "- add `Depends on: none`",
+    "- add `Parallelizable: No` unless parallel execution is confirmed safe",
+    "```md",
+    "## Execution order",
+    "1 of 1",
+    "```",
+  ];
+}
+
+export function buildRequirementsBlockerIssueComment(issue: GitHubIssue): string {
+  const dto = createIssueLintDto(issue);
+  const missingRequired =
+    dto.missingRequired.length > 0 ? quoteItems(dto.missingRequired) : "none";
+  const metadataErrors =
+    dto.metadataErrors.length > 0 ? dto.metadataErrors.map((error) => `- ${error}`) : ["- none"];
+  const requiredFixes =
+    dto.repairGuidance.length > 0 ? dto.repairGuidance.map((line) => `- ${line}`) : ["- none"];
+  const marker = buildRequirementsBlockerCommentMarker(issue.number);
+
+  return [
+    "Issue execution is currently blocked on execution-ready metadata.",
+    "",
+    `- blocker type: \`requirements\``,
+    `- missing required fields: ${missingRequired}`,
+    "metadata errors:",
+    ...metadataErrors,
+    "",
+    "Required fixes:",
+    ...requiredFixes,
+    "",
+    ...buildCanonicalRepairSection(issue),
+    "",
+    "Canonical reference: `docs/issue-metadata.md`",
+    "",
+    marker,
+  ].join("\n");
+}
+
+export function buildClearedRequirementsBlockerIssueComment(issueNumber: number): string {
+  return [
+    "This machine-managed requirements blocker comment is no longer current because the issue is now execution-ready.",
+    "",
+    "- blocker type: `requirements`",
+    "- status: cleared",
+    "- next action: continue the supervisor loop normally.",
+    "",
+    buildRequirementsBlockerCommentMarker(issueNumber),
+  ].join("\n");
+}
+
+export async function syncRequirementsBlockerIssueComment(
+  github: RequirementsBlockerIssueCommentGitHub,
+  issue: GitHubIssue,
+): Promise<void> {
+  if (!github.addIssueComment || !github.getIssueComments) {
+    return;
+  }
+
+  const body = buildRequirementsBlockerIssueComment(issue);
+  const existingComment = findOwnedRequirementsBlockerComment(
+    await github.getIssueComments(issue.number, {
+      purpose: "action",
+      issueVersion: issue.updatedAt,
+    }),
+    issue.number,
+  );
+  if (!existingComment) {
+    await github.addIssueComment(issue.number, body);
+    return;
+  }
+
+  if (existingComment.body === body || !github.updateIssueComment || typeof existingComment.databaseId !== "number") {
+    return;
+  }
+
+  await github.updateIssueComment(existingComment.databaseId, body);
+}
+
+export async function clearRequirementsBlockerIssueComment(
+  github: RequirementsBlockerIssueCommentGitHub,
+  issueNumber: number,
+  issueUpdatedAt: string | null = null,
+): Promise<void> {
+  if (!github.getIssueComments || !github.updateIssueComment) {
+    return;
+  }
+
+  const existingComment = findOwnedRequirementsBlockerComment(
+    await github.getIssueComments(issueNumber, {
+      purpose: "action",
+      issueVersion: issueUpdatedAt,
+    }),
+    issueNumber,
+  );
+  if (!existingComment || typeof existingComment.databaseId !== "number") {
+    return;
+  }
+
+  const body = buildClearedRequirementsBlockerIssueComment(issueNumber);
+  if (existingComment.body === body) {
+    return;
+  }
+
+  await github.updateIssueComment(existingComment.databaseId, body);
+}

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -5,6 +5,7 @@ import {
   resolveRunnableIssueContext,
 } from "./run-once-issue-selection";
 import { GitHubIssue, IssueRunRecord, SupervisorConfig, SupervisorStateFile } from "./core/types";
+import { syncRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -207,6 +208,137 @@ Add execution-ready gating.`,
   assert.match(state.issues["91"]?.last_error ?? "", /missing required execution-ready metadata/i);
   assert.equal(journalSyncs.length, 1);
   assert.equal(journalSyncs[0]?.issue_number, 91);
+});
+
+test("resolveRunnableIssueContext creates one machine-managed requirements blocker comment for a standalone issue", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = {
+    number: 191,
+    title: "Standalone metadata blocker",
+    body: `## Summary
+Add execution-ready gating.`,
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/191",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const savedStates: SupervisorStateFile[] = [];
+  const addedComments: Array<{ issueNumber: number; body: string }> = [];
+  const updatedComments: Array<{ commentId: number; body: string }> = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+      getIssueComments: async () => [],
+      addIssueComment: async (issueNumber, body) => {
+        addedComments.push({ issueNumber, body });
+      },
+      updateIssueComment: async (commentId, body) => {
+        updatedComments.push({ commentId, body });
+      },
+    },
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (record) => ({
+      workspace: record.workspace,
+      journal_path: `/tmp/workspaces/issue-${record.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+  });
+
+  assert.deepEqual(result, { kind: "restart" });
+  assert.equal(addedComments.length, 1);
+  assert.equal(updatedComments.length, 0);
+  assert.equal(addedComments[0]?.issueNumber, 191);
+  assert.match(
+    addedComments[0]?.body ?? "",
+    /missing required fields: `scope`, `acceptance criteria`, `verification`, `depends on`, `parallelizable`, `execution order`/i,
+  );
+  assert.match(addedComments[0]?.body ?? "", /omit `Part of:`/i);
+  assert.match(addedComments[0]?.body ?? "", /Depends on: none/);
+  assert.match(addedComments[0]?.body ?? "", /Parallelizable: No/);
+  assert.match(addedComments[0]?.body ?? "", /## Execution order[\s\S]*1 of 1/);
+  assert.doesNotMatch(addedComments[0]?.body ?? "", /Part of: none/i);
+});
+
+test("syncRequirementsBlockerIssueComment dedupes identical blocker comments and updates the sticky comment when the blocker changes", async () => {
+  const firstIssue: GitHubIssue = {
+    number: 192,
+    title: "Requirements blocker dedupe",
+    body: `## Summary
+Add execution-ready gating.`,
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/192",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+  const changedIssue: GitHubIssue = {
+    ...firstIssue,
+    body: `## Summary
+Repair duplicated scheduling metadata.
+
+## Scope
+- keep diagnostics explicit
+
+## Acceptance criteria
+- duplicated metadata is blocked clearly
+
+## Verification
+- npm test -- src/run-once-issue-selection.test.ts
+
+Depends on: none
+Depends on: #190
+Parallelizable: No`,
+    updatedAt: "2026-03-15T00:05:00Z",
+  };
+  const addedComments: Array<{ issueNumber: number; body: string }> = [];
+  const updatedComments: Array<{ commentId: number; body: string }> = [];
+  let commentBody = "";
+
+  const github = {
+    getIssueComments: async () =>
+      commentBody === ""
+        ? []
+        : [{
+          id: "comment-192",
+          databaseId: 501,
+          body: commentBody,
+          createdAt: "2026-03-15T00:01:00Z",
+          url: "https://example.test/issues/192#issuecomment-501",
+          author: { login: "codex-supervisor", typeName: "Bot" },
+          viewerDidAuthor: true,
+        }],
+    addIssueComment: async (issueNumber: number, body: string) => {
+      addedComments.push({ issueNumber, body });
+      commentBody = body;
+    },
+    updateIssueComment: async (commentId: number, body: string) => {
+      updatedComments.push({ commentId, body });
+      commentBody = body;
+    },
+  };
+
+  await syncRequirementsBlockerIssueComment(github as never, firstIssue);
+  await syncRequirementsBlockerIssueComment(github as never, firstIssue);
+  await syncRequirementsBlockerIssueComment(github as never, changedIssue);
+
+  assert.equal(addedComments.length, 1);
+  assert.equal(updatedComments.length, 1);
+  assert.equal(updatedComments[0]?.commentId, 501);
+  assert.match(updatedComments[0]?.body ?? "", /metadata errors:/i);
+  assert.match(updatedComments[0]?.body ?? "", /depends on must appear exactly once/i);
 });
 
 test("resolveRunnableIssueContext keeps the acquired lock attached to a ready issue handoff", async () => {

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -5,7 +5,10 @@ import {
   resolveRunnableIssueContext,
 } from "./run-once-issue-selection";
 import { GitHubIssue, IssueRunRecord, SupervisorConfig, SupervisorStateFile } from "./core/types";
-import { syncRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
+import {
+  buildRequirementsBlockerIssueComment,
+  syncRequirementsBlockerIssueComment,
+} from "./requirements-blocker-issue-comment";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -272,6 +275,43 @@ Add execution-ready gating.`,
   assert.doesNotMatch(addedComments[0]?.body ?? "", /Part of: none/i);
 });
 
+test("buildRequirementsBlockerIssueComment uses sequenced-child guidance without inventing a parent dependency", () => {
+  const issue: GitHubIssue = {
+    number: 193,
+    title: "Sequenced metadata blocker",
+    body: `## Summary
+Repair sequenced child metadata guidance.
+
+## Scope
+- verify the canonical blocker guidance
+
+## Acceptance criteria
+- sequenced repairs explain the predecessor dependency shape
+
+## Verification
+- npx tsx --test src/run-once-issue-selection.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+2 of 3`,
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/193",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+
+  const body = buildRequirementsBlockerIssueComment(issue);
+
+  assert.match(body, /Canonical sequenced-child repair:/);
+  assert.match(body, /Part of: #<number>/);
+  assert.match(body, /Depends on: #<previous-issue-number>.*Depends on: none/s);
+  assert.match(body, /## Execution order[\s\S]*2 of 3/);
+  assert.doesNotMatch(body, /parent epic.*Depends on:/i);
+});
+
 test("syncRequirementsBlockerIssueComment dedupes identical blocker comments and updates the sticky comment when the blocker changes", async () => {
   const firstIssue: GitHubIssue = {
     number: 192,
@@ -339,6 +379,123 @@ Parallelizable: No`,
   assert.equal(updatedComments[0]?.commentId, 501);
   assert.match(updatedComments[0]?.body ?? "", /metadata errors:/i);
   assert.match(updatedComments[0]?.body ?? "", /depends on must appear exactly once/i);
+});
+
+test("syncRequirementsBlockerIssueComment still dedupes authored sticky comments when databaseId is missing", async () => {
+  const issue: GitHubIssue = {
+    number: 194,
+    title: "Requirements blocker dedupe without database id",
+    body: `## Summary
+Add execution-ready gating.`,
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/194",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+  const changedIssue: GitHubIssue = {
+    ...issue,
+    body: `${issue.body}
+
+## Scope
+- keep the sticky comment machine-managed`,
+    updatedAt: "2026-03-15T00:05:00Z",
+  };
+  const addedComments: Array<{ issueNumber: number; body: string }> = [];
+  const updatedComments: Array<{ commentId: number; body: string }> = [];
+  let commentBody = "";
+
+  const github = {
+    getIssueComments: async () =>
+      commentBody === ""
+        ? []
+        : [{
+          id: "comment-194",
+          databaseId: null,
+          body: commentBody,
+          createdAt: "2026-03-15T00:01:00Z",
+          url: "https://example.test/issues/194#issuecomment-null",
+          author: { login: "codex-supervisor", typeName: "Bot" },
+          viewerDidAuthor: true,
+        }],
+    addIssueComment: async (issueNumber: number, body: string) => {
+      addedComments.push({ issueNumber, body });
+      commentBody = body;
+    },
+    updateIssueComment: async (commentId: number, body: string) => {
+      updatedComments.push({ commentId, body });
+      commentBody = body;
+    },
+  };
+
+  await syncRequirementsBlockerIssueComment(github as never, issue);
+  await syncRequirementsBlockerIssueComment(github as never, issue);
+  await syncRequirementsBlockerIssueComment(github as never, changedIssue);
+
+  assert.equal(addedComments.length, 1);
+  assert.equal(updatedComments.length, 0);
+});
+
+test("resolveRunnableIssueContext treats requirements blocker comment sync as best effort", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = {
+    number: 195,
+    title: "Best-effort blocker comment sync",
+    body: `## Summary
+Add execution-ready gating.`,
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/195",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const savedStates: SupervisorStateFile[] = [];
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (message?: unknown, ...args: unknown[]) => {
+    warnings.push([message, ...args].map((value) => String(value)).join(" "));
+  };
+
+  try {
+    const result = await resolveRunnableIssueContext({
+      github: {
+        listCandidateIssues: async () => [issue],
+        getIssue: async () => issue,
+        addIssueComment: async () => {},
+        getIssueComments: async () => {
+          throw new Error("comment sync offline");
+        },
+      },
+      config,
+      stateStore: createTouchStateStore(savedStates),
+      state,
+      currentRecord: null,
+      acquireIssueLock: async () => ({
+        acquired: true,
+        release: async () => {},
+      }),
+      ensureRecordJournalContext: async (record) => ({
+        workspace: record.workspace,
+        journal_path: `/tmp/workspaces/issue-${record.issue_number}/.codex-supervisor/issue-journal.md`,
+      }),
+      syncIssueJournal: async () => {},
+    });
+
+    assert.deepEqual(result, { kind: "restart" });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(savedStates.length, 2);
+  assert.equal(state.issues["195"]?.state, "blocked");
+  assert.equal(state.issues["195"]?.blocked_reason, "requirements");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? "", /Failed to sync requirements blocker issue comment for issue #195/i);
+  assert.match(warnings[0] ?? "", /comment sync offline/i);
 });
 
 test("resolveRunnableIssueContext keeps the acquired lock attached to a ready issue handoff", async () => {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -80,6 +80,20 @@ interface SyncIssueJournalArgs {
   maxChars: number;
 }
 
+async function syncRequirementsBlockerIssueCommentBestEffort(
+  github: IssueSelectionGitHub,
+  issue: GitHubIssue,
+): Promise<void> {
+  try {
+    await syncRequirementsBlockerIssueComment(github, issue);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to sync requirements blocker issue comment for issue #${issue.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+  }
+}
+
 interface ResolveRunnableIssueContextArgs {
   github: IssueSelectionGitHub;
   config: SupervisorConfig;
@@ -565,7 +579,7 @@ export async function resolveRunnableIssueContext(
         state.issues[String(blockedRecord.issue_number)] = blockedRecord;
         state.activeIssueNumber = null;
         await stateStore.save(state);
-        await syncRequirementsBlockerIssueComment(github, issue);
+        await syncRequirementsBlockerIssueCommentBestEffort(github, issue);
         if (blockedRecord.journal_path) {
           await syncIssueJournalImpl({
             issue,
@@ -663,7 +677,7 @@ export async function resolveRunnableIssueContext(
       state.issues[String(blockedRecord.issue_number)] = blockedRecord;
       state.activeIssueNumber = null;
       await stateStore.save(state);
-      await syncRequirementsBlockerIssueComment(github, issue);
+      await syncRequirementsBlockerIssueCommentBestEffort(github, issue);
       if (blockedRecord.journal_path) {
         await syncIssueJournalImpl({
           issue,

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -27,6 +27,7 @@ import {
   evaluateAutonomousExecutionTrust,
   isAutonomousExecutionTrustBlockedRecord,
 } from "./supervisor/supervisor-trust-gate";
+import { syncRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
 import { StateStore } from "./core/state-store";
 import {
   FailureContext,
@@ -59,7 +60,9 @@ export interface RestartRunOnce {
 type IssueSelectionResult = ReadyIssueContext | RestartRunOnce | string;
 
 type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues">;
-type IssueSelectionGitHub = IssueSelectionCandidateGitHub & Pick<GitHubClient, "getIssue">;
+type IssueSelectionGitHub = IssueSelectionCandidateGitHub
+  & Pick<GitHubClient, "getIssue">
+  & Partial<Pick<GitHubClient, "addIssueComment" | "getIssueComments" | "updateIssueComment">>;
 type IssueSelectionSaveStateStore = Pick<StateStore, "save">;
 type IssueSelectionStateStore = IssueSelectionSaveStateStore & Pick<StateStore, "touch">;
 
@@ -562,6 +565,7 @@ export async function resolveRunnableIssueContext(
         state.issues[String(blockedRecord.issue_number)] = blockedRecord;
         state.activeIssueNumber = null;
         await stateStore.save(state);
+        await syncRequirementsBlockerIssueComment(github, issue);
         if (blockedRecord.journal_path) {
           await syncIssueJournalImpl({
             issue,
@@ -659,6 +663,7 @@ export async function resolveRunnableIssueContext(
       state.issues[String(blockedRecord.issue_number)] = blockedRecord;
       state.activeIssueNumber = null;
       await stateStore.save(state);
+      await syncRequirementsBlockerIssueComment(github, issue);
       if (blockedRecord.journal_path) {
         await syncIssueJournalImpl({
           issue,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -551,6 +551,97 @@ test("reconcileRecoverableBlockedIssueStates requeues requirements-blocked issue
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates clears the machine-managed requirements blocker comment once metadata is execution-ready", async () => {
+  const config = createConfig();
+  const original = createRecord({
+    state: "blocked",
+    blocked_reason: "requirements",
+    last_error: "Missing required execution-ready metadata: scope, acceptance criteria, verification.",
+    last_failure_kind: null,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Issue #366 is not execution-ready because it is missing: scope, acceptance criteria, verification.",
+      signature: "requirements:scope|acceptance criteria|verification",
+      command: null,
+      details: [
+        "missing_required=scope, acceptance criteria, verification",
+        "missing_recommended=depends on, execution order",
+      ],
+      url: "https://example.test/issues/366",
+      updated_at: "2026-03-11T01:50:41.997Z",
+    },
+    last_failure_signature: "requirements:scope|acceptance criteria|verification",
+    repeated_failure_signature_count: 2,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issues: GitHubIssue[] = [
+    createIssue({
+      number: 366,
+      title: "P3: Add regression coverage",
+      body: executionReadyBody("Add regression coverage."),
+      updatedAt: "2026-03-11T06:40:00Z",
+      labels: [{ name: "codex" }],
+    }),
+  ];
+
+  const updatedComments: Array<{ commentId: number; body: string }> = [];
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...record,
+        ...patch,
+        updated_at: "2026-03-11T06:33:08.821Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileRecoverableBlockedIssueStates({
+    getPullRequestIfExists: async () => {
+      throw new Error("unexpected getPullRequestIfExists call");
+    },
+    getIssue: async () => {
+      throw new Error("unexpected getIssue call");
+    },
+    getChecks: async () => {
+      throw new Error("unexpected getChecks call");
+    },
+    getUnresolvedReviewThreads: async () => {
+      throw new Error("unexpected getUnresolvedReviewThreads call");
+    },
+    getIssueComments: async () => [{
+      id: "comment-366",
+      databaseId: 3661,
+      body:
+        "Issue execution is currently blocked on execution-ready metadata.\n\n" +
+        "<!-- codex-supervisor:requirements-blocker-comment issue=366 -->",
+      createdAt: "2026-03-11T02:00:00Z",
+      url: "https://example.test/issues/366#issuecomment-3661",
+      author: {
+        login: "codex-supervisor",
+        typeName: "Bot",
+      },
+      viewerDidAuthor: true,
+    }],
+    updateIssueComment: async (commentId: number, body: string) => {
+      updatedComments.push({ commentId, body });
+    },
+  }, stateStore, state, config, issues, {
+    shouldAutoRetryHandoffMissing,
+  });
+
+  assert.equal(saveCalls, 1);
+  assert.equal(updatedComments.length, 1);
+  assert.equal(updatedComments[0]?.commentId, 3661);
+  assert.match(updatedComments[0]?.body ?? "", /no longer current/i);
+  assert.match(updatedComments[0]?.body ?? "", /execution-ready/i);
+});
+
 test("reconcileRecoverableBlockedIssueStates resumes conflicted tracked PR handoff-missing issues into conflict repair", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = createSupervisorState({

--- a/src/supervisor/supervisor-selection-issue-lint.test.ts
+++ b/src/supervisor/supervisor-selection-issue-lint.test.ts
@@ -154,6 +154,40 @@ Parallelizable: No`,
   });
 });
 
+test("buildIssueLintDto uses canonical standalone execution-order repair guidance", async () => {
+  const issue = createIssue({
+    number: 607,
+    title: "Repair standalone scheduling metadata",
+    labels: [{ name: "codex" }],
+    body: `## Summary
+Keep standalone issue repair guidance canonical.
+
+## Scope
+- prove the repair guidance uses the section-based execution-order form
+
+## Acceptance criteria
+- standalone repair guidance matches docs/issue-metadata.md
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-lint.test.ts
+
+Depends on: none
+Parallelizable: No`,
+  });
+
+  const dto = await buildIssueLintDto(
+    {
+      getIssue: async () => issue,
+    },
+    issue.number,
+  );
+
+  assert.deepEqual(dto.missingRequired, ["execution order"]);
+  assert.deepEqual(dto.repairGuidance, [
+    "Add a `## Execution order` section with `1 of 1` for standalone work, or `N of M` for a sequenced series.",
+  ]);
+});
+
 test("buildIssueLintDto keeps repair guidance ordering stable", async () => {
   const issue = createIssue({
     number: 603,
@@ -193,7 +227,7 @@ Parallelizable: Later`,
       "Add a `## Scope` section with bullet points describing the in-scope work.",
       "Add a `## Acceptance criteria` section listing the observable completion checks.",
       "Add a `## Verification` section with the exact command, test file, or manual check to run.",
-      "Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Execution order: N of M`, and `Parallelizable: Yes|No` lines.",
+      "Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Parallelizable: Yes|No`, and a `## Execution order` section.",
       "Rewrite the issue to pick one auth path, remove the unresolved choice, and state the approved outcome explicitly.",
     ],
   });
@@ -210,7 +244,7 @@ Parallelizable: Later`,
       "repair_guidance_1=Add a `## Scope` section with bullet points describing the in-scope work.",
       "repair_guidance_2=Add a `## Acceptance criteria` section listing the observable completion checks.",
       "repair_guidance_3=Add a `## Verification` section with the exact command, test file, or manual check to run.",
-      "repair_guidance_4=Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Execution order: N of M`, and `Parallelizable: Yes|No` lines.",
+      "repair_guidance_4=Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Parallelizable: Yes|No`, and a `## Execution order` section.",
       "repair_guidance_5=Rewrite the issue to pick one auth path, remove the unresolved choice, and state the approved outcome explicitly.",
     ].join("\n"),
   );
@@ -264,8 +298,8 @@ Parallelizable: Yes`,
     repairGuidance: [
       "Add `Depends on: none` if nothing blocks this issue, or list blocking issues as `Depends on: #123, #456`.",
       "Add `Parallelizable: No` unless this issue is explicitly safe to run alongside related work.",
-      "Add `Execution order: 1 of 1` if this issue stands alone, or `Execution order: N of M` for a sequenced series.",
-      "Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Execution order: N of M`, and `Parallelizable: Yes|No` lines.",
+      "Add a `## Execution order` section with `1 of 1` for standalone work, or `N of M` for a sequenced series.",
+      "Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Parallelizable: Yes|No`, and a `## Execution order` section.",
     ],
   });
 });

--- a/src/supervisor/supervisor-selection-issue-lint.ts
+++ b/src/supervisor/supervisor-selection-issue-lint.ts
@@ -1,4 +1,5 @@
 import { GitHubClient } from "../github";
+import { GitHubIssue } from "../core/types";
 import {
   findHighRiskBlockingAmbiguity,
   hasAvailableIssueLabels,
@@ -28,6 +29,10 @@ export async function buildIssueLintDto(
   issueNumber: number,
 ): Promise<SupervisorIssueLintDto> {
   const issue = await github.getIssue(issueNumber);
+  return createIssueLintDto(issue);
+}
+
+export function createIssueLintDto(issue: GitHubIssue): SupervisorIssueLintDto {
   if (!hasAvailableIssueLabels(issue)) {
     return {
       issueNumber: issue.number,
@@ -102,7 +107,9 @@ function buildIssueLintRepairGuidance(
         guidance.push("Add `Parallelizable: No` unless this issue is explicitly safe to run alongside related work.");
         break;
       case "execution order":
-        guidance.push("Add `Execution order: 1 of 1` if this issue stands alone, or `Execution order: N of M` for a sequenced series.");
+        guidance.push(
+          "Add a `## Execution order` section with `1 of 1` for standalone work, or `N of M` for a sequenced series.",
+        );
         break;
       case "part of":
         guidance.push("Add `Part of: #<number>` when this sequenced codex issue belongs to a parent epic or tracking issue.");
@@ -114,7 +121,7 @@ function buildIssueLintRepairGuidance(
 
   if (metadataErrors.length > 0) {
     guidance.push(
-      "Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Execution order: N of M`, and `Parallelizable: Yes|No` lines.",
+      "Replace invalid scheduling metadata with valid `Part of: #<number>`, `Depends on: none|#<number>`, `Parallelizable: Yes|No`, and a `## Execution order` section.",
     );
   }
 
@@ -150,7 +157,9 @@ function buildIssueLintRepairGuidance(
         guidance.push("Add `Depends on: none` if nothing blocks this issue, or list blocking issues as `Depends on: #123, #456`.");
         break;
       case "execution order":
-        guidance.push("Add `Execution order: 1 of 1` if this issue stands alone, or `Execution order: N of M` for a sequenced series.");
+        guidance.push(
+          "Add a `## Execution order` section with `1 of 1` for standalone work, or `N of M` for a sequenced series.",
+        );
         break;
       case "scope boundary":
         guidance.push("Add one `## Scope` bullet that says what stays unchanged, excluded, or out of scope.");


### PR DESCRIPTION
Closes #1442
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the requirements-blocker issue comment flow and checkpointed it in `c4a690b` (`Comment on requirements-blocked issues`).

The change adds a machine-managed sticky GitHub issue comment for actionable execution-ready metadata failures, updates that comment in place when the blocker changes, and clears it when the issue becomes execution-ready again. I also aligned issue-lint repair guidance with the canonical `## Execution order` section form and added focused coverage for standalone guidance, sticky-comment dedupe/update, and blocker resolution. `npm run build` is clean.

Summary: Added machine-managed requirements-blocker issue comments, canonicalized execution-order repair guidance, cleared stale blocker comments on recovery, and committed the checkpoint as `c4a690b`.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/supervisor/supervisor-selection-issue-lint.test.ts src/run-once-issue-selection.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the branch PR so the new requirements-blocker comment behavior can be reviewed in GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine-managed blocker comments appear on issues missing execution-ready metadata and auto-clear when resolved.
  * Public issue-comment fetching now supports paginated reads to surface older sticky comments.

* **Bug Fixes**
  * Sticky blocker-comment deduplication improved to avoid redundant updates even when comment metadata is incomplete.
  * Syncing blocker comments on restarts is now best-effort (warns instead of hard-failing).

* **Documentation**
  * Execution order guidance updated to use a dedicated "## Execution order" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->