### PR TITLE
Fix stale tracked PR review bot blocker convergence

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,47 +1,33 @@
-# Issue #1520: Bug: run-once prelude revalidates historical closed issues via merged_issue_closures on every cycle
+# Issue #1524: Bug: tracked PR stale_review_bot blockers should auto-clear when GitHub threads are already resolved
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1520
-- Branch: codex/issue-1520
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1524
+- Branch: codex/issue-1524
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 717f492d1e7c713107e522573ab130135b57892f
+- Current phase: stabilizing
+- Attempt count: 3 (implementation=3, repair=0)
+- Last head SHA: 6154a5e6dac2c30fee62f3899fa5c7713440175b
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856w4vK|PRRT_kwDORgvdZ856w4vO
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T09:19:30.705Z
+- Last failure signature: stale-stabilizing-no-pr-recovery-loop
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T11:04:57.377Z
 
 ## Latest Codex Summary
-Implemented a narrow fix in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts) so `reconcileMergedIssueClosures()` no longer scans historical closed terminal records every cycle. It now revalidates only when the closed issue is still active locally, not yet terminal locally, or GitHub’s `updatedAt` is newer than the local terminal timestamps. That preserves convergence for suspicious/recently changed closures without paying O(history) GraphQL cost on old `done` backlogs.
-
-I added focused regressions in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts) and [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts) that prove a `160`-record historical closed backlog no longer causes `160` merged-closure lookups, while recently changed and non-terminal closed records still revalidate. I also updated the issue journal and committed the checkpoint as `717f492` with message `Bound merged issue closure revalidation`.
-
-Summary: Bounded `merged_issue_closures` revalidation to active, non-terminal, or newly changed closed issues; added direct and prelude regression tests; build passed; committed as `717f492`.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
-Next action: Open or update a draft PR for `codex/issue-1520` with commit `717f492` and let CI validate the bounded merged-closure behavior
-Failure signature: PRRT_kwDORgvdZ856w4vK|PRRT_kwDORgvdZ856w4vO
+- Tracked PR stale `stale_review_bot` reconciliation now ignores the auto-reply policy gate and always reprojections same-head tracked PR blockers from fresh GitHub facts; focused regressions and build passed locally.
 
 ## Active Failure Context
-- Category: review
-- Summary: 2 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391599
-- Details:
-  - .codex-supervisor/issue-journal.md:29 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Minor wording polish on verification note.** Line 29 reads more cleanly as “locally focused tests” (or “local-focused tests”). url=https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391599
-  - src/recovery-reconciliation.ts:366 summary=_⚠️ Potential issue_ | _🟠 Major_ **Keep provenance-free `done` records eligible for merged-closure backfill.** Once a record reaches `done`, this gate treats it as converged ba... url=https://github.com/TommyKammy/codex-supervisor/pull/1521#discussion_r3078391603
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The review-thread regression was real because the new timestamp-only gate could treat a provenance-free `done` record as converged forever, preventing `merged_issue_closures` from backfilling merged PR provenance for suspicious closed issues.
-- What changed: Tightened `shouldRevalidateMergedIssueClosureRecord()` in `src/recovery-reconciliation.ts` so `done` records still revalidate when `pr_number` or `last_head_sha` is missing, even if GitHub has not updated since the local terminal timestamp. Extended the direct reconciliation and `runOnceCyclePrelude` backlog tests to prove provenance-free `done` records still trigger bounded merged-closure lookups. Updated the verification note wording to "locally focused tests".
-- Current blocker: none
-- Next exact step: Commit the review-thread fix on `codex/issue-1520`, push the branch, and update PR #1521 so the unresolved automated review threads can be re-evaluated on the new head.
-- Verification gap: No PR/CI verification yet on the review-fix head; locally focused tests and `npm run build` passed.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/run-once-cycle-prelude.test.ts`
-- Rollback concern: Low. The change only widens revalidation for suspicious closed `done` records that are missing merged-closure provenance; historical terminal records with intact provenance remain bounded by the timestamp gate.
-- Last focused command: `npm run build`
+- Hypothesis: `stale_review_bot` was incorrectly treated as auto-recovery-policy-gated durable state; convergence should instead always reproject tracked PR blockers from fresh GitHub facts, even under `diagnose_only`.
+- What changed: refactored `src/supervisor/supervisor-execution-policy.ts` so `shouldAutoRecoverStaleReviewBot` stays policy-gated but `shouldReconcileTrackedPrStaleReviewBot` now only checks whether the record is a tracked `stale_review_bot` block; added regressions covering recovery, runOnce, explain, and doctor behavior under `diagnose_only`.
+- Current blocker: none.
+- Next exact step: commit the focused checkpoint, push `codex/issue-1524`, and open a draft PR for review.
+- Verification gap: none for the requested scope; targeted suites and `npm run build` passed locally.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-execution-policy.ts`, `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-pr-review-blockers.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/doctor.test.ts`.
+- Rollback concern: low; the behavior change is intentionally limited to stale tracked-PR blocker reprojection, while automatic stale-bot reply handling still depends on the configured policy.
+- Last focused commands: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,44 +5,38 @@
 - Branch: codex/issue-1524
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: resolving_conflict
-- Attempt count: 4 (implementation=3, repair=1)
-- Last head SHA: fed7a48657e0ad13f65c53bfea9cf316edbf76c7
+- Current phase: draft_pr
+- Attempt count: 5 (implementation=3, repair=2)
+- Last head SHA: b7f0e82e38f260e4de5e83506ae19d19e2f6d19d
 - Blocked reason: none
-- Last failure signature: dirty:fed7a48657e0ad13f65c53bfea9cf316edbf76c7
-- Repeated failure signature count: 3
-- Updated at: 2026-04-14T11:10:21.067Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T11:15:24Z
 
 ## Latest Codex Summary
-The tracked-PR reconciliation path now clears stale `stale_review_bot` blockers from fresh GitHub facts even when `staleConfiguredBotReviewPolicy=diagnose_only`, while the automatic reply/resolve path remains policy-gated in [src/supervisor/supervisor-execution-policy.ts](src/supervisor/supervisor-execution-policy.ts). I added focused regressions for reconciliation, `runOnce`, `explain`, and `doctor` in [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts), [src/supervisor/supervisor-pr-review-blockers.test.ts](src/supervisor/supervisor-pr-review-blockers.test.ts), [src/supervisor/supervisor-diagnostics-explain.test.ts](src/supervisor/supervisor-diagnostics-explain.test.ts), and [src/doctor.test.ts](src/doctor.test.ts).
+Merged `origin/main` into `codex/issue-1524` as commit `b7f0e82` to pick up PR `#1523`'s merged-closure provenance backfill in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts), [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts), and [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts). The only textual conflict was the issue journal, which I resolved in favor of the `#1524` record.
 
-I committed and pushed the checkpoint on `codex/issue-1524`, updated the issue journal, and opened draft PR `#1525`: https://github.com/TommyKammy/codex-supervisor/pull/1525. The only remaining local changes are untracked supervisor artifact directories under `.codex-supervisor/`, which I left out of git.
+The stale tracked-PR `stale_review_bot` auto-clear behavior remains intact on top of the new base. Focused verification passed with `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts` and `npm run build`. Draft PR `#1525` is ready for a push to refresh GitHub mergeability.
 
-Summary: Implemented and verified stale tracked-PR `stale_review_bot` auto-clear reconciliation, pushed branch, and opened draft PR #1525.
+Summary: Integrated `origin/main`, resolved the journal-only conflict, and reverified the stale tracked-PR blocker fix plus the merged recovery-path changes.
 State hint: draft_pr
 Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
-Next action: Wait for review and CI on draft PR #1525, then address any findings.
-Failure signature: dirty:fed7a48657e0ad13f65c53bfea9cf316edbf76c7
+Tests: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
+Next action: Push `codex/issue-1524` so PR #1525 can recompute mergeability on the integrated head, then address any new review or CI signals.
+Failure signature: none
 
 ## Active Failure Context
-- Category: conflict
-- Summary: PR #1525 has merge conflicts and needs a base-branch integration pass.
-- Command or source: git fetch origin && git merge origin/<default-branch>
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1525
-- Details:
-  - mergeStateStatus=DIRTY
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `stale_review_bot` was incorrectly treated as auto-recovery-policy-gated durable state; convergence should instead always reproject tracked PR blockers from fresh GitHub facts, even under `diagnose_only`.
-- What changed: refactored `src/supervisor/supervisor-execution-policy.ts` so `shouldAutoRecoverStaleReviewBot` stays policy-gated but `shouldReconcileTrackedPrStaleReviewBot` now only checks whether the record is a tracked `stale_review_bot` block; added regressions covering recovery, runOnce, explain, and doctor behavior under `diagnose_only`.
+- Hypothesis: the only real merge conflict was the per-issue journal; `#1523`'s merged-closure provenance backfill composes cleanly with `#1524`'s stale tracked-PR blocker convergence logic.
+- What changed: stashed supervisor artifacts, merged `origin/main`, kept the `#1524` journal content, accepted upstream edits in `src/recovery-reconciliation.ts`, `src/run-once-cycle-prelude.test.ts`, and `src/supervisor/supervisor-recovery-reconciliation.test.ts`, then reran the combined focused verification set.
 - Current blocker: none.
-- Next exact step: wait for review on draft PR #1525 and address any feedback or CI findings.
-- Verification gap: none for the requested scope; targeted suites and `npm run build` passed locally.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-execution-policy.ts`, `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-pr-review-blockers.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/doctor.test.ts`.
-- Rollback concern: low; the behavior change is intentionally limited to stale tracked-PR blocker reprojection, while automatic stale-bot reply handling still depends on the configured policy.
-- Last focused command:
-- Last focused commands: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`; `git push -u origin codex/issue-1524`; `gh pr edit 1525 --body ...`
+- Next exact step: push the integrated branch to update draft PR #1525, then confirm GitHub clears the old DIRTY merge state on the new head.
+- Verification gap: none for the issue-scoped and merge-scoped checks; GitHub-side mergeability still needs its normal post-push refresh.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
+- Rollback concern: low; this turn only integrates already-merged base-branch recovery changes on top of the existing stale tracked-PR blocker fix.
+- Last focused commands: `git stash push --include-untracked -m 'issue-1524-pre-merge' -- .codex-supervisor/issue-journal.md .codex-supervisor/pre-merge .codex-supervisor/replay .codex-supervisor/turn-in-progress.json`; `git fetch origin`; `git merge origin/main`; `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`; `git commit -m "Merge origin/main into codex/issue-1524"`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -14,7 +14,7 @@
 - Updated at: 2026-04-14T11:04:57.377Z
 
 ## Latest Codex Summary
-- Tracked PR stale `stale_review_bot` reconciliation now ignores the auto-reply policy gate and always reprojections same-head tracked PR blockers from fresh GitHub facts; focused regressions and build passed locally.
+- Tracked PR stale `stale_review_bot` reconciliation now ignores the auto-reply policy gate and always reprojects same-head tracked PR blockers from fresh GitHub facts; focused regressions and build passed locally, commit `13520d4` is pushed on `codex/issue-1524`, and draft PR #1525 is open.
 
 ## Active Failure Context
 - None recorded.
@@ -24,10 +24,10 @@
 - Hypothesis: `stale_review_bot` was incorrectly treated as auto-recovery-policy-gated durable state; convergence should instead always reproject tracked PR blockers from fresh GitHub facts, even under `diagnose_only`.
 - What changed: refactored `src/supervisor/supervisor-execution-policy.ts` so `shouldAutoRecoverStaleReviewBot` stays policy-gated but `shouldReconcileTrackedPrStaleReviewBot` now only checks whether the record is a tracked `stale_review_bot` block; added regressions covering recovery, runOnce, explain, and doctor behavior under `diagnose_only`.
 - Current blocker: none.
-- Next exact step: commit the focused checkpoint, push `codex/issue-1524`, and open a draft PR for review.
+- Next exact step: wait for review on draft PR #1525 and address any feedback or CI findings.
 - Verification gap: none for the requested scope; targeted suites and `npm run build` passed locally.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/supervisor/supervisor-execution-policy.ts`, `src/supervisor/supervisor-execution-policy.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-pr-review-blockers.test.ts`, `src/supervisor/supervisor-diagnostics-explain.test.ts`, `src/doctor.test.ts`.
 - Rollback concern: low; the behavior change is intentionally limited to stale tracked-PR blocker reprojection, while automatic stale-bot reply handling still depends on the configured policy.
-- Last focused commands: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
+- Last focused commands: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`; `git push -u origin codex/issue-1524`; `gh pr edit 1525 --body ...`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1673,6 +1673,90 @@ test("diagnoseSupervisorHost skips tracked PR hydration for historical done reco
   );
 });
 
+test("diagnoseSupervisorHost exposes stale_review_bot tracked PR mismatches when GitHub is already clear", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-172");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "fixture\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "fixture"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  execFileSync("git", ["-C", repoPath, "worktree", "add", "-b", "codex/reopen-issue-172", workspace], {
+    encoding: "utf8",
+  });
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    stateFile,
+    codexBinary: process.execPath,
+    localCiCommand: "npm run ci:local",
+  });
+  const trackedState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "172": createRecord({
+        issue_number: 172,
+        state: "blocked",
+        branch: "codex/reopen-issue-172",
+        workspace,
+        pr_number: 272,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: "head-ready-272",
+        last_failure_signature: "stalled-bot:thread-1",
+      }),
+    },
+  };
+  const readyPr = createPullRequest({
+    number: 272,
+    headRefName: "codex/reopen-issue-172",
+    headRefOid: "head-ready-272",
+  });
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config,
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => trackedState,
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 1,
+        truncated: false,
+      }),
+      getPullRequestIfExists: async () => readyPr,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#172 pr=#272 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes/,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=worktrees detail=recovery_guidance=Tracked PR facts are fresher than local state; run a one-shot supervisor cycle such as `node dist\/index\.js run-once --config \.\.\. --dry-run` to refresh tracked PR state\. Explicit requeue is unavailable for tracked PR work\./,
+  );
+});
+
 test("diagnoseSupervisorHost preserves draft tracked PR verification blockers instead of suggesting a no-op rerun", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -6,6 +6,7 @@ import { GitHubIssue, SupervisorStateFile } from "../core/types";
 import { Supervisor } from "./supervisor";
 import {
   branchName,
+  createConfig,
   createRecord,
   createPullRequest,
   createSupervisorFixture,
@@ -952,6 +953,109 @@ Explain should still render when tracked PR hydration fails.
   assert.match(explanation, /^blocked_reason=manual_review$/m);
   assert.doesNotMatch(explanation, /^tracked_pr_mismatch /m);
   assert.doesNotMatch(explanation, /^recovery_guidance=/m);
+});
+
+test("explain does not keep reporting stale_review_bot after a same-head tracked PR refresh clears it", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 173;
+  const branch = branchName(fixture.config, issueNumber);
+  const runHeadSha = git(["rev-parse", "HEAD"], fixture.repoPath);
+  const config = createConfig({
+    ...fixture.config,
+    staleConfiguredBotReviewPolicy: "diagnose_only",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 273,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: runHeadSha,
+        last_error: "configured bot review stayed stale on the current head",
+        last_failure_signature: "stalled-bot:thread-1",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-1",
+          command: null,
+          details: ["reviewer=copilot-pull-request-reviewer file=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/273#discussion_r1",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_stale_review_bot_reply_head_sha: runHeadSha,
+        last_stale_review_bot_reply_signature: "stalled-bot:thread-1",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain clears stale stale_review_bot after tracked PR reconciliation",
+    body: `## Summary
+Explain should stop reporting stale stale_review_bot blockers after fresh tracked PR hydration clears them.
+
+## Scope
+- clear stale same-head configured-bot blockers using authoritative GitHub facts
+
+## Acceptance criteria
+- explain reports the refreshed ready-to-merge state after the stale blocker converges
+
+## Verification
+- npm test -- src/supervisor/supervisor-diagnostics-explain.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const readyPr = createPullRequest({
+    number: 273,
+    headRefName: branch,
+    headRefOid: runHeadSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    copilotReviewState: "arrived",
+    copilotReviewArrivedAt: "2026-03-13T00:10:00Z",
+  });
+
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => readyPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequest: async () => readyPr,
+    getPullRequestIfExists: async () => readyPr,
+    getMergedPullRequestsClosingIssue: async () => [],
+    enableAutoMerge: async () => {},
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  await supervisor.runOnce({ dryRun: true });
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^state=ready_to_merge$/m);
+  assert.match(explanation, /^blocked_reason=none$/m);
+  assert.doesNotMatch(explanation, /^blocked_reason=stale_review_bot$/m);
+  assert.doesNotMatch(explanation, /^tracked_pr_mismatch /m);
 });
 
 test("explain reuses normalized change-risk policy for risky ambiguity blockers", async () => {

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -415,7 +415,7 @@ test("shouldReconcileTrackedPrStaleReviewBot keeps same-head stale configured-bo
   );
   assert.equal(
     shouldReconcileTrackedPrStaleReviewBot(record, createConfig({ staleConfiguredBotReviewPolicy: "diagnose_only" })),
-    false,
+    true,
   );
   assert.equal(
     shouldReconcileTrackedPrStaleReviewBot(createRecord({ ...record, pr_number: null }), createConfig({

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -75,6 +75,16 @@ function staleReviewBotRecoverySignature(record: Pick<IssueRunRecord, "last_fail
   return record.last_failure_signature ?? "stale_review_bot";
 }
 
+function isTrackedPrStaleReviewBot(
+  record: Pick<IssueRunRecord, "state" | "blocked_reason" | "pr_number">,
+): boolean {
+  return (
+    record.state === "blocked" &&
+    record.blocked_reason === "stale_review_bot" &&
+    record.pr_number !== null
+  );
+}
+
 function hasStaleReviewBotRecoveryPolicy(config: SupervisorConfig): boolean {
   return (
     config.staleConfiguredBotReviewPolicy === "reply_only" ||
@@ -103,16 +113,16 @@ function canAutoRecoverCurrentStaleReviewBotHead(
 }
 
 export function shouldAutoRecoverStaleReviewBot(record: IssueRunRecord, config: SupervisorConfig): boolean {
-  return shouldReconcileTrackedPrStaleReviewBot(record, config) && canAutoRecoverCurrentStaleReviewBotHead(record);
+  return (
+    isTrackedPrStaleReviewBot(record) &&
+    hasStaleReviewBotRecoveryPolicy(config) &&
+    canAutoRecoverCurrentStaleReviewBotHead(record)
+  );
 }
 
 export function shouldReconcileTrackedPrStaleReviewBot(record: IssueRunRecord, config: SupervisorConfig): boolean {
-  return (
-    record.state === "blocked" &&
-    record.blocked_reason === "stale_review_bot" &&
-    record.pr_number !== null &&
-    hasStaleReviewBotRecoveryPolicy(config)
-  );
+  void config;
+  return isTrackedPrStaleReviewBot(record);
 }
 
 export function shouldEnforceExecutionReady(

--- a/src/supervisor/supervisor-pr-review-blockers.test.ts
+++ b/src/supervisor/supervisor-pr-review-blockers.test.ts
@@ -280,6 +280,126 @@ test("runOnce clears stale same-head stalled review-thread blockers after GitHub
   assert.equal(record.last_failure_context, null);
 });
 
+test("runOnce clears stale same-head stale_review_bot blockers after GitHub threads are manually resolved under diagnose_only", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 118;
+  const branch = branchName(fixture.config, issueNumber);
+  const runHeadSha = git(["rev-parse", "HEAD"], fixture.repoPath);
+  const config = createConfig({
+    ...fixture.config,
+    staleConfiguredBotReviewPolicy: "diagnose_only",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: issueNumber,
+        last_head_sha: runHeadSha,
+        blocked_reason: "stale_review_bot",
+        last_failure_signature: "stalled-bot:thread-1",
+        repeated_failure_signature_count: 2,
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-1",
+          command: null,
+          details: ["reviewer=copilot-pull-request-reviewer file=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/118#discussion_r1",
+          updated_at: "2026-03-13T06:25:00Z",
+        },
+        last_stale_review_bot_reply_head_sha: runHeadSha,
+        last_stale_review_bot_reply_signature: "stalled-bot:thread-1",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Clear stale stale_review_bot blockers after manual GitHub thread resolution",
+    body: executionReadyBody("Clear stale stale_review_bot blockers after manual GitHub thread resolution."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: issueNumber,
+    title: "Clear stale review bot blockers",
+    url: `https://example.test/pr/${issueNumber}`,
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: runHeadSha,
+    copilotReviewState: "arrived",
+    copilotReviewArrivedAt: "2026-03-13T06:20:00Z",
+    mergedAt: null,
+  };
+
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      assert.equal(branchName, branch);
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return [];
+    },
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getPullRequestIfExists: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    enableAutoMerge: async (prNumber: number, headSha: string) => {
+      assert.equal(prNumber, issueNumber);
+      assert.equal(headSha, runHeadSha);
+    },
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /state=ready_to_merge/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "ready_to_merge");
+  assert.equal(record.blocked_reason, null);
+  assert.equal(record.last_failure_signature, null);
+  assert.equal(record.repeated_failure_signature_count, 0);
+  assert.equal(record.last_failure_context, null);
+});
+
 test("runOnce does not mark configured bot review threads as processed for a refreshed PR head it did not evaluate", async () => {
   const fixture = await createSupervisorFixture({
     codexScriptLines: [

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2558,6 +2558,113 @@ test("reconcileRecoverableBlockedIssueStates rehydrates same-head stale configur
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates clears stale same-head configured-bot blockers under diagnose_only when GitHub is already clear", async () => {
+  const config = createConfig({
+    staleConfiguredBotReviewPolicy: "diagnose_only",
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createTrackedPrStaleReviewRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        local_review_head_sha: "head-191",
+        local_review_summary_path: "/tmp/reviews/issue-366/head-191.md",
+        last_error: "Configured bot review stayed stale on the current head.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "blocked",
+          summary: "Configured bot review stayed stale on the current head.",
+          signature: "stale-configured-bot-review",
+          command: null,
+          details: ["tracked_pr=head-191"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "stale-configured-bot-review",
+        last_stale_review_bot_reply_head_sha: "head-191",
+        last_stale_review_bot_reply_signature: "stale-configured-bot-review",
+        stale_review_bot_reply_progress_keys: ["reply:thread-1@head-191"],
+        stale_review_bot_resolve_progress_keys: ["resolve:thread-1@head-191"],
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    isDraft: false,
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "ready_to_merge",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "ready_to_merge");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.last_stale_review_bot_reply_head_sha, "head-191");
+  assert.equal(updated.last_stale_review_bot_reply_signature, "stale-configured-bot-review");
+  assert.deepEqual(updated.stale_review_bot_reply_progress_keys, ["reply:thread-1@head-191"]);
+  assert.deepEqual(updated.stale_review_bot_resolve_progress_keys, ["resolve:thread-1@head-191"]);
+  assert.equal(
+    updated.last_recovery_reason,
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to ready_to_merge using fresh tracked PR #191 facts at head head-191",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to ready_to_merge using fresh tracked PR #191 facts at head head-191",
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates clears stale head-scoped review state after a tracked PR repair push", async () => {
   const config = createConfig({
     localReviewEnabled: true,


### PR DESCRIPTION
## Summary
- auto-clear tracked PR stale_review_bot blockers when fresh GitHub thread facts no longer support them
- keep stale configured-bot auto-reply behavior policy-gated while allowing tracked PR reconciliation under diagnose_only
- add focused regressions for reconciliation, runOnce, explain, and doctor

## Verification
- npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npm run build

Closes #1524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added diagnostic tests for stale review bot handling and tracked PR state mismatches.
  * Added recovery reconciliation tests for diagnose-only policy scenarios.
  * Enhanced test coverage for supervisor state synchronization with GitHub.

* **Refactor**
  * Simplified internal logic for handling stale review bot blockers and PR state reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->