### PR TITLE
Add workstation-local path-literal prompt guidance

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,47 +1,33 @@
-# Issue #1528: Perf: bound tracked_merged_but_open_issues reconciliation on large hosts
+# Issue #1607: Add workstation-local path-literal guidance to issue authoring and review prompts
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1528
-- Branch: codex/issue-1528
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1607
+- Branch: codex/issue-1607
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 1fee534698200459364f83a7ced37678f99e1858
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 5c06baf7648e92c7f5c35f94b289a46876264e5c
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ856z87d
-- Repeated failure signature count: 1
-- Updated at: 2026-04-14T12:36:09.008Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-20T21:59:16.296Z
 
 ## Latest Codex Summary
-Added bounded observability for `tracked_merged_but_open_issues`. The reconciliation path now emits an explicit recovery event when it stops at the per-cycle budget with backlog remaining, and read-only `status`/`doctor` now show the persisted resume cursor plus tracked backlog counts so operators can tell the loop is draining work rather than stuck. I also added a shared backlog-diagnostics helper and updated the focused reconciliation/diagnostics tests accordingly.
-
-Checkpoint commit: `1fee534` (`Bound tracked PR reconciliation backlog diagnostics`)
-
-Summary: Added bounded tracked-PR backlog diagnostics to recovery/status/doctor and committed the change as `1fee534`
-State hint: stabilizing
-Blocked reason: none
-Tests: `npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `npm run build`
-Next action: Open or update the PR with commit `1fee534`, then proceed with normal review/CI checks
-Failure signature: PRRT_kwDORgvdZ856z87d
+- None yet.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1529#discussion_r3079464712
-- Details:
-  - src/doctor.ts:631 summary=_⚠️ Potential issue_ | _🟠 Major_ **Guard backlog-state loading so doctor doesn’t fail hard on state-read errors.** Line 625 introduces an unguarded `loadState()` call. url=https://github.com/TommyKammy/codex-supervisor/pull/1529#discussion_r3079464712
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: the bounded backlog diagnostics were correct, but `doctor` still had one unguarded follow-up `loadState()` call after the main checks that could abort the whole command on filesystem read errors.
-- What changed: Guarded the backlog-only `loadState()` call in `diagnoseSupervisorHost`, degrade that failure into the canonical `state_file` doctor check with an explicit detail line, suppress the backlog diagnostic line when the follow-up read fails, and added a regression test for the second-read-throws path.
+- Hypothesis: The gap was limited to missing authoring/prompt guidance, so narrow prompt tests plus doc/template edits should close the issue without changing the detector or publication gate behavior.
+- What changed: Added concise workstation-local path-literal hygiene reminders to `docs/issue-metadata.md`, `.github/ISSUE_TEMPLATE/codex-execution-ready.md`, `src/codex/codex-prompt.ts`, and `src/local-review/prompt.ts`; added focused regression coverage in the corresponding prompt tests.
 - Current blocker: none
-- Next exact step: let PR #1529 resync on commit `e227a8d`, then resolve or reply to the remaining automated review thread if the refreshed diff still needs operator action.
-- Verification gap: none for this review-fix scope; I reran focused doctor/status diagnostics coverage plus a clean build and did not rerun unrelated reconciliation suites this turn.
-- Files touched: `.codex-supervisor/issue-journal.md`, `src/doctor.ts`, `src/doctor.test.ts`
-- Rollback concern: low; the change only affects `doctor` resilience when the diagnostic-only backlog reload fails, and the new failure mode is an explicit `state_file` diagnostic instead of a thrown command.
-- Last focused command: `npm run build`
+- Next exact step: Commit the verified checkpoint and open a draft PR for `codex/issue-1607`.
+- Verification gap: none for the requested local checks; detector/publication-gate behavior stayed unchanged and was covered indirectly by the unchanged `src/run-once-issue-selection.test.ts` pass.
+- Files touched: .github/ISSUE_TEMPLATE/codex-execution-ready.md, docs/issue-metadata.md, src/codex/codex-prompt.ts, src/codex/codex-prompt.test.ts, src/local-review/prompt.ts, src/local-review/prompt.test.ts
+- Rollback concern: Low; changes are prompt/doc text plus focused assertions only.
+- Last focused command: npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts src/run-once-issue-selection.test.ts && npm run build
 ### Scratchpad
-- Review fix committed and pushed as `e227a8d` (`Keep doctor resilient on backlog state reload failures`).
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/ISSUE_TEMPLATE/codex-execution-ready.md
+++ b/.github/ISSUE_TEMPLATE/codex-execution-ready.md
@@ -14,6 +14,7 @@ Standalone issue:
 - use Depends on: none
 - use Parallelizable: No unless you are sure
 - use Execution order: 1 of 1
+- avoid raw workstation-local absolute path literals in issue text, tests, fixtures, or examples when placeholders or fragment-based strings would verify the same behavior
 
 Sequenced child issue:
 - fill Part of with the parent epic number

--- a/docs/issue-metadata.md
+++ b/docs/issue-metadata.md
@@ -31,7 +31,7 @@ Safe default for a first standalone issue:
 
 Only add `Part of: #...` when the issue is a sequenced child under an epic or tracking issue.
 
-Path hygiene reminder: do not embed raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\Users\...` directly in issue text, tests, fixtures, or examples when placeholders or fragment-based strings would verify the same behavior.
+Path hygiene reminder: do not embed raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory directly in issue text, tests, fixtures, or examples when placeholders or fragment-based strings would verify the same behavior.
 
 ## Copy-paste examples
 

--- a/docs/issue-metadata.md
+++ b/docs/issue-metadata.md
@@ -31,6 +31,8 @@ Safe default for a first standalone issue:
 
 Only add `Part of: #...` when the issue is a sequenced child under an epic or tracking issue.
 
+Path hygiene reminder: do not embed raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\Users\...` directly in issue text, tests, fixtures, or examples when placeholders or fragment-based strings would verify the same behavior.
+
 ## Copy-paste examples
 
 Standalone `codex` issue:

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -250,7 +250,7 @@ test("buildCodexPrompt teaches implementation turns to avoid raw workstation-loc
 
   assert.match(
     prompt,
-    /Avoid raw workstation-local absolute path literals like `\/Users\/\.\.\.`, `\/home\/\.\.\.`, or `C:\\+Users\\+\.\.\.` in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior\./,
+    /Avoid raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior\./,
   );
 });
 

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -233,6 +233,27 @@ test("buildCodexPrompt includes fail-closed shared-memory heuristics for review-
   );
 });
 
+test("buildCodexPrompt teaches implementation turns to avoid raw workstation-local path literals in fixtures and durable artifacts", () => {
+  const prompt = buildCodexPrompt({
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "implementing" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  });
+
+  assert.match(
+    prompt,
+    /Avoid raw workstation-local absolute path literals like `\/Users\/\.\.\.`, `\/home\/\.\.\.`, or `C:\\+Users\\+\.\.\.` in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior\./,
+  );
+});
+
 test("buildCodexPrompt renders on-demand memory files even without always-read files", () => {
   const prompt = buildCodexPrompt({
     repoSlug: "owner/repo",

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -491,7 +491,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
       : []),
     "",
     "Path-literal hygiene:",
-    "- Avoid raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\\Users\\...` in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior.",
+    "- Avoid raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior.",
     "",
     ...failClosedReviewHeuristics,
     "",

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -490,6 +490,9 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
         ]
       : []),
     "",
+    "Path-literal hygiene:",
+    "- Avoid raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\\Users\\...` in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior.",
+    "",
     ...failClosedReviewHeuristics,
     "",
     ...authoritativeStateHeuristics,

--- a/src/local-review/prompt.test.ts
+++ b/src/local-review/prompt.test.ts
@@ -314,7 +314,7 @@ test("buildRolePrompt teaches reviewers to flag raw workstation-local path liter
 
   assert.match(
     prompt,
-    /Flag raw workstation-local absolute path literals like `\/Users\/\.\.\.`, `\/home\/\.\.\.`, or `C:\\+Users\\+\.\.\.` in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior\./,
+    /Flag raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior\./,
   );
 });
 
@@ -340,7 +340,7 @@ test("buildVerifierPrompt teaches verifiers to keep workstation-local path-liter
       {
         role: "reviewer",
         title: "Fixture uses a raw workstation-local path literal",
-        body: "The test embeds a raw /Users/... path even though a placeholder would verify the same behavior.",
+        body: "The test embeds a raw user-home absolute path literal even though a placeholder would verify the same behavior.",
         file: "src/example.test.ts",
         start: 12,
         end: 12,
@@ -356,7 +356,7 @@ test("buildVerifierPrompt teaches verifiers to keep workstation-local path-liter
 
   assert.match(
     prompt,
-    /Treat raw workstation-local absolute path literals like `\/Users\/\.\.\.`, `\/home\/\.\.\.`, or `C:\\+Users\\+\.\.\.` in tests, fixtures, docs, prompts, or committed examples as a real path-hygiene finding when a fragment-based or placeholder-based fixture would verify the same behavior\./,
+    /Treat raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, docs, prompts, or committed examples as a real path-hygiene finding when a fragment-based or placeholder-based fixture would verify the same behavior\./,
   );
 });
 

--- a/src/local-review/prompt.test.ts
+++ b/src/local-review/prompt.test.ts
@@ -287,6 +287,79 @@ test("buildRolePrompt teaches reviewer to flag unrelated cleanup but allow requi
   assert.match(prompt, /Do not treat minimal supporting changes as scope drift when they are necessary to make the issue fix correct, testable, or buildable\./);
 });
 
+test("buildRolePrompt teaches reviewers to flag raw workstation-local path literals as a path-hygiene regression", () => {
+  const prompt = buildRolePrompt({
+    repoSlug: "owner/repo",
+    issue: createIssue({
+      number: 206,
+      title: "Flag workstation-local path literals in review",
+      url: "https://example.test/issues/206",
+      createdAt: "2026-03-14T00:00:00Z",
+      updatedAt: "2026-03-14T00:00:00Z",
+    }),
+    branch: "codex/issue-206",
+    workspacePath: "/tmp/workspaces/issue-206",
+    defaultBranch: "main",
+    pr: createPullRequest({
+      number: 206,
+      url: "https://example.test/pr/206",
+      headRefOid: "head206",
+    }),
+    role: "reviewer",
+    alwaysReadFiles: [],
+    onDemandFiles: [],
+    confidenceThreshold: 0.7,
+    priorMissPatterns: [],
+  });
+
+  assert.match(
+    prompt,
+    /Flag raw workstation-local absolute path literals like `\/Users\/\.\.\.`, `\/home\/\.\.\.`, or `C:\\+Users\\+\.\.\.` in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior\./,
+  );
+});
+
+test("buildVerifierPrompt teaches verifiers to keep workstation-local path-literal findings actionable", () => {
+  const prompt = buildVerifierPrompt({
+    repoSlug: "owner/repo",
+    issue: createIssue({
+      number: 207,
+      title: "Verify workstation-local path-literal regressions",
+      url: "https://example.test/issues/207",
+      createdAt: "2026-03-14T00:00:00Z",
+      updatedAt: "2026-03-14T00:00:00Z",
+    }),
+    branch: "codex/issue-207",
+    workspacePath: "/tmp/workspaces/issue-207",
+    defaultBranch: "main",
+    pr: createPullRequest({
+      number: 207,
+      url: "https://example.test/pr/207",
+      headRefOid: "head207",
+    }),
+    findings: [
+      {
+        role: "reviewer",
+        title: "Fixture uses a raw workstation-local path literal",
+        body: "The test embeds a raw /Users/... path even though a placeholder would verify the same behavior.",
+        file: "src/example.test.ts",
+        start: 12,
+        end: 12,
+        severity: "medium",
+        confidence: 0.95,
+        category: "path_hygiene",
+        evidence: null,
+      },
+    ],
+    priorMissPatterns: [],
+    verifierGuardrails: [],
+  });
+
+  assert.match(
+    prompt,
+    /Treat raw workstation-local absolute path literals like `\/Users\/\.\.\.`, `\/home\/\.\.\.`, or `C:\\+Users\\+\.\.\.` in tests, fixtures, docs, prompts, or committed examples as a real path-hygiene finding when a fragment-based or placeholder-based fixture would verify the same behavior\./,
+  );
+});
+
 test("buildVerifierPrompt includes bounded relevant prior external misses", () => {
   const prompt = buildVerifierPrompt({
     repoSlug: "owner/repo",

--- a/src/local-review/prompt.ts
+++ b/src/local-review/prompt.ts
@@ -240,6 +240,7 @@ function roleGoal(role: string): string[] {
         "- On shared-memory failure paths, check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind.",
         "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
         "- Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit/roll back before crossing it.",
+        "- Flag raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\\Users\\...` in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior.",
         "- Ignore style nits unless they could hide a bug or maintenance trap.",
       ];
     case "docs_researcher":
@@ -407,6 +408,7 @@ export function buildVerifierPrompt(args: {
     "- Re-check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind.",
     "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
     "- Confirm that any transaction-scoped fix still commits or rolls back before network hops, queued work, adapter dispatch, or other remote waits.",
+    "- Treat raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\\Users\\...` in tests, fixtures, docs, prompts, or committed examples as a real path-hygiene finding when a fragment-based or placeholder-based fixture would verify the same behavior.",
     "",
     "Constraints:",
     "- Do not edit files, do not commit, and do not push.",

--- a/src/local-review/prompt.ts
+++ b/src/local-review/prompt.ts
@@ -240,7 +240,7 @@ function roleGoal(role: string): string[] {
         "- On shared-memory failure paths, check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind.",
         "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
         "- Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit/roll back before crossing it.",
-        "- Flag raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\\Users\\...` in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior.",
+        "- Flag raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior.",
         "- Ignore style nits unless they could hide a bug or maintenance trap.",
       ];
     case "docs_researcher":
@@ -408,7 +408,7 @@ export function buildVerifierPrompt(args: {
     "- Re-check that rejected mutations, forbidden writes, failed approval writes, and restore failures leave no orphan records, partial durable writes, or half-restored state behind.",
     "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
     "- Confirm that any transaction-scoped fix still commits or rolls back before network hops, queued work, adapter dispatch, or other remote waits.",
-    "- Treat raw workstation-local absolute path literals like `/Users/...`, `/home/...`, or `C:\\Users\\...` in tests, fixtures, docs, prompts, or committed examples as a real path-hygiene finding when a fragment-based or placeholder-based fixture would verify the same behavior.",
+    "- Treat raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, docs, prompts, or committed examples as a real path-hygiene finding when a fragment-based or placeholder-based fixture would verify the same behavior.",
     "",
     "Constraints:",
     "- Do not edit files, do not commit, and do not push.",


### PR DESCRIPTION
## Summary
- add workstation-local path-literal hygiene reminders to codex issue authoring docs and template
- teach Codex implementation and local-review prompts to avoid or flag raw workstation-local absolute path literals when placeholders or fragment assembly suffice
- keep detector, publication gate, and auto-normalization behavior unchanged

## Verification
- npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts src/run-once-issue-selection.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added path-hygiene reminders across issue templates and guidance documentation to discourage raw workstation-local absolute path literals in favor of placeholders and fragment-based strings.

* **Tests**
  * Added test cases validating path-literal hygiene instructions in code review and Codex prompts.

* **Chores**
  * Updated internal supervisor tracking and working notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->