### PR TITLE
same-thread review updates should bypass #1548 no-progress recovery suppression (#1549)

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1399,6 +1399,9 @@ export async function reconcileRecoverableBlockedIssueStates(
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
       });
+      if (recoverySuppression.progressSummary !== null) {
+        patch.last_tracked_pr_progress_summary = recoverySuppression.progressSummary;
+      }
       const recoveryEvent = buildTrackedPrResumeRecoveryEvent(
         record,
         trackedPullRequest,

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -24,6 +24,7 @@ import {
 } from "./pull-request-state-sync";
 import { blockedReasonForLifecycleState, isOpenPullRequest } from "./supervisor/supervisor-lifecycle";
 import { inferFailureContext } from "./supervisor/supervisor-failure-context";
+import { latestReviewThreadCommentFingerprint } from "./review-handling";
 
 type RecoveryGitHubLike = Pick<
   import("./github").GitHubClient,
@@ -79,6 +80,13 @@ function unresolvedReviewThreadIds(reviewThreads: ReviewThread[]): string[] {
     .sort();
 }
 
+function unresolvedReviewThreadFingerprints(reviewThreads: ReviewThread[]): string[] {
+  return reviewThreads
+    .filter((thread) => !thread.isResolved)
+    .map((thread) => `${thread.id}#${latestReviewThreadCommentFingerprint(thread) ?? "no-comment"}`)
+    .sort();
+}
+
 function parseTrackedPrProgressSnapshotThreadIds(
   snapshot: string | null | undefined,
 ): string[] | null {
@@ -91,6 +99,25 @@ function parseTrackedPrProgressSnapshotThreadIds(
     return Array.isArray(parsed?.unresolvedReviewThreadIds)
       ? parsed.unresolvedReviewThreadIds
         .filter((threadId: unknown): threadId is string => typeof threadId === "string")
+        .sort()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseTrackedPrProgressSnapshotThreadFingerprints(
+  snapshot: string | null | undefined,
+): string[] | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(snapshot);
+    return Array.isArray(parsed?.unresolvedReviewThreadFingerprints)
+      ? parsed.unresolvedReviewThreadFingerprints
+        .filter((fingerprint: unknown): fingerprint is string => typeof fingerprint === "string")
         .sort()
       : null;
   } catch {
@@ -129,6 +156,10 @@ export function suppressSameHeadNoProgressReviewThreadRecovery(
 
   const previousThreadIds = parseTrackedPrProgressSnapshotThreadIds(record.last_tracked_pr_progress_snapshot);
   const currentThreadIds = unresolvedReviewThreadIds(reviewThreads);
+  const previousThreadFingerprints = parseTrackedPrProgressSnapshotThreadFingerprints(
+    record.last_tracked_pr_progress_snapshot,
+  );
+  const currentThreadFingerprints = unresolvedReviewThreadFingerprints(reviewThreads);
   const failureSignature = record.last_failure_signature;
   const sameThreadIds =
     previousThreadIds !== null &&
@@ -137,11 +168,23 @@ export function suppressSameHeadNoProgressReviewThreadRecovery(
     previousThreadIds.every((threadId, index) => threadId === currentThreadIds[index]);
   const sameBlockingThread =
     typeof failureSignature === "string" && failureSignature.length > 0 && currentThreadIds.includes(failureSignature);
+  const sameThreadGuidance =
+    previousThreadFingerprints !== null &&
+    previousThreadFingerprints.length > 0 &&
+    previousThreadFingerprints.length === currentThreadFingerprints.length &&
+    previousThreadFingerprints.every((fingerprint, index) => fingerprint === currentThreadFingerprints[index]);
 
   if (!sameThreadIds || !sameBlockingThread) {
     return {
       shouldSuppress: false,
       progressSummary: null,
+    };
+  }
+
+  if (!sameThreadGuidance) {
+    return {
+      shouldSuppress: false,
+      progressSummary: "same_review_thread_guidance_changed",
     };
   }
 

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -168,16 +168,25 @@ export function suppressSameHeadNoProgressReviewThreadRecovery(
     previousThreadIds.every((threadId, index) => threadId === currentThreadIds[index]);
   const sameBlockingThread =
     typeof failureSignature === "string" && failureSignature.length > 0 && currentThreadIds.includes(failureSignature);
-  const sameThreadGuidance =
+  const hasComparableThreadGuidanceBaseline =
     previousThreadFingerprints !== null &&
     previousThreadFingerprints.length > 0 &&
-    previousThreadFingerprints.length === currentThreadFingerprints.length &&
+    previousThreadFingerprints.length === currentThreadFingerprints.length;
+  const sameThreadGuidance =
+    hasComparableThreadGuidanceBaseline &&
     previousThreadFingerprints.every((fingerprint, index) => fingerprint === currentThreadFingerprints[index]);
 
   if (!sameThreadIds || !sameBlockingThread) {
     return {
       shouldSuppress: false,
       progressSummary: null,
+    };
+  }
+
+  if (!hasComparableThreadGuidanceBaseline) {
+    return {
+      shouldSuppress: true,
+      progressSummary: "suppressed_same_head_same_review_thread_blocker",
     };
   }
 

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -148,6 +148,28 @@ function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPu
   };
 }
 
+function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this.",
+          createdAt: "2026-03-13T06:20:00Z",
+          url: "https://example.test/pr/42#discussion_r1",
+          author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
 function withStubbedDateNow<T>(nowIso: string, run: () => T): T {
   const originalDateNow = Date.now;
   Date.now = () => Date.parse(nowIso);
@@ -248,11 +270,12 @@ test("summarizeTrackedPrProgress treats merge state changes as tracked PR progre
       currentHeadCiGreenAt: null,
       configuredBotRateLimitedAt: null,
       configuredBotDraftSkipAt: null,
-      configuredBotTopLevelReviewStrength: null,
-      configuredBotTopLevelReviewSubmittedAt: null,
-      checks: ["build:pass:SUCCESS:CI"],
-      unresolvedReviewThreadIds: [],
-    }),
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotTopLevelReviewSubmittedAt: null,
+    checks: ["build:pass:SUCCESS:CI"],
+    unresolvedReviewThreadIds: [],
+    unresolvedReviewThreadFingerprints: [],
+  }),
   });
   const pr = createPullRequest({
     mergeStateStatus: "CLEAN",
@@ -309,6 +332,7 @@ test("determineTrackedPrRepeatFailureDisposition stays retryable over the repeat
       configuredBotTopLevelReviewSubmittedAt: null,
       checks: ["build:fail:FAILURE:CI"],
       unresolvedReviewThreadIds: [],
+      unresolvedReviewThreadFingerprints: [],
     }),
   });
   const pr = createPullRequest({
@@ -347,6 +371,7 @@ test("determineTrackedPrRepeatFailureDisposition stops over the repeat limit whe
     configuredBotTopLevelReviewSubmittedAt: null,
     checks: ["build:pass:SUCCESS:CI"],
     unresolvedReviewThreadIds: [],
+    unresolvedReviewThreadFingerprints: [],
   });
   const record = createRecord({
     last_failure_signature: "build (ubuntu-latest):fail",
@@ -371,6 +396,66 @@ test("determineTrackedPrRepeatFailureDisposition stops over the repeat limit whe
   assert.equal(result.decision, "stop_no_progress");
   assert.equal(result.progressSummary, "no_meaningful_tracked_pr_progress");
   assert.equal(result.progressSnapshot, snapshot);
+});
+
+test("summarizeTrackedPrProgress treats updated same-thread guidance as tracked PR progress", () => {
+  const record = createRecord({
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head123",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: null,
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-1"],
+      unresolvedReviewThreadFingerprints: ["thread-1#comment-1"],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads: ReviewThread[] = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Please address this.",
+            createdAt: "2026-03-13T06:20:00Z",
+            url: "https://example.test/pr/42#discussion_r1",
+            author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+          },
+          {
+            id: "comment-2",
+            body: "Please also handle this update.",
+            createdAt: "2026-03-13T06:25:00Z",
+            url: "https://example.test/pr/42#discussion_r2",
+            author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const result = summarizeTrackedPrProgress(
+    record,
+    pr,
+    [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  );
+
+  assert.match(result.summary ?? "", /same_review_thread_guidance_changed/);
 });
 
 test("derivePullRequestLifecycleSnapshot re-arms CodeRabbit waiting after ready-for-review when draft skip was the latest prior signal", () => {

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -19,6 +19,7 @@ import {
   localReviewHighSeverityNeedsBlock,
   localReviewRetryLoopStalled,
 } from "../review-handling";
+import { latestReviewThreadCommentFingerprint } from "../review-handling";
 import { inferFailureContext } from "./supervisor-failure-context";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor-status-rendering";
 import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
@@ -117,6 +118,7 @@ interface TrackedPrProgressSnapshot {
   configuredBotTopLevelReviewSubmittedAt: string | null;
   checks: string[];
   unresolvedReviewThreadIds: string[];
+  unresolvedReviewThreadFingerprints?: string[];
 }
 
 export interface TrackedPrRepeatFailureDisposition {
@@ -151,6 +153,10 @@ function buildTrackedPrProgressSnapshot(
     unresolvedReviewThreadIds: reviewThreads
       .filter((thread) => !thread.isResolved)
       .map((thread) => thread.id)
+      .sort(),
+    unresolvedReviewThreadFingerprints: reviewThreads
+      .filter((thread) => !thread.isResolved)
+      .map((thread) => `${thread.id}#${latestReviewThreadCommentFingerprint(thread) ?? "no-comment"}`)
       .sort(),
   };
 }
@@ -200,6 +206,20 @@ function listChangedSignals(previous: TrackedPrProgressSnapshot | null, current:
     (previous?.configuredBotTopLevelReviewStrength ?? null) !== current.configuredBotTopLevelReviewStrength ||
     (previous?.configuredBotTopLevelReviewSubmittedAt ?? null) !== current.configuredBotTopLevelReviewSubmittedAt ||
     (previous?.unresolvedReviewThreadIds.join("|") ?? null) !== current.unresolvedReviewThreadIds.join("|");
+  const previousThreadFingerprints = previous?.unresolvedReviewThreadFingerprints?.join("|") ?? null;
+  const currentThreadFingerprints = current.unresolvedReviewThreadFingerprints?.join("|") ?? null;
+  const sameThreadIds =
+    previous !== null &&
+    previous.unresolvedReviewThreadIds.join("|") === current.unresolvedReviewThreadIds.join("|");
+  const sameThreadGuidanceChanged =
+    previous !== null &&
+    sameThreadIds &&
+    previousThreadFingerprints !== null &&
+    currentThreadFingerprints !== null &&
+    previousThreadFingerprints !== currentThreadFingerprints;
+  if (sameThreadGuidanceChanged) {
+    signals.push("same_review_thread_guidance_changed");
+  }
   if (previous !== null && reviewSignalChanged) {
     signals.push("review_state_changed");
   }

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1825,6 +1825,132 @@ test("reconcileRecoverableBlockedIssueStates suppresses same-head tracked PR rec
   assert.deepEqual(recoveryEvents, []);
 });
 
+test("reconcileRecoverableBlockedIssueStates preserves same-head suppression when older progress snapshots lack review-thread fingerprints", async () => {
+  const config = createConfig();
+  const previousProgressSnapshot = JSON.stringify({
+    headRefOid: "head-191",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    copilotReviewState: null,
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: null,
+    currentHeadCiGreenAt: "2026-03-13T00:18:00Z",
+    configuredBotRateLimitedAt: null,
+    configuredBotDraftSkipAt: null,
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotTopLevelReviewSubmittedAt: null,
+    checks: ["build:pass:SUCCESS:CI"],
+    unresolvedReviewThreadIds: ["PRRT_thread_1"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "manual_review",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "PRRT_thread_1",
+          command: null,
+          details: ["reviewer=coderabbit path=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/191#discussion_r1",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "PRRT_thread_1",
+        repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_snapshot: previousProgressSnapshot,
+        last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: "PRRT_thread_1",
+          comments: {
+            nodes: [
+              {
+                id: "comment-1",
+                body: "Please address this thread.",
+                createdAt: "2026-03-13T00:19:00Z",
+                url: "https://example.test/pr/191#discussion_r1",
+                author: { login: "coderabbit", typeName: "Bot" },
+              },
+            ],
+          },
+        }),
+      ],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "local_review",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(
+    updated.last_tracked_pr_progress_summary,
+    "suppressed_same_head_same_review_thread_blocker",
+  );
+  assert.equal(updated.last_tracked_pr_repeat_failure_decision, "stop_no_progress");
+  assert.equal(updated.last_recovery_reason, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents, []);
+});
+
 test("reconcileRecoverableBlockedIssueStates allows same-head tracked PR recovery when the unresolved blocker guidance changes within the same thread", async () => {
   const config = createConfig();
   const previousProgressSnapshot = JSON.stringify({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1716,6 +1716,7 @@ test("reconcileRecoverableBlockedIssueStates suppresses same-head tracked PR rec
     configuredBotTopLevelReviewSubmittedAt: null,
     checks: ["build:pass:SUCCESS:CI"],
     unresolvedReviewThreadIds: ["PRRT_thread_1"],
+    unresolvedReviewThreadFingerprints: ["PRRT_thread_1#comment-1"],
   });
   const state: SupervisorStateFile = createSupervisorState({
     issues: [
@@ -1781,6 +1782,17 @@ test("reconcileRecoverableBlockedIssueStates suppresses same-head tracked PR rec
       getUnresolvedReviewThreads: async () => [
         createReviewThread({
           id: "PRRT_thread_1",
+          comments: {
+            nodes: [
+              {
+                id: "comment-1",
+                body: "Please address this thread.",
+                createdAt: "2026-03-13T00:19:00Z",
+                url: "https://example.test/pr/191#discussion_r1",
+                author: { login: "coderabbit", typeName: "Bot" },
+              },
+            ],
+          },
         }),
       ],
     },
@@ -1811,6 +1823,142 @@ test("reconcileRecoverableBlockedIssueStates suppresses same-head tracked PR rec
   assert.equal(updated.last_recovery_reason, null);
   assert.equal(saveCalls, 1);
   assert.deepEqual(recoveryEvents, []);
+});
+
+test("reconcileRecoverableBlockedIssueStates allows same-head tracked PR recovery when the unresolved blocker guidance changes within the same thread", async () => {
+  const config = createConfig();
+  const previousProgressSnapshot = JSON.stringify({
+    headRefOid: "head-191",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    copilotReviewState: null,
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: null,
+    currentHeadCiGreenAt: "2026-03-13T00:18:00Z",
+    configuredBotRateLimitedAt: null,
+    configuredBotDraftSkipAt: null,
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotTopLevelReviewSubmittedAt: null,
+    checks: ["build:pass:SUCCESS:CI"],
+    unresolvedReviewThreadIds: ["PRRT_thread_1"],
+    unresolvedReviewThreadFingerprints: ["PRRT_thread_1#comment-1"],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "manual_review",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "PRRT_thread_1",
+          command: null,
+          details: ["reviewer=coderabbit path=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/191#discussion_r1",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "PRRT_thread_1",
+        repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_snapshot: previousProgressSnapshot,
+        last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: "PRRT_thread_1",
+          comments: {
+            nodes: [
+              {
+                id: "comment-1",
+                body: "Please address this thread.",
+                createdAt: "2026-03-13T00:19:00Z",
+                url: "https://example.test/pr/191#discussion_r1",
+                author: { login: "coderabbit", typeName: "Bot" },
+              },
+              {
+                id: "comment-2",
+                body: "Additional guidance arrived on the same unresolved thread.",
+                createdAt: "2026-03-13T00:24:00Z",
+                url: "https://example.test/pr/191#discussion_r2",
+                author: { login: "coderabbit", typeName: "Bot" },
+              },
+            ],
+          },
+        }),
+      ],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "local_review",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "local_review");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_tracked_pr_progress_summary, "same_review_thread_guidance_changed");
+  assert.equal(updated.last_tracked_pr_repeat_failure_decision, "stop_no_progress");
+  assert.match(
+    updated.last_recovery_reason ?? "",
+    /tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to local_review using fresh tracked PR #191 facts at head head-191/,
+  );
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to local_review using fresh tracked PR #191 facts at head head-191",
+  ]);
 });
 
 test("reconcileRecoverableBlockedIssueStates keeps same-head draft tracked PRs blocked when the verification gate still fails", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -365,6 +365,60 @@ Parallelizable: No
   );
 });
 
+test("buildIssueExplainDto reports same-thread tracked PR blocker guidance changes distinctly", async () => {
+  const issue = createIssue({
+    number: 612,
+    title: "Changed same-thread tracked PR blocker",
+    body: `## Summary
+Allow same-head recovery when a review bot updates guidance inside the same unresolved thread.
+
+## Scope
+- surface materially changed same-thread review guidance distinctly in explain output
+
+## Acceptance criteria
+- explain shows the refreshed same-thread blocker signal
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 612,
+        state: "local_review",
+        blocked_reason: null,
+        last_failure_signature: "PRRT_thread_1",
+        repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_summary: "same_review_thread_guidance_changed",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+    },
+    createConfig(),
+    state,
+    612,
+  );
+
+  const rendered = renderIssueExplainDto(dto);
+  assert.match(
+    rendered,
+    /^tracked_pr_repeat_failure decision=stop_no_progress signal=same_review_thread_guidance_changed$/m,
+  );
+});
+
 test("buildIssueExplainDto degrades when PR resolution fails", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 606;


### PR DESCRIPTION
Closes #1549
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the `#1549` fix on `codex/issue-1549` in commit `f7159df`.

The recovery path now distinguishes unchanged same-thread blockers from refreshed same-thread guidance by persisting unresolved review-thread latest-comment fingerprints in the tracked-PR progress snapshot. Same-head suppression still holds for the unchanged blocker case, but it now yields to recovery when the configured bot updates guidance inside the same unresolved thread. Diagnostics and explain output surface that case as `same_review_thread_guidance_changed`.

Verification ran clean for the focused issue coverage and build:
`npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-lifecycle.test.ts`
`npm run build`

Summary: Same-thread review guidance updates now bypass same-head no-progress suppression by comparing latest-comment fingerprints, with focused regressions and diagnostics coverage added.
State hint: local_review
Blocked reason: none
Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-lifecycle.test.ts`; `npm run build`
Failure signature: none
Next action: run local review on commit `f7159df` and, if clean, open or update the draft PR for `codex/issue-1549`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of meaningful guidance changes within unresolved review threads so recovery is allowed when thread guidance updates, instead of incorrectly suppressing resumption when thread IDs match.
* **Tests**
  * Added tests covering fingerprint-based review-thread change detection and recovery/suppression behaviors, plus fixtures to model per-thread guidance updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->