### PR TITLE
Add snapshot-and-transaction integrity heuristics to committed shared memory (#1560)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -358,6 +358,11 @@ These are not "tuning" choices. They are part of the safety model.
 
 GitHub-authored issue bodies, review comments, and similar GitHub text are execution inputs. The current runtime uses `--dangerously-bypass-approvals-and-sandbox`, so the practical safety boundary is whether the repo and its GitHub authors are trusted.
 
+Operator prerequisite:
+
+- only use autonomous execution when this is a trusted repo with a trusted author set
+- if the repo or author trust is unclear, do not rely on bypassed sandbox or approval protections
+
 ### PR hydration authority
 
 Fresh GitHub PR facts are authoritative for review and merge decisions. Cached hydration can appear in diagnostics, but it is not the source of truth for readiness or merge safety.
@@ -365,8 +370,10 @@ Fresh GitHub PR facts are authoritative for review and merge decisions. Cached h
 ### JSON state recovery
 
 - missing JSON state is a normal empty bootstrap case
-- corrupted JSON state is not a normal bootstrap case
-- corrupted state should be treated as a recovery event until an operator inspects or resets it
+- corrupted JSON state is not a normal empty-state bootstrap case
+- corrupted state should be treated as a recovery event until an operator inspects, acknowledges, or resets it
+- if you need a concise rule: inspect, acknowledge, or reset before resuming normal automation
+- use `status` or `doctor` to inspect the condition before treating the recovered marker as safe progress
 
 ### Workspace restore order
 
@@ -377,6 +384,7 @@ When `ensureWorkspace()` restores an issue workspace, the intended order is:
 3. fresh bootstrap from `origin/<defaultBranch>`
 
 Fresh bootstrap is the fallback, not the default answer to every missing local branch.
+The restore flow prefers the local issue branch first, then the remote issue branch, and only then falls back to bootstrap from `origin/<defaultBranch>` or `origin/main`.
 
 ## Field Groups Reference
 
@@ -491,6 +499,9 @@ Important distinction:
 
 - `maxDoneWorkspaces` and `cleanupDoneWorkspacesAfterHours` apply to tracked done workspaces
 - `cleanupOrphanedWorkspacesAfterHours` is an age gate for explicit orphan pruning, not a background cleanup toggle
+- orphaned worktrees and orphaned workspaces are preserved until an explicit `prune-orphaned-workspaces` run evaluates them
+- preserve locked, recent, and `unsafe_target` orphaned workspaces instead of pruning them eagerly
+- use `prune-orphaned-workspaces` when you want explicit cleanup of eligible orphaned workspaces
 
 ### Repo-owned local CI contract
 

--- a/docs/shared-memory/constitution.example.md
+++ b/docs/shared-memory/constitution.example.md
@@ -15,6 +15,7 @@ This repository is operated with AI-assisted implementation loops. Durable proje
 - Keep operator-facing query surfaces resilient to partial or missing data. Prefer graceful degradation over hard failure in status, explain, doctor, and setup flows.
 - Do not let transport, refresh, or UI follow-up failures rewrite the outcome of a successful mutation.
 - When authoritative records and derived status surfaces disagree, repair the derived surface to match the authoritative record instead of teaching the system to trust the projection.
+- Do not hold a database transaction open across network hops, queued jobs, adapter dispatch, or other remote waits; cross the boundary only after commit or rollback.
 
 ## AI workflow rules
 

--- a/docs/shared-memory/decisions.example.md
+++ b/docs/shared-memory/decisions.example.md
@@ -16,6 +16,8 @@
 - Authoritative lifecycle records beat derived summaries, convenience projections, and operator-facing DTOs when they disagree.
 - Resolve `current`, `latest`, `active`, `terminal`, `open`, and `done` classifications from authoritative lifecycle fields first, then derive summaries from that result.
 - When selecting among competing records, authoritative lifecycle state, durable identifiers, terminal markers, and authoritative timestamps beat display order, badge text, convenience booleans, or whichever row refreshed last.
+- Multi-read responses such as readiness rollups, detail views, exports, backups, and restore previews should come from one committed snapshot or fail explicitly instead of mixing records from different snapshots.
+- One logical multi-record mutation should commit atomically; never leave partial durable state behind for later sessions to treat as truth.
 
 ## Operator surface model
 

--- a/docs/shared-memory/workflow.example.md
+++ b/docs/shared-memory/workflow.example.md
@@ -11,6 +11,7 @@
 7. Open or update the PR.
 8. Address CI failures and review feedback until mergeable.
 9. Before shipping a stateful change, check that current/latest/active/terminal selection still comes from the authoritative record rather than a summary DTO, timeline projection, or operator-facing status field.
+10. Before shipping aggregation, backup/restore/export, or multi-write persistence changes, verify the read path is snapshot-consistent and the write path is atomic across every affected record.
 
 ## Durable memory
 

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -195,6 +195,22 @@ test("buildCodexPrompt includes fail-closed shared-memory heuristics for review-
   assert.match(prompt, /Resolve `current`, `latest`, `active`, `terminal`, `open`, or `done` from the authoritative lifecycle source instead of whichever summary field or timeline entry was updated last/);
   assert.match(prompt, /Do not let timeline summaries, detail DTOs, badges, counters, or post-mutation refresh failures overwrite the outcome recorded by the authoritative mutation or lifecycle record/);
   assert.match(prompt, /When selecting among multiple records, define the winner from authoritative fields first/);
+  assert.match(
+    prompt,
+    /When a response, export, backup, restore, readiness check, or detail aggregation reads multiple records, make the read set snapshot-consistent or explicitly detect and reject mixed-snapshot results instead of stitching together whichever rows arrived from different points in time/,
+  );
+  assert.match(
+    prompt,
+    /When one logical change writes multiple records, persist it atomically so partial commits cannot become the durable truth for later sessions or follow-up reads/,
+  );
+  assert.match(
+    prompt,
+    /Do not hold database transactions open across network hops, queued jobs, adapter dispatch, or other remote waits; stage the boundary, commit or roll back, then continue in a new transaction if needed/,
+  );
+  assert.match(
+    prompt,
+    /Treat backup\/restore\/export flows and readiness or detail rollups as high-risk mixed-state surfaces: verify they read from one committed snapshot and represent all-or-nothing write boundaries faithfully/,
+  );
 });
 
 test("buildCodexPrompt renders on-demand memory files even without always-read files", () => {

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -454,6 +454,10 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     "- Do not let timeline summaries, detail DTOs, badges, counters, or post-mutation refresh failures overwrite the outcome recorded by the authoritative mutation or lifecycle record.",
     "- Treat operator-facing status text, human-readable summaries, and detail projections as derived surfaces that must be recalculated from authoritative state, not used as independent evidence for state transitions.",
     "- When a derived surface drifts from the authoritative record, fix the derivation and add or tighten the narrowest regression test at the authoritative selection boundary.",
+    "- When a response, export, backup, restore, readiness check, or detail aggregation reads multiple records, make the read set snapshot-consistent or explicitly detect and reject mixed-snapshot results instead of stitching together whichever rows arrived from different points in time.",
+    "- When one logical change writes multiple records, persist it atomically so partial commits cannot become the durable truth for later sessions or follow-up reads.",
+    "- Do not hold database transactions open across network hops, queued jobs, adapter dispatch, or other remote waits; stage the boundary, commit or roll back, then continue in a new transaction if needed.",
+    "- Treat backup/restore/export flows and readiness or detail rollups as high-risk mixed-state surfaces: verify they read from one committed snapshot and represent all-or-nothing write boundaries faithfully.",
   ];
 
   return [

--- a/src/committed-guardrails.test.ts
+++ b/src/committed-guardrails.test.ts
@@ -428,14 +428,30 @@ test("repo shared-memory examples encode authoritative-over-derived state guidan
     decisions,
     /Do not let refresh failures, timeline rows, badges, counters, or detail projections overwrite the authoritative outcome of a successful mutation or lifecycle transition\./,
   );
+  assert.match(
+    decisions,
+    /Multi-read responses such as readiness rollups, detail views, exports, backups, and restore previews should come from one committed snapshot or fail explicitly instead of mixing records from different snapshots\./,
+  );
+  assert.match(
+    decisions,
+    /One logical multi-record mutation should commit atomically; never leave partial durable state behind for later sessions to treat as truth\./,
+  );
 
   assert.match(
     constitution,
     /When authoritative records and derived status surfaces disagree, repair the derived surface to match the authoritative record instead of teaching the system to trust the projection\./,
   );
+  assert.match(
+    constitution,
+    /Do not hold a database transaction open across network hops, queued jobs, adapter dispatch, or other remote waits; cross the boundary only after commit or rollback\./,
+  );
 
   assert.match(
     workflow,
     /Before shipping a stateful change, check that current\/latest\/active\/terminal selection still comes from the authoritative record rather than a summary DTO, timeline projection, or operator-facing status field\./,
+  );
+  assert.match(
+    workflow,
+    /Before shipping aggregation, backup\/restore\/export, or multi-write persistence changes, verify the read path is snapshot-consistent and the write path is atomic across every affected record\./,
   );
 });

--- a/src/local-review/prompt.test.ts
+++ b/src/local-review/prompt.test.ts
@@ -210,6 +210,45 @@ test("buildRolePrompt teaches reviewer to anchor findings to the actual behavior
   );
 });
 
+test("buildRolePrompt teaches reviewers snapshot-consistency and transaction-boundary heuristics on shared-memory changes", () => {
+  const prompt = buildRolePrompt({
+    repoSlug: "owner/repo",
+    issue: createIssue({
+      number: 205,
+      title: "Review snapshot-consistent shared-memory changes",
+      url: "https://example.test/issues/205",
+      createdAt: "2026-03-14T00:00:00Z",
+      updatedAt: "2026-03-14T00:00:00Z",
+    }),
+    branch: "codex/issue-205",
+    workspacePath: "/tmp/workspaces/issue-205",
+    defaultBranch: "main",
+    pr: createPullRequest({
+      number: 205,
+      url: "https://example.test/pr/205",
+      headRefOid: "head205",
+    }),
+    role: "reviewer",
+    alwaysReadFiles: ["/tmp/workspaces/issue-205/.codex-supervisor/issue-journal.md"],
+    onDemandFiles: ["/tmp/workspaces/issue-205/docs/architecture.md"],
+    confidenceThreshold: 0.7,
+    priorMissPatterns: [],
+  });
+
+  assert.match(
+    prompt,
+    /On shared-memory, persistence, or aggregation changes, check that multi-read responses use one committed snapshot or explicitly reject mixed-snapshot assembly\./,
+  );
+  assert.match(
+    prompt,
+    /Check that logical multi-record writes commit atomically so backup\/restore\/export and readiness or detail rollups cannot persist partial state as durable truth\./,
+  );
+  assert.match(
+    prompt,
+    /Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit\/roll back before crossing it\./,
+  );
+});
+
 test("buildRolePrompt teaches reviewer to flag unrelated cleanup but allow required support changes", () => {
   const prompt = buildRolePrompt({
     repoSlug: "owner/repo",

--- a/src/local-review/prompt.ts
+++ b/src/local-review/prompt.ts
@@ -235,6 +235,9 @@ function roleGoal(role: string): string[] {
         "- Anchor findings and promoted guardrails to the decisive behavioral boundary or invariant, not an earlier or merely adjacent implementation location.",
         "- Flag tests or promoted guardrails that hard-code exact source line numbers when a stable behavior, identifier, or nearby intent anchor would verify the same thing.",
         "- Do not object to exact line assertions when source location itself is the intended contract.",
+        "- On shared-memory, persistence, or aggregation changes, check that multi-read responses use one committed snapshot or explicitly reject mixed-snapshot assembly.",
+        "- Check that logical multi-record writes commit atomically so backup/restore/export and readiness or detail rollups cannot persist partial state as durable truth.",
+        "- Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit/roll back before crossing it.",
         "- Ignore style nits unless they could hide a bug or maintenance trap.",
       ];
     case "docs_researcher":
@@ -397,6 +400,9 @@ export function buildVerifierPrompt(args: {
     "- Treat exact source lines as optional hints unless the finding is explicitly about a user-visible or contractual source location.",
     "- When a test or guardrail could anchor to stable behavior, identifiers, or nearby intent instead of a hard-coded line number, prefer that more stable reading.",
     "- Prefer the real transition or invariant boundary under review over a nearby setup step or incidental code location when deciding whether a finding still holds.",
+    "- Re-check shared-memory aggregations against snapshot consistency: mixed-snapshot reads should stay blocked or be called out as a real defect.",
+    "- Re-check that logical multi-record writes remain atomic and that backup/restore/export or readiness/detail rollups cannot publish partial durable state.",
+    "- Confirm that any transaction-scoped fix still commits or rolls back before network hops, queued work, adapter dispatch, or other remote waits.",
     "",
     "Constraints:",
     "- Do not edit files, do not commit, and do not push.",


### PR DESCRIPTION
Closes #1560
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the shared-memory safety guidance the issue asked for. The Codex start prompt now explicitly covers snapshot-consistent multi-read aggregation, atomic multi-record writes, backup/restore/export and readiness/detail rollups, and the rule to never hold transactions open across network hops or adapter dispatch. I also mirrored the same expectations into the local-review reviewer/verifier prompts and the committed shared-memory example docs, then tightened the prompt/example tests around those exact heuristics.

While running the requested verification, `src/execution-safety-docs.test.ts` exposed unrelated wording drift in [docs/configuration.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1560/docs/configuration.md), so I repaired that doc as part of the same turn to get the requested verification green. The repo changes are committed as `8039b73` (`Add snapshot integrity shared-memory heuristics`). The supervisor-local journal was updated in `.codex-supervisor/issues/1560/issue-journal.md`; it remains uncommitted because that path is gitignored.

Summary: Added snapshot/transaction integrity heuristics to committed shared-memory prompt surfaces and examples, with matching tests and a small configuration-doc wording repair to satisfy verification.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts src/execution-safety-docs.test.ts`; `npx tsx --test src/committed-gua...