### PR TITLE
Fix doctor warnings for synthetic parent-epic recovery records

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,30 +5,44 @@
 - Branch: codex/issue-1512
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: b18a909e920417b5b62eceb1365893eea23501d2
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 50c6d38ca2f446b94a33710434b2ea1cc20bb2ee
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T07:02:01.829Z
+- Last failure signature: PRRT_kwDORgvdZ856u-nB
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T07:13:45.135Z
 
 ## Latest Codex Summary
-- Scoped `doctor` to ignore recovery-only synthetic done records created for untracked parent-epic auto-closures, while leaving tracked worktree validation unchanged.
-- Added a focused `doctor` regression test for the synthetic parent-epic record shape and tightened read-only status coverage to use the same empty branch/workspace record form.
+Implemented the fix in [src/doctor.ts](src/doctor.ts): `doctor` now skips recovery-only synthetic done records that have no branch/workspace but do carry durable recovery metadata. That keeps the parent-epic auto-closure record visible on read-only surfaces without degrading real tracked-worktree diagnostics. I added the focused regression in [src/doctor.test.ts](src/doctor.test.ts) and tightened [src/supervisor/supervisor-diagnostics-status-selection.test.ts](src/supervisor/supervisor-diagnostics-status-selection.test.ts) to use the synthetic parent-epic record shape directly.
+
+I updated the issue journal, committed the change as `50c6d38`, pushed `codex/issue-1512`, and opened draft PR [#1513](https://github.com/TommyKammy/codex-supervisor/pull/1513). Local verification passed for the requested suites plus the focused reproducer. There are still untracked supervisor runtime artifacts under `.codex-supervisor/` from this workspace, but they were not included in the commit.
+
+Summary: Fixed false `doctor` worktree warnings for synthetic parent-epic recovery records, added regression coverage, pushed branch, and opened draft PR #1513.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
+Next action: wait for CI and review on PR #1513, then address any follow-up if checks surface regressions
+Failure signature: PRRT_kwDORgvdZ856u-nB
 
 ## Active Failure Context
-- Primary failure reproduced before the fix: `doctor` warned on synthetic parent-epic recovery records because they persist `workspace: ""` and were treated like tracked worktrees.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077714918
+- Details:
+  - src/doctor.ts:443 summary=_⚠️ Potential issue_ | _🟠 Major_ **Guard non-string state fields before calling `.trim()`.** `record.branch.trim()` and `record.workspace.trim()` can throw on malformed persist... url=https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077714918
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `diagnoseWorktrees` was validating every persisted issue record as a tracked workspace, including synthetic recovery-only parent-epic records that intentionally persist empty branch/workspace fields.
-- What changed: Added `isRecoveryOnlySyntheticRecord` in `src/doctor.ts` and skipped those records during worktree diagnostics; added/updated focused tests in `src/doctor.test.ts` and `src/supervisor/supervisor-diagnostics-status-selection.test.ts`.
+- Hypothesis: the review finding was valid, but the real failure surface was broader than `record.branch.trim()` and `record.workspace.trim()`; malformed persisted workspace fields also reached orphan-prune inspection and could flip the whole `worktrees` doctor check to `fail`.
+- What changed: hardened `isRecoveryOnlySyntheticRecord` against non-string branch/workspace values, taught `diagnoseWorktrees` to treat non-string or blank workspace fields as per-record missing-workspace warnings, filtered orphan-prune inspection to records with inspectable workspace strings, and added a focused malformed-record regression in `src/doctor.test.ts`.
 - Current blocker: none
-- Next exact step: commit the focused fix on `codex/issue-1512` and leave the branch ready for PR/open-review flow.
+- Next exact step: commit and push the review-fix patch on `codex/issue-1512`, then leave PR #1513 ready for the remaining GitHub review-thread follow-up.
 - Verification gap: none for the requested local verification set.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
-- Rollback concern: low; the exemption is intentionally narrow and only matches synthetic done records with empty branch/workspace plus durable recovery metadata.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`
+- Rollback concern: low; the new guards only affect malformed persisted state and the intentionally synthetic recovery-only parent-epic record shape.
 - Last focused command: `npm run build`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- Review thread `PRRT_kwDORgvdZ856u-nB` reproduced locally via a malformed synthetic done record with `branch: null` and `workspace: null`.
+- Commands run this turn: `npx tsx --test src/doctor.test.ts` (failed once while tracing the broader crash path, then passed after the full fix); `npm run build` (passed after each code iteration).
+- Remaining operator-facing step after push: decide whether to reply to or resolve the CodeRabbit thread on PR #1513.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -6,43 +6,43 @@
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 50c6d38ca2f446b94a33710434b2ea1cc20bb2ee
+- Attempt count: 3 (implementation=1, repair=2)
+- Last head SHA: 1db8b99444460e4f1c80890887f1b9cf52f51007
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856u-nB
+- Last failure signature: PRRT_kwDORgvdZ856vF7K
 - Repeated failure signature count: 1
-- Updated at: 2026-04-14T07:13:45.135Z
+- Updated at: 2026-04-14T07:21:33.301Z
 
 ## Latest Codex Summary
-Implemented the fix in [src/doctor.ts](src/doctor.ts): `doctor` now skips recovery-only synthetic done records that have no branch/workspace but do carry durable recovery metadata. That keeps the parent-epic auto-closure record visible on read-only surfaces without degrading real tracked-worktree diagnostics. I added the focused regression in [src/doctor.test.ts](src/doctor.test.ts) and tightened [src/supervisor/supervisor-diagnostics-status-selection.test.ts](src/supervisor/supervisor-diagnostics-status-selection.test.ts) to use the synthetic parent-epic record shape directly.
+Tightened `doctor` synthetic-record detection so recovery-only parent-epic records now require real recovery metadata instead of accepting `undefined` values as present. In [src/doctor.ts](src/doctor.ts), `isRecoveryOnlySyntheticRecord` now requires non-empty string `last_recovery_reason` and `last_recovery_at` values before skipping worktree diagnostics. I also added a focused regression in [src/doctor.test.ts](src/doctor.test.ts) covering a synthetic-like done record with empty branch/workspace fields but missing recovery metadata, which now correctly degrades to a warning instead of being skipped.
 
-I updated the issue journal, committed the change as `50c6d38`, pushed `codex/issue-1512`, and opened draft PR [#1513](https://github.com/TommyKammy/codex-supervisor/pull/1513). Local verification passed for the requested suites plus the focused reproducer. There are still untracked supervisor runtime artifacts under `.codex-supervisor/` from this workspace, but they were not included in the commit.
+The issue journal is updated with the review-fix verification run. I have not posted a GitHub reply or resolved the remaining CodeRabbit thread.
 
-Summary: Fixed false `doctor` worktree warnings for synthetic parent-epic recovery records, added regression coverage, pushed branch, and opened draft PR #1513.
-State hint: draft_pr
+Summary: Tightened recovery-only synthetic detection to reject missing recovery metadata, added a regression test, and re-ran the issue verification set
+State hint: addressing_review
 Blocked reason: none
-Tests: `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
-Next action: wait for CI and review on PR #1513, then address any follow-up if checks surface regressions
-Failure signature: PRRT_kwDORgvdZ856u-nB
+Tests: `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
+Next action: push the review-fix commit for PR #1513, then decide whether to reply to or resolve the remaining CodeRabbit review thread
+Failure signature: PRRT_kwDORgvdZ856vF7K
 
 ## Active Failure Context
 - Category: review
 - Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077714918
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077756591
 - Details:
-  - src/doctor.ts:443 summary=_⚠️ Potential issue_ | _🟠 Major_ **Guard non-string state fields before calling `.trim()`.** `record.branch.trim()` and `record.workspace.trim()` can throw on malformed persist... url=https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077714918
+  - src/doctor.ts:447 summary=_⚠️ Potential issue_ | _🟠 Major_ **Tighten synthetic-record detection to avoid false diagnostic skips.** The predicate treats `undefined` as “present” because it checks `!== nu... url=https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077756591
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the review finding was valid, but the real failure surface was broader than `record.branch.trim()` and `record.workspace.trim()`; malformed persisted workspace fields also reached orphan-prune inspection and could flip the whole `worktrees` doctor check to `fail`.
-- What changed: hardened `isRecoveryOnlySyntheticRecord` against non-string branch/workspace values, taught `diagnoseWorktrees` to treat non-string or blank workspace fields as per-record missing-workspace warnings, filtered orphan-prune inspection to records with inspectable workspace strings, and added a focused malformed-record regression in `src/doctor.test.ts`.
+- Hypothesis: the remaining CodeRabbit finding was valid because `record.last_recovery_reason !== null` and `record.last_recovery_at !== null` still treated `undefined` as present, which could misclassify malformed legacy records as recovery-only synthetic and suppress real workspace warnings.
+- What changed: tightened `isRecoveryOnlySyntheticRecord` to require non-empty string recovery metadata, while preserving the earlier non-string `branch`/`workspace` guards and missing-workspace degradation path; added a focused regression in `src/doctor.test.ts` for a synthetic-like done record with empty branch/workspace fields but missing recovery metadata.
 - Current blocker: none
-- Next exact step: commit and push the review-fix patch on `codex/issue-1512`, then leave PR #1513 ready for the remaining GitHub review-thread follow-up.
+- Next exact step: commit and push the review-fix patch on `codex/issue-1512`, then decide whether to reply to or resolve the remaining CodeRabbit thread on PR #1513.
 - Verification gap: none for the requested local verification set.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`
 - Rollback concern: low; the new guards only affect malformed persisted state and the intentionally synthetic recovery-only parent-epic record shape.
 - Last focused command: `npm run build`
 ### Scratchpad
-- Review thread `PRRT_kwDORgvdZ856u-nB` reproduced locally via a malformed synthetic done record with `branch: null` and `workspace: null`.
-- Commands run this turn: `npx tsx --test src/doctor.test.ts` (failed once while tracing the broader crash path, then passed after the full fix); `npm run build` (passed after each code iteration).
+- Review thread `PRRT_kwDORgvdZ856vF7K` reproduced locally from the live `!== null` checks in `isRecoveryOnlySyntheticRecord`; the branch still needed a follow-up patch beyond commit `1db8b99`.
+- Commands run this turn: `gh auth status && gh pr view 1513 --json number,url,reviewDecision,state,mergeStateStatus,comments,reviews`; `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`.
 - Remaining operator-facing step after push: decide whether to reply to or resolve the CodeRabbit thread on PR #1513.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,61 +1,34 @@
-# Issue #1510: Persist parent epic auto-closure recovery metadata for untracked parent epics
+# Issue #1512: Synthetic parent-epic recovery records should not trigger doctor worktree warnings
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1510
-- Branch: codex/issue-1510
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1512
+- Branch: codex/issue-1512
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 2b6619f6b9d303d9fa03aeeb481d97ca77f362a3
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: b18a909e920417b5b62eceb1365893eea23501d2
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856uaRt
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T06:32:33.292Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T07:02:01.829Z
 
 ## Latest Codex Summary
-Persisted parent-epic auto-closure recovery metadata when the parent had no prior `state.issues` record. The fix synthesizes a terminal no-PR `done` record during `reconcileParentEpicClosures`, applies the same recovery metadata patch used for tracked parents, and leaves it non-runnable. I also tightened tests for the untracked-parent reconciliation path and for the read-only status surface to confirm the recovered parent epic remains out of selection.
-
-Verification passed with the focused suites and build:
-`npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`
-and `npm run build`.
-
-Checkpoint commit: `2b6619f` (`Persist recovery metadata for untracked parent epics`)
-
-There are still untracked supervisor artifacts in the worktree:
-`.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, `.codex-supervisor/turn-in-progress.json`
-
-Summary: Persisted `latest_recovery` metadata for untracked auto-closed parent epics via a synthetic terminal record; focused tests and build pass; checkpoint committed as `2b6619f`.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
-Next action: Open or update a draft PR from `codex/issue-1510`, noting the committed fix and leaving the untracked supervisor artifacts out of the PR.
-Failure signature: PRRT_kwDORgvdZ856uaRt
+- Scoped `doctor` to ignore recovery-only synthetic done records created for untracked parent-epic auto-closures, while leaving tracked worktree validation unchanged.
+- Added a focused `doctor` regression test for the synthetic parent-epic record shape and tightened read-only status coverage to use the same empty branch/workspace record form.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1511#discussion_r3077509698
-- Details:
-  - .codex-supervisor/issue-journal.md:29 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Update the next-step note to reflect current PR status.** Line 29 says to “Commit the checkpoint,” but this PR already has checkpoint commit ... url=https://github.com/TommyKammy/codex-supervisor/pull/1511#discussion_r3077509698
+- Primary failure reproduced before the fix: `doctor` warned on synthetic parent-epic recovery records because they persist `workspace: ""` and were treated like tracked worktrees.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Parent-epic auto-closure recovery metadata was only durable when `state.issues[parent]` already existed; read-only status derives `latest_recovery` solely from persisted records.
-- What changed: Added `createUntrackedRecoveredDoneRecord()` and used it in `reconcileParentEpicClosures()` to synthesize a terminal record for untracked auto-closed parent epics; tightened reconciliation and status-selection tests around that path.
+- Hypothesis: `diagnoseWorktrees` was validating every persisted issue record as a tracked workspace, including synthetic recovery-only parent-epic records that intentionally persist empty branch/workspace fields.
+- What changed: Added `isRecoveryOnlySyntheticRecord` in `src/doctor.ts` and skipped those records during worktree diagnostics; added/updated focused tests in `src/doctor.test.ts` and `src/supervisor/supervisor-diagnostics-status-selection.test.ts`.
 - Current blocker: none
-- Next exact step: Open or update the draft PR from `codex/issue-1510` and note checkpoint commit `2b6619f`.
-- Verification gap: none for the scoped issue acceptance checks.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
-- Rollback concern: Low; the new persisted record is terminal (`state=done`, `pr_number=null`, `blocked_reason=null`) and should remain read-only in selection flows.
+- Next exact step: commit the focused fix on `codex/issue-1512` and leave the branch ready for PR/open-review flow.
+- Verification gap: none for the requested local verification set.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- Rollback concern: low; the exemption is intentionally narrow and only matches synthetic done records with empty branch/workspace plus durable recovery metadata.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
-- Reproduced failure signature before fix: `untracked-parent-epic-recovery-not-persisted`.
-- Addressed review signature: `PRRT_kwDORgvdZ856uaRt`.
-- Review-fix command: updated `.codex-supervisor/issue-journal.md` handoff note to match committed PR state.
-- Focused verification commands:
-- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`
-- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
-- `npx tsx --test src/run-once-cycle-prelude.test.ts`
-- `npm run build`

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -184,6 +184,55 @@ test("diagnoseSupervisorHost degrades malformed synthetic recovery records witho
   );
 });
 
+test("diagnoseSupervisorHost does not skip synthetic-like records missing recovery metadata", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({
+      activeIssueNumber: null,
+      issues: {
+        "123": {
+          ...createRecord({
+            issue_number: 123,
+            state: "done",
+            branch: "",
+            workspace: "",
+            pr_number: null,
+            journal_path: null,
+            codex_session_id: null,
+            blocked_reason: null,
+          }),
+          last_recovery_reason: undefined,
+          last_recovery_at: undefined,
+        } as unknown as SupervisorStateFile["issues"][string],
+      },
+    }),
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    diagnostics.checks.find((check) => check.name === "worktrees")?.details[0] ?? "",
+    /Issue #123 is missing workspace \./,
+  );
+});
+
 test("renderDoctorReport only warns for the legacy shared issue journal path", () => {
   const baseDiagnostics = {
     overallStatus: "pass" as const,

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -134,6 +134,56 @@ test("diagnoseSupervisorHost ignores recovery-only synthetic parent epic records
   assert.match(renderDoctorReport(diagnostics), /doctor_check name=worktrees status=pass summary=Tracked worktrees look consistent\./);
 });
 
+test("diagnoseSupervisorHost degrades malformed synthetic recovery records without throwing", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({
+      activeIssueNumber: null,
+      issues: {
+        "123": {
+          ...createRecord({
+            issue_number: 123,
+            state: "done",
+            pr_number: null,
+            journal_path: null,
+            codex_session_id: null,
+            blocked_reason: null,
+            last_recovery_reason:
+              "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed",
+            last_recovery_at: "2026-03-13T00:20:00Z",
+          }),
+          branch: null,
+          workspace: null,
+        } as unknown as SupervisorStateFile["issues"][string],
+      },
+    }),
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    diagnostics.checks.find((check) => check.name === "worktrees")?.details[0] ?? "",
+    /Issue #123 is missing workspace null\./,
+  );
+});
+
 test("renderDoctorReport only warns for the legacy shared issue journal path", () => {
   const baseDiagnostics = {
     overallStatus: "pass" as const,

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -89,6 +89,51 @@ test("diagnoseSupervisorHost reports representative auth, state, and workspace f
   );
 });
 
+test("diagnoseSupervisorHost ignores recovery-only synthetic parent epic records in worktree diagnostics", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({
+      activeIssueNumber: null,
+      issues: {
+        "123": createRecord({
+          issue_number: 123,
+          state: "done",
+          branch: "",
+          pr_number: null,
+          workspace: "",
+          journal_path: null,
+          codex_session_id: null,
+          blocked_reason: null,
+          last_recovery_reason:
+            "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed",
+          last_recovery_at: "2026-03-13T00:20:00Z",
+        }),
+      },
+    }),
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "pass");
+  assert.match(renderDoctorReport(diagnostics), /doctor_check name=worktrees status=pass summary=Tracked worktrees look consistent\./);
+});
+
 test("renderDoctorReport only warns for the legacy shared issue journal path", () => {
   const baseDiagnostics = {
     overallStatus: "pass" as const,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -436,6 +436,11 @@ function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
     return false;
   }
 
+  const hasRecoveryReason =
+    typeof record.last_recovery_reason === "string" && record.last_recovery_reason.trim().length > 0;
+  const hasRecoveryAt =
+    typeof record.last_recovery_at === "string" && record.last_recovery_at.trim().length > 0;
+
   return record.state === "done" &&
     record.branch.trim() === "" &&
     record.workspace.trim() === "" &&
@@ -443,8 +448,8 @@ function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
     record.pr_number === null &&
     record.codex_session_id === null &&
     record.blocked_reason === null &&
-    record.last_recovery_reason !== null &&
-    record.last_recovery_at !== null;
+    hasRecoveryReason &&
+    hasRecoveryAt;
 }
 
 function withInspectableWorkspaces(state: SupervisorStateFile): SupervisorStateFile {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -431,6 +431,18 @@ function parseWorktreeList(stdout: string): Set<string> {
   return worktrees;
 }
 
+function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
+  return record.state === "done" &&
+    record.branch.trim() === "" &&
+    record.workspace.trim() === "" &&
+    record.journal_path === null &&
+    record.pr_number === null &&
+    record.codex_session_id === null &&
+    record.blocked_reason === null &&
+    record.last_recovery_reason !== null &&
+    record.last_recovery_at !== null;
+}
+
 async function diagnoseWorktrees(
   config: SupervisorConfig,
   loadState: () => Promise<SupervisorStateFile>,
@@ -453,6 +465,10 @@ async function diagnoseWorktrees(
     const problems: string[] = [];
 
     for (const record of Object.values(state.issues)) {
+      if (isRecoveryOnlySyntheticRecord(record)) {
+        continue;
+      }
+
       try {
         await fs.access(record.workspace, fs.constants.F_OK);
       } catch {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -432,6 +432,10 @@ function parseWorktreeList(stdout: string): Set<string> {
 }
 
 function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
+  if (typeof record.branch !== "string" || typeof record.workspace !== "string") {
+    return false;
+  }
+
   return record.state === "done" &&
     record.branch.trim() === "" &&
     record.workspace.trim() === "" &&
@@ -441,6 +445,17 @@ function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
     record.blocked_reason === null &&
     record.last_recovery_reason !== null &&
     record.last_recovery_at !== null;
+}
+
+function withInspectableWorkspaces(state: SupervisorStateFile): SupervisorStateFile {
+  return {
+    ...state,
+    issues: Object.fromEntries(
+      Object.entries(state.issues).filter(([, record]) =>
+        typeof record.workspace === "string" && record.workspace.trim() !== ""
+      ),
+    ),
+  };
 }
 
 async function diagnoseWorktrees(
@@ -469,6 +484,11 @@ async function diagnoseWorktrees(
         continue;
       }
 
+      if (typeof record.workspace !== "string" || record.workspace.trim() === "") {
+        problems.push(`Issue #${record.issue_number} is missing workspace ${String(record.workspace)}.`);
+        continue;
+      }
+
       try {
         await fs.access(record.workspace, fs.constants.F_OK);
       } catch {
@@ -489,7 +509,7 @@ async function diagnoseWorktrees(
       }
     }
 
-    const orphanCandidates = await inspectOrphanedWorkspacePruneCandidates(config, state);
+    const orphanCandidates = await inspectOrphanedWorkspacePruneCandidates(config, withInspectableWorkspaces(state));
     const orphanDetails = orphanCandidates.map((candidate) =>
       `orphan_prune_candidate issue_number=${candidate.issueNumber} eligibility=${candidate.eligibility} workspace=${candidate.workspacePath} branch=${candidate.branch ?? "none"} modified_at=${candidate.modifiedAt ?? "unknown"} reason=${candidate.reason}`
     );

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3302,9 +3302,12 @@ test("status surfaces parent epic auto-closure as the latest recovery on read-on
       [String(parentIssueNumber)]: createRecord({
         issue_number: parentIssueNumber,
         state: "done",
-        branch: branchName(fixture.config, parentIssueNumber),
-        workspace: path.join(fixture.workspaceRoot, `issue-${parentIssueNumber}`),
+        branch: "",
+        workspace: "",
         journal_path: null,
+        pr_number: null,
+        codex_session_id: null,
+        blocked_reason: null,
         last_recovery_reason:
           "parent_epic_auto_closed: auto-closed parent epic #199 because child issues #201, #202 are closed",
         last_recovery_at: "2026-03-13T00:20:00Z",


### PR DESCRIPTION
## Summary
- skip doctor worktree diagnostics for recovery-only synthetic done records with no workspace
- add a focused doctor regression for untracked parent-epic auto-closure records
- tighten read-only status coverage to keep latest_recovery visible for the synthetic record shape

## Testing
- npx tsx --test src/doctor.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Closes #1512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostics now ignore synthetic recovery-only parent-epic records and treat missing/blank branch or workspace values as ignored, preventing false worktree warnings or failures.

* **Tests**
  * Added tests ensuring recovery-only synthetic records don’t trigger errors, malformed synthetic data yields warnings (not exceptions), and missing recovery metadata is handled as a warning.

* **Documentation**
  * Updated the internal issue journal entry to reflect the behavior changes and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->