### PR TITLE
Improve README guidance for supervisor.config profile-based model policy (#1502)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,51 +1,33 @@
-# Issue #1501: Surface effective Codex model policy in doctor and status
+# Issue #1502: Improve README guidance for supervisor.config profile-based model policy
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1501
-- Branch: codex/issue-1501
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1502
+- Branch: codex/issue-1502
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 5a9fde2946d7e04be1e63c132f805b4ce2247e18
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d6c482d5a544c902fdcdf5a057640725db76ec36
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856tLOl|PRRT_kwDORgvdZ856tLOn|PRRT_kwDORgvdZ856tLOt|PRRT_kwDORgvdZ856tLOv|PRRT_kwDORgvdZ856tLOx|PRRT_kwDORgvdZ856tLO2|PRRT_kwDORgvdZ856tLO3
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T04:07:54.578Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T04:18:14.686Z
 
 ## Latest Codex Summary
-Surfaced effective Codex model policy in the read-only reporting path without changing execution behavior. `doctor` now shows the default route, bounded repair override, local-review override, and best-effort host-default model resolution from Codex host config; active `status` now shows the effective route for the current state plus explicit override routing. I added a shared helper in [src/codex/codex-model-policy.ts](src/codex/codex-model-policy.ts:1) and wired it through [src/doctor.ts](src/doctor.ts:1), [src/supervisor/supervisor-selection-active-status.ts](src/supervisor/supervisor-selection-active-status.ts:1), and [src/supervisor/supervisor-status-model.ts](src/supervisor/supervisor-status-model.ts:1).
-
-Focused coverage was added in [src/doctor.test.ts](src/doctor.test.ts:1), [src/supervisor/supervisor-diagnostics-status-selection.test.ts](src/supervisor/supervisor-diagnostics-status-selection.test.ts:1), and [src/supervisor/supervisor-status-rendering.test.ts](src/supervisor/supervisor-status-rendering.test.ts:1). I committed the work on `codex/issue-1501`, pushed it, and opened draft PR #1504: https://github.com/TommyKammy/codex-supervisor/pull/1504
-
-Summary: Surfaced effective Codex model policy in doctor and status, added focused regression coverage, pushed branch, and opened draft PR #1504
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-rendering.test.ts`; `npm run build`
-Next action: Monitor draft PR #1504 and address any CI or review feedback on the new model-policy diagnostics
-Failure signature: PRRT_kwDORgvdZ856tLOl|PRRT_kwDORgvdZ856tLOn|PRRT_kwDORgvdZ856tLOt|PRRT_kwDORgvdZ856tLOv|PRRT_kwDORgvdZ856tLOx|PRRT_kwDORgvdZ856tLO2|PRRT_kwDORgvdZ856tLO3
+- None yet.
 
 ## Active Failure Context
-- Category: review
-- Summary: 7 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1504#discussion_r3077075001
-- Details:
-  - src/codex/codex-model-policy.ts:65 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Accept inline comments in `config.toml`.** A valid TOML line like `model = "gpt-5" # shared default` will miss this regex and get reported as... url=https://github.com/TommyKammy/codex-supervisor/pull/1504#discussion_r3077075001
-  - src/codex/codex-model-policy.ts:167 summary=_⚠️ Potential issue_ | _🟠 Major_ **Keep `defaultRoute` independent from `activeState`.** `defaultRoute.source` is labeled from `codexModelStrategy`, but `effectiveModel` comes ... url=https://github.com/TommyKammy/codex-supervisor/pull/1504#discussion_r3077075003
-  - src/codex/codex-model-policy.ts:196 summary=_⚠️ Potential issue_ | _🔴 Critical_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 10996 --- 🏁 Script executed: Repository: To... url=https://github.com/TommyKammy/codex-supervisor/pull/1504#discussion_r3077075011
-  - src/doctor.test.ts:186 summary=_⚠️ Potential issue_ | _🟡 Minor_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 816 --- 🏁 Script executed: Repository: TommyKa... url=https://github.com/TommyKammy/codex-supervisor/pull/1504#discussion_r3077075013
-  - src/doctor.ts:683 summary=_⚠️ Potential issue_ | _🟠 Major_ **Sanitize Codex policy lines before injecting them into doctor output.** Line 683 appends raw strings. url=https://github.com/TommyKammy/codex-supervisor/pull/1504#discussion_r3077075015
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The routing logic already existed, but operators could not see the effective route because read-only reporting never summarized default-vs-override policy or the inherited host default model.
-- What changed: Addressed the outstanding PR #1504 review feedback in `src/codex/codex-model-policy.ts`, `src/doctor.ts`, `src/doctor.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`, and `src/supervisor/supervisor-status-rendering.test.ts`. The helper now accepts inline TOML comments in host `config.toml`, keeps `defaultRoute` independent from active bounded-repair state, routes active `local_review` snapshots through `localReviewRoute` with target `local_review_generic`, sanitizes policy lines before doctor output, and restores `CODEX_HOME` safely in test teardown.
-- Current blocker: none
-- Next exact step: Commit the review-fix checkpoint on `codex/issue-1501`, push it to PR #1504, and then resolve or respond to the remaining automated review threads on GitHub.
-- Verification gap: Repo-wide `npm test` is still noisy because the package script runs the full suite and unrelated tests are currently red; the focused requested coverage and `npm run build` passed locally.
-- Files touched: .codex-supervisor/issue-journal.md; src/codex/codex-model-policy.ts; src/doctor.ts; src/doctor.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-status-rendering.test.ts
-- Rollback concern: Host-default resolution is intentionally best-effort and only inspects the top-level `model` key in Codex `config.toml`; if Codex host config layout changes, the output should degrade to `unresolved` without affecting execution.
-- Exact failures addressed: `PRRT_kwDORgvdZ856tLOl` inline TOML comments, `PRRT_kwDORgvdZ856tLOn` default route leaking active bounded-repair overrides, `PRRT_kwDORgvdZ856tLOt` missing active local-review route selection, `PRRT_kwDORgvdZ856tLOv|PRRT_kwDORgvdZ856tLO2|PRRT_kwDORgvdZ856tLO3` unsafe `CODEX_HOME` teardown, `PRRT_kwDORgvdZ856tLOx` unsanitized doctor policy lines.
-- Commands run: `git diff -- src/codex/codex-model-policy.ts src/doctor.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-rendering.test.ts`; `npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-rendering.test.ts`; `npm run build`
+- Hypothesis: README and getting-started were missing an explicit profile-selection rule (`--config` chooses the active file), explicit profile-based `issue-lint` / `status` / `doctor` examples, and the recommended `codexModelStrategy: "inherit"` posture that already lives in the configuration guide.
+- What changed: Added a focused docs regression in `src/execution-safety-docs.test.ts`; updated `README.md` and `docs/getting-started.md` to explain profile-based operation, explicit verification commands, and inherited-vs-fixed model routing; added one clarifying `fixed` sentence in `docs/configuration.md` to keep wording aligned.
+- Current blocker: None for the docs issue itself. Repo-wide test commands still hit unrelated pre-existing failures outside this change set.
+- Next exact step: Review the diff, then commit the docs/test changes as a coherent checkpoint on `codex/issue-1502`.
+- Verification gap: The focused added assertions pass via direct regex verification and the build passes. `npm test -- src/execution-safety-docs.test.ts` is not isolated in this repo and still runs unrelated failing tests; direct `npx tsx --test src/execution-safety-docs.test.ts` confirms the new profile-guidance test passes but surfaces older unrelated execution-safety doc failures.
+- Files touched: README.md; docs/getting-started.md; docs/configuration.md; src/execution-safety-docs.test.ts; .codex-supervisor/issue-journal.md
+- Rollback concern: Low. Changes are doc/test-only and keep the README/getting-started wording anchored to `docs/configuration.md` instead of adding a separate policy source.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/README.md
+++ b/README.md
@@ -75,25 +75,43 @@ Before the first run, keep the [Configuration guide](./docs/configuration.md) op
    cp supervisor.config.example.json supervisor.config.json
    ```
 
-3. Choose the review provider profile that matches your PR review flow, then either copy that file over `supervisor.config.json` as a starting point or copy its `reviewBotLogins` into the `supervisor.config.json` you created in step 2.
+3. Choose the review provider profile that matches your PR review flow. The active config is whichever file you pass with `--config`, so you can either keep a single `supervisor.config.json` file or operate directly against named profiles such as `supervisor.config.codex.json` or `supervisor.config.coderabbit.json`.
 
    - [supervisor.config.copilot.json](./supervisor.config.copilot.json)
    - [supervisor.config.codex.json](./supervisor.config.codex.json)
    - [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
 
-4. Edit `supervisor.config.json` and set `repoPath`, `repoSlug`, `workspaceRoot`, `codexBinary`, and any review-provider-specific values you want to keep before the first run. Use the [Configuration guide](./docs/configuration.md) as the source of truth while you edit. The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so you must replace it for your repo.
-
-5. Run a single pass first, then switch to the loop when the config looks right.
+   For example, if you want a Codex review profile as the active one:
 
    ```bash
-   node dist/index.js run-once --config /path/to/supervisor.config.json
-   node dist/index.js status --config /path/to/supervisor.config.json
+   cp supervisor.config.codex.json supervisor.config.local.json
    ```
 
-6. Start the durable loop only after the first pass looks sane.
+4. Edit whichever config file you will pass with `--config` and set `repoPath`, `repoSlug`, `workspaceRoot`, `codexBinary`, and any review-provider-specific values you want to keep before the first run. Use the [Configuration guide](./docs/configuration.md) as the source of truth while you edit. The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so you must replace it for your repo.
+
+   Recommended model posture:
+
+   - keep `codexModelStrategy: "inherit"` so the supervisor follows the host Codex CLI/App default model
+   - set the host Codex default model intentionally before you trust `loop`
+   - switch to `fixed` only when this supervisor profile must pin a specific model regardless of the host default model
+
+   Keep the detailed routing rules in the [Configuration guide](./docs/configuration.md) rather than maintaining a second model-policy story here.
+
+5. Validate the issue body and inspect the effective profile before you run the loop.
 
    ```bash
-   node dist/index.js loop --config /path/to/supervisor.config.json
+   node dist/index.js issue-lint 123 --config /path/to/supervisor.config.codex.json
+   node dist/index.js status --config /path/to/supervisor.config.codex.json
+   node dist/index.js doctor --config /path/to/supervisor.config.codex.json
+   ```
+
+   `status` and `doctor` are the fastest way to confirm you passed the intended profile file and that the host and config are healthy before `loop` starts trusting that config.
+
+6. Run a single supervised pass, then switch to the loop when the config looks right.
+
+   ```bash
+   node dist/index.js run-once --config /path/to/supervisor.config.codex.json
+   node dist/index.js loop --config /path/to/supervisor.config.codex.json
    ```
 
    On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path.
@@ -191,7 +209,7 @@ Parallelizable: No
 Before trusting a new issue as runnable work, lint it directly:
 
 ```bash
-node dist/index.js issue-lint 123 --config /path/to/supervisor.config.json
+node dist/index.js issue-lint 123 --config /path/to/supervisor.config.codex.json
 ```
 
 If `issue-lint` reports missing or malformed metadata, fix the issue body before running `run-once` or `loop`.
@@ -218,6 +236,21 @@ Choose the review provider profile that matches how PR feedback arrives in your 
 - CodeRabbit profile: [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
 
 Each profile is a starting point. Copy the review provider profile you want, then adjust the rest of `supervisor.config.json` for your repo before you run the supervisor.
+
+The active config is whichever file you pass with `--config`. If you keep several profiles side by side, verify the intended one with:
+
+```bash
+node dist/index.js status --config /path/to/supervisor.config.codex.json
+node dist/index.js doctor --config /path/to/supervisor.config.codex.json
+```
+
+Recommended model posture for those profiles:
+
+- keep `codexModelStrategy: "inherit"` so the supervisor follows the host Codex default model
+- set the host Codex default model intentionally
+- use `fixed` only when one profile must pin a model and ignore the host default model
+
+Use the [Configuration guide](./docs/configuration.md) for the full routing rules and validation details.
 
 ## Docs Map
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,6 +264,7 @@ Use this when you want `codex-supervisor` to follow the Codex CLI/App default mo
 ### Pin every Codex turn globally
 
 Use this when you want the supervisor to ignore the host default and always use one explicit model or alias.
+Choose `fixed` when one supervisor profile must pin a model and ignore the host default model.
 
 ```json
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,13 +74,13 @@ Create an active config from the base example:
 cp supervisor.config.example.json supervisor.config.json
 ```
 
-Then choose the review provider profile that matches your PR review flow:
+Then choose the review provider profile that matches your PR review flow. The active config is whichever file you pass with `--config`, so you can either edit a single `supervisor.config.json` file or keep several named profiles and choose between them at runtime:
 
 - [supervisor.config.copilot.json](../supervisor.config.copilot.json)
 - [supervisor.config.codex.json](../supervisor.config.codex.json)
 - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
 
-Either copy one of those files over `supervisor.config.json` as a starting point or copy only its `reviewBotLogins` into your active config.
+Either copy one of those files over `supervisor.config.json` as a starting point, copy it to a separate profile such as `supervisor.config.local.json`, or copy only its `reviewBotLogins` into your active config.
 
 At minimum, set these fields before the first run:
 
@@ -91,6 +91,15 @@ At minimum, set these fields before the first run:
 - provider-specific review settings you expect the supervisor to watch
 
 The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so operators must replace it before the first run.
+
+Recommended model posture for a first operator profile:
+
+- keep `codexModelStrategy: "inherit"` so the supervisor follows the host Codex CLI/App default model
+- set the host Codex default model intentionally before you trust `loop`
+- leave the bounded repair and local-review model overrides unset unless you intentionally want a separate route
+- switch to `fixed` only when this profile must pin one model and ignore the host default model
+
+Use the configuration guide as the source of truth for model routing details and validation rules rather than copying a second policy into local notes.
 
 If you need the full field-by-field setup, model policy, durable memory, or provider guidance, use the [Configuration reference](./configuration.md).
 
@@ -186,7 +195,7 @@ Before `run-once`, do this quick check:
 Validate one issue before the loop:
 
 ```bash
-node dist/index.js issue-lint 123 --config /path/to/supervisor.config.json
+node dist/index.js issue-lint 123 --config /path/to/supervisor.config.codex.json
 ```
 
 What to do with the result:
@@ -224,10 +233,13 @@ Issue readiness is not the same as trust. A perfectly structured issue is still 
 Start with a single supervised pass so you can inspect the repo selection, worktree setup, and resulting state before you hand over the loop:
 
 ```bash
-node dist/index.js run-once --config /path/to/supervisor.config.json
-node dist/index.js status --config /path/to/supervisor.config.json
-node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json
+node dist/index.js status --config /path/to/supervisor.config.codex.json
+node dist/index.js doctor --config /path/to/supervisor.config.codex.json
+node dist/index.js run-once --config /path/to/supervisor.config.codex.json
+node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.codex.json
 ```
+
+If you keep multiple profiles side by side, `status` and `doctor` are the fastest way to confirm that you are inspecting the same `supervisor.config.xxx.json` file you plan to use for `run-once` and `loop`.
 
 What to check after `run-once`:
 

--- a/src/execution-safety-docs.test.ts
+++ b/src/execution-safety-docs.test.ts
@@ -169,3 +169,81 @@ test("workspace cleanup docs distinguish tracked done cleanup from explicit orph
     "docs/configuration.md should define the explicit orphan prune eligibility contract",
   );
 });
+
+test("profile-based config docs keep README and getting-started aligned with model routing guidance", async () => {
+  const [readme, gettingStarted, configuration] = await Promise.all([
+    readDoc("README.md"),
+    readDoc(path.join("docs", "getting-started.md")),
+    readDoc(path.join("docs", "configuration.md")),
+  ]);
+
+  for (const [label, content] of [
+    ["README.md", readme],
+    ["docs/getting-started.md", gettingStarted],
+    ["docs/configuration.md", configuration],
+  ] as const) {
+    assert.match(
+      content,
+      /active config is whichever file you pass with `--config`/i,
+      `expected ${label} to define explicit --config profile selection`,
+    );
+    assert.match(
+      content,
+      /supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+      `expected ${label} to mention shipped profile filenames`,
+    );
+  }
+
+  assert.match(
+    readme,
+    /issue-lint[\s\S]{0,200}supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+    "expected README.md to show issue-lint against an explicit profile config",
+  );
+  assert.match(
+    readme,
+    /status[\s\S]{0,200}supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+    "expected README.md to show status against an explicit profile config",
+  );
+  assert.match(
+    readme,
+    /doctor[\s\S]{0,200}supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+    "expected README.md to show doctor against an explicit profile config",
+  );
+  assert.match(
+    gettingStarted,
+    /issue-lint[\s\S]{0,200}supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+    "expected docs/getting-started.md to show issue-lint against an explicit profile config",
+  );
+  assert.match(
+    gettingStarted,
+    /status[\s\S]{0,200}supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+    "expected docs/getting-started.md to show status against an explicit profile config",
+  );
+  assert.match(
+    gettingStarted,
+    /doctor[\s\S]{0,200}supervisor\.config\.(codex|coderabbit|copilot)\.json/i,
+    "expected docs/getting-started.md to show doctor against an explicit profile config",
+  );
+
+  for (const [label, content] of [
+    ["README.md", readme],
+    ["docs/getting-started.md", gettingStarted],
+    ["docs/configuration.md", configuration],
+  ] as const) {
+    assert.match(
+      content,
+      /codexModelStrategy:\s*"inherit"/i,
+      `expected ${label} to mention the recommended inherited model strategy`,
+    );
+    assert.match(
+      content,
+      /host Codex (?:CLI\/App )?default model|Codex CLI\/App default model|Codex default model/i,
+      `expected ${label} to explain that inherit follows the host default model`,
+    );
+    assert.match(
+      content,
+      /\bfixed\b[\s\S]{0,180}(?:ignore|override|pin)[\s\S]{0,180}(?:host|default model)/i,
+      `expected ${label} to explain when fixed routing is appropriate`,
+    );
+  }
+});


### PR DESCRIPTION
Closes #1502
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the operator docs so profile-based operation is explicit and consistent across [README.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1502/README.md), [docs/getting-started.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1502/docs/getting-started.md), and [docs/configuration.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1502/docs/configuration.md). The docs now state that the active config is whichever file is passed to `--config`, show explicit profile-based `issue-lint` / `status` / `doctor` / `run-once` / `loop` examples, and call out the recommended `codexModelStrategy: "inherit"` posture plus when `fixed` is appropriate. I also tightened [src/execution-safety-docs.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1502/src/execution-safety-docs.test.ts) with a focused regression that checks those profile-guidance expectations.

The changes are committed on `codex/issue-1502` as `ca19f7e` with message `docs: clarify profile-based config guidance`.

Verification: `npm run build` passed. A direct focused regex verification of the new assertions passed. `npm test -- src/execution-safety-docs.test.ts` is not isolated in this repo because the package script still expands the full test glob first, and that broader run failed on unrelated existing tests in `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-status-model-supervisor.test....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supervisor configuration is determined solely by the `--config` file path supplied at runtime.
  * Recommended using multiple named profile files and passing the desired one via `--config` instead of copying profiles.
  * Added guidance on model routing strategy settings and when to use fixed vs. inherited configurations.
  * Updated example commands across guides to reflect profile-based configuration.

* **Tests**
  * Added validation test ensuring documentation consistency across guides regarding configuration and model strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->