### PR TITLE
Tracked-PR reconciliation should not spend residual default budget on historical done records (#1518)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,31 +5,46 @@
 - Branch: codex/issue-1518
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 536f41bb45d29ca0e95ff03daf75a9ff48cf8737
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: ae78f5b942801b2a845cd2b9e35588ec2c185560
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T08:17:00.443Z
+- Last failure signature: PRRT_kwDORgvdZ856wH2h
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T08:31:52.003Z
 
 ## Latest Codex Summary
-- Added a focused tracked-PR reconciliation regression for mixed recoverable-plus-historical state and tightened the `runOnceCyclePrelude` regression to assert the first-cycle lookup set stops at the recoverable tracked PR records.
-- Changed default tracked-PR reconciliation selection so mixed-state passes process only recoverable tracked PR records; historical `done` records are now a fallback only when no recoverable tracked PR records remain.
-- Verified with `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts` and `npm run build`.
+Adjusted the default tracked-PR reconciliation slice so mixed-state passes stop after the recoverable tracked PR records instead of spending the remaining default budget on historical `done` records. The behavior change is in [src/recovery-tracked-pr-reconciliation.ts](src/recovery-tracked-pr-reconciliation.ts), and I added a direct regression in [src/recovery-tracked-pr-reconciliation.test.ts](src/recovery-tracked-pr-reconciliation.test.ts) plus tightened the prelude coverage in [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts). The issue journal was updated before closing the turn.
+
+Focused verification passed:
+- `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
+- `npm run build`
+
+Checkpoint commit: `ae78f5b` (`Prevent tracked PR reconciliation from spending budget on done history`)
+
+Summary: Default tracked-PR reconciliation now spends its first-cycle budget only on recoverable tracked PR records in mixed states; focused regressions and build passed.
+State hint: stabilizing
+Blocked reason: none
+Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
+Next action: Open or update the branch PR so this checkpoint can move into review/CI.
+Failure signature: PRRT_kwDORgvdZ856wH2h
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1519#discussion_r3078122159
+- Details:
+  - src/recovery-tracked-pr-reconciliation.ts:122 summary=_⚠️ Potential issue_ | _🟠 Major_ **Preserve the historical `done` cursor when you defer that bucket.** After this change, `records.length` in Lines 413-418 can mean “the recove... url=https://github.com/TommyKammy/codex-supervisor/pull/1519#discussion_r3078122159
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The default tracked-PR reconciliation pass still burned residual budget on historical `done + pr_number` records after checking the recoverable tracked PR subset because prioritization only reordered the array and did not cap the mixed-state pass to the recoverable bucket.
-- What changed: Added `src/recovery-tracked-pr-reconciliation.test.ts` to reproduce the mixed-state leak directly, tightened the prelude regression in `src/run-once-cycle-prelude.test.ts`, and updated `prioritizeTrackedMergedButOpenRecords(...)` in `src/recovery-tracked-pr-reconciliation.ts` so the default mixed-state pass only returns recoverable tracked PR records unless no recoverable records remain.
+- Hypothesis: The review finding was valid: after the mixed-state prioritization change, a pass that exhausted only the recoverable bucket could still clear `tracked_merged_but_open_last_processed_issue_number`, which discarded historical `done` resume progress.
+- What changed: Updated `prioritizeTrackedMergedButOpenRecords(...)` in `src/recovery-tracked-pr-reconciliation.ts` to return whether historical `done` records were deferred, and changed the end-of-pass cursor update to preserve the existing historical cursor when that deferred bucket remains. Added a direct regression in `src/recovery-tracked-pr-reconciliation.test.ts` that seeds a historical cursor and proves the mixed-state pass keeps it while still only looking up recoverable tracked PRs.
 - Current blocker: none
-- Next exact step: Commit the focused regression + fix checkpoint on `codex/issue-1518` and proceed with normal PR/update flow if requested.
+- Next exact step: Commit and push the review-fix checkpoint on `codex/issue-1518` so PR #1519 picks up the preserved historical-cursor behavior.
 - Verification gap: Focused regressions and TypeScript build passed; no broader full-suite run yet.
-- Files touched: .codex-supervisor/issue-journal.md; src/recovery-tracked-pr-reconciliation.ts; src/recovery-tracked-pr-reconciliation.test.ts; src/run-once-cycle-prelude.test.ts
-- Rollback concern: Low; the behavior change is limited to default mixed-state tracked-PR record selection and preserves historical `done` processing once no recoverable tracked PR records remain.
+- Files touched: .codex-supervisor/issue-journal.md; src/recovery-tracked-pr-reconciliation.ts; src/recovery-tracked-pr-reconciliation.test.ts
+- Rollback concern: Low; the behavior change is limited to mixed-state tracked-PR cursor handling and only preserves the existing historical `done` resume position when that bucket is intentionally deferred.
 - Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,34 +1,35 @@
-# Issue #1515: Bug: run-once --dry-run burns tracked-PR reconciliation budget on terminal done records
+# Issue #1518: Tracked-PR reconciliation should not spend residual default budget on historical done records
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1515
-- Branch: codex/issue-1515
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1518
+- Branch: codex/issue-1518
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 7534702f0a1afe18257f5bba0caeacfbd4d3dc84
+- Last head SHA: 536f41bb45d29ca0e95ff03daf75a9ff48cf8737
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T07:55:57.498Z
+- Updated at: 2026-04-14T08:17:00.443Z
 
 ## Latest Codex Summary
-- Reproduced the budget-burn regression with focused tests, then changed tracked-PR reconciliation to prioritize non-`done` tracked PR records ahead of historical `done + pr_number` records in the default slice.
-- Added regression coverage in the reconciliation suite and a prelude-level test that wires the real reconciliation path through `runOnceCyclePrelude`.
+- Added a focused tracked-PR reconciliation regression for mixed recoverable-plus-historical state and tightened the `runOnceCyclePrelude` regression to assert the first-cycle lookup set stops at the recoverable tracked PR records.
+- Changed default tracked-PR reconciliation selection so mixed-state passes process only recoverable tracked PR records; historical `done` records are now a fallback only when no recoverable tracked PR records remain.
+- Verified with `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts` and `npm run build`.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The default `reconcileTrackedMergedButOpenIssuesInModule(...)` candidate list was iterating tracked PR records in raw issue-number order, so large tails of historical `done + pr_number` records exhausted the default 25-record budget before recoverable tracked PR work was reached.
-- What changed: Added `prioritizeTrackedMergedButOpenRecords(...)` in `src/recovery-tracked-pr-reconciliation.ts` so the default pass processes non-`done` tracked PR records before historical `done` records while preserving round-robin resume ordering inside each tier. Added direct and prelude-level regressions for the `800 !== 901` failure mode.
+- Hypothesis: The default tracked-PR reconciliation pass still burned residual budget on historical `done + pr_number` records after checking the recoverable tracked PR subset because prioritization only reordered the array and did not cap the mixed-state pass to the recoverable bucket.
+- What changed: Added `src/recovery-tracked-pr-reconciliation.test.ts` to reproduce the mixed-state leak directly, tightened the prelude regression in `src/run-once-cycle-prelude.test.ts`, and updated `prioritizeTrackedMergedButOpenRecords(...)` in `src/recovery-tracked-pr-reconciliation.ts` so the default mixed-state pass only returns recoverable tracked PR records unless no recoverable records remain.
 - Current blocker: none
-- Next exact step: Review diff and create a checkpoint commit on `codex/issue-1515`.
-- Verification gap: none for requested local checks; targeted tests and build passed.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-tracked-pr-reconciliation.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`
-- Rollback concern: Low; change only affects default ordering for tracked-PR reconciliation when scanning multiple records and leaves `onlyIssueNumber` behavior intact.
-- Last focused command: `npm run build`
+- Next exact step: Commit the focused regression + fix checkpoint on `codex/issue-1518` and proceed with normal PR/update flow if requested.
+- Verification gap: Focused regressions and TypeScript build passed; no broader full-suite run yet.
+- Files touched: .codex-supervisor/issue-journal.md; src/recovery-tracked-pr-reconciliation.ts; src/recovery-tracked-pr-reconciliation.test.ts; src/run-once-cycle-prelude.test.ts
+- Rollback concern: Low; the behavior change is limited to default mixed-state tracked-PR record selection and preserves historical `done` processing once no recoverable tracked PR records remain.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-tracked-pr-reconciliation.test.ts
+++ b/src/recovery-tracked-pr-reconciliation.test.ts
@@ -78,3 +78,81 @@ test("reconcileTrackedMergedButOpenIssues default pass stops after recoverable t
   assert.equal(saveCalls, 0);
   assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, undefined);
 });
+
+test("reconcileTrackedMergedButOpenIssues preserves the historical done cursor when mixed-state passes defer that bucket", async () => {
+  const recoverableRecords = [
+    createRecord({
+      issue_number: 450,
+      state: "merging",
+      branch: "codex/reopen-issue-450",
+      pr_number: 901,
+      blocked_reason: null,
+    }),
+    createRecord({
+      issue_number: 451,
+      state: "waiting_ci",
+      branch: "codex/reopen-issue-451",
+      pr_number: 902,
+      blocked_reason: null,
+    }),
+  ];
+  const historicalDoneRecords = Array.from({ length: 30 }, (_, index) =>
+    createRecord({
+      issue_number: 300 + index,
+      state: "done",
+      branch: `codex/historical-done-${300 + index}`,
+      pr_number: 800 + index,
+      blocked_reason: null,
+    }));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: Object.fromEntries(
+      [...historicalDoneRecords, ...recoverableRecords].map((record) => [String(record.issue_number), record]),
+    ),
+    reconciliation_state: {
+      tracked_merged_but_open_last_processed_issue_number: 324,
+    },
+  };
+  const prLookups: number[] = [];
+  let saveCalls = 0;
+
+  await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async (prNumber) => {
+        prLookups.push(prNumber);
+        return null;
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:25:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    [],
+  );
+
+  assert.deepEqual(prLookups, [901, 902]);
+  assert.equal(saveCalls, 0);
+  assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, 324);
+});

--- a/src/recovery-tracked-pr-reconciliation.test.ts
+++ b/src/recovery-tracked-pr-reconciliation.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { type IssueRunRecord, type SupervisorStateFile } from "./core/types";
+import { reconcileTrackedMergedButOpenIssues } from "./recovery-reconciliation";
+import { createConfig, createRecord } from "./supervisor/supervisor-test-helpers";
+
+test("reconcileTrackedMergedButOpenIssues default pass stops after recoverable tracked PR records in a mixed state", async () => {
+  const recoverableRecords = [
+    createRecord({
+      issue_number: 450,
+      state: "merging",
+      branch: "codex/reopen-issue-450",
+      pr_number: 901,
+      blocked_reason: null,
+    }),
+    createRecord({
+      issue_number: 451,
+      state: "waiting_ci",
+      branch: "codex/reopen-issue-451",
+      pr_number: 902,
+      blocked_reason: null,
+    }),
+  ];
+  const historicalDoneRecords = Array.from({ length: 30 }, (_, index) =>
+    createRecord({
+      issue_number: 300 + index,
+      state: "done",
+      branch: `codex/historical-done-${300 + index}`,
+      pr_number: 800 + index,
+      blocked_reason: null,
+    }));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: Object.fromEntries(
+      [...historicalDoneRecords, ...recoverableRecords].map((record) => [String(record.issue_number), record]),
+    ),
+  };
+  const prLookups: number[] = [];
+  let saveCalls = 0;
+
+  await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async (prNumber) => {
+        prLookups.push(prNumber);
+        return null;
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:25:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    [],
+  );
+
+  assert.deepEqual(prLookups, [901, 902]);
+  assert.equal(saveCalls, 0);
+  assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, undefined);
+});

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -111,15 +111,24 @@ function orderTrackedMergedButOpenRecordsForResume(
 function prioritizeTrackedMergedButOpenRecords(
   records: IssueRunRecord[],
   lastProcessedIssueNumber: number | null,
-): IssueRunRecord[] {
+): {
+  records: IssueRunRecord[];
+  deferredHistoricalDoneRecords: boolean;
+} {
   const recoverableRecords = records.filter((record) => record.state !== "done");
   const historicalDoneRecords = records.filter((record) => record.state === "done");
 
   if (recoverableRecords.length > 0) {
-    return orderTrackedMergedButOpenRecordsForResume(recoverableRecords, lastProcessedIssueNumber);
+    return {
+      records: orderTrackedMergedButOpenRecordsForResume(recoverableRecords, lastProcessedIssueNumber),
+      deferredHistoricalDoneRecords: historicalDoneRecords.length > 0,
+    };
   }
 
-  return orderTrackedMergedButOpenRecordsForResume(historicalDoneRecords, lastProcessedIssueNumber);
+  return {
+    records: orderTrackedMergedButOpenRecordsForResume(historicalDoneRecords, lastProcessedIssueNumber),
+    deferredHistoricalDoneRecords: false,
+  };
 }
 
 export function buildTrackedPrResumeRecoveryEvent(
@@ -198,12 +207,16 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
     ? Object.values(state.issues)
     : [state.issues[String(options.onlyIssueNumber)]].filter((record): record is IssueRunRecord => record !== undefined);
   const prBearingRecords = selectedRecords.filter((record): record is IssueRunRecord => record.pr_number !== null);
-  const records = options.onlyIssueNumber === undefined || options.onlyIssueNumber === null
+  const prioritizedRecords = options.onlyIssueNumber === undefined || options.onlyIssueNumber === null
     ? prioritizeTrackedMergedButOpenRecords(
       prBearingRecords,
       trackedMergedButOpenLastProcessedIssueNumber(state),
     )
-    : prBearingRecords;
+    : {
+      records: prBearingRecords,
+      deferredHistoricalDoneRecords: false,
+    };
+  const { records, deferredHistoricalDoneRecords } = prioritizedRecords;
   let processedRecords = 0;
   let lastProcessedIssueNumber: number | null = null;
 
@@ -411,10 +424,16 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
   }
 
   if (options.onlyIssueNumber === undefined || options.onlyIssueNumber === null) {
-    const nextLastProcessedIssueNumber =
-      processedRecords === 0 || processedRecords >= records.length
-        ? null
-        : lastProcessedIssueNumber;
+    let nextLastProcessedIssueNumber: number | null;
+    if (processedRecords === 0) {
+      nextLastProcessedIssueNumber = null;
+    } else if (processedRecords >= records.length) {
+      nextLastProcessedIssueNumber = deferredHistoricalDoneRecords
+        ? trackedMergedButOpenLastProcessedIssueNumber(state)
+        : null;
+    } else {
+      nextLastProcessedIssueNumber = lastProcessedIssueNumber;
+    }
     if (setTrackedMergedButOpenLastProcessedIssueNumber(state, nextLastProcessedIssueNumber)) {
       saveNeeded = true;
     }

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -115,10 +115,11 @@ function prioritizeTrackedMergedButOpenRecords(
   const recoverableRecords = records.filter((record) => record.state !== "done");
   const historicalDoneRecords = records.filter((record) => record.state === "done");
 
-  return [
-    ...orderTrackedMergedButOpenRecordsForResume(recoverableRecords, lastProcessedIssueNumber),
-    ...orderTrackedMergedButOpenRecordsForResume(historicalDoneRecords, lastProcessedIssueNumber),
-  ];
+  if (recoverableRecords.length > 0) {
+    return orderTrackedMergedButOpenRecordsForResume(recoverableRecords, lastProcessedIssueNumber);
+  }
+
+  return orderTrackedMergedButOpenRecordsForResume(historicalDoneRecords, lastProcessedIssueNumber);
 }
 
 export function buildTrackedPrResumeRecoveryEvent(

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -209,13 +209,22 @@ test("runOnceCyclePrelude persists the last-known-good inventory snapshot after 
 });
 
 test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahead of historical done records", async () => {
-  const recoverableRecord = createRecord({
-    issue_number: 450,
-    state: "merging",
-    branch: "codex/reopen-issue-450",
-    pr_number: 901,
-    blocked_reason: null,
-  });
+  const recoverableRecords = [
+    createRecord({
+      issue_number: 450,
+      state: "merging",
+      branch: "codex/reopen-issue-450",
+      pr_number: 901,
+      blocked_reason: null,
+    }),
+    createRecord({
+      issue_number: 451,
+      state: "waiting_ci",
+      branch: "codex/reopen-issue-451",
+      pr_number: 902,
+      blocked_reason: null,
+    }),
+  ];
   const historicalDoneRecords = Array.from({ length: 30 }, (_, index) =>
     createRecord({
       issue_number: 300 + index,
@@ -227,25 +236,10 @@ test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahea
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
     issues: Object.fromEntries(
-      [...historicalDoneRecords, recoverableRecord].map((record) => [String(record.issue_number), record]),
+      [...historicalDoneRecords, ...recoverableRecords].map((record) => [String(record.issue_number), record]),
     ),
   };
-  const closedIssue = createIssue({
-    number: 450,
-    title: "Recoverable merging issue",
-    updatedAt: "2026-03-13T00:23:00Z",
-    state: "CLOSED",
-  });
-  const issues: GitHubIssue[] = [closedIssue];
-  const mergedPr = createPullRequest({
-    number: 901,
-    title: "Recoverable tracked PR",
-    url: "https://example.test/pr/901",
-    state: "MERGED",
-    headRefName: "codex/reopen-issue-450",
-    headRefOid: "merged-head-901",
-    mergedAt: "2026-03-13T00:22:00Z",
-  });
+  const issues: GitHubIssue[] = [];
   const prLookups: number[] = [];
   let saveCalls = 0;
 
@@ -265,14 +259,10 @@ test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahea
         {
           getPullRequestIfExists: async (prNumber) => {
             prLookups.push(prNumber);
-            if (prNumber === 901) {
-              return mergedPr;
-            }
             return null;
           },
-          getIssue: async (issueNumber) => {
-            assert.equal(issueNumber, 450);
-            return closedIssue;
+          getIssue: async () => {
+            throw new Error("unexpected getIssue call");
           },
           closeIssue: async () => {
             throw new Error("unexpected closeIssue call");
@@ -292,9 +282,8 @@ test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahea
               updated_at: "2026-03-13T00:25:00Z",
             };
           },
-          save: async (nextState) => {
+          save: async () => {
             saveCalls += 1;
-            assert.equal(nextState, loadedState);
           },
         },
         loadedState,
@@ -312,14 +301,11 @@ test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahea
   });
 
   assert.ok(!("kind" in result));
-  assert.equal(prLookups[0], 901);
-  assert.equal(prLookups.includes(901), true);
-  assert.equal(saveCalls, 2);
-  assert.equal(result.state.issues["450"]?.state, "done");
-  assert.equal(result.state.issues["450"]?.last_head_sha, "merged-head-901");
-  assert.deepEqual(result.recoveryEvents.map((event) => event.reason), [
-    "merged_pr_convergence: tracked PR #901 merged; marked issue #450 done",
-  ]);
+  assert.deepEqual(prLookups, [901, 902]);
+  assert.deepEqual(result.recoveryEvents, []);
+  assert.equal(saveCalls, 1);
+  assert.equal(result.state.issues["450"]?.state, "merging");
+  assert.equal(result.state.issues["451"]?.state, "waiting_ci");
 });
 
 test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving selection", async () => {


### PR DESCRIPTION
Closes #1518
This PR was opened by codex-supervisor.
Latest Codex summary:

Adjusted the default tracked-PR reconciliation slice so mixed-state passes stop after the recoverable tracked PR records instead of spending the remaining default budget on historical `done` records. The behavior change is in [src/recovery-tracked-pr-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1518/src/recovery-tracked-pr-reconciliation.ts), and I added a direct regression in [src/recovery-tracked-pr-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1518/src/recovery-tracked-pr-reconciliation.test.ts) plus tightened the prelude coverage in [src/run-once-cycle-prelude.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1518/src/run-once-cycle-prelude.test.ts). The issue journal was updated before closing the turn.

Focused verification passed:
- `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
- `npm run build`

Checkpoint commit: `ae78f5b` (`Prevent tracked PR reconciliation from spending budget on done history`)

Summary: Default tracked-PR reconciliation now spends its first-cycle budget only on recoverable tracked PR records in mixed states; focused regressions and build passed.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the branch P...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracked PR reconciliation to halt processing after recoverable records, preventing unnecessary consumption of processing budget on historical records.
  * Enhanced cursor preservation to maintain tracking progress state correctly when deferring historical records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->