### PR TITLE
Add cross-file deployment and config contract verification guards (#1567)

### DIFF
--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -38,12 +38,33 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
     "docs/workflow.md",
     "docs/decisions.md"
   ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
   "localReviewEnabled": true,
   "localReviewAutoDetect": true,
   "localReviewRoles": [],
   "localReviewArtifactDir": "/Users/yourname/Dev/codex-supervisor/.local/reviews",
   "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.8,
+      "minimumSeverity": "medium"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
   "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
   "localReviewFollowUpRepairEnabled": false,
   "localReviewManualReviewRepairEnabled": false,
   "localReviewFollowUpIssueCreationEnabled": false,

--- a/docs/shared-memory/verifier-guardrails.json
+++ b/docs/shared-memory/verifier-guardrails.json
@@ -18,6 +18,30 @@
       "rationale": "Raw regex or substring checks can falsely combine fields from different steps and treat non-executable YAML text as proof that a guarded command or artifact upload is actually wired into the workflow."
     },
     {
+      "id": "workflow-runtime-contracts-must-reference-live-scripts-and-artifacts",
+      "title": "Keep workflow commands and artifact paths aligned with runtime contracts",
+      "file": "src/ci-workflow.test.ts",
+      "line": 324,
+      "summary": "When CI workflows invoke `npm run` steps or upload repo-owned artifacts, verify those step names still exist in `package.json` and the uploaded artifact paths still match the runtime helper that writes them.",
+      "rationale": "A workflow can stay syntactically valid while silently drifting away from the script and artifact contracts the repo actually owns, leaving deployment diagnostics green until the specific path is exercised."
+    },
+    {
+      "id": "sample-config-docs-must-match-checked-in-examples",
+      "title": "Keep embedded sample configs aligned with checked-in example files",
+      "file": "src/committed-guardrails.test.ts",
+      "line": 475,
+      "summary": "When a docs page embeds a sample config that also ships as a checked-in example JSON file, verify both files describe the same contract instead of letting each drift independently.",
+      "rationale": "Operators often copy the docs snippet instead of the raw example file; if both stay locally valid but disagree cross-file, setup guidance becomes a silent source of stale configuration."
+    },
+    {
+      "id": "guardrail-schemas-must-match-loader-contract",
+      "title": "Keep committed guardrail schemas aligned with the loader contract",
+      "file": "src/committed-guardrails.test.ts",
+      "line": 496,
+      "summary": "Verify repo-owned JSON schema files for committed guardrails expose the same version constants, required keys, and additional-properties rules enforced by the runtime loader.",
+      "rationale": "Schema files and loader code can each look locally valid while disagreeing about the actual contract, which hides breakage until an operator trusts the wrong source of truth."
+    },
+    {
       "id": "committed-guardrails-malformed-input",
       "title": "Differentiate missing and malformed committed guardrails",
       "file": "src/committed-guardrails.ts",

--- a/src/ci-workflow.test.ts
+++ b/src/ci-workflow.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+import { REPLAY_CORPUS_MISMATCH_DETAILS_ARTIFACT_RELATIVE_PATH } from "./supervisor/replay-corpus-mismatch-artifact";
 
 const workflowPath = path.resolve(__dirname, "..", ".github/workflows/ci.yml");
 
@@ -317,5 +318,37 @@ test("CI workflow runs the workstation-local path hygiene gate on Ubuntu pull re
       if: "matrix.os == 'ubuntu-latest'",
       run: "npm run verify:paths",
     }),
+  );
+});
+
+test("CI workflow npm run steps reference package scripts and keep replay artifact paths aligned", async () => {
+  const workflow = parseWorkflow(await fs.readFile(workflowPath, "utf8"));
+  const packageJson = JSON.parse(await fs.readFile(path.resolve(__dirname, "..", "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  const workflowScriptNames = workflow.buildSteps
+    .map((step) => step.run)
+    .filter((run): run is string => typeof run === "string" && run.startsWith("npm run "))
+    .map((run) => run.slice("npm run ".length));
+  const missingScripts = workflowScriptNames.filter((name) => !packageJson.scripts?.[name]);
+
+  assert.deepEqual(
+    missingScripts,
+    [],
+    [
+      `${path.relative(process.cwd(), workflowPath)} must only invoke npm scripts that exist in package.json.`,
+      `Missing script definitions: ${missingScripts.join(", ") || "none"}.`,
+    ].join(" "),
+  );
+
+  const artifactStep = findBuildStep(workflow.buildSteps, {
+    if: "${{ failure() && matrix.os == 'ubuntu-latest' && steps.replay_corpus.outcome == 'failure' }}",
+    uses: "actions/upload-artifact@v4",
+  });
+
+  assert.equal(
+    artifactStep?.with.path,
+    REPLAY_CORPUS_MISMATCH_DETAILS_ARTIFACT_RELATIVE_PATH,
+    `${path.relative(process.cwd(), workflowPath)} artifact upload path must stay aligned with src/supervisor/replay-corpus-mismatch-artifact.ts`,
   );
 });

--- a/src/committed-guardrails.test.ts
+++ b/src/committed-guardrails.test.ts
@@ -476,7 +476,7 @@ test("atlaspm example markdown keeps its embedded config aligned with the checke
   const atlaspmMarkdownPath = path.join(process.cwd(), "docs", "examples", "atlaspm.md");
   const atlaspmJsonPath = path.join(process.cwd(), "docs", "examples", "atlaspm.supervisor.config.example.json");
   const atlaspmMarkdown = await fs.readFile(atlaspmMarkdownPath, "utf8");
-  const jsonBlockMatch = atlaspmMarkdown.match(/## Example config\n\n```json\n([\s\S]*?)\n```/u);
+  const jsonBlockMatch = atlaspmMarkdown.match(/## Example config\r?\n\r?\n```json\r?\n([\s\S]*?)\r?\n```/u);
 
   assert.ok(jsonBlockMatch, `${path.relative(process.cwd(), atlaspmMarkdownPath)} should include an Example config JSON block`);
 

--- a/src/committed-guardrails.test.ts
+++ b/src/committed-guardrails.test.ts
@@ -4,8 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  DURABLE_MISS_PATTERN_KEYS,
+  EXTERNAL_REVIEW_GUARDRAILS_SCHEMA_VERSION,
   formatCommittedGuardrails,
   validateCommittedGuardrails,
+  VERIFIER_GUARDRAIL_KEYS,
+  VERIFIER_GUARDRAILS_SCHEMA_VERSION,
 } from "./committed-guardrails";
 
 test("validateCommittedGuardrails rejects duplicate committed verifier ids and durable fingerprints", async () => {
@@ -465,5 +469,86 @@ test("repo shared-memory examples encode authoritative-over-derived state guidan
   assert.match(
     workflow,
     /Before shipping rejected, forbidden, approval-failure, or restore-failure paths, verify the system proves both outcomes: the path failed and no durable orphan, partial write, or half-restored state remained afterward\./,
+  );
+});
+
+test("atlaspm example markdown keeps its embedded config aligned with the checked-in example json", async () => {
+  const atlaspmMarkdownPath = path.join(process.cwd(), "docs", "examples", "atlaspm.md");
+  const atlaspmJsonPath = path.join(process.cwd(), "docs", "examples", "atlaspm.supervisor.config.example.json");
+  const atlaspmMarkdown = await fs.readFile(atlaspmMarkdownPath, "utf8");
+  const jsonBlockMatch = atlaspmMarkdown.match(/## Example config\n\n```json\n([\s\S]*?)\n```/u);
+
+  assert.ok(jsonBlockMatch, `${path.relative(process.cwd(), atlaspmMarkdownPath)} should include an Example config JSON block`);
+
+  const embeddedConfig = JSON.parse(jsonBlockMatch[1]) as Record<string, unknown>;
+  const checkedInConfig = JSON.parse(await fs.readFile(atlaspmJsonPath, "utf8")) as Record<string, unknown>;
+
+  assert.deepEqual(
+    embeddedConfig,
+    checkedInConfig,
+    [
+      `${path.relative(process.cwd(), atlaspmMarkdownPath)} and ${path.relative(process.cwd(), atlaspmJsonPath)} must describe the same example config contract.`,
+      "Update the markdown JSON block or the checked-in example so operators do not copy a stale sample that is locally valid but cross-file inconsistent.",
+    ].join(" "),
+  );
+});
+
+test("committed guardrail schemas stay aligned with the loader contract", async () => {
+  const rootDir = process.cwd();
+  const verifierSchemaPath = path.join(rootDir, "docs", "shared-memory", "verifier-guardrails.schema.json");
+  const externalReviewSchemaPath = path.join(rootDir, "docs", "shared-memory", "external-review-guardrails.schema.json");
+  const verifierSchema = JSON.parse(await fs.readFile(verifierSchemaPath, "utf8")) as {
+    properties?: {
+      version?: { const?: unknown };
+      rules?: { items?: { required?: unknown; properties?: Record<string, unknown>; additionalProperties?: unknown } };
+    };
+  };
+  const externalReviewSchema = JSON.parse(await fs.readFile(externalReviewSchemaPath, "utf8")) as {
+    properties?: {
+      version?: { const?: unknown };
+      patterns?: { items?: { required?: unknown; properties?: Record<string, unknown>; additionalProperties?: unknown } };
+    };
+  };
+
+  assert.equal(
+    verifierSchema.properties?.version?.const,
+    VERIFIER_GUARDRAILS_SCHEMA_VERSION,
+    `${path.relative(rootDir, verifierSchemaPath)} version const must match src/committed-guardrails.ts`,
+  );
+  assert.deepEqual(
+    verifierSchema.properties?.rules?.items?.required,
+    [...VERIFIER_GUARDRAIL_KEYS],
+    `${path.relative(rootDir, verifierSchemaPath)} required rule keys must match src/committed-guardrails.ts`,
+  );
+  assert.deepEqual(
+    Object.keys(verifierSchema.properties?.rules?.items?.properties ?? {}),
+    [...VERIFIER_GUARDRAIL_KEYS],
+    `${path.relative(rootDir, verifierSchemaPath)} rule property keys must match src/committed-guardrails.ts`,
+  );
+  assert.equal(
+    verifierSchema.properties?.rules?.items?.additionalProperties,
+    false,
+    `${path.relative(rootDir, verifierSchemaPath)} should reject unexpected rule keys for the same contract enforced by src/committed-guardrails.ts`,
+  );
+
+  assert.equal(
+    externalReviewSchema.properties?.version?.const,
+    EXTERNAL_REVIEW_GUARDRAILS_SCHEMA_VERSION,
+    `${path.relative(rootDir, externalReviewSchemaPath)} version const must match src/committed-guardrails.ts`,
+  );
+  assert.deepEqual(
+    externalReviewSchema.properties?.patterns?.items?.required,
+    [...DURABLE_MISS_PATTERN_KEYS],
+    `${path.relative(rootDir, externalReviewSchemaPath)} required pattern keys must match src/committed-guardrails.ts`,
+  );
+  assert.deepEqual(
+    Object.keys(externalReviewSchema.properties?.patterns?.items?.properties ?? {}),
+    [...DURABLE_MISS_PATTERN_KEYS],
+    `${path.relative(rootDir, externalReviewSchemaPath)} pattern property keys must match src/committed-guardrails.ts`,
+  );
+  assert.equal(
+    externalReviewSchema.properties?.patterns?.items?.additionalProperties,
+    false,
+    `${path.relative(rootDir, externalReviewSchemaPath)} should reject unexpected pattern keys for the same contract enforced by src/committed-guardrails.ts`,
   );
 });

--- a/src/committed-guardrails.ts
+++ b/src/committed-guardrails.ts
@@ -29,8 +29,8 @@ export const EXTERNAL_REVIEW_GUARDRAILS_PATH = path.join("docs", "shared-memory"
 export const VERIFIER_GUARDRAILS_SCHEMA_VERSION = 1;
 export const EXTERNAL_REVIEW_GUARDRAILS_SCHEMA_VERSION = 1;
 const GUARDRAILS_MAX_BYTES = 256 * 1024;
-const VERIFIER_GUARDRAIL_KEYS = ["id", "title", "file", "line", "summary", "rationale"] as const;
-const DURABLE_MISS_PATTERN_KEYS = [
+export const VERIFIER_GUARDRAIL_KEYS = ["id", "title", "file", "line", "summary", "rationale"] as const;
+export const DURABLE_MISS_PATTERN_KEYS = [
   "fingerprint",
   "reviewerLogin",
   "file",

--- a/src/supervisor/replay-corpus-mismatch-artifact.ts
+++ b/src/supervisor/replay-corpus-mismatch-artifact.ts
@@ -12,7 +12,7 @@ import {
   formatReplayCorpusOutcomeMismatch,
 } from "./replay-corpus-mismatch-formatting";
 
-export const REPLAY_CORPUS_MISMATCH_DETAILS_ARTIFACT_RELATIVE_PATH = path.join(
+export const REPLAY_CORPUS_MISMATCH_DETAILS_ARTIFACT_RELATIVE_PATH = path.posix.join(
   ".codex-supervisor",
   "replay",
   "replay-corpus-mismatch-details.json",

--- a/src/supervisor/replay-corpus-mismatch-artifact.ts
+++ b/src/supervisor/replay-corpus-mismatch-artifact.ts
@@ -12,8 +12,14 @@ import {
   formatReplayCorpusOutcomeMismatch,
 } from "./replay-corpus-mismatch-formatting";
 
+export const REPLAY_CORPUS_MISMATCH_DETAILS_ARTIFACT_RELATIVE_PATH = path.join(
+  ".codex-supervisor",
+  "replay",
+  "replay-corpus-mismatch-details.json",
+);
+
 function replayCorpusMismatchDetailsArtifactPath(config: SupervisorConfig): string {
-  return path.join(config.repoPath, ".codex-supervisor", "replay", "replay-corpus-mismatch-details.json");
+  return path.join(config.repoPath, REPLAY_CORPUS_MISMATCH_DETAILS_ARTIFACT_RELATIVE_PATH);
 }
 
 function relativeReplayPath(config: SupervisorConfig, targetPath: string): string {

--- a/src/verifier-guardrails.test.ts
+++ b/src/verifier-guardrails.test.ts
@@ -325,6 +325,34 @@ test("repo-committed verifier guardrails include repo-owned subprocess safety gu
   });
 });
 
+test("repo-committed verifier guardrails cover cross-file sample-config, schema, and workflow contract drift", async () => {
+  const changedFiles = ["src/ci-workflow.test.ts", "src/committed-guardrails.test.ts"];
+  const rules = await loadRelevantVerifierGuardrails({
+    workspacePath: process.cwd(),
+    changedFiles,
+    limit: 10,
+  });
+
+  assertContainsRelevantRule(rules, {
+    id: "workflow-runtime-contracts-must-reference-live-scripts-and-artifacts",
+    file: "src/ci-workflow.test.ts",
+    summary:
+      "When CI workflows invoke `npm run` steps or upload repo-owned artifacts, verify those step names still exist in `package.json` and the uploaded artifact paths still match the runtime helper that writes them.",
+  });
+  assertContainsRelevantRule(rules, {
+    id: "sample-config-docs-must-match-checked-in-examples",
+    file: "src/committed-guardrails.test.ts",
+    summary:
+      "When a docs page embeds a sample config that also ships as a checked-in example JSON file, verify both files describe the same contract instead of letting each drift independently.",
+  });
+  assertContainsRelevantRule(rules, {
+    id: "guardrail-schemas-must-match-loader-contract",
+    file: "src/committed-guardrails.test.ts",
+    summary:
+      "Verify repo-owned JSON schema files for committed guardrails expose the same version constants, required keys, and additional-properties rules enforced by the runtime loader.",
+  });
+});
+
 test("repo-committed verifier guardrails cover malformed guardrails and repair-context failure boundaries", async () => {
   const changedFiles = ["src/committed-guardrails.ts", "src/supervisor.ts"];
   const rules = await loadRelevantVerifierGuardrails({


### PR DESCRIPTION
Closes #1567
This PR was opened by codex-supervisor.
Latest Codex summary:

Added cross-file contract guards and committed them as `6f2cc0a` (`Add cross-file config and workflow contract guards`).

The first repro was a real drift in `docs/examples/atlaspm.md`: its embedded JSON sample had fallen behind `docs/examples/atlaspm.supervisor.config.example.json`. From there I added three focused guard classes:
- sample-config docs vs checked-in example JSON
- committed guardrail schema files vs the loader-enforced key/version contract
- CI workflow `npm run` / replay artifact references vs the runtime-owned script and artifact paths

I also updated `docs/shared-memory/verifier-guardrails.json` and `src/verifier-guardrails.test.ts` so the verifier guidance now explicitly covers these cross-file drift classes. `npm run build` passed, and the focused test bundle passed via direct `tsx --test` because `npm test -- <files>` expands to the full glob in this repo. The issue journal was updated in the worktree; it remains uncommitted because that path is gitignored.

Summary: Added cross-file config, schema, and workflow/runtime contract guards; fixed the live atlaspm sample drift; committed as `6f2cc0a`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/committed-guardrails.test.ts src/ci-workflow.test.ts src/verifier-guardrails.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1567` and let the supervisor continue from the committed checkpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Extended example configuration with new GSD settings and local-review threshold options.

* **Chores**
  * Added repository guardrail rules to enforce workflow/script/artifact consistency, example-config parity, and schema/loader contract alignment.

* **Tests**
  * Added tests to validate CI workflow scripts/artifacts, example-config vs checked-in example parity, and the new guardrail rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->