### PR TITLE
Follow-up: same-head progress retries should require actionable latest bot guidance (#1537)

### DIFF
--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -70,6 +70,9 @@ test("nextProcessedReviewThreadPatch refreshes reprocessed same-head ids to the 
 
 test("selectReviewThreadsForTurn re-includes same-head configured-bot threads when the follow-up allowance is active", () => {
   const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
     preRunState: "addressing_review",
     record: {
       processed_review_thread_ids: ["thread-1@head-a"],
@@ -84,6 +87,54 @@ test("selectReviewThreadsForTurn re-includes same-head configured-bot threads wh
 
   assert.equal(selected.length, 1);
   assert.equal(selected[0]?.id, "thread-1");
+});
+
+test("selectReviewThreadsForTurn does not reopen same-head follow-up when stale bookkeeping remains for non-actionable configured-bot threads", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: "head-a",
+      review_follow_up_remaining: 1,
+    },
+    pr: createPullRequest({ headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Please address this.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r1",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-2",
+              body: "The latest reply is from a human, so stale follow-up bookkeeping must not reopen this same-head repair turn.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "human-reviewer",
+                typeName: "User",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
 });
 
 test("nextReviewFollowUpPatch grants one same-head follow-up after partial configured-bot progress", () => {
@@ -106,6 +157,77 @@ test("nextReviewFollowUpPatch grants one same-head follow-up after partial confi
   assert.deepEqual(patch, {
     review_follow_up_head_sha: "head-a",
     review_follow_up_remaining: 1,
+  });
+});
+
+test("nextReviewFollowUpPatch clears same-head follow-up after progress when remaining configured-bot threads are no longer actionable", () => {
+  const patch = nextReviewFollowUpPatch({
+    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
+    preRunState: "addressing_review",
+    record: {
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    currentPr: { headRefOid: "head-a" },
+    evaluatedReviewHeadSha: "head-a",
+    preRunReviewThreads: [
+      createReviewThread({ id: "thread-1" }),
+      createReviewThread({
+        id: "thread-2",
+        path: "src/a.ts",
+        line: 10,
+        comments: {
+          nodes: [
+            {
+              id: "comment-2",
+              body: "Guard the nullable payload before accessing nested properties here.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    postRunReviewThreads: [
+      createReviewThread({
+        id: "thread-2",
+        path: "src/a.ts",
+        line: 10,
+        comments: {
+          nodes: [
+            {
+              id: "comment-2",
+              body: "Guard the nullable payload before accessing nested properties here.",
+              createdAt: "2026-03-11T00:00:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-3",
+              body: "The latest guidance here is now a Codex reply, so progress should not arm another same-head retry.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r3",
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(patch, {
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
   });
 });
 

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -17,6 +17,7 @@ import {
   processedReviewThreadKey,
 } from "./review-handling";
 import {
+  actionableConfiguredBotReviewThreads,
   configuredBotReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
 } from "./review-thread-reporting";
@@ -57,6 +58,7 @@ function shouldLoadExternalReviewContext(args: {
 }
 
 export function selectReviewThreadsForTurn(args: {
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">;
   preRunState: IssueRunRecord["state"];
   record: Pick<
     IssueRunRecord,
@@ -74,16 +76,23 @@ export function selectReviewThreadsForTurn(args: {
   }
 
   const currentPr = args.pr;
-  const pendingThreads = args.reviewThreads.filter((thread) => !hasProcessedReviewThread(args.record, currentPr, thread));
+  const actionableFollowUpThreads = actionableConfiguredBotReviewThreads(
+    args.config as SupervisorConfig,
+    args.reviewThreads,
+  ).filter((thread) => !thread.isResolved && !thread.isOutdated);
+  const pendingThreads = actionableFollowUpThreads.filter(
+    (thread) => !hasProcessedReviewThread(args.record, currentPr, thread),
+  );
   if (pendingThreads.length > 0) {
     return pendingThreads;
   }
 
   return (
     args.record.review_follow_up_head_sha === currentPr.headRefOid &&
-    (args.record.review_follow_up_remaining ?? 0) > 0
+    (args.record.review_follow_up_remaining ?? 0) > 0 &&
+    actionableFollowUpThreads.length > 0
   )
-    ? args.reviewThreads
+    ? actionableFollowUpThreads
     : pendingThreads;
 }
 
@@ -123,6 +132,7 @@ export async function prepareCodexTurnPrompt(args: {
   reviewThreadsToProcess: ReviewThread[];
 }> {
   const reviewThreadsToProcess = selectReviewThreadsForTurn({
+    config: args.config,
     preRunState: args.record.state,
     record: args.record,
     pr: args.pr,
@@ -328,12 +338,18 @@ export function nextReviewFollowUpPatch(args: {
     configuredBotReviewThreads(args.config as SupervisorConfig, reviewThreads).filter(
       (thread) => !thread.isResolved && !thread.isOutdated,
     );
+  const unresolvedActionableConfiguredBotThreads = (reviewThreads: ReviewThread[]) =>
+    actionableConfiguredBotReviewThreads(args.config as SupervisorConfig, reviewThreads).filter(
+      (thread) => !thread.isResolved && !thread.isOutdated,
+    );
 
   const preRunConfiguredThreads = unresolvedConfiguredBotThreads(args.preRunReviewThreads);
   const postRunConfiguredThreads = unresolvedConfiguredBotThreads(args.postRunReviewThreads);
   if (postRunConfiguredThreads.length === 0) {
     return defaultPatch;
   }
+
+  const postRunActionableConfiguredThreads = unresolvedActionableConfiguredBotThreads(args.postRunReviewThreads);
 
   if (
     args.record.review_follow_up_head_sha === args.evaluatedReviewHeadSha &&
@@ -351,9 +367,9 @@ export function nextReviewFollowUpPatch(args: {
     postRunConfiguredThreads.length < preRunConfiguredThreads.length ||
     [...preRunIds].some((threadId) => !postRunIds.has(threadId));
   const hasNarrowActionableThreadSet =
-    postRunConfiguredThreads.length > 0 &&
-    postRunConfiguredThreads.length <= MAX_NARROW_ACTIONABLE_REVIEW_THREADS &&
-    postRunConfiguredThreads.every((thread) => {
+    postRunActionableConfiguredThreads.length > 0 &&
+    postRunActionableConfiguredThreads.length <= MAX_NARROW_ACTIONABLE_REVIEW_THREADS &&
+    postRunActionableConfiguredThreads.every((thread) => {
       const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
       return (
         latestReviewCommentAuthorIsAllowedBot(args.config as SupervisorConfig, thread) &&
@@ -368,7 +384,7 @@ export function nextReviewFollowUpPatch(args: {
       );
     });
 
-  return madeProgress || hasNarrowActionableThreadSet
+  return (madeProgress && postRunActionableConfiguredThreads.length > 0) || hasNarrowActionableThreadSet
     ? {
         review_follow_up_head_sha: args.evaluatedReviewHeadSha,
         review_follow_up_remaining: 1,


### PR DESCRIPTION
Closes #1537
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened same-head review retry handling in [src/turn-execution-orchestration.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1537/src/turn-execution-orchestration.ts) and added focused regressions in [src/turn-execution-orchestration.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1537/src/turn-execution-orchestration.test.ts). The fix does two things: it only reopens same-head review work for unresolved actionable configured-bot threads, and it only preserves `review_follow_up_remaining=1` after progress if the remaining unresolved configured-bot threads still have latest guidance from an allowed configured bot.

I reproduced the issue first with narrow tests, verified the fix with the requested test scope, and committed the checkpoint as `fca29b7` (`Require actionable bot guidance for same-head review retries`). The issue journal was updated in the local supervisor path as requested; it is ignored by git in this repo, so it was not part of the commit.

Summary: Same-head review follow-up retries now require actionable latest configured-bot guidance, and stale follow-up bookkeeping no longer reopens non-actionable threads.
State hint: stabilizing
Blocked reason: none
Tests: `npm exec -- tsx --test src/turn-execution-orchestration.test.ts src/pull-request-state-thread-reprocessing.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the branch PR with commit `fca29b7`, then wait for CI or r...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review follow-up logic to prevent reopening threads that can no longer be addressed
  * Fixed state clearing for review follow-ups when eligible threads become non-actionable

* **Tests**
  * Enhanced test coverage for follow-up thread selection with configuration scenarios and stale state handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->