### PR TITLE
Improve tracked PR handling by repairing narrow unresolved review threads before blocking (#1533)

### DIFF
--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -129,6 +129,104 @@ test("nextReviewFollowUpPatch does not grant a follow-up when no configured-bot 
   });
 });
 
+test("nextReviewFollowUpPatch grants one same-head follow-up for a narrow actionable bot thread set even when thread counts do not shrink", () => {
+  const patch = nextReviewFollowUpPatch({
+    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
+    preRunState: "addressing_review",
+    record: {
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    currentPr: { headRefOid: "head-a" },
+    evaluatedReviewHeadSha: "head-a",
+    preRunReviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        path: "src/a.ts",
+        line: 10,
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Guard the nullable payload before accessing nested properties here.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-2",
+        path: "src/b.ts",
+        line: 20,
+        comments: {
+          nodes: [
+            {
+              id: "comment-2",
+              body: "Add a regression check so this branch stays covered on retries.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    postRunReviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        path: "src/a.ts",
+        line: 10,
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Guard the nullable payload before accessing nested properties here.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-2",
+        path: "src/b.ts",
+        line: 20,
+        comments: {
+          nodes: [
+            {
+              id: "comment-2",
+              body: "Add a regression check so this branch stays covered on retries.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(patch, {
+    review_follow_up_head_sha: "head-a",
+    review_follow_up_remaining: 1,
+  });
+});
+
 test("nextReviewFollowUpPatch ignores already-resolved configured-bot threads when evaluating same-head progress", () => {
   const patch = nextReviewFollowUpPatch({
     config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -227,6 +227,142 @@ test("nextReviewFollowUpPatch grants one same-head follow-up for a narrow action
   });
 });
 
+test("nextReviewFollowUpPatch does not treat non-concrete line numbers as actionable same-head review feedback", () => {
+  const patch = nextReviewFollowUpPatch({
+    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
+    preRunState: "addressing_review",
+    record: {
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    currentPr: { headRefOid: "head-a" },
+    evaluatedReviewHeadSha: "head-a",
+    preRunReviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        path: "src/a.ts",
+        line: 0,
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Guard the nullable payload before accessing nested properties here.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-2",
+        path: "src/b.ts",
+        line: -3,
+        comments: {
+          nodes: [
+            {
+              id: "comment-2",
+              body: "Add a regression check so this branch stays covered on retries.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-3",
+        path: "src/c.ts",
+        line: 4.5,
+        comments: {
+          nodes: [
+            {
+              id: "comment-3",
+              body: "Refactor this conditional so the retry path stays deterministic here.",
+              createdAt: "2026-03-11T00:10:00Z",
+              url: "https://example.test/pr/44#discussion_r3",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    postRunReviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        path: "src/a.ts",
+        line: 0,
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Guard the nullable payload before accessing nested properties here.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-2",
+        path: "src/b.ts",
+        line: -3,
+        comments: {
+          nodes: [
+            {
+              id: "comment-2",
+              body: "Add a regression check so this branch stays covered on retries.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-3",
+        path: "src/c.ts",
+        line: 4.5,
+        comments: {
+          nodes: [
+            {
+              id: "comment-3",
+              body: "Refactor this conditional so the retry path stays deterministic here.",
+              createdAt: "2026-03-11T00:10:00Z",
+              url: "https://example.test/pr/44#discussion_r3",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(patch, {
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+  });
+});
+
 test("nextReviewFollowUpPatch ignores already-resolved configured-bot threads when evaluating same-head progress", () => {
   const patch = nextReviewFollowUpPatch({
     config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -356,7 +356,8 @@ export function nextReviewFollowUpPatch(args: {
         typeof thread.path === "string" &&
         thread.path.trim().length > 0 &&
         typeof thread.line === "number" &&
-        Number.isFinite(thread.line) &&
+        Number.isInteger(thread.line) &&
+        thread.line > 0 &&
         latestComment !== null &&
         latestComment.body.trim().length >= 32 &&
         latestComment.body.trim().split(/\s+/).length >= 6

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -312,6 +312,7 @@ export function nextReviewFollowUpPatch(args: {
   postRunReviewThreads: ReviewThread[];
 }): Pick<IssueRunRecord, "review_follow_up_head_sha" | "review_follow_up_remaining"> {
   const defaultPatch = { review_follow_up_head_sha: null, review_follow_up_remaining: 0 };
+  const MAX_NARROW_ACTIONABLE_REVIEW_THREADS = 3;
   if (
     args.preRunState !== "addressing_review" ||
     !args.currentPr ||
@@ -346,8 +347,23 @@ export function nextReviewFollowUpPatch(args: {
   const madeProgress =
     postRunConfiguredThreads.length < preRunConfiguredThreads.length ||
     [...preRunIds].some((threadId) => !postRunIds.has(threadId));
+  const hasNarrowActionableThreadSet =
+    postRunConfiguredThreads.length > 0 &&
+    postRunConfiguredThreads.length <= MAX_NARROW_ACTIONABLE_REVIEW_THREADS &&
+    postRunConfiguredThreads.every((thread) => {
+      const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
+      return (
+        typeof thread.path === "string" &&
+        thread.path.trim().length > 0 &&
+        typeof thread.line === "number" &&
+        Number.isFinite(thread.line) &&
+        latestComment !== null &&
+        latestComment.body.trim().length >= 32 &&
+        latestComment.body.trim().split(/\s+/).length >= 6
+      );
+    });
 
-  return madeProgress
+  return madeProgress || hasNarrowActionableThreadSet
     ? {
         review_follow_up_head_sha: args.evaluatedReviewHeadSha,
         review_follow_up_remaining: 1,


### PR DESCRIPTION
Closes #1533
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused reproducer and fix for the same-head review follow-up gate. The change is in [src/turn-execution-orchestration.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1533/src/turn-execution-orchestration.ts) and [src/turn-execution-orchestration.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1533/src/turn-execution-orchestration.test.ts): the supervisor now grants one bounded same-head follow-up retry for up to 3 unresolved configured-bot threads when each remaining thread still looks concrete enough for machine repair, instead of requiring thread-count shrinkage first. That preserves the old stale path for vague or already-exhausted cases while unblocking the narrow actionable lane this issue targets.

Focused verification passed with `npx tsx --test src/turn-execution-orchestration.test.ts`, `npx tsx --test src/pull-request-state-thread-reprocessing.test.ts`, `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts`, and `npm run build`. I also updated the local issue journal handoff and committed the code as `cb48ce6` (`Allow narrow same-head review follow-up retry`).

Summary: Allow one bounded same-head retry for narrow actionable bot review threads
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/turn-execution-orchestration.test.ts`; `npx tsx --test src/pull-request-state-thread-reprocessing.test.ts`; `npx tsx --test src/supervisor/supervisor-pr-review-blockers.tes...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved review follow-up logic to recognize narrow actionable review thread patterns and trigger follow-up requests in additional valid scenarios.

* **Tests**
  * Added tests validating follow-up behavior for narrow actionable thread sets and a negative case where non-concrete signals do not trigger follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->