### PR TITLE
tracked PR recovery revives repeated review-thread blockers into local_review on the same head (#1541)

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -54,6 +54,7 @@ import {
   buildTrackedPrResumeRecoveryEvent,
   reconcileStaleFailedTrackedPrRecord,
   reconcileTrackedMergedButOpenIssuesInModule,
+  suppressSameHeadNoProgressReviewThreadRecovery,
 } from "./recovery-tracked-pr-reconciliation";
 export {
   inspectOrphanedWorkspacePruneCandidates,
@@ -1290,6 +1291,23 @@ export async function reconcileRecoverableBlockedIssueStates(
       });
       const nextState = projection.nextState;
       if (projection.shouldSuppressRecovery) {
+        continue;
+      }
+      const recoverySuppression = suppressSameHeadNoProgressReviewThreadRecovery(
+        record,
+        trackedPullRequest,
+        reviewThreads,
+        nextState,
+      );
+      if (recoverySuppression.shouldSuppress) {
+        const suppressionPatch: Partial<IssueRunRecord> = {
+          last_tracked_pr_progress_summary: recoverySuppression.progressSummary,
+        };
+        if (needsRecordUpdate(record, suppressionPatch)) {
+          const updated = stateStore.touch(record, suppressionPatch);
+          state.issues[String(record.issue_number)] = updated;
+          changed = true;
+        }
         continue;
       }
 

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -72,6 +72,85 @@ function matchesTrackedBranch(
   return pr.headRefName === record.branch;
 }
 
+function unresolvedReviewThreadIds(reviewThreads: ReviewThread[]): string[] {
+  return reviewThreads
+    .filter((thread) => !thread.isResolved)
+    .map((thread) => thread.id)
+    .sort();
+}
+
+function parseTrackedPrProgressSnapshotThreadIds(
+  snapshot: string | null | undefined,
+): string[] | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(snapshot);
+    return Array.isArray(parsed?.unresolvedReviewThreadIds)
+      ? parsed.unresolvedReviewThreadIds
+        .filter((threadId: unknown): threadId is string => typeof threadId === "string")
+        .sort()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function suppressSameHeadNoProgressReviewThreadRecovery(
+  record: Pick<
+    IssueRunRecord,
+    | "last_head_sha"
+    | "last_failure_signature"
+    | "last_tracked_pr_progress_snapshot"
+    | "last_tracked_pr_repeat_failure_decision"
+    | "state"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  reviewThreads: ReviewThread[],
+  nextState: IssueRunRecord["state"],
+): {
+  shouldSuppress: boolean;
+  progressSummary: string | null;
+} {
+  if (
+    record.state !== "blocked" ||
+    record.last_tracked_pr_repeat_failure_decision !== "stop_no_progress" ||
+    record.last_head_sha === null ||
+    record.last_head_sha !== pr.headRefOid ||
+    nextState === "blocked"
+  ) {
+    return {
+      shouldSuppress: false,
+      progressSummary: null,
+    };
+  }
+
+  const previousThreadIds = parseTrackedPrProgressSnapshotThreadIds(record.last_tracked_pr_progress_snapshot);
+  const currentThreadIds = unresolvedReviewThreadIds(reviewThreads);
+  const failureSignature = record.last_failure_signature;
+  const sameThreadIds =
+    previousThreadIds !== null &&
+    previousThreadIds.length > 0 &&
+    previousThreadIds.length === currentThreadIds.length &&
+    previousThreadIds.every((threadId, index) => threadId === currentThreadIds[index]);
+  const sameBlockingThread =
+    typeof failureSignature === "string" && failureSignature.length > 0 && currentThreadIds.includes(failureSignature);
+
+  if (!sameThreadIds || !sameBlockingThread) {
+    return {
+      shouldSuppress: false,
+      progressSummary: null,
+    };
+  }
+
+  return {
+    shouldSuppress: true,
+    progressSummary: "suppressed_same_head_same_review_thread_blocker",
+  };
+}
+
 function trackedMergedButOpenLastProcessedIssueNumber(state: SupervisorStateFile): number | null {
   return state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number ?? null;
 }

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1698,6 +1698,121 @@ test("reconcileRecoverableBlockedIssueStates rehydrates tracked PR manual-review
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates suppresses same-head tracked PR recovery after a repeated no-progress review-thread stop on the same blocker", async () => {
+  const config = createConfig();
+  const previousProgressSnapshot = JSON.stringify({
+    headRefOid: "head-191",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    copilotReviewState: null,
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: null,
+    currentHeadCiGreenAt: "2026-03-13T00:18:00Z",
+    configuredBotRateLimitedAt: null,
+    configuredBotDraftSkipAt: null,
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotTopLevelReviewSubmittedAt: null,
+    checks: ["build:pass:SUCCESS:CI"],
+    unresolvedReviewThreadIds: ["PRRT_thread_1"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "manual_review",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "PRRT_thread_1",
+          command: null,
+          details: ["reviewer=coderabbit path=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/191#discussion_r1",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "PRRT_thread_1",
+        repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_snapshot: previousProgressSnapshot,
+        last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: "PRRT_thread_1",
+        }),
+      ],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "local_review",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(
+    updated.last_tracked_pr_progress_summary,
+    "suppressed_same_head_same_review_thread_blocker",
+  );
+  assert.equal(updated.last_tracked_pr_repeat_failure_decision, "stop_no_progress");
+  assert.equal(updated.last_recovery_reason, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents, []);
+});
+
 test("reconcileRecoverableBlockedIssueStates keeps same-head draft tracked PRs blocked when the verification gate still fails", async () => {
   const config = createConfig({
     localCiCommand: "npm run verify:paths",

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -12,7 +12,7 @@ import {
   buildNonRunnableLocalStateReasons,
   renderIssueExplainDto,
 } from "./supervisor-selection-issue-explain";
-import { branchName, createConfig, createRecord, createSupervisorFixture } from "./supervisor-test-helpers";
+import { branchName, createConfig, createRecord, createSupervisorFixture, createSupervisorState } from "./supervisor-test-helpers";
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -308,6 +308,60 @@ test("buildIssueExplainDto exposes typed operator activity context", async () =>
   assert.match(
     rendered,
     /^recovery_loop_summary latest_reason=tracked_pr_head_advanced phase_change=blocked->addressing_review apparent_no_progress=yes$/m,
+  );
+});
+
+test("buildIssueExplainDto reports same-blocker tracked PR recovery suppression distinctly", async () => {
+  const issue = createIssue({
+    number: 611,
+    title: "Suppressed tracked PR recovery",
+    body: `## Summary
+Keep the same unresolved tracked PR review blocker stably blocked.
+
+## Scope
+- keep same-head tracked PR recovery suppressed when the unchanged review-thread blocker is still present
+
+## Acceptance criteria
+- explain shows the same-blocker tracked PR suppression signal
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 611,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        last_failure_signature: "PRRT_thread_1",
+        repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_summary: "suppressed_same_head_same_review_thread_blocker",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+    },
+    createConfig(),
+    state,
+    611,
+  );
+
+  const rendered = renderIssueExplainDto(dto);
+  assert.match(
+    rendered,
+    /^tracked_pr_repeat_failure decision=stop_no_progress signal=suppressed_same_head_same_review_thread_blocker$/m,
   );
 });
 


### PR DESCRIPTION
Closes #1541
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a narrow tracked-PR recovery guard for the blocked-state reconciliation path. Recovery is now suppressed only when all of these are true: the prior repeat-failure decision was `stop_no_progress`, the PR head is unchanged, the stored unresolved review-thread id set matches the current unresolved set, and the repeated failure signature still points at one of those same threads. In that case the issue stays stably `blocked` instead of reviving into `local_review`, and `explain` now surfaces `tracked_pr_repeat_failure decision=stop_no_progress signal=suppressed_same_head_same_review_thread_blocker`.

I added the focused regression in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1541/src/supervisor/supervisor-recovery-reconciliation.test.ts) plus the operator-facing explain assertion in [src/supervisor/supervisor-selection-issue-explain.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1541/src/supervisor/supervisor-selection-issue-explain.test.ts). The implementation lives in [src/recovery-tracked-pr-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1541/src/recovery-tracked-pr-reconciliation.ts) and is applied from [src/recovery-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1541/src/recovery-reconciliation.ts). Checkpoint commit: `064935d` (`Suppress same-head tracked PR ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recovery logic to prevent redundant recovery attempts for blocked tracked PR issues when the same PR head and blocking review threads persist without change. The system now explicitly tracks suppression decisions and reports them distinctly for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->