### PR TITLE
[codex] Preserve current-head bot review bookkeeping when unrelated tracked PR fields are stale (#1602)

### DIFF
--- a/src/recovery-reconciliation.test.ts
+++ b/src/recovery-reconciliation.test.ts
@@ -378,6 +378,68 @@ test("buildTrackedPrStaleFailureConvergencePatch clears stale head-scoped state 
   assert.equal(patch.repeated_failure_signature_count, 0);
 });
 
+test("buildTrackedPrStaleFailureConvergencePatch preserves current-head review bookkeeping when only unrelated head-scoped fields are stale", () => {
+  const failureContext = {
+    category: "manual" as const,
+    summary: "Configured bot thread is stale on the current head.",
+    signature: "stalled-bot:thread-1",
+    command: null,
+    details: ["processed_on_current_head=yes"],
+    url: "https://example.test/pr/191#discussion_r1",
+    updated_at: "2026-03-13T00:25:00Z",
+  };
+  const record = createRecord({
+    issue_number: 366,
+    state: "failed",
+    blocked_reason: "stale_review_bot",
+    pr_number: 191,
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_signature: "local-ci:blocker",
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Local CI passed on an older head.",
+      ran_at: "2026-03-12T00:05:00Z",
+      head_sha: "head-190",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 1,
+  });
+  const pr = createPullRequest({
+    number: 191,
+    headRefName: "codex/issue-366",
+    headRefOid: "head-191",
+  });
+
+  const patch = buildTrackedPrStaleFailureConvergencePatch({
+    record,
+    pr,
+    nextState: "blocked",
+    failureContext,
+    blockedReason: "stale_review_bot",
+  });
+
+  assert.equal(patch.state, "blocked");
+  assert.equal(patch.last_head_sha, "head-191");
+  assert.equal(patch.blocked_reason, "stale_review_bot");
+  assert.equal("review_follow_up_head_sha" in patch, false);
+  assert.equal("review_follow_up_remaining" in patch, false);
+  assert.equal("processed_review_thread_ids" in patch, false);
+  assert.equal("processed_review_thread_fingerprints" in patch, false);
+  assert.equal(patch.last_host_local_pr_blocker_comment_signature, null);
+  assert.equal(patch.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(patch.latest_local_ci_result, null);
+  assert.equal(patch.last_failure_signature, failureContext.signature);
+  assert.equal(patch.repeated_failure_signature_count, 1);
+});
+
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd,

--- a/src/recovery-reconciliation.test.ts
+++ b/src/recovery-reconciliation.test.ts
@@ -549,6 +549,68 @@ test("buildTrackedPrStaleFailureConvergencePatch clears processed review bookkee
   assert.equal(patch.repeated_failure_signature_count, 1);
 });
 
+test("buildTrackedPrStaleFailureConvergencePatch prunes stale processed review markers while preserving current-head bookkeeping", () => {
+  const failureContext = {
+    category: "manual" as const,
+    summary: "Configured bot thread still needs cleanup.",
+    signature: "stalled-bot:thread-1",
+    command: null,
+    details: ["processed_on_current_head=yes"],
+    url: "https://example.test/pr/191#discussion_r1",
+    updated_at: "2026-03-13T00:25:00Z",
+  };
+  const record = createRecord({
+    issue_number: 366,
+    state: "failed",
+    blocked_reason: "stale_review_bot",
+    pr_number: 191,
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-190", "thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-190#comment-1", "thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_signature: "local-ci:blocker",
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Local CI passed on an older head.",
+      ran_at: "2026-03-12T00:05:00Z",
+      head_sha: "head-190",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 1,
+  });
+  const pr = createPullRequest({
+    number: 191,
+    headRefName: "codex/issue-366",
+    headRefOid: "head-191",
+  });
+
+  const patch = buildTrackedPrStaleFailureConvergencePatch({
+    record,
+    pr,
+    nextState: "blocked",
+    failureContext,
+    blockedReason: "stale_review_bot",
+  });
+
+  assert.equal(patch.state, "blocked");
+  assert.equal(patch.last_head_sha, "head-191");
+  assert.equal(patch.blocked_reason, "stale_review_bot");
+  assert.equal(patch.review_follow_up_head_sha, undefined);
+  assert.equal(patch.review_follow_up_remaining, undefined);
+  assert.deepEqual(patch.processed_review_thread_ids, ["thread-1@head-191"]);
+  assert.deepEqual(patch.processed_review_thread_fingerprints, ["thread-1@head-191#comment-1"]);
+  assert.equal(patch.last_host_local_pr_blocker_comment_signature, null);
+  assert.equal(patch.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(patch.latest_local_ci_result, null);
+  assert.equal(patch.last_failure_signature, failureContext.signature);
+  assert.equal(patch.repeated_failure_signature_count, 1);
+});
+
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd,

--- a/src/recovery-reconciliation.test.ts
+++ b/src/recovery-reconciliation.test.ts
@@ -440,6 +440,53 @@ test("buildTrackedPrStaleFailureConvergencePatch preserves current-head review b
   assert.equal(patch.repeated_failure_signature_count, 1);
 });
 
+test("buildTrackedPrStaleFailureConvergencePatch clears review bookkeeping when the tracked head anchor is unknown", () => {
+  const record = createRecord({
+    issue_number: 366,
+    state: "failed",
+    pr_number: 191,
+    last_head_sha: null,
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Local CI passed on a stale blocker head.",
+      ran_at: "2026-03-12T00:05:00Z",
+      head_sha: "head-190",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+    last_failure_signature: "review:stale-bot",
+    repeated_failure_signature_count: 3,
+  });
+  const pr = createPullRequest({
+    number: 191,
+    headRefName: "codex/issue-366",
+    headRefOid: "head-191",
+  });
+
+  const patch = buildTrackedPrStaleFailureConvergencePatch({
+    record,
+    pr,
+    nextState: "addressing_review",
+    failureContext: null,
+    blockedReason: null,
+  });
+
+  assert.equal(patch.last_head_sha, "head-191");
+  assert.equal(patch.latest_local_ci_result, null);
+  assert.equal(patch.review_follow_up_head_sha, null);
+  assert.equal(patch.review_follow_up_remaining, 0);
+  assert.deepEqual(patch.processed_review_thread_ids, []);
+  assert.deepEqual(patch.processed_review_thread_fingerprints, []);
+  assert.equal(patch.last_failure_signature, null);
+  assert.equal(patch.repeated_failure_signature_count, 0);
+});
+
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd,

--- a/src/recovery-reconciliation.test.ts
+++ b/src/recovery-reconciliation.test.ts
@@ -487,6 +487,68 @@ test("buildTrackedPrStaleFailureConvergencePatch clears review bookkeeping when 
   assert.equal(patch.repeated_failure_signature_count, 0);
 });
 
+test("buildTrackedPrStaleFailureConvergencePatch clears processed review bookkeeping when markers belong to an older head", () => {
+  const failureContext = {
+    category: "manual" as const,
+    summary: "Configured bot thread still needs cleanup.",
+    signature: "stalled-bot:thread-1",
+    command: null,
+    details: ["processed_on_current_head=no"],
+    url: "https://example.test/pr/191#discussion_r1",
+    updated_at: "2026-03-13T00:25:00Z",
+  };
+  const record = createRecord({
+    issue_number: 366,
+    state: "failed",
+    blocked_reason: "manual_review",
+    pr_number: 191,
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-190"],
+    processed_review_thread_fingerprints: ["thread-1@head-190#comment-1"],
+    last_host_local_pr_blocker_comment_signature: "local-ci:blocker",
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Local CI passed on an older head.",
+      ran_at: "2026-03-12T00:05:00Z",
+      head_sha: "head-190",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 1,
+  });
+  const pr = createPullRequest({
+    number: 191,
+    headRefName: "codex/issue-366",
+    headRefOid: "head-191",
+  });
+
+  const patch = buildTrackedPrStaleFailureConvergencePatch({
+    record,
+    pr,
+    nextState: "blocked",
+    failureContext,
+    blockedReason: "manual_review",
+  });
+
+  assert.equal(patch.state, "blocked");
+  assert.equal(patch.last_head_sha, "head-191");
+  assert.equal(patch.blocked_reason, "manual_review");
+  assert.equal(patch.review_follow_up_head_sha, null);
+  assert.equal(patch.review_follow_up_remaining, 0);
+  assert.deepEqual(patch.processed_review_thread_ids, []);
+  assert.deepEqual(patch.processed_review_thread_fingerprints, []);
+  assert.equal(patch.last_host_local_pr_blocker_comment_signature, null);
+  assert.equal(patch.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(patch.latest_local_ci_result, null);
+  assert.equal(patch.last_failure_signature, failureContext.signature);
+  assert.equal(patch.repeated_failure_signature_count, 1);
+});
+
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd,

--- a/src/recovery-reconciliation.test.ts
+++ b/src/recovery-reconciliation.test.ts
@@ -437,7 +437,7 @@ test("buildTrackedPrStaleFailureConvergencePatch preserves current-head review b
   assert.equal(patch.last_host_local_pr_blocker_comment_head_sha, null);
   assert.equal(patch.latest_local_ci_result, null);
   assert.equal(patch.last_failure_signature, failureContext.signature);
-  assert.equal(patch.repeated_failure_signature_count, 1);
+  assert.equal(patch.repeated_failure_signature_count, 2);
 });
 
 test("buildTrackedPrStaleFailureConvergencePatch clears review bookkeeping when the tracked head anchor is unknown", () => {
@@ -546,7 +546,7 @@ test("buildTrackedPrStaleFailureConvergencePatch clears processed review bookkee
   assert.equal(patch.last_host_local_pr_blocker_comment_head_sha, null);
   assert.equal(patch.latest_local_ci_result, null);
   assert.equal(patch.last_failure_signature, failureContext.signature);
-  assert.equal(patch.repeated_failure_signature_count, 1);
+  assert.equal(patch.repeated_failure_signature_count, 2);
 });
 
 test("buildTrackedPrStaleFailureConvergencePatch prunes stale processed review markers while preserving current-head bookkeeping", () => {
@@ -608,7 +608,7 @@ test("buildTrackedPrStaleFailureConvergencePatch prunes stale processed review m
   assert.equal(patch.last_host_local_pr_blocker_comment_head_sha, null);
   assert.equal(patch.latest_local_ci_result, null);
   assert.equal(patch.last_failure_signature, failureContext.signature);
-  assert.equal(patch.repeated_failure_signature_count, 1);
+  assert.equal(patch.repeated_failure_signature_count, 2);
 });
 
 function git(cwd: string, args: string[]): string {

--- a/src/recovery-tracked-pr-support.ts
+++ b/src/recovery-tracked-pr-support.ts
@@ -24,7 +24,9 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
     copilotReviewTimeoutPatch = {},
   } = args;
   const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, pr.headRefOid);
-  const headAdvanced = Object.keys(headAdvanceResetPatch).length > 0;
+  // Same-head cleanup can still emit a non-empty patch; only reset repeat-failure
+  // bookkeeping when the tracked PR head actually changed.
+  const headAdvanced = record.last_head_sha !== pr.headRefOid;
   const failureSignatureBaseRecord = headAdvanced
     ? {
       ...record,

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -260,6 +260,60 @@ test("resetTrackedPrHeadScopedStateOnAdvance preserves current-head review bookk
   });
 });
 
+test("resetTrackedPrHeadScopedStateOnAdvance does not preserve review bookkeeping when the tracked head anchor is unknown", () => {
+  const record = createRecord({
+    last_head_sha: null,
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "stale local CI result",
+      head_sha: "head-190",
+      ran_at: "2026-03-16T10:00:00Z",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+
+  assert.deepEqual(resetTrackedPrHeadScopedStateOnAdvance(record, "head-191"), {
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    pre_merge_evaluation_outcome: null,
+    pre_merge_must_fix_count: 0,
+    pre_merge_manual_review_count: 0,
+    pre_merge_follow_up_count: 0,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    latest_local_ci_result: null,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
+    last_host_local_pr_blocker_comment_signature: null,
+    last_host_local_pr_blocker_comment_head_sha: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+  });
+});
+
 test("projectTrackedPrLifecycle keeps stale configured-bot classification when current-head review bookkeeping survives unrelated stale fields", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -314,6 +314,60 @@ test("resetTrackedPrHeadScopedStateOnAdvance does not preserve review bookkeepin
   });
 });
 
+test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when processed thread markers belong to an older head", () => {
+  const record = createRecord({
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-190"],
+    processed_review_thread_fingerprints: ["thread-1@head-190#comment-1"],
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "stale local CI result",
+      head_sha: "head-190",
+      ran_at: "2026-03-16T10:00:00Z",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+
+  assert.deepEqual(resetTrackedPrHeadScopedStateOnAdvance(record, "head-191"), {
+    local_review_head_sha: null,
+    local_review_blocker_summary: null,
+    local_review_summary_path: null,
+    local_review_run_at: null,
+    local_review_max_severity: null,
+    local_review_findings_count: 0,
+    local_review_root_cause_count: 0,
+    local_review_verified_max_severity: null,
+    local_review_verified_findings_count: 0,
+    local_review_recommendation: null,
+    local_review_degraded: false,
+    pre_merge_evaluation_outcome: null,
+    pre_merge_must_fix_count: 0,
+    pre_merge_manual_review_count: 0,
+    pre_merge_follow_up_count: 0,
+    last_local_review_signature: null,
+    repeated_local_review_signature_count: 0,
+    latest_local_ci_result: null,
+    external_review_head_sha: null,
+    external_review_misses_path: null,
+    external_review_matched_findings_count: 0,
+    external_review_near_match_findings_count: 0,
+    external_review_missed_findings_count: 0,
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
+    last_host_local_pr_blocker_comment_signature: null,
+    last_host_local_pr_blocker_comment_head_sha: null,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+  });
+});
+
 test("projectTrackedPrLifecycle keeps stale configured-bot classification when current-head review bookkeeping survives unrelated stale fields", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -229,7 +229,105 @@ test("projectTrackedPrLifecycle preserves processed bot-thread state when option
   });
 
   assert.equal(projection.nextState, "blocked");
-  assert.equal(projection.nextBlockedReason, "manual_review");
+  assert.equal(projection.nextBlockedReason, "stale_review_bot");
   assert.deepEqual(projection.recordForState.processed_review_thread_ids, ["thread-1@head-191"]);
   assert.deepEqual(projection.recordForState.processed_review_thread_fingerprints, ["thread-1@head-191#comment-1"]);
+});
+
+test("resetTrackedPrHeadScopedStateOnAdvance preserves current-head review bookkeeping when only unrelated head-scoped fields are stale", () => {
+  const record = createRecord({
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "stale local CI result",
+      head_sha: "head-190",
+      ran_at: "2026-03-16T10:00:00Z",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+
+  assert.deepEqual(resetTrackedPrHeadScopedStateOnAdvance(record, "head-191"), {
+    latest_local_ci_result: null,
+    last_host_local_pr_blocker_comment_signature: null,
+    last_host_local_pr_blocker_comment_head_sha: null,
+  });
+});
+
+test("projectTrackedPrLifecycle keeps stale configured-bot classification when current-head review bookkeeping survives unrelated stale fields", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    state: "blocked",
+    blocked_reason: "stale_review_bot",
+    pr_number: 191,
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "stale local CI result",
+      head_sha: "head-190",
+      ran_at: "2026-03-16T10:00:00Z",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    number: 191,
+    headRefOid: "head-191",
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotCurrentHeadObservedAt: "2026-03-16T10:04:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      isResolved: false,
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "This configured-bot finding is stale on the current head.",
+            createdAt: "2026-03-16T10:05:00Z",
+            url: "https://example.test/pr/191#discussion_r1",
+            author: {
+              login: "coderabbitai[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const projection = projectTrackedPrLifecycle({
+    config,
+    record,
+    pr,
+    checks: passingChecks(),
+    reviewThreads,
+  });
+
+  assert.equal(projection.nextState, "blocked");
+  assert.equal(projection.nextBlockedReason, "stale_review_bot");
+  assert.equal(projection.recordForState.review_follow_up_head_sha, "head-191");
+  assert.equal(projection.recordForState.review_follow_up_remaining, 0);
+  assert.deepEqual(projection.recordForState.processed_review_thread_ids, ["thread-1@head-191"]);
+  assert.deepEqual(projection.recordForState.processed_review_thread_fingerprints, ["thread-1@head-191#comment-1"]);
+  assert.equal(projection.recordForState.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(projection.recordForState.latest_local_ci_result, null);
 });

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -368,6 +368,35 @@ test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when proc
   });
 });
 
+test("resetTrackedPrHeadScopedStateOnAdvance prunes older processed thread markers while preserving current-head bookkeeping", () => {
+  const record = createRecord({
+    last_head_sha: "head-191",
+    review_follow_up_head_sha: "head-191",
+    review_follow_up_remaining: 0,
+    processed_review_thread_ids: ["thread-1@head-190", "thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-190#comment-1", "thread-1@head-191#comment-1"],
+    last_host_local_pr_blocker_comment_signature: "local-ci:blocker",
+    last_host_local_pr_blocker_comment_head_sha: "head-190",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Local CI passed on an older head.",
+      ran_at: "2026-03-12T00:05:00Z",
+      head_sha: "head-190",
+      execution_mode: "shell",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+
+  assert.deepEqual(resetTrackedPrHeadScopedStateOnAdvance(record, "head-191"), {
+    latest_local_ci_result: null,
+    last_host_local_pr_blocker_comment_signature: null,
+    last_host_local_pr_blocker_comment_head_sha: null,
+    processed_review_thread_ids: ["thread-1@head-191"],
+    processed_review_thread_fingerprints: ["thread-1@head-191#comment-1"],
+  });
+});
+
 test("projectTrackedPrLifecycle keeps stale configured-bot classification when current-head review bookkeeping survives unrelated stale fields", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -69,9 +69,28 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     || blockerCommentHeadStale
     || observedHostLocalBlockerHeadStale
     || localCiHeadStale;
+  const sameTrackedHead = record.last_head_sha === null || record.last_head_sha === nextHeadSha;
 
-  if ((record.last_head_sha === null || record.last_head_sha === nextHeadSha) && !headScopedStateDiverged) {
+  if (sameTrackedHead && !headScopedStateDiverged) {
     return {};
+  }
+
+  if (sameTrackedHead && !localReviewHeadStale && !externalReviewHeadStale && !reviewFollowUpHeadStale) {
+    return {
+      ...(localCiHeadStale ? { latest_local_ci_result: null } : {}),
+      ...(observedHostLocalBlockerHeadStale
+        ? {
+            last_observed_host_local_pr_blocker_signature: null,
+            last_observed_host_local_pr_blocker_head_sha: null,
+          }
+        : {}),
+      ...(blockerCommentHeadStale
+        ? {
+            last_host_local_pr_blocker_comment_signature: null,
+            last_host_local_pr_blocker_comment_head_sha: null,
+          }
+        : {}),
+    };
   }
 
   return {

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -69,7 +69,7 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     || blockerCommentHeadStale
     || observedHostLocalBlockerHeadStale
     || localCiHeadStale;
-  const sameTrackedHead = record.last_head_sha === null || record.last_head_sha === nextHeadSha;
+  const sameTrackedHead = record.last_head_sha === nextHeadSha;
 
   if (sameTrackedHead && !headScopedStateDiverged) {
     return {};

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -50,6 +50,13 @@ function processedReviewThreadIdsStaleForHead(
   return processedThreadIds.some((key) => key.includes("@") && !key.endsWith(`@${nextHeadSha}`));
 }
 
+function filterProcessedReviewThreadIdsForHead(
+  processedThreadIds: readonly string[],
+  nextHeadSha: string,
+): string[] {
+  return processedThreadIds.filter((key) => !key.includes("@") || key.endsWith(`@${nextHeadSha}`));
+}
+
 function processedReviewThreadFingerprintsStaleForHead(
   processedThreadFingerprints: readonly string[],
   nextHeadSha: string,
@@ -58,6 +65,17 @@ function processedReviewThreadFingerprintsStaleForHead(
     const fingerprintSeparator = key.indexOf("#");
     const threadKey = fingerprintSeparator >= 0 ? key.slice(0, fingerprintSeparator) : key;
     return threadKey.includes("@") && !threadKey.endsWith(`@${nextHeadSha}`);
+  });
+}
+
+function filterProcessedReviewThreadFingerprintsForHead(
+  processedThreadFingerprints: readonly string[],
+  nextHeadSha: string,
+): string[] {
+  return processedThreadFingerprints.filter((key) => {
+    const fingerprintSeparator = key.indexOf("#");
+    const threadKey = fingerprintSeparator >= 0 ? key.slice(0, fingerprintSeparator) : key;
+    return !threadKey.includes("@") || threadKey.endsWith(`@${nextHeadSha}`);
   });
 }
 
@@ -88,6 +106,14 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     record.processed_review_thread_fingerprints ?? [],
     nextHeadSha,
   );
+  const currentHeadProcessedThreadIds = filterProcessedReviewThreadIdsForHead(
+    record.processed_review_thread_ids ?? [],
+    nextHeadSha,
+  );
+  const currentHeadProcessedThreadFingerprints = filterProcessedReviewThreadFingerprintsForHead(
+    record.processed_review_thread_fingerprints ?? [],
+    nextHeadSha,
+  );
   const headScopedStateDiverged =
     localReviewHeadStale
     || externalReviewHeadStale
@@ -108,10 +134,23 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     && !localReviewHeadStale
     && !externalReviewHeadStale
     && !reviewFollowUpHeadStale
-    && !processedThreadIdsHeadStale
-    && !processedThreadFingerprintsHeadStale
+    && (
+      (!processedThreadIdsHeadStale && !processedThreadFingerprintsHeadStale) ||
+      currentHeadProcessedThreadIds.length > 0 ||
+      currentHeadProcessedThreadFingerprints.length > 0
+    )
   ) {
     return {
+      ...(processedThreadIdsHeadStale
+        ? {
+            processed_review_thread_ids: currentHeadProcessedThreadIds,
+          }
+        : {}),
+      ...(processedThreadFingerprintsHeadStale
+        ? {
+            processed_review_thread_fingerprints: currentHeadProcessedThreadFingerprints,
+          }
+        : {}),
       ...(localCiHeadStale ? { latest_local_ci_result: null } : {}),
       ...(observedHostLocalBlockerHeadStale
         ? {

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -43,6 +43,24 @@ export interface TrackedPrLifecycleProjection {
   shouldSuppressRecovery: boolean;
 }
 
+function processedReviewThreadIdsStaleForHead(
+  processedThreadIds: readonly string[],
+  nextHeadSha: string,
+): boolean {
+  return processedThreadIds.some((key) => key.includes("@") && !key.endsWith(`@${nextHeadSha}`));
+}
+
+function processedReviewThreadFingerprintsStaleForHead(
+  processedThreadFingerprints: readonly string[],
+  nextHeadSha: string,
+): boolean {
+  return processedThreadFingerprints.some((key) => {
+    const fingerprintSeparator = key.indexOf("#");
+    const threadKey = fingerprintSeparator >= 0 ? key.slice(0, fingerprintSeparator) : key;
+    return threadKey.includes("@") && !threadKey.endsWith(`@${nextHeadSha}`);
+  });
+}
+
 export function resetTrackedPrHeadScopedStateOnAdvance(
   record: IssueRunRecord,
   nextHeadSha: string,
@@ -62,20 +80,37 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
   const localCiHeadStale =
     record.latest_local_ci_result?.head_sha != null
     && record.latest_local_ci_result.head_sha !== nextHeadSha;
+  const processedThreadIdsHeadStale = processedReviewThreadIdsStaleForHead(
+    record.processed_review_thread_ids ?? [],
+    nextHeadSha,
+  );
+  const processedThreadFingerprintsHeadStale = processedReviewThreadFingerprintsStaleForHead(
+    record.processed_review_thread_fingerprints ?? [],
+    nextHeadSha,
+  );
   const headScopedStateDiverged =
     localReviewHeadStale
     || externalReviewHeadStale
     || reviewFollowUpHeadStale
     || blockerCommentHeadStale
     || observedHostLocalBlockerHeadStale
-    || localCiHeadStale;
+    || localCiHeadStale
+    || processedThreadIdsHeadStale
+    || processedThreadFingerprintsHeadStale;
   const sameTrackedHead = record.last_head_sha === nextHeadSha;
 
   if (sameTrackedHead && !headScopedStateDiverged) {
     return {};
   }
 
-  if (sameTrackedHead && !localReviewHeadStale && !externalReviewHeadStale && !reviewFollowUpHeadStale) {
+  if (
+    sameTrackedHead
+    && !localReviewHeadStale
+    && !externalReviewHeadStale
+    && !reviewFollowUpHeadStale
+    && !processedThreadIdsHeadStale
+    && !processedThreadFingerprintsHeadStale
+  ) {
     return {
       ...(localCiHeadStale ? { latest_local_ci_result: null } : {}),
       ...(observedHostLocalBlockerHeadStale


### PR DESCRIPTION
Closes #1602
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the fix in `91ddab6` on `codex/issue-1602`.

`resetTrackedPrHeadScopedStateOnAdvance(...)` now distinguishes between real head advancement / stale review bookkeeping versus unrelated same-head drift. On the same tracked PR head, stale fields like `latest_local_ci_result` and blocker-comment head markers are cleared selectively, while current-head configured-bot bookkeeping is preserved. If the review bookkeeping itself is stale, the broader reset still happens. I added focused regressions for lifecycle projection and the shared stale-recovery patch path, and updated the local issue journal working notes.

Tests:
- `npx tsx --test src/tracked-pr-lifecycle-projection.test.ts`
- `npx tsx --test src/recovery-reconciliation.test.ts`
- `npx tsx --test src/pull-request-state-policy.test.ts`
- `npx tsx --test src/supervisor/supervisor-failure-context.test.ts`
- `npm run build`

Summary: Preserved current-head configured-bot review bookkeeping during same-head tracked PR projection/recovery when only unrelated head-scoped fields were stale; committed as `91ddab6`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/tracked-pr-lifecycle-projection.test.ts`; `npx tsx --test src/recovery-reconciliation.test.ts`; `npx tsx --test src/pull-request-state-policy.test.ts`; `npx tsx --test src/supervisor/supervisor-failure-context.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1602` with commit `91ddab6...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit coverage for PR recovery and lifecycle: full reset when tracked head is unknown; partial-preserve when tracked head matches; pruning stale review markers from older heads; asserting blocked-reason transitions to "stale_review_bot" and preservation/clearing of head-scoped bookkeeping as appropriate.

* **Refactor**
  * Improved head-compatibility logic to selectively clear stale CI/blocker and host-local comment fields, prune outdated processed-review markers, preserve current-head review bookkeeping when appropriate, and only reset failure-signature tracking when the PR head actually advances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->