### PR TITLE
Add negative-path no-partial-write heuristics to committed shared memory (#1561)

### DIFF
--- a/docs/shared-memory/constitution.example.md
+++ b/docs/shared-memory/constitution.example.md
@@ -16,6 +16,7 @@ This repository is operated with AI-assisted implementation loops. Durable proje
 - Do not let transport, refresh, or UI follow-up failures rewrite the outcome of a successful mutation.
 - When authoritative records and derived status surfaces disagree, repair the derived surface to match the authoritative record instead of teaching the system to trust the projection.
 - Do not hold a database transaction open across network hops, queued jobs, adapter dispatch, or other remote waits; cross the boundary only after commit or rollback.
+- Do not treat a thrown error, rejected mutation, or failed restore as sufficient by itself; verify the failed path leaves no orphan or partial durable state behind.
 
 ## AI workflow rules
 

--- a/docs/shared-memory/decisions.example.md
+++ b/docs/shared-memory/decisions.example.md
@@ -18,6 +18,7 @@
 - When selecting among competing records, authoritative lifecycle state, durable identifiers, terminal markers, and authoritative timestamps beat display order, badge text, convenience booleans, or whichever row refreshed last.
 - Multi-read responses such as readiness rollups, detail views, exports, backups, and restore previews should come from one committed snapshot or fail explicitly instead of mixing records from different snapshots.
 - One logical multi-record mutation should commit atomically; never leave partial durable state behind for later sessions to treat as truth.
+- On rejected, forbidden, restore-failure, or other failed mutation paths, prove the durable state stayed clean: no orphan records, no partial writes, and no half-restored state should survive the attempt.
 
 ## Operator surface model
 

--- a/docs/shared-memory/workflow.example.md
+++ b/docs/shared-memory/workflow.example.md
@@ -12,6 +12,7 @@
 8. Address CI failures and review feedback until mergeable.
 9. Before shipping a stateful change, check that current/latest/active/terminal selection still comes from the authoritative record rather than a summary DTO, timeline projection, or operator-facing status field.
 10. Before shipping aggregation, backup/restore/export, or multi-write persistence changes, verify the read path is snapshot-consistent and the write path is atomic across every affected record.
+11. Before shipping rejected, forbidden, approval-failure, or restore-failure paths, verify the system proves both outcomes: the path failed and no durable orphan, partial write, or half-restored state remained afterward.
 
 ## Durable memory
 

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -211,6 +211,14 @@ test("buildCodexPrompt includes fail-closed shared-memory heuristics for review-
     prompt,
     /Treat backup\/restore\/export flows and readiness or detail rollups as high-risk mixed-state surfaces: verify they read from one committed snapshot and represent all-or-nothing write boundaries faithfully/,
   );
+  assert.match(
+    prompt,
+    /On rejected, forbidden, failed, or restore-failure paths, verify that no orphan record, partial durable write, or half-restored state survives the attempt/,
+  );
+  assert.match(
+    prompt,
+    /Do not stop at proving that an exception was raised or an error was returned; also prove the durable state remained clean after the failed path/,
+  );
 });
 
 test("buildCodexPrompt renders on-demand memory files even without always-read files", () => {

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -458,6 +458,8 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     "- When one logical change writes multiple records, persist it atomically so partial commits cannot become the durable truth for later sessions or follow-up reads.",
     "- Do not hold database transactions open across network hops, queued jobs, adapter dispatch, or other remote waits; stage the boundary, commit or roll back, then continue in a new transaction if needed.",
     "- Treat backup/restore/export flows and readiness or detail rollups as high-risk mixed-state surfaces: verify they read from one committed snapshot and represent all-or-nothing write boundaries faithfully.",
+    "- On rejected, forbidden, failed, or restore-failure paths, verify that no orphan record, partial durable write, or half-restored state survives the attempt.",
+    "- Do not stop at proving that an exception was raised or an error was returned; also prove the durable state remained clean after the failed path.",
   ];
 
   return [

--- a/src/committed-guardrails.test.ts
+++ b/src/committed-guardrails.test.ts
@@ -436,6 +436,10 @@ test("repo shared-memory examples encode authoritative-over-derived state guidan
     decisions,
     /One logical multi-record mutation should commit atomically; never leave partial durable state behind for later sessions to treat as truth\./,
   );
+  assert.match(
+    decisions,
+    /On rejected, forbidden, restore-failure, or other failed mutation paths, prove the durable state stayed clean: no orphan records, no partial writes, and no half-restored state should survive the attempt\./,
+  );
 
   assert.match(
     constitution,
@@ -445,6 +449,10 @@ test("repo shared-memory examples encode authoritative-over-derived state guidan
     constitution,
     /Do not hold a database transaction open across network hops, queued jobs, adapter dispatch, or other remote waits; cross the boundary only after commit or rollback\./,
   );
+  assert.match(
+    constitution,
+    /Do not treat a thrown error, rejected mutation, or failed restore as sufficient by itself; verify the failed path leaves no orphan or partial durable state behind\./,
+  );
 
   assert.match(
     workflow,
@@ -453,5 +461,9 @@ test("repo shared-memory examples encode authoritative-over-derived state guidan
   assert.match(
     workflow,
     /Before shipping aggregation, backup\/restore\/export, or multi-write persistence changes, verify the read path is snapshot-consistent and the write path is atomic across every affected record\./,
+  );
+  assert.match(
+    workflow,
+    /Before shipping rejected, forbidden, approval-failure, or restore-failure paths, verify the system proves both outcomes: the path failed and no durable orphan, partial write, or half-restored state remained afterward\./,
   );
 });

--- a/src/local-review/prompt.test.ts
+++ b/src/local-review/prompt.test.ts
@@ -247,6 +247,14 @@ test("buildRolePrompt teaches reviewers snapshot-consistency and transaction-bou
     prompt,
     /Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit\/roll back before crossing it\./,
   );
+  assert.match(
+    prompt,
+    /On shared-memory failure paths, check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind\./,
+  );
+  assert.match(
+    prompt,
+    /Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated\./,
+  );
 });
 
 test("buildRolePrompt teaches reviewer to flag unrelated cleanup but allow required support changes", () => {

--- a/src/local-review/prompt.ts
+++ b/src/local-review/prompt.ts
@@ -237,6 +237,8 @@ function roleGoal(role: string): string[] {
         "- Do not object to exact line assertions when source location itself is the intended contract.",
         "- On shared-memory, persistence, or aggregation changes, check that multi-read responses use one committed snapshot or explicitly reject mixed-snapshot assembly.",
         "- Check that logical multi-record writes commit atomically so backup/restore/export and readiness or detail rollups cannot persist partial state as durable truth.",
+        "- On shared-memory failure paths, check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind.",
+        "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
         "- Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit/roll back before crossing it.",
         "- Ignore style nits unless they could hide a bug or maintenance trap.",
       ];
@@ -402,6 +404,8 @@ export function buildVerifierPrompt(args: {
     "- Prefer the real transition or invariant boundary under review over a nearby setup step or incidental code location when deciding whether a finding still holds.",
     "- Re-check shared-memory aggregations against snapshot consistency: mixed-snapshot reads should stay blocked or be called out as a real defect.",
     "- Re-check that logical multi-record writes remain atomic and that backup/restore/export or readiness/detail rollups cannot publish partial durable state.",
+    "- Re-check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind.",
+    "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
     "- Confirm that any transaction-scoped fix still commits or rolls back before network hops, queued work, adapter dispatch, or other remote waits.",
     "",
     "Constraints:",


### PR DESCRIPTION
Closes #1561
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the committed shared-memory guidance to make the negative-path requirement explicit: failed, forbidden, rejected, approval-failure, and restore-failure paths now must prove both that the operation failed and that no orphan, partial durable write, or half-restored state survived. The change is wired through the Codex implementation prompt, local review/verifier prompts, and the shared-memory example docs so the guidance stays consistent.

I tightened the narrow tests first, reproduced the gap, then fixed it and committed the repo changes as `fe044c7` with message `Add negative-path shared-memory durability heuristics`. I also updated the local issue journal handoff notes for the next supervisor turn.

Summary: Added negative-path no-partial-write shared-memory heuristics across prompts and committed shared-memory examples; focused tests and build pass; committed as `fe044c7`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts src/committed-guardrails.test.ts`; `npx tsx --test src/execution-safety-docs.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1561` with commit `fe044c7` and proceed to review/CI handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced shared-memory guidelines and decision rules to require verification that failed operations (rejected mutations, restore failures) leave no orphaned or partially-created durable state.

* **Tests**
  * Extended test coverage to verify new durability validation guidance for failure paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->