### PR TITLE
Bug: bound merged_issue_closures reconciliation on large hosts (#1526)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,42 +1,33 @@
-# Issue #1524: Bug: tracked PR stale_review_bot blockers should auto-clear when GitHub threads are already resolved
+# Issue #1526: Bug: bound merged_issue_closures reconciliation on large hosts
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1524
-- Branch: codex/issue-1524
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1526
+- Branch: codex/issue-1526
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: draft_pr
-- Attempt count: 5 (implementation=3, repair=2)
-- Last head SHA: b7f0e82e38f260e4de5e83506ae19d19e2f6d19d
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: c18c814661a12a0e18edb80c4061ce4eb8f687c0
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T11:15:24Z
+- Updated at: 2026-04-14T11:47:07.467Z
 
 ## Latest Codex Summary
-Merged `origin/main` into `codex/issue-1524` as commit `b7f0e82` to pick up PR `#1523`'s merged-closure provenance backfill in [src/recovery-reconciliation.ts](src/recovery-reconciliation.ts), [src/run-once-cycle-prelude.test.ts](src/run-once-cycle-prelude.test.ts), and [src/supervisor/supervisor-recovery-reconciliation.test.ts](src/supervisor/supervisor-recovery-reconciliation.test.ts). The only textual conflict was the issue journal, which I resolved in favor of the `#1524` record.
-
-The stale tracked-PR `stale_review_bot` auto-clear behavior remains intact on top of the new base. Focused verification passed with `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts` and `npm run build`. Draft PR `#1525` is ready for a push to refresh GitHub mergeability.
-
-Summary: Integrated `origin/main`, resolved the journal-only conflict, and reverified the stale tracked-PR blocker fix plus the merged recovery-path changes.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`
-Next action: Push `codex/issue-1524` so PR #1525 can recompute mergeability on the integrated head, then address any new review or CI signals.
-Failure signature: none
+- Added bounded, resumable `merged_issue_closures` reconciliation with persisted cursor state and phase progress propagation, plus focused two-cycle backlog coverage.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the only real merge conflict was the per-issue journal; `#1523`'s merged-closure provenance backfill composes cleanly with `#1524`'s stale tracked-PR blocker convergence logic.
-- What changed: stashed supervisor artifacts, merged `origin/main`, kept the `#1524` journal content, accepted upstream edits in `src/recovery-reconciliation.ts`, `src/run-once-cycle-prelude.test.ts`, and `src/supervisor/supervisor-recovery-reconciliation.test.ts`, then reran the combined focused verification set.
-- Current blocker: none.
-- Next exact step: push the integrated branch to update draft PR #1525, then confirm GitHub clears the old DIRTY merge state on the new head.
-- Verification gap: none for the issue-scoped and merge-scoped checks; GitHub-side mergeability still needs its normal post-push refresh.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-reconciliation.ts`, `src/run-once-cycle-prelude.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`.
-- Rollback concern: low; this turn only integrates already-merged base-branch recovery changes on top of the existing stale tracked-PR blocker fix.
-- Last focused commands: `git stash push --include-untracked -m 'issue-1524-pre-merge' -- .codex-supervisor/issue-journal.md .codex-supervisor/pre-merge .codex-supervisor/replay .codex-supervisor/turn-in-progress.json`; `git fetch origin`; `git merge origin/main`; `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npm run build`; `git commit -m "Merge origin/main into codex/issue-1524"`
+- Hypothesis: `reconcileMergedIssueClosures` was still doing an unbounded sweep over every revalidation-eligible closed record because it had no per-cycle budget or persisted cursor, so large hosts always restarted at the beginning of the backlog.
+- What changed: Added `merged_issue_closures_last_processed_issue_number` to `reconciliation_state`; bounded `reconcileMergedIssueClosures` to 25 records per pass by default; persisted and resumed a merged-closure cursor across cycles; propagated merged-closure target progress through `runOnceCyclePrelude`; added focused coverage for two-cycle resume behavior and merged-phase progress updates.
+- Current blocker: none
+- Next exact step: Commit the bounded/resumable reconciliation changes on `codex/issue-1526`.
+- Verification gap: none for the requested local scope; existing tests still emit known execution-metrics warning logs in fixtures, but the suites pass.
+- Files touched: .codex-supervisor/issue-journal.md; src/core/types.ts; src/recovery-reconciliation.ts; src/run-once-cycle-prelude.ts; src/run-once-cycle-prelude.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor.ts
+- Rollback concern: Cursor resume order now prioritizes an active closed issue before the resumed backlog; if reverted, large-host `merged_issue_closures` prelude latency will return to full-scan behavior.
+- Last focused command: npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -396,6 +396,7 @@ export interface SupervisorStateFile {
   issues: Record<string, IssueRunRecord>;
   reconciliation_state?: {
     tracked_merged_but_open_last_processed_issue_number?: number | null;
+    merged_issue_closures_last_processed_issue_number?: number | null;
   };
   inventory_refresh_failure?: InventoryRefreshFailure;
   last_successful_inventory_snapshot?: LastSuccessfulInventorySnapshot;

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -230,6 +230,67 @@ function orderTrackedMergedButOpenRecordsForResume(
   ];
 }
 
+function mergedIssueClosuresLastProcessedIssueNumber(state: SupervisorStateFile): number | null {
+  return state.reconciliation_state?.merged_issue_closures_last_processed_issue_number ?? null;
+}
+
+function setMergedIssueClosuresLastProcessedIssueNumber(
+  state: SupervisorStateFile,
+  issueNumber: number | null,
+): boolean {
+  const currentIssueNumber = mergedIssueClosuresLastProcessedIssueNumber(state);
+  if (currentIssueNumber === issueNumber) {
+    return false;
+  }
+
+  state.reconciliation_state = {
+    ...(state.reconciliation_state ?? {}),
+    merged_issue_closures_last_processed_issue_number: issueNumber,
+  };
+  return true;
+}
+
+function orderMergedIssueClosureRecordsForResume(
+  records: IssueRunRecord[],
+  lastProcessedIssueNumber: number | null,
+): IssueRunRecord[] {
+  const ordered = [...records].sort((left, right) => left.issue_number - right.issue_number);
+  if (lastProcessedIssueNumber === null) {
+    return ordered;
+  }
+
+  const nextIndex = ordered.findIndex((record) => record.issue_number > lastProcessedIssueNumber);
+  if (nextIndex === -1) {
+    return ordered;
+  }
+
+  return [
+    ...ordered.slice(nextIndex),
+    ...ordered.slice(0, nextIndex),
+  ];
+}
+
+function prioritizeMergedIssueClosureRecords(
+  records: IssueRunRecord[],
+  lastProcessedIssueNumber: number | null,
+  activeIssueNumber: number | null,
+): IssueRunRecord[] {
+  const activeRecord = activeIssueNumber === null
+    ? null
+    : records.find((record) => record.issue_number === activeIssueNumber) ?? null;
+  const remainingRecords = activeRecord === null
+    ? records
+    : records.filter((record) => record.issue_number !== activeRecord.issue_number);
+  const orderedRemainingRecords = orderMergedIssueClosureRecordsForResume(
+    remainingRecords,
+    activeRecord === null ? lastProcessedIssueNumber : activeRecord.issue_number,
+  );
+
+  return activeRecord === null
+    ? orderedRemainingRecords
+    : [activeRecord, ...orderedRemainingRecords];
+}
+
 export function buildRecoveryEvent(issueNumber: number, reason: string): RecoveryEvent {
   return {
     issueNumber,
@@ -603,24 +664,52 @@ export async function reconcileMergedIssueClosures(
   state: SupervisorStateFile,
   config: SupervisorConfig,
   issues: GitHubIssue[],
+  updateReconciliationProgress: ((patch: {
+    targetIssueNumber?: number | null;
+    targetPrNumber?: number | null;
+    waitStep?: string | null;
+  }) => Promise<void>) | null = null,
+  options: {
+    maxRecords?: number | null;
+  } = {},
 ): Promise<RecoveryEvent[]> {
-  let changed = false;
+  const defaultMaxRecordsPerCycle = 25;
+  const maxRecordsPerCycle =
+    typeof options.maxRecords === "number" && Number.isFinite(options.maxRecords) && options.maxRecords >= 1
+      ? Math.floor(options.maxRecords)
+      : defaultMaxRecordsPerCycle;
+  let saveNeeded = false;
   const recoveryEvents: RecoveryEvent[] = [];
   const issueByNumber = new Map(issues.map((issue) => [issue.number, issue]));
-
-  for (const record of Object.values(state.issues)) {
+  const revalidationEligibleRecords = Object.values(state.issues).filter((record) => {
     const issue = issueByNumber.get(record.issue_number);
-    if (issue?.state !== "CLOSED") {
+    return issue?.state === "CLOSED" && shouldRevalidateMergedIssueClosureRecord(record, issue, state.activeIssueNumber);
+  });
+  const orderedRecords = prioritizeMergedIssueClosureRecords(
+    revalidationEligibleRecords,
+    mergedIssueClosuresLastProcessedIssueNumber(state),
+    state.activeIssueNumber,
+  );
+  let processedRecords = 0;
+  let lastProcessedIssueNumber: number | null = null;
+
+  for (const record of orderedRecords) {
+    if (processedRecords >= maxRecordsPerCycle) {
+      break;
+    }
+    processedRecords += 1;
+    lastProcessedIssueNumber = record.issue_number;
+
+    await updateReconciliationProgress?.({
+      targetIssueNumber: record.issue_number,
+      targetPrNumber: record.pr_number,
+      waitStep: null,
+    });
+
+    const issue = issueByNumber.get(record.issue_number);
+    if (!issue) {
       continue;
     }
-
-    // Historical done records with no newer GitHub activity do not need a fresh
-    // merged-closure GraphQL scan every cycle. Revalidate only active, non-terminal,
-    // or recently changed closed issues.
-    if (!shouldRevalidateMergedIssueClosureRecord(record, issue, state.activeIssueNumber)) {
-      continue;
-    }
-
     const satisfyingPullRequests = await github.getMergedPullRequestsClosingIssue(record.issue_number);
     const satisfyingPullRequest = satisfyingPullRequests[0] ?? null;
 
@@ -629,11 +718,11 @@ export async function reconcileMergedIssueClosures(
       if (needsRecordUpdate(record, patch)) {
         const updated = stateStore.touch(record, patch);
         state.issues[String(record.issue_number)] = updated;
-        changed = true;
+        saveNeeded = true;
       }
       if (state.activeIssueNumber === record.issue_number) {
         state.activeIssueNumber = null;
-        changed = true;
+        saveNeeded = true;
       }
       continue;
     }
@@ -664,7 +753,7 @@ export async function reconcileMergedIssueClosures(
       );
       const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
       state.issues[String(record.issue_number)] = updated;
-      changed = true;
+      saveNeeded = true;
       recoveryEvents.push(recoveryEvent);
       await syncExecutionMetricsRunSummarySafely({
         previousRecord: record,
@@ -692,11 +781,19 @@ export async function reconcileMergedIssueClosures(
     }
     if (state.activeIssueNumber === record.issue_number) {
       state.activeIssueNumber = null;
-      changed = true;
+      saveNeeded = true;
     }
   }
 
-  if (changed) {
+  const nextLastProcessedIssueNumber =
+    processedRecords === 0 || processedRecords >= orderedRecords.length
+      ? null
+      : lastProcessedIssueNumber;
+  if (setMergedIssueClosuresLastProcessedIssueNumber(state, nextLastProcessedIssueNumber)) {
+    saveNeeded = true;
+  }
+
+  if (saveNeeded) {
     await stateStore.save(state);
   }
 

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -844,7 +844,13 @@ test("runOnceCyclePrelude publishes reconciliation target updates within a phase
       });
       return [];
     },
-    reconcileMergedIssueClosures: async () => [],
+    reconcileMergedIssueClosures: async (_loadedState, _loadedIssues, updateReconciliationProgress) => {
+      await updateReconciliationProgress({
+        targetIssueNumber: 88,
+        targetPrNumber: 188,
+      });
+      return [];
+    },
     reconcileStaleFailedIssueStates: async () => {},
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
@@ -874,6 +880,12 @@ test("runOnceCyclePrelude publishes reconciliation target updates within a phase
       phase: "merged_issue_closures",
       targetIssueNumber: null,
       targetPrNumber: null,
+      waitStep: null,
+    },
+    {
+      phase: "merged_issue_closures",
+      targetIssueNumber: 88,
+      targetPrNumber: 188,
       waitStep: null,
     },
     {

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -56,6 +56,7 @@ interface RunOnceCyclePreludeArgs {
   reconcileMergedIssueClosures: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
+    updateReconciliationProgress: (patch: ReconciliationProgressPatch) => Promise<void>,
   ) => Promise<RecoveryEvent[]>;
   reconcileStaleFailedIssueStates: (
     state: SupervisorStateFile,
@@ -273,7 +274,7 @@ export async function runOnceCyclePrelude(
     emitRecoveryEvents(trackedMergedEvents);
 
     await setReconciliationPhase("merged_issue_closures");
-    const mergedIssueClosureEvents = await args.reconcileMergedIssueClosures(state, issues);
+    const mergedIssueClosureEvents = await args.reconcileMergedIssueClosures(state, issues, updateReconciliationProgress);
     recoveryEvents.push(...mergedIssueClosureEvents);
     emitRecoveryEvents(mergedIssueClosureEvents);
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3856,6 +3856,212 @@ test("reconcileMergedIssueClosures backfills merged convergence provenance even 
   ]);
 });
 
+test("reconcileMergedIssueClosures bounds historical backlog processing and resumes from the persisted cursor on the next cycle", async () => {
+  const firstCycleHistoricalRecord = createRecord({
+    issue_number: 959,
+    state: "done",
+    pr_number: 1959,
+    last_head_sha: "stale-head-959",
+    last_recovery_reason:
+      "merged_pr_convergence: merged PR #1959 satisfied issue #959; marked issue #959 done",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const firstCycleRecentlyChangedRecord = createRecord({
+    issue_number: 960,
+    state: "done",
+    pr_number: 1960,
+    last_head_sha: "stale-head-960",
+    last_recovery_reason:
+      "merged_pr_convergence: merged PR #1960 satisfied issue #960; marked issue #960 done",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const secondCycleNonTerminalRecord = createRecord({
+    issue_number: 961,
+    state: "waiting_ci",
+    pr_number: 1961,
+    last_head_sha: "head-961",
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const secondCycleSuspiciousDoneRecord = createRecord({
+    issue_number: 962,
+    state: "done",
+    pr_number: 1962,
+    last_head_sha: "wrong-head-962",
+    last_recovery_reason: null,
+    updated_at: "2026-03-13T00:25:00Z",
+    last_recovery_at: "2026-03-13T00:25:00Z",
+    last_failure_context: null,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_signature: null,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      firstCycleHistoricalRecord,
+      firstCycleRecentlyChangedRecord,
+      secondCycleNonTerminalRecord,
+      secondCycleSuspiciousDoneRecord,
+    ],
+  });
+  const issues = [
+    createIssue({
+      number: firstCycleHistoricalRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:30:00Z",
+    }),
+    createIssue({
+      number: firstCycleRecentlyChangedRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:30:00Z",
+    }),
+    createIssue({
+      number: secondCycleNonTerminalRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
+    createIssue({
+      number: secondCycleSuspiciousDoneRecord.issue_number,
+      state: "CLOSED",
+      updatedAt: "2026-03-13T00:20:00Z",
+    }),
+  ];
+  const mergedClosureLookups: number[] = [];
+  let saveCalls = 0;
+
+  const github = {
+    getMergedPullRequestsClosingIssue: async (issueNumber: number) => {
+      mergedClosureLookups.push(issueNumber);
+      if (issueNumber === 959) {
+        return [
+          createPullRequest({
+            number: 1959,
+            state: "MERGED",
+            headRefOid: "head-959",
+            mergedAt: "2026-03-13T00:29:00Z",
+          }),
+        ];
+      }
+      if (issueNumber === 960) {
+        return [
+          createPullRequest({
+            number: 1960,
+            state: "MERGED",
+            headRefOid: "head-960",
+            mergedAt: "2026-03-13T00:29:00Z",
+          }),
+        ];
+      }
+      if (issueNumber === 961) {
+        return [
+          createPullRequest({
+            number: 1961,
+            state: "MERGED",
+            headRefOid: "head-961",
+            mergedAt: "2026-03-13T00:19:00Z",
+          }),
+        ];
+      }
+      if (issueNumber === 962) {
+        return [
+          createPullRequest({
+            number: 1962,
+            state: "MERGED",
+            headRefOid: "head-962",
+            mergedAt: "2026-03-13T00:19:00Z",
+          }),
+        ];
+      }
+      return [];
+    },
+    getPullRequestIfExists: async () => null,
+    closePullRequest: async () => {
+      throw new Error("unexpected closePullRequest call");
+    },
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    getIssue: async () => {
+      throw new Error("unexpected getIssue call");
+    },
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:35:00Z",
+      };
+    },
+    save: async () => {
+      saveCalls += 1;
+    },
+  };
+
+  const firstCycleEvents = await reconcileMergedIssueClosures(
+    github,
+    stateStore,
+    state,
+    createConfig(),
+    issues,
+    null,
+    { maxRecords: 2 },
+  );
+
+  assert.deepEqual(mergedClosureLookups, [959, 960]);
+  assert.equal(state.reconciliation_state?.merged_issue_closures_last_processed_issue_number, 960);
+  assert.equal(state.issues["959"]?.last_head_sha, "head-959");
+  assert.equal(state.issues["960"]?.last_head_sha, "head-960");
+  assert.equal(state.issues["961"]?.state, "waiting_ci");
+  assert.equal(state.issues["962"]?.last_head_sha, "wrong-head-962");
+  assert.deepEqual(firstCycleEvents.map((event) => event.reason), [
+    "merged_pr_convergence: merged PR #1959 satisfied issue #959; marked issue #959 done",
+    "merged_pr_convergence: merged PR #1960 satisfied issue #960; marked issue #960 done",
+  ]);
+
+  const secondCycleEvents = await reconcileMergedIssueClosures(
+    github,
+    stateStore,
+    state,
+    createConfig(),
+    issues,
+    null,
+    { maxRecords: 2 },
+  );
+
+  assert.deepEqual(mergedClosureLookups, [959, 960, 961, 962]);
+  assert.equal(state.reconciliation_state?.merged_issue_closures_last_processed_issue_number, null);
+  assert.equal(state.issues["961"]?.state, "done");
+  assert.equal(state.issues["961"]?.pr_number, 1961);
+  assert.equal(state.issues["961"]?.last_head_sha, "head-961");
+  assert.equal(state.issues["962"]?.last_head_sha, "head-962");
+  assert.equal(saveCalls, 2);
+  assert.deepEqual(secondCycleEvents.map((event) => event.reason), [
+    "merged_pr_convergence: merged PR #1961 satisfied issue #961; marked issue #961 done",
+    "merged_pr_convergence: merged PR #1962 satisfied issue #962; marked issue #962 done",
+  ]);
+});
+
 test("reconcileStaleFailedIssueStates requeues failed no-PR issues when the issue definition changes materially", async () => {
   const config = createConfig();
   const originalIssue = createIssue({

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -1080,8 +1080,15 @@ export class Supervisor {
           updateReconciliationProgress,
           options,
         ),
-      reconcileMergedIssueClosures: (state, issues) =>
-        reconcileMergedIssueClosures(this.github, this.stateStore, state, this.config, issues),
+      reconcileMergedIssueClosures: (state, issues, updateReconciliationProgress) =>
+        reconcileMergedIssueClosures(
+          this.github,
+          this.stateStore,
+          state,
+          this.config,
+          issues,
+          updateReconciliationProgress,
+        ),
       reconcileStaleFailedIssueStates: (state, issues, updateReconciliationProgress) =>
         reconcileStaleFailedIssueStates(this.github, this.stateStore, state, this.config, issues, {
           inferStateFromPullRequest,


### PR DESCRIPTION
Closes #1526
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented bounded, resumable `merged_issue_closures` reconciliation and committed it as `fd30d9e` (`Bound merged issue closure reconciliation`).

The change adds a persisted `merged_issue_closures_last_processed_issue_number` cursor, caps merged-closure reconciliation to 25 records per pass by default, resumes from the saved cursor on the next cycle, and threads merged-phase target progress through `runOnceCyclePrelude`. Focused tests now cover a multi-cycle closed-record backlog plus merged-phase progress reporting, and the issue journal handoff is updated. Only supervisor-local ephemeral artifacts remain untracked: `.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, and `.codex-supervisor/turn-in-progress.json`.

Summary: Bounded `merged_issue_closures` per cycle, persisted resume cursor state, added focused two-cycle backlog coverage, propagated merged-phase progress updates, and committed the result in `fd30d9e`.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR for commit `fd30d9e5c894bec7e29b92abeb1b6fd47cdc0140` so the bounded merged-closure checkpoint can enter review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merged issue closures reconciliation now processes records in bounded batches (25 per cycle by default) instead of all at once, with progress persisted and automatically resumed across cycles for improved efficiency and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->