### PR TITLE
Restore post-merge audit artifact provenance typing after trusted durable artifact rollout

### DIFF
--- a/src/supervisor/post-merge-audit-artifact.ts
+++ b/src/supervisor/post-merge-audit-artifact.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { type GitHubIssue, type GitHubPullRequest, type IssueRunRecord, type SupervisorConfig } from "../core/types";
 import { readJsonIfExists, writeJsonAtomic } from "../core/utils";
-import { withTrustedGeneratedDurableArtifactProvenance } from "../durable-artifact-provenance";
+import {
+  TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE,
+  withTrustedGeneratedDurableArtifactProvenance,
+} from "../durable-artifact-provenance";
 import { normalizeDurableTrackedArtifactContent } from "../core/journal";
 import { executionMetricsRunSummaryPath } from "./execution-metrics-run-summary";
 import {
@@ -13,7 +16,7 @@ import { type LocalReviewArtifact } from "../local-review/types";
 export const POST_MERGE_AUDIT_ARTIFACT_SCHEMA_VERSION = 1;
 
 export interface PostMergeAuditArtifact {
-  codexSupervisorProvenance?: "trusted-generated-durable-artifact/v1";
+  codexSupervisorProvenance: typeof TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE;
   schemaVersion: typeof POST_MERGE_AUDIT_ARTIFACT_SCHEMA_VERSION;
   issueNumber: number;
   branch: string;

--- a/src/supervisor/post-merge-audit-summary.test.ts
+++ b/src/supervisor/post-merge-audit-summary.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { writeJsonAtomic } from "../core/utils";
+import { TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE } from "../durable-artifact-provenance";
 import type { ExternalReviewMissArtifact } from "../external-review/external-review-miss-artifact-types";
 import { createConfig } from "../turn-execution-test-helpers";
 import type { LocalReviewArtifact } from "../local-review/types";
@@ -80,6 +81,7 @@ function createLocalReviewArtifact(overrides: Partial<LocalReviewArtifact> = {})
 function createPostMergeArtifact(overrides: Partial<PostMergeAuditArtifact> = {}): PostMergeAuditArtifact {
   const localReviewArtifact = createLocalReviewArtifact();
   return {
+    codexSupervisorProvenance: TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE,
     schemaVersion: 1,
     issueNumber: 102,
     branch: "codex/issue-102",
@@ -335,6 +337,31 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
   assert.deepEqual(summary.promotionCandidates[0]?.supportingFindingKeys, [
     "src/supervisor.ts|210|214|retry path|stale context",
   ]);
+});
+
+test("summarizePostMergeAuditPatterns skips persisted artifacts missing trusted provenance", async () => {
+  const { reviewDir } = await createArtifactTestPaths("post-merge-audit-summary-provenance");
+  const config = createConfig({
+    localReviewArtifactDir: reviewDir,
+    repoSlug: "owner/repo",
+  });
+  const artifactDir = postMergeAuditArtifactDir(config);
+  const artifact = createPostMergeArtifact();
+
+  await fs.mkdir(artifactDir, { recursive: true });
+  const { codexSupervisorProvenance, ...artifactWithoutProvenance } = artifact;
+  void codexSupervisorProvenance;
+  await writeJsonAtomic(path.join(artifactDir, "issue-102-head-merged-head.json"), artifactWithoutProvenance);
+
+  const summary = await summarizePostMergeAuditPatterns(config);
+
+  assert.equal(summary.artifactsAnalyzed, 0);
+  assert.equal(summary.artifactsSkipped, 1);
+  assert.deepEqual(summary.reviewPatterns, []);
+  assert.deepEqual(summary.failurePatterns, []);
+  assert.deepEqual(summary.recoveryPatterns, []);
+  assert.deepEqual(summary.followUpCandidates, []);
+  assert.deepEqual(summary.promotionCandidates, []);
 });
 
 test("validatePostMergeAuditPatternSummary rejects unsupported schema versions and missing required fields", () => {

--- a/src/supervisor/post-merge-audit-summary.ts
+++ b/src/supervisor/post-merge-audit-summary.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { nowIso } from "../core/utils";
 import type { SupervisorConfig } from "../core/types";
+import { TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE } from "../durable-artifact-provenance";
 import type { ExternalReviewMissArtifact, ExternalReviewRegressionCandidate } from "../external-review/external-review-miss-artifact-types";
 import type { ActionableSeverity, LocalReviewRootCauseSummary } from "../local-review/types";
 import { hasMatchingPromotionIdentity } from "../persisted-artifact-promotion";
@@ -572,6 +573,7 @@ function isPostMergeAuditArtifact(value: unknown): value is PostMergeAuditArtifa
 
   const candidate = value as Partial<PostMergeAuditArtifact>;
   return (
+    candidate.codexSupervisorProvenance === TRUSTED_GENERATED_DURABLE_ARTIFACT_PROVENANCE_VALUE &&
     candidate.schemaVersion === 1 &&
     typeof candidate.issueNumber === "number" &&
     typeof candidate.capturedAt === "string" &&


### PR DESCRIPTION
Closes #1587

## Summary
- require trusted durable artifact provenance on `PostMergeAuditArtifact`
- reject persisted post-merge audit artifacts without trusted provenance when building summaries
- add a focused regression test covering the fail-closed summary path

## Verification
- npm exec -- tsx --test src/supervisor/post-merge-audit-artifact.test.ts
- npm exec -- tsx --test src/supervisor/post-merge-audit-summary.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation logic for post-merge audit artifacts to enforce required provenance markers.

* **Tests**
  * Added test coverage to verify artifacts without required provenance information are properly skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->