### PR TITLE
[codex] Respect timeout retry precedence before failed no-PR manual-review downgrade (#1598)

### DIFF
--- a/src/recovery-no-pr-reconciliation.ts
+++ b/src/recovery-no-pr-reconciliation.ts
@@ -3,7 +3,7 @@ import { type GitHubIssue, type IssueRunRecord, type SupervisorConfig, type Supe
 import { nowIso, truncate } from "./core/utils";
 import { isSafeCleanupTarget } from "./core/workspace";
 import { type RecoveryEvent } from "./run-once-cycle-prelude";
-import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
+import { applyFailureSignature, shouldAutoRetryTimeout } from "./supervisor/supervisor-failure-helpers";
 import {
   buildFailedNoPrBranchFailureContext,
   classifyFailedNoPrBranchRecovery,
@@ -82,6 +82,9 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     ensureOriginDefaultBranchFetched,
     isSafeCleanupTarget,
   });
+  if (branchRecovery.state === "dirty_workspace" && shouldAutoRetryTimeout(record, config)) {
+    return false;
+  }
   if (branchRecovery.state !== "recoverable") {
     const branchRecoveryReason = branchRecovery.state === "already_satisfied_on_main"
       ? `failed_no_pr_manual_review: blocked issue #${record.issue_number} after failed no-PR recovery found an open issue with no authoritative completion signal`
@@ -92,7 +95,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     );
     const manualReviewFailureContext = buildFailedNoPrBranchFailureContext({
       record,
-      branchRecoveryState: branchRecovery.state,
+      branchRecoveryState: branchRecovery.state === "dirty_workspace" ? "manual_review_required" : branchRecovery.state,
       headSha: branchRecovery.headSha,
       defaultBranch: config.defaultBranch,
       preservedTrackedFiles: branchRecovery.preservedTrackedFiles,

--- a/src/recovery-support.ts
+++ b/src/recovery-support.ts
@@ -12,7 +12,11 @@ import { resolveTrackedIssueHostPaths } from "./core/journal";
 import { type IssueRunRecord, type SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
 
-type FailedNoPrBranchRecoveryState = "recoverable" | "already_satisfied_on_main" | "manual_review_required";
+type FailedNoPrBranchRecoveryState =
+  | "recoverable"
+  | "dirty_workspace"
+  | "already_satisfied_on_main"
+  | "manual_review_required";
 
 const FAILED_NO_PR_ALREADY_SATISFIED_SIGNATURE = "failed-no-pr-already-satisfied-on-main";
 const FAILED_NO_PR_MANUAL_REVIEW_SIGNATURE = "failed-no-pr-manual-review-required";
@@ -191,7 +195,7 @@ export async function classifyFailedNoPrBranchRecovery(args: {
     }
 
     return {
-      state: "manual_review_required",
+      state: "dirty_workspace",
       headSha: headResult.stdout.trim() || null,
       preservedTrackedFiles: [
         ...new Set([

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -6834,6 +6834,136 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileStaleFailedIssueStates keeps retryable timeout failed no-PR issues failed when the workspace is structurally valid but dirty", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+  await fs.writeFile(path.join(workspacePath, "feature.txt"), "recoverable checkpoint\n");
+  await runCommand("git", ["-C", workspacePath, "add", "feature.txt"]);
+  await runCommand("git", ["-C", workspacePath, "commit", "-m", "recoverable checkpoint"]);
+  await fs.writeFile(path.join(workspacePath, "feature.txt"), "recoverable checkpoint\nextra dirty edit\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    timeoutRetryLimit: 2,
+  });
+  const originalFailureContext = {
+    category: "codex" as const,
+    summary: "Command timed out after 1800000ms: codex exec resume thread-366",
+    signature: "timeout-resume-thread-366",
+    command: null,
+    details: ["provider=codex", "phase=recovering"],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const originalRuntimeFailureContext = {
+    category: "codex" as const,
+    summary: "Supervisor failed while recovering a Codex turn for issue #366.",
+    signature: "recovering-timeout-thread-366",
+    command: null,
+    details: [
+      "previous_state=reproducing",
+      "workspace_dirty=yes",
+      "workspace_head=deadbee",
+      "pr_number=none",
+      "pr_head=none",
+      "codex_session_id=thread-366",
+    ],
+    url: null,
+    updated_at: "2026-03-13T00:20:05Z",
+  };
+  const original = createRecord({
+    issue_number: 366,
+    state: "failed",
+    branch: "codex/reopen-issue-366",
+    workspace: workspacePath,
+    journal_path: journalPath,
+    pr_number: null,
+    last_head_sha: baseHead,
+    last_error: originalFailureContext.summary,
+    last_failure_kind: "timeout",
+    last_failure_context: originalFailureContext,
+    last_failure_signature: originalFailureContext.signature,
+    repeated_failure_signature_count: 1,
+    timeout_retry_count: 1,
+    last_runtime_error: originalRuntimeFailureContext.summary,
+    last_runtime_failure_kind: "timeout",
+    last_runtime_failure_context: originalRuntimeFailureContext,
+    codex_session_id: "session-366",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Keep retryable timeout no-PR failure pending",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.deepEqual(updated, original);
+  assert.equal(saveCalls, 0);
+});
+
 test("reconcileStaleFailedIssueStates snapshots the original runtime failure when no-PR manual review replaces failure context", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -132,6 +132,82 @@ test("buildNonRunnableLocalStateReasons keeps retry-budget ordering stable", () 
   ]);
 });
 
+test("buildIssueExplainSummary reports retryable timeout failures as timeout_retry pending", async () => {
+  const config = createConfig({
+    timeoutRetryLimit: 2,
+  });
+  const issue = createIssue({
+    number: 604,
+    title: "Retry timeout before manual review",
+    body: `## Summary
+Keep retryable timeout failures on the timeout retry path.
+
+## Scope
+- preserve retryable timeout diagnostics on failed no-PR records
+
+## Acceptance criteria
+- explain output reports timeout retry pending
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Execution order: 1 of 1
+Parallelizable: No`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issue.number)]: createRecord({
+        issue_number: issue.number,
+        state: "failed",
+        blocked_reason: null,
+        last_error: "Command timed out after 1800000ms: codex exec resume thread-604",
+        last_failure_kind: "timeout",
+        last_failure_context: {
+          category: "codex",
+          summary: "Command timed out after 1800000ms: codex exec resume thread-604",
+          signature: "timeout-resume-thread-604",
+          command: null,
+          details: ["provider=codex"],
+          url: null,
+          updated_at: "2026-03-19T00:00:00Z",
+        },
+        timeout_retry_count: 1,
+        last_runtime_failure_kind: "timeout",
+        last_runtime_failure_context: {
+          category: "codex",
+          summary: "Supervisor failed while recovering a Codex turn for issue #604.",
+          signature: "runtime-timeout-thread-604",
+          command: null,
+          details: ["workspace_dirty=yes"],
+          url: null,
+          updated_at: "2026-03-19T00:01:00Z",
+        },
+      }),
+    },
+  };
+
+  const lines = await buildIssueExplainSummary(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+    },
+    config,
+    state,
+    issue.number,
+  );
+
+  assert.ok(lines.includes("state=failed"));
+  assert.ok(lines.includes("blocked_reason=none"));
+  assert.ok(lines.includes("runnable=yes"));
+  assert.ok(lines.some((line) => line.startsWith("selection_reason=ready ")));
+  assert.ok(lines.some((line) => line.includes("retry_state=timeout_retry:1/2")));
+  assert.ok(lines.includes("runtime_failure_kind=timeout"));
+  assert.ok(lines.includes("runtime_failure_summary=Supervisor failed while recovering a Codex turn for issue #604."));
+});
+
 test("buildIssueExplainDto exposes typed operator activity context", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 605;


### PR DESCRIPTION
Closes #1598
This PR was opened by codex-supervisor.
Latest Codex summary:

I changed the failed no-PR recovery boundary so timeout-retry precedence is preserved when the workspace is structurally valid but merely dirty. In [src/recovery-support.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1598/src/recovery-support.ts:15) I split `dirty_workspace` from true structural-unsafety, and in [src/recovery-no-pr-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1598/src/recovery-no-pr-reconciliation.ts:82) I leave retryable timeout records unchanged in that case so they stay on the existing failed/timeout retry path. I added regressions in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1598/src/supervisor/supervisor-recovery-reconciliation.test.ts:6837) and [src/supervisor/supervisor-selection-issue-explain.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1598/src/supervisor/supervisor-selection-issue-explain.test.ts:135) to pin both the reconciliation behavior and the operator-facing `timeout_retry` diagnostics. Checkpoint commit is `a624f47`.

Focused verification passed for the new behavior and the adjacent unsafe-workspace controls via targeted `npx tsx --test --test-name-pattern ...` runs, and `npm run build` passed when rerun serially. The requested `npm test -- src/supervisor/...` commands still exit non-zero because this repo’s `npm test` script runs the full suite, and...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced automatic retry handling for timeout failures in failed branches, with improved distinction between recoverable dirty workspaces and cases requiring manual review.

* **Tests**
  * Added test coverage for timeout retry scenarios and dirty workspace state reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->