### PR TITLE
Detect committed supervisor artifacts and machine-local paths in tracked content (#1563)

### DIFF
--- a/scripts/check-workstation-local-paths.ts
+++ b/scripts/check-workstation-local-paths.ts
@@ -15,7 +15,7 @@ function usage(): string {
   return [
     "Usage: tsx scripts/check-workstation-local-paths.ts [--workspace <path>] [--exclude-path <repo-relative-path>]",
     "",
-    "Scans tracked durable text artifacts for workstation-local absolute paths that point to operator-specific home directories.",
+    "Scans tracked durable text artifacts for workstation-local absolute paths and tracked supervisor-generated local artifacts.",
     "Approved committed fixtures/examples must be exempted intentionally by repo-relative path via --exclude-path",
     `or by extending DEFAULT_EXCLUDED_PATHS in ${path.posix.join("src", "workstation-local-paths.ts")}.`,
   ].join("\n");
@@ -64,7 +64,7 @@ async function main(): Promise<void> {
   const findings = await findForbiddenWorkstationLocalPaths(workspacePath, excludedPaths);
 
   if (findings.length === 0) {
-    console.log(`No forbidden workstation-local absolute paths found in tracked durable artifacts under ${workspacePath}.`);
+    console.log(`No forbidden workstation-local artifacts found in tracked durable artifacts under ${workspacePath}.`);
     return;
   }
 
@@ -73,10 +73,10 @@ async function main(): Promise<void> {
 
   throw new Error(
     [
-      "Forbidden workstation-local absolute path references found:",
+      "Forbidden workstation-local artifacts found:",
       renderedFindings,
       "",
-      "If a tracked fixture/example is intentionally committed with one of these paths, exempt it explicitly with --exclude-path",
+      "If a tracked fixture/example is intentionally committed, exempt it explicitly with --exclude-path",
       `or extend DEFAULT_EXCLUDED_PATHS in ${path.posix.join("src", "workstation-local-paths.ts")}.`,
       "",
       "Active excluded paths:",

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -59,7 +59,7 @@ function extractRenderedFindingLines(stderr: string): string[] {
   let collecting = false;
 
   for (const line of lines) {
-    if (line.includes("Forbidden workstation-local absolute path references found:")) {
+    if (line.includes("Forbidden workstation-local artifacts found:")) {
       collecting = true;
       continue;
     }
@@ -102,7 +102,7 @@ test("workstation-local path detector flags tracked durable artifacts and allows
 
   const failingResult = runDetector(repoPath, "--workspace", repoPath);
   assert.notEqual(failingResult.status, 0, "expected forbidden tracked path to fail");
-  assert.match(failingResult.stderr, /Forbidden workstation-local absolute path references found:/);
+  assert.match(failingResult.stderr, /Forbidden workstation-local artifacts found:/);
   assert.match(failingResult.stderr, /docs\/guide\.md:1/);
   assert.match(failingResult.stderr, new RegExp(SAMPLE_FORBIDDEN_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 
@@ -143,6 +143,26 @@ test("workstation-local path detector honors repo-owned default exclusions for c
   );
 });
 
+test("workstation-local path detector blocks tracked supervisor-generated artifacts even without leaked home paths", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, ".codex-supervisor", "pre-merge"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, ".codex-supervisor", "pre-merge", "assessment-snapshot.json"),
+    JSON.stringify({ kind: "pre-merge", status: "blocked" }, null, 2).concat("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", ".codex-supervisor/pre-merge/assessment-snapshot.json");
+
+  const result = runDetector(repoPath, "--workspace", repoPath);
+  assert.notEqual(result.status, 0, "expected tracked supervisor-generated artifact to fail");
+  assert.match(result.stderr, /\.codex-supervisor\/pre-merge\/assessment-snapshot\.json/);
+  assert.match(result.stderr, /remove/i);
+});
+
 test("npm run verify:paths exposes the focused workstation-local path detector", async (t) => {
   const repoPath = await createTrackedRepo();
   t.after(async () => {
@@ -160,7 +180,7 @@ test("npm run verify:paths exposes the focused workstation-local path detector",
 
   const failingResult = runVerifyPaths(repoPath);
   assert.notEqual(failingResult.status, 0, "expected forbidden tracked path to fail via package script");
-  assert.match(failingResult.stderr, /Forbidden workstation-local absolute path references found:/);
+  assert.match(failingResult.stderr, /Forbidden workstation-local artifacts found:/);
   assert.match(failingResult.stderr, /README\.md:1/);
 });
 
@@ -177,7 +197,9 @@ test("runtime gate reuses the CLI finding rendering for workstation-local path v
   const detectorResult = runDetector(repoPath, "--workspace", repoPath);
   assert.notEqual(detectorResult.status, 0, "expected forbidden tracked path to fail");
   const renderedFindings = extractRenderedFindingLines(detectorResult.stderr);
-  assert.deepEqual(renderedFindings, [`- docs/guide.md:1 matched /home/<user>/ (Linux user home directory) via ${JSON.stringify(SAMPLE_FORBIDDEN_PATH)}`]);
+  assert.deepEqual(renderedFindings, [
+    `- docs/guide.md:1 matched /home/<user>/ (Linux user home directory) via ${JSON.stringify(SAMPLE_FORBIDDEN_PATH)}. Remediation: rewrite the path repo-relatively or redact the operator-local absolute path`,
+  ]);
 
   const gateResult = await runWorkstationLocalPathGate({
     workspacePath: repoPath,
@@ -326,7 +348,9 @@ test("runtime gate distinguishes auto-normalized journals from expected-local du
   assert.doesNotMatch(summary, /\.codex-supervisor\/issues\/181\/issue-journal\.md/);
   assert.deepEqual(
     gateResult.failureContext?.details,
-    [`- WORKLOG.md:1 matched /home/<user>/ (Linux user home directory) via ${JSON.stringify(SAMPLE_FORBIDDEN_PATH)}`],
+    [
+      `- WORKLOG.md:1 matched /home/<user>/ (Linux user home directory) via ${JSON.stringify(SAMPLE_FORBIDDEN_PATH)}. Remediation: rewrite the path repo-relatively or redact the operator-local absolute path`,
+    ],
   );
   const redactedJournal = await fs.readFile(otherJournalPath, "utf8");
   assert.doesNotMatch(redactedJournal, new RegExp(SAMPLE_FORBIDDEN_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));

--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -256,3 +256,29 @@ test("findForbiddenWorkstationLocalPaths skips tracked files omitted by sparse c
     ],
   );
 });
+
+test("findForbiddenWorkstationLocalPaths flags tracked supervisor-generated artifacts by path", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  const artifactPath = path.join(repoPath, ".codex-supervisor", "pre-merge", "assessment-snapshot.json");
+  await fs.mkdir(path.dirname(artifactPath), { recursive: true });
+  await fs.writeFile(artifactPath, JSON.stringify({ kind: "pre-merge", ok: false }, null, 2).concat("\n"), "utf8");
+  git(repoPath, "add", ".codex-supervisor/pre-merge/assessment-snapshot.json");
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath);
+
+  assert.deepEqual(findings, [
+    {
+      filePath: ".codex-supervisor/pre-merge/assessment-snapshot.json",
+      line: null,
+      remediation:
+        "remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached .codex-supervisor/pre-merge/assessment-snapshot.json)",
+      match: ".codex-supervisor/pre-merge/assessment-snapshot.json",
+      prefix: ".codex-supervisor/pre-merge/",
+      reason: "is a supervisor-generated pre-merge artifact that must stay machine-local",
+    },
+  ]);
+});

--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -209,18 +209,22 @@ test("findForbiddenWorkstationLocalPaths skips tracked files omitted by sparse c
 
   const currentJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "102", "issue-journal.md");
   const otherJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  const hiddenArtifactPath = path.join(repoPath, ".codex-supervisor", "pre-merge", "assessment-snapshot.json");
   const visibleDocPath = path.join(repoPath, "docs", "guide.md");
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(hiddenArtifactPath), { recursive: true });
   await fs.mkdir(path.dirname(visibleDocPath), { recursive: true });
   await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
   await fs.writeFile(otherJournalPath, `- What changed: ${buildMacHomePath("alice", "Dev", "private-repo")}\n`, "utf8");
+  await fs.writeFile(hiddenArtifactPath, JSON.stringify({ kind: "pre-merge", ok: false }, null, 2).concat("\n"), "utf8");
   await fs.writeFile(visibleDocPath, `Visible leak: ${buildUnixHomePath("alice", "dev", "private-repo")}\n`, "utf8");
   git(
     repoPath,
     "add",
     ".codex-supervisor/issues/102/issue-journal.md",
     ".codex-supervisor/issues/181/issue-journal.md",
+    ".codex-supervisor/pre-merge/assessment-snapshot.json",
     "docs/guide.md",
   );
   git(repoPath, "commit", "-m", "seed sparse checkout fixture");
@@ -234,6 +238,7 @@ test("findForbiddenWorkstationLocalPaths skips tracked files omitted by sparse c
   git(repoPath, "read-tree", "-mu", "HEAD");
 
   await assert.rejects(fs.access(otherJournalPath), { code: "ENOENT" });
+  await assert.rejects(fs.access(hiddenArtifactPath), { code: "ENOENT" });
 
   const findings = await findForbiddenWorkstationLocalPaths(repoPath);
 

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -264,6 +264,19 @@ export async function findForbiddenWorkstationLocalPaths(
       continue;
     }
 
+    const absolutePath = path.join(workspacePath, filePath);
+    let rawContents: Buffer;
+    try {
+      rawContents = await fs.readFile(absolutePath);
+    } catch (error) {
+      const maybeErr = error as NodeJS.ErrnoException;
+      if (maybeErr.code === "ENOENT") {
+        continue;
+      }
+
+      throw error;
+    }
+
     const forbiddenArtifact = classifyForbiddenSupervisorArtifactPath(filePath);
     if (forbiddenArtifact) {
       findings.push({
@@ -277,18 +290,6 @@ export async function findForbiddenWorkstationLocalPaths(
       continue;
     }
 
-    const absolutePath = path.join(workspacePath, filePath);
-    let rawContents: Buffer;
-    try {
-      rawContents = await fs.readFile(absolutePath);
-    } catch (error) {
-      const maybeErr = error as NodeJS.ErrnoException;
-      if (maybeErr.code === "ENOENT") {
-        continue;
-      }
-
-      throw error;
-    }
     if (isBinary(rawContents)) {
       continue;
     }

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -47,14 +47,19 @@ const CANDIDATE_PATTERNS: ReadonlyArray<{
 
 export interface WorkstationLocalPathMatch {
   filePath: string;
-  line: number;
+  line: number | null;
+  remediation: string;
   match: string;
   prefix: string;
   reason: string;
 }
 
 export function formatWorkstationLocalPathMatch(finding: WorkstationLocalPathMatch): string {
-  return `- ${finding.filePath}:${finding.line} matched ${finding.prefix} (${finding.reason}) via ${JSON.stringify(finding.match)}`;
+  if (finding.line === null) {
+    return `- ${finding.filePath} ${finding.reason}. Remediation: ${finding.remediation}`;
+  }
+
+  return `- ${finding.filePath}:${finding.line} matched ${finding.prefix} (${finding.reason}) via ${JSON.stringify(finding.match)}. Remediation: ${finding.remediation}`;
 }
 
 function escapeForRegex(value: string): string {
@@ -181,6 +186,7 @@ function collectMatches(filePath: string, contents: string): WorkstationLocalPat
           matches.push({
             filePath,
             line: lineIndex + 1,
+            remediation: "rewrite the path repo-relatively or redact the operator-local absolute path",
             match: candidate,
             prefix: classification.label,
             reason: classification.reason,
@@ -193,6 +199,58 @@ function collectMatches(filePath: string, contents: string): WorkstationLocalPat
   return matches;
 }
 
+function classifyForbiddenSupervisorArtifactPath(filePath: string): { prefix: string; reason: string; remediation: string } | null {
+  if (filePath === ".codex-supervisor/turn-in-progress.json") {
+    return {
+      prefix: ".codex-supervisor/turn-in-progress.json",
+      reason: "is a supervisor-generated interrupted-turn marker that must stay machine-local",
+      remediation: `remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached ${filePath})`,
+    };
+  }
+
+  if (filePath === ".codex-supervisor/replay" || filePath.startsWith(".codex-supervisor/replay/")) {
+    return {
+      prefix: ".codex-supervisor/replay/",
+      reason: "is a supervisor-generated replay artifact that must stay machine-local",
+      remediation: `remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached ${filePath})`,
+    };
+  }
+
+  if (filePath === ".codex-supervisor/pre-merge" || filePath.startsWith(".codex-supervisor/pre-merge/")) {
+    return {
+      prefix: ".codex-supervisor/pre-merge/",
+      reason: "is a supervisor-generated pre-merge artifact that must stay machine-local",
+      remediation: `remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached ${filePath})`,
+    };
+  }
+
+  if (filePath === ".codex-supervisor/execution-metrics" || filePath.startsWith(".codex-supervisor/execution-metrics/")) {
+    return {
+      prefix: ".codex-supervisor/execution-metrics/",
+      reason: "is a supervisor-generated execution-metrics artifact that must stay machine-local",
+      remediation: `remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached ${filePath})`,
+    };
+  }
+
+  if (filePath === ".codex-supervisor/loop.out") {
+    return {
+      prefix: ".codex-supervisor/loop.out",
+      reason: "is a supervisor runtime log that must stay machine-local",
+      remediation: `remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached ${filePath})`,
+    };
+  }
+
+  if (filePath === ".codex-supervisor/current-reconciliation-phase.json") {
+    return {
+      prefix: ".codex-supervisor/current-reconciliation-phase.json",
+      reason: "is a supervisor runtime state artifact that must stay machine-local",
+      remediation: `remove the tracked file or rewrite the fixture outside live supervisor paths (for example: git rm --cached ${filePath})`,
+    };
+  }
+
+  return null;
+}
+
 export async function findForbiddenWorkstationLocalPaths(
   workspacePath: string,
   excludedPaths: Iterable<string> = DEFAULT_EXCLUDED_PATHS,
@@ -203,6 +261,19 @@ export async function findForbiddenWorkstationLocalPaths(
 
   for (const filePath of trackedFiles) {
     if (normalizedExcludedPaths.has(filePath)) {
+      continue;
+    }
+
+    const forbiddenArtifact = classifyForbiddenSupervisorArtifactPath(filePath);
+    if (forbiddenArtifact) {
+      findings.push({
+        filePath,
+        line: null,
+        remediation: forbiddenArtifact.remediation,
+        match: filePath,
+        prefix: forbiddenArtifact.prefix,
+        reason: forbiddenArtifact.reason,
+      });
       continue;
     }
 


### PR DESCRIPTION
Closes #1563
This PR was opened by codex-supervisor.
Latest Codex summary:

Committed `3a668e1` to make `verify:paths` reject tracked supervisor-generated local artifacts like `.codex-supervisor/pre-merge/*` in addition to workstation-home absolute paths. The detector now renders per-finding remediation text, and the focused reproducer plus detector/build checks are green.

Summary: Added tracked supervisor-artifact detection to `verify:paths`, updated focused tests, and committed checkpoint `3a668e1`; exact issue verification command still fails because the repo-wide npm test entrypoint surfaces unrelated suite failures outside this slice.
State hint: stabilizing
Blocked reason: verification
Tests: passed `npx tsx --test src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/ci-workflow.test.ts`; passed `npm run build`; failed `npm test -- src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/ci-workflow.test.ts` due repo-wide failures in `src/supervisor/supervisor-pr-readiness.test.ts`, `src/supervisor/supervisor-status-model-supervisor.test.ts`, and `src/tracked-pr-lifecycle-projection.test.ts`
Failure signature: full-suite-baseline-failures
Next action: Triage the remaining repo-wide test failures to confirm which are unrelated baseline regressions versus newly exposed interactions, then rerun the exact issue verification command once that suite is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection now includes tracked supervisor-generated artifacts in addition to workstation-local path checks.

* **Bug Fixes**
  * Reporting language updated from "absolute paths" to "artifacts" for clarity.
  * Failure messages now include explicit remediation guidance (rewrite paths or remove artifacts) and surface specific tracked artifact paths when found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->