### PR TITLE
bug: repeat-stop tracked PR sticky status sync must not mutate during dry-run (#1605)

### DIFF
--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1038,6 +1038,10 @@ test("runOnce blocks tracked PR review work instead of failing after repeated id
   const reviewThreads = [createReviewThread()];
 
   let getPullRequestCalls = 0;
+  let addIssueCommentCalls = 0;
+  let updateIssueCommentCalls = 0;
+  let replyToReviewThreadCalls = 0;
+  let resolveReviewThreadCalls = 0;
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
@@ -1062,6 +1066,29 @@ test("runOnce blocks tracked PR review work instead of failing after repeated id
       assert.equal(prNumber, pr.number);
       return pr;
     },
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return pr;
+    },
+    getExternalReviewSurface: async (prNumber: number) => {
+      assert.equal(prNumber, pr.number);
+      return {
+        reviews: [],
+        issueComments: [],
+      };
+    },
+    addIssueComment: async () => {
+      addIssueCommentCalls += 1;
+    },
+    updateIssueComment: async () => {
+      updateIssueCommentCalls += 1;
+    },
+    replyToReviewThread: async () => {
+      replyToReviewThreadCalls += 1;
+    },
+    resolveReviewThread: async () => {
+      resolveReviewThreadCalls += 1;
+    },
     getMergedPullRequestsClosingIssue: async () => [],
     closeIssue: async () => {
       throw new Error("unexpected closeIssue call");
@@ -1078,6 +1105,10 @@ test("runOnce blocks tracked PR review work instead of failing after repeated id
   const record = persisted.issues[String(issueNumber)];
   assert.equal(persisted.activeIssueNumber, null);
   assert.equal(getPullRequestCalls, 1);
+  assert.equal(addIssueCommentCalls, 0);
+  assert.equal(updateIssueCommentCalls, 0);
+  assert.equal(replyToReviewThreadCalls, 0);
+  assert.equal(resolveReviewThreadCalls, 0);
   assert.equal(record.state, "blocked");
   assert.equal(record.blocked_reason, "manual_review");
   assert.equal(record.last_failure_kind, null);

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -637,21 +637,23 @@ export class Supervisor {
               "manual_review",
           });
           state.issues[String(record.issue_number)] = record;
-          record = await syncTrackedPrPersistentStatusComment({
-            github: this.github,
-            stateStore: this.stateStore,
-            state,
-            record,
-            pr,
-            checks,
-            reviewThreads,
-            syncJournal,
-            config: this.config,
-            failureContext: effectiveFailureContext,
-            summarizeChecks,
-            manualReviewThreadCount: manualReviewThreads(this.config, reviewThreads).length,
-            skipAutoHandleStaleConfiguredBotReview: true,
-          });
+          if (!options.dryRun) {
+            record = await syncTrackedPrPersistentStatusComment({
+              github: this.github,
+              stateStore: this.stateStore,
+              state,
+              record,
+              pr,
+              checks,
+              reviewThreads,
+              syncJournal,
+              config: this.config,
+              failureContext: effectiveFailureContext,
+              summarizeChecks,
+              manualReviewThreadCount: manualReviewThreads(this.config, reviewThreads).length,
+              skipAutoHandleStaleConfiguredBotReview: true,
+            });
+          }
           state.issues[String(record.issue_number)] = record;
           state.activeIssueNumber = null;
           await this.stateStore.save(state);


### PR DESCRIPTION
Closes #1605
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed the repeat-stop path in [src/supervisor/supervisor.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1605/src/supervisor/supervisor.ts:622) so dry-run no longer calls `syncTrackedPrPersistentStatusComment(...)`. Non-dry-run behavior is unchanged, so the sticky tracked-PR comment still refreshes for real repeat-stop `manual_review` and `stale_review_bot` blockers. I also tightened the existing regression in [src/supervisor/supervisor-execution-orchestration.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1605/src/supervisor/supervisor-execution-orchestration.test.ts:1026) to prove the dry-run repeat-stop path makes zero calls to `addIssueComment`, `updateIssueComment`, `replyToReviewThread`, or `resolveReviewThread`.

The issue journal was updated in the ignored worktree path `.codex-supervisor/issues/1605/issue-journal.md`, and the code/test change is committed as `ee80a35` with message `Avoid repeat-stop sticky sync during dry-run`. Focused verification passed with `npx tsx --test --test-name-pattern="runOnce blocks tracked PR review work instead of failing after repeated identical same-head review signatures|runOnce refreshes the sticky tracked PR status comment when repeated review failures block the current head|runPreparedIssue only refreshes the sticky tracked PR status comment when repeated review failures stop on stale configured-bot blockers" src/supervisor/supervisor-execution-orchestration.test.ts` a...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dry-run mode to properly prevent review automation side effects from executing. Running with dry-run enabled now prevents comments, thread updates, and status synchronization from modifying pull requests during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->