### PR TITLE
Tracked PR can get stuck verification-blocked when current-head local review is missing (#1530)

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -6270,6 +6270,110 @@ test("handlePostTurnPullRequestTransitionsPhase reruns local review on a ready P
   assert.equal(result.record.pre_merge_evaluation_outcome, "mergeable");
 });
 
+test("handlePostTurnPullRequestTransitionsPhase reruns local review on a ready block-merge PR head update when the current head has no matching review", async () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+  });
+  const readyPr = createPullRequest({
+    title: "Re-review the current head before merge under block-merge policy",
+    isDraft: false,
+    headRefOid: "head-new",
+  });
+  let localReviewCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: createDefaultGithub(),
+    context: {
+      state: {
+        activeIssueNumber: 102,
+        issues: {
+          "102": createRecord({
+            state: "blocked",
+            blocked_reason: "verification",
+            pr_number: readyPr.number,
+            local_review_head_sha: null,
+            local_review_findings_count: 0,
+            local_review_recommendation: null,
+            pre_merge_evaluation_outcome: null,
+            last_error: "Waiting for a current-head local review run.",
+          }),
+        },
+      },
+      record: createRecord({
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: readyPr.number,
+        local_review_head_sha: null,
+        local_review_findings_count: 0,
+        local_review_recommendation: null,
+        pre_merge_evaluation_outcome: null,
+        last_error: "Waiting for a current-head local review run.",
+      }),
+      issue: createIssue({ title: "Require block-merge current-head local review before merge" }),
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => undefined,
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr: readyPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record, pr, checks, reviewThreads) =>
+      deriveSupervisorPullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: (record, pr, checks, reviewThreads) =>
+      resolveBlockedReasonFromReviewState(config, record, pr, checks, reviewThreads),
+    summarizeChecks,
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalReviewImpl: async () => {
+      localReviewCalls += 1;
+      return {
+        ranAt: "2026-03-24T00:11:00Z",
+        summaryPath: "/tmp/reviews/owner-repo/issue-102/head-new.md",
+        findingsPath: "/tmp/reviews/owner-repo/issue-102/head-new.json",
+        summary: "Local review revalidated the current head.",
+        blockerSummary: null,
+        findingsCount: 0,
+        rootCauseCount: 0,
+        maxSeverity: "none",
+        verifiedFindingsCount: 0,
+        verifiedMaxSeverity: "none",
+        recommendation: "ready",
+        degraded: false,
+        finalEvaluation: {
+          outcome: "mergeable",
+          residualFindings: [],
+          mustFixCount: 0,
+          manualReviewCount: 0,
+          followUpCount: 0,
+        },
+        rawOutput: "raw output",
+      };
+    },
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: readyPr,
+      checks: [] satisfies PullRequestCheck[],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(localReviewCalls, 1);
+  assert.equal(result.record.state, "ready_to_merge");
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(result.record.local_review_head_sha, "head-new");
+  assert.equal(result.record.pre_merge_evaluation_outcome, "mergeable");
+});
+
 test("handlePostTurnPullRequestTransitionsPhase reruns local review on a later cycle after pending checks clear for a stale ready PR head", async () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/pull-request-failure-context.test.ts
+++ b/src/pull-request-failure-context.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildChecksFailureContext, buildConflictFailureContext } from "./pull-request-failure-context";
+import {
+  buildChecksFailureContext,
+  buildConflictFailureContext,
+  buildCurrentHeadLocalReviewPendingFailureContext,
+} from "./pull-request-failure-context";
 import { GitHubPullRequest, PullRequestCheck } from "./core/types";
 
 function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
@@ -55,4 +59,42 @@ test("buildConflictFailureContext preserves merge-conflict reporting fields", ()
   assert.equal(context.command, "git fetch origin && git merge origin/<default-branch>");
   assert.deepEqual(context.details, ["mergeStateStatus=DIRTY"]);
   assert.equal(context.url, "https://example.test/pr/42");
+});
+
+test("buildCurrentHeadLocalReviewPendingFailureContext preserves missing-review reporting fields", () => {
+  const context = buildCurrentHeadLocalReviewPendingFailureContext({
+    pr: createPullRequest({ headRefOid: "head-new" }),
+    record: { local_review_head_sha: null },
+  });
+
+  assert.equal(context.category, "blocked");
+  assert.equal(context.summary, "Current PR head is still waiting for a local review run.");
+  assert.equal(context.signature, "local-review-missing:head-new");
+  assert.equal(context.command, null);
+  assert.deepEqual(context.details, [
+    "reviewed_head_sha=none",
+    "pr_head_sha=head-new",
+    "status=missing",
+    "summary=awaiting_local_review",
+  ]);
+  assert.equal(context.url, null);
+});
+
+test("buildCurrentHeadLocalReviewPendingFailureContext preserves stale-review reporting fields", () => {
+  const context = buildCurrentHeadLocalReviewPendingFailureContext({
+    pr: createPullRequest({ headRefOid: "head-new" }),
+    record: { local_review_head_sha: "head-old" },
+  });
+
+  assert.equal(context.category, "blocked");
+  assert.equal(context.summary, "Current PR head is still waiting for a fresh local review run.");
+  assert.equal(context.signature, "local-review-stale:head-old:head-new");
+  assert.equal(context.command, null);
+  assert.deepEqual(context.details, [
+    "reviewed_head_sha=head-old",
+    "pr_head_sha=head-new",
+    "status=stale",
+    "summary=awaiting_local_review",
+  ]);
+  assert.equal(context.url, null);
 });

--- a/src/pull-request-failure-context.ts
+++ b/src/pull-request-failure-context.ts
@@ -29,3 +29,33 @@ export function buildConflictFailureContext(pr: GitHubPullRequest): FailureConte
     updated_at: nowIso(),
   };
 }
+
+export function buildCurrentHeadLocalReviewPendingFailureContext(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  record: { local_review_head_sha: string | null };
+}): FailureContext {
+  const status = args.record.local_review_head_sha === null ? "missing" : "stale";
+  const summary =
+    status === "missing"
+      ? "Current PR head is still waiting for a local review run."
+      : "Current PR head is still waiting for a fresh local review run.";
+  const signature =
+    status === "missing"
+      ? `local-review-missing:${args.pr.headRefOid}`
+      : `local-review-stale:${args.record.local_review_head_sha}:${args.pr.headRefOid}`;
+
+  return {
+    category: "blocked",
+    summary,
+    signature,
+    command: null,
+    details: [
+      `reviewed_head_sha=${args.record.local_review_head_sha ?? "none"}`,
+      `pr_head_sha=${args.pr.headRefOid}`,
+      `status=${status}`,
+      "summary=awaiting_local_review",
+    ],
+    url: null,
+    updated_at: nowIso(),
+  };
+}

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -471,7 +471,7 @@ test("inferStateFromPullRequest covers local review policy gating combinations",
       expected: "ready_to_merge",
     },
     {
-      name: "block_merge keeps gating until the current head has a resolved final evaluation",
+      name: "block_merge keeps stale current-head local review gating runnable once the rerun lane is clear",
       config: { localReviewEnabled: true, localReviewPolicy: "block_merge", copilotReviewWaitMinutes: 0 },
       record: {
         state: "pr_open",
@@ -481,7 +481,35 @@ test("inferStateFromPullRequest covers local review policy gating combinations",
         local_review_recommendation: "changes_requested",
       },
       pr: { isDraft: false, headRefOid: "newhead" },
-      expected: "blocked",
+      expected: "local_review",
+    },
+    {
+      name: "block_merge routes a ready non-draft PR into current-head local review when the recorded local review head is stale",
+      config: { localReviewEnabled: true, localReviewPolicy: "block_merge", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "pr_open",
+        last_head_sha: "newhead",
+        local_review_head_sha: "oldhead",
+        local_review_findings_count: 0,
+        local_review_recommendation: "ready",
+        pre_merge_evaluation_outcome: "mergeable",
+      },
+      pr: { isDraft: false, headRefOid: "newhead" },
+      expected: "local_review",
+    },
+    {
+      name: "block_merge routes a ready non-draft PR with no recorded current-head local review into current-head local review",
+      config: { localReviewEnabled: true, localReviewPolicy: "block_merge", copilotReviewWaitMinutes: 0 },
+      record: {
+        state: "pr_open",
+        last_head_sha: "newhead",
+        local_review_head_sha: null,
+        local_review_findings_count: 0,
+        local_review_recommendation: null,
+        pre_merge_evaluation_outcome: null,
+      },
+      pr: { isDraft: false, headRefOid: "newhead" },
+      expected: "local_review",
     },
     {
       name: "advisory never blocks merge for ready PRs with raw findings",
@@ -609,6 +637,28 @@ test("inferStateFromPullRequest waits for pending checks before rerunning tracke
     localReviewEnabled: true,
     localReviewPolicy: "advisory",
     trackedPrCurrentHeadLocalReviewRequired: true,
+    copilotReviewWaitMinutes: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    local_review_head_sha: "oldhead",
+    local_review_findings_count: 0,
+    local_review_recommendation: "ready",
+    pre_merge_evaluation_outcome: "mergeable",
+  });
+  const checks = [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }] as const;
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, createPullRequest({ isDraft: false, headRefOid: "newhead" }), [...checks], []),
+    "waiting_ci",
+  );
+});
+
+test("inferStateFromPullRequest waits for pending checks before rerunning block-merge current-head local review", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
     copilotReviewWaitMinutes: 0,
   });
   const record = createRecord({

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -891,7 +891,6 @@ export function inferStateFromPullRequest(
 
   if (
     !pr.isDraft &&
-    config.trackedPrCurrentHeadLocalReviewRequired &&
     shouldRunLocalReview(config, record, pr) &&
     !checkSummary.hasPending &&
     unresolvedBotThreads.length === 0 &&
@@ -902,7 +901,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
-    config.trackedPrCurrentHeadLocalReviewRequired &&
+    !pr.isDraft &&
     shouldRunLocalReview(config, record, pr) &&
     checkSummary.hasPending &&
     unresolvedBotThreads.length === 0 &&

--- a/src/supervisor/supervisor-failure-context.test.ts
+++ b/src/supervisor/supervisor-failure-context.test.ts
@@ -340,6 +340,91 @@ test("inferFailureContext reports stale current-head local review explicitly ins
   ]);
 });
 
+test("inferFailureContext keeps unresolved manual review ahead of pending current-head local review", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+    humanReviewBlocksMerge: true,
+  });
+  const pr = createPullRequest({ headRefOid: "head-new", isDraft: false });
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "verification",
+    local_review_head_sha: null,
+  });
+  const manualThread = createReviewThread({
+    id: "manual-thread-1",
+    comments: {
+      nodes: [
+        {
+          id: "manual-comment-1",
+          body: "Please resolve this before merge.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "teammate",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+
+  const context = inferFailureContext(config, record, pr, [], [manualThread]);
+
+  assert.equal(context?.category, "manual");
+  assert.equal(context?.summary, "1 unresolved manual or unconfigured review thread(s) require human attention.");
+  assert.match(context?.signature ?? "", /^manual:manual-thread-1$/);
+});
+
+test("inferFailureContext keeps unresolved configured bot review ahead of pending current-head local review", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: false,
+  });
+  const pr = createPullRequest({ headRefOid: "head-new", isDraft: false });
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "verification",
+    local_review_head_sha: null,
+  });
+
+  const context = inferFailureContext(config, record, pr, [], [createReviewThread({ id: "bot-thread-1" })]);
+
+  assert.equal(context?.category, "review");
+  assert.equal(context?.summary, "1 unresolved automated review thread(s) remain.");
+  assert.equal(context?.signature, "bot-thread-1");
+});
+
+test("inferFailureContext keeps merge conflicts ahead of pending current-head local review", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+  });
+  const pr = createPullRequest({
+    headRefOid: "head-new",
+    isDraft: false,
+    mergeStateStatus: "DIRTY",
+    mergeable: "CONFLICTING",
+  });
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "verification",
+    local_review_head_sha: null,
+  });
+
+  const context = inferFailureContext(config, record, pr, [], []);
+
+  assert.equal(context?.category, "conflict");
+  assert.equal(context?.summary, "PR #44 has merge conflicts and needs a base-branch integration pass.");
+  assert.equal(context?.signature, "dirty:head-new");
+});
+
 test("inferFailureContext returns merge conflict context when no earlier blocker applies", () => {
   const context = inferFailureContext(
     createConfig(),

--- a/src/supervisor/supervisor-failure-context.test.ts
+++ b/src/supervisor/supervisor-failure-context.test.ts
@@ -280,6 +280,66 @@ test("inferFailureContext returns degraded local review blocker context for curr
   assert.match(context?.signature ?? "", /:degraded$/);
 });
 
+test("inferFailureContext reports missing current-head local review explicitly instead of a synthetic clean review summary", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+  });
+  const pr = createPullRequest({ headRefOid: "head-new", isDraft: false });
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "verification",
+    local_review_head_sha: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_recommendation: null,
+    pre_merge_evaluation_outcome: null,
+  });
+
+  const context = inferFailureContext(config, record, pr, [], []);
+
+  assert.equal(context?.category, "blocked");
+  assert.equal(context?.summary, "Current PR head is still waiting for a local review run.");
+  assert.equal(context?.signature, "local-review-missing:head-new");
+  assert.deepEqual(context?.details, [
+    "reviewed_head_sha=none",
+    "pr_head_sha=head-new",
+    "status=missing",
+    "summary=awaiting_local_review",
+  ]);
+});
+
+test("inferFailureContext reports stale current-head local review explicitly instead of a synthetic clean review summary", () => {
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+  });
+  const pr = createPullRequest({ headRefOid: "head-new", isDraft: false });
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "verification",
+    local_review_head_sha: "head-old",
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_recommendation: "ready",
+    pre_merge_evaluation_outcome: "mergeable",
+  });
+
+  const context = inferFailureContext(config, record, pr, [], []);
+
+  assert.equal(context?.category, "blocked");
+  assert.equal(context?.summary, "Current PR head is still waiting for a fresh local review run.");
+  assert.equal(context?.signature, "local-review-stale:head-old:head-new");
+  assert.deepEqual(context?.details, [
+    "reviewed_head_sha=head-old",
+    "pr_head_sha=head-new",
+    "status=stale",
+    "summary=awaiting_local_review",
+  ]);
+});
+
 test("inferFailureContext returns merge conflict context when no earlier blocker applies", () => {
   const context = inferFailureContext(
     createConfig(),

--- a/src/supervisor/supervisor-failure-context.ts
+++ b/src/supervisor/supervisor-failure-context.ts
@@ -95,14 +95,6 @@ export function inferFailureContext(
       return localReviewStallFailureContext(record);
     }
 
-    if (!pr.isDraft && shouldRunLocalReview(config, record, pr)) {
-      return buildCurrentHeadLocalReviewPendingFailureContext({ pr, record });
-    }
-
-    if (localReviewHighSeverityNeedsBlock(config, record, pr)) {
-      return localReviewFailureContext(record);
-    }
-
     const manualReviewContext =
       config.humanReviewBlocksMerge ? buildManualReviewFailureContext(manualReviewThreads(config, reviewThreads)) : null;
     if (manualReviewContext) {
@@ -124,16 +116,24 @@ export function inferFailureContext(
       return stalledBotReviewContext;
     }
 
-    if (localReviewDegradedNeedsBlock(config, record, pr)) {
+    if (localReviewHighSeverityNeedsBlock(config, record, pr)) {
       return localReviewFailureContext(record);
     }
 
-    if (localReviewBlocksMerge(config, record, pr)) {
+    if (!pr.isDraft && !mergeConflictDetected(pr) && shouldRunLocalReview(config, record, pr)) {
+      return buildCurrentHeadLocalReviewPendingFailureContext({ pr, record });
+    }
+
+    if (localReviewDegradedNeedsBlock(config, record, pr)) {
       return localReviewFailureContext(record);
     }
 
     if (mergeConflictDetected(pr)) {
       return buildConflictFailureContext(pr);
+    }
+
+    if (localReviewBlocksMerge(config, record, pr)) {
+      return localReviewFailureContext(record);
     }
   }
 

--- a/src/supervisor/supervisor-failure-context.ts
+++ b/src/supervisor/supervisor-failure-context.ts
@@ -1,4 +1,9 @@
-import { buildChecksFailureContext, buildConflictFailureContext } from "../pull-request-failure-context";
+import {
+  buildChecksFailureContext,
+  buildConflictFailureContext,
+  buildCurrentHeadLocalReviewPendingFailureContext,
+} from "../pull-request-failure-context";
+import { shouldRunLocalReview } from "../local-review";
 import { buildCopilotReviewTimeoutFailureContext } from "../pull-request-state";
 import {
   configuredBotReviewFollowUpState,
@@ -88,6 +93,10 @@ export function inferFailureContext(
       )
     ) {
       return localReviewStallFailureContext(record);
+    }
+
+    if (!pr.isDraft && shouldRunLocalReview(config, record, pr)) {
+      return buildCurrentHeadLocalReviewPendingFailureContext({ pr, record });
     }
 
     if (localReviewHighSeverityNeedsBlock(config, record, pr)) {


### PR DESCRIPTION
Closes #1530
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the tracked-PR local-review lifecycle so non-draft `block_merge` PRs no longer get stranded in `blocked`/`verification` when the current head has no matching local-review result. The state machine now routes any non-draft PR with `shouldRunLocalReview()===true` into `local_review` once the lane is clear, or `waiting_ci` while checks are still pending. I also replaced the misleading synthetic clean-review blocker with an explicit missing/stale current-head local-review failure context, and added focused regressions at the state-policy, failure-context, and post-turn lifecycle layers.

Files changed include [src/pull-request-state-policy.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1530/src/pull-request-state-policy.ts), [src/pull-request-failure-context.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1530/src/pull-request-failure-context.ts), [src/supervisor/supervisor-failure-context.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1530/src/supervisor/supervisor-failure-context.ts), and the focused tests in the corresponding `*.test.ts` files plus [src/post-turn-pull-request.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1530/src/post-turn-pull-request.test.ts). I updated the issue journal working notes locally before finishing. The code/test checkpoint is committed as `a016ed1` with message `Fix tracked PR current-head local review reruns`.

Verification...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PR state and failure messages now distinguish missing vs. stale local review runs and surface clearer "waiting for local review" summaries and signatures.
  * Scenarios that rerun a local review now transition to "local_review" (instead of stale "blocked") and update pre-merge evaluation/status accordingly.

* **Tests**
  * Added tests covering missing/stale current-head local reviews, rerun behavior, and precedence of other blockers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->