### PR TITLE
#1609 Allow one bounded transient no-PR auto-requeue

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #1607: Add workstation-local path-literal guidance to issue authoring and review prompts
+# Issue #1609: Evaluate auto-requeue for transient no-PR codex failures with no meaningful branch diff
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1607
-- Branch: codex/issue-1607
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1609
+- Branch: codex/issue-1609
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 5c06baf7648e92c7f5c35f94b289a46876264e5c
+- Last head SHA: dd53cd3531d4bbace76892f823498a3b43c98faa
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-20T21:59:16.296Z
+- Updated at: 2026-04-21T06:24:48.135Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,13 +21,13 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The gap was limited to missing authoring/prompt guidance, so narrow prompt tests plus doc/template edits should close the issue without changing the detector or publication gate behavior.
-- What changed: Added concise workstation-local path-literal hygiene reminders to `docs/issue-metadata.md`, `.github/ISSUE_TEMPLATE/codex-execution-ready.md`, `src/codex/codex-prompt.ts`, and `src/local-review/prompt.ts`; added focused regression coverage in the corresponding prompt tests.
+- Hypothesis: Safe `already_satisfied_on_main` failed no-PR workspaces should auto-requeue exactly once when preserved runtime evidence is transient and allowlisted, while unsafe states and later recurrences stay fail-closed on manual review.
+- What changed: Added a transient-runtime allowlist at the failed no-PR reconciliation boundary, auto-requeueing the first safe `already_satisfied_on_main` recurrence and preserving later recurrences on manual review; added focused recovery plus explain/status regression coverage for the new path and updated older no-diff artifact expectations to the new one-time retry behavior.
 - Current blocker: none
-- Next exact step: Commit the verified checkpoint and open a draft PR for `codex/issue-1607`.
-- Verification gap: none for the requested local checks; detector/publication-gate behavior stayed unchanged and was covered indirectly by the unchanged `src/run-once-issue-selection.test.ts` pass.
-- Files touched: .github/ISSUE_TEMPLATE/codex-execution-ready.md, docs/issue-metadata.md, src/codex/codex-prompt.ts, src/codex/codex-prompt.test.ts, src/local-review/prompt.ts, src/local-review/prompt.test.ts
-- Rollback concern: Low; changes are prompt/doc text plus focused assertions only.
-- Last focused command: npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts src/run-once-issue-selection.test.ts && npm run build
+- Next exact step: Review the diff, commit the checkpoint on `codex/issue-1609`, and open or update the draft PR if needed.
+- Verification gap: No extra gap in the requested local gates; broader suite coverage beyond the focused bundle was not run this turn.
+- Files touched: .codex-supervisor/issue-journal.md; src/recovery-no-pr-reconciliation.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Rollback concern: The transient allowlist is intentionally narrow (`timeout` and `provider-capacity` via retained runtime evidence); widening it without new tests would weaken the fail-closed boundary.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-no-pr-reconciliation.ts
+++ b/src/recovery-no-pr-reconciliation.ts
@@ -37,6 +37,21 @@ function preserveOriginalRuntimeFailureContext(record: IssueRunRecord): Partial<
   };
 }
 
+function transientNoPrRuntimeEvidenceLabel(record: Pick<
+  IssueRunRecord,
+  "last_runtime_failure_kind" | "last_runtime_failure_context" | "last_failure_kind" | "last_failure_context"
+>): string | null {
+  const runtimeFailureKind = record.last_runtime_failure_kind ?? record.last_failure_kind;
+  const runtimeFailureContext = record.last_runtime_failure_context ?? record.last_failure_context;
+  if (runtimeFailureKind === "timeout") {
+    return "timeout";
+  }
+  if (runtimeFailureContext?.signature === "provider-capacity") {
+    return "provider-capacity";
+  }
+  return null;
+}
+
 export async function reconcileStaleFailedNoPrRecord(args: {
   github: Pick<import("./github").GitHubClient, "getIssue">;
   stateStore: StateStoreLike;
@@ -85,6 +100,37 @@ export async function reconcileStaleFailedNoPrRecord(args: {
   if (branchRecovery.state === "dirty_workspace" && shouldAutoRetryTimeout(record, config)) {
     return false;
   }
+  const previousNoPrRecoveryCount = record.stale_stabilizing_no_pr_recovery_count ?? 0;
+  const transientRuntimeEvidence = transientNoPrRuntimeEvidenceLabel(record);
+  const shouldAutoRequeueAlreadySatisfiedOnMain =
+    branchRecovery.state === "already_satisfied_on_main"
+    && transientRuntimeEvidence !== null
+    && previousNoPrRecoveryCount === 0;
+  if (shouldAutoRequeueAlreadySatisfiedOnMain) {
+    const recoveryEvent = buildRecoveryEvent(
+      record.issue_number,
+      `failed_no_pr_transient_retry: requeued issue #${record.issue_number} from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence ${transientRuntimeEvidence}`,
+    );
+    const patch: Partial<IssueRunRecord> = {
+      state: "queued",
+      pr_number: null,
+      codex_session_id: null,
+      blocked_reason: null,
+      last_error: null,
+      last_failure_kind: null,
+      last_failure_context: null,
+      last_blocker_signature: null,
+      last_failure_signature: null,
+      repeated_blocker_count: 0,
+      repeated_failure_signature_count: 0,
+      stale_stabilizing_no_pr_recovery_count: 1,
+      last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
+      ...preserveOriginalRuntimeFailureContext(record),
+    };
+    const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
+    state.issues[String(record.issue_number)] = updated;
+    return true;
+  }
   if (branchRecovery.state !== "recoverable") {
     const branchRecoveryReason = branchRecovery.state === "already_satisfied_on_main"
       ? `failed_no_pr_manual_review: blocked issue #${record.issue_number} after failed no-PR recovery found an open issue with no authoritative completion signal`
@@ -110,7 +156,10 @@ export async function reconcileStaleFailedNoPrRecord(args: {
       last_failure_context: manualReviewFailureContext,
       last_blocker_signature: null,
       repeated_blocker_count: 0,
-      stale_stabilizing_no_pr_recovery_count: 0,
+      stale_stabilizing_no_pr_recovery_count:
+        branchRecovery.state === "already_satisfied_on_main" && transientRuntimeEvidence !== null && previousNoPrRecoveryCount > 0
+          ? previousNoPrRecoveryCount
+          : 0,
       last_head_sha: branchRecovery.headSha ?? record.last_head_sha,
       ...preserveOriginalRuntimeFailureContext(record),
       ...applyFailureSignature(record, manualReviewFailureContext),

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1458,3 +1458,71 @@ test("explain does not report local_state failed after tracked PR recovery resum
   assert.doesNotMatch(explanation, /^reason_\d+=local_state failed$/m);
   assert.doesNotMatch(explanation, /^reason_\d+=blocked_failure /m);
 });
+
+test("explain surfaces failed no-PR transient auto-requeue recovery reasons", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 104;
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Failed no-PR transient auto-requeue recovery",
+    body: executionReadyBody("Explain should show why a transient already-satisfied failed no-PR issue was auto-requeued."),
+    createdAt: "2026-03-18T00:00:00Z",
+    updatedAt: "2026-03-18T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "queued",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: null,
+        blocked_reason: null,
+        last_error: null,
+        last_failure_kind: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        stale_stabilizing_no_pr_recovery_count: 1,
+        last_runtime_error: "Selected model is at capacity. Please try a different model.",
+        last_runtime_failure_kind: "codex_exit",
+        last_runtime_failure_context: {
+          category: "codex",
+          summary: "Selected model is at capacity. Please try a different model.",
+          signature: "provider-capacity",
+          command: null,
+          details: ["provider=codex"],
+          url: null,
+          updated_at: "2026-03-18T00:10:00Z",
+        },
+        last_recovery_reason:
+          "failed_no_pr_transient_retry: requeued issue #104 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity",
+        last_recovery_at: "2026-03-19T00:20:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => issue,
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^state=queued$/m);
+  assert.match(explanation, /^runnable=yes$/m);
+  assert.match(
+    explanation,
+    /^latest_recovery issue=#104 at=2026-03-19T00:20:00Z reason=failed_no_pr_transient_retry detail=requeued issue #104 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity$/m,
+  );
+  assert.match(explanation, /^runtime_failure_kind=codex_exit$/m);
+  assert.match(explanation, /^runtime_failure_summary=Selected model is at capacity\. Please try a different model\.$/m);
+});

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3658,3 +3658,47 @@ test("status does not surface tracked PR mismatch diagnostics after tracked PR r
     /^latest_recovery issue=#173 at=2026-03-13T00:20:00Z reason=tracked_pr_lifecycle_recovered detail=resumed issue #173 from failed to addressing_review using fresh tracked PR #273 facts at head head-273$/m,
   );
 });
+
+test("status surfaces failed no-PR transient auto-requeue recovery on read-only status surfaces", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 204;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "queued",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: null,
+        blocked_reason: null,
+        last_recovery_reason:
+          "failed_no_pr_transient_retry: requeued issue #204 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity",
+        last_recovery_at: "2026-03-13T00:20:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^latest_recovery issue=#204 at=2026-03-13T00:20:00Z reason=failed_no_pr_transient_retry detail=requeued issue #204 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity$/m,
+  );
+
+  const status = await supervisor.status();
+  assert.match(
+    status,
+    /^latest_recovery issue=#204 at=2026-03-13T00:20:00Z reason=failed_no_pr_transient_retry detail=requeued issue #204 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity$/m,
+  );
+});

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -7578,6 +7578,272 @@ test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when no 
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when no meaningful branch diff matches allowlisted timeout runtime evidence", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    timeoutRetryLimit: 2,
+  });
+  const originalRuntimeFailureContext = {
+    category: "codex" as const,
+    summary: "Supervisor failed while recovering a Codex turn for issue #366.",
+    signature: "recovering-timeout-thread-366",
+    command: null,
+    details: [
+      "previous_state=reproducing",
+      "workspace_dirty=no",
+      "workspace_head=deadbee",
+      "pr_number=none",
+      "pr_head=none",
+      "codex_session_id=thread-366",
+    ],
+    url: null,
+    updated_at: "2026-03-13T00:20:05Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: "Command timed out after 1800000ms: codex exec resume thread-366",
+        last_failure_kind: "timeout",
+        last_failure_context: {
+          category: "codex",
+          summary: "Command timed out after 1800000ms: codex exec resume thread-366",
+          signature: "timeout-resume-thread-366",
+          command: null,
+          details: ["provider=codex", "phase=recovering"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "timeout-resume-thread-366",
+        repeated_failure_signature_count: 1,
+        last_runtime_error: originalRuntimeFailureContext.summary,
+        last_runtime_failure_kind: "timeout",
+        last_runtime_failure_context: originalRuntimeFailureContext,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Retry already-satisfied timeout failed no-PR issue once",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "queued");
+  assert.equal(updated.pr_number, null);
+  assert.equal(updated.codex_session_id, null);
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.last_runtime_error, originalRuntimeFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "timeout");
+  assert.deepEqual(updated.last_runtime_failure_context, originalRuntimeFailureContext);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
+  assert.equal(
+    updated.last_recovery_reason,
+    "failed_no_pr_transient_retry: requeued issue #366 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence timeout",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
+test("reconcileStaleFailedIssueStates blocks already-satisfied failed no-PR issues for manual review when runtime evidence is not allowlisted", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+  });
+  const originalRuntimeFailureContext = {
+    category: "codex" as const,
+    summary: "Codex exited with a non-transient repository check failure.",
+    signature: "not-allowed",
+    command: null,
+    details: ["provider=codex", "classification=repository-check"],
+    url: null,
+    updated_at: "2026-03-13T00:20:05Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: originalRuntimeFailureContext.summary,
+        last_failure_kind: "codex_exit",
+        last_failure_context: originalRuntimeFailureContext,
+        last_failure_signature: "not-allowed",
+        repeated_failure_signature_count: 1,
+        last_runtime_error: originalRuntimeFailureContext.summary,
+        last_runtime_failure_kind: "codex_exit",
+        last_runtime_failure_context: originalRuntimeFailureContext,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Fail closed when already-satisfied failed no-PR runtime evidence is not allowlisted",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.pr_number, null);
+  assert.equal(updated.codex_session_id, null);
+  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.match(updated.last_error ?? "", /no longer differs from origin\/main/i);
+  assert.equal(updated.last_runtime_error, originalRuntimeFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.deepEqual(updated.last_runtime_failure_context, originalRuntimeFailureContext);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(
+    updated.last_recovery_reason,
+    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileStaleFailedIssueStates sends second already-satisfied transient failed no-PR recurrences to manual review", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -7081,7 +7081,7 @@ test("reconcileStaleFailedIssueStates snapshots the original runtime failure whe
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when only supervisor-local artifacts are dirty on an open issue", async () => {
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when only supervisor-local artifacts are dirty on an open issue", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -7185,31 +7185,26 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "blocked");
+  assert.equal(updated.state, "queued");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
-  assert.match(updated.last_error ?? "", /confirm whether the implementation already landed elsewhere/i);
-  assert.deepEqual(updated.last_failure_context?.details ?? [], [
-    "state=failed",
-    "tracked_pr=none",
-    "branch_state=already_satisfied_on_main",
-    "default_branch=origin/main",
-    `head_sha=${updated.last_head_sha ?? "unknown"}`,
-    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
-  ]);
-  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_runtime_error, "Selected model is at capacity. Please try a different model.");
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.equal(updated.last_runtime_failure_context?.signature, "provider-capacity");
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
   assert.equal(
     updated.last_recovery_reason,
-    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
+    "failed_no_pr_transient_retry: requeued issue #366 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when only supervisor-local artifact commits remain on an open issue", async () => {
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when only supervisor-local artifact commits remain on an open issue", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -7317,32 +7312,27 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "blocked");
+  assert.equal(updated.state, "queued");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
   assert.equal(updated.last_failure_kind, null);
-  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
-  assert.match(updated.last_error ?? "", /confirm whether the implementation already landed elsewhere/i);
+  assert.equal(updated.last_failure_context, null);
   assert.equal(updated.last_head_sha, headSha);
-  assert.deepEqual(updated.last_failure_context?.details ?? [], [
-    "state=failed",
-    "tracked_pr=none",
-    "branch_state=already_satisfied_on_main",
-    "default_branch=origin/main",
-    `head_sha=${headSha}`,
-    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
-  ]);
-  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(updated.last_runtime_error, "Selected model is at capacity. Please try a different model.");
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.equal(updated.last_runtime_failure_context?.signature, "provider-capacity");
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
   assert.equal(
     updated.last_recovery_reason,
-    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
+    "failed_no_pr_transient_retry: requeued issue #366 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity",
   );
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
 });
 
-test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual review when an open no-PR issue has no meaningful branch diff", async () => {
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when an open no-PR issue has no meaningful branch diff", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({
     repoPath,
@@ -7443,22 +7433,264 @@ test("reconcileStaleFailedIssueStates blocks failed no-PR issues for manual revi
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "blocked");
+  assert.equal(updated.state, "queued");
   assert.equal(updated.pr_number, null);
   assert.equal(updated.codex_session_id, null);
-  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
   assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_runtime_error, "Selected model is at capacity. Please try a different model.");
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.equal(updated.last_runtime_failure_context?.signature, "provider-capacity");
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
+  assert.equal(
+    updated.last_recovery_reason,
+    "failed_no_pr_transient_retry: requeued issue #366 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when no meaningful branch diff matches allowlisted transient runtime evidence", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+  });
+  const originalRuntimeFailureContext = {
+    category: "codex" as const,
+    summary: "Selected model is at capacity. Please try a different model.",
+    signature: "provider-capacity",
+    command: null,
+    details: ["provider=codex"],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: originalRuntimeFailureContext.summary,
+        last_failure_kind: "codex_exit",
+        last_failure_context: originalRuntimeFailureContext,
+        last_failure_signature: "provider-capacity",
+        repeated_failure_signature_count: 1,
+        last_runtime_error: originalRuntimeFailureContext.summary,
+        last_runtime_failure_kind: "codex_exit",
+        last_runtime_failure_context: originalRuntimeFailureContext,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Retry already-satisfied transient failed no-PR issue once",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "queued");
+  assert.equal(updated.pr_number, null);
+  assert.equal(updated.codex_session_id, null);
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.last_runtime_error, originalRuntimeFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.deepEqual(updated.last_runtime_failure_context, originalRuntimeFailureContext);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
+  assert.equal(
+    updated.last_recovery_reason,
+    "failed_no_pr_transient_retry: requeued issue #366 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence provider-capacity",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
+test("reconcileStaleFailedIssueStates sends second already-satisfied transient failed no-PR recurrences to manual review", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+  });
+  const originalRuntimeFailureContext = {
+    category: "codex" as const,
+    summary: "Selected model is at capacity. Please try a different model.",
+    signature: "provider-capacity",
+    command: null,
+    details: ["provider=codex"],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: originalRuntimeFailureContext.summary,
+        last_failure_kind: "codex_exit",
+        last_failure_context: originalRuntimeFailureContext,
+        last_failure_signature: "provider-capacity",
+        repeated_failure_signature_count: 1,
+        stale_stabilizing_no_pr_recovery_count: 1,
+        last_runtime_error: originalRuntimeFailureContext.summary,
+        last_runtime_failure_kind: "codex_exit",
+        last_runtime_failure_context: originalRuntimeFailureContext,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Stop already-satisfied transient failed no-PR issue after one retry",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "manual_review");
   assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
-  assert.match(updated.last_error ?? "", /confirm whether the implementation already landed elsewhere/i);
-  assert.deepEqual(updated.last_failure_context?.details ?? [], [
-    "state=failed",
-    "tracked_pr=none",
-    "branch_state=already_satisfied_on_main",
-    "default_branch=origin/main",
-    `head_sha=${updated.last_head_sha ?? "unknown"}`,
-    "operator_action=confirm whether the implementation already landed elsewhere or requeue manually if more work is still required",
-  ]);
-  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(updated.last_runtime_error, originalRuntimeFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "codex_exit");
+  assert.deepEqual(updated.last_runtime_failure_context, originalRuntimeFailureContext);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
   assert.equal(
     updated.last_recovery_reason,
     "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -7720,6 +7720,133 @@ test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when no 
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when allowlisted timeout evidence only exists in legacy failure fields", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    timeoutRetryLimit: 2,
+  });
+  const legacyTimeoutFailureContext = {
+    category: "codex" as const,
+    summary: "Command timed out after 1800000ms: codex exec resume thread-366",
+    signature: "timeout-resume-thread-366",
+    command: null,
+    details: ["provider=codex", "phase=recovering"],
+    url: null,
+    updated_at: "2026-03-13T00:20:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: legacyTimeoutFailureContext.summary,
+        last_failure_kind: "timeout",
+        last_failure_context: legacyTimeoutFailureContext,
+        last_failure_signature: legacyTimeoutFailureContext.signature,
+        repeated_failure_signature_count: 1,
+        last_runtime_error: null,
+        last_runtime_failure_kind: null,
+        last_runtime_failure_context: null,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Retry already-satisfied timeout failed no-PR issue once from legacy failure fields",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "queued");
+  assert.equal(updated.pr_number, null);
+  assert.equal(updated.codex_session_id, null);
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.last_runtime_error, legacyTimeoutFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "timeout");
+  assert.deepEqual(updated.last_runtime_failure_context, legacyTimeoutFailureContext);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 1);
+  assert.equal(
+    updated.last_recovery_reason,
+    "failed_no_pr_transient_retry: requeued issue #366 from failed to queued after failed no-PR recovery found no meaningful branch diff and matched transient runtime evidence timeout",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileStaleFailedIssueStates blocks already-satisfied failed no-PR issues for manual review when runtime evidence is not allowlisted", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({


### PR DESCRIPTION
## Summary
- auto-requeue safe failed no-PR `already_satisfied_on_main` records once when retained runtime evidence matches a narrow transient allowlist
- preserve fail-closed manual-review behavior for unsafe or ambiguous workspaces and for later recurrences
- surface the transient auto-requeue reason in explain/status output

## Testing
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-requeue for failed no-PR workspaces when transient runtime failures are detected (first occurrence requeues; later recurrences require manual review). Runtime-failure metadata is preserved while failure-context fields are cleared.

* **Tests**
  * Added/expanded tests covering transient no-PR auto-requeue, recurrence behavior, and updated diagnostics/status output reflecting requeue details.

* **Documentation**
  * Updated internal issue journal and operational notes to reflect the new recovery behavior and next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->