### PR TITLE
Bug: run-once --dry-run burns tracked-PR reconciliation budget on terminal done records (#1515)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,34 @@
-# Issue #1514: Bug: doctor/status hydrate tracked PR diagnostics for every historical done record with pr_number
+# Issue #1515: Bug: run-once --dry-run burns tracked-PR reconciliation budget on terminal done records
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1514
-- Branch: codex/issue-1514
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1515
+- Branch: codex/issue-1515
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 19ac2f5ff0bd8bbea2be8182596f1cdb0a96bfef
+- Last head SHA: 7534702f0a1afe18257f5bba0caeacfbd4d3dc84
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T07:39:00.156Z
+- Updated at: 2026-04-14T07:55:57.498Z
 
 ## Latest Codex Summary
-- Reproduced the regression with focused counter-based tests, then narrowed default tracked-PR hydration in `doctor` and `status` to skip historical `done` records while preserving actionable blocked tracked-PR mismatch diagnostics.
+- Reproduced the budget-burn regression with focused tests, then changed tracked-PR reconciliation to prioritize non-`done` tracked PR records ahead of historical `done + pr_number` records in the default slice.
+- Added regression coverage in the reconciliation suite and a prelude-level test that wires the real reconciliation path through `runOnceCyclePrelude`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Default read-only tracked-PR diagnostics were hydrating every record with `pr_number`, including historical terminal `done` entries that can never produce actionable mismatch output.
-- What changed: Added regression tests for `doctor` and `status` that seed 160 historical `done + pr_number` records plus one blocked actionable record; introduced `shouldHydrateTrackedPrDiagnostics(...)` and used it in both read-only hydration loops to skip terminal `done` records before PR fetches.
+- Hypothesis: The default `reconcileTrackedMergedButOpenIssuesInModule(...)` candidate list was iterating tracked PR records in raw issue-number order, so large tails of historical `done + pr_number` records exhausted the default 25-record budget before recoverable tracked PR work was reached.
+- What changed: Added `prioritizeTrackedMergedButOpenRecords(...)` in `src/recovery-tracked-pr-reconciliation.ts` so the default pass processes non-`done` tracked PR records before historical `done` records while preserving round-robin resume ordering inside each tier. Added direct and prelude-level regressions for the `800 !== 901` failure mode.
 - Current blocker: none
-- Next exact step: Commit the reproducer-plus-fix checkpoint on `codex/issue-1514`.
-- Verification gap: none for the requested local scope; the targeted test files and `npm run build` pass.
-- Files touched: .codex-supervisor/issue-journal.md, src/doctor.ts, src/supervisor/supervisor-read-only-reporting.ts, src/supervisor/tracked-pr-mismatch.ts, src/doctor.test.ts, src/supervisor/supervisor-diagnostics-status-selection.test.ts
-- Rollback concern: Low; the new guard only skips tracked-PR hydration for terminal `done` records and leaves non-terminal tracked PR records on the existing path.
-- Last focused command: npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Next exact step: Review diff and create a checkpoint commit on `codex/issue-1515`.
+- Verification gap: none for requested local checks; targeted tests and build passed.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-tracked-pr-reconciliation.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`
+- Rollback concern: Low; change only affects default ordering for tracked-PR reconciliation when scanning multiple records and leaves `onlyIssueNumber` behavior intact.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -108,6 +108,19 @@ function orderTrackedMergedButOpenRecordsForResume(
   return [...ordered.slice(nextIndex), ...ordered.slice(0, nextIndex)];
 }
 
+function prioritizeTrackedMergedButOpenRecords(
+  records: IssueRunRecord[],
+  lastProcessedIssueNumber: number | null,
+): IssueRunRecord[] {
+  const recoverableRecords = records.filter((record) => record.state !== "done");
+  const historicalDoneRecords = records.filter((record) => record.state === "done");
+
+  return [
+    ...orderTrackedMergedButOpenRecordsForResume(recoverableRecords, lastProcessedIssueNumber),
+    ...orderTrackedMergedButOpenRecordsForResume(historicalDoneRecords, lastProcessedIssueNumber),
+  ];
+}
+
 export function buildTrackedPrResumeRecoveryEvent(
   record: Pick<IssueRunRecord, "issue_number" | "state" | "last_head_sha" | "blocked_reason">,
   pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "isDraft">,
@@ -185,7 +198,7 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
     : [state.issues[String(options.onlyIssueNumber)]].filter((record): record is IssueRunRecord => record !== undefined);
   const prBearingRecords = selectedRecords.filter((record): record is IssueRunRecord => record.pr_number !== null);
   const records = options.onlyIssueNumber === undefined || options.onlyIssueNumber === null
-    ? orderTrackedMergedButOpenRecordsForResume(
+    ? prioritizeTrackedMergedButOpenRecords(
       prBearingRecords,
       trackedMergedButOpenLastProcessedIssueNumber(state),
     )

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -2,12 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { GitHubIssue, SupervisorStateFile } from "./core/types";
 import { GitHubInventoryRefreshError } from "./github";
+import { reconcileTrackedMergedButOpenIssues } from "./recovery-reconciliation";
 import { RecoveryEvent, runOnceCyclePrelude } from "./run-once-cycle-prelude";
 import {
   shouldAutoRecoverStaleReviewBot,
   shouldReconcileTrackedPrStaleReviewBot,
 } from "./supervisor/supervisor-execution-policy";
-import { createConfig, createRecord } from "./supervisor/supervisor-test-helpers";
+import { createConfig, createIssue, createPullRequest, createRecord } from "./supervisor/supervisor-test-helpers";
 
 test("runOnceCyclePrelude loads state and aggregates recovery setup events in order", async () => {
   const state: SupervisorStateFile = {
@@ -205,6 +206,120 @@ test("runOnceCyclePrelude persists the last-known-good inventory snapshot after 
   assert.deepEqual(savedStates[0]?.last_successful_inventory_snapshot?.issues, issues);
   assert.equal(result.state.last_successful_inventory_snapshot?.source, "gh issue list");
   assert.equal(result.state.last_successful_inventory_snapshot?.issue_count, 2);
+});
+
+test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahead of historical done records", async () => {
+  const recoverableRecord = createRecord({
+    issue_number: 450,
+    state: "merging",
+    branch: "codex/reopen-issue-450",
+    pr_number: 901,
+    blocked_reason: null,
+  });
+  const historicalDoneRecords = Array.from({ length: 30 }, (_, index) =>
+    createRecord({
+      issue_number: 300 + index,
+      state: "done",
+      branch: `codex/historical-done-${300 + index}`,
+      pr_number: 800 + index,
+      blocked_reason: null,
+    }));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: Object.fromEntries(
+      [...historicalDoneRecords, recoverableRecord].map((record) => [String(record.issue_number), record]),
+    ),
+  };
+  const closedIssue = createIssue({
+    number: 450,
+    title: "Recoverable merging issue",
+    updatedAt: "2026-03-13T00:23:00Z",
+    state: "CLOSED",
+  });
+  const issues: GitHubIssue[] = [closedIssue];
+  const mergedPr = createPullRequest({
+    number: 901,
+    title: "Recoverable tracked PR",
+    url: "https://example.test/pr/901",
+    state: "MERGED",
+    headRefName: "codex/reopen-issue-450",
+    headRefOid: "merged-head-901",
+    mergedAt: "2026-03-13T00:22:00Z",
+  });
+  const prLookups: number[] = [];
+  let saveCalls = 0;
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => issues,
+    reconcileTrackedMergedButOpenIssues: async (loadedState, loadedIssues, updateReconciliationProgress, options) =>
+      reconcileTrackedMergedButOpenIssues(
+        {
+          getPullRequestIfExists: async (prNumber) => {
+            prLookups.push(prNumber);
+            if (prNumber === 901) {
+              return mergedPr;
+            }
+            return null;
+          },
+          getIssue: async (issueNumber) => {
+            assert.equal(issueNumber, 450);
+            return closedIssue;
+          },
+          closeIssue: async () => {
+            throw new Error("unexpected closeIssue call");
+          },
+          closePullRequest: async () => {
+            throw new Error("unexpected closePullRequest call");
+          },
+          getChecks: async () => [],
+          getMergedPullRequestsClosingIssue: async () => [],
+          getUnresolvedReviewThreads: async () => [],
+        },
+        {
+          touch(record, patch) {
+            return {
+              ...record,
+              ...patch,
+              updated_at: "2026-03-13T00:25:00Z",
+            };
+          },
+          save: async (nextState) => {
+            saveCalls += 1;
+            assert.equal(nextState, loadedState);
+          },
+        },
+        loadedState,
+        createConfig(),
+        loadedIssues,
+        updateReconciliationProgress,
+        options,
+      ),
+    reconcileMergedIssueClosures: async () => [],
+    reconcileStaleFailedIssueStates: async () => {},
+    reconcileRecoverableBlockedIssueStates: async () => [],
+    reconcileParentEpicClosures: async () => [],
+    cleanupExpiredDoneWorkspaces: async () => [],
+    reserveRunnableIssueSelection: async () => false,
+  });
+
+  assert.ok(!("kind" in result));
+  assert.equal(prLookups[0], 901);
+  assert.equal(prLookups.includes(901), true);
+  assert.equal(saveCalls, 2);
+  assert.equal(result.state.issues["450"]?.state, "done");
+  assert.equal(result.state.issues["450"]?.last_head_sha, "merged-head-901");
+  assert.deepEqual(result.recoveryEvents.map((event) => event.reason), [
+    "merged_pr_convergence: tracked PR #901 merged; marked issue #450 done",
+  ]);
 });
 
 test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving selection", async () => {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -4617,6 +4617,96 @@ test("reconcileTrackedMergedButOpenIssues resumes from the next higher issue whe
   ]);
 });
 
+test("reconcileTrackedMergedButOpenIssues prioritizes recoverable tracked PR records ahead of historical done records", async () => {
+  const recoverableRecord = createRecord({
+    issue_number: 450,
+    state: "merging",
+    branch: "codex/reopen-issue-450",
+    pr_number: 901,
+    blocked_reason: null,
+  });
+  const historicalDoneRecords = Array.from({ length: 30 }, (_, index) =>
+    createRecord({
+      issue_number: 300 + index,
+      state: "done",
+      branch: `codex/historical-done-${300 + index}`,
+      pr_number: 800 + index,
+      blocked_reason: null,
+    }));
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [...historicalDoneRecords, recoverableRecord],
+  });
+  const closedIssue = createIssue({
+    number: 450,
+    title: "Recoverable merging issue",
+    updatedAt: "2026-03-13T00:23:00Z",
+    state: "CLOSED",
+  });
+  const mergedPr = createPullRequest({
+    number: 901,
+    title: "Recoverable tracked PR",
+    url: "https://example.test/pr/901",
+    state: "MERGED",
+    headRefName: "codex/reopen-issue-450",
+    headRefOid: "merged-head-901",
+    mergedAt: "2026-03-13T00:22:00Z",
+  });
+
+  const prLookups: number[] = [];
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async (prNumber) => {
+        prLookups.push(prNumber);
+        if (prNumber === 901) {
+          return mergedPr;
+        }
+        return null;
+      },
+      getIssue: async (issueNumber) => {
+        assert.equal(issueNumber, 450);
+        return closedIssue;
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    createConfig(),
+    [closedIssue],
+    null,
+  );
+
+  assert.equal(prLookups[0], 901);
+  assert.equal(prLookups.includes(901), true);
+  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["450"]?.state, "done");
+  assert.equal(state.issues["450"]?.last_head_sha, "merged-head-901");
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "merged_pr_convergence: tracked PR #901 merged; marked issue #450 done",
+  ]);
+});
+
 test("reconcileTrackedMergedButOpenIssues keeps merged convergence done when audit persistence fails", async () => {
   const artifactRootFile = path.join(
     await fs.mkdtemp(path.join(os.tmpdir(), "reconcile-audit-failure-")),


### PR DESCRIPTION
Closes #1515
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed the default tracked-PR reconciliation ordering so non-`done` tracked PR records are processed before historical `done + pr_number` records, while keeping the existing resume cursor behavior within each tier. That prevents the default 25-record prelude slice from getting consumed by terminal history before it reaches recoverable tracked PR work.

I added two regressions: one direct reconciliation test and one `runOnceCyclePrelude` test that exercises the real reconciliation path under a state file dominated by historical `done` records. Both now pass, and `npm run build` is green. I also recorded the work in the issue journal and committed the checkpoint as `1850a3e` (`Prioritize recoverable tracked PR reconciliation`).

Summary: Prioritized recoverable tracked PR records ahead of historical done records in default reconciliation, with direct and prelude regression coverage
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for branch `codex/issue-1515` with commit `1850a3e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tracked pull request reconciliation to correctly prioritize incomplete records before processing historical completed records during system cycles. This ensures incomplete pull requests are handled first, significantly improving both recovery and overall system reconciliation accuracy.

* **Tests**
  * Added comprehensive test coverage for the new tracked pull request record prioritization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->