### PR TITLE
Persist parent epic auto-closure recovery metadata for untracked parent epics (#1510)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,28 +5,46 @@
 - Branch: codex/issue-1510
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 42f00c07fcfc83ffdef2a2fb030ac1db20a2b260
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 2b6619f6b9d303d9fa03aeeb481d97ca77f362a3
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T06:13:31.580Z
+- Last failure signature: PRRT_kwDORgvdZ856uaRt
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T06:32:33.292Z
 
 ## Latest Codex Summary
-- Reproduced the gap with a focused reconciliation test: `reconcileParentEpicClosures` emitted a recovery event but skipped `state.issues` persistence when the parent epic had no existing record.
-- Persisted a synthetic terminal no-PR record for untracked auto-closed parent epics so read-only status surfaces can keep showing `latest_recovery` without re-enabling selection.
-- Verified with focused tests and `npm run build`.
+Persisted parent-epic auto-closure recovery metadata when the parent had no prior `state.issues` record. The fix synthesizes a terminal no-PR `done` record during `reconcileParentEpicClosures`, applies the same recovery metadata patch used for tracked parents, and leaves it non-runnable. I also tightened tests for the untracked-parent reconciliation path and for the read-only status surface to confirm the recovered parent epic remains out of selection.
+
+Verification passed with the focused suites and build:
+`npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`
+and `npm run build`.
+
+Checkpoint commit: `2b6619f` (`Persist recovery metadata for untracked parent epics`)
+
+There are still untracked supervisor artifacts in the worktree:
+`.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, `.codex-supervisor/turn-in-progress.json`
+
+Summary: Persisted `latest_recovery` metadata for untracked auto-closed parent epics via a synthetic terminal record; focused tests and build pass; checkpoint committed as `2b6619f`.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
+Next action: Open or update a draft PR from `codex/issue-1510`, noting the committed fix and leaving the untracked supervisor artifacts out of the PR.
+Failure signature: PRRT_kwDORgvdZ856uaRt
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1511#discussion_r3077509698
+- Details:
+  - .codex-supervisor/issue-journal.md:29 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Update the next-step note to reflect current PR status.** Line 29 says to “Commit the checkpoint,” but this PR already has checkpoint commit ... url=https://github.com/TommyKammy/codex-supervisor/pull/1511#discussion_r3077509698
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: Parent-epic auto-closure recovery metadata was only durable when `state.issues[parent]` already existed; read-only status derives `latest_recovery` solely from persisted records.
 - What changed: Added `createUntrackedRecoveredDoneRecord()` and used it in `reconcileParentEpicClosures()` to synthesize a terminal record for untracked auto-closed parent epics; tightened reconciliation and status-selection tests around that path.
 - Current blocker: none
-- Next exact step: Commit the checkpoint on `codex/issue-1510` and leave the branch ready for PR creation/update.
+- Next exact step: Open or update the draft PR from `codex/issue-1510` and note checkpoint commit `2b6619f`.
 - Verification gap: none for the scoped issue acceptance checks.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
 - Rollback concern: Low; the new persisted record is terminal (`state=done`, `pr_number=null`, `blocked_reason=null`) and should remain read-only in selection flows.
@@ -34,6 +52,8 @@
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - Reproduced failure signature before fix: `untracked-parent-epic-recovery-not-persisted`.
+- Addressed review signature: `PRRT_kwDORgvdZ856uaRt`.
+- Review-fix command: updated `.codex-supervisor/issue-journal.md` handoff note to match committed PR state.
 - Focused verification commands:
 - `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`
 - `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,41 @@
-# Issue #1508: Parent epic auto-closure should be surfaced as an explicit recovery event
+# Issue #1510: Persist parent epic auto-closure recovery metadata for untracked parent epics
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1508
-- Branch: codex/issue-1508
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1510
+- Branch: codex/issue-1510
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 941fafe431cfdbb1d366c55e73e3309775acce5f
+- Last head SHA: 42f00c07fcfc83ffdef2a2fb030ac1db20a2b260
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T05:48:45.077Z
+- Updated at: 2026-04-14T06:13:31.580Z
 
 ## Latest Codex Summary
-- Added explicit `parent_epic_auto_closed` recovery events to parent epic closure reconciliation, threaded those events through prelude recovery aggregation, and covered the operator-facing status surface via `latest_recovery`.
+- Reproduced the gap with a focused reconciliation test: `reconcileParentEpicClosures` emitted a recovery event but skipped `state.issues` persistence when the parent epic had no existing record.
+- Persisted a synthetic terminal no-PR record for untracked auto-closed parent epics so read-only status surfaces can keep showing `latest_recovery` without re-enabling selection.
+- Verified with focused tests and `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Parent epic auto-closure can reuse the existing recovery-event and `latest_recovery` plumbing if reconciliation returns a typed event and persists it on the parent issue record.
-- What changed: `reconcileParentEpicClosures(...)` now returns `parent_epic_auto_closed` recovery events with parent and child issue numbers, applies the recovery metadata to tracked parent records, and `runOnceCyclePrelude(...)` now carries/emits those events like other recoveries. Added focused coverage for reconciliation, prelude aggregation, and read-only status rendering.
-- Current blocker: None on the issue implementation. The literal `npm test -- ...` command still expands to the repository's full suite and surfaced unrelated baseline failures outside this issue.
-- Next exact step: Commit the checkpoint and, if desired, open/update the draft PR with the focused verification results plus the note that repo-wide `npm test -- ...` currently exercises unrelated failing tests.
-- Verification gap: Issue-targeted suites and `npm run build` pass. The literal `npm test -- src/...` command is not isolateable in this repo because the `test` script also runs `src/**/*.test.ts`, which surfaced unrelated failures in `supervisor-pr-readiness`, `supervisor-status-model-supervisor`, and `tracked-pr-lifecycle-projection`.
-- Files touched: src/recovery-reconciliation.ts; src/run-once-cycle-prelude.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/run-once-cycle-prelude.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts
-- Rollback concern: Low. The change is additive to recovery visibility and preserves existing closure eligibility/side effects.
-- Last focused command: npm run build
+- Hypothesis: Parent-epic auto-closure recovery metadata was only durable when `state.issues[parent]` already existed; read-only status derives `latest_recovery` solely from persisted records.
+- What changed: Added `createUntrackedRecoveredDoneRecord()` and used it in `reconcileParentEpicClosures()` to synthesize a terminal record for untracked auto-closed parent epics; tightened reconciliation and status-selection tests around that path.
+- Current blocker: none
+- Next exact step: Commit the checkpoint on `codex/issue-1510` and leave the branch ready for PR creation/update.
+- Verification gap: none for the scoped issue acceptance checks.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- Rollback concern: Low; the new persisted record is terminal (`state=done`, `pr_number=null`, `blocked_reason=null`) and should remain read-only in selection flows.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- Reproduced failure signature before fix: `untracked-parent-epic-recovery-not-persisted`.
+- Focused verification commands:
+- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`
+- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- `npx tsx --test src/run-once-cycle-prelude.test.ts`
+- `npm run build`

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -238,6 +238,93 @@ export function buildRecoveryEvent(issueNumber: number, reason: string): Recover
   };
 }
 
+function createUntrackedRecoveredDoneRecord(issueNumber: number): IssueRunRecord {
+  const updatedAt = nowIso();
+  return {
+    issue_number: issueNumber,
+    state: "done",
+    branch: "",
+    pr_number: null,
+    workspace: "",
+    journal_path: null,
+    review_wait_started_at: null,
+    review_wait_head_sha: null,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
+    merge_readiness_last_evaluated_at: null,
+    copilot_review_requested_observed_at: null,
+    copilot_review_requested_head_sha: null,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    codex_session_id: null,
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    pre_merge_evaluation_outcome: null,
+    pre_merge_must_fix_count: 0,
+    pre_merge_manual_review_count: 0,
+    pre_merge_follow_up_count: 0,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    latest_local_ci_result: null,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    attempt_count: 0,
+    implementation_attempt_count: 0,
+    repair_attempt_count: 0,
+    timeout_retry_count: 0,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+    stale_stabilizing_no_pr_recovery_count: 0,
+    last_head_sha: null,
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+    workspace_restore_source: null,
+    workspace_restore_ref: null,
+    last_codex_summary: null,
+    last_recovery_reason: null,
+    last_recovery_at: null,
+    issue_definition_fingerprint: null,
+    issue_definition_updated_at: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_runtime_error: null,
+    last_runtime_failure_kind: null,
+    last_runtime_failure_context: null,
+    last_blocker_signature: null,
+    last_failure_signature: null,
+    last_tracked_pr_progress_snapshot: null,
+    last_tracked_pr_progress_summary: null,
+    last_tracked_pr_repeat_failure_decision: null,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
+    last_host_local_pr_blocker_comment_signature: null,
+    last_host_local_pr_blocker_comment_head_sha: null,
+    last_stale_review_bot_reply_signature: null,
+    last_stale_review_bot_reply_head_sha: null,
+    stale_review_bot_reply_progress_keys: [],
+    stale_review_bot_resolve_progress_keys: [],
+    blocked_reason: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    updated_at: updatedAt,
+  };
+}
+
 function latestFiniteTimestamp(...values: Array<string | null | undefined>): number | null {
   let latest: number | null = null;
   for (const value of values) {
@@ -1263,6 +1350,13 @@ export async function reconcileParentEpicClosures(
         state.activeIssueNumber = null;
         changed = true;
       }
+    } else {
+      const created = stateStore.touch(
+        createUntrackedRecoveredDoneRecord(parentIssue.number),
+        applyRecoveryEvent(doneResetPatch(), recoveryEvent),
+      );
+      state.issues[String(parentIssue.number)] = created;
+      changed = true;
     }
   }
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3333,6 +3333,8 @@ test("status surfaces parent epic auto-closure as the latest recovery on read-on
   };
 
   const report = await supervisor.statusReport();
+  assert.equal(report.selectionSummary, null);
+  assert.equal(report.activeIssue, null);
   assert.match(
     report.detailedStatusLines.join("\n"),
     /^latest_recovery issue=#199 at=2026-03-13T00:20:00Z reason=parent_epic_auto_closed detail=auto-closed parent epic #199 because child issues #201, #202 are closed$/m,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3782,6 +3782,93 @@ test("reconcileParentEpicClosures returns an explicit recovery event and persist
   assert.deepEqual(persistedState.issues["123"], state.issues["123"]);
 });
 
+test("reconcileParentEpicClosures persists recovery metadata for an untracked parent epic without making it active work", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const issues: GitHubIssue[] = [
+    {
+      number: 123,
+      title: "Parent issue",
+      body: "",
+      createdAt: "2026-03-13T00:00:00Z",
+      updatedAt: "2026-03-13T00:00:00Z",
+      url: "https://example.test/issues/123",
+      state: "OPEN",
+    },
+    {
+      number: 201,
+      title: "Child one",
+      body: "Part of #123",
+      createdAt: "2026-03-13T00:00:00Z",
+      updatedAt: "2026-03-13T00:00:00Z",
+      url: "https://example.test/issues/201",
+      state: "CLOSED",
+    },
+    {
+      number: 202,
+      title: "Child two",
+      body: "- Part of: #123",
+      createdAt: "2026-03-13T00:00:00Z",
+      updatedAt: "2026-03-13T00:00:00Z",
+      url: "https://example.test/issues/202",
+      state: "CLOSED",
+    },
+  ];
+
+  let savedState: SupervisorStateFile | null = null;
+  let touchCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      touchCalls += 1;
+      return { ...current, ...patch };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      savedState = structuredClone(nextState);
+    },
+  };
+
+  const recoveryEvents = await reconcileParentEpicClosures(
+    {
+      closeIssue: async () => {},
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+      getPullRequestIfExists: async () => null,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    issues,
+  );
+
+  assert.equal(touchCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+  assert.equal(recoveryEvents[0]?.issueNumber, 123);
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["123"]?.issue_number, 123);
+  assert.equal(state.issues["123"]?.state, "done");
+  assert.equal(state.issues["123"]?.pr_number, null);
+  assert.equal(state.issues["123"]?.blocked_reason, null);
+  assert.equal(state.issues["123"]?.codex_session_id, null);
+  assert.equal(
+    state.issues["123"]?.last_recovery_reason,
+    "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed",
+  );
+  assert.ok(state.issues["123"]?.last_recovery_at);
+  if (savedState === null) {
+    throw new Error("expected state to be saved");
+  }
+  const persistedState: SupervisorStateFile = savedState;
+  assert.deepEqual(persistedState.issues["123"], state.issues["123"]);
+});
+
 test("reconcileTrackedMergedButOpenIssues fetches missing issue snapshots for non-merging merged records", async () => {
   const record = createRecord({
     issue_number: 366,


### PR DESCRIPTION
Closes #1510
This PR was opened by codex-supervisor.
Latest Codex summary:

Persisted parent-epic auto-closure recovery metadata when the parent had no prior `state.issues` record. The fix synthesizes a terminal no-PR `done` record during `reconcileParentEpicClosures`, applies the same recovery metadata patch used for tracked parents, and leaves it non-runnable. I also tightened tests for the untracked-parent reconciliation path and for the read-only status surface to confirm the recovered parent epic remains out of selection.

Verification passed with the focused suites and build:
`npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`
and `npm run build`.

Checkpoint commit: `2b6619f` (`Persist recovery metadata for untracked parent epics`)

There are still untracked supervisor artifacts in the worktree:
`.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, `.codex-supervisor/turn-in-progress.json`

Summary: Persisted `latest_recovery` metadata for untracked auto-closed parent epics via a synthetic terminal record; focused tests and build pass; checkpoint committed as `2b6619f`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR from `codex/issue-1510`, noting the committed fix...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persist recovery records for automatically closed parent issues when no prior state exists, ensuring read-only status views consistently show the latest recovery.

* **Tests**
  * Added tests verifying creation and persistence of untracked parent recovery records and that active selection remains unchanged.

* **Documentation**
  * Updated internal issue journal to reflect the new reconciliation and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->