### PR TITLE
Perf: bound tracked_merged_but_open_issues reconciliation on large hosts (#1528)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,33 @@
-# Issue #1526: Bug: bound merged_issue_closures reconciliation on large hosts
+# Issue #1528: Perf: bound tracked_merged_but_open_issues reconciliation on large hosts
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1526
-- Branch: codex/issue-1526
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1528
+- Branch: codex/issue-1528
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: c18c814661a12a0e18edb80c4061ce4eb8f687c0
+- Last head SHA: c6699985f008033c5ac92f965a84c68729193330
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-14T11:47:07.467Z
+- Updated at: 2026-04-14T12:21:28.003Z
 
 ## Latest Codex Summary
-- Added bounded, resumable `merged_issue_closures` reconciliation with persisted cursor state and phase progress propagation, plus focused two-cycle backlog coverage.
+- Added bounded-backlog observability for `tracked_merged_but_open_issues`: recovery events now say when a pass deferred remaining tracked PR backlog, and status/doctor now surface the persisted resume cursor and backlog counts.
 
 ## Active Failure Context
 - None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `reconcileMergedIssueClosures` was still doing an unbounded sweep over every revalidation-eligible closed record because it had no per-cycle budget or persisted cursor, so large hosts always restarted at the beginning of the backlog.
-- What changed: Added `merged_issue_closures_last_processed_issue_number` to `reconciliation_state`; bounded `reconcileMergedIssueClosures` to 25 records per pass by default; persisted and resumed a merged-closure cursor across cycles; propagated merged-closure target progress through `runOnceCyclePrelude`; added focused coverage for two-cycle resume behavior and merged-phase progress updates.
+- Hypothesis: `tracked_merged_but_open_issues` was already cursor-backed and capped, but operators still lacked a clear signal that a pass intentionally stopped early and would resume from persisted state next cycle.
+- What changed: Added a bounded-backlog recovery event in tracked PR reconciliation; added shared tracked-backlog diagnostics used by read-only status and doctor; expanded focused tests and updated supervisor reconciliation expectations for the new event.
 - Current blocker: none
-- Next exact step: Commit the bounded/resumable reconciliation changes on `codex/issue-1526`.
-- Verification gap: none for the requested local scope; existing tests still emit known execution-metrics warning logs in fixtures, but the suites pass.
-- Files touched: .codex-supervisor/issue-journal.md; src/core/types.ts; src/recovery-reconciliation.ts; src/run-once-cycle-prelude.ts; src/run-once-cycle-prelude.test.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor.ts
-- Rollback concern: Cursor resume order now prioritizes an active closed issue before the resumed backlog; if reverted, large-host `merged_issue_closures` prelude latency will return to full-scan behavior.
-- Last focused command: npx tsx --test src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
+- Next exact step: stage the code+journal changes, commit the checkpoint on `codex/issue-1528`, and leave the branch ready for PR/update work.
+- Verification gap: none for the targeted issue scope; broader unrelated suites were not rerun beyond the focused reconciliation and diagnostics coverage.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-tracked-pr-reconciliation.ts`, `src/reconciliation-backlog-diagnostics.ts`, `src/supervisor/supervisor-read-only-reporting.ts`, `src/doctor.ts`, `src/recovery-tracked-pr-reconciliation.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- Rollback concern: low; the new runtime behavior is additive observability plus one extra recovery event on bounded passes, but any automation that assumed an exact single-event list for tracked PR bounded passes would need the updated expectations already included here.
+- Last focused command: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,29 +5,42 @@
 - Branch: codex/issue-1528
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: c6699985f008033c5ac92f965a84c68729193330
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 1fee534698200459364f83a7ced37678f99e1858
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-14T12:21:28.003Z
+- Last failure signature: PRRT_kwDORgvdZ856z87d
+- Repeated failure signature count: 1
+- Updated at: 2026-04-14T12:36:09.008Z
 
 ## Latest Codex Summary
-- Added bounded-backlog observability for `tracked_merged_but_open_issues`: recovery events now say when a pass deferred remaining tracked PR backlog, and status/doctor now surface the persisted resume cursor and backlog counts.
+Added bounded observability for `tracked_merged_but_open_issues`. The reconciliation path now emits an explicit recovery event when it stops at the per-cycle budget with backlog remaining, and read-only `status`/`doctor` now show the persisted resume cursor plus tracked backlog counts so operators can tell the loop is draining work rather than stuck. I also added a shared backlog-diagnostics helper and updated the focused reconciliation/diagnostics tests accordingly.
+
+Checkpoint commit: `1fee534` (`Bound tracked PR reconciliation backlog diagnostics`)
+
+Summary: Added bounded tracked-PR backlog diagnostics to recovery/status/doctor and committed the change as `1fee534`
+State hint: stabilizing
+Blocked reason: none
+Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
+Next action: Open or update the PR with commit `1fee534`, then proceed with normal review/CI checks
+Failure signature: PRRT_kwDORgvdZ856z87d
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1529#discussion_r3079464712
+- Details:
+  - src/doctor.ts:631 summary=_⚠️ Potential issue_ | _🟠 Major_ **Guard backlog-state loading so doctor doesn’t fail hard on state-read errors.** Line 625 introduces an unguarded `loadState()` call. url=https://github.com/TommyKammy/codex-supervisor/pull/1529#discussion_r3079464712
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `tracked_merged_but_open_issues` was already cursor-backed and capped, but operators still lacked a clear signal that a pass intentionally stopped early and would resume from persisted state next cycle.
-- What changed: Added a bounded-backlog recovery event in tracked PR reconciliation; added shared tracked-backlog diagnostics used by read-only status and doctor; expanded focused tests and updated supervisor reconciliation expectations for the new event.
+- Hypothesis: the bounded backlog diagnostics were correct, but `doctor` still had one unguarded follow-up `loadState()` call after the main checks that could abort the whole command on filesystem read errors.
+- What changed: Guarded the backlog-only `loadState()` call in `diagnoseSupervisorHost`, degrade that failure into the canonical `state_file` doctor check with an explicit detail line, suppress the backlog diagnostic line when the follow-up read fails, and added a regression test for the second-read-throws path.
 - Current blocker: none
-- Next exact step: stage the code+journal changes, commit the checkpoint on `codex/issue-1528`, and leave the branch ready for PR/update work.
-- Verification gap: none for the targeted issue scope; broader unrelated suites were not rerun beyond the focused reconciliation and diagnostics coverage.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/recovery-tracked-pr-reconciliation.ts`, `src/reconciliation-backlog-diagnostics.ts`, `src/supervisor/supervisor-read-only-reporting.ts`, `src/doctor.ts`, `src/recovery-tracked-pr-reconciliation.test.ts`, `src/supervisor/supervisor-recovery-reconciliation.test.ts`, `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
-- Rollback concern: low; the new runtime behavior is additive observability plus one extra recovery event on bounded passes, but any automation that assumed an exact single-event list for tracked PR bounded passes would need the updated expectations already included here.
-- Last focused command: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
+- Next exact step: commit the doctor review fix on `codex/issue-1528`, push the branch, and let the PR resync against the remaining review thread.
+- Verification gap: none for this review-fix scope; I reran focused doctor/status diagnostics coverage plus a clean build and did not rerun unrelated reconciliation suites this turn.
+- Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`
+- Rollback concern: low; the change only affects `doctor` resilience when the diagnostic-only backlog reload fails, and the new failure mode is an explicit `state_file` diagnostic instead of a thrown command.
+- Last focused command: `npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -37,10 +37,11 @@ Failure signature: PRRT_kwDORgvdZ856z87d
 - Hypothesis: the bounded backlog diagnostics were correct, but `doctor` still had one unguarded follow-up `loadState()` call after the main checks that could abort the whole command on filesystem read errors.
 - What changed: Guarded the backlog-only `loadState()` call in `diagnoseSupervisorHost`, degrade that failure into the canonical `state_file` doctor check with an explicit detail line, suppress the backlog diagnostic line when the follow-up read fails, and added a regression test for the second-read-throws path.
 - Current blocker: none
-- Next exact step: commit the doctor review fix on `codex/issue-1528`, push the branch, and let the PR resync against the remaining review thread.
+- Next exact step: let PR #1529 resync on commit `e227a8d`, then resolve or reply to the remaining automated review thread if the refreshed diff still needs operator action.
 - Verification gap: none for this review-fix scope; I reran focused doctor/status diagnostics coverage plus a clean build and did not rerun unrelated reconciliation suites this turn.
 - Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`
 - Rollback concern: low; the change only affects `doctor` resilience when the diagnostic-only backlog reload fails, and the new failure mode is an explicit `state_file` diagnostic instead of a thrown command.
-- Last focused command: `npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+- Last focused command: `npm run build`
 ### Scratchpad
+- Review fix committed and pushed as `e227a8d` (`Keep doctor resilient on backlog state reload failures`).
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -184,6 +184,62 @@ test("diagnoseSupervisorHost degrades malformed synthetic recovery records witho
   );
 });
 
+test("diagnoseSupervisorHost records reconciliation backlog reload failures without throwing", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(stateFile, `${JSON.stringify({
+    activeIssueNumber: null,
+    issues: {},
+  }, null, 2)}\n`, "utf8");
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+
+  let loadStateCalls = 0;
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => {
+      loadStateCalls += 1;
+      if (loadStateCalls === 1) {
+        return {
+          activeIssueNumber: null,
+          issues: {},
+        };
+      }
+
+      throw new Error("EACCES: permission denied");
+    },
+  });
+
+  assert.equal(loadStateCalls, 2);
+  assert.equal(diagnostics.overallStatus, "fail");
+  assert.equal(diagnostics.reconciliationBacklogLine, null);
+  assert.equal(diagnostics.checks.find((check) => check.name === "github_auth")?.status, "pass");
+  assert.equal(diagnostics.checks.find((check) => check.name === "codex_cli")?.status, "pass");
+  assert.equal(diagnostics.checks.find((check) => check.name === "state_file")?.status, "fail");
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "pass");
+  assert.match(
+    diagnostics.checks.find((check) => check.name === "state_file")?.summary ?? "",
+    /Failed to read JSON state file for reconciliation backlog diagnostics:/,
+  );
+  assert.match(
+    renderDoctorReport(diagnostics),
+    /doctor_detail name=state_file detail=reconciliation_backlog_state_read_failed location=.*state\.json message=EACCES: permission denied/,
+  );
+});
+
 test("diagnoseSupervisorHost does not skip synthetic-like records missing recovery metadata", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -36,6 +36,7 @@ import {
 } from "./supervisor/supervisor-selection-readiness-summary";
 import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./supervisor/tracked-pr-mismatch";
 import { buildTrustAndConfigWarnings, buildWarning, renderDoctorWarningLine } from "./warning-formatting";
+import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "./reconciliation-backlog-diagnostics";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
 
@@ -50,6 +51,7 @@ export interface DoctorDiagnostics {
   overallStatus: DoctorCheckStatus;
   checks: DoctorCheck[];
   codexModelPolicyLines?: string[];
+  reconciliationBacklogLine?: string | null;
   trustDiagnostics: TrustDiagnosticsSummary;
   cadenceDiagnostics: CadenceDiagnosticsSummary;
   candidateDiscoverySummary: string;
@@ -620,11 +622,13 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
       activeRecord: null,
     }),
   );
+  const state = await loadState();
 
   return {
     overallStatus: overallStatusForChecks(checks),
     checks,
     codexModelPolicyLines,
+    reconciliationBacklogLine: buildTrackedMergedButOpenBacklogDiagnosticLine(state, "doctor_reconciliation_backlog"),
     trustDiagnostics: summarizeTrustDiagnostics(args.config),
     cadenceDiagnostics: summarizeCadenceDiagnostics(args.config),
     candidateDiscoverySummary: formatCandidateDiscoveryBehaviorLine(args.config, "doctor_candidate_discovery"),
@@ -725,6 +729,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     `doctor_cadence poll_interval_seconds=${diagnostics.cadenceDiagnostics.pollIntervalSeconds} merge_critical_recheck_seconds=${mergeCriticalRecheckSeconds} merge_critical_effective_seconds=${diagnostics.cadenceDiagnostics.mergeCriticalEffectiveSeconds} enabled=${diagnostics.cadenceDiagnostics.mergeCriticalRecheckEnabled}`,
     diagnostics.candidateDiscoverySummary,
     ...codexModelPolicyLines,
+    ...(diagnostics.reconciliationBacklogLine ? [diagnostics.reconciliationBacklogLine] : []),
     `doctor_loop_runtime state=${loopRuntime.state} host_mode=${loopRuntime.hostMode} pid=${loopRuntime.pid === null ? "none" : String(loopRuntime.pid)} started_at=${loopRuntime.startedAt ?? "none"} detail=${sanitizeDoctorValue(loopRuntime.detail ?? "none")}`,
     ...(diagnostics.orphanPolicySummary ? [diagnostics.orphanPolicySummary] : []),
     `doctor_workspace_preparation configured=${workspacePreparationContract.configured} source=${workspacePreparationContract.source} command=${sanitizeDoctorValue(workspacePreparationContract.command ?? "none")} summary=${sanitizeDoctorValue(workspacePreparationContract.summary)}`,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -144,6 +144,54 @@ function overallStatusForChecks(checks: DoctorCheck[]): DoctorCheckStatus {
   return "pass";
 }
 
+function withReconciliationBacklogStateReadFailure(
+  checks: DoctorCheck[],
+  config: SupervisorConfig,
+  error: unknown,
+): DoctorCheck[] {
+  const message = error instanceof Error ? error.message : String(error);
+  const summary = config.stateBackend === "json"
+    ? `Failed to read JSON state file for reconciliation backlog diagnostics: ${config.stateFile}`
+    : `Failed to read SQLite state file for reconciliation backlog diagnostics: ${config.stateFile}`;
+  const detail = `reconciliation_backlog_state_read_failed location=${config.stateFile} message=${message}`;
+  let replaced = false;
+
+  const nextChecks = checks.map((check) => {
+    if (check.name !== "state_file") {
+      return check;
+    }
+
+    replaced = true;
+    if (check.status === "fail") {
+      return {
+        ...check,
+        details: [...check.details, detail],
+      };
+    }
+
+    return {
+      ...check,
+      status: "fail" as DoctorCheckStatus,
+      summary,
+      details: [...check.details, detail],
+    };
+  });
+
+  if (replaced) {
+    return nextChecks;
+  }
+
+  return [
+    ...checks,
+    {
+      name: "state_file",
+      status: "fail",
+      summary,
+      details: [detail],
+    },
+  ];
+}
+
 async function commandOnPath(command: string): Promise<string | null> {
   const result = await runCommand("which", [command], { allowExitCodes: [0, 1] });
   return result.exitCode === 0 ? result.stdout.trim().split(/\r?\n/, 1)[0] ?? null : null;
@@ -605,7 +653,7 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     args.github ??
     new GitHubClient(args.config);
 
-  const checks = await Promise.all([
+  const checks: DoctorCheck[] = await Promise.all([
     diagnoseGitHubAuth(authStatus),
     diagnoseCodexCli(args.config),
     diagnoseStateFile(args.config),
@@ -622,13 +670,21 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
       activeRecord: null,
     }),
   );
-  const state = await loadState();
+  let state: SupervisorStateFile | null = null;
+  let finalChecks = checks;
+  try {
+    state = await loadState();
+  } catch (error) {
+    finalChecks = withReconciliationBacklogStateReadFailure(checks, args.config, error);
+  }
 
   return {
-    overallStatus: overallStatusForChecks(checks),
-    checks,
+    overallStatus: overallStatusForChecks(finalChecks),
+    checks: finalChecks,
     codexModelPolicyLines,
-    reconciliationBacklogLine: buildTrackedMergedButOpenBacklogDiagnosticLine(state, "doctor_reconciliation_backlog"),
+    reconciliationBacklogLine: state === null
+      ? null
+      : buildTrackedMergedButOpenBacklogDiagnosticLine(state, "doctor_reconciliation_backlog"),
     trustDiagnostics: summarizeTrustDiagnostics(args.config),
     cadenceDiagnostics: summarizeCadenceDiagnostics(args.config),
     candidateDiscoverySummary: formatCandidateDiscoveryBehaviorLine(args.config, "doctor_candidate_discovery"),

--- a/src/reconciliation-backlog-diagnostics.ts
+++ b/src/reconciliation-backlog-diagnostics.ts
@@ -1,0 +1,32 @@
+import type { SupervisorStateFile } from "./core/types";
+
+function formatIssueCursor(issueNumber: number | null): string {
+  return issueNumber === null ? "none" : `#${issueNumber}`;
+}
+
+export function buildTrackedMergedButOpenBacklogDiagnosticLine(
+  state: Pick<SupervisorStateFile, "issues" | "reconciliation_state">,
+  prefix = "reconciliation_backlog",
+): string | null {
+  const trackedRecords = Object.values(state.issues).filter((record) => record.pr_number !== null);
+  if (trackedRecords.length === 0) {
+    return null;
+  }
+
+  const historicalDoneRecords = trackedRecords.filter((record) => record.state === "done").length;
+  if (historicalDoneRecords === 0) {
+    return null;
+  }
+
+  const recoverableRecords = trackedRecords.length - historicalDoneRecords;
+  const resumeAfterIssue = state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number ?? null;
+
+  return [
+    prefix,
+    "phase=tracked_merged_but_open_issues",
+    `resume_after_issue=${formatIssueCursor(resumeAfterIssue)}`,
+    `historical_done_records=${historicalDoneRecords}`,
+    `recoverable_records=${recoverableRecords}`,
+    `tracked_records=${trackedRecords.length}`,
+  ].join(" ");
+}

--- a/src/recovery-tracked-pr-reconciliation.test.ts
+++ b/src/recovery-tracked-pr-reconciliation.test.ts
@@ -156,3 +156,63 @@ test("reconcileTrackedMergedButOpenIssues preserves the historical done cursor w
   assert.equal(saveCalls, 0);
   assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, 324);
 });
+
+test("reconcileTrackedMergedButOpenIssues emits a bounded backlog recovery event when historical tracked PR work is deferred", async () => {
+  const historicalDoneRecords = Array.from({ length: 30 }, (_, index) =>
+    createRecord({
+      issue_number: 300 + index,
+      state: "done",
+      branch: `codex/historical-done-${300 + index}`,
+      pr_number: 800 + index,
+      blocked_reason: null,
+    }));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: Object.fromEntries(historicalDoneRecords.map((record) => [String(record.issue_number), record])),
+  };
+  const prLookups: number[] = [];
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async (prNumber) => {
+        prLookups.push(prNumber);
+        return null;
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:25:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    [],
+  );
+
+  assert.deepEqual(prLookups, historicalDoneRecords.slice(0, 25).map((record) => record.pr_number));
+  assert.equal(saveCalls, 1);
+  assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, 324);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_reconciliation_bounded: deferred 5 tracked PR backlog record(s) after issue #324; resume after this cursor next cycle",
+  ]);
+});

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -424,6 +424,7 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
   }
 
   if (options.onlyIssueNumber === undefined || options.onlyIssueNumber === null) {
+    const deferredRecordCount = Math.max(records.length - processedRecords, 0);
     let nextLastProcessedIssueNumber: number | null;
     if (processedRecords === 0) {
       nextLastProcessedIssueNumber = null;
@@ -436,6 +437,12 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
     }
     if (setTrackedMergedButOpenLastProcessedIssueNumber(state, nextLastProcessedIssueNumber)) {
       saveNeeded = true;
+    }
+    if (deferredRecordCount > 0 && lastProcessedIssueNumber !== null) {
+      recoveryEvents.push(helpers.buildRecoveryEvent(
+        lastProcessedIssueNumber,
+        `tracked_pr_reconciliation_bounded: deferred ${deferredRecordCount} tracked PR backlog record(s) after issue #${lastProcessedIssueNumber}; resume after this cursor next cycle`,
+      ));
     }
   }
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2169,6 +2169,74 @@ test("statusReport exposes typed reconciliation target and wait-step context whi
   );
 });
 
+test("status and doctor surface tracked merged-but-open backlog cursor diagnostics when historical backlog remains", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "320": createRecord({
+        issue_number: 320,
+        state: "done",
+        pr_number: 920,
+        blocked_reason: null,
+      }),
+      "321": createRecord({
+        issue_number: 321,
+        state: "done",
+        pr_number: 921,
+        blocked_reason: null,
+      }),
+      "400": createRecord({
+        issue_number: 400,
+        state: "waiting_ci",
+        pr_number: 990,
+        blocked_reason: null,
+      }),
+    },
+    reconciliation_state: {
+      tracked_merged_but_open_last_processed_issue_number: 321,
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getCandidateDiscoveryDiagnostics: async () => ({
+      fetchWindow: 100,
+      observedMatchingOpenIssues: 0,
+      truncated: false,
+    }),
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /reconciliation_backlog phase=tracked_merged_but_open_issues resume_after_issue=#321 historical_done_records=2 recoverable_records=1 tracked_records=3/,
+  );
+
+  const status = await supervisor.status();
+  assert.match(
+    status,
+    /reconciliation_backlog phase=tracked_merged_but_open_issues resume_after_issue=#321 historical_done_records=2 recoverable_records=1 tracked_records=3/,
+  );
+
+  const doctor = await supervisor.doctor();
+  assert.match(
+    doctor,
+    /doctor_reconciliation_backlog phase=tracked_merged_but_open_issues resume_after_issue=#321 historical_done_records=2 recoverable_records=1 tracked_records=3/,
+  );
+});
+
 test("status emits a warning only after reconciliation exceeds the long-running threshold", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -49,6 +49,7 @@ import {
   sanitizeStatusValue,
   summarizeChecks,
 } from "./supervisor-status-rendering";
+import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "../reconciliation-backlog-diagnostics";
 
 const LONG_RECONCILIATION_WARNING_THRESHOLD_MS = 5 * 60 * 1000;
 const MAX_RENDERED_STATUS_STATE_LOAD_FINDINGS = 5;
@@ -191,6 +192,7 @@ export async function buildSupervisorStatusReport(args: {
       waitStep: reconciliationSnapshot.waitStep,
     };
   const trackedPrMismatchLines: string[] = [];
+  const trackedMergedBacklogLine = buildTrackedMergedButOpenBacklogDiagnosticLine(state);
 
   for (const record of Object.values(state.issues)) {
     if (!shouldHydrateTrackedPrDiagnostics(record)) {
@@ -243,6 +245,7 @@ export async function buildSupervisorStatusReport(args: {
         ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
         ...inventoryRefreshDiagnosticLines,
         ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
+        ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
       ];
 
@@ -299,6 +302,7 @@ export async function buildSupervisorStatusReport(args: {
         ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
         ...inventoryRefreshDiagnosticLines,
         ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
+        ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
       ];
 
@@ -338,6 +342,7 @@ export async function buildSupervisorStatusReport(args: {
         inventoryPostureLine,
         ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
         ...inventoryRefreshDiagnosticLines,
+        ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
       ];
 
@@ -416,6 +421,7 @@ export async function buildSupervisorStatusReport(args: {
     ...(inventoryRefreshStatusLine === null ? [] : [inventoryRefreshStatusLine]),
     ...inventoryRefreshDiagnosticLines,
     ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
+    ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
     ...githubRateLimitStatus.githubRateLimitLines,
   ];
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -4954,6 +4954,7 @@ test("reconcileTrackedMergedButOpenIssues stops after the per-cycle budget and d
   assert.equal(state.issues["367"]?.pr_number, 192);
   assert.deepEqual(recoveryEvents.map((event) => event.reason), [
     "merged_pr_convergence: tracked PR #191 merged; marked issue #366 done",
+    "tracked_pr_reconciliation_bounded: deferred 1 tracked PR backlog record(s) after issue #366; resume after this cursor next cycle",
   ]);
 });
 
@@ -5057,6 +5058,7 @@ test("reconcileTrackedMergedButOpenIssues resumes from persisted progress in the
 
   assert.deepEqual(firstCycleEvents.map((event) => event.reason), [
     "tracked_pr_head_advanced: resumed issue #366 from waiting_ci to ready_to_merge after tracked PR #191 advanced from abcdef1 to open-head-191",
+    "tracked_pr_reconciliation_bounded: deferred 1 tracked PR backlog record(s) after issue #366; resume after this cursor next cycle",
   ]);
   assert.deepEqual(prLookups, [191]);
   assert.equal(saveCalls, 1);
@@ -5104,6 +5106,7 @@ test("reconcileTrackedMergedButOpenIssues resumes from persisted progress in the
   assert.equal(state.issues["367"]?.last_head_sha, "merged-head-192");
   assert.deepEqual(secondCycleEvents.map((event) => event.reason), [
     "merged_pr_convergence: tracked PR #192 merged; marked issue #367 done",
+    "tracked_pr_reconciliation_bounded: deferred 1 tracked PR backlog record(s) after issue #367; resume after this cursor next cycle",
   ]);
 });
 
@@ -5215,6 +5218,7 @@ test("reconcileTrackedMergedButOpenIssues resumes from the next higher issue whe
   assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, 367);
   assert.deepEqual(recoveryEvents.map((event) => event.reason), [
     "merged_pr_convergence: tracked PR #192 merged; marked issue #367 done",
+    "tracked_pr_reconciliation_bounded: deferred 1 tracked PR backlog record(s) after issue #367; resume after this cursor next cycle",
   ]);
 });
 


### PR DESCRIPTION
Closes #1528
This PR was opened by codex-supervisor.
Latest Codex summary:

Added bounded observability for `tracked_merged_but_open_issues`. The reconciliation path now emits an explicit recovery event when it stops at the per-cycle budget with backlog remaining, and read-only `status`/`doctor` now show the persisted resume cursor plus tracked backlog counts so operators can tell the loop is draining work rather than stuck. I also added a shared backlog-diagnostics helper and updated the focused reconciliation/diagnostics tests accordingly.

Checkpoint commit: `1fee534` (`Bound tracked PR reconciliation backlog diagnostics`)

Summary: Added bounded tracked-PR backlog diagnostics to recovery/status/doctor and committed the change as `1fee534`
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the PR with commit `1fee534`, then proceed with normal review/CI checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostics showing reconciliation backlog status: resume cursor, historical/recoverable/total counts, and bounded-backlog recovery events.
  * Doctor/status outputs now include reconciliation-backlog lines and explicit notes when work is deferred to the next cycle.

* **Tests**
  * Added and updated tests covering bounded backlog recovery events, resumed-processing behavior, and diagnostics/reporting of backlog read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->