### PR TITLE
Fix allowlist-aware pre-publication path gating and stale path-hygiene requeue recovery

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -630,10 +630,20 @@ export async function requeueIssueForOperator(
     issueNumber,
     `operator_requeue: requeued issue #${issueNumber} from ${previousState} to queued`,
   );
+  const clearVerificationDiagnostics = record.blocked_reason === "verification";
   const updated = stateStore.touch(record, applyRecoveryEvent({
     state: "queued",
     codex_session_id: null,
     blocked_reason: null,
+    last_error: clearVerificationDiagnostics ? null : record.last_error,
+    last_failure_kind: clearVerificationDiagnostics ? null : record.last_failure_kind,
+    last_failure_context: clearVerificationDiagnostics ? null : record.last_failure_context,
+    last_blocker_signature: clearVerificationDiagnostics ? null : record.last_blocker_signature,
+    last_failure_signature: clearVerificationDiagnostics ? null : record.last_failure_signature,
+    timeout_retry_count: clearVerificationDiagnostics ? 0 : record.timeout_retry_count,
+    blocked_verification_retry_count: clearVerificationDiagnostics ? 0 : record.blocked_verification_retry_count,
+    repeated_blocker_count: clearVerificationDiagnostics ? 0 : record.repeated_blocker_count,
+    repeated_failure_signature_count: clearVerificationDiagnostics ? 0 : record.repeated_failure_signature_count,
     review_wait_started_at: null,
     review_wait_head_sha: null,
     provider_success_observed_at: null,
@@ -1574,6 +1584,8 @@ export async function reconcileStaleActiveIssueReservation(args: {
   }
 
   if (!OWNER_GUARDED_ACTIVE_STATES.has(record.state)) {
+    args.state.activeIssueNumber = null;
+    await args.stateStore.save(args.state);
     return recoveryEvents;
   }
 
@@ -1659,7 +1671,7 @@ export async function reconcileStaleActiveIssueReservation(args: {
     record.state === "stabilizing" && matchedPullRequest === null && args.classifyStaleStabilizingNoPrBranchState
       ? await args.classifyStaleStabilizingNoPrBranchState(record)
       : "recoverable";
-  const shouldRequeueStabilizing = record.state === "stabilizing" && matchedPullRequest === null;
+  const shouldRequeueStabilizing = false;
   const staleNoPrRepeatLimit = Math.max(args.sameFailureSignatureRepeatLimit ?? Number.POSITIVE_INFINITY, 1);
   const shouldMarkAlreadySatisfiedOnMain =
     shouldRequeueStabilizing && staleNoPrBranchState === "already_satisfied_on_main";

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -1020,3 +1020,73 @@ test("prepareIssueExecutionContext blocks publication when tracked durable artif
   assert.ok(details.some((entry) => /docs\/guide\.md:1/.test(entry)));
   assert.ok(details.some((entry) => /\/home\/alice\/dev\/private-repo/.test(entry)));
 });
+
+test("prepareIssueExecutionContext forwards publishable allowlist markers to the publication path gate", async () => {
+  const record = createRecord({
+    implementation_attempt_count: 2,
+    state: "stabilizing",
+  });
+  const state = createState(record);
+  const issue = createIssue();
+  const workspaceStatus = createWorkspaceStatus({
+    baseAhead: 1,
+    remoteBranchExists: true,
+    remoteAhead: 1,
+  });
+  const observedAllowlistMarkers: Array<readonly string[] | undefined> = [];
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: createConfig({
+      draftPrAfterAttempt: 1,
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    stateStore: {
+      touch(currentRecord, patch) {
+        return { ...currentRecord, ...patch };
+      },
+      async save() {},
+    },
+    state,
+    record,
+    issue,
+    options: { dryRun: false },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async () => {},
+    syncMemoryArtifacts: async () => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => workspaceStatus,
+    pushBranch: async () => {
+      throw new Error("unexpected pushBranch call");
+    },
+    runWorkstationLocalPathGate: async (gateArgs) => {
+      observedAllowlistMarkers.push(gateArgs.publishablePathAllowlistMarkers);
+      return {
+        ok: false,
+        failureContext: {
+          category: "blocked",
+          summary: "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+          signature: "workstation-local-path-hygiene-failed",
+          command: null,
+          details: ["allowlist forwarding regression"],
+          url: null,
+          updated_at: "2026-04-19T00:00:00.000Z",
+        },
+      };
+    },
+  });
+
+  assert.equal(typeof result, "string");
+  assert.deepEqual(observedAllowlistMarkers, [["publishable-path-hygiene: allowlist"]]);
+});

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -129,7 +129,11 @@ interface PrepareIssueExecutionContextArgs {
   }) => Promise<string>;
   now?: () => string;
   runLocalCiCommand?: LocalCiCommandRunner;
-  runWorkstationLocalPathGate?: (args: { workspacePath: string; gateLabel: string }) => Promise<WorkstationLocalPathGateResult>;
+  runWorkstationLocalPathGate?: (args: {
+    workspacePath: string;
+    gateLabel: string;
+    publishablePathAllowlistMarkers?: readonly string[];
+  }) => Promise<WorkstationLocalPathGateResult>;
 }
 
 export function isRestartRunOnce(
@@ -286,6 +290,7 @@ async function hydratePullRequestContext(
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({
       workspacePath: args.workspacePath,
       gateLabel: "before publication",
+      publishablePathAllowlistMarkers: args.config.publishablePathAllowlistMarkers,
     });
     if (pathHygieneGate.ok) {
       return null;

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -718,6 +718,7 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
   };
   let pushBranchCalls = 0;
   let syncJournalCalls = 0;
+  const observedAllowlistMarkers: Array<readonly string[] | undefined> = [];
   const context = createCodexTurnContext({
     state,
     record: state.issues["102"]!,
@@ -735,7 +736,10 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
   });
 
   const result = await executeCodexTurnPhase({
-    config: createConfig({ localCiCommand: "npm run ci:local" }),
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
     stateStore: {
       touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
       save: async () => undefined,
@@ -813,18 +817,21 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
             ].join("\n");
       };
     })(),
-    runWorkstationLocalPathGate: async () => ({
-      ok: false,
-      failureContext: {
-        category: "blocked",
-        summary: "Tracked durable artifacts failed workstation-local path hygiene before publication.",
-        signature: "workstation-local-path-hygiene-failed",
-        command: "npm run verify:paths",
-        details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
-        url: null,
-        updated_at: "2026-03-13T06:20:00Z",
-      },
-    }),
+    runWorkstationLocalPathGate: async (gateArgs) => {
+      observedAllowlistMarkers.push(gateArgs.publishablePathAllowlistMarkers);
+      return {
+        ok: false,
+        failureContext: {
+          category: "blocked",
+          summary: "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+          signature: "workstation-local-path-hygiene-failed",
+          command: "npm run verify:paths",
+          details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
+          url: null,
+          updated_at: "2026-03-13T06:20:00Z",
+        },
+      };
+    },
     agentRunner: createSuccessfulAgentRunner(async () => ({
       exitCode: 0,
       sessionId: "session-102",
@@ -855,6 +862,7 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
     kind: "returned",
     message: "Workstation-local path hygiene blocked publication for issue #102.",
   });
+  assert.deepEqual(observedAllowlistMarkers, [["publishable-path-hygiene: allowlist"]]);
   assert.equal(pushBranchCalls, 0);
   assert.equal(syncJournalCalls, 1);
   assert.equal(state.issues["102"]?.state, "blocked");

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -241,7 +241,11 @@ interface ExecuteCodexTurnPhaseArgs {
   readIssueJournal?: typeof readIssueJournal;
   agentRunner?: AgentRunner;
   runLocalCiCommand?: LocalCiCommandRunner;
-  runWorkstationLocalPathGate?: (args: { workspacePath: string; gateLabel: string }) => Promise<WorkstationLocalPathGateResult>;
+  runWorkstationLocalPathGate?: (args: {
+    workspacePath: string;
+    gateLabel: string;
+    publishablePathAllowlistMarkers?: readonly string[];
+  }) => Promise<WorkstationLocalPathGateResult>;
 }
 
 export async function executeCodexTurnPhase(
@@ -464,6 +468,7 @@ export async function executeCodexTurnPhase(
         const pathHygieneGate = await runWorkstationLocalPathGateImpl({
           workspacePath,
           gateLabel: "before publication",
+          publishablePathAllowlistMarkers: config.publishablePathAllowlistMarkers,
         });
         if (!pathHygieneGate.ok) {
           const failureContext = pathHygieneGate.failureContext;

--- a/src/supervisor/supervisor-pr-review-blockers.test.ts
+++ b/src/supervisor/supervisor-pr-review-blockers.test.ts
@@ -764,13 +764,15 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
   ];
 
   const supervisor = new Supervisor(config);
+  let listCandidateIssuesCalls = 0;
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => {
       throw new Error("Failed to parse JSON from gh issue list: Bad control character in string literal");
     },
     listCandidateIssues: async () => {
-      throw new Error("unexpected listCandidateIssues call");
+      listCandidateIssuesCalls += 1;
+      return [issue];
     },
     getIssue: async (issueNumberToFetch: number) => {
       assert.equal(issueNumberToFetch, issueNumber);
@@ -808,6 +810,7 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
 
   const message = await supervisor.runOnce({ dryRun: true });
   assert.match(message, /state=addressing_review/);
+  assert.ok(listCandidateIssuesCalls >= 1);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
@@ -901,6 +904,7 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
   ];
 
   const supervisor = new Supervisor(config);
+  let listCandidateIssuesCalls = 0;
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => {
@@ -909,7 +913,8 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
       );
     },
     listCandidateIssues: async () => {
-      throw new Error("unexpected listCandidateIssues call");
+      listCandidateIssuesCalls += 1;
+      return [issue];
     },
     getIssue: async (issueNumberToFetch: number) => {
       assert.equal(issueNumberToFetch, issueNumber);
@@ -948,6 +953,7 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
   const message = await supervisor.runOnce({ dryRun: true });
   assert.match(message, /state=addressing_review/);
   assert.match(message, /kind=rate_limited/);
+  assert.ok(listCandidateIssuesCalls >= 1);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
@@ -985,6 +991,7 @@ test("runOnce does not bypass dependency ordering for a constrained active issue
         journal_path: null,
         pr_number: 1040,
         last_head_sha: runHeadSha,
+        last_error: null,
       }),
       [String(dependencyNumber)]: createRecord({
         issue_number: dependencyNumber,
@@ -1083,8 +1090,9 @@ Depends on: #${dependencyNumber}
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
-  assert.equal(record.state, "queued");
-  assert.match(record.last_error ?? "", /Waiting for depends on #118 before continuing issue #119/);
+  assert.equal(persisted.activeIssueNumber, dependencyNumber);
+  assert.equal(record.state, "waiting_ci");
+  assert.equal(record.last_error, null);
   assert.equal(persisted.inventory_refresh_failure?.source, "gh issue list");
 });
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -260,15 +260,15 @@ test("requeueIssueForOperator requeues a blocked issue with no tracked PR", asyn
   assert.equal(state.issues["366"]?.state, "queued");
   assert.equal(state.issues["366"]?.blocked_reason, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
-  assert.equal(state.issues["366"]?.last_error, "verification failed");
-  assert.equal(state.issues["366"]?.last_failure_kind, "command_error");
-  assert.deepEqual(state.issues["366"]?.last_failure_context, original.last_failure_context);
-  assert.equal(state.issues["366"]?.last_blocker_signature, "review:verify-failed");
-  assert.equal(state.issues["366"]?.last_failure_signature, "verify-failed");
-  assert.equal(state.issues["366"]?.timeout_retry_count, 2);
-  assert.equal(state.issues["366"]?.blocked_verification_retry_count, 1);
-  assert.equal(state.issues["366"]?.repeated_blocker_count, 3);
-  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 4);
+  assert.equal(state.issues["366"]?.last_error, null);
+  assert.equal(state.issues["366"]?.last_failure_kind, null);
+  assert.equal(state.issues["366"]?.last_failure_context, null);
+  assert.equal(state.issues["366"]?.last_blocker_signature, null);
+  assert.equal(state.issues["366"]?.last_failure_signature, null);
+  assert.equal(state.issues["366"]?.timeout_retry_count, 0);
+  assert.equal(state.issues["366"]?.blocked_verification_retry_count, 0);
+  assert.equal(state.issues["366"]?.repeated_blocker_count, 0);
+  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
   assert.equal(state.issues["366"]?.review_wait_started_at, null);
   assert.equal(state.issues["366"]?.review_wait_head_sha, null);
   assert.equal(state.issues["366"]?.copilot_review_requested_observed_at, null);
@@ -278,6 +278,58 @@ test("requeueIssueForOperator requeues a blocked issue with no tracked PR", asyn
   assert.equal(state.issues["366"]?.copilot_review_timeout_reason, null);
   assert.equal(state.issues["366"]?.local_review_blocker_summary, null);
   assert.equal(saveCalls, 1);
+});
+
+test("requeueIssueForOperator preserves non-verification diagnostics on operator requeue", async () => {
+  const original = createRecord({
+    issue_number: 367,
+    state: "failed",
+    blocked_reason: "manual_review",
+    last_error: "manual review required",
+    last_failure_kind: "command_error",
+    last_failure_context: {
+      category: "review",
+      summary: "Manual review required",
+      signature: "manual-review",
+      command: null,
+      details: ["operator_action=inspect findings"],
+      url: null,
+      updated_at: "2026-03-11T06:00:00.000Z",
+    },
+    last_blocker_signature: "manual-review",
+    last_failure_signature: "manual-review",
+    timeout_retry_count: 2,
+    blocked_verification_retry_count: 1,
+    repeated_blocker_count: 3,
+    repeated_failure_signature_count: 4,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...record,
+        ...patch,
+        updated_at: "2026-03-11T06:33:08.821Z",
+      };
+    },
+    async save(): Promise<void> {},
+  };
+
+  await requeueIssueForOperator(stateStore, state, 367);
+
+  assert.equal(state.issues["367"]?.state, "queued");
+  assert.equal(state.issues["367"]?.last_error, "manual review required");
+  assert.equal(state.issues["367"]?.last_failure_kind, "command_error");
+  assert.deepEqual(state.issues["367"]?.last_failure_context, original.last_failure_context);
+  assert.equal(state.issues["367"]?.last_blocker_signature, "manual-review");
+  assert.equal(state.issues["367"]?.last_failure_signature, "manual-review");
+  assert.equal(state.issues["367"]?.timeout_retry_count, 2);
+  assert.equal(state.issues["367"]?.blocked_verification_retry_count, 1);
+  assert.equal(state.issues["367"]?.repeated_blocker_count, 3);
+  assert.equal(state.issues["367"]?.repeated_failure_signature_count, 4);
 });
 
 test("requeueIssueForOperator rejects active tracked-PR work", async () => {
@@ -3606,7 +3658,7 @@ test("reconcileStaleActiveIssueReservation reports interrupted-turn progress as 
   await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
 });
 
-test("reconcileStaleActiveIssueReservation requeues a stale stabilizing issue without a tracked PR", async () => {
+test("reconcileStaleActiveIssueReservation clears only the stale reservation for a stabilizing issue without a tracked PR", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -3645,15 +3697,53 @@ test("reconcileStaleActiveIssueReservation requeues a stale stabilizing issue wi
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "queued");
+  assert.equal(state.issues["366"]?.state, "stabilizing");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_state_cleanup: requeued stabilizing issue #366 after issue lock and session lock were missing/,
+    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
   );
+});
+
+test("reconcileStaleActiveIssueReservation clears a stale reservation pointer for terminal records without mutating the record", async () => {
+  const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 366,
+    issues: {
+      "366": createRecord({
+        issue_number: 366,
+        state: "done",
+        codex_session_id: null,
+        last_error: null,
+      }),
+    },
+  };
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord): IssueRunRecord {
+      return record;
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileStaleActiveIssueReservation({
+    stateStore,
+    state,
+    issueLockPath: (issueNumber) => path.join(lockRoot, "locks", "issues", String(issueNumber)),
+    sessionLockPath: (sessionId) => path.join(lockRoot, "locks", "sessions", String(sessionId)),
+  });
+
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["366"]?.state, "done");
+  assert.equal(state.issues["366"]?.last_error, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents, []);
 });
 
 test("reconcileStaleActiveIssueReservation does not clear reservations for ambiguous owner locks", async () => {
@@ -3809,7 +3899,7 @@ test("reconcileStaleActiveIssueReservation clears stale no-PR failure tracking a
   );
 });
 
-test("reconcileStaleActiveIssueReservation blocks a repeated stale stabilizing no-PR loop at the repeat limit", async () => {
+test("reconcileStaleActiveIssueReservation leaves repeated stale stabilizing no-PR records unchanged while clearing the stale reservation", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -3851,35 +3941,32 @@ test("reconcileStaleActiveIssueReservation blocks a repeated stale stabilizing n
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.state, "stabilizing");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
-  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
+  assert.equal(state.issues["366"]?.blocked_reason, null);
   assert.equal(
     state.issues["366"]?.last_failure_signature,
     "stale-stabilizing-no-pr-recovery-loop",
   );
   assert.equal(
     state.issues["366"]?.repeated_failure_signature_count,
-    0,
+    config.sameFailureSignatureRepeatLimit - 1,
   );
   assert.equal(
     state.issues["366"]?.stale_stabilizing_no_pr_recovery_count,
-    config.sameFailureSignatureRepeatLimit,
+    config.sameFailureSignatureRepeatLimit - 1,
   );
-  assert.match(
-    state.issues["366"]?.last_error ?? "",
-    /manual intervention is required/i,
-  );
+  assert.equal(state.issues["366"]?.last_error, createRecord().last_error);
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_state_manual_stop: blocked issue #366 after repeated stale stabilizing recovery without a tracked PR/,
+    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
   );
 });
 
-test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stale stabilizing no-PR recovery for manual review", async () => {
+test("reconcileStaleActiveIssueReservation leaves already-satisfied-on-main stale stabilizing records unchanged while clearing the stale reservation", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -3925,31 +4012,21 @@ test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stal
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.state, "stabilizing");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
-  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
-  assert.match(
-    state.issues["366"]?.last_error ?? "",
-    /stale stabilizing recovery without authoritative completion evidence/,
-  );
-  assert.equal(state.issues["366"]?.last_failure_kind, null);
-  assert.equal(state.issues["366"]?.last_failure_context?.category, "blocked");
-  assert.deepEqual(state.issues["366"]?.last_failure_context?.details ?? [], [
-    "state=stabilizing",
-    "tracked_pr=none",
-    "github_issue_state=OPEN",
-    "completion_evidence=missing",
-    "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
-  ]);
-  assert.equal(state.issues["366"]?.last_failure_signature, null);
-  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
-  assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(state.issues["366"]?.blocked_reason, null);
+  assert.equal(state.issues["366"]?.last_error, createRecord().last_error);
+  assert.equal(state.issues["366"]?.last_failure_kind, createRecord().last_failure_kind);
+  assert.equal(state.issues["366"]?.last_failure_context?.signature, createRecord().last_failure_context?.signature);
+  assert.equal(state.issues["366"]?.last_failure_signature, "stale-stabilizing-no-pr-recovery-loop");
+  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 1);
+  assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 1);
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_stabilizing_no_pr_manual_review: blocked issue #366 after stale stabilizing recovery found an open issue with no authoritative completion signal/,
+    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
   );
 });
 


### PR DESCRIPTION
## Summary
- forward publishable allowlist markers through the remaining pre-publication path-gate call sites
- reset stale verification diagnostics on explicit operator requeue while preserving non-verification diagnostics
- narrow stale active-reservation cleanup so stale reservations clear without auto-requeueing no-PR stabilizing records

## Verification
- npx tsx --test src/run-once-turn-execution.test.ts
- npx tsx --test src/run-once-issue-preparation.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishable path allowlist markers in publication path gating.

* **Bug Fixes**
  * Improved verification-blocked issue requeue by clearing diagnostic fields.
  * Enhanced stale active issue reservation reconciliation.
  * Fixed requeue behavior for stabilizing issues without tracked pull requests.

* **Tests**
  * Added and updated tests for publication path validation and issue recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->