### PR TITLE
Bug: run-once prelude revalidates historical closed issues via merged_issue_closures on every cycle (#1520)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,30 +5,43 @@
 - Branch: codex/issue-1520
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 97386e4ff2efd63260a4b66185c4471f357570f1
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 717f492d1e7c713107e522573ab130135b57892f
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T09:02:17.448Z
+- Last failure signature: PRRT_kwDORgvdZ856w4vK|PRRT_kwDORgvdZ856w4vO
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T09:19:30.705Z
 
 ## Latest Codex Summary
-- Added a freshness gate to `reconcileMergedIssueClosures()` so ordinary prelude cycles skip historical terminal closed records unless the issue is active, still non-terminal locally, or GitHub updated the closed issue after the local terminal record.
-- Added focused regression coverage at both the reconciliation layer and `runOnceCyclePrelude` layer to prove a 160-record historical closed backlog no longer triggers 160 merged-closure GraphQL lookups.
+Implemented a narrow fix in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts) so `reconcileMergedIssueClosures()` no longer scans historical closed terminal records every cycle. It now revalidates only when the closed issue is still active locally, not yet terminal locally, or GitHub’s `updatedAt` is newer than the local terminal timestamps. That preserves convergence for suspicious/recently changed closures without paying O(history) GraphQL cost on old `done` backlogs.
+
+I added focused regressions in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts) and [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts) that prove a `160`-record historical closed backlog no longer causes `160` merged-closure lookups, while recently changed and non-terminal closed records still revalidate. I also updated the issue journal and committed the checkpoint as `717f492` with message `Bound merged issue closure revalidation`.
+
+Summary: Bounded `merged_issue_closures` revalidation to active, non-terminal, or newly changed closed issues; added direct and prelude regression tests; build passed; committed as `717f492`.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
+Next action: Open or update a draft PR for `codex/issue-1520` with commit `717f492` and let CI validate the bounded merged-closure behavior
+Failure signature: PRRT_kwDORgvdZ856w4vK|PRRT_kwDORgvdZ856w4vO
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391599
+- Details:
+  - .codex-supervisor/issue-journal.md:29 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Minor wording polish on verification note.** Line 29 reads more cleanly as “locally focused tests” (or “local-focused tests”). url=https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391599
+  - src/recovery-reconciliation.ts:366 summary=_⚠️ Potential issue_ | _🟠 Major_ **Keep provenance-free `done` records eligible for merged-closure backfill.** Once a record reaches `done`, this gate treats it as converged ba... url=https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391603
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `merged_issue_closures` was O(history) because it called `getMergedPullRequestsClosingIssue()` for every `CLOSED` issue record, even when the local record was already stably `done` and GitHub had not changed since the terminal write.
-- What changed: Added `shouldRevalidateMergedIssueClosureRecord()` in `src/recovery-reconciliation.ts` and used it to skip historical `done` records unless they are active, non-terminal, or the GitHub issue `updatedAt` is newer than the latest local terminal timestamp. Added bounded-lookup regressions in `src/supervisor/supervisor-recovery-reconciliation.test.ts` and `src/run-once-cycle-prelude.test.ts`.
+- Hypothesis: The review-thread regression was real because the new timestamp-only gate could treat a provenance-free `done` record as converged forever, preventing `merged_issue_closures` from backfilling merged PR provenance for suspicious closed issues.
+- What changed: Tightened `shouldRevalidateMergedIssueClosureRecord()` in `src/recovery-reconciliation.ts` so `done` records still revalidate when `pr_number` or `last_head_sha` is missing, even if GitHub has not updated since the local terminal timestamp. Extended the direct reconciliation and `runOnceCyclePrelude` backlog tests to prove provenance-free `done` records still trigger bounded merged-closure lookups. Updated the verification note wording to "locally focused tests".
 - Current blocker: none
-- Next exact step: Commit the bounded merged-closure fix on `codex/issue-1520` and prepare the branch for PR creation/update.
-- Verification gap: No PR/CI verification yet; local focused tests and `npm run build` passed.
+- Next exact step: Commit the review-thread fix on `codex/issue-1520`, push the branch, and update PR #1521 so the unresolved automated review threads can be re-evaluated on the new head.
+- Verification gap: No PR/CI verification yet on the review-fix head; locally focused tests and `npm run build` passed.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/run-once-cycle-prelude.test.ts`
-- Rollback concern: Low. The gate only skips revalidation for stale terminal closed records; active, non-terminal, and newly changed closed issues still run the existing reconciliation path.
+- Rollback concern: Low. The change only widens revalidation for suspicious closed `done` records that are missing merged-closure provenance; historical terminal records with intact provenance remain bounded by the timestamp gate.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,50 +1,34 @@
-# Issue #1518: Tracked-PR reconciliation should not spend residual default budget on historical done records
+# Issue #1520: Bug: run-once prelude revalidates historical closed issues via merged_issue_closures on every cycle
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1518
-- Branch: codex/issue-1518
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1520
+- Branch: codex/issue-1520
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: ae78f5b942801b2a845cd2b9e35588ec2c185560
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 97386e4ff2efd63260a4b66185c4471f357570f1
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856wH2h
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T08:31:52.003Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T09:02:17.448Z
 
 ## Latest Codex Summary
-Adjusted the default tracked-PR reconciliation slice so mixed-state passes stop after the recoverable tracked PR records instead of spending the remaining default budget on historical `done` records. The behavior change is in [src/recovery-tracked-pr-reconciliation.ts](src/recovery-tracked-pr-reconciliation.ts), and I added a direct regression in [src/recovery-tracked-pr-reconciliation.test.ts](src/recovery-tracked-pr-reconciliation.test.ts) plus tightened the prelude coverage in [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts). The issue journal was updated before closing the turn.
-
-Focused verification passed:
-- `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
-- `npm run build`
-
-Checkpoint commit: `ae78f5b` (`Prevent tracked PR reconciliation from spending budget on done history`)
-
-Summary: Default tracked-PR reconciliation now spends its first-cycle budget only on recoverable tracked PR records in mixed states; focused regressions and build passed.
-State hint: stabilizing
-Blocked reason: none
-Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
-Next action: Open or update the branch PR so this checkpoint can move into review/CI.
-Failure signature: PRRT_kwDORgvdZ856wH2h
+- Added a freshness gate to `reconcileMergedIssueClosures()` so ordinary prelude cycles skip historical terminal closed records unless the issue is active, still non-terminal locally, or GitHub updated the closed issue after the local terminal record.
+- Added focused regression coverage at both the reconciliation layer and `runOnceCyclePrelude` layer to prove a 160-record historical closed backlog no longer triggers 160 merged-closure GraphQL lookups.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1519#discussion_r3078122159
-- Details:
-  - src/recovery-tracked-pr-reconciliation.ts:122 summary=_⚠️ Potential issue_ | _🟠 Major_ **Preserve the historical `done` cursor when you defer that bucket.** After this change, `records.length` in Lines 413-418 can mean “the recove... url=https://github.com/TommyKammy/codex-supervisor/pull/1519#discussion_r3078122159
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The review finding was valid: after the mixed-state prioritization change, a pass that exhausted only the recoverable bucket could still clear `tracked_merged_but_open_last_processed_issue_number`, which discarded historical `done` resume progress.
-- What changed: Updated `prioritizeTrackedMergedButOpenRecords(...)` in `src/recovery-tracked-pr-reconciliation.ts` to return whether historical `done` records were deferred, and changed the end-of-pass cursor update to preserve the existing historical cursor when that deferred bucket remains. Added a direct regression in `src/recovery-tracked-pr-reconciliation.test.ts` that seeds a historical cursor and proves the mixed-state pass keeps it while still only looking up recoverable tracked PRs.
+- Hypothesis: `merged_issue_closures` was O(history) because it called `getMergedPullRequestsClosingIssue()` for every `CLOSED` issue record, even when the local record was already stably `done` and GitHub had not changed since the terminal write.
+- What changed: Added `shouldRevalidateMergedIssueClosureRecord()` in `src/recovery-reconciliation.ts` and used it to skip historical `done` records unless they are active, non-terminal, or the GitHub issue `updatedAt` is newer than the latest local terminal timestamp. Added bounded-lookup regressions in `src/supervisor/supervisor-recovery-reconciliation.test.ts` and `src/run-once-cycle-prelude.test.ts`.
 - Current blocker: none
-- Next exact step: Commit and push the review-fix checkpoint on `codex/issue-1518` so PR #1519 picks up the preserved historical-cursor behavior.
-- Verification gap: Focused regressions and TypeScript build passed; no broader full-suite run yet.
-- Files touched: .codex-supervisor/issue-journal.md; src/recovery-tracked-pr-reconciliation.ts; src/recovery-tracked-pr-reconciliation.test.ts
-- Rollback concern: Low; the behavior change is limited to mixed-state tracked-PR cursor handling and only preserves the existing historical `done` resume position when that bucket is intentionally deferred.
-- Last focused command: npm run build
+- Next exact step: Commit the bounded merged-closure fix on `codex/issue-1520` and prepare the branch for PR creation/update.
+- Verification gap: No PR/CI verification yet; local focused tests and `npm run build` passed.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/run-once-cycle-prelude.test.ts`
+- Rollback concern: Low. The gate only skips revalidation for stale terminal closed records; active, non-terminal, and newly changed closed issues still run the existing reconciliation path.
+- Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -340,7 +340,13 @@ function latestFiniteTimestamp(...values: Array<string | null | undefined>): num
 function shouldRevalidateMergedIssueClosureRecord(
   record: Pick<
     IssueRunRecord,
-    "issue_number" | "state" | "last_failure_context" | "last_recovery_at" | "updated_at"
+    | "issue_number"
+    | "state"
+    | "pr_number"
+    | "last_head_sha"
+    | "last_failure_context"
+    | "last_recovery_at"
+    | "updated_at"
   >,
   issue: Pick<GitHubIssue, "updatedAt">,
   activeIssueNumber: number | null,
@@ -350,6 +356,10 @@ function shouldRevalidateMergedIssueClosureRecord(
   }
 
   if (record.state !== "done") {
+    return true;
+  }
+
+  if (record.pr_number === null || record.last_head_sha === null) {
     return true;
   }
 

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -337,6 +337,35 @@ function latestFiniteTimestamp(...values: Array<string | null | undefined>): num
   return latest;
 }
 
+function shouldRevalidateMergedIssueClosureRecord(
+  record: Pick<
+    IssueRunRecord,
+    "issue_number" | "state" | "last_failure_context" | "last_recovery_at" | "updated_at"
+  >,
+  issue: Pick<GitHubIssue, "updatedAt">,
+  activeIssueNumber: number | null,
+): boolean {
+  if (activeIssueNumber === record.issue_number) {
+    return true;
+  }
+
+  if (record.state !== "done") {
+    return true;
+  }
+
+  const issueUpdatedAtMs = Date.parse(issue.updatedAt);
+  const localTerminalObservedAtMs = latestFiniteTimestamp(
+    record.last_failure_context?.updated_at,
+    record.last_recovery_at,
+    record.updated_at,
+  );
+  if (!Number.isFinite(issueUpdatedAtMs) || localTerminalObservedAtMs === null) {
+    return true;
+  }
+
+  return issueUpdatedAtMs > localTerminalObservedAtMs;
+}
+
 function shouldReconsiderBlockedNoPrStaleManualStop(
   record: Pick<
     IssueRunRecord,
@@ -563,10 +592,17 @@ export async function reconcileMergedIssueClosures(
   let changed = false;
   const recoveryEvents: RecoveryEvent[] = [];
   const issueByNumber = new Map(issues.map((issue) => [issue.number, issue]));
-  const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
 
   for (const record of Object.values(state.issues)) {
-    if (issueStateByNumber.get(record.issue_number) !== "CLOSED") {
+    const issue = issueByNumber.get(record.issue_number);
+    if (issue?.state !== "CLOSED") {
+      continue;
+    }
+
+    // Historical done records with no newer GitHub activity do not need a fresh
+    // merged-closure GraphQL scan every cycle. Revalidate only active, non-terminal,
+    // or recently changed closed issues.
+    if (!shouldRevalidateMergedIssueClosureRecord(record, issue, state.activeIssueNumber)) {
       continue;
     }
 

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -324,6 +324,20 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
       last_failure_kind: null,
       last_failure_signature: null,
     }));
+  const provenanceFreeDoneRecord = createRecord({
+    issue_number: 959,
+    state: "done",
+    branch: "codex/provenance-free-959",
+    pr_number: null,
+    last_head_sha: null,
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
   const recentlyChangedClosedRecord = createRecord({
     issue_number: 960,
     state: "done",
@@ -354,7 +368,12 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
     issues: Object.fromEntries(
-      [...historicalDoneRecords, recentlyChangedClosedRecord, nonTerminalClosedRecord]
+      [
+        ...historicalDoneRecords,
+        provenanceFreeDoneRecord,
+        recentlyChangedClosedRecord,
+        nonTerminalClosedRecord,
+      ]
         .map((record) => [String(record.issue_number), record]),
     ),
   };
@@ -364,6 +383,11 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
       state: "CLOSED",
       updatedAt: "2026-03-13T00:20:00Z",
     })),
+    createIssue({
+      number: provenanceFreeDoneRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
     createIssue({
       number: recentlyChangedClosedRecord.issue_number,
       state: "CLOSED",
@@ -431,7 +455,7 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
   });
 
   assert.ok(!("kind" in result));
-  assert.deepEqual(mergedClosureLookups, [960, 961]);
+  assert.deepEqual(mergedClosureLookups, [959, 960, 961]);
 });
 
 test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving selection", async () => {

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -308,6 +308,132 @@ test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahea
   assert.equal(result.state.issues["451"]?.state, "waiting_ci");
 });
 
+test("runOnceCyclePrelude bounds merged issue closure revalidation for historical closed backlogs", async () => {
+  const historicalDoneRecords = Array.from({ length: 160 }, (_, index) =>
+    createRecord({
+      issue_number: 700 + index,
+      state: "done",
+      branch: `codex/historical-done-${700 + index}`,
+      pr_number: 1700 + index,
+      last_head_sha: `head-${700 + index}`,
+      updated_at: "2026-03-13T00:25:00Z",
+      last_recovery_at: "2026-03-13T00:25:00Z",
+      last_failure_context: null,
+      blocked_reason: null,
+      last_error: null,
+      last_failure_kind: null,
+      last_failure_signature: null,
+    }));
+  const recentlyChangedClosedRecord = createRecord({
+    issue_number: 960,
+    state: "done",
+    branch: "codex/recently-changed-960",
+    pr_number: 1960,
+    last_head_sha: "head-960",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const nonTerminalClosedRecord = createRecord({
+    issue_number: 961,
+    state: "waiting_ci",
+    branch: "codex/non-terminal-961",
+    pr_number: 1961,
+    last_head_sha: "head-961",
+    updated_at: "2026-03-13T00:25:00Z",
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: Object.fromEntries(
+      [...historicalDoneRecords, recentlyChangedClosedRecord, nonTerminalClosedRecord]
+        .map((record) => [String(record.issue_number), record]),
+    ),
+  };
+  const issues: GitHubIssue[] = [
+    ...historicalDoneRecords.map((record) => createIssue({
+      number: record.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    })),
+    createIssue({
+      number: recentlyChangedClosedRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:30:00Z",
+    }),
+    createIssue({
+      number: nonTerminalClosedRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
+  ];
+  const mergedClosureLookups: number[] = [];
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => {},
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => issues,
+    reconcileTrackedMergedButOpenIssues: async () => [],
+    reconcileMergedIssueClosures: async (loadedState, loadedIssues) => {
+      const { reconcileMergedIssueClosures } = await import("./recovery-reconciliation");
+      return reconcileMergedIssueClosures(
+        {
+          getMergedPullRequestsClosingIssue: async (issueNumber) => {
+            mergedClosureLookups.push(issueNumber);
+            return [];
+          },
+          getPullRequestIfExists: async () => null,
+          closePullRequest: async () => {
+            throw new Error("unexpected closePullRequest call");
+          },
+          closeIssue: async () => {
+            throw new Error("unexpected closeIssue call");
+          },
+          getIssue: async () => {
+            throw new Error("unexpected getIssue call");
+          },
+          getChecks: async () => [],
+          getUnresolvedReviewThreads: async () => [],
+        },
+        {
+          touch(record, patch) {
+            return {
+              ...record,
+              ...patch,
+              updated_at: "2026-03-13T00:35:00Z",
+            };
+          },
+          save: async () => {},
+        },
+        loadedState,
+        createConfig(),
+        loadedIssues,
+      );
+    },
+    reconcileStaleFailedIssueStates: async () => {},
+    reconcileRecoverableBlockedIssueStates: async () => [],
+    reconcileParentEpicClosures: async () => [],
+    cleanupExpiredDoneWorkspaces: async () => [],
+    reserveRunnableIssueSelection: async () => false,
+  });
+
+  assert.ok(!("kind" in result));
+  assert.deepEqual(mergedClosureLookups, [960, 961]);
+});
+
 test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving selection", async () => {
   const state: SupervisorStateFile = {
     activeIssueNumber: null,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3476,6 +3476,19 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
       last_failure_kind: null,
       last_failure_signature: null,
     }));
+  const provenanceFreeDoneRecord = createRecord({
+    issue_number: 959,
+    state: "done",
+    pr_number: null,
+    last_head_sha: null,
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
   const recentlyChangedClosedRecord = createRecord({
     issue_number: 960,
     state: "done",
@@ -3502,7 +3515,12 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
     last_failure_signature: null,
   });
   const state: SupervisorStateFile = createSupervisorState({
-    issues: [...historicalDoneRecords, recentlyChangedClosedRecord, nonTerminalClosedRecord],
+    issues: [
+      ...historicalDoneRecords,
+      provenanceFreeDoneRecord,
+      recentlyChangedClosedRecord,
+      nonTerminalClosedRecord,
+    ],
   });
   const issues = [
     ...historicalDoneRecords.map((record) => createIssue({
@@ -3510,6 +3528,11 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
       state: "CLOSED",
       updatedAt: "2026-03-13T00:20:00Z",
     })),
+    createIssue({
+      number: provenanceFreeDoneRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
     createIssue({
       number: recentlyChangedClosedRecord.issue_number,
       state: "CLOSED",
@@ -3553,7 +3576,7 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
     issues,
   );
 
-  assert.deepEqual(mergedClosureLookups, [960, 961]);
+  assert.deepEqual(mergedClosureLookups, [959, 960, 961]);
   assert.deepEqual(recoveryEvents, []);
 });
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3461,6 +3461,102 @@ test("reconcileMergedIssueClosures clears a stale active issue pointer even when
   assert.deepEqual(state.issues["366"], original);
 });
 
+test("reconcileMergedIssueClosures skips historical terminal records but still revalidates changed or non-terminal closed issues", async () => {
+  const historicalDoneRecords = Array.from({ length: 160 }, (_, index) =>
+    createRecord({
+      issue_number: 700 + index,
+      state: "done",
+      pr_number: 1700 + index,
+      last_head_sha: `head-${700 + index}`,
+      updated_at: "2026-03-13T00:25:00Z",
+      last_recovery_at: "2026-03-13T00:25:00Z",
+      last_failure_context: null,
+      blocked_reason: null,
+      last_error: null,
+      last_failure_kind: null,
+      last_failure_signature: null,
+    }));
+  const recentlyChangedClosedRecord = createRecord({
+    issue_number: 960,
+    state: "done",
+    pr_number: 1960,
+    last_head_sha: "head-960",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const nonTerminalClosedRecord = createRecord({
+    issue_number: 961,
+    state: "waiting_ci",
+    pr_number: 1961,
+    last_head_sha: "head-961",
+    updated_at: "2026-03-13T00:25:00Z",
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [...historicalDoneRecords, recentlyChangedClosedRecord, nonTerminalClosedRecord],
+  });
+  const issues = [
+    ...historicalDoneRecords.map((record) => createIssue({
+      number: record.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    })),
+    createIssue({
+      number: recentlyChangedClosedRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:30:00Z",
+    }),
+    createIssue({
+      number: nonTerminalClosedRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
+  ];
+  const mergedClosureLookups: number[] = [];
+
+  const recoveryEvents = await reconcileMergedIssueClosures(
+    {
+      getMergedPullRequestsClosingIssue: async (issueNumber) => {
+        mergedClosureLookups.push(issueNumber);
+        return [];
+      },
+      getPullRequestIfExists: async () => null,
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return { ...current, ...patch };
+      },
+      save: async () => {},
+    },
+    state,
+    createConfig(),
+    issues,
+  );
+
+  assert.deepEqual(mergedClosureLookups, [960, 961]);
+  assert.deepEqual(recoveryEvents, []);
+});
+
 test("reconcileStaleFailedIssueStates requeues failed no-PR issues when the issue definition changes materially", async () => {
   const config = createConfig();
   const originalIssue = createIssue({


### PR DESCRIPTION
Closes #1520
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a narrow fix in [src/recovery-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1520/src/recovery-reconciliation.ts) so `reconcileMergedIssueClosures()` no longer scans historical closed terminal records every cycle. It now revalidates only when the closed issue is still active locally, not yet terminal locally, or GitHub’s `updatedAt` is newer than the local terminal timestamps. That preserves convergence for suspicious/recently changed closures without paying O(history) GraphQL cost on old `done` backlogs.

I added focused regressions in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1520/src/supervisor/supervisor-recovery-reconciliation.test.ts) and [src/run-once-cycle-prelude.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1520/src/run-once-cycle-prelude.test.ts) that prove a `160`-record historical closed backlog no longer causes `160` merged-closure lookups, while recently changed and non-terminal closed records still revalidate. I also updated the issue journal and committed the checkpoint as `717f492` with message `Bound merged issue closure revalidation`.

Summary: Bounded `merged_issue_closures` revalidation to active, non-terminal, or newly changed closed issues; added direct and prelude regression tests; build passed; committed as `717f492`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation now skips unnecessary revalidation of old closed issues unless activity or provenance indicates freshness, reducing redundant background scans.

* **Tests**
  * Added focused regression tests that verify only recent or non-terminal issues trigger closure revalidation when a large historical backlog exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->