### PR TITLE
Auto-rehydrate missing local-only issue journals on resumed tracked workspaces (#1546)

### DIFF
--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -75,6 +75,7 @@ function buildNotesTemplate(): string {
 }
 
 const NOTES_TEMPLATE = buildNotesTemplate();
+const ISSUE_SCOPED_JOURNAL_PATH_PATTERN = /^\.codex-supervisor\/issues\/(\d+)\/issue-journal\.md$/;
 
 function extractJournalIssueNumber(content: string | null | undefined): number | null {
   if (!content) {
@@ -532,7 +533,9 @@ export function trackedIssueJournalRelativePath(
   }
 
   const relativeJournalPath = workspaceRelativeJournalPath(workspacePath, journalPath);
+  const scopedMatch = relativeJournalPath.match(ISSUE_SCOPED_JOURNAL_PATH_PATTERN);
   return relativeJournalPath === LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH
+    || (scopedMatch !== null && Number.parseInt(scopedMatch[1], 10) !== issueNumber)
     ? canonicalRelativePath
     : relativeJournalPath;
 }
@@ -630,9 +633,54 @@ export async function syncIssueJournal(args: {
     existing && (existingIssueNumber === null || existingIssueNumber === issue.number)
       ? normalizeDurableIssueJournalContent(preserveCodexNotes(existing), record.workspace)
       : null;
+  const rehydrationNotes =
+    existing === null && shouldAnnotateJournalRehydration(record)
+      ? buildRehydratedJournalNotes()
+      : null;
   const snapshot = buildSupervisorSnapshot({ issue, record, journalPath });
-  const nextContent = `${snapshot}\n${notes ? compactCodexNotes(notes, maxChars) : NOTES_TEMPLATE}`;
+  const nextContent = `${snapshot}\n${notes ? compactCodexNotes(notes, maxChars) : rehydrationNotes ?? NOTES_TEMPLATE}`;
   await writeFileAtomic(journalPath, nextContent);
+}
+
+function shouldAnnotateJournalRehydration(
+  record: Pick<
+    IssueRunRecord,
+    | "attempt_count"
+    | "implementation_attempt_count"
+    | "repair_attempt_count"
+    | "pr_number"
+    | "codex_session_id"
+    | "last_codex_summary"
+    | "last_error"
+    | "last_failure_context"
+    | "last_recovery_reason"
+  >,
+): boolean {
+  return (
+    record.attempt_count > 0 ||
+    record.implementation_attempt_count > 0 ||
+    record.repair_attempt_count > 0 ||
+    record.pr_number !== null ||
+    record.codex_session_id !== null ||
+    record.last_codex_summary !== null ||
+    record.last_error !== null ||
+    record.last_failure_context !== null ||
+    record.last_recovery_reason !== null
+  );
+}
+
+function buildRehydratedJournalNotes(): string {
+  return [
+    NOTES_MARKER,
+    "### Current Handoff",
+    ...HANDOFF_FIELDS.map((field) => `- ${field}:`),
+    "",
+    "### Scratchpad",
+    "- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.",
+    "- Prior host-local handoff text could not be recovered from durable state when recreating the local journal.",
+    "- Keep this section short. The supervisor may compact older notes automatically.",
+    "",
+  ].join("\n");
 }
 
 export async function normalizeCommittedIssueJournal(args: {

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -657,9 +657,9 @@ function shouldAnnotateJournalRehydration(
   >,
 ): boolean {
   return (
-    record.attempt_count > 0 ||
-    record.implementation_attempt_count > 0 ||
-    record.repair_attempt_count > 0 ||
+    record.attempt_count > 1 ||
+    record.implementation_attempt_count > 1 ||
+    record.repair_attempt_count > 1 ||
     record.pr_number !== null ||
     record.codex_session_id !== null ||
     record.last_codex_summary !== null ||

--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -146,6 +146,27 @@ test("syncIssueJournal writes workspace metadata as workspace-relative paths", a
   assert.doesNotMatch(content, new RegExp(tempDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
+test("syncIssueJournal records when a missing local-only journal is rehydrated from supervisor state", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-rehydrated-"));
+  const journalPath = issueJournalPath(tempDir, DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH, issue.number);
+
+  await syncIssueJournal({
+    issue,
+    record: createRecord({
+      workspace: tempDir,
+      journal_path: journalPath,
+      state: "addressing_review",
+      last_codex_summary: "Summary: resume the tracked PR follow-up after recreating the local journal.",
+      last_error: "Previous host-local handoff text is unavailable on this machine.",
+    }),
+    journalPath,
+  });
+
+  const content = await fs.readFile(journalPath, "utf8");
+  assert.match(content, /rehydrated on this host because the prior local-only handoff journal was unavailable/i);
+  assert.match(content, /recreating the local journal/i);
+});
+
 test("resolveIssueJournalRelativePath scopes the default journal path by issue number", () => {
   assert.equal(
     resolveIssueJournalRelativePath(DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH, 177),
@@ -267,6 +288,30 @@ test("resolveTrackedIssueHostPaths falls back to the canonical journal path when
     createRecord({
       workspace: "/tmp/other-host/worktrees/issue-177",
       journal_path: "/tmp/other-host/.codex-supervisor/issues/177/issue-journal.md",
+    }),
+  );
+
+  assert.equal(resolved.workspace, canonicalWorkspace);
+  assert.equal(
+    resolved.journal_path,
+    path.join(canonicalWorkspace, ".codex-supervisor", "issues", "177", "issue-journal.md"),
+  );
+});
+
+test("resolveTrackedIssueHostPaths falls back to the canonical journal path when persisted hints point at another issue journal", async () => {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "journal-host-paths-cross-issue-"));
+  const canonicalWorkspace = path.join(workspaceRoot, "issue-177");
+  await fs.mkdir(canonicalWorkspace, { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n");
+
+  const resolved = resolveTrackedIssueHostPaths(
+    {
+      workspaceRoot,
+      issueJournalRelativePath: DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH,
+    },
+    createRecord({
+      workspace: canonicalWorkspace,
+      journal_path: path.join(canonicalWorkspace, ".codex-supervisor", "issues", "1264", "issue-journal.md"),
     }),
   );
 

--- a/src/journal.test.ts
+++ b/src/journal.test.ts
@@ -167,6 +167,21 @@ test("syncIssueJournal records when a missing local-only journal is rehydrated f
   assert.match(content, /recreating the local journal/i);
 });
 
+test("syncIssueJournal does not mark a fresh journal as rehydrated from default attempt counters alone", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "journal-fresh-"));
+  const journalPath = issueJournalPath(tempDir, DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH, issue.number);
+
+  await syncIssueJournal({
+    issue,
+    record: createRecord({ workspace: tempDir, journal_path: journalPath }),
+    journalPath,
+  });
+
+  const content = await fs.readFile(journalPath, "utf8");
+  assert.doesNotMatch(content, /rehydrated on this host/i);
+  assert.doesNotMatch(content, /Prior host-local handoff text could not be recovered/i);
+});
+
 test("resolveIssueJournalRelativePath scopes the default journal path by issue number", () => {
   assert.equal(
     resolveIssueJournalRelativePath(DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH, 177),

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -291,7 +291,7 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
   });
 
   const result = await executeCodexTurnPhase({
-    config: createConfig(),
+    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
     stateStore: {
       touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
       save: async () => undefined,
@@ -1033,6 +1033,167 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
   assert.equal(requests[0]?.kind, "start");
   assert.equal(requests[1]?.kind, "resume");
   assert.equal(requests[1]?.sessionId, "session-existing");
+});
+
+test("executeCodexTurnPhase rehydrates a missing local journal before resuming a tracked turn", async () => {
+  await withTempWorkspace("codex-turn-missing-journal-", async (workspacePath) => {
+    const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": createRecord({
+          state: "stabilizing",
+          codex_session_id: "session-existing",
+          workspace: workspacePath,
+          journal_path: journalPath,
+          pr_number: 116,
+        }),
+      },
+    };
+
+    let syncJournalCalls = 0;
+    let journalExistedDuringRun = false;
+
+    const result = await executeCodexTurnPhase({
+      config: createConfig({
+        issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+      }),
+      stateStore: {
+        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-26T01:00:01.000Z" }),
+        save: async () => undefined,
+      },
+      github: {
+        resolvePullRequestForBranch: async () => createPullRequest({ number: 116, headRefOid: "head-116" }),
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => {
+          throw new Error("unexpected getExternalReviewSurface call");
+        },
+      },
+      context: {
+        state,
+        record: state.issues["102"]!,
+        issue: createIssue({ number: 102, title: "Rehydrate missing journal before resume" }),
+        previousCodexSummary: null,
+        previousError: null,
+        workspacePath,
+        journalPath,
+        syncJournal: async () => {
+          syncJournalCalls += 1;
+          await fs.mkdir(path.dirname(journalPath), { recursive: true });
+          await fs.writeFile(
+            journalPath,
+            [
+              "# Issue #102: Rehydrate missing journal before resume",
+              "",
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: restore the missing journal before the resume turn runs.",
+              "- What changed: journal was rehydrated on this host because the local-only copy was missing.",
+              "- Current blocker:",
+              "- Next exact step: resume the tracked PR follow-up safely.",
+              "- Verification gap:",
+              "- Files touched:",
+              "- Rollback concern:",
+              "- Last focused command:",
+              "",
+              "### Scratchpad",
+              "- Keep this section short. The supervisor may compact older notes automatically.",
+              "",
+            ].join("\n"),
+            "utf8",
+          );
+        },
+        memoryArtifacts: {
+          alwaysReadFiles: [],
+          onDemandFiles: [],
+          contextIndexPath: "/tmp/context-index.md",
+          agentsPath: "/tmp/AGENTS.generated.md",
+        },
+        workspaceStatus: createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
+        pr: createPullRequest({ number: 116, headRefOid: "head-116" }),
+        checks: [],
+        reviewThreads: [],
+        options: { dryRun: false },
+      },
+      acquireSessionLock: async () => null,
+      classifyFailure: () => "command_error",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-03-26T01:00:01.000Z",
+      }),
+      applyFailureSignature: () => ({
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+      }),
+      normalizeBlockerSignature: () => null,
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: (record) => ({
+        recordForState: record,
+        nextState: "stabilizing",
+        failureContext: null,
+        reviewWaitPatch: {},
+        copilotRequestObservationPatch: {},
+        mergeLatencyVisibilityPatch: {
+          provider_success_observed_at: null,
+          provider_success_head_sha: null,
+          merge_readiness_last_evaluated_at: null,
+        },
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: null,
+          copilot_review_timeout_action: null,
+          copilot_review_timeout_reason: null,
+        },
+      }),
+      inferStateWithoutPullRequest: () => "stabilizing",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+        throw error instanceof Error ? error : new Error(String(error));
+      },
+      getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
+      pushBranch: async () => {
+        throw new Error("unexpected pushBranch call");
+      },
+      agentRunner: createSuccessfulAgentRunner(async (request) => {
+        assert.equal(request.kind, "resume");
+        await fs.access(journalPath);
+        journalExistedDuringRun = true;
+        await fs.appendFile(journalPath, "- What changed: resume turn completed after journal rehydration.\n", "utf8");
+        return {
+          exitCode: 0,
+          sessionId: "session-existing",
+          supervisorMessage: "Paused on the resumed head after rehydrating the missing journal.",
+          stderr: "",
+          stdout: "",
+          structuredResult: {
+            summary: "Paused on the resumed head after rehydrating the missing journal.",
+            stateHint: "blocked",
+            blockedReason: "manual_review",
+            failureSignature: null,
+            nextAction: "continue from the recreated journal",
+            tests: "not run",
+          },
+          failureKind: null,
+          failureContext: null,
+        };
+      }),
+    });
+
+    assert.equal(result.kind, "returned");
+    assert.match(result.message, /Codex reported blocked/);
+    assert.ok(syncJournalCalls >= 1);
+    assert.equal(journalExistedDuringRun, true);
+    const journalContent = await fs.readFile(journalPath, "utf8");
+    assert.match(journalContent, /local-only copy was missing/);
+  });
 });
 
 test("executeCodexTurnPhase writes a durable interrupted-turn marker before runTurn and clears it after success", async () => {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -1196,6 +1196,119 @@ test("executeCodexTurnPhase rehydrates a missing local journal before resuming a
   });
 });
 
+test("executeCodexTurnPhase does not rehydrate a missing local journal when the resume lock is unavailable", async () => {
+  await withTempWorkspace("codex-turn-missing-journal-locked-", async (workspacePath) => {
+    const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": createRecord({
+          state: "stabilizing",
+          codex_session_id: "session-existing",
+          workspace: workspacePath,
+          journal_path: journalPath,
+          pr_number: 116,
+        }),
+      },
+    };
+
+    let syncJournalCalls = 0;
+    let journalReadCalls = 0;
+
+    const result = await executeCodexTurnPhase({
+      config: createConfig({
+        issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+      }),
+      stateStore: {
+        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-26T01:00:01.000Z" }),
+        save: async () => undefined,
+      },
+      github: {
+        resolvePullRequestForBranch: async () => createPullRequest({ number: 116, headRefOid: "head-116" }),
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => {
+          throw new Error("unexpected getExternalReviewSurface call");
+        },
+      },
+      context: {
+        state,
+        record: state.issues["102"]!,
+        issue: createIssue({ number: 102, title: "Skip missing journal rehydration when the resume lock is unavailable" }),
+        previousCodexSummary: null,
+        previousError: null,
+        workspacePath,
+        journalPath,
+        syncJournal: async () => {
+          syncJournalCalls += 1;
+        },
+        memoryArtifacts: {
+          alwaysReadFiles: [],
+          onDemandFiles: [],
+          contextIndexPath: "/tmp/context-index.md",
+          agentsPath: "/tmp/AGENTS.generated.md",
+        },
+        workspaceStatus: createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
+        pr: createPullRequest({ number: 116, headRefOid: "head-116" }),
+        checks: [],
+        reviewThreads: [],
+        options: { dryRun: false },
+      },
+      acquireSessionLock: async () => ({
+        sessionId: "session-existing",
+        acquired: false,
+        reason: "session already locked elsewhere",
+        release: async () => undefined,
+      }),
+      classifyFailure: () => "command_error",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-03-26T01:00:01.000Z",
+      }),
+      applyFailureSignature: () => ({
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+      }),
+      normalizeBlockerSignature: () => null,
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: () => {
+        throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
+      },
+      inferStateWithoutPullRequest: () => "stabilizing",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+        throw error instanceof Error ? error : new Error(String(error));
+      },
+      getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
+      pushBranch: async () => {
+        throw new Error("unexpected pushBranch call");
+      },
+      readIssueJournal: async () => {
+        journalReadCalls += 1;
+        return null;
+      },
+      agentRunner: createSuccessfulAgentRunner(async () => {
+        throw new Error("unexpected agentRunner.runTurn call");
+      }),
+    });
+
+    assert.deepEqual(result, {
+      kind: "returned",
+      message: "Skipped issue #102: session already locked elsewhere.",
+    });
+    assert.equal(syncJournalCalls, 0);
+    assert.equal(journalReadCalls, 0);
+  });
+});
+
 test("executeCodexTurnPhase writes a durable interrupted-turn marker before runTurn and clears it after success", async () => {
   await withTempWorkspace("codex-turn-marker-", async (workspacePath) => {
     const markerPath = interruptedTurnMarkerPath(workspacePath);

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -278,7 +278,12 @@ export async function executeCodexTurnPhase(
       };
     }
 
-    const journalContent = (await readIssueJournalImpl(journalPath)) ?? "";
+    let journalContent = await readIssueJournalImpl(journalPath);
+    if (journalContent === null) {
+      await syncJournal(record);
+      journalContent = await readIssueJournalImpl(journalPath);
+    }
+    const effectiveJournalContent = journalContent ?? "";
     const preRunState = record.state;
     const shouldResumeTurn = shouldResumeAgentTurn({
       record,
@@ -307,7 +312,7 @@ export async function executeCodexTurnPhase(
         previousError,
         workspacePath,
         journalPath,
-        journalContent,
+        journalContent: effectiveJournalContent,
         syncJournal,
         memoryArtifacts,
         pr,
@@ -357,7 +362,7 @@ export async function executeCodexTurnPhase(
       if (
         turnResult.exitCode === 0 &&
         (!effectiveJournalAfterRun ||
-          effectiveJournalAfterRun === journalContent ||
+          effectiveJournalAfterRun === effectiveJournalContent ||
           !hasMeaningfulJournalHandoff(effectiveJournalAfterRun))
       ) {
         record = await persistMissingCodexJournalHandoffImpl({

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -278,12 +278,6 @@ export async function executeCodexTurnPhase(
       };
     }
 
-    let journalContent = await readIssueJournalImpl(journalPath);
-    if (journalContent === null) {
-      await syncJournal(record);
-      journalContent = await readIssueJournalImpl(journalPath);
-    }
-    const effectiveJournalContent = journalContent ?? "";
     const preRunState = record.state;
     const shouldResumeTurn = shouldResumeAgentTurn({
       record,
@@ -300,6 +294,13 @@ export async function executeCodexTurnPhase(
         message: `Skipped issue #${record.issue_number}: ${sessionLock.reason}.`,
       };
     }
+
+    let journalContent = await readIssueJournalImpl(journalPath);
+    if (journalContent === null) {
+      await syncJournal(record);
+      journalContent = await readIssueJournalImpl(journalPath);
+    }
+    const effectiveJournalContent = journalContent ?? "";
 
     try {
       const preparedTurn = await prepareCodexTurnPrompt({


### PR DESCRIPTION
Closes #1546
This PR was opened by codex-supervisor.
Latest Codex summary:

Summary: Rehydration now covers missing local-only issue journals in the execution path and canonicalizes stale cross-issue journal hints back to the current issue’s journal. I added focused regressions in `src/journal.test.ts` and `src/run-once-turn-execution.test.ts`, updated `src/core/journal.ts` and `src/run-once-turn-execution.ts`, and committed the checkpoint as `bba8e38` (`Rehydrate missing local issue journals on resume`).

State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/journal.test.ts src/run-once-issue-preparation.test.ts src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1546` with commit `bba8e38` and continue broader supervisor-loop verification if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Journal rehydration now recreates missing local journals with annotated recovery notes and a "Journal rehydration" scratchpad.

* **Bug Fixes**
  * Improved synchronization and resume behavior so missing journals are recovered before resuming work.
  * Fixed journal path resolution to prefer canonical issue journals when scoped paths reference a different issue.

* **Tests**
  * Added tests covering rehydration, resume behavior, and canonical path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->