### PR TITLE
Sparse-present cross-issue journals can still block publication after #1496 (#1497)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,38 +1,35 @@
-# Issue #1494: Current publication can still be blocked by unrelated sparse issue journal in active worktree
+# Issue #1497: Sparse-present cross-issue journals can still block publication after #1496
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1494
-- Branch: codex/issue-1494
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1497
+- Branch: codex/issue-1497
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: be9b36a9023b2178e62aaf46d2297c05ead7db19
+- Last head SHA: 60ad4340d05398523e4ed9f923cebf76bdd412c7
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T01:50:51.960Z
+- Updated at: 2026-04-14T02:43:52Z
 
 ## Latest Codex Summary
-- Reproduced tracked ready-promotion blocking on a sparse-omitted cross-issue journal path and fixed publication persistence to ignore rewritten journal paths that are not present in the active sparse worktree.
+- Hardened sparse publication filtering to require both on-disk presence and successful `git add --dry-run` in the active worktree before journal normalization paths are considered publishable.
+- Added regression coverage for sparse-present cross-issue journals in both draft publication and tracked PR ready-promotion flows.
+- Verified the targeted publication tests and `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: tracked PR ready-promotion still tried to persist every rewritten supervisor-owned journal path, including tracked cross-issue journals omitted by sparse checkout, so `git add` turned an unrelated omitted journal into a false `workstation-local-path-hygiene-failed` blocker.
-- What changed: added a focused sparse regression for `handlePostTurnPullRequestTransitionsPhase`; filtered rewritten journal persistence paths down to files present in the active worktree before commit/push in the tracked ready-promotion path and the shared publication callers.
+- Hypothesis: Sparse-present cross-issue journals were slipping through because publication only checked `existsSync`, not whether the current sparse worktree could update the index for that path.
+- What changed: `filterPresentTrackedFilePaths(...)` is now async and only returns paths that both exist and pass `git add --dry-run -- <path>`; updated all publication callers to await it; added sparse-present regression tests for `applyCodexTurnPublicationGate(...)` and `handlePostTurnPullRequestTransitionsPhase(...)`.
 - Current blocker: none.
-- Next exact step: review the final diff and continue with PR/update flow from this checkpoint.
-- Verification gap: full `npm test -- src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts` still runs unrelated baseline failures in this worktree, so verification stayed focused on the targeted node test-name runs plus `npm run build`.
-- Files touched: .codex-supervisor/issue-journal.md; src/core/workspace.ts; src/post-turn-pull-request.ts; src/post-turn-pull-request.test.ts; src/turn-execution-publication-gate.ts; src/run-once-turn-execution.ts
-- Rollback concern: low; the change only skips commit attempts for rewritten journal paths absent from the active sparse worktree and leaves current in-scope hygiene blockers unchanged.
-- Last focused command: npm run build
+- Next exact step: review diff and create a checkpoint commit on `codex/issue-1497`.
+- Verification gap: none for the scoped issue verification (`node --test --import tsx src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts`, `npm run build`).
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/core/workspace.ts`, `src/turn-execution-publication-gate.ts`, `src/post-turn-pull-request.ts`, `src/run-once-turn-execution.ts`, `src/turn-execution-publication-gate.test.ts`, `src/post-turn-pull-request.test.ts`.
+- Rollback concern: reverting the async filter requires restoring all three await call sites together or TypeScript/build breaks.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
-- Focused verification:
-- `node --test --import tsx --test-name-pattern "handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-issue journal rewrites during ready promotion" src/post-turn-pull-request.test.ts`
-- `node --test --import tsx --test-name-pattern "handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when workstation-local path hygiene fails" src/post-turn-pull-request.test.ts`
-- `node --test --import tsx --test-name-pattern "applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitted by sparse checkout" src/turn-execution-publication-gate.test.ts`
-- `npm run build`

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -434,10 +434,25 @@ export async function commitAndPushTrackedFiles(args: {
   return true;
 }
 
-export function filterPresentTrackedFilePaths(workspacePath: string, filePaths: string[]): string[] {
-  return [...new Set(filePaths.map((filePath) => filePath.trim()).filter(Boolean))].filter((filePath) =>
-    fs.existsSync(path.join(workspacePath, filePath)),
+async function isIndexUpdatableTrackedFilePath(workspacePath: string, filePath: string): Promise<boolean> {
+  if (!fs.existsSync(path.join(workspacePath, filePath))) {
+    return false;
+  }
+
+  const result = await runCommand(
+    "git",
+    ["-C", workspacePath, "add", "--dry-run", "--", filePath],
+    { allowExitCodes: [0, 1] },
   );
+  return result.exitCode === 0;
+}
+
+export async function filterPresentTrackedFilePaths(workspacePath: string, filePaths: string[]): Promise<string[]> {
+  const uniquePaths = [...new Set(filePaths.map((filePath) => filePath.trim()).filter(Boolean))];
+  const presentPaths = await Promise.all(
+    uniquePaths.map(async (filePath) => (await isIndexUpdatableTrackedFilePath(workspacePath, filePath) ? filePath : null)),
+  );
+  return presentPaths.filter((filePath): filePath is string => filePath !== null);
 }
 
 export async function cleanupWorkspace(

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4658,7 +4658,7 @@ test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-i
   assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102"), /refs\/heads\/codex\/issue-102/);
 });
 
-test("handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-issue journal rewrites during ready promotion", async (t) => {
+test("handlePostTurnPullRequestTransitionsPhase tolerates sparse-present cross-issue journal rewrites during ready promotion", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {
     await fs.rm(workspacePath, { recursive: true, force: true });
@@ -4694,6 +4694,20 @@ test("handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-i
   );
   git(workspacePath, "read-tree", "-mu", "HEAD");
   await assert.rejects(fs.access(otherJournalPath), { code: "ENOENT" });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.writeFile(
+    otherJournalPath,
+    [
+      "# Issue #181: stale leak",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      `- What changed: rewrote ${SAMPLE_MACOS_WORKSTATION_PATH} after sparse checkout.`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.access(otherJournalPath);
 
   const config = createConfig({
     localCiCommand: "npm run ci:local",
@@ -4797,7 +4811,7 @@ test("handlePostTurnPullRequestTransitionsPhase tolerates sparse-omitted cross-i
   assert.equal(localCiCalls, 1);
   assert.equal(workspacePreparationCalls, 0);
   assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed sparse ready-gate journal leak");
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "M .codex-supervisor/issues/181/issue-journal.md");
 });
 
 test("handlePostTurnPullRequestTransitionsPhase blocks ready promotion until a local normalization commit reaches the PR head", async (t) => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -1404,7 +1404,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       };
     }
     const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-    const presentRewrittenJournalPaths = filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
+    const presentRewrittenJournalPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
     if (presentRewrittenJournalPaths.length > 0) {
       let persistedNormalizationCommit = false;
       try {

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -490,7 +490,7 @@ export async function executeCodexTurnPhase(
           };
         }
         const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-        const presentRewrittenJournalPaths = filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
+        const presentRewrittenJournalPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
         if (presentRewrittenJournalPaths.length > 0) {
           try {
             await commitAndPushTrackedFiles({

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -213,7 +213,7 @@ test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journal
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 
-test("applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitted by sparse checkout", async (t) => {
+test("applyCodexTurnPublicationGate tolerates sparse-present tracked cross-issue journals outside the sparse checkout", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {
     await fs.rm(workspacePath, { recursive: true, force: true });
@@ -248,6 +248,20 @@ test("applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitt
   );
   git(workspacePath, "read-tree", "-mu", "HEAD");
   await assert.rejects(fs.access(otherJournalPath), { code: "ENOENT" });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.writeFile(
+    otherJournalPath,
+    [
+      "# Issue #181: stale leak",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      `- What changed: rewrote ${SAMPLE_MACOS_WORKSTATION_PATH} after sparse checkout.`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.access(otherJournalPath);
 
   let createPullRequestCalls = 0;
   const issue = createIssue({ title: "Gate sparse cross-issue journal hygiene without blocking publication" });
@@ -310,7 +324,7 @@ test("applyCodexTurnPublicationGate tolerates tracked cross-issue journals omitt
   assert.equal(result.record.state, "stabilizing");
   assert.equal(result.record.last_failure_signature, null);
   assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed sparse cross-issue journal leak");
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "M .codex-supervisor/issues/181/issue-journal.md");
 });
 
 test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails", async () => {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -120,7 +120,7 @@ export async function applyCodexTurnPublicationGate(args: {
       };
     }
     const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-    const presentRewrittenJournalPaths = filterPresentTrackedFilePaths(args.workspacePath, rewrittenJournalPaths);
+    const presentRewrittenJournalPaths = await filterPresentTrackedFilePaths(args.workspacePath, rewrittenJournalPaths);
     if (presentRewrittenJournalPaths.length > 0) {
       try {
         await commitAndPushTrackedFiles({


### PR DESCRIPTION
Closes #1497
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the shared publication filter so rewritten journal paths are only considered publishable when they both exist on disk and succeed under `git add --dry-run` in the active sparse worktree. That closes the residual case where a cross-issue journal is rewritten back onto disk after sparse checkout and would otherwise fail later with `outside of your sparse-checkout definition`.

I added focused regressions for both publication paths: draft PR creation and tracked PR ready-promotion. The tests now reproduce the exact sparse-present shape, confirm no normalization commit is attempted for the excluded cross-issue journal, and preserve the existing current-issue hygiene blocker behavior. The change is committed on `codex/issue-1497` as `95be43d` (`Handle sparse-present cross-issue journals`).

Summary: Hardened sparse journal publication filtering to require real index-updatability, added sparse-present regressions for both publication callers, and committed the fix as `95be43d`.
State hint: stabilizing
Blocked reason: none
Tests: `node --test --import tsx src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts`; `npm run build`
Failure signature: none
Next action: review or open/update the draft PR from commit `95be43d` on `codex/issue-1497`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file publication validation for sparse checkout scenarios by using git's native indexing capabilities to accurately determine which journal files can be safely published.

* **Tests**
  * Added regression test coverage for cross-issue journal behavior in sparse checkout environments, ensuring proper handling during draft publication and PR ready-promotion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->