### PR TITLE
Current publication can still be blocked by unrelated sparse issue journal in active worktree (#1494)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,49 +1,38 @@
-# Issue #1442: Comment on GitHub issues when execution-ready metadata is missing
+# Issue #1494: Current publication can still be blocked by unrelated sparse issue journal in active worktree
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1442
-- Branch: codex/issue-1442
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1494
+- Branch: codex/issue-1494
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: c4a690b5b9df9f0b928af9706176cc6bd9772573
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: be9b36a9023b2178e62aaf46d2297c05ead7db19
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856sDWV|PRRT_kwDORgvdZ856sDWX|PRRT_kwDORgvdZ856sDWb|PRRT_kwDORgvdZ856sDWe
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T01:40:55.000Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T01:50:51.960Z
 
 ## Latest Codex Summary
-Addressed the active review threads on top of `c4a690b` by tightening sticky-comment ownership matching, narrowing sequenced-child repair guidance to the canonical predecessor-dependency shape, making blocker-comment sync best-effort on restart paths, and paginating issue comment reads so older sticky comments remain discoverable.
-
-I intentionally did not broad-brush paginate every PR comment surface mentioned by CodeRabbit. The concrete regression here was issue-comment lookup for machine-managed sticky comments; widening the patch to unrelated review-thread and PR top-level comment surfaces would have exceeded the issue scope without evidence of a behavior break in those paths. Focused tests covering the new guidance, null-`databaseId` dedupe, best-effort warning path, issue-comment pagination, recovery clearing, and `npm run build` are green.
-
-Summary: Addressed review feedback for sticky comment dedupe, sequenced-child guidance, best-effort sync, and issue-comment pagination.
-State hint: addressing_review
-Blocked reason: none
-Tests: `npx tsx --test src/run-once-issue-selection.test.ts src/github/github.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
-Next action: Commit the review-fix checkpoint, then push/update PR #1495 for re-review.
-Failure signature: none
+- Reproduced tracked ready-promotion blocking on a sparse-omitted cross-issue journal path and fixed publication persistence to ignore rewritten journal paths that are not present in the active sparse worktree.
 
 ## Active Failure Context
-- Category: review
-- Summary: 4 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667581
-- Details:
-  - src/github/github-review-surface.ts:588 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 529 --- 🏁 Script executed: Repository: TommyKa... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667581
-  - src/requirements-blocker-issue-comment.ts:33 summary=_⚠️ Potential issue_ | _🟠 Major_ **Don't require `databaseId` just to recognize the sticky comment.** `IssueComment.databaseId` is nullable in `src/core/types.ts`, and `fetchIs... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667585
-  - src/requirements-blocker-issue-comment.ts:61 summary=_⚠️ Potential issue_ | _🟠 Major_ **Fix the sequenced-child `Depends on:` guidance.** This template currently tells sequenced children to keep `Depends on: none`, which is the w... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667590
-  - src/run-once-issue-selection.ts:568 summary=_⚠️ Potential issue_ | _🟠 Major_ **Treat requirements-blocker comment sync as best-effort to avoid restart-path failures.** If this external call fails, the function throws aft... url=https://github.com/TommyKammy/codex-supervisor/pull/1495#discussion_r3076667593
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The remaining automated review findings were a mix of one real dedupe bug (`databaseId` nullable), one real resilience gap (comment sync on restart path), one guidance wording gap for sequenced children, and one overly broad pagination suggestion whose concrete regression surface was older issue comments rather than every PR comment feed.
-- What changed: Removed the `databaseId` requirement from sticky-comment recognition in `src/requirements-blocker-issue-comment.ts`; updated sequenced-child repair text to prefer `Depends on: #<previous-issue-number>` when earlier sequence work truly blocks execution while still allowing `Depends on: none`; wrapped requirements-blocker comment sync in a best-effort warning helper in `src/run-once-issue-selection.ts`; paginated `fetchIssueComments` in `src/github/github-review-surface.ts`; added focused tests in `src/run-once-issue-selection.test.ts` and `src/github/github.test.ts`.
-- Current blocker: none
-- Next exact step: Commit the current diff and update PR #1495 so GitHub can re-evaluate the addressed review threads.
-- Verification gap: No broader full-suite rerun beyond the focused areas touched in this repair pass.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/requirements-blocker-issue-comment.ts`, `src/run-once-issue-selection.ts`, `src/github/github-review-surface.ts`, `src/run-once-issue-selection.test.ts`, `src/github/github.test.ts`.
-- Rollback concern: Low; the runtime changes are narrowly scoped to issue-comment lookup, blocker-comment ownership/guidance, and restart-path error handling.
-- Last focused command: `npx tsx --test src/run-once-issue-selection.test.ts src/github/github.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
+- Hypothesis: tracked PR ready-promotion still tried to persist every rewritten supervisor-owned journal path, including tracked cross-issue journals omitted by sparse checkout, so `git add` turned an unrelated omitted journal into a false `workstation-local-path-hygiene-failed` blocker.
+- What changed: added a focused sparse regression for `handlePostTurnPullRequestTransitionsPhase`; filtered rewritten journal persistence paths down to files present in the active worktree before commit/push in the tracked ready-promotion path and the shared publication callers.
+- Current blocker: none.
+- Next exact step: review the final diff and continue with PR/update flow from this checkpoint.
+- Verification gap: full `npm test -- src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts` still runs unrelated baseline failures in this worktree, so verification stayed focused on the targeted node test-name runs plus `npm run build`.
+- Files touched: .codex-supervisor/issue-journal.md; src/core/workspace.ts; src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts; src/turn-execution-publication-gate.ts; src/run-once-turn-execution.ts
+- Rollback concern: low; the change only skips commit attempts for rewritten journal paths absent from the active sparse worktree and leaves current in-scope hygiene blockers unchanged.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- Focused verification:
+- `node --test --import tsx --test-name-pattern "handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-issue journal rewrites during ready promotion" src/post-turn-pull-request.test.ts`
+- `node --test --import tsx --test-name-pattern "handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workstation-local path hygiene fails" src/post-turn-pull-request.test.ts`
+- `node --test --import tsx --test-name-pattern "applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitted by sparse checkout" src/turn-execution-publication-gate.test.ts`
+- `npm run build`

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -434,6 +434,12 @@ export async function commitAndPushTrackedFiles(args: {
   return true;
 }
 
+export function filterPresentTrackedFilePaths(workspacePath: string, filePaths: string[]): string[] {
+  return [...new Set(filePaths.map((filePath) => filePath.trim()).filter(Boolean))].filter((filePath) =>
+    fs.existsSync(path.join(workspacePath, filePath)),
+  );
+}
+
 export async function cleanupWorkspace(
   repoPath: string,
   workspacePath: string,

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4658,6 +4658,148 @@ test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-i
   assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102"), /refs\/heads\/codex\/issue-102/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-issue journal rewrites during ready promotion", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(
+    otherJournalPath,
+    [
+      "# Issue #181: stale leak",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      `- What changed: copied ${SAMPLE_MACOS_WORKSTATION_PATH} from another workstation.`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md", ".codex-supervisor/issues/181/issue-journal.md");
+  git(workspacePath, "commit", "-m", "seed sparse ready-gate journal leak");
+  git(workspacePath, "push", "-u", "origin", "codex/issue-102");
+
+  git(workspacePath, "sparse-checkout", "init", "--no-cone");
+  await fs.writeFile(
+    path.join(workspacePath, ".git", "info", "sparse-checkout"),
+    ["/README.md", "/.codex-supervisor/issues/102/"].join("\n").concat("\n"),
+    "utf8",
+  );
+  git(workspacePath, "read-tree", "-mu", "HEAD");
+  await assert.rejects(fs.access(otherJournalPath), { code: "ENOENT" });
+
+  const config = createConfig({
+    localCiCommand: "npm run ci:local",
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  });
+  const issue = createIssue({ title: "Gate sparse ready promotion on cross-issue journal hygiene" });
+  const headSha = git(workspacePath, "rev-parse", "HEAD").trim();
+  const draftPr = createPullRequest({
+    title: "Gate sparse ready promotion",
+    isDraft: true,
+    headRefName: "codex/issue-102",
+    headRefOid: headSha,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: draftPr.number,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  let readyCalls = 0;
+  let localCiCalls = 0;
+  let workspacePreparationCalls = 0;
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      markPullRequestReady: async (prNumber: number) => {
+        assert.equal(prNumber, 116);
+        readyCalls += 1;
+      },
+    }),
+    context: createPostTurnContext({
+      issue,
+      pr: draftPr,
+      workspacePath,
+      state,
+      record: state.issues["102"]!,
+    }),
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "pr_open",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+      rewrittenJournalPaths: [".codex-supervisor/issues/181/issue-journal.md"],
+    }),
+    runWorkspacePreparationCommand: async () => {
+      workspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      localCiCalls += 1;
+    },
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: {
+        ...draftPr,
+        isDraft: readyCalls === 0,
+        headRefOid: git(workspacePath, "rev-parse", "HEAD").trim(),
+      },
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(result.record.state, "pr_open");
+  assert.equal(result.record.last_failure_signature, null);
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(result.record.last_head_sha, git(workspacePath, "rev-parse", "HEAD").trim());
+  assert.equal(readyCalls, 1);
+  assert.equal(localCiCalls, 1);
+  assert.equal(workspacePreparationCalls, 0);
+  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed sparse ready-gate journal leak");
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+});
+
 test("handlePostTurnPullRequestTransitionsPhase blocks ready promotion until a local normalization commit reaches the PR head", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -46,7 +46,7 @@ import {
 import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
 import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
 import { parseIssueMetadata } from "./issue-metadata";
-import { commitAndPushTrackedFiles, getWorkspaceStatus } from "./core/workspace";
+import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
 import {
   derivePostTurnLocalReviewDecision,
   derivePostTurnLocalReviewFailurePatch,
@@ -1404,14 +1404,15 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       };
     }
     const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-    if (rewrittenJournalPaths.length > 0) {
+    const presentRewrittenJournalPaths = filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
+    if (presentRewrittenJournalPaths.length > 0) {
       let persistedNormalizationCommit = false;
       try {
         persistedNormalizationCommit = await commitAndPushTrackedFiles({
           workspacePath,
           branch: refreshed.pr.headRefName,
           remoteBranchExists: true,
-          filePaths: rewrittenJournalPaths,
+          filePaths: presentRewrittenJournalPaths,
           commitMessage: SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE,
         });
       } catch (error) {
@@ -1419,7 +1420,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         const failureContext = buildWorkstationLocalPathFailureContext({
           gateLabel: `before marking PR #${refreshed.pr.number} ready`,
           details: [
-            `journal normalization persistence failed for ${rewrittenJournalPaths.join(", ")}: ${message}`,
+            `journal normalization persistence failed for ${presentRewrittenJournalPaths.join(", ")}: ${message}`,
           ],
         });
         record = stateStore.touch(record, {
@@ -1448,7 +1449,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         const failureContext = buildWorkstationLocalPathFailureContext({
           gateLabel: `before marking PR #${refreshed.pr.number} ready`,
           details: [
-            `journal normalization reported rewritten paths for ${rewrittenJournalPaths.join(", ")} but did not create a commit to publish.`,
+            `journal normalization reported rewritten paths for ${presentRewrittenJournalPaths.join(", ")} but did not create a commit to publish.`,
           ],
         });
         record = stateStore.touch(record, {

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -48,7 +48,7 @@ import {
   WorkspaceStatus,
 } from "./core/types";
 import { truncate } from "./core/utils";
-import { commitAndPushTrackedFiles, getWorkspaceStatus, pushBranch } from "./core/workspace";
+import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus, pushBranch } from "./core/workspace";
 import { AgentRunner, createCodexAgentRunner } from "./supervisor/agent-runner";
 import {
   executionMetricsRetentionRootPath,
@@ -490,13 +490,14 @@ export async function executeCodexTurnPhase(
           };
         }
         const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-        if (rewrittenJournalPaths.length > 0) {
+        const presentRewrittenJournalPaths = filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
+        if (presentRewrittenJournalPaths.length > 0) {
           try {
             await commitAndPushTrackedFiles({
               workspacePath,
               branch: record.branch,
               remoteBranchExists: workspaceStatus.remoteBranchExists,
-              filePaths: rewrittenJournalPaths,
+              filePaths: presentRewrittenJournalPaths,
               commitMessage: SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE,
             });
           } catch (error) {
@@ -504,7 +505,7 @@ export async function executeCodexTurnPhase(
             const failureContext = buildWorkstationLocalPathFailureContext({
               gateLabel: "before publication",
               details: [
-                `journal normalization persistence failed for ${rewrittenJournalPaths.join(", ")}: ${message}`,
+                `journal normalization persistence failed for ${presentRewrittenJournalPaths.join(", ")}: ${message}`,
               ],
             });
             record = stateStore.touch(record, {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -19,7 +19,7 @@ import {
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
 } from "./workstation-local-path-gate";
-import { commitAndPushTrackedFiles, getWorkspaceStatus } from "./core/workspace";
+import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
 
 function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
@@ -120,13 +120,14 @@ export async function applyCodexTurnPublicationGate(args: {
       };
     }
     const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-    if (rewrittenJournalPaths.length > 0) {
+    const presentRewrittenJournalPaths = filterPresentTrackedFilePaths(args.workspacePath, rewrittenJournalPaths);
+    if (presentRewrittenJournalPaths.length > 0) {
       try {
         await commitAndPushTrackedFiles({
           workspacePath: args.workspacePath,
           branch: record.branch,
           remoteBranchExists: workspaceStatus.remoteBranchExists,
-          filePaths: rewrittenJournalPaths,
+          filePaths: presentRewrittenJournalPaths,
           commitMessage: SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE,
         });
       } catch (error) {
@@ -134,7 +135,7 @@ export async function applyCodexTurnPublicationGate(args: {
         const failureContext = buildWorkstationLocalPathFailureContext({
           gateLabel: "before publication",
           details: [
-            `journal normalization persistence failed for ${rewrittenJournalPaths.join(", ")}: ${message}`,
+            `journal normalization persistence failed for ${presentRewrittenJournalPaths.join(", ")}: ${message}`,
           ],
         });
         record = args.stateStore.touch(record, {


### PR DESCRIPTION
Closes #1494
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a narrow sparse-worktree fix and committed it as `809635c` (`Skip sparse-omitted journal rewrites during publication`). The tracked ready-promotion path now filters rewritten supervisor journal paths to files actually present in the active worktree before attempting persistence, so omitted cross-issue journals no longer turn into false `workstation-local-path-hygiene-failed` blockers. I also added a focused regression for the tracked PR path and kept the existing blocking behavior coverage for real in-scope hygiene failures.

Summary: Filter sparse-omitted rewritten journal paths before publication persistence, add tracked ready-promotion regression, and keep real active-issue hygiene blockers intact
State hint: draft_pr
Blocked reason: none
Tests: `node --test --import tsx --test-name-pattern "handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-issue journal rewrites during ready promotion" src/post-turn-pull-request.test.ts`; `node --test --import tsx --test-name-pattern "handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workstation-local path hygiene fails" src/post-turn-pull-request.test.ts`; `node --test --import tsx --test-name-pattern "applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitted by sparse checkout" src/turn-execution-publication-gate.test.ts`; `npm run build`
Failure signature: none
Next action: Push `codex/issue-1494` and open or update the draft PR with commit `809635c`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sparse checkout repositories by filtering tracked file paths to only include those present in the active workspace. This prevents publication and commit operations from failing when attempting to process journal files that don't exist in the sparse checkout, ensuring smoother workflow across different workspace configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->