### PR TITLE
Expose high-leverage optional fields in starter configs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,8 @@ Most operators start from one of these files:
 - [supervisor.config.codex.json](../supervisor.config.codex.json)
 - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
 
+The shipped starter configs intentionally surface a short list of high-leverage optional fields in addition to the required baseline. In practice, operators most often need to discover model-routing overrides (`boundedRepairModel*`, `localReviewModel*`), current-head local-review freshness (`trackedPrCurrentHeadLocalReviewRequired`), and repo-owned host contracts (`workspacePreparationCommand`, `localCiCommand`) without reading the full schema first.
+
 The simplest workflow is:
 
 1. copy a starter file to `supervisor.config.json`

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -17,6 +17,8 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
   "codexModel": "",
   "boundedRepairModelStrategy": "",
   "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
   "codexReasoningEffortByState": {
     "planning": "low",
     "reproducing": "medium",
@@ -51,6 +53,8 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
+  "workspacePreparationCommand": "",
+  "localCiCommand": "",
   "skipTitlePrefixes": ["Epic:"],
   "branchPrefix": "codex/issue-",
   "pollIntervalSeconds": 120,
@@ -78,6 +82,8 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - If you use GSD for upstream planning, enable `gsdEnabled` and point `gsdPlanningFiles` at `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, and `STATE.md`.
 - Copilot review is expected to start automatically after the PR is marked ready.
 - Leave `boundedRepairModelStrategy` unset unless you explicitly want `repairing_ci` and `addressing_review` turns to use a smaller bounded-repair model such as `gpt-5.4-mini`.
+- Leave `localReviewModelStrategy` unset unless you explicitly want generic local-review turns to use a separate review model.
+- Keep `workspacePreparationCommand` and `localCiCommand` explicit when the repo owns host-local setup and verification entrypoints; otherwise leave them unset instead of expecting the supervisor to infer a contract.
 - The shipped starter profiles keep local review disabled by default. This atlaspm example intentionally shows the recommended once enabled posture.
 - A local review swarm should usually run with `localReviewPolicy: "block_merge"` so it acts as a practical merge gate, with Markdown (`head-<sha>.md`) and JSON (`head-<sha>.json`) artifacts written under the supervisor's `.local/reviews` directory.
 - Leaving `localReviewRoles` empty while `localReviewAutoDetect` is `true` lets the supervisor add repo-specific specialists such as `prisma_postgres_reviewer`, `migration_invariant_reviewer`, `contract_consistency_reviewer`, and workflow-oriented roles like `github_actions_semantics_reviewer`, `workflow_test_reviewer`, and `portability_reviewer` when the repo shape suggests them.

--- a/docs/examples/atlaspm.supervisor.config.example.json
+++ b/docs/examples/atlaspm.supervisor.config.example.json
@@ -10,6 +10,8 @@
   "codexModel": "",
   "boundedRepairModelStrategy": "",
   "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
   "codexReasoningEffortByState": {
     "planning": "low",
     "reproducing": "medium",
@@ -67,6 +69,8 @@
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
+  "workspacePreparationCommand": "",
+  "localCiCommand": "",
   "skipTitlePrefixes": [
     "Epic:"
   ],

--- a/supervisor.config.coderabbit.json
+++ b/supervisor.config.coderabbit.json
@@ -9,6 +9,10 @@
   "codexBinary": "codex",
   "codexModelStrategy": "inherit",
   "codexModel": "",
+  "boundedRepairModelStrategy": "",
+  "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
   "codexReasoningEffortByState": {
     "planning": "low",
     "reproducing": "medium",
@@ -55,7 +59,9 @@
     }
   },
   "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
   "localReviewFollowUpRepairEnabled": false,
+  "localReviewManualReviewRepairEnabled": false,
   "localReviewFollowUpIssueCreationEnabled": false,
   "localReviewHighSeverityAction": "blocked",
   "reviewBotLogins": [
@@ -66,6 +72,8 @@
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
+  "workspacePreparationCommand": "",
+  "localCiCommand": "",
   "skipTitlePrefixes": [
     "Epic:"
   ],

--- a/supervisor.config.codex.json
+++ b/supervisor.config.codex.json
@@ -11,6 +11,8 @@
   "codexModel": "",
   "boundedRepairModelStrategy": "",
   "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
   "codexReasoningEffortByState": {
     "planning": "low",
     "reproducing": "medium",
@@ -57,6 +59,7 @@
     }
   },
   "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
   "localReviewFollowUpRepairEnabled": false,
   "localReviewFollowUpIssueCreationEnabled": false,
   "localReviewHighSeverityAction": "blocked",
@@ -67,6 +70,8 @@
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
+  "workspacePreparationCommand": "",
+  "localCiCommand": "",
   "skipTitlePrefixes": ["Epic:"],
   "branchPrefix": "codex/issue-",
   "pollIntervalSeconds": 120,

--- a/supervisor.config.copilot.json
+++ b/supervisor.config.copilot.json
@@ -11,6 +11,8 @@
   "codexModel": "",
   "boundedRepairModelStrategy": "",
   "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
   "codexReasoningEffortByState": {
     "planning": "low",
     "reproducing": "medium",
@@ -57,6 +59,7 @@
     }
   },
   "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
   "localReviewFollowUpRepairEnabled": false,
   "localReviewFollowUpIssueCreationEnabled": false,
   "localReviewHighSeverityAction": "blocked",
@@ -67,6 +70,8 @@
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
+  "workspacePreparationCommand": "",
+  "localCiCommand": "",
   "skipTitlePrefixes": ["Epic:"],
   "branchPrefix": "codex/issue-",
   "pollIntervalSeconds": 120,


### PR DESCRIPTION
## Summary
- expose a small shortlist of high-leverage optional fields in the shipped starter configs
- keep the existing starter behavior unchanged by leaving the new fields unset by default
- document why the starter configs now surface these advanced-but-practical knobs

## What changed
- added `localReviewModelStrategy` / `localReviewModel` to the Codex, Copilot, CodeRabbit, and AtlasPM starter configs
- added `trackedPrCurrentHeadLocalReviewRequired`, `workspacePreparationCommand`, and `localCiCommand` where they were still missing from shipped starter configs
- preserved the CodeRabbit starter profile's fail-fast `repoSlug: "REPLACE_ME"` and existing local-review posture
- updated the configuration guide and AtlasPM example docs to explain the surfaced optional fields

## Verification
- `npm run build`
- `npx tsx --test src/config.test.ts src/core/config-local-review-model-routing.test.ts src/getting-started-docs.test.ts`

## Notes
- `supervisor.config.example.json` already matched the shortlist before this change, so it required no additional diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced configuration documentation with a guide to high-leverage optional fields.
  * Updated example configurations to showcase new model selection and command execution options for local review, workspace preparation, and CI execution.
  * Added new configurable fields across example configurations with safe default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->