### PR TITLE
Harden Ruff and static-analysis policy for changed tests and scripts

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -362,6 +362,12 @@ Minimum expectations for that contract:
 - any non-zero exit code means the configured local verification failed and the supervisor should treat that failure as the repo-declared result of the contract
 - stdout and stderr are informative logs from the repo command, not a second machine-readable protocol the supervisor needs to interpret
 
+When that repo-owned command includes Ruff or similar static-analysis checks for `tests/` or `scripts/`, keep intentional fixture exceptions explicit and narrow:
+
+- prefer fixing the finding outright when possible
+- when a fixture truly needs an exception, use an inline suppression with the exact rule code and a short rationale, for example `# noqa: S106 - dummy fixture credential` or `# noqa: S104 - test fixture requires wildcard bind`
+- avoid broad file-level ignores or silent drift for intentional fixture patterns
+
 Backward compatibility stays simple: if no local CI contract is configured, `codex-supervisor` keeps the existing behavior. It does not invent a fallback verification command, and it continues to rely on the issue's `## Verification` guidance plus normal operator/repo workflow instead of pretending a canonical local CI entrypoint exists when the repo has not declared one.
 
 Steady-state posture to read after setup:

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -109,6 +109,10 @@ test("getting-started defines the repo-owned local CI contract for pre-PR verifi
   assert.match(content, /codex-supervisor only runs the configured entrypoint/i);
   assert.match(content, /exit code 0/i);
   assert.match(content, /any non-zero exit code/i);
+  assert.match(content, /Ruff or similar static-analysis checks for `tests\/` or `scripts\/`/i);
+  assert.match(content, /inline suppression with the exact rule code and a short rationale/i);
+  assert.match(content, /# noqa: S106 - dummy fixture credential/i);
+  assert.match(content, /# noqa: S104 - test fixture requires wildcard bind/i);
   assert.match(content, /if no local CI contract is configured/i);
   assert.match(content, /does not infer or reconstruct workflow logic from GitHub Actions YAML/i);
   assert.match(content, /when configured local CI fails, PR publication stays blocked/i);

--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -171,6 +171,50 @@ test("runLocalCiGate preserves stdout and stderr details from command failures",
   ]);
 });
 
+test("runLocalCiGate adds Ruff/static-analysis remediation hints for changed tests and scripts", async () => {
+  const failure = Object.assign(
+    new Error(`Command failed: sh -lc +1 args
+exitCode=1
+tests/python/test_api.py:14:9: F821 Undefined name 'fixture_value'
+tests/python/test_api.py:27:5: S106 Possible hardcoded password assigned to argument: "password"
+scripts/check_fixture.py:8:1: S104 Possible binding to all interfaces
+scripts/check_fixture.py:12:5: RUF059 Unused unpacked variable 'unused_fixture'
+scripts/check_fixture.py:18:1: F402 Import 'fixture_value' from line 1 shadowed by loop variable`),
+    {
+      stderr: `tests/python/test_api.py:14:9: F821 Undefined name 'fixture_value'
+tests/python/test_api.py:27:5: S106 Possible hardcoded password assigned to argument: "password"
+scripts/check_fixture.py:8:1: S104 Possible binding to all interfaces
+scripts/check_fixture.py:12:5: RUF059 Unused unpacked variable 'unused_fixture'
+scripts/check_fixture.py:18:1: F402 Import 'fixture_value' from line 1 shadowed by loop variable`,
+    },
+  );
+
+  const result = await runLocalCiGate({
+    config: { localCiCommand: "npm run ci:local" },
+    workspacePath: "/tmp/workspaces/issue-102",
+    gateLabel: "before marking PR #116 ready",
+    runLocalCiCommand: async () => {
+      throw failure;
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.failureContext?.signature, "local-ci-gate-non_zero_exit");
+  assert.match(
+    result.failureContext?.details.join("\n") ?? "",
+    /ruff\/static-analysis hint: changed tests\/scripts triggered F402, F821, RUF059, S104, S106 in scripts\/check_fixture\.py, tests\/python\/test_api\.py\./u,
+  );
+  assert.match(
+    result.failureContext?.details.join("\n") ?? "",
+    /prefer the narrowest inline suppression with the exact rule code and a short rationale comment instead of broad file-level ignores/u,
+  );
+  assert.match(result.failureContext?.details.join("\n") ?? "", /# noqa: F821 - provided by fixture/u);
+  assert.match(result.failureContext?.details.join("\n") ?? "", /# noqa: F402 - fixture rebinding is intentional/u);
+  assert.match(result.failureContext?.details.join("\n") ?? "", /# noqa: RUF059 - fixture unpacking is intentional/u);
+  assert.match(result.failureContext?.details.join("\n") ?? "", /# noqa: S104 - test fixture requires wildcard bind/u);
+  assert.match(result.failureContext?.details.join("\n") ?? "", /# noqa: S106 - dummy fixture credential/u);
+});
+
 test("runLocalCiGate preserves timeout summaries at the tail of bounded stderr details", async () => {
   const failure = Object.assign(
     new Error(`Command timed out: sh -lc +1 args\nexitCode=1\nprefix\n${"x".repeat(2_000)}\nCommand timed out after 5000ms: sh -lc +1 args`),

--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -240,6 +240,30 @@ test("runLocalCiGate preserves timeout summaries at the tail of bounded stderr d
   assert.match(result.failureContext?.details[2] ?? "", /\n\.\.\.\n/);
 });
 
+test("runLocalCiGate bounds ruff/static-analysis hint paths when many findings match", async () => {
+  const lines = Array.from({ length: 10 }, (_, index) => {
+    const fixtureNumber = index + 1;
+    return `tests/python/test_fixture_${fixtureNumber}.py:14:9: F821 Undefined name 'fixture_value_${fixtureNumber}'`;
+  }).join("\n");
+
+  const failure = Object.assign(new Error(lines), { stderr: lines });
+
+  const result = await runLocalCiGate({
+    config: { localCiCommand: "npm run ci:local" },
+    workspacePath: "/tmp/workspaces/issue-102",
+    gateLabel: "before marking PR #116 ready",
+    runLocalCiCommand: async () => {
+      throw failure;
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.failureContext?.details.join("\n") ?? "",
+    /ruff\/static-analysis hint: changed tests\/scripts triggered F821 in tests\/python\/test_fixture_1\.py, tests\/python\/test_fixture_10\.py, tests\/python\/test_fixture_2\.py, tests\/python\/test_fixture_3\.py, tests\/python\/test_fixture_4\.py, tests\/python\/test_fixture_5\.py, tests\/python\/test_fixture_6\.py, tests\/python\/test_fixture_7\.py \(\+2 more\)\./u,
+  );
+});
+
 test("runWorkspacePreparationGate explains when a repo-relative helper is missing from the issue worktree", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-workspace-prep-"));
   t.after(async () => {

--- a/src/local-ci.ts
+++ b/src/local-ci.ts
@@ -52,6 +52,7 @@ interface RuffFinding {
 
 const TARGETED_STATIC_ANALYSIS_FILE_PATTERN =
   /(?:^|\/)(?:test|tests|__tests__|scripts)\/.+|(?:^|\/)[^/]+\.(?:test|spec)\.py$/i;
+const MAX_STATIC_ANALYSIS_HINT_PATHS = 8;
 
 const RUFF_REMEDIATION_HINTS = new Map<string, string>([
   [
@@ -360,9 +361,13 @@ function buildTargetedStaticAnalysisGuidance(error: unknown): string[] {
 
   const codes = [...new Set(findings.map((finding) => finding.code))].sort();
   const paths = [...new Set(findings.map((finding) => finding.filePath))];
+  const shownPaths = paths.slice(0, MAX_STATIC_ANALYSIS_HINT_PATHS);
+  const remainingPathCount = paths.length - shownPaths.length;
+  const pathSummary =
+    remainingPathCount > 0 ? `${shownPaths.join(", ")} (+${remainingPathCount} more)` : shownPaths.join(", ");
 
   return [
-    `ruff/static-analysis hint: changed tests/scripts triggered ${codes.join(", ")} in ${paths.join(", ")}.`,
+    `ruff/static-analysis hint: changed tests/scripts triggered ${codes.join(", ")} in ${pathSummary}.`,
     "ruff/static-analysis policy: for intentional test fixtures, prefer the narrowest inline suppression with the exact rule code and a short rationale comment instead of broad file-level ignores.",
     ...codes
       .map((code) => RUFF_REMEDIATION_HINTS.get(code))

--- a/src/local-ci.ts
+++ b/src/local-ci.ts
@@ -45,6 +45,37 @@ type ErrorWithOutput = Error & {
   stderr?: string;
 };
 
+interface RuffFinding {
+  filePath: string;
+  code: string;
+}
+
+const TARGETED_STATIC_ANALYSIS_FILE_PATTERN =
+  /(?:^|\/)(?:test|tests|__tests__|scripts)\/.+|(?:^|\/)[^/]+\.(?:test|spec)\.py$/i;
+
+const RUFF_REMEDIATION_HINTS = new Map<string, string>([
+  [
+    "F821",
+    "F821 hint: define or import the symbol explicitly when possible. If a test framework injects it intentionally, use the narrowest inline suppression such as `# noqa: F821 - provided by fixture` on the affected line.",
+  ],
+  [
+    "F402",
+    "F402 hint: avoid fixture-local rebinding that shadows imports when you can. If the rebinding is deliberate for a test fixture, suppress only that line with an exact code and rationale such as `# noqa: F402 - fixture rebinding is intentional`.",
+  ],
+  [
+    "RUF059",
+    "RUF059 hint: prefer explicit fixture variables or `_` placeholders for intentionally unused unpacked values. If the unpacking is intentional for coverage, use an inline suppression such as `# noqa: RUF059 - fixture unpacking is intentional`.",
+  ],
+  [
+    "S104",
+    "S104 hint: bind test servers to `127.0.0.1` or `localhost` when possible. If an integration fixture must bind all interfaces, suppress only that line with an exact code and rationale such as `# noqa: S104 - test fixture requires wildcard bind`.",
+  ],
+  [
+    "S106",
+    "S106 hint: prefer fixture/env injection over hardcoded credentials. If a dummy test credential is intentional, suppress only that line with an exact code and rationale such as `# noqa: S106 - dummy fixture credential`.",
+  ],
+]);
+
 function stripWrappingQuotes(value: string): string {
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
@@ -270,6 +301,75 @@ function renderFailureOutput(label: "stdout" | "stderr", output: string | undefi
   return `${label}:\n${truncatePreservingStartAndEnd(trimmed, 1500) ?? trimmed}`;
 }
 
+function collectCommandErrorLines(error: unknown): string[] {
+  if (!(error instanceof Error)) {
+    return [String(error)];
+  }
+
+  const outputError = error as ErrorWithOutput;
+  return [error.message, outputError.stdout, outputError.stderr]
+    .filter((value): value is string => typeof value === "string")
+    .flatMap((value) => value.split(/\r?\n/u));
+}
+
+function normalizeStaticAnalysisPath(filePath: string): string {
+  return filePath.trim().replaceAll("\\", "/").replace(/^\.\/+/, "");
+}
+
+function collectTargetedRuffFindings(error: unknown): RuffFinding[] {
+  const findings = new Map<string, RuffFinding>();
+  const linePattern = /^(.+?):\d+(?::\d+)?:\s*([A-Z]+[0-9]{3})\b/u;
+
+  for (const line of collectCommandErrorLines(error)) {
+    const match = line.trim().match(linePattern);
+    if (!match) {
+      continue;
+    }
+
+    const rawPath = match[1];
+    const code = match[2];
+    if (!rawPath || !code) {
+      continue;
+    }
+
+    const filePath = normalizeStaticAnalysisPath(rawPath);
+    if (!TARGETED_STATIC_ANALYSIS_FILE_PATTERN.test(filePath)) {
+      continue;
+    }
+
+    if (!RUFF_REMEDIATION_HINTS.has(code)) {
+      continue;
+    }
+
+    findings.set(`${filePath}:${code}`, { filePath, code });
+  }
+
+  return [...findings.values()].sort((left, right) => {
+    if (left.filePath === right.filePath) {
+      return left.code.localeCompare(right.code);
+    }
+    return left.filePath.localeCompare(right.filePath);
+  });
+}
+
+function buildTargetedStaticAnalysisGuidance(error: unknown): string[] {
+  const findings = collectTargetedRuffFindings(error);
+  if (findings.length === 0) {
+    return [];
+  }
+
+  const codes = [...new Set(findings.map((finding) => finding.code))].sort();
+  const paths = [...new Set(findings.map((finding) => finding.filePath))];
+
+  return [
+    `ruff/static-analysis hint: changed tests/scripts triggered ${codes.join(", ")} in ${paths.join(", ")}.`,
+    "ruff/static-analysis policy: for intentional test fixtures, prefer the narrowest inline suppression with the exact rule code and a short rationale comment instead of broad file-level ignores.",
+    ...codes
+      .map((code) => RUFF_REMEDIATION_HINTS.get(code))
+      .filter((hint): hint is string => typeof hint === "string"),
+  ];
+}
+
 function buildFailureDetails(error: unknown, executionMode: LocalCiExecutionMode | null): string[] {
   const message =
     truncatePreservingStartAndEnd(error instanceof Error ? error.message : String(error), 1500) ?? "unknown error";
@@ -278,6 +378,7 @@ function buildFailureDetails(error: unknown, executionMode: LocalCiExecutionMode
   return [
     executionMode ? `execution mode: ${renderExecutionMode(executionMode)}` : null,
     message,
+    ...buildTargetedStaticAnalysisGuidance(error),
     renderFailureOutput("stdout", outputError?.stdout),
     renderFailureOutput("stderr", outputError?.stderr),
   ].filter((detail): detail is string => detail !== null);


### PR DESCRIPTION
## Summary
- add targeted local-CI remediation hints for common Ruff/static-analysis findings in changed tests and scripts
- document the preferred narrow inline `# noqa: CODE - rationale` suppression shape for intentional fixtures
- add focused regression coverage for the new guidance

## Testing
- npx tsx --test src/local-ci.test.ts
- npx tsx --test src/getting-started-docs.test.ts
- npx tsx --test src/ci-workflow.test.ts
- npx tsx --test src/build.test.ts
- npm run build

Closes #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual static-analysis remediation hints that highlight offending rules and suggest narrow inline suppressions for checks failing in test/script files.

* **Documentation**
  * Updated getting-started guidance to prefer explicit, rule-specific inline suppressions with short rationales and to avoid broad file-level ignores for fixtures.

* **Tests**
  * Added tests covering detection, summarization, and concise presentation of static-analysis findings and suggested inline suppression patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->