### PR TITLE
Surface parent epic auto-closure recovery events

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,34 +1,33 @@
-# Issue #1506: Epic auto-closure should fall back to canonical child lists in epic bodies
+# Issue #1508: Parent epic auto-closure should be surfaced as an explicit recovery event
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1506
-- Branch: codex/issue-1506
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1508
+- Branch: codex/issue-1508
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 43774cdb67f50572eecf97a479e050a72aea277b
+- Last head SHA: 941fafe431cfdbb1d366c55e73e3309775acce5f
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T05:09:03.082Z
+- Updated at: 2026-04-14T05:48:45.077Z
 
 ## Latest Codex Summary
-- Added a narrow epic-body fallback for parent auto-closure by parsing only `## Child issues` sections with `- #<number>` bullets, while preserving child-side `Part of:` metadata as the primary path when present.
-- Reproduced the gap with a focused `findParentIssuesReadyToClose` test, added a negative prose test, and refreshed two stale tracked-PR patch expectations so the requested verification suite passes.
+- Added explicit `parent_epic_auto_closed` recovery events to parent epic closure reconciliation, threaded those events through prelude recovery aggregation, and covered the operator-facing status surface via `latest_recovery`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Parent epic auto-closure only derived relationships from child-side `Part of:` metadata, so epics with canonical child lists in the epic body never became closure candidates when children omitted `Part of:`.
-- What changed: Added `parseCanonicalEpicChildIssueNumbers`, taught `findParentIssuesReadyToClose` to use a complete `## Child issues` bullet list as a fallback closure source, added focused positive/negative tests, and updated two stale `recovery-reconciliation.test.ts` expectations for existing blocker-observation fields.
-- Current blocker: none
-- Next exact step: Commit the verified fallback implementation and updated tests on `codex/issue-1506`.
-- Verification gap: none for the requested local verification set; broader CI remains unrun locally beyond `npm run build`.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/issue-metadata/issue-metadata-parser.ts`, `src/issue-metadata/issue-metadata.ts`, `src/issue-metadata/issue-metadata.test.ts`, `src/recovery-reconciliation.test.ts`
-- Rollback concern: The fallback intentionally fails closed unless the epic body uses the exact `## Child issues` plus `- #<number>` shape and every referenced child is present in the inventory.
-- Last focused command: `npx tsx --test src/issue-metadata/issue-metadata.test.ts src/run-once-cycle-prelude.test.ts src/recovery-reconciliation.test.ts`
+- Hypothesis: Parent epic auto-closure can reuse the existing recovery-event and `latest_recovery` plumbing if reconciliation returns a typed event and persists it on the parent issue record.
+- What changed: `reconcileParentEpicClosures(...)` now returns `parent_epic_auto_closed` recovery events with parent and child issue numbers, applies the recovery metadata to tracked parent records, and `runOnceCyclePrelude(...)` now carries/emits those events like other recoveries. Added focused coverage for reconciliation, prelude aggregation, and read-only status rendering.
+- Current blocker: None on the issue implementation. The literal `npm test -- ...` command still expands to the repository's full suite and surfaced unrelated baseline failures outside this issue.
+- Next exact step: Commit the checkpoint and, if desired, open/update the draft PR with the focused verification results plus the note that repo-wide `npm test -- ...` currently exercises unrelated failing tests.
+- Verification gap: Issue-targeted suites and `npm run build` pass. The literal `npm test -- src/...` command is not isolateable in this repo because the `test` script also runs `src/**/*.test.ts`, which surfaced unrelated failures in `supervisor-pr-readiness`, `supervisor-status-model-supervisor`, and `tracked-pr-lifecycle-projection`.
+- Files touched: src/recovery-reconciliation.ts; src/run-once-cycle-prelude.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/run-once-cycle-prelude.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Rollback concern: Low. The change is additive to recovery visibility and preserves existing closure eligibility/side effects.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1227,27 +1227,33 @@ export async function reconcileParentEpicClosures(
   stateStore: StateStoreLike,
   state: SupervisorStateFile,
   issues: GitHubIssue[],
-): Promise<void> {
+): Promise<RecoveryEvent[]> {
   const parentIssuesReadyToClose = findParentIssuesReadyToClose(issues);
   if (parentIssuesReadyToClose.length === 0) {
-    return;
+    return [];
   }
 
   let changed = false;
+  const recoveryEvents: RecoveryEvent[] = [];
 
   for (const { parentIssue, childIssues } of parentIssuesReadyToClose) {
     const childIssueNumbers = childIssues
       .map((childIssue) => `#${childIssue.number}`)
       .sort((left, right) => Number(left.slice(1)) - Number(right.slice(1)));
+    const recoveryEvent = buildRecoveryEvent(
+      parentIssue.number,
+      `parent_epic_auto_closed: auto-closed parent epic #${parentIssue.number} because child issues ${childIssueNumbers.join(", ")} are closed`,
+    );
 
     await github.closeIssue(
       parentIssue.number,
       `Closed automatically because all child issues are closed: ${childIssueNumbers.join(", ")}.`,
     );
+    recoveryEvents.push(recoveryEvent);
 
     const existingRecord = state.issues[String(parentIssue.number)];
     if (existingRecord) {
-      const patch = doneResetPatch();
+      const patch = applyRecoveryEvent(doneResetPatch(), recoveryEvent);
       if (needsRecordUpdate(existingRecord, patch)) {
         const updated = stateStore.touch(existingRecord, patch);
         state.issues[String(parentIssue.number)] = updated;
@@ -1263,6 +1269,8 @@ export async function reconcileParentEpicClosures(
   if (changed) {
     await stateStore.save(state);
   }
+
+  return recoveryEvents;
 }
 
 export async function reconcileStaleActiveIssueReservation(args: {

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -47,6 +47,11 @@ test("runOnceCyclePrelude loads state and aggregates recovery setup events in or
     reason: "blocked recovery",
     at: "2026-03-14T00:03:00Z",
   };
+  const parentEpicClosureEvent: RecoveryEvent = {
+    issueNumber: 45,
+    reason: "parent_epic_auto_closed: auto-closed parent epic #45 because child issues #46, #47 are closed",
+    at: "2026-03-14T00:03:30Z",
+  };
   const orphanCleanupEvent: RecoveryEvent = {
     issueNumber: 44,
     reason: "pruned orphaned worktree",
@@ -106,6 +111,7 @@ test("runOnceCyclePrelude loads state and aggregates recovery setup events in or
       calls.push("reconcileParentEpicClosures");
       assert.equal(loadedState, state);
       assert.equal(loadedIssues, issues);
+      return [parentEpicClosureEvent];
     },
     cleanupExpiredDoneWorkspaces: async (loadedState) => {
       calls.push("cleanupExpiredDoneWorkspaces");
@@ -134,6 +140,7 @@ test("runOnceCyclePrelude loads state and aggregates recovery setup events in or
     staleReservationEvent,
     mergedConvergenceEvent,
     blockedRecoveryEvent,
+    parentEpicClosureEvent,
     orphanCleanupEvent,
   ]);
 });
@@ -186,7 +193,7 @@ test("runOnceCyclePrelude persists the last-known-good inventory snapshot after 
     reconcileMergedIssueClosures: async () => [],
     reconcileStaleFailedIssueStates: async () => {},
     reconcileRecoverableBlockedIssueStates: async () => [],
-    reconcileParentEpicClosures: async () => {},
+    reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
   });
 
@@ -263,6 +270,7 @@ test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving select
     },
     reconcileParentEpicClosures: async () => {
       calls.push("parent_epics");
+      return [];
     },
     cleanupExpiredDoneWorkspaces: async () => {
       calls.push("cleanup");
@@ -354,6 +362,7 @@ test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a
     },
     reconcileParentEpicClosures: async () => {
       calls.push("parent_epics");
+      return [];
     },
     cleanupExpiredDoneWorkspaces: async () => {
       calls.push("cleanup");
@@ -442,6 +451,7 @@ test("runOnceCyclePrelude reconciles tracked PR-open issues before reserving a n
     },
     reconcileParentEpicClosures: async () => {
       calls.push("parent_epics");
+      return [];
     },
     cleanupExpiredDoneWorkspaces: async () => {
       calls.push("cleanup");
@@ -537,7 +547,7 @@ test("runOnceCyclePrelude publishes the active reconciliation phase and clears i
     reconcileMergedIssueClosures: async () => [],
     reconcileStaleFailedIssueStates: async () => {},
     reconcileRecoverableBlockedIssueStates: async () => [],
-    reconcileParentEpicClosures: async () => {},
+    reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
   });
 
@@ -582,7 +592,7 @@ test("runOnceCyclePrelude publishes reconciliation target updates within a phase
     reconcileMergedIssueClosures: async () => [],
     reconcileStaleFailedIssueStates: async () => {},
     reconcileRecoverableBlockedIssueStates: async () => [],
-    reconcileParentEpicClosures: async () => {},
+    reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
   });
 
@@ -670,7 +680,7 @@ test("runOnceCyclePrelude emits typed recovery events for transport adapters", a
     reconcileMergedIssueClosures: async () => [],
     reconcileStaleFailedIssueStates: async () => {},
     reconcileRecoverableBlockedIssueStates: async () => [],
-    reconcileParentEpicClosures: async () => {},
+    reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
   });
 
@@ -1676,6 +1686,7 @@ test("runOnceCyclePrelude does not reconcile parent epic closures from tracked i
     },
     reconcileParentEpicClosures: async (_loadedState, loadedIssues) => {
       parentEpicClosureCalls.push(loadedIssues);
+      return [];
     },
     cleanupExpiredDoneWorkspaces: async () => {
       throw new Error("unexpected cleanupExpiredDoneWorkspaces call");
@@ -1746,6 +1757,7 @@ test("runOnceCyclePrelude does not attempt degraded parent epic closure from a p
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => {
       parentEpicClosureCalls += 1;
+      return [];
     },
     cleanupExpiredDoneWorkspaces: async () => [],
   });
@@ -1843,6 +1855,7 @@ test("runOnceCyclePrelude does not fetch parent epics for degraded parent closur
     },
     reconcileParentEpicClosures: async (_loadedState, loadedIssues) => {
       parentEpicClosureCalls.push(loadedIssues);
+      return [];
     },
     cleanupExpiredDoneWorkspaces: async () => {
       throw new Error("unexpected cleanupExpiredDoneWorkspaces call");

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -74,7 +74,7 @@ interface RunOnceCyclePreludeArgs {
   reconcileParentEpicClosures: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
-  ) => Promise<void>;
+  ) => Promise<RecoveryEvent[]>;
   cleanupExpiredDoneWorkspaces: (state: SupervisorStateFile) => Promise<RecoveryEvent[]>;
 }
 
@@ -312,7 +312,9 @@ export async function runOnceCyclePrelude(
     }
 
     await setReconciliationPhase("parent_epic_closures");
-    await args.reconcileParentEpicClosures(state, issues);
+    const parentEpicClosureEvents = await args.reconcileParentEpicClosures(state, issues) ?? [];
+    recoveryEvents.push(...parentEpicClosureEvents);
+    emitRecoveryEvents(parentEpicClosureEvents);
 
     await setReconciliationPhase("cleanup_expired_done_workspaces");
     const cleanupEvents = await args.cleanupExpiredDoneWorkspaces(state);

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3292,6 +3292,59 @@ test("status does not surface tracked PR mismatch diagnostics after tracked PR r
   );
 });
 
+test("status surfaces parent epic auto-closure as the latest recovery on read-only status surfaces", async () => {
+  const fixture = await createSupervisorFixture();
+  const parentIssueNumber = 199;
+  const newerIssueNumber = 200;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(parentIssueNumber)]: createRecord({
+        issue_number: parentIssueNumber,
+        state: "done",
+        branch: branchName(fixture.config, parentIssueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${parentIssueNumber}`),
+        journal_path: null,
+        last_recovery_reason:
+          "parent_epic_auto_closed: auto-closed parent epic #199 because child issues #201, #202 are closed",
+        last_recovery_at: "2026-03-13T00:20:00Z",
+      }),
+      [String(newerIssueNumber)]: createRecord({
+        issue_number: newerIssueNumber,
+        state: "done",
+        branch: branchName(fixture.config, newerIssueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${newerIssueNumber}`),
+        journal_path: null,
+        updated_at: "2026-03-13T00:25:00Z",
+        last_recovery_reason: null,
+        last_recovery_at: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^latest_recovery issue=#199 at=2026-03-13T00:20:00Z reason=parent_epic_auto_closed detail=auto-closed parent epic #199 because child issues #201, #202 are closed$/m,
+  );
+
+  const status = await supervisor.status();
+  assert.match(
+    status,
+    /^latest_recovery issue=#199 at=2026-03-13T00:20:00Z reason=parent_epic_auto_closed detail=auto-closed parent epic #199 because child issues #201, #202 are closed$/m,
+  );
+});
+
 test("status does not surface tracked PR mismatch diagnostics after tracked PR recovery persists addressing_review state", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.reviewBotLogins = ["copilot-pull-request-reviewer"];

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3638,10 +3638,12 @@ test("reconcileParentEpicClosures clears a stale active issue pointer even when 
   let touchCalls = 0;
   let saveCalls = 0;
   let closeIssueCalls = 0;
+  let touchedRecord: IssueRunRecord | null = null;
   const stateStore = {
     touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
       touchCalls += 1;
-      return { ...current, ...patch };
+      touchedRecord = { ...current, ...patch };
+      return touchedRecord;
     },
     async save(): Promise<void> {
       saveCalls += 1;
@@ -3670,10 +3672,114 @@ test("reconcileParentEpicClosures clears a stale active issue pointer even when 
   );
 
   assert.equal(closeIssueCalls, 1);
-  assert.equal(touchCalls, 0);
+  assert.equal(touchCalls, 1);
   assert.equal(saveCalls, 1);
   assert.equal(state.activeIssueNumber, null);
-  assert.deepEqual(state.issues["123"], original);
+  assert.equal(
+    state.issues["123"]?.last_recovery_reason,
+    "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed",
+  );
+  assert.ok(state.issues["123"]?.last_recovery_at);
+  assert.equal(state.issues["123"]?.state, "done");
+  assert.deepEqual(state.issues["123"], touchedRecord);
+});
+
+test("reconcileParentEpicClosures returns an explicit recovery event and persists it on the parent record", async () => {
+  const original = createRecord({
+    issue_number: 123,
+    state: "reproducing",
+    pr_number: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "123": original,
+    },
+  };
+  const issues: GitHubIssue[] = [
+    {
+      number: 123,
+      title: "Parent issue",
+      body: "",
+      createdAt: "2026-03-13T00:00:00Z",
+      updatedAt: "2026-03-13T00:00:00Z",
+      url: "https://example.test/issues/123",
+      state: "OPEN",
+    },
+    {
+      number: 201,
+      title: "Child one",
+      body: "Part of #123",
+      createdAt: "2026-03-13T00:00:00Z",
+      updatedAt: "2026-03-13T00:00:00Z",
+      url: "https://example.test/issues/201",
+      state: "CLOSED",
+    },
+    {
+      number: 202,
+      title: "Child two",
+      body: "- Part of: #123",
+      createdAt: "2026-03-13T00:00:00Z",
+      updatedAt: "2026-03-13T00:00:00Z",
+      url: "https://example.test/issues/202",
+      state: "CLOSED",
+    },
+  ];
+
+  let savedState: SupervisorStateFile | null = null;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return { ...current, ...patch };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      savedState = structuredClone(nextState);
+    },
+  };
+
+  const recoveryEvents = await reconcileParentEpicClosures(
+    {
+      closeIssue: async () => {},
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+      getPullRequestIfExists: async () => null,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    issues,
+  );
+
+  assert.equal(recoveryEvents.length, 1);
+  assert.equal(recoveryEvents[0]?.issueNumber, 123);
+  assert.equal(
+    recoveryEvents[0]?.reason,
+    "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed",
+  );
+  assert.equal(state.issues["123"]?.state, "done");
+  assert.equal(
+    state.issues["123"]?.last_recovery_reason,
+    "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed",
+  );
+  assert.ok(state.issues["123"]?.last_recovery_at);
+  if (savedState === null) {
+    throw new Error("expected state to be saved");
+  }
+  const persistedState: SupervisorStateFile = savedState;
+  assert.deepEqual(persistedState.issues["123"], state.issues["123"]);
 });
 
 test("reconcileTrackedMergedButOpenIssues fetches missing issue snapshots for non-merging merged records", async () => {


### PR DESCRIPTION
## Summary
- emit an explicit recovery event when parent epic auto-closure runs
- carry the event through the run-once recovery log path
- surface the recovery on read-only status via latest_recovery

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/run-once-cycle-prelude.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

## Notes
- The literal issue-body command `npm test -- src/...` currently expands to the repository's full suite because of the existing npm script and surfaced unrelated baseline failures outside this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parent epic auto-closure events are now explicitly tracked and surfaced in recovery status reports, providing visibility into when parent epics are automatically closed based on child issue closures.

* **Tests**
  * Added test coverage for parent epic auto-closure recovery event persistence and status report display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->