### PR TITLE
Fix trusted durable artifact path normalization at publish gates

### DIFF
--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -336,6 +336,13 @@ export function normalizeDurableIssueJournalContent(
   return normalizeDurableJournalText(content, workspacePath);
 }
 
+export function normalizeDurableTrackedArtifactContent(
+  content: string | null | undefined,
+  workspacePath: string,
+): string {
+  return normalizeDurableJournalText(content, workspacePath);
+}
+
 function truncateSummaryBody(summary: string, maxLength: number): string {
   if (summary.length === 0 || maxLength <= 0) {
     return "";

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4654,7 +4654,7 @@ test("handlePostTurnPullRequestTransitionsPhase redacts supervisor-owned cross-i
   const redactedJournal = await fs.readFile(otherJournalPath, "utf8");
   assert.doesNotMatch(redactedJournal, new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(redactedJournal, /<redacted-local-path>/);
-  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize supervisor-owned issue journals for path hygiene/);
+  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
   assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102"), /refs\/heads\/codex\/issue-102/);
 });
 

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -94,7 +94,7 @@ type HostLocalTrackedPrBlockerGateType =
   | "local_ci"
   | "workstation_local_path_hygiene";
 
-const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
+const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
 const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
@@ -1403,24 +1403,27 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         reviewThreads: refreshed.reviewThreads,
       };
     }
-    const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-    const presentRewrittenJournalPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
-    if (presentRewrittenJournalPaths.length > 0) {
+    const rewrittenTrackedPaths = [
+      ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+      ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+    ];
+    const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenTrackedPaths);
+    if (presentRewrittenTrackedPaths.length > 0) {
       let persistedNormalizationCommit = false;
       try {
         persistedNormalizationCommit = await commitAndPushTrackedFiles({
           workspacePath,
           branch: refreshed.pr.headRefName,
           remoteBranchExists: true,
-          filePaths: presentRewrittenJournalPaths,
-          commitMessage: SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE,
+          filePaths: presentRewrittenTrackedPaths,
+          commitMessage: TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const failureContext = buildWorkstationLocalPathFailureContext({
           gateLabel: `before marking PR #${refreshed.pr.number} ready`,
           details: [
-            `journal normalization persistence failed for ${presentRewrittenJournalPaths.join(", ")}: ${message}`,
+            `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
           ],
         });
         record = stateStore.touch(record, {
@@ -1449,7 +1452,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         const failureContext = buildWorkstationLocalPathFailureContext({
           gateLabel: `before marking PR #${refreshed.pr.number} ready`,
           details: [
-            `journal normalization reported rewritten paths for ${presentRewrittenJournalPaths.join(", ")} but did not create a commit to publish.`,
+            `durable artifact normalization reported rewritten paths for ${presentRewrittenTrackedPaths.join(", ")} but did not create a commit to publish.`,
           ],
         });
         record = stateStore.touch(record, {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -436,7 +436,7 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
     state.issues["102"]?.processed_review_thread_fingerprints,
     [`thread-1@${normalizedHead}#comment-1`],
   );
-  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize supervisor-owned issue journals for path hygiene/);
+  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
   assert.doesNotMatch(
     await fs.readFile(otherJournalPath, "utf8"),
     new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -96,7 +96,7 @@ export interface CodexTurnResult {
   reviewThreads: ReviewThread[];
 }
 
-const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
+const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
 
 export interface CodexTurnShortCircuit {
   kind: "returned";
@@ -495,23 +495,26 @@ export async function executeCodexTurnPhase(
             message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
           };
         }
-        const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-        const presentRewrittenJournalPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenJournalPaths);
-        if (presentRewrittenJournalPaths.length > 0) {
+        const rewrittenTrackedPaths = [
+          ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+          ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+        ];
+        const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenTrackedPaths);
+        if (presentRewrittenTrackedPaths.length > 0) {
           try {
             await commitAndPushTrackedFiles({
               workspacePath,
               branch: record.branch,
               remoteBranchExists: workspaceStatus.remoteBranchExists,
-              filePaths: presentRewrittenJournalPaths,
-              commitMessage: SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE,
+              filePaths: presentRewrittenTrackedPaths,
+              commitMessage: TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
             });
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             const failureContext = buildWorkstationLocalPathFailureContext({
               gateLabel: "before publication",
               details: [
-                `journal normalization persistence failed for ${presentRewrittenJournalPaths.join(", ")}: ${message}`,
+                `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
               ],
             });
             record = stateStore.touch(record, {

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -9,6 +9,8 @@ import { SupervisorStateFile } from "./core/types";
 import { createConfig, createIssue, createPullRequest, createRecord } from "./turn-execution-test-helpers";
 
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
+const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
+  "<!-- codex-supervisor-provenance: trusted-generated-durable-artifact/v1 -->";
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], {
@@ -208,8 +210,108 @@ test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journal
   const redactedJournal = await fs.readFile(otherJournalPath, "utf8");
   assert.doesNotMatch(redactedJournal, new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(redactedJournal, /<redacted-local-path>/);
-  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize supervisor-owned issue journals for path hygiene/);
+  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
   assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102"), /refs\/heads\/codex\/issue-102/);
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+});
+
+test("applyCodexTurnPublicationGate persists trusted generated artifact normalization before PR creation", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const repoOwnedAbsolutePath = path.join(workspacePath, "docs", "guide.md");
+  const trustedArtifactPath = path.join(workspacePath, "docs", "generated-summary.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(repoOwnedAbsolutePath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(repoOwnedAbsolutePath, "# Guide\n", "utf8");
+  await fs.writeFile(
+    trustedArtifactPath,
+    [
+      TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+      "",
+      `Repo note: ${repoOwnedAbsolutePath}`,
+      `Host note: ${SAMPLE_MACOS_WORKSTATION_PATH}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md", "docs/guide.md", "docs/generated-summary.md");
+  git(workspacePath, "commit", "-m", "seed trusted generated artifact leak");
+
+  let createPullRequestCalls = 0;
+  const issue = createIssue({ title: "Normalize trusted generated artifacts before publication" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        return createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    runLocalCiCommand: async () => undefined,
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "ready");
+  assert.equal(createPullRequestCalls, 1);
+  assert.equal(result.record.last_head_sha, git(workspacePath, "rev-parse", "HEAD").trim());
+  const normalizedArtifact = await fs.readFile(trustedArtifactPath, "utf8");
+  assert.match(normalizedArtifact, /Repo note: docs\/guide\.md/);
+  assert.match(normalizedArtifact, /Host note: <redacted-local-path>/);
+  assert.doesNotMatch(normalizedArtifact, new RegExp(repoOwnedAbsolutePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(
+    normalizedArtifact,
+    new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
+  assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex\/issue-102"), /refs\/heads\/codex\/issue-102/);
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -46,7 +46,7 @@ export type CodexTurnPublicationGateResult =
   | CodexTurnPublicationGateBlockedResult
   | CodexTurnPublicationGateReadyResult;
 
-const SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE = "Normalize supervisor-owned issue journals for path hygiene";
+const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
 
 export async function applyCodexTurnPublicationGate(args: {
   config: Pick<
@@ -119,23 +119,26 @@ export async function applyCodexTurnPublicationGate(args: {
         reviewThreads: [],
       };
     }
-    const rewrittenJournalPaths = pathHygieneGate.rewrittenJournalPaths ?? [];
-    const presentRewrittenJournalPaths = await filterPresentTrackedFilePaths(args.workspacePath, rewrittenJournalPaths);
-    if (presentRewrittenJournalPaths.length > 0) {
+    const rewrittenTrackedPaths = [
+      ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+      ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+    ];
+    const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(args.workspacePath, rewrittenTrackedPaths);
+    if (presentRewrittenTrackedPaths.length > 0) {
       try {
         await commitAndPushTrackedFiles({
           workspacePath: args.workspacePath,
           branch: record.branch,
           remoteBranchExists: workspaceStatus.remoteBranchExists,
-          filePaths: presentRewrittenJournalPaths,
-          commitMessage: SUPERVISOR_JOURNAL_NORMALIZATION_COMMIT_MESSAGE,
+          filePaths: presentRewrittenTrackedPaths,
+          commitMessage: TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const failureContext = buildWorkstationLocalPathFailureContext({
           gateLabel: "before publication",
           details: [
-            `journal normalization persistence failed for ${presentRewrittenJournalPaths.join(", ")}: ${message}`,
+            `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
           ],
         });
         record = args.stateStore.touch(record, {

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -412,8 +412,51 @@ test("runtime gate classifies explicitly marked generated artifacts separately f
 
   assert.equal(gateResult.ok, false);
   const summary = gateResult.failureContext?.summary ?? "";
-  assert.match(summary, /Review trusted generated durable artifacts before supervisor-managed path rewriting\./);
-  assert.match(summary, /docs\/generated-summary\.md \(1 match, Linux user home directory\)/);
+  assert.match(summary, /Trusted generated durable artifact was auto-normalized before rechecking remaining blockers\./);
   assert.match(summary, /Edit tracked publishable content to remove workstation-local paths\./);
   assert.match(summary, /docs\/manual-handoff\.md \(1 match, Linux user home directory\)/);
+  assert.deepEqual(gateResult.rewrittenTrustedGeneratedArtifactPaths, ["docs/generated-summary.md"]);
+  const normalizedArtifact = await fs.readFile(path.join(repoPath, "docs", "generated-summary.md"), "utf8");
+  assert.match(normalizedArtifact, /<redacted-local-path>/);
+  assert.doesNotMatch(normalizedArtifact, new RegExp(SAMPLE_FORBIDDEN_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("runtime gate auto-normalizes trusted generated durable artifacts by relativizing in-repo paths and redacting host-only paths", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  const repoOwnedAbsolutePath = path.join(repoPath, "docs", "guide.md");
+  const trustedArtifactPath = path.join(repoPath, "docs", "generated-summary.md");
+  await fs.mkdir(path.dirname(repoOwnedAbsolutePath), { recursive: true });
+  await fs.writeFile(repoOwnedAbsolutePath, "# Guide\n", "utf8");
+  await fs.writeFile(
+    trustedArtifactPath,
+    [
+      TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+      "",
+      `Repo note: ${repoOwnedAbsolutePath}`,
+      `Host note: ${SAMPLE_FORBIDDEN_PATH}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "docs/guide.md", "docs/generated-summary.md");
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before publication",
+  });
+
+  assert.equal(gateResult.ok, true);
+  assert.equal(gateResult.failureContext, null);
+  assert.deepEqual(gateResult.rewrittenTrustedGeneratedArtifactPaths, ["docs/generated-summary.md"]);
+
+  const normalizedArtifact = await fs.readFile(trustedArtifactPath, "utf8");
+  assert.match(normalizedArtifact, /Repo note: docs\/guide\.md/);
+  assert.match(normalizedArtifact, /Host note: <redacted-local-path>/);
+  assert.doesNotMatch(normalizedArtifact, new RegExp(repoOwnedAbsolutePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(normalizedArtifact, new RegExp(SAMPLE_FORBIDDEN_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(normalizedArtifact, /trusted-generated-durable-artifact\/v1/);
 });

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -5,6 +5,7 @@ import { nowIso } from "./core/utils";
 import {
   LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH,
   normalizeCommittedIssueJournal,
+  normalizeDurableTrackedArtifactContent,
   readIssueJournal,
 } from "./core/journal";
 import { hasTrustedGeneratedDurableArtifactProvenance } from "./durable-artifact-provenance";
@@ -20,6 +21,7 @@ export interface WorkstationLocalPathGateResult {
   ok: boolean;
   failureContext: FailureContext | null;
   rewrittenJournalPaths?: string[];
+  rewrittenTrustedGeneratedArtifactPaths?: string[];
 }
 
 function normalizeRepoRelativePath(filePath: string): string {
@@ -37,6 +39,11 @@ function isSupervisorOwnedDurableJournalPath(filePath: string): boolean {
 function formatJournalNormalizationFailureDetail(journalPath: string, error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `journal normalization failed for ${journalPath}: ${message}`;
+}
+
+function formatTrustedGeneratedArtifactNormalizationFailureDetail(filePath: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `trusted durable artifact normalization failed for ${filePath}: ${message}`;
 }
 
 export function buildWorkstationLocalPathFailureContext(args: {
@@ -159,8 +166,10 @@ async function summarizeWorkstationLocalPathRemediation(args: {
   workspacePath: string;
   gateLabel: string;
   findings: WorkstationLocalPathMatch[];
-  normalizationErrors: string[];
+  journalNormalizationErrors: string[];
+  trustedGeneratedArtifactNormalizationErrors: string[];
   rewrittenJournalPaths: string[];
+  rewrittenTrustedGeneratedArtifactPaths: string[];
 }): Promise<string | undefined> {
   const parts: string[] = [];
 
@@ -170,12 +179,31 @@ async function summarizeWorkstationLocalPathRemediation(args: {
     );
   }
 
-  if (args.normalizationErrors.length > 0) {
+  if (args.journalNormalizationErrors.length > 0) {
     const journalSummary = await summarizeCategoryMatches(args.workspacePath, args.findings, "supervisor_owned_journal");
     parts.push(
       journalSummary
         ? `Supervisor-owned issue journal auto-normalization still needs attention. ${journalSummary}`
         : "Supervisor-owned issue journal auto-normalization still needs attention.",
+    );
+  }
+
+  if (args.rewrittenTrustedGeneratedArtifactPaths.length > 0) {
+    parts.push(
+      `Trusted generated durable artifact${args.rewrittenTrustedGeneratedArtifactPaths.length === 1 ? " was" : "s were"} auto-normalized before rechecking remaining blockers.`,
+    );
+  }
+
+  if (args.trustedGeneratedArtifactNormalizationErrors.length > 0) {
+    const trustedGeneratedSummary = await summarizeCategoryMatches(
+      args.workspacePath,
+      args.findings,
+      "trusted_generated_durable_artifact",
+    );
+    parts.push(
+      trustedGeneratedSummary
+        ? `Trusted generated durable artifact auto-normalization still needs attention. ${trustedGeneratedSummary}`
+        : "Trusted generated durable artifact auto-normalization still needs attention.",
     );
   }
 
@@ -243,21 +271,87 @@ async function redactSupervisorOwnedJournalLeaks(
   return { rewrittenJournalPaths, normalizationErrors };
 }
 
+async function redactTrustedGeneratedArtifactLeaks(
+  workspacePath: string,
+  findings: Awaited<ReturnType<typeof findForbiddenWorkstationLocalPaths>>,
+): Promise<{ rewrittenTrustedGeneratedArtifactPaths: string[]; normalizationErrors: string[] }> {
+  const artifactPaths = [
+    ...new Set(
+      await Promise.all(
+        findings.map(async (finding) => (
+          await categorizeWorkstationLocalArtifact(workspacePath, finding.filePath)) === "trusted_generated_durable_artifact"
+          ? finding.filePath
+          : null),
+      ),
+    ),
+  ].filter((value): value is string => value !== null);
+
+  const settledResults = await Promise.allSettled(
+    artifactPaths.map(async (artifactPath) => {
+      const absoluteArtifactPath = path.join(workspacePath, artifactPath);
+      const existing = await fs.readFile(absoluteArtifactPath, "utf8");
+      const normalized = normalizeDurableTrackedArtifactContent(existing, workspacePath);
+      if (normalized !== existing) {
+        await fs.writeFile(absoluteArtifactPath, normalized, "utf8");
+      }
+      return { artifactPath, rewritten: normalized !== existing };
+    }),
+  );
+
+  const rewrittenTrustedGeneratedArtifactPaths: string[] = [];
+  const normalizationErrors: string[] = [];
+  for (const [index, result] of settledResults.entries()) {
+    if (result.status === "fulfilled") {
+      if (result.value.rewritten) {
+        rewrittenTrustedGeneratedArtifactPaths.push(result.value.artifactPath);
+      }
+      continue;
+    }
+
+    const artifactPath = artifactPaths[index] ?? "<unknown-artifact>";
+    normalizationErrors.push(formatTrustedGeneratedArtifactNormalizationFailureDetail(artifactPath, result.reason));
+  }
+
+  return { rewrittenTrustedGeneratedArtifactPaths, normalizationErrors };
+}
+
 export async function runWorkstationLocalPathGate(args: {
   workspacePath: string;
   gateLabel: string;
 }): Promise<WorkstationLocalPathGateResult> {
   let findings = await findForbiddenWorkstationLocalPaths(args.workspacePath);
-  let normalizationErrors: string[] = [];
+  let journalNormalizationErrors: string[] = [];
   let rewrittenJournalPaths: string[] = [];
+  let trustedGeneratedArtifactNormalizationErrors: string[] = [];
+  let rewrittenTrustedGeneratedArtifactPaths: string[] = [];
   if (findings.some((finding) => isSupervisorOwnedDurableJournalPath(finding.filePath))) {
     const redactionResult = await redactSupervisorOwnedJournalLeaks(args.workspacePath, findings);
-    normalizationErrors = redactionResult.normalizationErrors;
+    journalNormalizationErrors = redactionResult.normalizationErrors;
     rewrittenJournalPaths = redactionResult.rewrittenJournalPaths;
     findings = await findForbiddenWorkstationLocalPaths(args.workspacePath);
   }
-  if (findings.length === 0 && normalizationErrors.length === 0) {
-    return { ok: true, failureContext: null, rewrittenJournalPaths };
+  if (findings.length > 0) {
+    const redactionResult = await redactTrustedGeneratedArtifactLeaks(args.workspacePath, findings);
+    trustedGeneratedArtifactNormalizationErrors = redactionResult.normalizationErrors;
+    rewrittenTrustedGeneratedArtifactPaths = redactionResult.rewrittenTrustedGeneratedArtifactPaths;
+    if (
+      rewrittenTrustedGeneratedArtifactPaths.length > 0
+      || trustedGeneratedArtifactNormalizationErrors.length > 0
+    ) {
+      findings = await findForbiddenWorkstationLocalPaths(args.workspacePath);
+    }
+  }
+  if (
+    findings.length === 0
+    && journalNormalizationErrors.length === 0
+    && trustedGeneratedArtifactNormalizationErrors.length === 0
+  ) {
+    return {
+      ok: true,
+      failureContext: null,
+      rewrittenJournalPaths,
+      rewrittenTrustedGeneratedArtifactPaths,
+    };
   }
 
   const remediationSummary = summarizeWorkstationLocalPathMatches(findings);
@@ -265,19 +359,26 @@ export async function runWorkstationLocalPathGate(args: {
     ok: false,
     failureContext: buildWorkstationLocalPathFailureContext({
       gateLabel: args.gateLabel,
-      details: [...normalizationErrors, ...findings.map(formatWorkstationLocalPathMatch)],
+      details: [
+        ...journalNormalizationErrors,
+        ...trustedGeneratedArtifactNormalizationErrors,
+        ...findings.map(formatWorkstationLocalPathMatch),
+      ],
       summary:
         await summarizeWorkstationLocalPathRemediation({
           workspacePath: args.workspacePath,
           gateLabel: args.gateLabel,
           findings,
-          normalizationErrors,
+          journalNormalizationErrors,
+          trustedGeneratedArtifactNormalizationErrors,
           rewrittenJournalPaths,
+          rewrittenTrustedGeneratedArtifactPaths,
         })
         ?? (remediationSummary
           ? `Tracked durable artifacts failed workstation-local path hygiene ${args.gateLabel}. ${remediationSummary}`
           : undefined),
     }),
     rewrittenJournalPaths,
+    rewrittenTrustedGeneratedArtifactPaths,
   };
 }


### PR DESCRIPTION
## Summary
- auto-normalize trusted generated durable artifacts at workstation-local path hygiene gates
- relativize in-repo absolute paths and redact host-only local paths
- persist rewritten trusted artifacts at publication and ready-promotion gates

## Testing
- npx tsx --test src/workstation-local-path-detector.test.ts src/turn-execution-publication-gate.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts
- npm run build

Closes #1581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended path hygiene and redaction to trusted generated artifact files, in addition to issue journals, ensuring comprehensive protection of local workstation paths.

* **Bug Fixes**
  * Improved detection and redaction of forbidden workstation paths across all durable artifact types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->