### PR TITLE
Canonicalize tracked workspace and issue journal path resolution across hosts

### DIFF
--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -1,6 +1,7 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { GitHubIssue, IssueRunRecord } from "./types";
+import { GitHubIssue, IssueRunRecord, SupervisorConfig } from "./types";
 import { ensureDir, truncate, writeFileAtomic } from "./utils";
 
 const NOTES_MARKER = "## Codex Working Notes";
@@ -558,6 +559,35 @@ export function issueJournalPath(workspacePath: string, relativePathTemplate: st
       ? relativePathTemplate
       : resolveIssueJournalRelativePath(relativePathTemplate, issueNumber);
   return path.resolve(workspacePath, relativePath);
+}
+
+function hasLocalTrackedWorkspace(workspacePath: string): boolean {
+  return fsSync.existsSync(path.join(workspacePath, ".git"));
+}
+
+export function resolveTrackedIssueHostPaths(
+  config: Pick<SupervisorConfig, "workspaceRoot" | "issueJournalRelativePath">,
+  record: Pick<IssueRunRecord, "issue_number" | "workspace" | "journal_path">,
+): {
+  workspace: string;
+  journal_path: string;
+  usingCanonicalWorkspace: boolean;
+} {
+  const canonicalWorkspacePath = path.join(config.workspaceRoot, `issue-${record.issue_number}`);
+  const usingCanonicalWorkspace = hasLocalTrackedWorkspace(canonicalWorkspacePath);
+  const workspacePath = usingCanonicalWorkspace ? canonicalWorkspacePath : record.workspace;
+  const journalRelativePath = trackedIssueJournalRelativePath(
+    record.workspace,
+    record.journal_path,
+    config.issueJournalRelativePath,
+    record.issue_number,
+  );
+
+  return {
+    workspace: workspacePath,
+    journal_path: path.resolve(workspacePath, journalRelativePath),
+    usingCanonicalWorkspace,
+  };
 }
 
 export async function readIssueJournal(journalPath: string): Promise<string | null> {

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -582,10 +582,23 @@ export function resolveTrackedIssueHostPaths(
     config.issueJournalRelativePath,
     record.issue_number,
   );
+  const resolvedJournalPath = path.resolve(workspacePath, journalRelativePath);
+  const relativeToWorkspace = path.relative(workspacePath, resolvedJournalPath);
+  const escapesWorkspace =
+    relativeToWorkspace === ".." ||
+    relativeToWorkspace.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeToWorkspace);
 
   return {
     workspace: workspacePath,
-    journal_path: path.resolve(workspacePath, journalRelativePath),
+    journal_path: escapesWorkspace
+      ? trackedIssueJournalPath(
+        workspacePath,
+        null,
+        config.issueJournalRelativePath,
+        record.issue_number,
+      )
+      : resolvedJournalPath,
     usingCanonicalWorkspace,
   };
 }

--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -253,6 +253,30 @@ test("resolveTrackedIssueHostPaths derives the canonical journal path for null j
   );
 });
 
+test("resolveTrackedIssueHostPaths falls back to the canonical journal path when persisted hints would escape the local workspace", async () => {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "journal-host-paths-escape-"));
+  const canonicalWorkspace = path.join(workspaceRoot, "issue-177");
+  await fs.mkdir(canonicalWorkspace, { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n");
+
+  const resolved = resolveTrackedIssueHostPaths(
+    {
+      workspaceRoot,
+      issueJournalRelativePath: DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH,
+    },
+    createRecord({
+      workspace: "/tmp/other-host/worktrees/issue-177",
+      journal_path: "/tmp/other-host/.codex-supervisor/issues/177/issue-journal.md",
+    }),
+  );
+
+  assert.equal(resolved.workspace, canonicalWorkspace);
+  assert.equal(
+    resolved.journal_path,
+    path.join(canonicalWorkspace, ".codex-supervisor", "issues", "177", "issue-journal.md"),
+  );
+});
+
 test("syncIssueJournal normalizes absolute local paths before writing durable content", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-path-normalization-"));
   const journalPath = path.join(tempDir, ".codex-supervisor", "issue-journal.md");

--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH,
   issueJournalPath,
   LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH,
+  resolveTrackedIssueHostPaths,
   resolveIssueJournalRelativePath,
   syncIssueJournal,
   trackedIssueJournalPath,
@@ -179,6 +180,76 @@ test("trackedIssueJournal helpers canonicalize the legacy shared path but preser
       177,
     ),
     "/tmp/workspaces/issue-177/.codex-supervisor/issues/177/issue-journal.md",
+  );
+});
+
+test("resolveTrackedIssueHostPaths reanchors default and legacy journal paths onto the canonical local workspace", async () => {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "journal-host-paths-default-"));
+  const canonicalWorkspace = path.join(workspaceRoot, "issue-177");
+  await fs.mkdir(canonicalWorkspace, { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n");
+
+  const resolved = resolveTrackedIssueHostPaths(
+    {
+      workspaceRoot,
+      issueJournalRelativePath: DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH,
+    },
+    createRecord({
+      workspace: "/tmp/other-host/issue-177",
+      journal_path: "/tmp/other-host/issue-177/.codex-supervisor/issue-journal.md",
+    }),
+  );
+
+  assert.equal(resolved.workspace, canonicalWorkspace);
+  assert.equal(resolved.usingCanonicalWorkspace, true);
+  assert.equal(
+    resolved.journal_path,
+    path.join(canonicalWorkspace, ".codex-supervisor", "issues", "177", "issue-journal.md"),
+  );
+});
+
+test("resolveTrackedIssueHostPaths preserves custom journal templates when rebasing onto the canonical local workspace", async () => {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "journal-host-paths-custom-"));
+  const canonicalWorkspace = path.join(workspaceRoot, "issue-177");
+  await fs.mkdir(canonicalWorkspace, { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n");
+
+  const resolved = resolveTrackedIssueHostPaths(
+    {
+      workspaceRoot,
+      issueJournalRelativePath: ".codex-supervisor/custom-journal.md",
+    },
+    createRecord({
+      workspace: "/tmp/other-host/issue-177",
+      journal_path: "/tmp/other-host/issue-177/.codex-supervisor/custom-journal.md",
+    }),
+  );
+
+  assert.equal(resolved.workspace, canonicalWorkspace);
+  assert.equal(resolved.journal_path, path.join(canonicalWorkspace, ".codex-supervisor", "custom-journal.md"));
+});
+
+test("resolveTrackedIssueHostPaths derives the canonical journal path for null journal records when the canonical workspace exists locally", async () => {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "journal-host-paths-null-"));
+  const canonicalWorkspace = path.join(workspaceRoot, "issue-177");
+  await fs.mkdir(canonicalWorkspace, { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n");
+
+  const resolved = resolveTrackedIssueHostPaths(
+    {
+      workspaceRoot,
+      issueJournalRelativePath: DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH,
+    },
+    createRecord({
+      workspace: "/tmp/other-host/issue-177",
+      journal_path: null,
+    }),
+  );
+
+  assert.equal(resolved.workspace, canonicalWorkspace);
+  assert.equal(
+    resolved.journal_path,
+    path.join(canonicalWorkspace, ".codex-supervisor", "issues", "177", "issue-journal.md"),
   );
 });
 

--- a/src/recovery-support.ts
+++ b/src/recovery-support.ts
@@ -8,7 +8,7 @@ import {
   parseGitStatusPorcelainV1Paths,
   parseGitWorktreePaths,
 } from "./core/git-workspace-helpers";
-import { trackedIssueJournalPath } from "./core/journal";
+import { resolveTrackedIssueHostPaths } from "./core/journal";
 import { type IssueRunRecord, type SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
 
@@ -117,17 +117,15 @@ export async function classifyFailedNoPrBranchRecovery(args: {
   ) => boolean;
 }): Promise<{ state: FailedNoPrBranchRecoveryState; headSha: string | null; preservedTrackedFiles?: string[] }> {
   const { config, record } = args;
-  if (!args.isSafeCleanupTarget(config, record.workspace, record.branch) || !fs.existsSync(path.join(record.workspace, ".git"))) {
+  const resolvedPaths = resolveTrackedIssueHostPaths(config, record);
+  if (
+    !args.isSafeCleanupTarget(config, resolvedPaths.workspace, record.branch) ||
+    !fs.existsSync(path.join(resolvedPaths.workspace, ".git"))
+  ) {
     return { state: "manual_review_required", headSha: null };
   }
 
-  const journalPath = trackedIssueJournalPath(
-    record.workspace,
-    record.journal_path,
-    config.issueJournalRelativePath,
-    record.issue_number,
-  );
-  const journalRelativePath = path.relative(record.workspace, journalPath).replace(/\\/g, "/");
+  const journalRelativePath = path.relative(resolvedPaths.workspace, resolvedPaths.journal_path).replace(/\\/g, "/");
   const gitProbeTimeoutMs = config.codexExecTimeoutMinutes * 60_000;
 
   try {
@@ -136,13 +134,13 @@ export async function classifyFailedNoPrBranchRecovery(args: {
       ["-C", config.repoPath, "worktree", "list", "--porcelain"],
       { timeoutMs: gitProbeTimeoutMs },
     );
-    if (!parseGitWorktreePaths(worktreeListResult.stdout).has(normalizeGitPath(record.workspace))) {
+    if (!parseGitWorktreePaths(worktreeListResult.stdout).has(normalizeGitPath(resolvedPaths.workspace))) {
       return { state: "manual_review_required", headSha: null };
     }
 
     const branchResult = await runCommand(
       "git",
-      ["-C", record.workspace, "symbolic-ref", "--quiet", "--short", "HEAD"],
+      ["-C", resolvedPaths.workspace, "symbolic-ref", "--quiet", "--short", "HEAD"],
       {
         allowExitCodes: [0, 1],
         timeoutMs: gitProbeTimeoutMs,
@@ -154,18 +152,18 @@ export async function classifyFailedNoPrBranchRecovery(args: {
 
     await args.ensureOriginDefaultBranchFetched();
     const [headResult, baseAheadResult, baseDiffResult, workspaceStatusResult] = await Promise.all([
-      runCommand("git", ["-C", record.workspace, "rev-parse", "HEAD"], {
+      runCommand("git", ["-C", resolvedPaths.workspace, "rev-parse", "HEAD"], {
         timeoutMs: gitProbeTimeoutMs,
       }),
       runCommand(
         "git",
-        ["-C", record.workspace, "rev-list", "--left-right", "--count", `origin/${config.defaultBranch}...HEAD`],
+        ["-C", resolvedPaths.workspace, "rev-list", "--left-right", "--count", `origin/${config.defaultBranch}...HEAD`],
         { timeoutMs: gitProbeTimeoutMs },
       ),
-      runCommand("git", ["-C", record.workspace, "diff", "--name-only", `origin/${config.defaultBranch}...HEAD`], {
+      runCommand("git", ["-C", resolvedPaths.workspace, "diff", "--name-only", `origin/${config.defaultBranch}...HEAD`], {
         timeoutMs: gitProbeTimeoutMs,
       }),
-      runCommand("git", ["-C", record.workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all"], {
+      runCommand("git", ["-C", resolvedPaths.workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all"], {
         timeoutMs: gitProbeTimeoutMs,
       }),
     ]);

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   formatNoRunnableIssueFoundMessage,
   resolveRunnableIssueContext,
@@ -211,6 +214,66 @@ Add execution-ready gating.`,
   assert.match(state.issues["91"]?.last_error ?? "", /missing required execution-ready metadata/i);
   assert.equal(journalSyncs.length, 1);
   assert.equal(journalSyncs[0]?.issue_number, 91);
+});
+
+test("resolveRunnableIssueContext normalizes cross-host workspace and journal hints onto the local canonical workspace", async () => {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "run-once-selection-host-paths-"));
+  const config = createConfig({
+    workspaceRoot,
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  });
+  const issueNumber = 91;
+  const canonicalWorkspace = path.join(workspaceRoot, `issue-${issueNumber}`);
+  await fs.mkdir(canonicalWorkspace, { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Underspecified issue",
+    body: "## Summary\nMissing the rest.",
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-15T00:00:00Z",
+    url: "https://example.test/issues/91",
+    labels: [],
+    state: "OPEN",
+  };
+  const staleWorkspace = "/tmp/other-host/issue-91";
+  const staleJournalPath = `${staleWorkspace}/.codex-supervisor/issue-journal.md`;
+  const currentRecord = createRecord(issueNumber, {
+    workspace: staleWorkspace,
+    journal_path: staleJournalPath,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: currentRecord,
+    },
+  };
+  const savedStates: SupervisorStateFile[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+    },
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.deepEqual(result, { kind: "restart" });
+  assert.equal(savedStates.length, 1);
+  assert.equal(state.issues[String(issueNumber)]?.workspace, canonicalWorkspace);
+  assert.equal(
+    state.issues[String(issueNumber)]?.journal_path,
+    path.join(canonicalWorkspace, ".codex-supervisor", "issues", "91", "issue-journal.md"),
+  );
 });
 
 test("resolveRunnableIssueContext creates one machine-managed requirements blocker comment for a standalone issue", async () => {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -12,7 +12,7 @@ import {
   parseIssueMetadata,
   validateIssueMetadataSyntax,
 } from "./issue-metadata";
-import { issueJournalPath, syncIssueJournal } from "./core/journal";
+import { issueJournalPath, resolveTrackedIssueHostPaths, syncIssueJournal } from "./core/journal";
 import { acquireFileLock, LockHandle } from "./core/lock";
 import {
   applyFailureSignature,
@@ -339,10 +339,11 @@ async function defaultEnsureRecordJournalContext(
   config: SupervisorConfig,
   record: IssueRunRecord,
 ): Promise<IssueJournalContext> {
-  if (record.journal_path) {
+  const resolvedPaths = resolveTrackedIssueHostPaths(config, record);
+  if (record.journal_path || resolvedPaths.usingCanonicalWorkspace) {
     return {
-      workspace: record.workspace,
-      journal_path: record.journal_path,
+      workspace: resolvedPaths.workspace,
+      journal_path: resolvedPaths.journal_path,
     };
   }
 

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -13,6 +13,7 @@ import {
   ReviewThread,
   SupervisorStateFile,
 } from "../core/types";
+import { ensureWorkspace } from "../core/workspace";
 import {
   branchName,
   createConfig,
@@ -167,6 +168,66 @@ test("handleAuthFailure blocks the active issue and preserves failure tracking f
   assert.equal(updated.last_failure_signature, "gh-auth-unavailable");
   assert.equal(updated.repeated_failure_signature_count, 1);
   assert.equal(updated.blocked_reason, "unknown");
+});
+
+test("runOnce reanchors cross-host tracked workspace and journal hints onto the local canonical workspace before blocking", async () => {
+  const fixture = await createSupervisorFixture();
+  await fs.mkdir(fixture.workspaceRoot, { recursive: true });
+  const realWorkspaceRoot = await fs.realpath(fixture.workspaceRoot);
+  fixture.config.workspaceRoot = realWorkspaceRoot;
+  fixture.config.issueJournalRelativePath = ".codex-supervisor/issues/{issueNumber}/issue-journal.md";
+  const issueNumber = 91;
+  const canonicalWorkspace = path.join(realWorkspaceRoot, `issue-${issueNumber}`);
+  await ensureWorkspace(fixture.config, issueNumber, branchName(fixture.config, issueNumber));
+
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [
+      createTrackedSupervisorRecord(fixture.config, realWorkspaceRoot, issueNumber, {
+        state: "queued",
+        workspace: "/tmp/other-host/issue-91",
+        journal_path: "/tmp/other-host/issue-91/.codex-supervisor/issue-journal.md",
+      }),
+    ],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+
+  const issue = createTrackedIssue(issueNumber, {
+    title: "Cross-host path normalization",
+    body: "## Summary\nMissing the rest.",
+    labels: [{ name: "codex" }],
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: false });
+  assert.match(message, /issue #91/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "blocked");
+  assert.equal(record.workspace, canonicalWorkspace);
+  assert.equal(
+    record.journal_path,
+    path.join(canonicalWorkspace, ".codex-supervisor", "issues", "91", "issue-journal.md"),
+  );
 });
 
 test("runOnce dry-run selects an issue and hydrates workspace and PR context before tracked draft PR progression", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -586,6 +586,68 @@ test("buildIssueExplainDto surfaces preserved partial work for no-PR manual-revi
   assert.match(renderIssueExplainDto(dto), /^partial_work=preserved tracked_files=feature\.txt\|src\/workflow\.ts$/m);
 });
 
+test("buildIssueExplainDto reads the canonical host journal when a tracked record has a null journal path", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 608;
+  const canonicalWorkspace = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
+  const journalPath = path.join(canonicalWorkspace, ".codex-supervisor", "issue-journal.md");
+
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n", "utf8");
+  await fs.writeFile(
+    journalPath,
+    `# Issue #${issueNumber}: Canonical host journal
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker: Waiting on review feedback.
+- Next exact step: Re-run explain after wiring the canonical journal path.
+`,
+    "utf8",
+  );
+
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Explain canonical host journal",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: "/tmp/other-host/issue-608",
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+      }),
+    },
+  };
+  const config = createConfig({
+    workspaceRoot: fixture.workspaceRoot,
+    stateFile: fixture.stateFile,
+    repoPath: fixture.repoPath,
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+    },
+    config,
+    state,
+    issueNumber,
+  );
+
+  assert.ok(dto.activityContext);
+  assert.equal(
+    dto.activityContext.handoffSummary,
+    "blocker: Waiting on review feedback. | next: Re-run explain after wiring the canonical journal path.",
+  );
+});
+
 test("buildIssueExplainSummary surfaces repeated stale cleanup risk for no-PR recovery loops", async () => {
   const config = createConfig({
     sameFailureSignatureRepeatLimit: 3,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -33,7 +33,7 @@ import {
 } from "./supervisor-status-rendering";
 import { formatLatestRecoveryStatusLine } from "./supervisor-detailed-status-assembly";
 import { externalSignalReadinessDiagnostics } from "./supervisor-status-review-bot";
-import { readIssueJournal, summarizeIssueJournalHandoff } from "../core/journal";
+import { readIssueJournal, resolveTrackedIssueHostPaths, summarizeIssueJournalHandoff } from "../core/journal";
 import { formatInventoryRefreshDiagnosticLines, formatInventoryRefreshStatusLine } from "../inventory-refresh-state";
 import { buildTrackedPrMismatch } from "./tracked-pr-mismatch";
 import {
@@ -248,7 +248,9 @@ export async function buildIssueExplainDto(
   let handoffSummary: string | null = null;
   if (record?.journal_path) {
     try {
-      handoffSummary = summarizeIssueJournalHandoff(await readIssueJournal(record.journal_path));
+      handoffSummary = summarizeIssueJournalHandoff(
+        await readIssueJournal(resolveTrackedIssueHostPaths(config, record).journal_path),
+      );
     } catch {
       handoffSummary = null;
     }

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -245,12 +245,11 @@ export async function buildIssueExplainDto(
       pr = null;
     }
   }
+  const resolvedPaths = record ? resolveTrackedIssueHostPaths(config, record) : null;
   let handoffSummary: string | null = null;
-  if (record?.journal_path) {
+  if (record && resolvedPaths && (record.journal_path !== null || resolvedPaths.usingCanonicalWorkspace)) {
     try {
-      handoffSummary = summarizeIssueJournalHandoff(
-        await readIssueJournal(resolveTrackedIssueHostPaths(config, record).journal_path),
-      );
+      handoffSummary = summarizeIssueJournalHandoff(await readIssueJournal(resolvedPaths.journal_path));
     } catch {
       handoffSummary = null;
     }

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { runCommand } from "../core/command";
 import { loadConfig } from "../core/config";
 import { GitHubClient } from "../github";
-import { issueJournalPath, trackedIssueJournalPath } from "../core/journal";
+import { issueJournalPath, resolveTrackedIssueHostPaths, trackedIssueJournalPath } from "../core/journal";
 import { acquireFileLock, LockHandle } from "../core/lock";
 import {
   cleanupExpiredDoneWorkspaces,
@@ -231,16 +231,12 @@ async function ensureRecordJournalContext(
   config: SupervisorConfig,
   record: IssueRunRecord,
 ): Promise<Pick<IssueRunRecord, "issue_number" | "workspace" | "journal_path">> {
-  if (record.journal_path) {
+  const resolvedPaths = resolveTrackedIssueHostPaths(config, record);
+  if (record.journal_path || resolvedPaths.usingCanonicalWorkspace) {
     return {
       issue_number: record.issue_number,
-      workspace: record.workspace,
-      journal_path: trackedIssueJournalPath(
-        record.workspace,
-        record.journal_path,
-        config.issueJournalRelativePath,
-        record.issue_number,
-      ),
+      workspace: resolvedPaths.workspace,
+      journal_path: resolvedPaths.journal_path,
     };
   }
 
@@ -340,13 +336,8 @@ export class Supervisor {
   private async classifyStaleStabilizingNoPrBranchState(
     record: Pick<IssueRunRecord, "issue_number" | "workspace" | "journal_path">,
   ): Promise<"recoverable" | "already_satisfied_on_main"> {
-    const journalPath = trackedIssueJournalPath(
-      record.workspace,
-      record.journal_path,
-      this.config.issueJournalRelativePath,
-      record.issue_number,
-    );
-    const journalRelativePath = path.relative(record.workspace, journalPath).replace(/\\/g, "/");
+    const resolvedPaths = resolveTrackedIssueHostPaths(this.config, record);
+    const journalRelativePath = path.relative(resolvedPaths.workspace, resolvedPaths.journal_path).replace(/\\/g, "/");
     const gitProbeTimeoutMs = this.config.codexExecTimeoutMinutes * 60_000;
 
     try {
@@ -354,10 +345,10 @@ export class Supervisor {
         timeoutMs: gitProbeTimeoutMs,
       });
       const [baseDiffResult, workspaceStatusResult] = await Promise.all([
-        runCommand("git", ["-C", record.workspace, "diff", "--name-only", `origin/${this.config.defaultBranch}...HEAD`], {
+        runCommand("git", ["-C", resolvedPaths.workspace, "diff", "--name-only", `origin/${this.config.defaultBranch}...HEAD`], {
           timeoutMs: gitProbeTimeoutMs,
         }),
-        runCommand("git", ["-C", record.workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all"], {
+        runCommand("git", ["-C", resolvedPaths.workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all"], {
           timeoutMs: gitProbeTimeoutMs,
         }),
       ]);


### PR DESCRIPTION
## Summary
- add a shared tracked-path resolver that derives journal relative paths from persisted hints and reanchors them onto the current host's canonical workspace when available
- use the resolver in selection, supervisor recovery/classification, and issue explain journal reads instead of trusting persisted absolute host paths verbatim
- add focused regressions for default/custom templates, legacy absolute paths, null journal-path records, and orchestration coverage

## Verification
- npx tsx --test src/journal.test.ts src/run-once-issue-selection.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build

Closes #1544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace and journal hints are now normalized to a local canonical per-issue workspace when present, ensuring journal reads, cleanup, and git operations target the correct local paths and avoiding incorrect cross-host references.
  * Safer handling when persisted journal hints point outside the workspace; falls back to the canonical journal location.

* **Tests**
  * Added tests covering normalization, fallbacks, and end-to-end behaviors for canonical workspace/journal resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->