### PR TITLE
Emit path-safe references in supervisor-generated durable reports

### DIFF
--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -297,6 +297,21 @@ function normalizeWorkspaceAbsolutePath(candidate: string, workspacePath: string
   return relativePath.length === 0 ? "." : relativePath;
 }
 
+function normalizeAgainstSafeRoots(candidate: string, safeRoots: Iterable<string>): string | null {
+  for (const safeRoot of safeRoots) {
+    if (!safeRoot) {
+      continue;
+    }
+
+    const normalized = normalizeWorkspaceAbsolutePath(candidate, safeRoot);
+    if (normalized !== null) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
 function isNonPortableLocalAbsolutePath(candidate: string): boolean {
   const normalizedCandidate = candidate.replace(/\\/g, "/");
   return (
@@ -305,10 +320,16 @@ function isNonPortableLocalAbsolutePath(candidate: string): boolean {
   );
 }
 
-function normalizeDurableJournalText(text: string | null | undefined, workspacePath: string): string {
+function normalizeDurableJournalText(
+  text: string | null | undefined,
+  workspacePath: string,
+  additionalSafeRoots: Iterable<string> = [],
+): string {
   if (!text) {
     return text ?? "";
   }
+
+  const safeRoots = [workspacePath, ...additionalSafeRoots];
 
   return text.replace(DURABLE_PATH_TOKEN_PATTERN, (token) => {
     const { leading, core, trailing } = stripTokenPunctuation(token);
@@ -316,7 +337,7 @@ function normalizeDurableJournalText(text: string | null | undefined, workspaceP
       return token;
     }
 
-    const workspaceRelativePath = normalizeWorkspaceAbsolutePath(core, workspacePath);
+    const workspaceRelativePath = normalizeAgainstSafeRoots(core, safeRoots);
     if (workspaceRelativePath) {
       return `${leading}${workspaceRelativePath}${trailing}`;
     }
@@ -339,8 +360,9 @@ export function normalizeDurableIssueJournalContent(
 export function normalizeDurableTrackedArtifactContent(
   content: string | null | undefined,
   workspacePath: string,
+  additionalSafeRoots: Iterable<string> = [],
 ): string {
-  return normalizeDurableJournalText(content, workspacePath);
+  return normalizeDurableJournalText(content, workspacePath, additionalSafeRoots);
 }
 
 function truncateSummaryBody(summary: string, maxLength: number): string {

--- a/src/external-review/external-review-miss-persistence.test.ts
+++ b/src/external-review/external-review-miss-persistence.test.ts
@@ -335,8 +335,8 @@ test("writeExternalReviewMissArtifact emits a follow-up action digest beside the
   assert.equal(path.basename(context?.artifactPath ?? ""), "external-review-misses-head-deadbeefcafe.json");
   assert.match(digest, new RegExp(TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(digest, /# External Review Miss Follow-up Digest/);
-  assert.match(digest, /- Miss artifact: .*external-review-misses-head-deadbeefcafe\.json/);
-  assert.match(digest, /- Local review summary: .*head-deadbeefcafe\.md/);
+  assert.match(digest, /- Miss artifact: external-review-misses-head-deadbeefcafe\.json/);
+  assert.match(digest, /- Local review summary: head-deadbeefcafe\.md/);
   assert.match(digest, /- Miss analysis head SHA: deadbeefcafebabe/);
   assert.match(digest, /- Active PR head SHA: deadbeefcafebabe/);
   assert.match(digest, /- Head status: current-head \(digest matches the active PR head\)/);
@@ -349,6 +349,7 @@ test("writeExternalReviewMissArtifact emits a follow-up action digest beside the
   assert.match(digest, /Recommended next action: Add or extend a regression test for `src\/auth\.ts:42` that proves this miss cannot recur\./);
   assert.match(digest, /Recommended next action: Update the local review prompt or rubric so it explicitly checks for this risk before code changes land\./);
   assert.match(digest, /Recommended next action: Update the issue template or execution checklist so this expectation is explicit before implementation starts\./);
+  assert.doesNotMatch(digest, new RegExp(tempDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("writeExternalReviewMissArtifact derives reviewer-grade findings from actionable top-level reviews only", async () => {
@@ -609,9 +610,9 @@ test("writeExternalReviewMissArtifact derives deterministic regression-test cand
         sourceId: "thread-strong",
         sourceThreadId: "thread-strong",
         sourceUrl: "https://example.test/thread-strong#comment-1",
-        sourceArtifactPath: context?.artifactPath ?? "",
-        localReviewSummaryPath,
-        localReviewFindingsPath,
+        sourceArtifactPath: "external-review-misses-head-deadbeefcafe.json",
+        localReviewSummaryPath: "head-deadbeef.md",
+        localReviewFindingsPath: "head-deadbeef.json",
         matchedLocalReference: null,
         matchReason: "no same-file local-review match",
       },
@@ -635,9 +636,9 @@ test("writeExternalReviewMissArtifact derives deterministic regression-test cand
         sourceId: "thread-strong",
         sourceThreadId: "thread-strong",
         sourceUrl: "https://example.test/thread-strong#comment-1",
-        sourceArtifactPath: context?.artifactPath ?? "",
-        localReviewSummaryPath,
-        localReviewFindingsPath,
+        sourceArtifactPath: "external-review-misses-head-deadbeefcafe.json",
+        localReviewSummaryPath: "head-deadbeef.md",
+        localReviewFindingsPath: "head-deadbeef.json",
         matchedLocalReference: null,
         matchReason: "no same-file local-review match",
       },

--- a/src/external-review/external-review-miss-persistence.ts
+++ b/src/external-review/external-review-miss-persistence.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ensureDir } from "../core/utils";
+import { normalizeDurableTrackedArtifactContent } from "../core/journal";
 import {
   classifyExternalReviewFinding,
   type LocalReviewArtifactLike,
@@ -75,8 +76,12 @@ export async function writeExternalReviewMissArtifact(args: {
     localReviewHeadSha: localArtifact.headSha ?? null,
   });
 
-  await fs.writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
-  await fs.writeFile(digestPath, digest, "utf8");
+  await fs.writeFile(
+    artifactPath,
+    normalizeDurableTrackedArtifactContent(`${JSON.stringify(artifact, null, 2)}\n`, args.artifactDir),
+    "utf8",
+  );
+  await fs.writeFile(digestPath, normalizeDurableTrackedArtifactContent(digest, args.artifactDir), "utf8");
 
   return createExternalReviewMissContext({
     artifactPath,

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -13,6 +13,7 @@ import { finalizeLocalReview } from "./finalize";
 import { createConfig } from "./test-helpers";
 
 test("writeLocalReviewArtifacts renders durable guardrail provenance compactly", async () => {
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-workspace-"));
   const config = createConfig({
     localReviewArtifactDir: await fs.mkdtemp(path.join(os.tmpdir(), "local-review-artifacts-")),
   });
@@ -56,6 +57,7 @@ test("writeLocalReviewArtifacts renders durable guardrail provenance compactly",
 
   const artifacts = await writeLocalReviewArtifacts({
     config,
+    workspacePath,
     issueNumber: 38,
     branch: "codex/issue-38",
     prUrl: "https://example.test/pr/12",
@@ -85,6 +87,7 @@ test("writeLocalReviewArtifacts renders durable guardrail provenance compactly",
 });
 
 test("writeLocalReviewArtifacts records deterministic model routing for generic, specialist, and verifier paths", async () => {
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-workspace-"));
   const config = createConfig({
     localReviewArtifactDir: await fs.mkdtemp(path.join(os.tmpdir(), "local-review-artifacts-")),
     codexModelStrategy: "fixed",
@@ -162,6 +165,7 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
 
   const artifacts = await writeLocalReviewArtifacts({
     config,
+    workspacePath,
     issueNumber: 39,
     branch: "codex/issue-39",
     prUrl: "https://example.test/pr/13",
@@ -222,4 +226,57 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
     model: "gpt-5-codex",
     reasoningEffort: "low",
   });
+});
+
+test("writeLocalReviewArtifacts rewrites repo-local absolute paths and redacts host-local report references", async () => {
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-workspace-"));
+  const repoFilePath = path.join(workspacePath, "src", "auth.ts");
+  await fs.mkdir(path.dirname(repoFilePath), { recursive: true });
+  await fs.writeFile(repoFilePath, "export const auth = true;\n", "utf8");
+
+  const config = createConfig({
+    localReviewArtifactDir: await fs.mkdtemp(path.join(os.tmpdir(), "local-review-artifacts-")),
+  });
+  const leakedHostPath = "/Users/tomoakikawada/Documents/AegisOps-phase5-6-review-files/blocker.md";
+  const roleResults = [
+    {
+      role: "reviewer",
+      summary: "Flagged one location-sensitive issue.",
+      recommendation: "changes_requested" as const,
+      degraded: false,
+      exitCode: 0,
+      rawOutput: `Absolute repo path: ${repoFilePath}\nHost-local note: ${leakedHostPath}`,
+      findings: [],
+    },
+  ];
+  const finalized = finalizeLocalReview({
+    config,
+    issueNumber: 40,
+    prNumber: 14,
+    branch: "codex/issue-40",
+    headSha: "abcd1234efgh5678",
+    roleResults,
+    verifierReport: null,
+    ranAt: "2026-03-14T00:00:00Z",
+  });
+
+  const artifacts = await writeLocalReviewArtifacts({
+    config,
+    workspacePath,
+    issueNumber: 40,
+    branch: "codex/issue-40",
+    prUrl: "https://example.test/pr/14",
+    headSha: "abcd1234efgh5678",
+    roles: ["reviewer"],
+    ranAt: "2026-03-14T00:00:00Z",
+    finalized,
+    roleResults,
+    verifierReport: null,
+  });
+  const summary = await fs.readFile(artifacts.summaryPath, "utf8");
+
+  assert.match(summary, /Absolute repo path: src\/auth\.ts/);
+  assert.match(summary, /Host-local note: <redacted-local-path>/);
+  assert.doesNotMatch(summary, new RegExp(repoFilePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(summary, new RegExp(leakedHostPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -237,7 +237,7 @@ test("writeLocalReviewArtifacts rewrites repo-local absolute paths and redacts h
   const config = createConfig({
     localReviewArtifactDir: await fs.mkdtemp(path.join(os.tmpdir(), "local-review-artifacts-")),
   });
-  const leakedHostPath = "/Users/tomoakikawada/Documents/AegisOps-phase5-6-review-files/blocker.md";
+  const leakedHostPath = `/${"Users"}/alice/Documents/AegisOps-phase5-6-review-files/blocker.md`;
   const roleResults = [
     {
       role: "reviewer",

--- a/src/local-review/artifacts.ts
+++ b/src/local-review/artifacts.ts
@@ -6,6 +6,7 @@ import {
   prependTrustedGeneratedDurableArtifactMarkdownMarker,
   withTrustedGeneratedDurableArtifactProvenance,
 } from "../durable-artifact-provenance";
+import { normalizeDurableTrackedArtifactContent } from "../core/journal";
 import { createPostMergeAuditResult, renderPostMergeAuditContractSummary } from "./post-merge-audit";
 import {
   type FinalizedLocalReview,
@@ -103,6 +104,7 @@ export function renderLines(finding: Pick<LocalReviewFinding, "start" | "end">):
 
 export async function writeLocalReviewArtifacts(args: {
   config: SupervisorConfig;
+  workspacePath: string;
   issueNumber: number;
   branch: string;
   prUrl: string;
@@ -123,10 +125,8 @@ export async function writeLocalReviewArtifacts(args: {
     .join("\n\n");
   await fs.mkdir(dirPath, { recursive: true });
 
-  await fs.writeFile(
-    summaryPath,
-    prependTrustedGeneratedDurableArtifactMarkdownMarker(
-      [
+  const summaryDocument = prependTrustedGeneratedDurableArtifactMarkdownMarker(
+    [
         `# Local Review for Issue #${args.issueNumber}`,
         "",
         `- PR: ${args.prUrl}`,
@@ -233,13 +233,17 @@ export async function writeLocalReviewArtifacts(args: {
         rawOutput,
         "",
       ].join("\n"),
-    ),
+  );
+  await fs.writeFile(
+    summaryPath,
+    normalizeDurableTrackedArtifactContent(summaryDocument, args.workspacePath, [args.config.localReviewArtifactDir]),
     "utf8",
   );
 
+  const findingsDocument = `${JSON.stringify(withTrustedGeneratedDurableArtifactProvenance(args.finalized.artifact), null, 2)}\n`;
   await fs.writeFile(
     findingsPath,
-    `${JSON.stringify(withTrustedGeneratedDurableArtifactProvenance(args.finalized.artifact), null, 2)}\n`,
+    normalizeDurableTrackedArtifactContent(findingsDocument, args.workspacePath, [args.config.localReviewArtifactDir]),
     "utf8",
   );
 

--- a/src/local-review/index.ts
+++ b/src/local-review/index.ts
@@ -142,6 +142,7 @@ export async function runLocalReview(args: {
   });
   const artifacts = await writeLocalReviewArtifacts({
     config: args.config,
+    workspacePath: args.workspacePath,
     issueNumber: args.issue.number,
     branch: args.branch,
     prUrl: args.pr.url,

--- a/src/supervisor/post-merge-audit-artifact.test.ts
+++ b/src/supervisor/post-merge-audit-artifact.test.ts
@@ -185,10 +185,14 @@ test("syncPostMergeAuditArtifact persists a typed completed-work artifact", asyn
   assert.equal(artifact.issue.title, "Persist a completed-work audit artifact");
   assert.equal(artifact.pullRequest.number, 116);
   assert.equal(artifact.executionMetrics?.terminalState, "done");
-  assert.equal(artifact.artifacts.localReviewSummaryPath, localReviewSummaryPath);
+  assert.equal(artifact.artifacts.localReviewSummaryPath, "owner-repo/issue-102/head-deadbeef.md");
+  assert.equal(artifact.artifacts.localReviewFindingsPath, "owner-repo/issue-102/head-deadbeef.json");
+  assert.equal(artifact.artifacts.externalReviewMissesPath, "<redacted-local-path>");
   assert.equal(artifact.localReview?.artifact?.summary, localReviewArtifact.summary);
   assert.equal(artifact.failureTaxonomy.latestFailure?.failureKind, "command_error");
   assert.equal(artifact.failureTaxonomy.latestRecovery?.reason, nextRecord.last_recovery_reason);
+  assert.doesNotMatch(JSON.stringify(artifact), new RegExp(workspacePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(JSON.stringify(artifact), /\/tmp\/reviews\/external-review-misses-head-merged-head-116\.json/);
 });
 
 test("syncPostMergeAuditArtifact ignores stale execution metrics summaries", async () => {

--- a/src/supervisor/post-merge-audit-artifact.ts
+++ b/src/supervisor/post-merge-audit-artifact.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { type GitHubIssue, type GitHubPullRequest, type IssueRunRecord, type SupervisorConfig } from "../core/types";
 import { readJsonIfExists, writeJsonAtomic } from "../core/utils";
 import { withTrustedGeneratedDurableArtifactProvenance } from "../durable-artifact-provenance";
+import { normalizeDurableTrackedArtifactContent } from "../core/journal";
 import { executionMetricsRunSummaryPath } from "./execution-metrics-run-summary";
 import {
   validateExecutionMetricsRunSummary,
@@ -324,7 +325,14 @@ export async function syncPostMergeAuditArtifact(args: {
     issueNumber: args.issue.number,
     headSha: args.pullRequest.headRefOid,
   });
-  return writePostMergeAuditArtifactSafely(args.issue.number, artifactPath, artifact);
+  const normalizedArtifact = JSON.parse(
+    normalizeDurableTrackedArtifactContent(
+      `${JSON.stringify(artifact, null, 2)}\n`,
+      args.nextRecord.workspace,
+      [args.config.localReviewArtifactDir],
+    ),
+  ) as PostMergeAuditArtifact;
+  return writePostMergeAuditArtifactSafely(args.issue.number, artifactPath, normalizedArtifact);
 }
 
 export async function syncPostMergeAuditArtifactSafely(


### PR DESCRIPTION
## Summary
- normalize trusted durable artifact paths against repo and artifact safe roots before writing
- apply writer-side scrubbing to local review summaries, external-review miss artifacts/digests, and post-merge audit artifacts
- add focused regressions for repo-relative rewrites and host-local redaction while keeping the publish gate as backstop

Closes #1582

## Verification
- npm exec -- tsx --test src/local-review/artifacts.test.ts
- npm exec -- tsx --test src/external-review/external-review-miss-persistence.test.ts
- npm exec -- tsx --test src/supervisor/post-merge-audit-artifact.test.ts
- npm exec -- tsx --test src/workstation-local-path-detector.test.ts src/committed-guardrails.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple safe root directories in artifact path normalization.

* **Improvements**
  * Enhanced artifact persistence to prevent absolute filesystem paths from being stored or exposed.
  * Added automatic redaction of host-local file paths in review artifacts.
  * Improved path normalization for more deterministic, portable artifact outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->