### PR TITLE
Surface host-migration diagnostics in doctor, status, and explain

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -261,6 +261,12 @@ Beginner troubleshooting shortcut:
 - `doctor` answers “is the host or state unhealthy?”
 - `explain <issue-number>` answers “why is this specific issue blocked, skipped, or not selected?”
 
+Host-migration note for worktree-local journals:
+
+- If a tracked issue was moved to a new host and the persisted `workspace` or `journal_path` still points at the old absolute path, `status`, `doctor`, and `explain` can emit `issue_host_paths ... guidance=no_manual_action_required` to show that the supervisor repaired the stale path to the canonical local worktree.
+- If the old host-local journal could not be recovered and the supervisor recreated the issue-scoped local journal, the same surfaces can emit `issue_journal_state ... status=rehydrated guidance=no_manual_action_required detail=prior_local_only_handoff_unavailable`. Treat that as an informational repair, not a blocking failure.
+- If those diagnostics instead say `guidance=manual_action_required`, the canonical local journal is still missing and the operator should inspect the current worktree before resuming autonomous execution.
+
 Execution metrics are retained independently of issue worktree cleanup. Terminal run summaries live under `<dirname(stateFile)>/execution-metrics/run-summaries/`, and `node dist/index.js rollup-execution-metrics --config /path/to/supervisor.config.json` writes `<dirname(stateFile)>/execution-metrics/daily-rollups.json` from those retained summaries.
 
 ### Setup/readiness contract for first-run UX

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -12,6 +12,8 @@ const DURABLE_PATH_TOKEN_PATTERN =
 const LEADING_PATH_PUNCTUATION = "([{";
 const TRAILING_PATH_PUNCTUATION = ")]},;:!?";
 const REDACTED_LOCAL_PATH = "<redacted-local-path>";
+const REHYDRATED_JOURNAL_NOTE =
+  "Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.";
 const NON_PORTABLE_LOCAL_PATH_PREFIXES = [
   "/home/",
   "/Users/",
@@ -606,6 +608,69 @@ export function resolveTrackedIssueHostPaths(
   };
 }
 
+export interface TrackedIssueHostDiagnostics {
+  resolvedPaths: {
+    workspace: string;
+    journal_path: string;
+    usingCanonicalWorkspace: boolean;
+  };
+  journalReadPath: string;
+  workspaceStatus: "current" | "auto_repaired" | "missing";
+  journalPathStatus: "current" | "auto_repaired" | "missing";
+  journalStatus: "current" | "rehydrated" | "missing";
+  guidance: "no_manual_action_required" | "manual_action_required" | null;
+  journalContent: string | null;
+}
+
+export function isRehydratedIssueJournalContent(content: string | null | undefined): boolean {
+  return typeof content === "string" && content.includes(REHYDRATED_JOURNAL_NOTE);
+}
+
+export async function inspectTrackedIssueHostDiagnostics(
+  config: Pick<SupervisorConfig, "workspaceRoot" | "issueJournalRelativePath">,
+  record: Pick<IssueRunRecord, "issue_number" | "workspace" | "journal_path">,
+): Promise<TrackedIssueHostDiagnostics> {
+  const resolvedPaths = resolveTrackedIssueHostPaths(config, record);
+  const persistedWorkspace = path.resolve(record.workspace);
+  const workspaceStatus =
+    resolvedPaths.usingCanonicalWorkspace && persistedWorkspace !== resolvedPaths.workspace
+      ? "auto_repaired"
+      : "current";
+  const journalPathStatus =
+    record.journal_path !== null && path.resolve(record.journal_path) !== resolvedPaths.journal_path
+      ? "auto_repaired"
+      : "current";
+  const journalReadPath =
+    resolvedPaths.usingCanonicalWorkspace || record.journal_path === null
+      ? resolvedPaths.journal_path
+      : record.journal_path;
+  const journalContent = await readIssueJournal(journalReadPath);
+  const journalStatus =
+    journalContent === null
+      ? "missing"
+      : isRehydratedIssueJournalContent(journalContent)
+        ? "rehydrated"
+        : "current";
+  const guidance =
+    !resolvedPaths.usingCanonicalWorkspace
+      ? null
+      : journalStatus === "missing"
+        ? "manual_action_required"
+        : workspaceStatus === "auto_repaired" || journalPathStatus === "auto_repaired" || journalStatus === "rehydrated"
+          ? "no_manual_action_required"
+          : null;
+
+  return {
+    resolvedPaths,
+    journalReadPath,
+    workspaceStatus,
+    journalPathStatus,
+    journalStatus,
+    guidance,
+    journalContent,
+  };
+}
+
 export async function readIssueJournal(journalPath: string): Promise<string | null> {
   try {
     return await fs.readFile(journalPath, "utf8");
@@ -676,7 +741,7 @@ function buildRehydratedJournalNotes(): string {
     ...HANDOFF_FIELDS.map((field) => `- ${field}:`),
     "",
     "### Scratchpad",
-    "- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.",
+    `- ${REHYDRATED_JOURNAL_NOTE}`,
     "- Prior host-local handoff text could not be recovered from durable state when recreating the local journal.",
     "- Keep this section short. The supervisor may compact older notes automatically.",
     "",

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -204,6 +204,99 @@ test("diagnoseSupervisorHost surfaces host-migration path repair and journal reh
   assert.doesNotMatch(report, /missing workspace/);
 });
 
+test("diagnoseSupervisorHost degrades per-issue host inspection failures and continues other worktree diagnostics", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-host-inspect-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  const brokenIssueNumber = 188;
+  const migratedIssueNumber = 189;
+  const brokenWorkspacePath = path.join(workspaceRoot, `issue-${brokenIssueNumber}`);
+  const migratedWorkspacePath = path.join(workspaceRoot, `issue-${migratedIssueNumber}`);
+  const migratedJournalPath = path.join(
+    migratedWorkspacePath,
+    ".codex-supervisor",
+    "issues",
+    String(migratedIssueNumber),
+    "issue-journal.md",
+  );
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.email", "codex@example.test"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "seed\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "seed"], { cwd: repoPath });
+  execFileSync("git", ["worktree", "add", "-b", "codex/issue-188", brokenWorkspacePath, "HEAD"], { cwd: repoPath });
+  execFileSync("git", ["worktree", "add", "-b", "codex/issue-189", migratedWorkspacePath, "HEAD"], { cwd: repoPath });
+  await fs.mkdir(path.dirname(migratedJournalPath), { recursive: true });
+  await fs.writeFile(
+    migratedJournalPath,
+    `# Issue #189: Host migration
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker: None.
+- Next exact step:
+
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+`,
+    "utf8",
+  );
+
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({
+      activeIssueNumber: null,
+      issues: {
+        [String(brokenIssueNumber)]: createRecord({
+          issue_number: brokenIssueNumber,
+          workspace: brokenWorkspacePath,
+          journal_path: brokenWorkspacePath,
+        }),
+        [String(migratedIssueNumber)]: createRecord({
+          issue_number: migratedIssueNumber,
+          workspace: `/tmp/other-host/issue-${migratedIssueNumber}`,
+          journal_path: `/tmp/other-host/issue-${migratedIssueNumber}/.codex-supervisor/issues/${migratedIssueNumber}/issue-journal.md`,
+        }),
+      },
+    }),
+  });
+
+  const worktreesCheck = diagnostics.checks.find((check) => check.name === "worktrees");
+  assert.equal(worktreesCheck?.status, "warn");
+  assert.match(
+    worktreesCheck?.summary ?? "",
+    /1 tracked workspace issue\(s\) detected\./,
+  );
+  const report = renderDoctorReport(diagnostics);
+  assert.match(
+    report,
+    /^doctor_detail name=worktrees detail=Issue #188 host diagnostics could not be inspected: EISDIR: illegal operation on a directory, read\.$/m,
+  );
+  assert.match(
+    report,
+    /^doctor_detail name=worktrees detail=issue_host_paths issue=#189 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m,
+  );
+  assert.match(
+    report,
+    /^doctor_detail name=worktrees detail=issue_journal_state issue=#189 status=rehydrated guidance=no_manual_action_required detail=prior_local_only_handoff_unavailable$/m,
+  );
+});
+
 test("diagnoseSupervisorHost degrades malformed synthetic recovery records without throwing", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -134,6 +134,76 @@ test("diagnoseSupervisorHost ignores recovery-only synthetic parent epic records
   assert.match(renderDoctorReport(diagnostics), /doctor_check name=worktrees status=pass summary=Tracked worktrees look consistent\./);
 });
 
+test("diagnoseSupervisorHost surfaces host-migration path repair and journal rehydration without downgrading worktree health", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-host-migration-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  const issueNumber = 177;
+  const workspacePath = path.join(workspaceRoot, `issue-${issueNumber}`);
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", String(issueNumber), "issue-journal.md");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.email", "codex@example.test"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "README.md"), "seed\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "seed"], { cwd: repoPath });
+  execFileSync("git", ["worktree", "add", "-b", "codex/reopen-issue-177", workspacePath, "HEAD"], { cwd: repoPath });
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    `# Issue #177: Host migration
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker: None.
+- Next exact step:
+
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+`,
+    "utf8",
+  );
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({
+      activeIssueNumber: null,
+      issues: {
+        [String(issueNumber)]: createRecord({
+          issue_number: issueNumber,
+          workspace: `/tmp/other-host/issue-${issueNumber}`,
+          journal_path: `/tmp/other-host/issue-${issueNumber}/.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
+        }),
+      },
+    }),
+  });
+
+  assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "pass");
+  const report = renderDoctorReport(diagnostics);
+  assert.match(
+    report,
+    /^doctor_detail name=worktrees detail=issue_host_paths issue=#177 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m,
+  );
+  assert.match(
+    report,
+    /^doctor_detail name=worktrees detail=issue_journal_state issue=#177 status=rehydrated guidance=no_manual_action_required detail=prior_local_only_handoff_unavailable$/m,
+  );
+  assert.doesNotMatch(report, /missing workspace/);
+});
+
 test("diagnoseSupervisorHost degrades malformed synthetic recovery records without throwing", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -23,6 +23,8 @@ import {
   type TrustDiagnosticsSummary,
   type WorkspacePreparationContractSummary,
 } from "./core/types";
+import { normalizeGitPath, parseGitWorktreePaths } from "./core/git-workspace-helpers";
+import { inspectTrackedIssueHostDiagnostics, resolveTrackedIssueHostPaths } from "./core/journal";
 import { inspectOrphanedWorkspacePruneCandidates } from "./recovery-reconciliation";
 import {
   buildMacOsLoopHostWarning,
@@ -471,16 +473,6 @@ export async function loadStateReadonlyForDoctor(config: SupervisorConfig): Prom
   }
 }
 
-function parseWorktreeList(stdout: string): Set<string> {
-  const worktrees = new Set<string>();
-  for (const line of stdout.split(/\r?\n/)) {
-    if (line.startsWith("worktree ")) {
-      worktrees.add(line.slice("worktree ".length).trim());
-    }
-  }
-  return worktrees;
-}
-
 function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
   if (typeof record.branch !== "string" || typeof record.workspace !== "string") {
     return false;
@@ -502,13 +494,24 @@ function isRecoveryOnlySyntheticRecord(record: IssueRunRecord): boolean {
     hasRecoveryAt;
 }
 
-function withInspectableWorkspaces(state: SupervisorStateFile): SupervisorStateFile {
+function withInspectableWorkspaces(
+  config: Pick<SupervisorConfig, "workspaceRoot" | "issueJournalRelativePath">,
+  state: SupervisorStateFile,
+): SupervisorStateFile {
   return {
     ...state,
     issues: Object.fromEntries(
-      Object.entries(state.issues).filter(([, record]) =>
-        typeof record.workspace === "string" && record.workspace.trim() !== ""
-      ),
+      Object.entries(state.issues)
+        .filter(([, record]) =>
+          typeof record.workspace === "string" && record.workspace.trim() !== ""
+        )
+        .map(([issueNumber, record]) => [
+          issueNumber,
+          {
+            ...record,
+            workspace: resolveTrackedIssueHostPaths(config, record).workspace,
+          },
+        ]),
     ),
   };
 }
@@ -530,9 +533,10 @@ async function diagnoseWorktrees(
     }
 
     const worktreeList = await runCommand("git", ["-C", config.repoPath, "worktree", "list", "--porcelain"]);
-    const knownWorktrees = parseWorktreeList(worktreeList.stdout);
+    const knownWorktrees = parseGitWorktreePaths(worktreeList.stdout);
     const state = await loadState();
     const problems: string[] = [];
+    const infoDetails: string[] = [];
 
     for (const record of Object.values(state.issues)) {
       if (isRecoveryOnlySyntheticRecord(record)) {
@@ -544,27 +548,52 @@ async function diagnoseWorktrees(
         continue;
       }
 
+      const hostDiagnostics = await inspectTrackedIssueHostDiagnostics(config, record);
+      const workspacePath = hostDiagnostics.resolvedPaths.workspace;
+      if (hostDiagnostics.guidance !== null) {
+        infoDetails.push(
+          [
+            "issue_host_paths",
+            `issue=#${record.issue_number}`,
+            `workspace=${hostDiagnostics.workspaceStatus}`,
+            `journal_path=${hostDiagnostics.journalPathStatus}`,
+            `guidance=${hostDiagnostics.guidance}`,
+          ].join(" "),
+        );
+        if (hostDiagnostics.journalStatus !== "current") {
+          infoDetails.push(
+            [
+              "issue_journal_state",
+              `issue=#${record.issue_number}`,
+              `status=${hostDiagnostics.journalStatus}`,
+              `guidance=${hostDiagnostics.guidance}`,
+              `detail=${hostDiagnostics.journalStatus === "rehydrated" ? "prior_local_only_handoff_unavailable" : "resolved_local_journal_missing"}`,
+            ].join(" "),
+          );
+        }
+      }
+
       try {
-        await fs.access(record.workspace, fs.constants.F_OK);
+        await fs.access(workspacePath, fs.constants.F_OK);
       } catch {
-        problems.push(`Issue #${record.issue_number} is missing workspace ${record.workspace}.`);
+        problems.push(`Issue #${record.issue_number} is missing workspace ${workspacePath}.`);
         continue;
       }
 
-      const gitDir = path.join(record.workspace, ".git");
+      const gitDir = path.join(workspacePath, ".git");
       try {
         await fs.access(gitDir, fs.constants.F_OK);
       } catch {
-        problems.push(`Issue #${record.issue_number} workspace is not a git worktree: ${record.workspace}.`);
+        problems.push(`Issue #${record.issue_number} workspace is not a git worktree: ${workspacePath}.`);
         continue;
       }
 
-      if (!knownWorktrees.has(record.workspace)) {
-        problems.push(`Issue #${record.issue_number} workspace is not registered in git worktree list: ${record.workspace}.`);
+      if (!knownWorktrees.has(normalizeGitPath(workspacePath))) {
+        problems.push(`Issue #${record.issue_number} workspace is not registered in git worktree list: ${workspacePath}.`);
       }
     }
 
-    const orphanCandidates = await inspectOrphanedWorkspacePruneCandidates(config, withInspectableWorkspaces(state));
+    const orphanCandidates = await inspectOrphanedWorkspacePruneCandidates(config, withInspectableWorkspaces(config, state));
     const orphanDetails = orphanCandidates.map((candidate) =>
       `orphan_prune_candidate issue_number=${candidate.issueNumber} eligibility=${candidate.eligibility} workspace=${candidate.workspacePath} branch=${candidate.branch ?? "none"} modified_at=${candidate.modifiedAt ?? "unknown"} reason=${candidate.reason}`
     );
@@ -602,7 +631,7 @@ async function diagnoseWorktrees(
         name: "worktrees",
         status: "pass",
         summary: "Tracked worktrees look consistent.",
-        details: [],
+        details: infoDetails,
       };
     }
 
@@ -629,7 +658,7 @@ async function diagnoseWorktrees(
       ]
         .filter((value): value is string => value !== null)
         .join(" "),
-      details: [...problems, ...orphanDetails, ...trackedPrMismatchDetails],
+      details: [...problems, ...infoDetails, ...orphanDetails, ...trackedPrMismatchDetails],
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -548,29 +548,35 @@ async function diagnoseWorktrees(
         continue;
       }
 
-      const hostDiagnostics = await inspectTrackedIssueHostDiagnostics(config, record);
-      const workspacePath = hostDiagnostics.resolvedPaths.workspace;
-      if (hostDiagnostics.guidance !== null) {
-        infoDetails.push(
-          [
-            "issue_host_paths",
-            `issue=#${record.issue_number}`,
-            `workspace=${hostDiagnostics.workspaceStatus}`,
-            `journal_path=${hostDiagnostics.journalPathStatus}`,
-            `guidance=${hostDiagnostics.guidance}`,
-          ].join(" "),
-        );
-        if (hostDiagnostics.journalStatus !== "current") {
+      let workspacePath = resolveTrackedIssueHostPaths(config, record).workspace;
+      try {
+        const hostDiagnostics = await inspectTrackedIssueHostDiagnostics(config, record);
+        workspacePath = hostDiagnostics.resolvedPaths.workspace;
+        if (hostDiagnostics.guidance !== null) {
           infoDetails.push(
             [
-              "issue_journal_state",
+              "issue_host_paths",
               `issue=#${record.issue_number}`,
-              `status=${hostDiagnostics.journalStatus}`,
+              `workspace=${hostDiagnostics.workspaceStatus}`,
+              `journal_path=${hostDiagnostics.journalPathStatus}`,
               `guidance=${hostDiagnostics.guidance}`,
-              `detail=${hostDiagnostics.journalStatus === "rehydrated" ? "prior_local_only_handoff_unavailable" : "resolved_local_journal_missing"}`,
             ].join(" "),
           );
+          if (hostDiagnostics.journalStatus !== "current") {
+            infoDetails.push(
+              [
+                "issue_journal_state",
+                `issue=#${record.issue_number}`,
+                `status=${hostDiagnostics.journalStatus}`,
+                `guidance=${hostDiagnostics.guidance}`,
+                `detail=${hostDiagnostics.journalStatus === "rehydrated" ? "prior_local_only_handoff_unavailable" : "resolved_local_journal_missing"}`,
+              ].join(" "),
+            );
+          }
         }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        problems.push(`Issue #${record.issue_number} host diagnostics could not be inspected: ${message}.`);
       }
 
       try {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -248,6 +248,98 @@ test("status reports bootstrap repos as not ready for expected CI and review sig
   );
 });
 
+test("status surfaces host-migration path repair and journal rehydration from the canonical local journal", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 145;
+  const branch = branchName(fixture.config, issueNumber);
+  const workspacePath = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", String(issueNumber), "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(path.join(workspacePath, ".git"), "gitdir: /tmp/fake\n", "utf8");
+  await fs.writeFile(
+    journalPath,
+    `# Issue #145: Host migration
+
+## Supervisor Snapshot
+- Updated at: 2026-04-17T00:10:00Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker: No blocker.
+- Next exact step: Resume focused verification from the local worktree.
+
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+`,
+    "utf8",
+  );
+
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "reproducing",
+        branch,
+        workspace: `/tmp/other-host/issue-${issueNumber}`,
+        journal_path: `/tmp/other-host/issue-${issueNumber}/.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
+        blocked_reason: null,
+        last_error: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => ({
+      number: issueNumber,
+      title: "Host migration diagnostics",
+      body: executionReadyBody("Surface host migration diagnostics in status."),
+      createdAt: "2026-04-17T00:00:00Z",
+      updatedAt: "2026-04-17T00:00:00Z",
+      url: `https://example.test/issues/${issueNumber}`,
+      labels: [],
+      state: "OPEN",
+    } satisfies GitHubIssue),
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    resolvePullRequestForBranch: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+    getPullRequestIfExists: async () => null,
+  };
+
+  const status = await supervisor.status();
+
+  assert.match(
+    status,
+    /^handoff_summary=next: Resume focused verification from the local worktree\.$/m,
+  );
+  assert.match(
+    status,
+    /^issue_host_paths issue=#145 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m,
+  );
+  assert.match(
+    status,
+    /^issue_journal_state issue=#145 status=rehydrated guidance=no_manual_action_required detail=prior_local_only_handoff_unavailable$/m,
+  );
+  assert.doesNotMatch(status, /status_warning=/);
+});
+
 test("status does not warn for issue-scoped or custom issue journal paths", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -412,6 +412,8 @@ export async function buildSupervisorStatusReport(args: {
     verificationPolicySummary: activeStatus.verificationPolicySummary,
     durableGuardrailSummary: activeStatus.durableGuardrailSummary,
     externalReviewFollowUpSummary: activeStatus.externalReviewFollowUpSummary,
+    hostPathSummary: activeStatus.hostPathSummary,
+    journalStateSummary: activeStatus.journalStateSummary,
     executionMetricsSummaryLines: activeStatus.executionMetricsSummaryLines,
   });
   const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);

--- a/src/supervisor/supervisor-selection-active-status.ts
+++ b/src/supervisor/supervisor-selection-active-status.ts
@@ -1,4 +1,4 @@
-import { readIssueJournal, summarizeIssueJournalHandoff } from "../core/journal";
+import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
 import {
   GitHubIssue,
   GitHubPullRequest,
@@ -48,6 +48,8 @@ export interface ActiveIssueStatusSnapshot {
   verificationPolicySummary: string | null;
   durableGuardrailSummary: string | null;
   externalReviewFollowUpSummary: string | null;
+  hostPathSummary: string | null;
+  journalStateSummary: string | null;
   executionMetricsSummaryLines: string[];
   warningMessage: string | null;
 }
@@ -71,16 +73,37 @@ export async function loadActiveIssueStatusSnapshot(args: {
   let verificationPolicySummary: string | null = null;
   let durableGuardrailSummary: string | null = null;
   let externalReviewFollowUpSummary: string | null = null;
+  let hostPathSummary: string | null = null;
+  let journalStateSummary: string | null = null;
   let executionMetricsSummaryLines: string[] = [];
   let warningMessage: string | null = null;
   let preMergeEvaluation = null;
 
-  if (args.activeRecord.journal_path) {
-    try {
-      handoffSummary = summarizeIssueJournalHandoff(await readIssueJournal(args.activeRecord.journal_path));
-    } catch (error) {
-      warningMessage = error instanceof Error ? error.message : String(error);
+  try {
+    const hostDiagnostics = await inspectTrackedIssueHostDiagnostics(args.config, args.activeRecord);
+    if (hostDiagnostics.guidance !== null) {
+      hostPathSummary = [
+        "issue_host_paths",
+        `issue=#${args.activeRecord.issue_number}`,
+        `workspace=${hostDiagnostics.workspaceStatus}`,
+        `journal_path=${hostDiagnostics.journalPathStatus}`,
+        `guidance=${hostDiagnostics.guidance}`,
+      ].join(" ");
+      if (hostDiagnostics.journalStatus !== "current") {
+        journalStateSummary = [
+          "issue_journal_state",
+          `issue=#${args.activeRecord.issue_number}`,
+          `status=${hostDiagnostics.journalStatus}`,
+          `guidance=${hostDiagnostics.guidance}`,
+          `detail=${hostDiagnostics.journalStatus === "rehydrated" ? "prior_local_only_handoff_unavailable" : "resolved_local_journal_missing"}`,
+        ].join(" ");
+      }
     }
+    if (hostDiagnostics.journalContent !== null) {
+      handoffSummary = summarizeIssueJournalHandoff(hostDiagnostics.journalContent);
+    }
+  } catch (error) {
+    warningMessage = error instanceof Error ? error.message : String(error);
   }
 
   try {
@@ -154,6 +177,8 @@ export async function loadActiveIssueStatusSnapshot(args: {
     verificationPolicySummary,
     durableGuardrailSummary,
     externalReviewFollowUpSummary,
+    hostPathSummary,
+    journalStateSummary,
     executionMetricsSummaryLines,
     warningMessage,
   };

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -528,6 +528,88 @@ test("buildIssueExplainDto degrades when PR resolution fails", async () => {
   });
 });
 
+test("buildIssueExplainSummary surfaces host-migration path repair and journal rehydration from the canonical local journal", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 606;
+  const workspacePath = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", String(issueNumber), "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(path.join(workspacePath, ".git"), "gitdir: /tmp/fake\n", "utf8");
+  await fs.writeFile(
+    journalPath,
+    `# Issue #606: Host migration explain
+
+## Supervisor Snapshot
+- Updated at: 2026-04-17T00:20:00Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker:
+- Next exact step: Continue from the canonical local worktree.
+
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+`,
+    "utf8",
+  );
+
+  const config = createConfig({
+    workspaceRoot: fixture.workspaceRoot,
+    stateFile: fixture.stateFile,
+    repoPath: fixture.repoPath,
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  });
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Explain host migration diagnostics",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        blocked_reason: "unknown",
+        branch: branchName(config, issueNumber),
+        workspace: `/tmp/other-host/issue-${issueNumber}`,
+        journal_path: `/tmp/other-host/issue-${issueNumber}/.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
+      }),
+    },
+  };
+
+  const lines = await buildIssueExplainSummary(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+      resolvePullRequestForBranch: async () => null,
+    },
+    config,
+    state,
+    issueNumber,
+  );
+
+  const explanation = lines.join("\n");
+  assert.match(
+    explanation,
+    /^issue_host_paths issue=#606 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m,
+  );
+  assert.match(
+    explanation,
+    /^issue_journal_state issue=#606 status=rehydrated guidance=no_manual_action_required detail=prior_local_only_handoff_unavailable$/m,
+  );
+  assert.match(
+    explanation,
+    /^reason_2=local_state blocked$/m,
+  );
+});
+
 test("buildIssueExplainDto surfaces preserved partial work for no-PR manual-review recovery", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 607;

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -33,7 +33,7 @@ import {
 } from "./supervisor-status-rendering";
 import { formatLatestRecoveryStatusLine } from "./supervisor-detailed-status-assembly";
 import { externalSignalReadinessDiagnostics } from "./supervisor-status-review-bot";
-import { readIssueJournal, resolveTrackedIssueHostPaths, summarizeIssueJournalHandoff } from "../core/journal";
+import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
 import { formatInventoryRefreshDiagnosticLines, formatInventoryRefreshStatusLine } from "../inventory-refresh-state";
 import { buildTrackedPrMismatch } from "./tracked-pr-mismatch";
 import {
@@ -71,6 +71,8 @@ export interface SupervisorExplainDto {
   inventoryRefreshDiagnostics?: string[];
   changeRiskLines: string[];
   externalReviewFollowUpSummary: string | null;
+  hostPathSummary?: string | null;
+  journalStateSummary?: string | null;
   latestRecoverySummary: string | null;
   staleRecoveryWarningSummary: string | null;
   activityContext: SupervisorIssueActivityContextDto | null;
@@ -245,11 +247,33 @@ export async function buildIssueExplainDto(
       pr = null;
     }
   }
-  const resolvedPaths = record ? resolveTrackedIssueHostPaths(config, record) : null;
   let handoffSummary: string | null = null;
-  if (record && resolvedPaths && (record.journal_path !== null || resolvedPaths.usingCanonicalWorkspace)) {
+  let hostPathSummary: string | null = null;
+  let journalStateSummary: string | null = null;
+  if (record) {
     try {
-      handoffSummary = summarizeIssueJournalHandoff(await readIssueJournal(resolvedPaths.journal_path));
+      const hostDiagnostics = await inspectTrackedIssueHostDiagnostics(config, record);
+      if (hostDiagnostics.journalContent !== null) {
+        handoffSummary = summarizeIssueJournalHandoff(hostDiagnostics.journalContent);
+      }
+      if (hostDiagnostics.guidance !== null) {
+        hostPathSummary = [
+          "issue_host_paths",
+          `issue=#${record.issue_number}`,
+          `workspace=${hostDiagnostics.workspaceStatus}`,
+          `journal_path=${hostDiagnostics.journalPathStatus}`,
+          `guidance=${hostDiagnostics.guidance}`,
+        ].join(" ");
+        if (hostDiagnostics.journalStatus !== "current") {
+          journalStateSummary = [
+            "issue_journal_state",
+            `issue=#${record.issue_number}`,
+            `status=${hostDiagnostics.journalStatus}`,
+            `guidance=${hostDiagnostics.guidance}`,
+            `detail=${hostDiagnostics.journalStatus === "rehydrated" ? "prior_local_only_handoff_unavailable" : "resolved_local_journal_missing"}`,
+          ].join(" ");
+        }
+      }
     } catch {
       handoffSummary = null;
     }
@@ -355,6 +379,8 @@ export async function buildIssueExplainDto(
     inventoryRefreshDiagnostics,
     changeRiskLines,
     externalReviewFollowUpSummary,
+    hostPathSummary,
+    journalStateSummary,
     latestRecoverySummary,
     staleRecoveryWarningSummary,
     activityContext: record
@@ -404,6 +430,8 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.inventoryRefreshDiagnostics ?? []),
     ...dto.changeRiskLines,
     ...(dto.externalReviewFollowUpSummary ? [dto.externalReviewFollowUpSummary] : []),
+    ...(dto.hostPathSummary ? [dto.hostPathSummary] : []),
+    ...(dto.journalStateSummary ? [dto.journalStateSummary] : []),
     ...(preMergeEvaluationLine ? [preMergeEvaluationLine] : []),
     ...(localCiStatusLine ? [localCiStatusLine] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),

--- a/src/supervisor/supervisor-status-model.ts
+++ b/src/supervisor/supervisor-status-model.ts
@@ -64,6 +64,8 @@ export interface BuildDetailedStatusSummaryLinesArgs {
   verificationPolicySummary?: string | null;
   durableGuardrailSummary?: string | null;
   externalReviewFollowUpSummary?: string | null;
+  hostPathSummary?: string | null;
+  journalStateSummary?: string | null;
   executionMetricsSummaryLines?: string[];
 }
 
@@ -90,12 +92,22 @@ export function buildDetailedStatusSummaryLines(args: BuildDetailedStatusSummary
     verificationPolicySummary = null,
     durableGuardrailSummary = null,
     externalReviewFollowUpSummary = null,
+    hostPathSummary = null,
+    journalStateSummary = null,
     executionMetricsSummaryLines = [],
   } = args;
   const lines: string[] = [];
 
   if (handoffSummary) {
     lines.push(`handoff_summary=${truncate(sanitizeStatusValue(handoffSummary), 200)}`);
+  }
+
+  if (hostPathSummary) {
+    lines.push(truncate(sanitizeStatusValue(hostPathSummary), 200) ?? "");
+  }
+
+  if (journalStateSummary) {
+    lines.push(truncate(sanitizeStatusValue(journalStateSummary), 200) ?? "");
   }
 
   for (const codexModelPolicySummaryLine of codexModelPolicySummaryLines) {


### PR DESCRIPTION
## Summary
- surface auto-repaired host-migration paths and rehydrated local journals in doctor, status, and explain
- treat repaired migrated worktrees as healthy by normalizing git worktree registration paths
- document when host-migration repair is informational versus when manual action is still required

## Testing
- npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/getting-started-docs.test.ts
- npm run build

Closes #1547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting note explaining host-migration scenarios and diagnostic guidance codes for worktree-local journals.

* **New Features**
  * Detect and report when issue workspaces or journal paths reference moved hosts; auto-repair path resolution where possible.
  * Detect and surface “rehydrated” journals migrated from another host and include actionable guidance in status reports.

* **Tests**
  * Added integration tests covering host-migration, path repair, and journal rehydration reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->