### PR TITLE
Classify trusted generated durable artifacts before any path auto-normalization (#1580)

### DIFF
--- a/src/durable-artifact-provenance.ts
+++ b/src/durable-artifact-provenance.ts
@@ -1,0 +1,39 @@
+export const TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE = "trusted-generated-durable-artifact/v1";
+export const TRUSTED_GENERATED_DURABLE_ARTIFACT_JSON_KEY = "codexSupervisorProvenance";
+export const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
+  `<!-- codex-supervisor-provenance: ${TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE} -->`;
+
+export function withTrustedGeneratedDurableArtifactProvenance<T extends object>(
+  artifact: T,
+): T & { codexSupervisorProvenance: typeof TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE } {
+  return {
+    ...artifact,
+    [TRUSTED_GENERATED_DURABLE_ARTIFACT_JSON_KEY]: TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE,
+  } as T & { codexSupervisorProvenance: typeof TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE };
+}
+
+export function prependTrustedGeneratedDurableArtifactMarkdownMarker(document: string): string {
+  return `${TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER}\n${document}`;
+}
+
+export function hasTrustedGeneratedDurableArtifactProvenance(contents: string): boolean {
+  if (contents.includes(TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER)) {
+    return true;
+  }
+
+  const trimmed = contents.trimStart();
+  if (!trimmed.startsWith("{")) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    return (
+      !!parsed &&
+      !Array.isArray(parsed) &&
+      parsed[TRUSTED_GENERATED_DURABLE_ARTIFACT_JSON_KEY] === TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/external-review/external-review-miss-artifact-types.ts
+++ b/src/external-review/external-review-miss-artifact-types.ts
@@ -76,6 +76,7 @@ export interface DurableExternalReviewGuardrails {
 }
 
 export interface ExternalReviewMissArtifact {
+  codexSupervisorProvenance?: "trusted-generated-durable-artifact/v1";
   issueNumber: number;
   prNumber: number;
   branch: string;

--- a/src/external-review/external-review-miss-artifact.ts
+++ b/src/external-review/external-review-miss-artifact.ts
@@ -1,4 +1,5 @@
 import { nowIso } from "../core/utils";
+import { withTrustedGeneratedDurableArtifactProvenance } from "../durable-artifact-provenance";
 import { hasMatchingPromotionIdentity, isNullablePromotionEvidenceString } from "../persisted-artifact-promotion";
 import { type ExternalReviewMissFinding } from "./external-review-classifier";
 import {
@@ -199,7 +200,7 @@ export function buildExternalReviewMissArtifact(args: {
     .map((finding) => toRegressionTestCandidate(finding))
     .filter((candidate): candidate is ExternalReviewRegressionCandidate => candidate !== null);
 
-  return {
+  return withTrustedGeneratedDurableArtifactProvenance({
     issueNumber: args.issueNumber,
     prNumber: args.prNumber,
     branch: args.branch,
@@ -216,7 +217,7 @@ export function buildExternalReviewMissArtifact(args: {
       nearMatch: findings.filter((finding) => finding.classification === "near_match").length,
       missedByLocalReview: findings.filter((finding) => finding.classification === "missed_by_local_review").length,
     },
-  };
+  });
 }
 
 export function createExternalReviewMissContext(args: {

--- a/src/external-review/external-review-miss-digest.ts
+++ b/src/external-review/external-review-miss-digest.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { prependTrustedGeneratedDurableArtifactMarkdownMarker } from "../durable-artifact-provenance";
 import {
   type ExternalReviewArtifactFinding,
   type ExternalReviewMissArtifact,
@@ -164,7 +165,7 @@ export function buildExternalReviewMissFollowUpDigest(args: {
 
   if (typedMissedFindings.length === 0) {
     lines.push("", "No missed external-review findings were identified in this analysis.");
-    return `${lines.join("\n")}\n`;
+    return `${prependTrustedGeneratedDurableArtifactMarkdownMarker(lines.join("\n"))}\n`;
   }
 
   for (const target of PREVENTION_TARGET_ORDER) {
@@ -187,5 +188,5 @@ export function buildExternalReviewMissFollowUpDigest(args: {
     lines.pop();
   }
 
-  return `${lines.join("\n")}\n`;
+  return `${prependTrustedGeneratedDurableArtifactMarkdownMarker(lines.join("\n"))}\n`;
 }

--- a/src/external-review/external-review-miss-persistence.test.ts
+++ b/src/external-review/external-review-miss-persistence.test.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE,
+} from "../durable-artifact-provenance";
 import { loadLocalReviewArtifact } from "./external-review-local-artifact-io";
 import { writeExternalReviewMissArtifact } from "./external-review-miss-persistence";
 import { collectExternalReviewSignals } from "./external-review-signal-collection";
@@ -137,6 +141,7 @@ test("writeExternalReviewMissArtifact persists missed external findings for the 
 
   const artifactPath = context?.artifactPath ?? "";
   const artifact = JSON.parse(await fs.readFile(artifactPath, "utf8")) as {
+    codexSupervisorProvenance: string;
     headSha: string;
     reusableMissPatterns: Array<{ file: string; summary: string }>;
     counts: { missedByLocalReview: number };
@@ -149,6 +154,7 @@ test("writeExternalReviewMissArtifact persists missed external findings for the 
     }>;
   };
   assert.equal(artifact.headSha, "deadbeefcafebabe");
+  assert.equal(artifact.codexSupervisorProvenance, TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE);
   assert.equal(artifact.counts.missedByLocalReview, 1);
   assert.equal(artifact.reusableMissPatterns.length, 1);
   assert.equal(artifact.reusableMissPatterns[0]?.file, "src/auth.ts");
@@ -327,6 +333,7 @@ test("writeExternalReviewMissArtifact emits a follow-up action digest beside the
   const digest = await fs.readFile(digestPath, "utf8");
 
   assert.equal(path.basename(context?.artifactPath ?? ""), "external-review-misses-head-deadbeefcafe.json");
+  assert.match(digest, new RegExp(TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(digest, /# External Review Miss Follow-up Digest/);
   assert.match(digest, /- Miss artifact: .*external-review-misses-head-deadbeefcafe\.json/);
   assert.match(digest, /- Local review summary: .*head-deadbeefcafe\.md/);

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -3,6 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import {
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_JSON_KEY,
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE,
+} from "../durable-artifact-provenance";
 import { writeLocalReviewArtifacts } from "./artifacts";
 import { finalizeLocalReview } from "./finalize";
 import { createConfig } from "./test-helpers";
@@ -62,7 +67,9 @@ test("writeLocalReviewArtifacts renders durable guardrail provenance compactly",
     verifierReport: null,
   });
   const summary = await fs.readFile(artifacts.summaryPath, "utf8");
+  const findings = JSON.parse(await fs.readFile(artifacts.findingsPath, "utf8")) as Record<string, unknown>;
 
+  assert.match(summary, new RegExp(TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(summary, /## Durable guardrails/);
   assert.match(summary, /## Pre-merge final evaluation/);
   assert.match(summary, /- Outcome: mergeable/);
@@ -74,6 +81,7 @@ test("writeLocalReviewArtifacts renders durable guardrail provenance compactly",
   assert.match(summary, /- Verifier committed: 1 from docs\/shared-memory\/verifier-guardrails\.json/);
   assert.match(summary, /- External review committed: 1 from docs\/shared-memory\/external-review-guardrails\.json/);
   assert.match(summary, /- External review runtime: 2 from owner-repo\/issue-38\/external-review-misses-head-111122223333\.json/);
+  assert.equal(findings[TRUSTED_GENERATED_DURABLE_ARTIFACT_JSON_KEY], TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE);
 });
 
 test("writeLocalReviewArtifacts records deterministic model routing for generic, specialist, and verifier paths", async () => {

--- a/src/local-review/artifacts.ts
+++ b/src/local-review/artifacts.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { type LocalReviewRoleSelection } from "../review-role-detector";
 import { type SupervisorConfig } from "../core/types";
+import {
+  prependTrustedGeneratedDurableArtifactMarkdownMarker,
+  withTrustedGeneratedDurableArtifactProvenance,
+} from "../durable-artifact-provenance";
 import { createPostMergeAuditResult, renderPostMergeAuditContractSummary } from "./post-merge-audit";
 import {
   type FinalizedLocalReview,
@@ -121,119 +125,121 @@ export async function writeLocalReviewArtifacts(args: {
 
   await fs.writeFile(
     summaryPath,
-    [
-      `# Local Review for Issue #${args.issueNumber}`,
-      "",
-      `- PR: ${args.prUrl}`,
-      `- Branch: ${args.branch}`,
-      `- Head SHA: ${args.headSha}`,
-      `- Ran at: ${args.ranAt}`,
-      `- Roles: ${args.roles.join(", ")}`,
-      `- Confidence threshold: ${args.config.localReviewConfidenceThreshold.toFixed(2)}`,
-      `- Actionable findings: ${args.finalized.findingsCount}`,
-      `- Root causes: ${args.finalized.rootCauseCount}`,
-      `- Max severity: ${args.finalized.maxSeverity}`,
-      `- Verified findings: ${args.finalized.verifiedFindingsCount}`,
-      `- Verified max severity: ${args.finalized.verifiedMaxSeverity}`,
-      `- Recommendation: ${args.finalized.recommendation}`,
-      `- Degraded: ${args.finalized.degraded ? "yes" : "no"}`,
-      `- Final evaluation outcome: ${args.finalized.finalEvaluation.outcome}`,
-      "",
-      "## Pre-merge final evaluation",
-      `- Outcome: ${args.finalized.finalEvaluation.outcome}`,
-      `- Must-fix residuals: ${args.finalized.finalEvaluation.mustFixCount}`,
-      `- Manual-review residuals: ${args.finalized.finalEvaluation.manualReviewCount}`,
-      `- Follow-up-eligible residuals: ${args.finalized.finalEvaluation.followUpCount}`,
-      "",
-      "## Post-merge audit contract",
-      renderPostMergeAuditContractSummary(
-        createPostMergeAuditResult({
-          recurringPatterns: [],
-          promotionCandidates: [],
-        }),
-      ),
-      "",
-      "## Auto-detected roles",
-      ...summarizeAutoDetectedRoles(args.finalized.artifact.autoDetectedRoles),
-      "",
-      "## Role summaries",
-      summarizeRoles(args.roleResults),
-      "",
-      "## Reviewer thresholds",
-      ...args.finalized.artifact.roleReports.map((report) =>
-        `- ${report.role}: type=${report.reviewerType} confidence>=${report.confidenceThreshold.toFixed(2)} severity>=${report.minimumSeverity} actionable=${report.actionableFindingsCount}`,
-      ),
-      "",
-      "## Model routing",
-      ...summarizeModelRouting(args.finalized),
-      "",
-      "## Durable guardrails",
-      ...summarizeGuardrailProvenance(args.finalized.artifact.guardrailProvenance),
-      "",
-      "## Actionable findings",
-      ...(args.finalized.actionableFindings.length > 0
-        ? args.finalized.actionableFindings.map((finding, index) =>
-            [
-              `### ${index + 1}. ${finding.title}`,
-              `- Role: ${finding.role}`,
-              `- Severity: ${finding.severity}`,
-              `- Confidence: ${finding.confidence.toFixed(2)}`,
-              `- File: ${finding.file ?? "none"}`,
-              `- Lines: ${renderLines(finding)}`,
-              `- Category: ${finding.category ?? "none"}`,
-              `- Body: ${finding.body}`,
-              ...(finding.evidence ? [`- Evidence: ${finding.evidence}`] : []),
-              "",
-            ].join("\n"),
-          )
-        : ["- No actionable findings above the confidence threshold.", ""]),
-      "## Root-cause summaries",
-      ...(args.finalized.rootCauseSummaries.length > 0
-        ? args.finalized.rootCauseSummaries.map((rootCause, index) =>
-            [
-              `### Root cause ${index + 1}`,
-              `- Severity: ${rootCause.severity}`,
-              `- Findings: ${rootCause.findingsCount}`,
-              `- Roles: ${rootCause.roles.join(", ")}`,
-              `- File: ${rootCause.file ?? "multiple"}`,
-              `- Lines: ${rootCause.file ? renderLines(rootCause) : "multiple"}`,
-              `- Category: ${rootCause.category ?? "none"}`,
-              `- Summary: ${rootCause.summary}`,
-              "",
-            ].join("\n"),
-          )
-        : ["- No compressed root causes.", ""]),
-      "## High-Severity Verification",
-      `- Required: ${args.finalized.artifact.verification.required ? "yes" : "no"}`,
-      `- Summary: ${args.finalized.artifact.verification.summary}`,
-      `- Recommendation: ${args.finalized.artifact.verification.recommendation}`,
-      `- Degraded: ${args.finalized.artifact.verification.degraded ? "yes" : "no"}`,
-      `- Verified findings: ${args.finalized.verifiedFindingsCount}`,
-      `- Verified max severity: ${args.finalized.verifiedMaxSeverity}`,
-      ...(args.finalized.artifact.verification.findings.length > 0
-        ? [
-            "",
-            ...args.finalized.artifact.verification.findings.map((finding, index) =>
+    prependTrustedGeneratedDurableArtifactMarkdownMarker(
+      [
+        `# Local Review for Issue #${args.issueNumber}`,
+        "",
+        `- PR: ${args.prUrl}`,
+        `- Branch: ${args.branch}`,
+        `- Head SHA: ${args.headSha}`,
+        `- Ran at: ${args.ranAt}`,
+        `- Roles: ${args.roles.join(", ")}`,
+        `- Confidence threshold: ${args.config.localReviewConfidenceThreshold.toFixed(2)}`,
+        `- Actionable findings: ${args.finalized.findingsCount}`,
+        `- Root causes: ${args.finalized.rootCauseCount}`,
+        `- Max severity: ${args.finalized.maxSeverity}`,
+        `- Verified findings: ${args.finalized.verifiedFindingsCount}`,
+        `- Verified max severity: ${args.finalized.verifiedMaxSeverity}`,
+        `- Recommendation: ${args.finalized.recommendation}`,
+        `- Degraded: ${args.finalized.degraded ? "yes" : "no"}`,
+        `- Final evaluation outcome: ${args.finalized.finalEvaluation.outcome}`,
+        "",
+        "## Pre-merge final evaluation",
+        `- Outcome: ${args.finalized.finalEvaluation.outcome}`,
+        `- Must-fix residuals: ${args.finalized.finalEvaluation.mustFixCount}`,
+        `- Manual-review residuals: ${args.finalized.finalEvaluation.manualReviewCount}`,
+        `- Follow-up-eligible residuals: ${args.finalized.finalEvaluation.followUpCount}`,
+        "",
+        "## Post-merge audit contract",
+        renderPostMergeAuditContractSummary(
+          createPostMergeAuditResult({
+            recurringPatterns: [],
+            promotionCandidates: [],
+          }),
+        ),
+        "",
+        "## Auto-detected roles",
+        ...summarizeAutoDetectedRoles(args.finalized.artifact.autoDetectedRoles),
+        "",
+        "## Role summaries",
+        summarizeRoles(args.roleResults),
+        "",
+        "## Reviewer thresholds",
+        ...args.finalized.artifact.roleReports.map((report) =>
+          `- ${report.role}: type=${report.reviewerType} confidence>=${report.confidenceThreshold.toFixed(2)} severity>=${report.minimumSeverity} actionable=${report.actionableFindingsCount}`,
+        ),
+        "",
+        "## Model routing",
+        ...summarizeModelRouting(args.finalized),
+        "",
+        "## Durable guardrails",
+        ...summarizeGuardrailProvenance(args.finalized.artifact.guardrailProvenance),
+        "",
+        "## Actionable findings",
+        ...(args.finalized.actionableFindings.length > 0
+          ? args.finalized.actionableFindings.map((finding, index) =>
               [
-                `### Verification ${index + 1}`,
-                `- Finding key: ${finding.findingKey}`,
-                `- Verdict: ${finding.verdict}`,
-                `- Rationale: ${finding.rationale}`,
+                `### ${index + 1}. ${finding.title}`,
+                `- Role: ${finding.role}`,
+                `- Severity: ${finding.severity}`,
+                `- Confidence: ${finding.confidence.toFixed(2)}`,
+                `- File: ${finding.file ?? "none"}`,
+                `- Lines: ${renderLines(finding)}`,
+                `- Category: ${finding.category ?? "none"}`,
+                `- Body: ${finding.body}`,
+                ...(finding.evidence ? [`- Evidence: ${finding.evidence}`] : []),
                 "",
               ].join("\n"),
-            ),
-          ]
-        : [""]),
-      "## Raw role outputs",
-      rawOutput,
-      "",
-    ].join("\n"),
+            )
+          : ["- No actionable findings above the confidence threshold.", ""]),
+        "## Root-cause summaries",
+        ...(args.finalized.rootCauseSummaries.length > 0
+          ? args.finalized.rootCauseSummaries.map((rootCause, index) =>
+              [
+                `### Root cause ${index + 1}`,
+                `- Severity: ${rootCause.severity}`,
+                `- Findings: ${rootCause.findingsCount}`,
+                `- Roles: ${rootCause.roles.join(", ")}`,
+                `- File: ${rootCause.file ?? "multiple"}`,
+                `- Lines: ${rootCause.file ? renderLines(rootCause) : "multiple"}`,
+                `- Category: ${rootCause.category ?? "none"}`,
+                `- Summary: ${rootCause.summary}`,
+                "",
+              ].join("\n"),
+            )
+          : ["- No compressed root causes.", ""]),
+        "## High-Severity Verification",
+        `- Required: ${args.finalized.artifact.verification.required ? "yes" : "no"}`,
+        `- Summary: ${args.finalized.artifact.verification.summary}`,
+        `- Recommendation: ${args.finalized.artifact.verification.recommendation}`,
+        `- Degraded: ${args.finalized.artifact.verification.degraded ? "yes" : "no"}`,
+        `- Verified findings: ${args.finalized.verifiedFindingsCount}`,
+        `- Verified max severity: ${args.finalized.verifiedMaxSeverity}`,
+        ...(args.finalized.artifact.verification.findings.length > 0
+          ? [
+              "",
+              ...args.finalized.artifact.verification.findings.map((finding, index) =>
+                [
+                  `### Verification ${index + 1}`,
+                  `- Finding key: ${finding.findingKey}`,
+                  `- Verdict: ${finding.verdict}`,
+                  `- Rationale: ${finding.rationale}`,
+                  "",
+                ].join("\n"),
+              ),
+            ]
+          : [""]),
+        "## Raw role outputs",
+        rawOutput,
+        "",
+      ].join("\n"),
+    ),
     "utf8",
   );
 
   await fs.writeFile(
     findingsPath,
-    `${JSON.stringify(args.finalized.artifact, null, 2)}\n`,
+    `${JSON.stringify(withTrustedGeneratedDurableArtifactProvenance(args.finalized.artifact), null, 2)}\n`,
     "utf8",
   );
 

--- a/src/supervisor/post-merge-audit-artifact.test.ts
+++ b/src/supervisor/post-merge-audit-artifact.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+import {
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE,
+} from "../durable-artifact-provenance";
 import { writeJsonAtomic } from "../core/utils";
 import { type LocalReviewArtifact } from "../local-review/types";
 import { createConfig, createFailureContext, createIssue, createPullRequest, createRecord } from "../turn-execution-test-helpers";
@@ -177,6 +180,7 @@ test("syncPostMergeAuditArtifact persists a typed completed-work artifact", asyn
   );
 
   const artifact = JSON.parse(await fs.readFile(artifactPath!, "utf8")) as PostMergeAuditArtifact;
+  assert.equal(artifact.codexSupervisorProvenance, TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE);
   assert.equal(artifact.schemaVersion, 1);
   assert.equal(artifact.issue.title, "Persist a completed-work audit artifact");
   assert.equal(artifact.pullRequest.number, 116);

--- a/src/supervisor/post-merge-audit-artifact.ts
+++ b/src/supervisor/post-merge-audit-artifact.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { type GitHubIssue, type GitHubPullRequest, type IssueRunRecord, type SupervisorConfig } from "../core/types";
 import { readJsonIfExists, writeJsonAtomic } from "../core/utils";
+import { withTrustedGeneratedDurableArtifactProvenance } from "../durable-artifact-provenance";
 import { executionMetricsRunSummaryPath } from "./execution-metrics-run-summary";
 import {
   validateExecutionMetricsRunSummary,
@@ -11,6 +12,7 @@ import { type LocalReviewArtifact } from "../local-review/types";
 export const POST_MERGE_AUDIT_ARTIFACT_SCHEMA_VERSION = 1;
 
 export interface PostMergeAuditArtifact {
+  codexSupervisorProvenance?: "trusted-generated-durable-artifact/v1";
   schemaVersion: typeof POST_MERGE_AUDIT_ARTIFACT_SCHEMA_VERSION;
   issueNumber: number;
   branch: string;
@@ -235,7 +237,7 @@ export async function syncPostMergeAuditArtifact(args: {
     localReviewRecord.local_review_summary_path,
   );
 
-  const artifact: PostMergeAuditArtifact = {
+  const artifact: PostMergeAuditArtifact = withTrustedGeneratedDurableArtifactProvenance({
     schemaVersion: POST_MERGE_AUDIT_ARTIFACT_SCHEMA_VERSION,
     issueNumber: args.issue.number,
     branch: args.nextRecord.branch,
@@ -315,7 +317,7 @@ export async function syncPostMergeAuditArtifact(args: {
       },
       staleStabilizingNoPrRecoveryCount: args.previousRecord.stale_stabilizing_no_pr_recovery_count ?? 0,
     },
-  };
+  });
 
   const artifactPath = postMergeAuditArtifactPath({
     config: args.config,

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -7,6 +7,8 @@ import test from "node:test";
 import { runWorkstationLocalPathGate } from "./workstation-local-path-gate";
 
 const SAMPLE_FORBIDDEN_PATH = ["", "home", "alice", "dev", "private-repo"].join("/");
+const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
+  "<!-- codex-supervisor-provenance: trusted-generated-durable-artifact/v1 -->";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], {
@@ -377,4 +379,41 @@ test("runtime gate treats nested WORKLOG.md files as publishable tracked content
   assert.match(summary, /Edit tracked publishable content to remove workstation-local paths\./);
   assert.match(summary, /docs\/WORKLOG\.md \(1 match, Linux user home directory\)/);
   assert.doesNotMatch(summary, /Review repo policy or exclusions for expected-local durable artifacts\./);
+});
+
+test("runtime gate classifies explicitly marked generated artifacts separately from untrusted publishable content", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "docs", "generated-summary.md"),
+    [TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER, "", `Generated note: ${SAMPLE_FORBIDDEN_PATH}`, ""].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(repoPath, "docs", "manual-handoff.md"),
+    [
+      "<!-- codex-supervisor-provenance: trusted-generated-durable-artifact -->",
+      "",
+      `Manual note: ${SAMPLE_FORBIDDEN_PATH}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "docs/generated-summary.md", "docs/manual-handoff.md");
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before publication",
+  });
+
+  assert.equal(gateResult.ok, false);
+  const summary = gateResult.failureContext?.summary ?? "";
+  assert.match(summary, /Review trusted generated durable artifacts before supervisor-managed path rewriting\./);
+  assert.match(summary, /docs\/generated-summary\.md \(1 match, Linux user home directory\)/);
+  assert.match(summary, /Edit tracked publishable content to remove workstation-local paths\./);
+  assert.match(summary, /docs\/manual-handoff\.md \(1 match, Linux user home directory\)/);
 });

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import fs from "node:fs/promises";
 import { FailureContext } from "./core/types";
 import { nowIso } from "./core/utils";
 import {
@@ -6,6 +7,7 @@ import {
   normalizeCommittedIssueJournal,
   readIssueJournal,
 } from "./core/journal";
+import { hasTrustedGeneratedDurableArtifactProvenance } from "./durable-artifact-provenance";
 import {
   findForbiddenWorkstationLocalPaths,
   formatWorkstationLocalPathMatch,
@@ -106,9 +108,13 @@ function summarizeWorkstationLocalPathMatches(
 type WorkstationLocalArtifactCategory =
   | "supervisor_owned_journal"
   | "expected_local_durable_artifact"
+  | "trusted_generated_durable_artifact"
   | "publishable_tracked_content";
 
-function categorizeWorkstationLocalArtifact(filePath: string): WorkstationLocalArtifactCategory {
+async function categorizeWorkstationLocalArtifact(
+  workspacePath: string,
+  filePath: string,
+): Promise<WorkstationLocalArtifactCategory> {
   const repoRelativePath = normalizeRepoRelativePath(filePath);
 
   if (isSupervisorOwnedDurableJournalPath(repoRelativePath)) {
@@ -119,24 +125,43 @@ function categorizeWorkstationLocalArtifact(filePath: string): WorkstationLocalA
     return "expected_local_durable_artifact";
   }
 
+  try {
+    const contents = await fs.readFile(path.join(workspacePath, repoRelativePath), "utf8");
+    if (hasTrustedGeneratedDurableArtifactProvenance(contents)) {
+      return "trusted_generated_durable_artifact";
+    }
+  } catch {
+    // Fail closed into generic publishable content when the trusted signal cannot be read.
+  }
+
   return "publishable_tracked_content";
 }
 
-function summarizeCategoryMatches(
+async function summarizeCategoryMatches(
+  workspacePath: string,
   findings: WorkstationLocalPathMatch[],
   category: WorkstationLocalArtifactCategory,
-): string {
+): Promise<string> {
+  const categorizedFindings = await Promise.all(
+    findings.map(async (finding) => ({
+      finding,
+      category: await categorizeWorkstationLocalArtifact(workspacePath, finding.filePath),
+    })),
+  );
   return summarizeWorkstationLocalPathMatches(
-    findings.filter((finding) => categorizeWorkstationLocalArtifact(finding.filePath) === category),
+    categorizedFindings
+      .filter((entry) => entry.category === category)
+      .map((entry) => entry.finding),
   );
 }
 
-function summarizeWorkstationLocalPathRemediation(args: {
+async function summarizeWorkstationLocalPathRemediation(args: {
+  workspacePath: string;
   gateLabel: string;
   findings: WorkstationLocalPathMatch[];
   normalizationErrors: string[];
   rewrittenJournalPaths: string[];
-}): string | undefined {
+}): Promise<string | undefined> {
   const parts: string[] = [];
 
   if (args.rewrittenJournalPaths.length > 0) {
@@ -146,7 +171,7 @@ function summarizeWorkstationLocalPathRemediation(args: {
   }
 
   if (args.normalizationErrors.length > 0) {
-    const journalSummary = summarizeCategoryMatches(args.findings, "supervisor_owned_journal");
+    const journalSummary = await summarizeCategoryMatches(args.workspacePath, args.findings, "supervisor_owned_journal");
     parts.push(
       journalSummary
         ? `Supervisor-owned issue journal auto-normalization still needs attention. ${journalSummary}`
@@ -154,12 +179,25 @@ function summarizeWorkstationLocalPathRemediation(args: {
     );
   }
 
-  const expectedLocalSummary = summarizeCategoryMatches(args.findings, "expected_local_durable_artifact");
+  const expectedLocalSummary = await summarizeCategoryMatches(
+    args.workspacePath,
+    args.findings,
+    "expected_local_durable_artifact",
+  );
   if (expectedLocalSummary) {
     parts.push(`Review repo policy or exclusions for expected-local durable artifacts. ${expectedLocalSummary}`);
   }
 
-  const publishableSummary = summarizeCategoryMatches(args.findings, "publishable_tracked_content");
+  const trustedGeneratedSummary = await summarizeCategoryMatches(
+    args.workspacePath,
+    args.findings,
+    "trusted_generated_durable_artifact",
+  );
+  if (trustedGeneratedSummary) {
+    parts.push(`Review trusted generated durable artifacts before supervisor-managed path rewriting. ${trustedGeneratedSummary}`);
+  }
+
+  const publishableSummary = await summarizeCategoryMatches(args.workspacePath, args.findings, "publishable_tracked_content");
   if (publishableSummary) {
     parts.push(`Edit tracked publishable content to remove workstation-local paths. ${publishableSummary}`);
   }
@@ -229,7 +267,8 @@ export async function runWorkstationLocalPathGate(args: {
       gateLabel: args.gateLabel,
       details: [...normalizationErrors, ...findings.map(formatWorkstationLocalPathMatch)],
       summary:
-        summarizeWorkstationLocalPathRemediation({
+        await summarizeWorkstationLocalPathRemediation({
+          workspacePath: args.workspacePath,
           gateLabel: args.gateLabel,
           findings,
           normalizationErrors,


### PR DESCRIPTION
Closes #1580
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed the `#1580` checkpoint at `5d706b8` (`Classify trusted generated durable artifacts`).

The gate now distinguishes explicitly marked generated durable artifacts from ordinary publishable tracked content without widening path detection. I added a shared provenance marker helper, used it in the generated artifact writers that are plausible durable/tracked outputs, and updated the path-hygiene gate so missing or malformed markers still fail closed into the generic publishable bucket. I also added the focused regression that reproduced the issue and marker-emission assertions on the relevant artifact writers.

One repo-state note: the worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, and `.codex-supervisor/turn-in-progress.json`; I left those alone.

Summary: Added explicit trusted-generated durable artifact provenance markers, classified marked artifacts separately in the workstation-local path gate, updated generated artifact writers, and committed the fix as `5d706b8`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/workstation-local-paths.test.ts src/workstation-local-path-detector.test.ts`; `npx tsx --test src/workstation-local-paths.test.ts src/workstation-local-path-detector.test.ts src/local-review/artifacts.test.ts src/external-review/external-review-miss-persistence.test.ts src/supervisor/post-merge-audit-artifact.test.ts`; `npm run build`
Fail...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance tracking to mark and identify AI-generated artifacts.
  * Enhanced artifact validation to recognize trusted-generated artifacts and provide specific remediation guidance.

* **Bug Fixes**
  * Improved workstation-local-path detection to distinguish between AI-generated and manually-created content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->