### PR TITLE
Make verify:paths honor CODEX_SUPERVISOR_CONFIG by default

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,6 +9,7 @@ import {
   loadConfig,
   loadConfigSummary,
   loadConfigSummaryFromDocument,
+  resolveConfigPath,
   summarizeCadenceDiagnostics,
 } from "./core/config";
 import { SupervisorConfig } from "./core/types";
@@ -109,6 +110,26 @@ test("loadConfigSummaryFromDocument resolves config-relative paths for in-memory
   assert.equal(summary.config?.codexBinary, path.join(path.dirname(configPath), "bin", "codex"));
   assert.deepEqual(summary.missingRequiredFields, []);
   assert.deepEqual(summary.invalidFields, []);
+});
+
+test("resolveConfigPath honors CODEX_SUPERVISOR_CONFIG by default while keeping explicit config precedence", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  const originalEnv = process.env.CODEX_SUPERVISOR_CONFIG;
+  t.after(async () => {
+    if (originalEnv === undefined) {
+      delete process.env.CODEX_SUPERVISOR_CONFIG;
+    } else {
+      process.env.CODEX_SUPERVISOR_CONFIG = originalEnv;
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const envConfigPath = path.join(tempDir, "supervisor.config.coderabbit.json");
+  const explicitConfigPath = path.join(tempDir, "supervisor.config.explicit.json");
+  process.env.CODEX_SUPERVISOR_CONFIG = envConfigPath;
+
+  assert.equal(resolveConfigPath(), envConfigPath);
+  assert.equal(resolveConfigPath(explicitConfigPath), explicitConfigPath);
 });
 
 test("loadConfigSummary surfaces the default trust diagnostics posture", async (t) => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -83,9 +83,16 @@ function buildConfigLoadSummaryFromDocument(raw: Record<string, unknown>, resolv
 }
 
 export function resolveConfigPath(configPath?: string): string {
-  return configPath
-    ? path.resolve(configPath)
-    : path.resolve(process.cwd(), DEFAULT_CONFIG_FILE);
+  if (configPath) {
+    return path.resolve(configPath);
+  }
+
+  const envConfigPath = process.env.CODEX_SUPERVISOR_CONFIG?.trim();
+  if (envConfigPath) {
+    return path.resolve(envConfigPath);
+  }
+
+  return path.resolve(process.cwd(), DEFAULT_CONFIG_FILE);
 }
 
 export function loadConfigSummary(configPath?: string): ConfigLoadSummary {

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -27,7 +27,11 @@ async function createTrackedRepo(): Promise<string> {
   return repoPath;
 }
 
-function runDetector(repoPath: string, ...args: string[]): SpawnSyncReturns<string> {
+function runDetectorWithEnv(
+  repoPath: string,
+  envOverrides: NodeJS.ProcessEnv,
+  ...args: string[]
+): SpawnSyncReturns<string> {
   const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
   return spawnSync(
     npxCommand,
@@ -37,22 +41,36 @@ function runDetector(repoPath: string, ...args: string[]): SpawnSyncReturns<stri
       encoding: "utf8",
       env: {
         ...process.env,
+        ...envOverrides,
         FORCE_COLOR: "0",
       },
     },
   );
 }
 
-function runVerifyPaths(repoPath: string, ...args: string[]): SpawnSyncReturns<string> {
+function runDetector(repoPath: string, ...args: string[]): SpawnSyncReturns<string> {
+  return runDetectorWithEnv(repoPath, {}, ...args);
+}
+
+function runVerifyPathsWithEnv(
+  repoPath: string,
+  envOverrides: NodeJS.ProcessEnv,
+  ...args: string[]
+): SpawnSyncReturns<string> {
   const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
   return spawnSync(npmCommand, ["run", "verify:paths", "--", "--workspace", repoPath, ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
     env: {
       ...process.env,
+      ...envOverrides,
       FORCE_COLOR: "0",
     },
   });
+}
+
+function runVerifyPaths(repoPath: string, ...args: string[]): SpawnSyncReturns<string> {
+  return runVerifyPathsWithEnv(repoPath, {}, ...args);
 }
 
 function extractRenderedFindingLines(stderr: string): string[] {
@@ -261,6 +279,48 @@ test("verify:paths and runtime gate honor configured same-line publishable allow
   assert.equal(gateResult.ok, false);
   assert.equal(gateResult.failureContext?.details.some((detail) => detail.includes("tests/fixtures.py:1")), false);
   assert.equal(gateResult.failureContext?.details.some((detail) => detail.includes("tests/fixtures.py:2")), true);
+});
+
+test("verify:paths honors CODEX_SUPERVISOR_CONFIG when --config is omitted", async (t) => {
+  const repoPath = await createTrackedRepo();
+  const configDir = await fs.mkdtemp(path.join(os.tmpdir(), "workstation-local-path-config-"));
+  const configPath = path.join(configDir, "supervisor.config.coderabbit.json");
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "tests"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "tests", "fixtures.py"),
+    [
+      `ALLOWED = "${["", "Users", "alice", "Dev", "fixture"].join("/")}"  # publishable-path-hygiene: allowlist`,
+      `BLOCKED = "${["", "Users", "alice", "Dev", "real-leak"].join("/")}"`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "tests/fixtures.py");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    "utf8",
+  );
+
+  const verifyPathsResult = runVerifyPathsWithEnv(repoPath, { CODEX_SUPERVISOR_CONFIG: configPath });
+  assert.notEqual(verifyPathsResult.status, 0, "expected non-allowlisted line to keep failing");
+  assert.doesNotMatch(verifyPathsResult.stderr, /tests\/fixtures\.py:1/);
+  assert.match(verifyPathsResult.stderr, /tests\/fixtures\.py:2/);
 });
 
 test("verify:paths and runtime gate do not let same-line publishable allowlist markers suppress special-case tracked artifacts", async (t) => {


### PR DESCRIPTION
## Summary
- make verify:paths resolve the active supervisor config from CODEX_SUPERVISOR_CONFIG when --config is omitted
- keep explicit --config precedence ahead of the env-selected profile and default fallback
- add focused regressions for env-driven detector behavior and config-path precedence

## Verification
- npx tsx --test src/workstation-local-path-detector.test.ts
- npx tsx --test src/config.test.ts
- npm run build

Closes #1593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration path resolution now supports environment variable configuration, with explicit arguments maintaining priority over environment settings.

* **Tests**
  * Improved test coverage for configuration path resolution and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->