### PR TITLE
Follow-up: non-actionable same-head bot threads should not report processed_on_current_head (#1538)

### DIFF
--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -117,3 +117,52 @@ test("staleConfiguredBotReviewThreads requires current-head processing evidence 
   assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [processedThread]), [processedThread]);
   assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [unprocessedThread]), []);
 });
+
+test("staleConfiguredBotReviewThreads excludes same-head configured-bot threads whose latest comment is no longer actionable", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const pr: Pick<GitHubPullRequest, "headRefOid"> = { headRefOid: "head123" };
+  const record: Pick<
+    IssueRunRecord,
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+    | "last_head_sha"
+    | "review_follow_up_head_sha"
+    | "review_follow_up_remaining"
+  > = {
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+    last_head_sha: "head123",
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+  };
+  const nonActionableSameHeadThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-2",
+          body: "Handled manually elsewhere.",
+          createdAt: "2026-03-11T00:10:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "octocat",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [nonActionableSameHeadThread]), []);
+});

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -144,7 +144,7 @@ export function staleConfiguredBotReviewThreads(
   pr: Pick<GitHubPullRequest, "headRefOid">,
   reviewThreads: ReviewThread[],
 ): ReviewThread[] {
-  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  const configuredThreads = actionableConfiguredBotReviewThreads(config, reviewThreads);
   if (configuredThreads.length === 0) {
     return [];
   }
@@ -158,6 +158,15 @@ export function staleConfiguredBotReviewThreads(
   }
 
   return configuredThreads;
+}
+
+export function nonActionableConfiguredBotReviewThreads(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  return configuredBotReviewThreads(config, reviewThreads).filter(
+    (thread) => !latestReviewCommentAuthorIsAllowedBot(config, thread),
+  );
 }
 
 export function buildReviewFailureContext(reviewThreads: ReviewThread[]): FailureContext | null {
@@ -231,6 +240,31 @@ export function buildStalledBotReviewFailureContext(
         ? `${reviewThreads.length} configured bot review thread(s) remain unresolved after exhausting the one allowed same-head follow-up repair turn and now require manual attention.`
         : `${reviewThreads.length} configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.`,
     signature: reviewThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
+    command: null,
+    details,
+    url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,
+    updated_at: nowIso(),
+  };
+}
+
+export function buildNonActionableConfiguredBotReviewFailureContext(
+  reviewThreads: ReviewThread[],
+): FailureContext | null {
+  if (reviewThreads.length === 0) {
+    return null;
+  }
+
+  const details = reviewThreads.slice(0, 5).map((thread) => {
+    const latestComment = latestReviewComment(thread);
+    const author = latestComment?.author?.login ?? "unknown";
+    return `reviewer=${author} file=${thread.path ?? "unknown"} line=${thread.line ?? "?"} processed_on_current_head=no latest_comment_actionable=no`;
+  });
+
+  return {
+    category: "manual",
+    summary:
+      `${reviewThreads.length} configured bot review thread(s) remain unresolved, but the latest comment is no longer actionable by an allowed review bot on the current head, so manual attention is required.`,
+    signature: reviewThreads.map((thread) => `non-actionable-bot:${thread.id}`).join("|"),
     command: null,
     details,
     url: reviewThreads[0]?.comments.nodes[0]?.url ?? null,

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -450,6 +450,76 @@ Show stale configured-bot review blockers distinctly in explain output.
   assert.match(explanation, /^reason_2=local_state blocked$/m);
 });
 
+test("explain keeps non-actionable same-head configured-bot blockers on manual review without claiming current-head processing", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 96;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "manual_review",
+        last_error:
+          "1 configured bot review thread(s) remain unresolved, but the latest comment is no longer actionable by an allowed review bot on the current head, so manual attention is required.",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved, but the latest comment is no longer actionable by an allowed review bot on the current head, so manual attention is required.",
+          signature: "non-actionable-bot:thread-1",
+          command: null,
+          details: [
+            "reviewer=octocat file=src/file.ts line=12 processed_on_current_head=no latest_comment_actionable=no",
+          ],
+          url: "https://example.test/pr/196#discussion_r2",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain non-actionable same-head configured bot blockers",
+    body: `## Summary
+Explain should keep non-actionable same-head configured-bot blockers on manual review without implying current-head reprocessing.
+
+## Scope
+- surface unresolved configured-bot threads whose latest comment is no longer actionable
+
+## Acceptance criteria
+- explain keeps the blocker on manual_review and shows processed_on_current_head=no
+
+## Verification
+- npm test -- src/supervisor/supervisor-diagnostics-explain.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^blocked_reason=manual_review$/m);
+  assert.match(
+    explanation,
+    /^failure_summary=1 configured bot review thread\(s\) remain unresolved, but the latest comment is no longer actionable by an allowed review bot on the current head, so manual attention is required\.$/m,
+  );
+  assert.doesNotMatch(explanation, /^failure_details=.*processed_on_current_head=yes/m);
+});
+
 test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.staleConfiguredBotReviewPolicy = "reply_and_resolve";

--- a/src/supervisor/supervisor-failure-context.ts
+++ b/src/supervisor/supervisor-failure-context.ts
@@ -9,11 +9,14 @@ import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
   buildManualReviewFailureContext,
+  buildNonActionableConfiguredBotReviewFailureContext,
   buildRequestedChangesFailureContext,
   buildReviewFailureContext,
   buildStalledBotReviewFailureContext,
   manualReviewThreads,
+  nonActionableConfiguredBotReviewThreads,
   pendingBotReviewThreads,
+  staleConfiguredBotReviewThreads,
 } from "../review-thread-reporting";
 import {
   localReviewBlocksMerge,
@@ -63,10 +66,16 @@ export function inferFailureContext(
         return reviewContext;
       }
 
+      const nonActionableConfiguredBotContext = buildNonActionableConfiguredBotReviewFailureContext(
+        nonActionableConfiguredBotReviewThreads(config, reviewThreads),
+      );
+      if (nonActionableConfiguredBotContext) {
+        return nonActionableConfiguredBotContext;
+      }
+
       const stalledBotReviewContext = buildStalledBotReviewFailureContext(
-        configuredBotReviewThreads(config, reviewThreads),
-        configuredBotReviewFollowUpState(config, record, pr, configuredBotReviewThreads(config, reviewThreads)) ===
-          "exhausted"
+        staleConfiguredBotReviewThreads(config, record, pr, reviewThreads),
+        configuredBotReviewFollowUpState(config, record, pr, configuredBotReviewThreads(config, reviewThreads)) === "exhausted"
           ? "exhausted_follow_up"
           : "no_progress",
       );
@@ -106,8 +115,15 @@ export function inferFailureContext(
       return reviewContext;
     }
 
+    const nonActionableConfiguredBotContext = buildNonActionableConfiguredBotReviewFailureContext(
+      nonActionableConfiguredBotReviewThreads(config, reviewThreads),
+    );
+    if (nonActionableConfiguredBotContext) {
+      return nonActionableConfiguredBotContext;
+    }
+
     const stalledBotReviewContext = buildStalledBotReviewFailureContext(
-      configuredBotReviewThreads(config, reviewThreads),
+      staleConfiguredBotReviewThreads(config, record, pr, reviewThreads),
       configuredBotReviewFollowUpState(config, record, pr, configuredBotReviewThreads(config, reviewThreads)) === "exhausted"
         ? "exhausted_follow_up"
         : "no_progress",

--- a/src/supervisor/supervisor-pr-review-blockers.test.ts
+++ b/src/supervisor/supervisor-pr-review-blockers.test.ts
@@ -164,6 +164,166 @@ test("runOnce reprocesses a configured bot review thread once after a new PR hea
   );
 });
 
+test("runOnce keeps same-head configured-bot blockers on manual review when the latest thread comment is no longer actionable", async () => {
+  const fixture = await createSupervisorFixture({
+    codexScriptLines: [
+      "#!/bin/sh",
+      "set -eu",
+      "echo unexpected codex execution >&2",
+      "exit 42",
+      "",
+    ],
+  });
+  const issueNumber = 117;
+  const branch = branchName(fixture.config, issueNumber);
+  const runHeadSha = git(["rev-parse", "HEAD"], fixture.repoPath);
+  const config = createConfig({
+    ...fixture.config,
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "pr_open",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: issueNumber,
+        last_head_sha: runHeadSha,
+        processed_review_thread_ids: [`thread-1@${runHeadSha}`],
+        processed_review_thread_fingerprints: [`thread-1@${runHeadSha}#comment-1`],
+        blocked_reason: "manual_review",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Keep non-actionable same-head configured bot blockers off the stale bucket",
+    body: executionReadyBody("Keep non-actionable same-head configured bot blockers off the stale bucket."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: issueNumber,
+    title: "Keep non-actionable same-head configured bot blockers manual",
+    url: `https://example.test/pr/${issueNumber}`,
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: runHeadSha,
+    mergedAt: null,
+  };
+  const reviewThreads = [
+    createReviewThread({
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Please address this.",
+            createdAt: "2026-03-13T06:20:00Z",
+            url: `https://example.test/pr/${issueNumber}#discussion_r1`,
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+          {
+            id: "comment-2",
+            body: "Handled manually elsewhere.",
+            createdAt: "2026-03-13T06:30:00Z",
+            url: `https://example.test/pr/${issueNumber}#discussion_r2`,
+            author: {
+              login: "octocat",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      assert.equal(branchName, branch);
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return reviewThreads;
+    },
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: false });
+  assert.match(message, /state=blocked/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "blocked");
+  assert.equal(record.last_head_sha, runHeadSha);
+  assert.equal(record.blocked_reason, "manual_review");
+  assert.deepEqual(record.processed_review_thread_ids, [`thread-1@${runHeadSha}`]);
+  assert.deepEqual(record.processed_review_thread_fingerprints, [`thread-1@${runHeadSha}#comment-1`]);
+  assert.equal(record.last_failure_context?.category, "manual");
+  assert.equal(
+    record.last_failure_context?.summary,
+    "1 configured bot review thread(s) remain unresolved, but the latest comment is no longer actionable by an allowed review bot on the current head, so manual attention is required.",
+  );
+  assert.deepEqual(record.last_failure_context?.details, [
+    "reviewer=octocat file=src/file.ts line=12 processed_on_current_head=no latest_comment_actionable=no",
+  ]);
+
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: record,
+    latestRecord: record,
+    trackedIssueCount: 1,
+    pr,
+    checks: [],
+    reviewThreads,
+  });
+  assert.match(
+    status,
+    /failure_context category=manual summary=1 configured bot review thread\(s\) remain unresolved, but the latest comment is no longer actionable by an allowed review bot on the current head, so manual attention is required\./,
+  );
+  assert.match(
+    status,
+    /failure_details=reviewer=octocat file=src\/file\.ts line=12 processed_on_current_head=no latest_comment_actionable=no/,
+  );
+});
+
 test("runOnce clears stale same-head stalled review-thread blockers after GitHub reports the threads resolved", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 116;


### PR DESCRIPTION
Closes #1538
This PR was opened by codex-supervisor.
Latest Codex summary:

Adjusted the same-head configured-bot reporting path so only actionable latest-bot threads can enter the stale `processed_on_current_head=yes` bucket. Unresolved configured-bot threads whose latest comment is now human/non-allowed stay blocked under `manual_review` with a distinct manual failure context that reports `processed_on_current_head=no latest_comment_actionable=no`. I added focused regressions for the classifier, persisted blocker state/status rendering, and `explain` output.

Committed on `codex/issue-1538` as `ebad68c` with message `Fix non-actionable same-head review bot reporting`. I left the existing untracked supervisor runtime artifacts in `.codex-supervisor/` alone.

Summary: Fixed non-actionable same-head configured-bot threads so they no longer report `processed_on_current_head=yes`; added focused regression coverage and committed the change.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/review-thread-reporting.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1538` with commit `ebad68c` and let CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of automated review comments that are overridden by human responses. The system now properly distinguishes between actionable and non-actionable automated reviews, ensuring accurate tracking and reporting of stale review threads when human comments supersede bot comments.

* **Tests**
  * Added comprehensive test coverage for non-actionable automated review thread scenarios, including failure context reporting and supervisor diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->