### PR TITLE
Replace weak grep-based verification with execution-aware guardrails (#1564)

### DIFF
--- a/docs/shared-memory/external-review-guardrails.json
+++ b/docs/shared-memory/external-review-guardrails.json
@@ -2,6 +2,72 @@
   "version": 1,
   "patterns": [
     {
+      "fingerprint": "src/core/state-store.ts|new-persisted-nullable-fields-must-be-normalized-during-hydration",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/core/state-store.ts",
+      "line": null,
+      "summary": "Flag newly added persisted nullable fields that are written by current code but not normalized from older state files during load or hydration.",
+      "rationale": "Durable state remains stable only when schema additions converge old and new records to one canonical in-memory shape instead of leaking undefined drift.",
+      "sourceArtifactPath": "promoted-from-pr-1159",
+      "sourceHeadSha": "pr-1159",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/github/github-review-signals.ts|provider-specific-review-signals-must-stay-provider-scoped",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/github/github-review-signals.ts",
+      "line": null,
+      "summary": "Flag review-bot lifecycle or status inference that accepts success or arrival signals from a different provider than the gate being evaluated.",
+      "rationale": "Multi-provider review systems stay safe only when each merge gate is driven by that provider's own signals; cross-provider success can unlock merge prematurely.",
+      "sourceArtifactPath": "promoted-from-pr-1149",
+      "sourceHeadSha": "pr-1149",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/github/github.ts|per-request-diagnostic-capture-must-not-use-process-global-env-mutation",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/github/github.ts",
+      "line": null,
+      "summary": "Flag request-scoped or refresh-scoped diagnostic capture that is passed through mutable process-global environment variables across async execution.",
+      "rationale": "Concurrent operations can leak or overwrite each other's capture targets when request-local state is routed through process-global mutation.",
+      "sourceArtifactPath": "promoted-from-pr-1162",
+      "sourceHeadSha": "pr-1162",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/pull-request-state.ts|bot-thread-exceptions-must-not-bypass-human-review-gates",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/pull-request-state.ts",
+      "line": null,
+      "summary": "Flag exceptions that relax configured-bot thread blocking when they also suppress human review requirements such as human CHANGES_REQUESTED or REVIEW_REQUIRED.",
+      "rationale": "Bot-specific merge exceptions are only safe when they narrow bot blocking; they must never override human review decisions.",
+      "sourceArtifactPath": "promoted-from-pr-1149",
+      "sourceHeadSha": "pr-1149",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/setup-readiness.ts|invalid-optional-fields-must-still-fail-readiness",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/setup-readiness.ts",
+      "line": null,
+      "summary": "Flag readiness or setup-status logic that ignores optional fields in the invalid state instead of treating them as configuration failures.",
+      "rationale": "Optional fields may be missing, but once present they must be valid; otherwise readiness can report configured state for a broken config document.",
+      "sourceArtifactPath": "promoted-from-pr-1201",
+      "sourceHeadSha": "pr-1201",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
+      "fingerprint": "src/supervisor/supervisor-selection-issue-explain.ts|diagnostics-only-hydration-should-fail-soft-on-auxiliary-fetch-errors",
+      "reviewerLogin": "coderabbitai",
+      "file": "src/supervisor/supervisor-selection-issue-explain.ts",
+      "line": null,
+      "summary": "Flag diagnostics-only enrichments that throw through the primary explain or status response when optional auxiliary GitHub hydration fails.",
+      "rationale": "Operator diagnostics are most useful when core output survives partial enrichment failure and clearly marks missing auxiliary data instead of aborting entirely.",
+      "sourceArtifactPath": "promoted-from-pr-1161",
+      "sourceHeadSha": "pr-1161",
+      "lastSeenAt": "2026-03-30T00:00:00Z"
+    },
+    {
       "fingerprint": ".codex-supervisor/issue-journal.md|committed-journal-snapshot-handoff-sections-must-stay-internally-consistent",
       "reviewerLogin": "coderabbitai",
       "file": ".codex-supervisor/issue-journal.md",
@@ -99,72 +165,6 @@
       "sourceArtifactPath": "promoted-from-issue-204",
       "sourceHeadSha": "issue-204",
       "lastSeenAt": "2026-03-14T00:00:00Z"
-    },
-    {
-      "fingerprint": "src/github/github-review-signals.ts|provider-specific-review-signals-must-stay-provider-scoped",
-      "reviewerLogin": "coderabbitai",
-      "file": "src/github/github-review-signals.ts",
-      "line": null,
-      "summary": "Flag review-bot lifecycle or status inference that accepts success or arrival signals from a different provider than the gate being evaluated.",
-      "rationale": "Multi-provider review systems stay safe only when each merge gate is driven by that provider's own signals; cross-provider success can unlock merge prematurely.",
-      "sourceArtifactPath": "promoted-from-pr-1149",
-      "sourceHeadSha": "pr-1149",
-      "lastSeenAt": "2026-03-30T00:00:00Z"
-    },
-    {
-      "fingerprint": "src/pull-request-state.ts|bot-thread-exceptions-must-not-bypass-human-review-gates",
-      "reviewerLogin": "coderabbitai",
-      "file": "src/pull-request-state.ts",
-      "line": null,
-      "summary": "Flag exceptions that relax configured-bot thread blocking when they also suppress human review requirements such as human CHANGES_REQUESTED or REVIEW_REQUIRED.",
-      "rationale": "Bot-specific merge exceptions are only safe when they narrow bot blocking; they must never override human review decisions.",
-      "sourceArtifactPath": "promoted-from-pr-1149",
-      "sourceHeadSha": "pr-1149",
-      "lastSeenAt": "2026-03-30T00:00:00Z"
-    },
-    {
-      "fingerprint": "src/core/state-store.ts|new-persisted-nullable-fields-must-be-normalized-during-hydration",
-      "reviewerLogin": "coderabbitai",
-      "file": "src/core/state-store.ts",
-      "line": null,
-      "summary": "Flag newly added persisted nullable fields that are written by current code but not normalized from older state files during load or hydration.",
-      "rationale": "Durable state remains stable only when schema additions converge old and new records to one canonical in-memory shape instead of leaking undefined drift.",
-      "sourceArtifactPath": "promoted-from-pr-1159",
-      "sourceHeadSha": "pr-1159",
-      "lastSeenAt": "2026-03-30T00:00:00Z"
-    },
-    {
-      "fingerprint": "src/github/github.ts|per-request-diagnostic-capture-must-not-use-process-global-env-mutation",
-      "reviewerLogin": "coderabbitai",
-      "file": "src/github/github.ts",
-      "line": null,
-      "summary": "Flag request-scoped or refresh-scoped diagnostic capture that is passed through mutable process-global environment variables across async execution.",
-      "rationale": "Concurrent operations can leak or overwrite each other's capture targets when request-local state is routed through process-global mutation.",
-      "sourceArtifactPath": "promoted-from-pr-1162",
-      "sourceHeadSha": "pr-1162",
-      "lastSeenAt": "2026-03-30T00:00:00Z"
-    },
-    {
-      "fingerprint": "src/supervisor/supervisor-selection-issue-explain.ts|diagnostics-only-hydration-should-fail-soft-on-auxiliary-fetch-errors",
-      "reviewerLogin": "coderabbitai",
-      "file": "src/supervisor/supervisor-selection-issue-explain.ts",
-      "line": null,
-      "summary": "Flag diagnostics-only enrichments that throw through the primary explain or status response when optional auxiliary GitHub hydration fails.",
-      "rationale": "Operator diagnostics are most useful when core output survives partial enrichment failure and clearly marks missing auxiliary data instead of aborting entirely.",
-      "sourceArtifactPath": "promoted-from-pr-1161",
-      "sourceHeadSha": "pr-1161",
-      "lastSeenAt": "2026-03-30T00:00:00Z"
-    },
-    {
-      "fingerprint": "src/setup-readiness.ts|invalid-optional-fields-must-still-fail-readiness",
-      "reviewerLogin": "coderabbitai",
-      "file": "src/setup-readiness.ts",
-      "line": null,
-      "summary": "Flag readiness or setup-status logic that ignores optional fields in the invalid state instead of treating them as configuration failures.",
-      "rationale": "Optional fields may be missing, but once present they must be valid; otherwise readiness can report configured state for a broken config document.",
-      "sourceArtifactPath": "promoted-from-pr-1201",
-      "sourceHeadSha": "pr-1201",
-      "lastSeenAt": "2026-03-30T00:00:00Z"
     }
   ]
 }

--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -2,6 +2,22 @@
   "version": 1,
   "rules": [
     {
+      "id": "ui-tests-should-assert-usability-state-not-mere-presence",
+      "title": "Assert UI usability state, not just element presence",
+      "file": "src/backend/webui-dashboard.test.ts",
+      "line": 2061,
+      "summary": "When a fake DOM or harness does not faithfully enforce hidden or disabled behavior, verifier coverage should assert that the control is visible and enabled before treating click plumbing as sufficient evidence.",
+      "rationale": "Presence-only assertions can pass while the control is still unusable to real users; tests should prove usability at the behavioral boundary."
+    },
+    {
+      "id": "workflow-tests-should-validate-executable-steps-not-grep-yaml",
+      "title": "Validate executable workflow steps, not raw YAML matches",
+      "file": "src/ci-workflow.test.ts",
+      "line": 226,
+      "summary": "Workflow verification should parse the job step structure and assert exact same-step `if`, `run`, `uses`, and `with` fields rather than grepping raw YAML for loose substrings or adjacent lines.",
+      "rationale": "Raw regex or substring checks can falsely combine fields from different steps and treat non-executable YAML text as proof that a guarded command or artifact upload is actually wired into the workflow."
+    },
+    {
       "id": "committed-guardrails-malformed-input",
       "title": "Differentiate missing and malformed committed guardrails",
       "file": "src/committed-guardrails.ts",
@@ -48,14 +64,6 @@
       "line": 114,
       "summary": "When loader output is intentionally extensible, assert on the rule or property under test instead of snapshotting the full returned array or document unless exact full output is the behavior being verified.",
       "rationale": "Full-array or full-document snapshots make maintainability guardrails brittle as new rules are added later; exact-output assertions are still appropriate when the exact structure itself is the contract."
-    },
-    {
-      "id": "ui-tests-should-assert-usability-state-not-mere-presence",
-      "title": "Assert UI usability state, not just element presence",
-      "file": "src/backend/webui-dashboard.test.ts",
-      "line": 2061,
-      "summary": "When a fake DOM or harness does not faithfully enforce hidden or disabled behavior, verifier coverage should assert that the control is visible and enabled before treating click plumbing as sufficient evidence.",
-      "rationale": "Presence-only assertions can pass while the control is still unusable to real users; tests should prove usability at the behavioral boundary."
     }
   ]
 }

--- a/src/ci-workflow.test.ts
+++ b/src/ci-workflow.test.ts
@@ -5,57 +5,317 @@ import test from "node:test";
 
 const workflowPath = path.resolve(__dirname, "..", ".github/workflows/ci.yml");
 
-test("CI workflow cancels stale runs for the same branch or PR", async () => {
-  const workflow = await fs.readFile(workflowPath, "utf8");
+interface WorkflowStep {
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+  with: Record<string, string>;
+}
 
-  assert.match(workflow, /on:\s*[\s\S]*push:\s*[\s\S]*branches:\s*-\s*main[\s\S]*pull_request:/);
-  assert.match(
-    workflow,
-    /concurrency:\s*group:\s*\$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.head\.repo\.full_name \|\| github\.repository \}\}-\$\{\{ github\.head_ref \|\| github\.ref_name \}\}\s*cancel-in-progress:\s*true/,
+interface ParsedWorkflow {
+  on: {
+    pushBranches: string[];
+    hasPullRequest: boolean;
+  };
+  concurrency: {
+    group: string | null;
+    cancelInProgress: string | null;
+  };
+  buildSteps: WorkflowStep[];
+}
+
+function countIndent(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+function splitKeyValue(raw: string): [string, string] | null {
+  const separatorIndex = raw.indexOf(":");
+  if (separatorIndex < 0) {
+    return null;
+  }
+
+  const key = raw.slice(0, separatorIndex).trim();
+  const value = raw.slice(separatorIndex + 1).trim();
+  return key === "" ? null : [key, value];
+}
+
+function collectBlock(lines: string[], startIndex: number): Array<{ indent: number; text: string }> {
+  const block: Array<{ indent: number; text: string }> = [];
+  const parentIndent = countIndent(lines[startIndex] ?? "");
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const indent = countIndent(line);
+    if (indent <= parentIndent) {
+      break;
+    }
+
+    block.push({ indent, text: trimmed });
+  }
+
+  return block;
+}
+
+function findSectionIndex(lines: string[], expected: string, startIndex = 0): number {
+  for (let index = startIndex; index < lines.length; index += 1) {
+    if ((lines[index] ?? "").trim() === expected) {
+      return index;
+    }
+  }
+
+  throw new Error(`Expected workflow section "${expected}" to exist.`);
+}
+
+function parseStepEntry(text: string): [string, string] | null {
+  if (!text.startsWith("- ")) {
+    return null;
+  }
+
+  return splitKeyValue(text.slice(2));
+}
+
+function parseWorkflow(workflow: string): ParsedWorkflow {
+  const lines = workflow.split(/\r?\n/u);
+
+  const onIndex = findSectionIndex(lines, "on:");
+  const onBlock = collectBlock(lines, onIndex);
+  const pushBranches: string[] = [];
+  let hasPullRequest = false;
+  let inPushBranches = false;
+
+  for (const entry of onBlock) {
+    if (entry.indent === 2 && entry.text === "push:") {
+      inPushBranches = false;
+      continue;
+    }
+    if (entry.indent === 2 && entry.text === "pull_request:") {
+      hasPullRequest = true;
+      inPushBranches = false;
+      continue;
+    }
+    if (entry.indent === 4 && entry.text === "branches:") {
+      inPushBranches = true;
+      continue;
+    }
+    if (inPushBranches && entry.indent === 6 && entry.text.startsWith("- ")) {
+      pushBranches.push(entry.text.slice(2).trim());
+      continue;
+    }
+    if (entry.indent <= 4) {
+      inPushBranches = false;
+    }
+  }
+
+  const concurrencyIndex = findSectionIndex(lines, "concurrency:");
+  const concurrencyBlock = collectBlock(lines, concurrencyIndex);
+  const concurrency = {
+    group: null as string | null,
+    cancelInProgress: null as string | null,
+  };
+  for (const entry of concurrencyBlock) {
+    if (entry.indent !== 2) {
+      continue;
+    }
+    const pair = splitKeyValue(entry.text);
+    if (!pair) {
+      continue;
+    }
+    const [key, value] = pair;
+    if (key === "group") {
+      concurrency.group = value;
+    }
+    if (key === "cancel-in-progress") {
+      concurrency.cancelInProgress = value;
+    }
+  }
+
+  const jobsIndex = findSectionIndex(lines, "jobs:");
+  const buildIndex = findSectionIndex(lines, "build:", jobsIndex + 1);
+  const stepsIndex = findSectionIndex(lines, "steps:", buildIndex + 1);
+  const stepsBlock = collectBlock(lines, stepsIndex);
+  const buildSteps: WorkflowStep[] = [];
+  let currentStep: WorkflowStep | null = null;
+  let inWithBlock = false;
+
+  for (const entry of stepsBlock) {
+    const inlinePair = parseStepEntry(entry.text);
+    if (entry.indent === 6 && inlinePair) {
+      currentStep = { with: {} };
+      inWithBlock = false;
+      buildSteps.push(currentStep);
+      const [key, value] = inlinePair;
+      if (key === "id") {
+        currentStep.id = value;
+      } else if (key === "if") {
+        currentStep.if = value;
+      } else if (key === "run") {
+        currentStep.run = value;
+      } else if (key === "uses") {
+        currentStep.uses = value;
+      }
+      continue;
+    }
+
+    if (!currentStep) {
+      continue;
+    }
+
+    if (entry.indent === 8 && entry.text === "with:") {
+      inWithBlock = true;
+      continue;
+    }
+
+    const pair = splitKeyValue(entry.text);
+    if (!pair) {
+      inWithBlock = false;
+      continue;
+    }
+
+    const [key, value] = pair;
+    if (inWithBlock && entry.indent === 10) {
+      currentStep.with[key] = value;
+      continue;
+    }
+
+    inWithBlock = false;
+    if (entry.indent !== 8) {
+      continue;
+    }
+
+    if (key === "id") {
+      currentStep.id = value;
+    } else if (key === "if") {
+      currentStep.if = value;
+    } else if (key === "run") {
+      currentStep.run = value;
+    } else if (key === "uses") {
+      currentStep.uses = value;
+    }
+  }
+
+  return {
+    on: {
+      pushBranches,
+      hasPullRequest,
+    },
+    concurrency,
+    buildSteps,
+  };
+}
+
+function findBuildStep(
+  steps: WorkflowStep[],
+  expected: Partial<Pick<WorkflowStep, "id" | "if" | "run" | "uses">>,
+): WorkflowStep | undefined {
+  return steps.find((step) =>
+    Object.entries(expected).every(([key, value]) => {
+      if (value === undefined) {
+        return true;
+      }
+
+      return step[key as keyof Pick<WorkflowStep, "id" | "if" | "run" | "uses">] === value;
+    }),
+  );
+}
+
+test("workflow parser does not treat separate step fields as one executable step", () => {
+  const parsed = parseWorkflow(`
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+concurrency:
+  group: ci-group
+  cancel-in-progress: true
+jobs:
+  build:
+    steps:
+      - if: matrix.os == 'ubuntu-latest'
+        run: echo "different command"
+      - run: npm run verify:paths
+`);
+
+  assert.equal(
+    findBuildStep(parsed.buildSteps, {
+      if: "matrix.os == 'ubuntu-latest'",
+      run: "npm run verify:paths",
+    }),
+    undefined,
   );
 });
 
-test("CI workflow surfaces the compact replay corpus summary in pull request output", async () => {
-  const workflow = await fs.readFile(workflowPath, "utf8");
+test("CI workflow cancels stale runs for the same branch or PR", async () => {
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
 
-  assert.match(
-    workflow,
-    /-\s*id:\s*replay_corpus\s*if:\s*matrix\.os == 'ubuntu-latest'\s*[\s\S]*?run:\s*npx tsx src\/index\.ts replay-corpus(?:\s|$)/,
+  assert.deepEqual(workflow.on.pushBranches, ["main"]);
+  assert.equal(workflow.on.hasPullRequest, true);
+  assert.equal(
+    workflow.concurrency.group,
+    "${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}",
+  );
+  assert.equal(workflow.concurrency.cancelInProgress, "true");
+});
+
+test("CI workflow surfaces the compact replay corpus summary in pull request output", async () => {
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
+
+  assert.ok(
+    findBuildStep(workflow.buildSteps, {
+      id: "replay_corpus",
+      if: "matrix.os == 'ubuntu-latest'",
+      run: "npx tsx src/index.ts replay-corpus",
+    }),
   );
 });
 
 test("CI workflow uploads replay corpus mismatch details only when the Ubuntu replay run fails", async () => {
-  const workflow = await fs.readFile(workflowPath, "utf8");
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
+  const artifactStep = findBuildStep(workflow.buildSteps, {
+    if: "${{ failure() && matrix.os == 'ubuntu-latest' && steps.replay_corpus.outcome == 'failure' }}",
+    uses: "actions/upload-artifact@v4",
+  });
 
-  assert.match(
-    workflow,
-    /-\s*if:\s*\$\{\{\s*failure\(\)\s*&&\s*matrix\.os == 'ubuntu-latest'\s*&&\s*steps\.replay_corpus\.outcome == 'failure'\s*\}\}\s*uses:\s*actions\/upload-artifact@v4[\s\S]*?name:\s*replay-corpus-mismatch-details[\s\S]*?path:\s*\.codex-supervisor\/replay\/replay-corpus-mismatch-details\.json(?:\s|$)/,
-  );
+  assert.ok(artifactStep);
+  assert.equal(artifactStep.with.name, "replay-corpus-mismatch-details");
+  assert.equal(artifactStep.with.path, ".codex-supervisor/replay/replay-corpus-mismatch-details.json");
 });
 
 test("CI workflow runs the focused malformed-inventory regression suite on Ubuntu pull request jobs", async () => {
-  const workflow = await fs.readFile(workflowPath, "utf8");
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
 
-  assert.match(
-    workflow,
-    /-\s*if:\s*matrix\.os == 'ubuntu-latest'\s*run:\s*npm run test:malformed-inventory-regressions(?:\s|$)/,
+  assert.ok(
+    findBuildStep(workflow.buildSteps, {
+      if: "matrix.os == 'ubuntu-latest'",
+      run: "npm run test:malformed-inventory-regressions",
+    }),
   );
 });
 
 test("CI workflow runs the focused managed-restart regression suite on Ubuntu pull request jobs", async () => {
-  const workflow = await fs.readFile(workflowPath, "utf8");
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
 
-  assert.match(
-    workflow,
-    /-\s*if:\s*matrix\.os == 'ubuntu-latest'\s*run:\s*npm run test:managed-restart-regressions(?:\s|$)/,
+  assert.ok(
+    findBuildStep(workflow.buildSteps, {
+      if: "matrix.os == 'ubuntu-latest'",
+      run: "npm run test:managed-restart-regressions",
+    }),
   );
 });
 
 test("CI workflow runs the workstation-local path hygiene gate on Ubuntu pull request jobs", async () => {
-  const workflow = await fs.readFile(workflowPath, "utf8");
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
 
-  assert.match(
-    workflow,
-    /-\s*if:\s*matrix\.os == 'ubuntu-latest'\s*run:\s*npm run verify:paths(?:\s|$)/,
+  assert.ok(
+    findBuildStep(workflow.buildSteps, {
+      if: "matrix.os == 'ubuntu-latest'",
+      run: "npm run verify:paths",
+    }),
   );
 });


### PR DESCRIPTION
Closes #1564
This PR was opened by codex-supervisor.
Latest Codex summary:

Summary: Replaced regex-based CI workflow verification with a structure-aware same-step parser, added a regression proving adjacent step fields must not be combined, and added committed verifier guidance for workflow checks. Checkpoint commit: `ca10f24` (`Tighten workflow verification guardrails`).
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/verifier-guardrails.test.ts src/committed-guardrails.test.ts src/ci-workflow.test.ts`; `npm run guardrails:check`; `npm run build`
Failure signature: none
Next action: Open or update a draft PR from `codex/issue-1564`, then let CI confirm the committed guardrail normalization and workflow-test changes end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external review guardrails with six new quality patterns.
  * Added two new verifier guardrails for UI test usability assertions and workflow executable step validation.

* **Tests**
  * Enhanced CI workflow tests with robust YAML parsing instead of text-based pattern matching for improved reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->