### PR TITLE
Fix stale merged closure provenance revalidation

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,31 +5,42 @@
 - Branch: codex/issue-1522
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 6154a5e6dac2c30fee62f3899fa5c7713440175b
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 742a3c30e4d26985648097bb950dbcdf746433a3
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T09:30:52.069Z
+- Last failure signature: PRRT_kwDORgvdZ856xSZQ
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T09:42:25.160Z
 
 ## Latest Codex Summary
-- Reproduced the stale-provenance gap with a focused `reconcileMergedIssueClosures()` test.
-- Tightened merged-closure trust rules so closed `done` records only skip revalidation when they already carry recorded `merged_pr_convergence` provenance.
-- Verified the stale-provenance repro, the bounded historical backlog behavior, and the TypeScript build.
+Implemented and verified the stale merged-provenance fix on `codex/issue-1522`. The gate in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts:344) now treats closed `done` records as safely skippable only when they already carry recorded `merged_pr_convergence` provenance; otherwise they remain eligible for merged-closure reconciliation even if the GitHub issue `updatedAt` is older than the local terminal timestamp. I added the narrow repro in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts:3584) and kept the bounded-backlog coverage aligned in [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts:311).
+
+The work is committed as `742a3c3` (`Revalidate stale merged closure provenance`), pushed to `origin/codex/issue-1522`, and a draft PR is open at https://github.com/TommyKammy/codex-supervisor/pull/1523. The worktree is otherwise clean apart from existing untracked supervisor artifacts under `.codex-supervisor/`.
+
+Summary: Fixed merged-closure revalidation so stale closed `done` provenance without recorded convergence is no longer skipped forever; added focused regression coverage; committed and opened draft PR #1523
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
+Next action: Let PR #1523 run CI and address any review or check failures if they appear
+Failure signature: PRRT_kwDORgvdZ856xSZQ
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1523#discussion_r3078535348
+- Details:
+  - src/recovery-reconciliation.ts:369 summary=_⚠️ Potential issue_ | _🟠 Major_ **Persist repaired provenance even when the done patch is otherwise unchanged.** Line 367 correctly forces suspicious records into revalidation... url=https://github.com/TommyKammy/codex-supervisor/pull/1523#discussion_r3078535348
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `shouldRevalidateMergedIssueClosureRecord()` was trusting any closed `done` record with non-null `pr_number` and `last_head_sha`, so stale merged provenance without recorded convergence was skipped forever when the GitHub issue timestamp was older than the local terminal timestamp.
-- What changed: Added a focused stale-provenance repro test; updated the merged-closure gate to keep records without recorded `merged_pr_convergence` eligible for reconciliation; marked the historical bounded-backlog fixtures as trusted converged records with explicit recovery provenance.
+- Hypothesis: the remaining review thread was valid because `reconcileMergedIssueClosures()` re-entered suspicious closed `done` records, but it only persisted a repair when `doneResetPatch()` changed structural fields; records whose stored PR/head already matched never backfilled `merged_pr_convergence` provenance and kept re-entering reconciliation forever.
+- What changed: Kept the earlier suspicious-record revalidation gate and added a persistence backfill in `reconcileMergedIssueClosures()` so matching PR/head records still write `merged_pr_convergence` recovery metadata once; added a focused regression covering the "correct PR/head, wrong recovery reason" case.
 - Current blocker: none.
-- Next exact step: commit the verified fix on `codex/issue-1522`.
+- Next exact step: commit and push the review fix on `codex/issue-1522`, then refresh PR #1523.
 - Verification gap: none for the issue-scoped checks; broader suite not run.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/run-once-cycle-prelude.test.ts`.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
 - Rollback concern: the new trust rule treats old closed `done` records without `merged_pr_convergence` recovery metadata as suspicious, so legacy state may re-enter reconciliation until repaired.
-- Last focused command: `npm run build`
+- Last focused commands: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,47 +1,35 @@
-# Issue #1520: Bug: run-once prelude revalidates historical closed issues via merged_issue_closures on every cycle
+# Issue #1522: Bug: merged issue closure gate skips suspicious done records with stale provenance
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1520
-- Branch: codex/issue-1520
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1522
+- Branch: codex/issue-1522
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 717f492d1e7c713107e522573ab130135b57892f
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 6154a5e6dac2c30fee62f3899fa5c7713440175b
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856w4vK|PRRT_kwDORgvdZ856w4vO
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T09:19:30.705Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T09:30:52.069Z
 
 ## Latest Codex Summary
-Implemented a narrow fix in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts) so `reconcileMergedIssueClosures()` no longer scans historical closed terminal records every cycle. It now revalidates only when the closed issue is still active locally, not yet terminal locally, or GitHub’s `updatedAt` is newer than the local terminal timestamps. That preserves convergence for suspicious/recently changed closures without paying O(history) GraphQL cost on old `done` backlogs.
-
-I added focused regressions in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts) and [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts) that prove a `160`-record historical closed backlog no longer causes `160` merged-closure lookups, while recently changed and non-terminal closed records still revalidate. I also updated the issue journal and committed the checkpoint as `717f492` with message `Bound merged issue closure revalidation`.
-
-Summary: Bounded `merged_issue_closures` revalidation to active, non-terminal, or newly changed closed issues; added direct and prelude regression tests; build passed; committed as `717f492`.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
-Next action: Open or update a draft PR for `codex/issue-1520` with commit `717f492` and let CI validate the bounded merged-closure behavior
-Failure signature: PRRT_kwDORgvdZ856w4vK|PRRT_kwDORgvdZ856w4vO
+- Reproduced the stale-provenance gap with a focused `reconcileMergedIssueClosures()` test.
+- Tightened merged-closure trust rules so closed `done` records only skip revalidation when they already carry recorded `merged_pr_convergence` provenance.
+- Verified the stale-provenance repro, the bounded historical backlog behavior, and the TypeScript build.
 
 ## Active Failure Context
-- Category: review
-- Summary: 2 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391599
-- Details:
-  - .codex-supervisor/issue-journal.md:29 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Minor wording polish on verification note.** Line 29 reads more cleanly as “locally focused tests” (or “local-focused tests”). url=https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391599
-  - src/recovery-reconciliation.ts:366 summary=_⚠️ Potential issue_ | _🟠 Major_ **Keep provenance-free `done` records eligible for merged-closure backfill.** Once a record reaches `done`, this gate treats it as converged ba... url=https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391603
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The review-thread regression was real because the new timestamp-only gate could treat a provenance-free `done` record as converged forever, preventing `merged_issue_closures` from backfilling merged PR provenance for suspicious closed issues.
-- What changed: Tightened `shouldRevalidateMergedIssueClosureRecord()` in `src/recovery-reconciliation.ts` so `done` records still revalidate when `pr_number` or `last_head_sha` is missing, even if GitHub has not updated since the local terminal timestamp. Extended the direct reconciliation and `runOnceCyclePrelude` backlog tests to prove provenance-free `done` records still trigger bounded merged-closure lookups. Updated the verification note wording to "locally focused tests".
-- Current blocker: none
-- Next exact step: Commit the review-thread fix on `codex/issue-1520`, push the branch, and update PR #1521 so the unresolved automated review threads can be re-evaluated on the new head.
-- Verification gap: No PR/CI verification yet on the review-fix head; locally focused tests and `npm run build` passed.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/run-once-cycle-prelude.test.ts`
-- Rollback concern: Low. The change only widens revalidation for suspicious closed `done` records that are missing merged-closure provenance; historical terminal records with intact provenance remain bounded by the timestamp gate.
+- Hypothesis: `shouldRevalidateMergedIssueClosureRecord()` was trusting any closed `done` record with non-null `pr_number` and `last_head_sha`, so stale merged provenance without recorded convergence was skipped forever when the GitHub issue timestamp was older than the local terminal timestamp.
+- What changed: Added a focused stale-provenance repro test; updated the merged-closure gate to keep records without recorded `merged_pr_convergence` eligible for reconciliation; marked the historical bounded-backlog fixtures as trusted converged records with explicit recovery provenance.
+- Current blocker: none.
+- Next exact step: commit the verified fix on `codex/issue-1522`.
+- Verification gap: none for the issue-scoped checks; broader suite not run.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/run-once-cycle-prelude.test.ts`.
+- Rollback concern: the new trust rule treats old closed `done` records without `merged_pr_convergence` recovery metadata as suspicious, so legacy state may re-enter reconciliation until repaired.
 - Last focused command: `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -6,23 +6,23 @@
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 742a3c30e4d26985648097bb950dbcdf746433a3
+- Attempt count: 3 (implementation=1, repair=1)
+- Last head SHA: 9e34edb601fd6e0f0abd64cdec05f9206dbe4632
 - Blocked reason: none
 - Last failure signature: PRRT_kwDORgvdZ856xSZQ
 - Repeated failure signature count: 1
-- Updated at: 2026-04-14T09:42:25.160Z
+- Updated at: 2026-04-14T09:52:06.449Z
 
 ## Latest Codex Summary
-Implemented and verified the stale merged-provenance fix on `codex/issue-1522`. The gate in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts:344) now treats closed `done` records as safely skippable only when they already carry recorded `merged_pr_convergence` provenance; otherwise they remain eligible for merged-closure reconciliation even if the GitHub issue `updatedAt` is older than the local terminal timestamp. I added the narrow repro in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts:3584) and kept the bounded-backlog coverage aligned in [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts:311).
+Patched [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts:654) so merged-closure reconciliation now writes a `merged_pr_convergence` recovery event even when the stored `pr_number` and `last_head_sha` already match the satisfying merged PR. That prevents suspicious closed `done` records from re-entering the expensive reconciliation path forever without ever converging locally.
 
-The work is committed as `742a3c3` (`Revalidate stale merged closure provenance`), pushed to `origin/codex/issue-1522`, and a draft PR is open at https://github.com/TommyKammy/codex-supervisor/pull/1523. The worktree is otherwise clean apart from existing untracked supervisor artifacts under `.codex-supervisor/`.
+Added a focused regression in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts:3666) for the exact review case: correct merged PR metadata, stale recovery provenance, older GitHub `updatedAt`, and a required one-time backfill. Verified with `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts` and `npm run build`, then committed and pushed as `9e34edb` on `codex/issue-1522`. I did not post a GitHub reply or resolve the review thread.
 
-Summary: Fixed merged-closure revalidation so stale closed `done` provenance without recorded convergence is no longer skipped forever; added focused regression coverage; committed and opened draft PR #1523
-State hint: draft_pr
+Summary: Backfilled merged-closure convergence provenance for already-matching done records, added a regression test for the review case, and pushed commit `9e34edb` to PR #1523
+State hint: addressing_review
 Blocked reason: none
 Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
-Next action: Let PR #1523 run CI and address any review or check failures if they appear
+Next action: Refresh PR #1523 review state and, if desired, reply to or resolve the remaining automated review thread based on commit `9e34edb`
 Failure signature: PRRT_kwDORgvdZ856xSZQ
 
 ## Active Failure Context
@@ -35,12 +35,13 @@ Failure signature: PRRT_kwDORgvdZ856xSZQ
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: the remaining review thread was valid because `reconcileMergedIssueClosures()` re-entered suspicious closed `done` records, but it only persisted a repair when `doneResetPatch()` changed structural fields; records whose stored PR/head already matched never backfilled `merged_pr_convergence` provenance and kept re-entering reconciliation forever.
-- What changed: Kept the earlier suspicious-record revalidation gate and added a persistence backfill in `reconcileMergedIssueClosures()` so matching PR/head records still write `merged_pr_convergence` recovery metadata once; added a focused regression covering the "correct PR/head, wrong recovery reason" case.
+- What changed: Verified the CodeRabbit major finding is already fixed on `HEAD` via the `needsMergedConvergenceBackfill` write path, then tightened the stale-provenance regression fixture to set `last_recovery_reason: null` explicitly so future `createRecord()` default changes cannot accidentally make the test record trusted.
 - Current blocker: none.
-- Next exact step: commit and push the review fix on `codex/issue-1522`, then refresh PR #1523.
+- Next exact step: commit and push the explicit test-fixture follow-up on `codex/issue-1522`, then refresh PR #1523 and decide whether to reply to or resolve the still-open CodeRabbit thread manually.
 - Verification gap: none for the issue-scoped checks; broader suite not run.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
 - Rollback concern: the new trust rule treats old closed `done` records without `merged_pr_convergence` recovery metadata as suspicious, so legacy state may re-enter reconciliation until repaired.
-- Last focused commands: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
+- Last focused command:
+- Last focused commands: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `python3 .../fetch_comments.py TommyKammy/codex-supervisor 1523`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -655,7 +655,9 @@ export async function reconcileMergedIssueClosures(
       pr_number: satisfyingPullRequest.number,
       last_head_sha: satisfyingPullRequest.headRefOid,
     });
-    if (needsRecordUpdate(record, patch)) {
+    const needsMergedConvergenceBackfill =
+      !record.last_recovery_reason?.startsWith("merged_pr_convergence:");
+    if (needsRecordUpdate(record, patch) || needsMergedConvergenceBackfill) {
       const recoveryEvent = buildRecoveryEvent(
         record.issue_number,
         `merged_pr_convergence: merged PR #${satisfyingPullRequest.number} satisfied issue #${record.issue_number}; marked issue #${record.issue_number} done`,

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -344,6 +344,7 @@ function shouldRevalidateMergedIssueClosureRecord(
     | "state"
     | "pr_number"
     | "last_head_sha"
+    | "last_recovery_reason"
     | "last_failure_context"
     | "last_recovery_at"
     | "updated_at"
@@ -360,6 +361,10 @@ function shouldRevalidateMergedIssueClosureRecord(
   }
 
   if (record.pr_number === null || record.last_head_sha === null) {
+    return true;
+  }
+
+  if (!record.last_recovery_reason?.startsWith("merged_pr_convergence:")) {
     return true;
   }
 

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -316,6 +316,8 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
       branch: `codex/historical-done-${700 + index}`,
       pr_number: 1700 + index,
       last_head_sha: `head-${700 + index}`,
+      last_recovery_reason:
+        `merged_pr_convergence: merged PR #${1700 + index} satisfied issue #${700 + index}; marked issue #${700 + index} done`,
       updated_at: "2026-03-13T00:25:00Z",
       last_recovery_at: "2026-03-13T00:25:00Z",
       last_failure_context: null,
@@ -344,6 +346,8 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
     branch: "codex/recently-changed-960",
     pr_number: 1960,
     last_head_sha: "head-960",
+    last_recovery_reason:
+      "merged_pr_convergence: merged PR #1960 satisfied issue #960; marked issue #960 done",
     updated_at: "2026-03-13T00:25:00Z",
     last_recovery_at: "2026-03-13T00:25:00Z",
     last_failure_context: null,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3590,6 +3590,7 @@ test("reconcileMergedIssueClosures revalidates suspicious closed done records wi
     state: "done",
     pr_number: 191,
     last_head_sha: "wrong-head-191",
+    last_recovery_reason: null,
     updated_at: "2026-03-13T00:25:00Z",
     last_recovery_at: "2026-03-13T00:25:00Z",
     last_failure_context: null,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3468,6 +3468,8 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
       state: "done",
       pr_number: 1700 + index,
       last_head_sha: `head-${700 + index}`,
+      last_recovery_reason:
+        `merged_pr_convergence: merged PR #${1700 + index} satisfied issue #${700 + index}; marked issue #${700 + index} done`,
       updated_at: "2026-03-13T00:25:00Z",
       last_recovery_at: "2026-03-13T00:25:00Z",
       last_failure_context: null,
@@ -3494,6 +3496,8 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
     state: "done",
     pr_number: 1960,
     last_head_sha: "head-960",
+    last_recovery_reason:
+      "merged_pr_convergence: merged PR #1960 satisfied issue #960; marked issue #960 done",
     updated_at: "2026-03-13T00:25:00Z",
     last_recovery_at: "2026-03-13T00:25:00Z",
     last_failure_context: null,
@@ -3578,6 +3582,85 @@ test("reconcileMergedIssueClosures skips historical terminal records but still r
 
   assert.deepEqual(mergedClosureLookups, [959, 960, 961]);
   assert.deepEqual(recoveryEvents, []);
+});
+
+test("reconcileMergedIssueClosures revalidates suspicious closed done records with stale merged provenance even when issue updatedAt is older", async () => {
+  const staleProvenanceRecord = createRecord({
+    issue_number: 962,
+    state: "done",
+    pr_number: 191,
+    last_head_sha: "wrong-head-191",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [staleProvenanceRecord],
+  });
+  const issues = [
+    createIssue({
+      number: staleProvenanceRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
+  ];
+  const mergedClosureLookups: number[] = [];
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileMergedIssueClosures(
+    {
+      getMergedPullRequestsClosingIssue: async (issueNumber) => {
+        mergedClosureLookups.push(issueNumber);
+        return [
+          createPullRequest({
+            number: 191,
+            state: "MERGED",
+            headRefOid: "head-new-191",
+            mergedAt: "2026-03-13T00:19:00Z",
+          }),
+        ];
+      },
+      getPullRequestIfExists: async () => null,
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:35:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    issues,
+  );
+
+  assert.deepEqual(mergedClosureLookups, [962]);
+  assert.equal(state.issues["962"]?.pr_number, 191);
+  assert.equal(state.issues["962"]?.last_head_sha, "head-new-191");
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "merged_pr_convergence: merged PR #191 satisfied issue #962; marked issue #962 done",
+  ]);
 });
 
 test("reconcileStaleFailedIssueStates requeues failed no-PR issues when the issue definition changes materially", async () => {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3663,6 +3663,91 @@ test("reconcileMergedIssueClosures revalidates suspicious closed done records wi
   ]);
 });
 
+test("reconcileMergedIssueClosures backfills merged convergence provenance even when stored PR metadata already matches", async () => {
+  const convergedButUntrustedRecord = createRecord({
+    issue_number: 963,
+    state: "done",
+    pr_number: 191,
+    last_head_sha: "head-current-191",
+    last_recovery_reason: "manual_requeue: operator requeued issue #963 previously",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [convergedButUntrustedRecord],
+  });
+  const issues = [
+    createIssue({
+      number: convergedButUntrustedRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
+  ];
+  const mergedClosureLookups: number[] = [];
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileMergedIssueClosures(
+    {
+      getMergedPullRequestsClosingIssue: async (issueNumber) => {
+        mergedClosureLookups.push(issueNumber);
+        return [
+          createPullRequest({
+            number: 191,
+            state: "MERGED",
+            headRefOid: "head-current-191",
+            mergedAt: "2026-03-13T00:19:00Z",
+          }),
+        ];
+      },
+      getPullRequestIfExists: async () => null,
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:35:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    issues,
+  );
+
+  assert.deepEqual(mergedClosureLookups, [963]);
+  assert.equal(state.issues["963"]?.pr_number, 191);
+  assert.equal(state.issues["963"]?.last_head_sha, "head-current-191");
+  assert.equal(
+    state.issues["963"]?.last_recovery_reason,
+    "merged_pr_convergence: merged PR #191 satisfied issue #963; marked issue #963 done",
+  );
+  assert.equal(state.issues["963"]?.updated_at, "2026-03-13T00:35:00Z");
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "merged_pr_convergence: merged PR #191 satisfied issue #963; marked issue #963 done",
+  ]);
+});
+
 test("reconcileStaleFailedIssueStates requeues failed no-PR issues when the issue definition changes materially", async () => {
   const config = createConfig();
   const originalIssue = createIssue({


### PR DESCRIPTION
## Summary
- revalidate closed done records when merged provenance is present but lacks recorded merged-closure convergence
- keep the bounded historical backlog behavior for records with trusted merged_pr_convergence provenance
- add focused regressions for stale provenance and the bounded prelude backlog path

## Testing
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts
- npm run build

Closes #1522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted merged-closure revalidation to reliably backfill and persist merged-resolution provenance even in cases where PR metadata appears to match, and to force revalidation when prior provenance is missing or untrusted.

* **Tests**
  * Added tests covering backfill and revalidation behaviors for historical and recently-changed closed issues, including cases with stale or missing provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->