### PR TITLE
Restrict publishable path allowlist markers to ordinary tracked content (#1592)

### DIFF
--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -263,6 +263,95 @@ test("verify:paths and runtime gate honor configured same-line publishable allow
   assert.equal(gateResult.failureContext?.details.some((detail) => detail.includes("tests/fixtures.py:2")), true);
 });
 
+test("verify:paths and runtime gate do not let same-line publishable allowlist markers suppress special-case tracked artifacts", async (t) => {
+  const repoPath = await createTrackedRepo();
+  const configDir = await fs.mkdtemp(path.join(os.tmpdir(), "workstation-local-path-config-"));
+  const configPath = path.join(configDir, "supervisor.config.json");
+  const currentJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const otherJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(
+    otherJournalPath,
+    [
+      "# Issue #181",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      `- What changed: copied ${SAMPLE_FORBIDDEN_PATH} # publishable-path-hygiene: allowlist`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(repoPath, "WORKLOG.md"),
+    `Operator note: ${SAMPLE_FORBIDDEN_PATH} # publishable-path-hygiene: allowlist\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(repoPath, "docs", "generated-summary.md"),
+    [
+      TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+      "",
+      `Generated note: ${SAMPLE_FORBIDDEN_PATH} # publishable-path-hygiene: allowlist`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    "utf8",
+  );
+  git(
+    repoPath,
+    "add",
+    ".codex-supervisor/issues/102/issue-journal.md",
+    ".codex-supervisor/issues/181/issue-journal.md",
+    "WORKLOG.md",
+    "docs/generated-summary.md",
+  );
+
+  const detectorResult = runDetector(repoPath, "--workspace", repoPath, "--config", configPath);
+  assert.notEqual(detectorResult.status, 0, "expected special-case artifacts to keep failing");
+  assert.match(detectorResult.stderr, /\.codex-supervisor\/issues\/181\/issue-journal\.md:5/);
+  assert.match(detectorResult.stderr, /WORKLOG\.md:1/);
+  assert.match(detectorResult.stderr, /docs\/generated-summary\.md:3/);
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before publication",
+    publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+  });
+
+  assert.equal(gateResult.ok, false);
+  assert.deepEqual(gateResult.rewrittenJournalPaths, [".codex-supervisor/issues/181/issue-journal.md"]);
+  assert.deepEqual(gateResult.rewrittenTrustedGeneratedArtifactPaths, ["docs/generated-summary.md"]);
+  const summary = gateResult.failureContext?.summary ?? "";
+  assert.match(summary, /Supervisor-owned issue journal(?:s were| was) auto-normalized before rechecking remaining blockers\./);
+  assert.match(summary, /Trusted generated durable artifact(?:s were| was) auto-normalized before rechecking remaining blockers\./);
+  assert.match(summary, /Review repo policy or exclusions for expected-local durable artifacts\./);
+  assert.match(summary, /WORKLOG\.md \(1 match, Linux user home directory\)/);
+  assert.doesNotMatch(summary, /\.codex-supervisor\/issues\/181\/issue-journal\.md/);
+  assert.doesNotMatch(summary, /docs\/generated-summary\.md/);
+});
+
 test("runtime gate fails closed when supervisor-owned journal normalization throws", async (t) => {
   if (process.platform === "win32") {
     t.skip("directory permission semantics differ on Windows");

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -8,10 +8,11 @@ import {
   normalizeDurableTrackedArtifactContent,
   readIssueJournal,
 } from "./core/journal";
-import { hasTrustedGeneratedDurableArtifactProvenance } from "./durable-artifact-provenance";
 import {
+  classifyWorkstationLocalArtifact,
   findForbiddenWorkstationLocalPaths,
   formatWorkstationLocalPathMatch,
+  type WorkstationLocalArtifactCategory,
   type WorkstationLocalPathMatch,
 } from "./workstation-local-paths";
 
@@ -112,36 +113,19 @@ function summarizeWorkstationLocalPathMatches(
   return visibleFiles.length > 0 ? `First fix: ${visibleFiles.join("; ")}${tail}.` : "";
 }
 
-type WorkstationLocalArtifactCategory =
-  | "supervisor_owned_journal"
-  | "expected_local_durable_artifact"
-  | "trusted_generated_durable_artifact"
-  | "publishable_tracked_content";
-
 async function categorizeWorkstationLocalArtifact(
   workspacePath: string,
   filePath: string,
 ): Promise<WorkstationLocalArtifactCategory> {
   const repoRelativePath = normalizeRepoRelativePath(filePath);
 
-  if (isSupervisorOwnedDurableJournalPath(repoRelativePath)) {
-    return "supervisor_owned_journal";
-  }
-
-  if (repoRelativePath === "WORKLOG.md") {
-    return "expected_local_durable_artifact";
-  }
-
   try {
     const contents = await fs.readFile(path.join(workspacePath, repoRelativePath), "utf8");
-    if (hasTrustedGeneratedDurableArtifactProvenance(contents)) {
-      return "trusted_generated_durable_artifact";
-    }
+    return classifyWorkstationLocalArtifact({ filePath: repoRelativePath, contents });
   } catch {
     // Fail closed into generic publishable content when the trusted signal cannot be read.
+    return classifyWorkstationLocalArtifact({ filePath: repoRelativePath });
   }
-
-  return "publishable_tracked_content";
 }
 
 async function summarizeCategoryMatches(

--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -6,6 +6,9 @@ import path from "node:path";
 import test from "node:test";
 import { classifyWorkstationLocalPathCandidate, findForbiddenWorkstationLocalPaths } from "./workstation-local-paths";
 
+const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
+  "<!-- codex-supervisor-provenance: trusted-generated-durable-artifact/v1 -->";
+
 function buildUnixHomePath(owner: string, ...segments: string[]): string {
   return ["/", "home", "/", owner, ...segments.flatMap((segment) => ["/", segment])].join("");
 }
@@ -247,6 +250,91 @@ test("findForbiddenWorkstationLocalPaths honors configured same-line publishable
         filePath: "tests/fixtures.py",
         line: 3,
         match: buildMacHomePath("alice", "Dev", "real-leak"),
+      },
+    ],
+  );
+});
+
+test("findForbiddenWorkstationLocalPaths limits same-line publishable allowlist markers to ordinary tracked content", async (t) => {
+  const repoPath = await createTrackedRepo();
+  const currentJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const otherJournalPath = path.join(repoPath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  const trustedArtifactPath = path.join(repoPath, "docs", "generated-summary.md");
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(trustedArtifactPath), { recursive: true });
+  await fs.mkdir(path.join(repoPath, "tests"), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(
+    otherJournalPath,
+    [
+      "# Issue #181",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      `- What changed: copied ${buildMacHomePath("alice", "Dev", "fixture")} # publishable-path-hygiene: allowlist`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(repoPath, "WORKLOG.md"),
+    `Operator note: ${buildUnixHomePath("alice", "dev", "fixture")} # publishable-path-hygiene: allowlist\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    trustedArtifactPath,
+    [
+      TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+      "",
+      `Generated note: ${buildUnixHomePath("alice", "dev", "fixture")} # publishable-path-hygiene: allowlist`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(repoPath, "tests", "fixtures.py"),
+    [
+      `ALLOWED = "${buildMacHomePath("alice", "Dev", "fixture")}"  # publishable-path-hygiene: allowlist`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(
+    repoPath,
+    "add",
+    ".codex-supervisor/issues/102/issue-journal.md",
+    ".codex-supervisor/issues/181/issue-journal.md",
+    "WORKLOG.md",
+    "docs/generated-summary.md",
+    "tests/fixtures.py",
+  );
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath, undefined, {
+    publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+  });
+
+  assert.deepEqual(
+    findings.map((finding) => ({ filePath: finding.filePath, line: finding.line, match: finding.match })),
+    [
+      {
+        filePath: ".codex-supervisor/issues/181/issue-journal.md",
+        line: 5,
+        match: buildMacHomePath("alice", "Dev", "fixture"),
+      },
+      {
+        filePath: "WORKLOG.md",
+        line: 1,
+        match: buildUnixHomePath("alice", "dev", "fixture"),
+      },
+      {
+        filePath: "docs/generated-summary.md",
+        line: 3,
+        match: buildUnixHomePath("alice", "dev", "fixture"),
       },
     ],
   );

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { hasTrustedGeneratedDurableArtifactProvenance } from "./durable-artifact-provenance";
 
 export const DEFAULT_EXCLUDED_PATHS = [
   "docs/examples/atlaspm.supervisor.config.example.json",
@@ -53,6 +54,12 @@ export interface WorkstationLocalPathMatch {
   prefix: string;
   reason: string;
 }
+
+export type WorkstationLocalArtifactCategory =
+  | "supervisor_owned_journal"
+  | "expected_local_durable_artifact"
+  | "trusted_generated_durable_artifact"
+  | "publishable_tracked_content";
 
 export function formatWorkstationLocalPathMatch(finding: WorkstationLocalPathMatch): string {
   if (finding.line === null) {
@@ -263,6 +270,37 @@ function classifyForbiddenSupervisorArtifactPath(filePath: string): { prefix: st
   return null;
 }
 
+function isSupervisorOwnedDurableJournalPath(filePath: string): boolean {
+  return (
+    filePath === ".codex-supervisor/issue-journal.md"
+    || /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/.test(filePath)
+  );
+}
+
+export function classifyWorkstationLocalArtifact(args: {
+  filePath: string;
+  contents?: string;
+}): WorkstationLocalArtifactCategory {
+  const repoRelativePath = normalizeRepoRelativePath(args.filePath);
+
+  if (isSupervisorOwnedDurableJournalPath(repoRelativePath)) {
+    return "supervisor_owned_journal";
+  }
+
+  if (repoRelativePath === "WORKLOG.md") {
+    return "expected_local_durable_artifact";
+  }
+
+  if (
+    typeof args.contents === "string"
+    && hasTrustedGeneratedDurableArtifactProvenance(args.contents)
+  ) {
+    return "trusted_generated_durable_artifact";
+  }
+
+  return "publishable_tracked_content";
+}
+
 export async function findForbiddenWorkstationLocalPaths(
   workspacePath: string,
   excludedPaths: Iterable<string> = DEFAULT_EXCLUDED_PATHS,
@@ -310,7 +348,15 @@ export async function findForbiddenWorkstationLocalPaths(
       continue;
     }
 
-    findings.push(...collectMatches(filePath, rawContents.toString("utf8"), publishablePathAllowlistMarkers));
+    const textContents = rawContents.toString("utf8");
+    const artifactCategory = classifyWorkstationLocalArtifact({ filePath, contents: textContents });
+    findings.push(
+      ...collectMatches(
+        filePath,
+        textContents,
+        artifactCategory === "publishable_tracked_content" ? publishablePathAllowlistMarkers : [],
+      ),
+    );
   }
 
   return findings;


### PR DESCRIPTION
Closes #1592
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the fail-closed boundary change and committed it at `5148c21` on `codex/issue-1592`. The fix classifies tracked artifacts before applying same-line `publishablePathAllowlistMarkers`, so only ordinary publishable tracked content can suppress findings; supervisor-owned journals, `WORKLOG.md`, and trusted generated durable artifacts keep their existing blocker/normalization paths. I also added detector- and gate-level regressions that reproduced the bug before the fix and now pass.

Summary: Restricted publishable allowlist marker suppression to ordinary tracked content, added regressions for journals/WORKLOG/trusted-generated artifacts, and committed the checkpoint as `5148c21`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/workstation-local-paths.test.ts --test-name-pattern "limits same-line publishable allowlist markers to ordinary tracked content"`; `npx tsx --test src/workstation-local-path-detector.test.ts --test-name-pattern "do not let same-line publishable allowlist markers suppress special-case tracked artifacts"`; `npm run build`
Failure signature: none
Next action: open or update a draft PR from `codex/issue-1592` with commit `5148c21`, then let the supervisor continue broader validation/CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced local path detection with intelligent artifact type classification
  * Allowlist markers now apply selectively—only to publishable tracked content
  * Trusted generated artifacts properly excluded from forbidden path detection
  * Improved path normalization and reporting accuracy

* **Tests**
  * Added comprehensive tests for artifact classification and path detection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->