### PR TITLE
Honor managed-repo publishable path allowlists in verify:paths publication gate (#1590)

### DIFF
--- a/.codex-supervisor/issues/1590/issue-journal.md
+++ b/.codex-supervisor/issues/1590/issue-journal.md
@@ -5,28 +5,42 @@
 - Branch: codex/issue-1590
 - Workspace: .
 - Journal: .codex-supervisor/issues/1590/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: b25f7833d4f1d0d3fbfd8cf67d4d749d1a1216cd
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 4f955939e515859c850b339927c5d66f0e54ae9f
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-18T11:00:06.002Z
+- Last failure signature: PRRT_kwDORgvdZ8577xsp|PRRT_kwDORgvdZ8577xsq
+- Repeated failure signature count: 1
+- Updated at: 2026-04-18T11:20:53.000Z
 
 ## Latest Codex Summary
-- None yet.
+Implemented the `publishablePathAllowlistMarkers` contract and wired it through the three relevant surfaces: `scripts/check-workstation-local-paths.ts`, the shared workstation-local path gate, and the publication / ready-promotion call sites. The suppression stays fail-closed by default, only applies to same-line tracked text matches when the operator config opts in, and does not widen trust for supervisor-owned or special durable-artifact handling.
+
+Addressed the review finding that empty allowlist markers could create a fail-open suppression path by rejecting empty and whitespace-only `publishablePathAllowlistMarkers` entries during config parsing. Added focused regression coverage in `src/config.test.ts`, reran the targeted verification bundle plus `npm run build`, and committed the code checkpoint as `4f95593` (`Reject empty publishable allowlist markers`).
+
+Summary: Rejected empty and whitespace-only publishable allowlist markers, added regression coverage, and kept the focused path-gate verification bundle plus build green.
+State hint: addressing_review
+Blocked reason: none
+Tests: `npm run build`; `npx tsx --test src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/config.test.ts`
+Next action: push `codex/issue-1590`, then recheck and resolve the addressed review threads on PR `#1591`
+Failure signature: none
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: Local review fixes are committed; pending step is to push the branch update and recheck PR thread state.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1591#discussion_r3105054267
+- Details:
+  - `.codex-supervisor/issues/1590/issue-journal.md` refreshed to the current review-fix checkpoint and next PR action.
+  - `src/core/config-parsing.ts` now rejects empty and whitespace-only allowlist markers; `src/config.test.ts` covers the regression.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: `verify:paths` and the publication gates need the same line-level marker contract, sourced from supervisor config, so managed-repo fixture allowlists stay opt-in and fail closed elsewhere.
-- What changed: Added optional `publishablePathAllowlistMarkers` config parsing, taught the detector/gate/CLI to suppress only same-line tracked text matches containing a configured marker, and added regression coverage for detector semantics plus publication and ready-promotion gate plumbing.
+- Hypothesis: The implementation is locally complete; the remaining review work is to publish the branch update and clear the two addressed PR threads.
+- What changed: Rejected empty and whitespace-only `publishablePathAllowlistMarkers` entries in config parsing, added a focused config regression test, and refreshed the journal snapshot for the current review-fix checkpoint.
 - Current blocker: none
-- Next exact step: stage the changed source/test files, exclude generated `.codex-supervisor/` runtime artifacts, and commit the checkpoint for issue `#1590`.
+- Next exact step: push `codex/issue-1590`, verify PR `#1591` reflects commit `4f95593`, and resolve or recheck the two CodeRabbit review threads.
 - Verification gap: `npm test -- ...` package-script wrappers also run unrelated repo-wide tests with pre-existing failures; isolated verification used direct `npx tsx --test` on the touched suites plus `npm run build`.
-- Files touched: `scripts/check-workstation-local-paths.ts`; `src/core/types.ts`; `src/core/config-parsing.ts`; `src/workstation-local-paths.ts`; `src/workstation-local-path-gate.ts`; `src/turn-execution-publication-gate.ts`; `src/post-turn-pull-request.ts`; targeted tests under `src/`.
+- Files touched: `.codex-supervisor/issues/1590/issue-journal.md`; `scripts/check-workstation-local-paths.ts`; `src/core/types.ts`; `src/core/config-parsing.ts`; `src/workstation-local-paths.ts`; `src/workstation-local-path-gate.ts`; `src/turn-execution-publication-gate.ts`; `src/post-turn-pull-request.ts`; targeted tests under `src/`.
 - Rollback concern: low; the new behavior is gated behind explicit config opt-in and still ignores markers for supervisor-owned/special durable artifact handling.
 - Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/config.test.ts`
 ### Scratchpad

--- a/.codex-supervisor/issues/1590/issue-journal.md
+++ b/.codex-supervisor/issues/1590/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #1590: Honor managed-repo publishable path allowlists in verify:paths publication gate
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1590
+- Branch: codex/issue-1590
+- Workspace: .
+- Journal: .codex-supervisor/issues/1590/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: b25f7833d4f1d0d3fbfd8cf67d4d749d1a1216cd
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-18T11:00:06.002Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: `verify:paths` and the publication gates need the same line-level marker contract, sourced from supervisor config, so managed-repo fixture allowlists stay opt-in and fail closed elsewhere.
+- What changed: Added optional `publishablePathAllowlistMarkers` config parsing, taught the detector/gate/CLI to suppress only same-line tracked text matches containing a configured marker, and added regression coverage for detector semantics plus publication and ready-promotion gate plumbing.
+- Current blocker: none
+- Next exact step: stage the changed source/test files, exclude generated `.codex-supervisor/` runtime artifacts, and commit the checkpoint for issue `#1590`.
+- Verification gap: `npm test -- ...` package-script wrappers also run unrelated repo-wide tests with pre-existing failures; isolated verification used direct `npx tsx --test` on the touched suites plus `npm run build`.
+- Files touched: `scripts/check-workstation-local-paths.ts`; `src/core/types.ts`; `src/core/config-parsing.ts`; `src/workstation-local-paths.ts`; `src/workstation-local-path-gate.ts`; `src/turn-execution-publication-gate.ts`; `src/post-turn-pull-request.ts`; targeted tests under `src/`.
+- Rollback concern: low; the new behavior is gated behind explicit config opt-in and still ignores markers for supervisor-owned/special durable artifact handling.
+- Last focused command: `npx tsx --test src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/config.test.ts`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/scripts/check-workstation-local-paths.ts
+++ b/scripts/check-workstation-local-paths.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { loadConfigSummary } from "../src/core/config";
 import {
   DEFAULT_EXCLUDED_PATHS,
   findForbiddenWorkstationLocalPaths,
@@ -9,14 +10,16 @@ import {
 interface Args {
   workspacePath: string;
   excludedPaths: Set<string>;
+  configPath?: string;
 }
 
 function usage(): string {
   return [
-    "Usage: tsx scripts/check-workstation-local-paths.ts [--workspace <path>] [--exclude-path <repo-relative-path>]",
+    "Usage: tsx scripts/check-workstation-local-paths.ts [--workspace <path>] [--config <path>] [--exclude-path <repo-relative-path>]",
     "",
     "Scans tracked durable text artifacts for workstation-local absolute paths and tracked supervisor-generated local artifacts.",
     "Approved committed fixtures/examples must be exempted intentionally by repo-relative path via --exclude-path",
+    "or by operator-configured line markers from publishablePathAllowlistMarkers in supervisor config.",
     `or by extending DEFAULT_EXCLUDED_PATHS in ${path.posix.join("src", "workstation-local-paths.ts")}.`,
   ].join("\n");
 }
@@ -24,6 +27,7 @@ function usage(): string {
 function parseArgs(argv: string[]): Args {
   const excludedPaths = new Set<string>(DEFAULT_EXCLUDED_PATHS);
   let workspacePath = process.cwd();
+  let configPath: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -45,6 +49,15 @@ function parseArgs(argv: string[]): Args {
       continue;
     }
 
+    if (token === "--config") {
+      index += 1;
+      if (index >= argv.length) {
+        throw new Error(`Missing value for --config\n\n${usage()}`);
+      }
+      configPath = path.resolve(argv[index]);
+      continue;
+    }
+
     if (token === "--help" || token === "-h") {
       console.log(usage());
       process.exit(0);
@@ -56,12 +69,17 @@ function parseArgs(argv: string[]): Args {
   return {
     workspacePath,
     excludedPaths,
+    configPath,
   };
 }
 
 async function main(): Promise<void> {
-  const { workspacePath, excludedPaths } = parseArgs(process.argv.slice(2));
-  const findings = await findForbiddenWorkstationLocalPaths(workspacePath, excludedPaths);
+  const { workspacePath, excludedPaths, configPath } = parseArgs(process.argv.slice(2));
+  const configSummary = loadConfigSummary(configPath);
+  const publishablePathAllowlistMarkers = configSummary.config?.publishablePathAllowlistMarkers ?? [];
+  const findings = await findForbiddenWorkstationLocalPaths(workspacePath, excludedPaths, {
+    publishablePathAllowlistMarkers,
+  });
 
   if (findings.length === 0) {
     console.log(`No forbidden workstation-local artifacts found in tracked durable artifacts under ${workspacePath}.`);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -255,6 +255,32 @@ test("loadConfig accepts explicit publishable path allowlist markers", async (t)
   assert.deepEqual(config.publishablePathAllowlistMarkers, ["publishable-path-hygiene: allowlist"]);
 });
 
+test("loadConfig rejects empty publishable path allowlist markers", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      publishablePathAllowlistMarkers: ["", "   ", "publishable-path-hygiene: allowlist"],
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+  assert.deepEqual(config.publishablePathAllowlistMarkers, ["publishable-path-hygiene: allowlist"]);
+});
+
 test("loadConfig accepts explicit local review follow-up issue creation opt-in", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -229,6 +229,32 @@ test("loadConfig accepts explicit local review same-PR manual-review repair opt-
   assert.equal(config.localReviewManualReviewRepairEnabled, true);
 });
 
+test("loadConfig accepts explicit publishable path allowlist markers", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+  assert.deepEqual(config.publishablePathAllowlistMarkers, ["publishable-path-hygiene: allowlist"]);
+});
+
 test("loadConfig accepts explicit local review follow-up issue creation opt-in", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -384,7 +384,9 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
         ? (raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
         : "blocked",
     publishablePathAllowlistMarkers: Array.isArray(raw.publishablePathAllowlistMarkers)
-      ? raw.publishablePathAllowlistMarkers.filter((value): value is string => typeof value === "string")
+      ? raw.publishablePathAllowlistMarkers.filter(
+          (value): value is string => typeof value === "string" && value.trim().length > 0,
+        )
       : [],
     staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -383,6 +383,9 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
       VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS.has(raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
         ? (raw.localReviewHighSeverityAction as LocalReviewHighSeverityAction)
         : "blocked",
+    publishablePathAllowlistMarkers: Array.isArray(raw.publishablePathAllowlistMarkers)
+      ? raw.publishablePathAllowlistMarkers.filter((value): value is string => typeof value === "string")
+      : [],
     staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)
       ? raw.reviewBotLogins

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -174,6 +174,7 @@ export interface SupervisorConfig {
   localReviewManualReviewRepairEnabled?: boolean;
   localReviewFollowUpIssueCreationEnabled?: boolean;
   localReviewHighSeverityAction: LocalReviewHighSeverityAction;
+  publishablePathAllowlistMarkers?: string[];
   staleConfiguredBotReviewPolicy?: StaleConfiguredBotReviewPolicy;
   reviewBotLogins: string[];
   configuredReviewProviders?: ConfiguredReviewProvider[];

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1714,6 +1714,116 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion 
   assert.match(result.record.last_failure_context?.details[0] ?? "", /docs\/guide\.md:1/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase forwards publishable allowlist markers to the path hygiene gate", async () => {
+  const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
+  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  const config = createConfig({
+    localCiCommand: "npm run ci:local",
+    publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+  });
+  const issue = createIssue({ title: "Forward publishable allowlist markers during ready promotion" });
+  const draftPr = createPullRequest({ title: "Forward allowlist markers", isDraft: true, headRefOid: headSha });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: draftPr.number,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+        last_head_sha: headSha,
+      }),
+    },
+  };
+
+  let readyCalls = 0;
+  const observedCalls: Array<readonly string[] | undefined> = [];
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        readyCalls += 1;
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath,
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async (args) => {
+      observedCalls.push(args.publishablePathAllowlistMarkers);
+      return {
+        ok: true,
+        failureContext: null,
+      };
+    },
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(readyCalls, 1);
+  assert.deepEqual(observedCalls, [["publishable-path-hygiene: allowlist"]]);
+  assert.equal(result.record.blocked_reason, null);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-local path hygiene blocks tracked ready promotion", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -1140,7 +1140,11 @@ export interface HandlePostTurnPullRequestTransitionsArgs {
   runLocalReviewImpl?: typeof runLocalReview;
   runWorkspacePreparationCommand?: LocalCiCommandRunner;
   runLocalCiCommand?: LocalCiCommandRunner;
-  runWorkstationLocalPathGate?: (args: { workspacePath: string; gateLabel: string }) => Promise<WorkstationLocalPathGateResult>;
+  runWorkstationLocalPathGate?: (args: {
+    workspacePath: string;
+    gateLabel: string;
+    publishablePathAllowlistMarkers?: readonly string[];
+  }) => Promise<WorkstationLocalPathGateResult>;
   emitEvent?: SupervisorEventSink;
   loadOpenPullRequestSnapshot?: (prNumber: number) => Promise<{
     pr: GitHubPullRequest;
@@ -1360,6 +1364,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({
       workspacePath,
       gateLabel: `before marking PR #${refreshed.pr.number} ready`,
+      publishablePathAllowlistMarkers: config.publishablePathAllowlistMarkers,
     });
     if (!pathHygieneGate.ok) {
       const failureContext = pathHygieneGate.failureContext;

--- a/src/pull-request-state-test-helpers.ts
+++ b/src/pull-request-state-test-helpers.ts
@@ -34,6 +34,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     },
     localReviewPolicy: "block_ready",
     localReviewHighSeverityAction: "retry",
+    publishablePathAllowlistMarkers: [],
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,
     issueJournalRelativePath: ".codex-supervisor/issue-journal.md",

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -50,6 +50,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     },
     localReviewPolicy: "block_ready",
     localReviewHighSeverityAction: "retry",
+    publishablePathAllowlistMarkers: [],
     staleConfiguredBotReviewPolicy: "diagnose_only",
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -121,6 +121,69 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene f
   assert.equal(runLocalCiCalls, 0);
 });
 
+test("applyCodexTurnPublicationGate forwards publishable allowlist markers to the path hygiene gate", async () => {
+  const issue = createIssue({ title: "Honor publishable allowlist markers before PR creation" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  const observedCalls: Array<readonly string[] | undefined> = [];
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath: "/tmp/workspaces/issue-102",
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-102",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" }),
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    runWorkstationLocalPathGate: async (args) => {
+      observedCalls.push(args.publishablePathAllowlistMarkers);
+      return {
+        ok: true,
+        failureContext: null,
+      };
+    },
+    runLocalCiCommand: async () => undefined,
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "ready");
+  assert.deepEqual(observedCalls, [["publishable-path-hygiene: allowlist"]]);
+});
+
 test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journals before publication", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -51,7 +51,12 @@ const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted
 export async function applyCodexTurnPublicationGate(args: {
   config: Pick<
     SupervisorConfig,
-    "repoPath" | "defaultBranch" | "draftPrAfterAttempt" | "workspacePreparationCommand" | "localCiCommand"
+    | "repoPath"
+    | "defaultBranch"
+    | "draftPrAfterAttempt"
+    | "workspacePreparationCommand"
+    | "localCiCommand"
+    | "publishablePathAllowlistMarkers"
   >;
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
@@ -73,6 +78,7 @@ export async function applyCodexTurnPublicationGate(args: {
   runWorkstationLocalPathGate?: (args: {
     workspacePath: string;
     gateLabel: string;
+    publishablePathAllowlistMarkers?: readonly string[];
   }) => Promise<WorkstationLocalPathGateResult>;
   syncExecutionMetricsRunSummary: (record: IssueRunRecord) => Promise<void>;
 }): Promise<CodexTurnPublicationGateResult> {
@@ -91,6 +97,7 @@ export async function applyCodexTurnPublicationGate(args: {
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({
       workspacePath: args.workspacePath,
       gateLabel: "before publication",
+      publishablePathAllowlistMarkers: args.config.publishablePathAllowlistMarkers,
     });
     if (!pathHygieneGate.ok) {
       const failureContext = pathHygieneGate.failureContext;

--- a/src/turn-execution-test-helpers.ts
+++ b/src/turn-execution-test-helpers.ts
@@ -38,6 +38,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     localReviewPolicy: "block_ready",
     localReviewFollowUpIssueCreationEnabled: false,
     localReviewHighSeverityAction: "retry",
+    publishablePathAllowlistMarkers: [],
     staleConfiguredBotReviewPolicy: "diagnose_only",
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -212,6 +212,57 @@ test("runtime gate reuses the CLI finding rendering for workstation-local path v
   assert.deepEqual(gateResult.failureContext?.details, renderedFindings);
 });
 
+test("verify:paths and runtime gate honor configured same-line publishable allowlist markers", async (t) => {
+  const repoPath = await createTrackedRepo();
+  const configDir = await fs.mkdtemp(path.join(os.tmpdir(), "workstation-local-path-config-"));
+  const configPath = path.join(configDir, "supervisor.config.json");
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "tests"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "tests", "fixtures.py"),
+    [
+      `ALLOWED = "${["", "Users", "alice", "Dev", "fixture"].join("/")}"  # publishable-path-hygiene: allowlist`,
+      `BLOCKED = "${["", "Users", "alice", "Dev", "real-leak"].join("/")}"`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "tests/fixtures.py");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    "utf8",
+  );
+
+  const detectorResult = runDetector(repoPath, "--workspace", repoPath, "--config", configPath);
+  assert.notEqual(detectorResult.status, 0, "expected non-allowlisted line to keep failing");
+  assert.doesNotMatch(detectorResult.stderr, /tests\/fixtures\.py:1/);
+  assert.match(detectorResult.stderr, /tests\/fixtures\.py:2/);
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before publication",
+    publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+  });
+  assert.equal(gateResult.ok, false);
+  assert.equal(gateResult.failureContext?.details.some((detail) => detail.includes("tests/fixtures.py:1")), false);
+  assert.equal(gateResult.failureContext?.details.some((detail) => detail.includes("tests/fixtures.py:2")), true);
+});
+
 test("runtime gate fails closed when supervisor-owned journal normalization throws", async (t) => {
   if (process.platform === "win32") {
     t.skip("directory permission semantics differ on Windows");

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -318,8 +318,10 @@ async function redactTrustedGeneratedArtifactLeaks(
 export async function runWorkstationLocalPathGate(args: {
   workspacePath: string;
   gateLabel: string;
+  publishablePathAllowlistMarkers?: readonly string[];
 }): Promise<WorkstationLocalPathGateResult> {
-  let findings = await findForbiddenWorkstationLocalPaths(args.workspacePath);
+  const detectorOptions = { publishablePathAllowlistMarkers: args.publishablePathAllowlistMarkers ?? [] };
+  let findings = await findForbiddenWorkstationLocalPaths(args.workspacePath, undefined, detectorOptions);
   let journalNormalizationErrors: string[] = [];
   let rewrittenJournalPaths: string[] = [];
   let trustedGeneratedArtifactNormalizationErrors: string[] = [];
@@ -328,7 +330,7 @@ export async function runWorkstationLocalPathGate(args: {
     const redactionResult = await redactSupervisorOwnedJournalLeaks(args.workspacePath, findings);
     journalNormalizationErrors = redactionResult.normalizationErrors;
     rewrittenJournalPaths = redactionResult.rewrittenJournalPaths;
-    findings = await findForbiddenWorkstationLocalPaths(args.workspacePath);
+    findings = await findForbiddenWorkstationLocalPaths(args.workspacePath, undefined, detectorOptions);
   }
   if (findings.length > 0) {
     const redactionResult = await redactTrustedGeneratedArtifactLeaks(args.workspacePath, findings);
@@ -338,7 +340,7 @@ export async function runWorkstationLocalPathGate(args: {
       rewrittenTrustedGeneratedArtifactPaths.length > 0
       || trustedGeneratedArtifactNormalizationErrors.length > 0
     ) {
-      findings = await findForbiddenWorkstationLocalPaths(args.workspacePath);
+      findings = await findForbiddenWorkstationLocalPaths(args.workspacePath, undefined, detectorOptions);
     }
   }
   if (

--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -201,6 +201,57 @@ test("findForbiddenWorkstationLocalPaths classifies mixed-prefix path lists with
   );
 });
 
+test("findForbiddenWorkstationLocalPaths honors configured same-line publishable allowlist markers only when opted in", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "tests"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "tests", "fixtures.py"),
+    [
+      `ALLOWED = "${buildMacHomePath("alice", "Dev", "fixture")}"  # publishable-path-hygiene: allowlist`,
+      "# publishable-path-hygiene: allowlist",
+      `STILL_BLOCKED = "${buildMacHomePath("alice", "Dev", "real-leak")}"`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "tests/fixtures.py");
+
+  const withoutOptIn = await findForbiddenWorkstationLocalPaths(repoPath);
+  assert.deepEqual(
+    withoutOptIn.map((finding) => ({ filePath: finding.filePath, line: finding.line, match: finding.match })),
+    [
+      {
+        filePath: "tests/fixtures.py",
+        line: 1,
+        match: buildMacHomePath("alice", "Dev", "fixture"),
+      },
+      {
+        filePath: "tests/fixtures.py",
+        line: 3,
+        match: buildMacHomePath("alice", "Dev", "real-leak"),
+      },
+    ],
+  );
+
+  const withOptIn = await findForbiddenWorkstationLocalPaths(repoPath, undefined, {
+    publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+  });
+  assert.deepEqual(
+    withOptIn.map((finding) => ({ filePath: finding.filePath, line: finding.line, match: finding.match })),
+    [
+      {
+        filePath: "tests/fixtures.py",
+        line: 3,
+        match: buildMacHomePath("alice", "Dev", "real-leak"),
+      },
+    ],
+  );
+});
+
 test("findForbiddenWorkstationLocalPaths skips tracked files omitted by sparse checkout", async (t) => {
   const repoPath = await createTrackedRepo();
   t.after(async () => {

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -161,19 +161,31 @@ function splitCompoundCandidate(candidate: string): string[] {
   return parts.filter((part) => part.length > 0);
 }
 
-function collectMatches(filePath: string, contents: string): WorkstationLocalPathMatch[] {
+function lineContainsConfiguredAllowlistMarker(line: string, markers: readonly string[]): boolean {
+  return markers.some((marker) => marker.length > 0 && line.includes(marker));
+}
+
+function collectMatches(
+  filePath: string,
+  contents: string,
+  publishablePathAllowlistMarkers: readonly string[] = [],
+): WorkstationLocalPathMatch[] {
   const matches: WorkstationLocalPathMatch[] = [];
   const seen = new Set<string>();
   const lines = contents.split(/\r?\n/);
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const line = lines[lineIndex];
+    const allowlistedLine = lineContainsConfiguredAllowlistMarker(line, publishablePathAllowlistMarkers);
     for (const pattern of CANDIDATE_PATTERNS) {
       pattern.regex.lastIndex = 0;
       for (const match of line.matchAll(pattern.regex)) {
         for (const candidate of splitCompoundCandidate(match[0])) {
           const classification = pattern.classify(candidate);
           if (!classification?.blocked) {
+            continue;
+          }
+          if (allowlistedLine) {
             continue;
           }
 
@@ -254,9 +266,13 @@ function classifyForbiddenSupervisorArtifactPath(filePath: string): { prefix: st
 export async function findForbiddenWorkstationLocalPaths(
   workspacePath: string,
   excludedPaths: Iterable<string> = DEFAULT_EXCLUDED_PATHS,
+  options?: {
+    publishablePathAllowlistMarkers?: readonly string[];
+  },
 ): Promise<WorkstationLocalPathMatch[]> {
   const trackedFiles = gitTrackedFiles(workspacePath);
   const normalizedExcludedPaths = new Set([...excludedPaths].map((entry) => normalizeRepoRelativePath(entry)));
+  const publishablePathAllowlistMarkers = options?.publishablePathAllowlistMarkers ?? [];
   const findings: WorkstationLocalPathMatch[] = [];
 
   for (const filePath of trackedFiles) {
@@ -294,7 +310,7 @@ export async function findForbiddenWorkstationLocalPaths(
       continue;
     }
 
-    findings.push(...collectMatches(filePath, rawContents.toString("utf8")));
+    findings.push(...collectMatches(filePath, rawContents.toString("utf8"), publishablePathAllowlistMarkers));
   }
 
   return findings;


### PR DESCRIPTION
Closes #1590
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the `publishablePathAllowlistMarkers` contract and wired it through the three relevant surfaces: `scripts/check-workstation-local-paths.ts`, the shared workstation-local path gate, and the publication / ready-promotion call sites. The suppression stays fail-closed by default, only applies to same-line tracked text matches when the operator config opts in, and does not widen trust for supervisor-owned or special durable-artifact handling.

I added regression coverage for detector semantics, CLI/runtime alignment, config parsing, and both gate plumbings. The isolated verification bundle and `npm run build` are green. I also updated the issue journal and committed the checkpoint as `a5352ea` (`Honor publishable path allowlist markers in verify paths`). The worktree still has only untracked generated supervisor runtime artifacts under `.codex-supervisor/`, which I left out of the commit.

Summary: Added operator-configured same-line publishable path allowlist markers to `verify:paths` and publication gates, with focused regression coverage and a green build.
State hint: implementing
Blocked reason: none
Tests: `npm run build`; `npx tsx --test src/post-turn-pull-request.test.ts src/turn-execution-publication-gate.test.ts src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/config.test.ts`
Failure signature: none
Next action: open or update the draft PR for `codex/issue-1590`, then let the supervisor resume from the committed checkpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `publishablePathAllowlistMarkers` config option to suppress path-hygiene findings on allowlisted lines.
  * CLI script accepts optional `--config <path>` to load config.
  * Publication/path-validation gates now honor configured allowlist markers.
  * Config parsing now rejects empty or whitespace-only allowlist entries.

* **Tests**
  * Added comprehensive tests covering allowlist parsing, CLI behavior, detector, and gate forwarding.

* **Documentation**
  * Added an issue journal entry documenting the change and follow-up steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->