### PR TITLE
Bug: doctor/status hydrate tracked PR diagnostics for every historical done record with pr_number (#1514)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,48 +1,33 @@
-# Issue #1512: Synthetic parent-epic recovery records should not trigger doctor worktree warnings
+# Issue #1514: Bug: doctor/status hydrate tracked PR diagnostics for every historical done record with pr_number
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1512
-- Branch: codex/issue-1512
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1514
+- Branch: codex/issue-1514
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 3 (implementation=1, repair=2)
-- Last head SHA: 1db8b99444460e4f1c80890887f1b9cf52f51007
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 19ac2f5ff0bd8bbea2be8182596f1cdb0a96bfef
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856vF7K
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T07:21:33.301Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T07:39:00.156Z
 
 ## Latest Codex Summary
-Tightened `doctor` synthetic-record detection so recovery-only parent-epic records now require real recovery metadata instead of accepting `undefined` values as present. In [src/doctor.ts](src/doctor.ts), `isRecoveryOnlySyntheticRecord` now requires non-empty string `last_recovery_reason` and `last_recovery_at` values before skipping worktree diagnostics. I also added a focused regression in [src/doctor.test.ts](src/doctor.test.ts) covering a synthetic-like done record with empty branch/workspace fields but missing recovery metadata, which now correctly degrades to a warning instead of being skipped.
-
-The issue journal is updated with the review-fix verification run. I have not posted a GitHub reply or resolved the remaining CodeRabbit thread.
-
-Summary: Tightened recovery-only synthetic detection to reject missing recovery metadata, added a regression test, and re-ran the issue verification set
-State hint: addressing_review
-Blocked reason: none
-Tests: `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
-Next action: push the review-fix commit for PR #1513, then decide whether to reply to or resolve the remaining CodeRabbit review thread
-Failure signature: PRRT_kwDORgvdZ856vF7K
+- Reproduced the regression with focused counter-based tests, then narrowed default tracked-PR hydration in `doctor` and `status` to skip historical `done` records while preserving actionable blocked tracked-PR mismatch diagnostics.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077756591
-- Details:
-  - src/doctor.ts:447 summary=_⚠️ Potential issue_ | _🟠 Major_ **Tighten synthetic-record detection to avoid false diagnostic skips.** The predicate treats `undefined` as “present” because it checks `!== nu... url=https://github.com/TommyKammy/codex-supervisor/pull/1513#discussion_r3077756591
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the remaining CodeRabbit finding was valid because `record.last_recovery_reason !== null` and `record.last_recovery_at !== null` still treated `undefined` as present, which could misclassify malformed legacy records as recovery-only synthetic and suppress real workspace warnings.
-- What changed: tightened `isRecoveryOnlySyntheticRecord` to require non-empty string recovery metadata, while preserving the earlier non-string `branch`/`workspace` guards and missing-workspace degradation path; added a focused regression in `src/doctor.test.ts` for a synthetic-like done record with empty branch/workspace fields but missing recovery metadata.
+- Hypothesis: Default read-only tracked-PR diagnostics were hydrating every record with `pr_number`, including historical terminal `done` entries that can never produce actionable mismatch output.
+- What changed: Added regression tests for `doctor` and `status` that seed 160 historical `done + pr_number` records plus one blocked actionable record; introduced `shouldHydrateTrackedPrDiagnostics(...)` and used it in both read-only hydration loops to skip terminal `done` records before PR fetches.
 - Current blocker: none
-- Next exact step: commit and push the review-fix patch on `codex/issue-1512`, then decide whether to reply to or resolve the remaining CodeRabbit thread on PR #1513.
-- Verification gap: none for the requested local verification set.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`
-- Rollback concern: low; the new guards only affect malformed persisted state and the intentionally synthetic recovery-only parent-epic record shape.
-- Last focused command: `npm run build`
+- Next exact step: Commit the reproducer-plus-fix checkpoint on `codex/issue-1514`.
+- Verification gap: none for the requested local scope; the targeted test files and `npm run build` pass.
+- Files touched: .codex-supervisor/issue-journal.md, src/doctor.ts, src/supervisor/supervisor-read-only-reporting.ts, src/supervisor/tracked-pr-mismatch.ts, src/doctor.test.ts, src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Rollback concern: Low; the new guard only skips tracked-PR hydration for terminal `done` records and leaves non-terminal tracked PR records on the existing path.
+- Last focused command: npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
 ### Scratchpad
-- Review thread `PRRT_kwDORgvdZ856vF7K` reproduced locally from the live `!== null` checks in `isRecoveryOnlySyntheticRecord`; the branch still needed a follow-up patch beyond commit `1db8b99`.
-- Commands run this turn: `gh auth status && gh pr view 1513 --json number,url,reviewDecision,state,mergeStateStatus,comments,reviews`; `npx tsx --test src/doctor.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`.
-- Remaining operator-facing step after push: decide whether to reply to or resolve the CodeRabbit thread on PR #1513.
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1569,6 +1569,110 @@ test("diagnoseSupervisorHost exposes tracked PR mismatches when GitHub is ready 
   );
 });
 
+test("diagnoseSupervisorHost skips tracked PR hydration for historical done records", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-171");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "fixture"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  execFileSync("git", ["-C", repoPath, "worktree", "add", "-b", "codex/reopen-issue-171", workspace], {
+    encoding: "utf8",
+  });
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    stateFile,
+    codexBinary: process.execPath,
+    localCiCommand: "npm run ci:local",
+  });
+
+  const historicalRecords = Object.fromEntries(
+    Array.from({ length: 160 }, (_, index) => {
+      const issueNumber = 3000 + index;
+      return [
+        String(issueNumber),
+        createRecord({
+          issue_number: issueNumber,
+          state: "done",
+          branch: "codex/reopen-issue-171",
+          workspace,
+          pr_number: 5000 + index,
+          blocked_reason: null,
+          last_head_sha: `done-head-${issueNumber}`,
+        }),
+      ];
+    }),
+  );
+
+  const trackedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      ...historicalRecords,
+      "171": createRecord({
+        issue_number: 171,
+        state: "blocked",
+        branch: "codex/reopen-issue-171",
+        workspace,
+        pr_number: 271,
+        blocked_reason: "manual_review",
+        last_head_sha: "head-ready-271",
+      }),
+    },
+  };
+
+  const readyPr = createPullRequest({
+    number: 271,
+    headRefName: "codex/reopen-issue-171",
+    headRefOid: "head-ready-271",
+  });
+  let getPullRequestIfExistsCalls = 0;
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config,
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => trackedState,
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 1,
+        truncated: false,
+      }),
+      getPullRequestIfExists: async (prNumber) => {
+        getPullRequestIfExistsCalls += 1;
+        return prNumber === readyPr.number ? readyPr : null;
+      },
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+  });
+
+  assert.equal(getPullRequestIfExistsCalls, 1);
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes/,
+  );
+});
+
 test("diagnoseSupervisorHost preserves draft tracked PR verification blockers instead of suggesting a no-op rerun", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -34,7 +34,7 @@ import {
   formatCandidateDiscoveryBehaviorLine,
   formatCandidateDiscoveryWarningDetail,
 } from "./supervisor/supervisor-selection-readiness-summary";
-import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
+import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./supervisor/tracked-pr-mismatch";
 import { buildTrustAndConfigWarnings, buildWarning, renderDoctorWarningLine } from "./warning-formatting";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
@@ -522,7 +522,7 @@ async function diagnoseWorktrees(
     let trackedPrMismatchCount = 0;
     if (github?.getPullRequestIfExists && github.getChecks && github.getUnresolvedReviewThreads) {
       for (const record of Object.values(state.issues)) {
-        if (record.pr_number === null) {
+        if (!shouldHydrateTrackedPrDiagnostics(record)) {
           continue;
         }
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2714,6 +2714,85 @@ test("status surfaces tracked PR mismatches when GitHub is ready but local state
   );
 });
 
+test("status skips tracked PR hydration for historical done records", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 171;
+  const prNumber = 271;
+  const branch = branchName(fixture.config, issueNumber);
+  const historicalRecords = Object.fromEntries(
+    Array.from({ length: 160 }, (_, index) => {
+      const historicalIssueNumber = 3000 + index;
+      return [
+        String(historicalIssueNumber),
+        createRecord({
+          issue_number: historicalIssueNumber,
+          state: "done",
+          branch,
+          workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+          journal_path: null,
+          pr_number: 5000 + index,
+          blocked_reason: null,
+          last_head_sha: `done-head-${historicalIssueNumber}`,
+        }),
+      ];
+    }),
+  );
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      ...historicalRecords,
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "manual_review",
+        last_error: "waiting on stale review signal",
+        last_head_sha: "head-ready-271",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked PR mismatch",
+    body: executionReadyBody("Surface GitHub-ready versus local-blocked tracked PR mismatches."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const readyPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-ready-271",
+  });
+
+  let getPullRequestIfExistsCalls = 0;
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async (requestedPrNumber: number) => {
+      getPullRequestIfExistsCalls += 1;
+      return requestedPrNumber === readyPr.number ? readyPr : null;
+    },
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.equal(getPullRequestIfExistsCalls, 1);
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
+  );
+});
+
 test("status preserves draft tracked PR lifecycle when ready-for-review promotion is blocked by local verification", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 174;

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -31,7 +31,7 @@ import {
   renderGitHubRateLimitLine,
   type SupervisorStatusDto,
 } from "./supervisor-status-report";
-import { buildTrackedPrMismatch } from "./tracked-pr-mismatch";
+import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./tracked-pr-mismatch";
 import { buildMacOsLoopHostWarning, readSupervisorLoopRuntime } from "./supervisor-loop-runtime-state";
 import { loadActiveIssueStatusSnapshot } from "./supervisor-selection-active-status";
 import {
@@ -193,7 +193,7 @@ export async function buildSupervisorStatusReport(args: {
   const trackedPrMismatchLines: string[] = [];
 
   for (const record of Object.values(state.issues)) {
-    if (record.pr_number === null) {
+    if (!shouldHydrateTrackedPrDiagnostics(record)) {
       continue;
     }
 

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -28,6 +28,12 @@ export interface TrackedPrMismatch {
   detailLines: string[];
 }
 
+export function shouldHydrateTrackedPrDiagnostics(
+  record: IssueRunRecord,
+): record is IssueRunRecord & { pr_number: number } {
+  return record.pr_number !== null && record.state !== "done";
+}
+
 function isBlockedLikeState(state: RunState): boolean {
   return state === "blocked" || state === "failed";
 }


### PR DESCRIPTION
Closes #1514
This PR was opened by codex-supervisor.
Latest Codex summary:

Narrowed default tracked-PR diagnostics so both `doctor` and `status` skip hydrating historical terminal `done` records before any GitHub PR fetch. I kept the actionable path unchanged for non-terminal tracked PR records by routing both loops through a shared `shouldHydrateTrackedPrDiagnostics(...)` type guard in [tracked-pr-mismatch.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1514/src/supervisor/tracked-pr-mismatch.ts). I also added focused regressions in [doctor.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1514/src/doctor.test.ts) and [supervisor-diagnostics-status-selection.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1514/src/supervisor/supervisor-diagnostics-status-selection.test.ts) that seed 160 historical `done + pr_number` records plus one blocked actionable record and assert only the actionable PR is hydrated.

The reproducer initially failed with `161 !== 1` PR fetches on both surfaces. After the fix, the requested verification passes and I committed the checkpoint as `a18e005` with message `Skip tracked PR hydration for done records`.

Summary: Reproduced the over-hydration, added bounded regression tests, and fixed `doctor`/`status` to skip tracked PR hydration for historical `done` records while preserving actionable blocked tracked-PR diagnostics.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/doctor.test.ts src/supervisor/supervisor-di...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized diagnostics generation to reduce unnecessary API calls when processing historical issue records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->