### PR TITLE
Respect timeout retry budget in failed no-PR transient auto-requeue (#1614)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #1609: Evaluate auto-requeue for transient no-PR codex failures with no meaningful branch diff
+# Issue #1614: Respect timeout retry budget in failed no-PR transient auto-requeue
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1609
-- Branch: codex/issue-1609
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1614
+- Branch: codex/issue-1614
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: dd53cd3531d4bbace76892f823498a3b43c98faa
+- Last head SHA: 0b9daef8d8590529bee4dfc162ab65f430a52f1e
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-21T06:24:48.135Z
+- Updated at: 2026-04-21T08:22:50.897Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,13 +21,13 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Safe `already_satisfied_on_main` failed no-PR workspaces should auto-requeue exactly once when preserved runtime evidence is transient and allowlisted, while unsafe states and later recurrences stay fail-closed on manual review.
-- What changed: Added a transient-runtime allowlist at the failed no-PR reconciliation boundary, auto-requeueing the first safe `already_satisfied_on_main` recurrence and preserving later recurrences on manual review; added focused recovery plus explain/status regression coverage for the new path and updated older no-diff artifact expectations to the new one-time retry behavior.
+- Hypothesis: Failed no-PR `already_satisfied_on_main` transient auto-requeue was treating timeout runtime evidence as always allowlisted, so exhausted timeout budgets still received one extra retry outside `shouldAutoRetryTimeout()`.
+- What changed: Added an exhausted-timeout regression test and tightened the no-PR transient runtime classifier so `timeout` only stays allowlisted when the timeout retry budget still permits another retry; non-timeout `provider-capacity` behavior remains one-shot.
 - Current blocker: none
-- Next exact step: Review the diff, commit the checkpoint on `codex/issue-1609`, and open or update the draft PR if needed.
-- Verification gap: No extra gap in the requested local gates; broader suite coverage beyond the focused bundle was not run this turn.
-- Files touched: .codex-supervisor/issue-journal.md; src/recovery-no-pr-reconciliation.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts
-- Rollback concern: The transient allowlist is intentionally narrow (`timeout` and `provider-capacity` via retained runtime evidence); widening it without new tests would weaken the fail-closed boundary.
-- Last focused command: npm run build
+- Next exact step: Stage only the issue journal and source/test changes, then create a checkpoint commit on `codex/issue-1614`.
+- Verification gap: none for the issue scope; requested reconciliation/diagnostic tests and `npm run build` passed locally.
+- Files touched: .codex-supervisor/issue-journal.md; src/recovery-no-pr-reconciliation.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts
+- Rollback concern: Low; the change only narrows timeout-based no-PR auto-requeue eligibility to the existing canonical timeout retry policy.
+- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/recovery-no-pr-reconciliation.ts
+++ b/src/recovery-no-pr-reconciliation.ts
@@ -37,13 +37,25 @@ function preserveOriginalRuntimeFailureContext(record: IssueRunRecord): Partial<
   };
 }
 
-function transientNoPrRuntimeEvidenceLabel(record: Pick<
-  IssueRunRecord,
-  "last_runtime_failure_kind" | "last_runtime_failure_context" | "last_failure_kind" | "last_failure_context"
->): string | null {
+function transientNoPrRuntimeEvidenceLabel(
+  record: Pick<
+    IssueRunRecord,
+    "state"
+    | "last_runtime_failure_kind"
+    | "last_runtime_failure_context"
+    | "last_failure_kind"
+    | "last_failure_context"
+    | "timeout_retry_count"
+  >,
+  config: Pick<SupervisorConfig, "timeoutRetryLimit">,
+): string | null {
   const runtimeFailureKind = record.last_runtime_failure_kind ?? record.last_failure_kind;
   const runtimeFailureContext = record.last_runtime_failure_context ?? record.last_failure_context;
-  if (runtimeFailureKind === "timeout") {
+  const timeoutRetryAllowed =
+    record.state === "failed"
+    && record.last_failure_kind === "timeout"
+    && record.timeout_retry_count < config.timeoutRetryLimit;
+  if (runtimeFailureKind === "timeout" && timeoutRetryAllowed) {
     return "timeout";
   }
   if (runtimeFailureContext?.signature === "provider-capacity") {
@@ -101,7 +113,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     return false;
   }
   const previousNoPrRecoveryCount = record.stale_stabilizing_no_pr_recovery_count ?? 0;
-  const transientRuntimeEvidence = transientNoPrRuntimeEvidenceLabel(record);
+  const transientRuntimeEvidence = transientNoPrRuntimeEvidenceLabel(record, config);
   const shouldAutoRequeueAlreadySatisfiedOnMain =
     branchRecovery.state === "already_satisfied_on_main"
     && transientRuntimeEvidence !== null

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -7847,6 +7847,146 @@ test("reconcileStaleFailedIssueStates requeues failed no-PR issues once when all
   assert.equal(saveCalls, 1);
 });
 
+test("reconcileStaleFailedIssueStates does not requeue already-satisfied failed no-PR timeout records after the timeout retry budget is exhausted", async () => {
+  const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
+  const workspacePath = await createIssueWorktree({
+    repoPath,
+    workspaceRoot,
+    issueNumber: 366,
+    branch: "codex/reopen-issue-366",
+  });
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, "# local journal\n");
+
+  const config = createConfig({
+    repoPath,
+    workspaceRoot,
+    timeoutRetryLimit: 0,
+  });
+  const originalRuntimeFailureContext = {
+    category: "codex" as const,
+    summary: "Supervisor failed while recovering a Codex turn for issue #366.",
+    signature: "recovering-timeout-thread-366",
+    command: null,
+    details: [
+      "previous_state=reproducing",
+      "workspace_dirty=no",
+      "workspace_head=deadbee",
+      "pr_number=none",
+      "pr_head=none",
+      "codex_session_id=thread-366",
+    ],
+    url: null,
+    updated_at: "2026-03-13T00:20:05Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 366,
+        state: "failed",
+        branch: "codex/reopen-issue-366",
+        workspace: workspacePath,
+        journal_path: journalPath,
+        pr_number: null,
+        last_head_sha: baseHead,
+        last_error: "Command timed out after 1800000ms: codex exec resume thread-366",
+        last_failure_kind: "timeout",
+        last_failure_context: {
+          category: "codex",
+          summary: "Command timed out after 1800000ms: codex exec resume thread-366",
+          signature: "timeout-resume-thread-366",
+          command: null,
+          details: ["provider=codex", "phase=recovering"],
+          url: null,
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+        last_failure_signature: "timeout-resume-thread-366",
+        repeated_failure_signature_count: 1,
+        last_runtime_error: originalRuntimeFailureContext.summary,
+        last_runtime_failure_kind: "timeout",
+        last_runtime_failure_context: originalRuntimeFailureContext,
+        codex_session_id: "session-366",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 366,
+    title: "Do not auto-requeue already-satisfied timeout failed no-PR issue after exhausting the budget",
+    updatedAt: "2026-03-13T00:21:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-03-13T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  await reconcileStaleFailedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getMergedPullRequestsClosingIssue: async () => [],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      inferStateFromPullRequest: () => "draft_pr",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest: () => true,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.pr_number, null);
+  assert.equal(updated.codex_session_id, null);
+  assert.equal(updated.blocked_reason, "manual_review");
+  assert.equal(updated.last_failure_kind, null);
+  assert.equal(updated.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.match(updated.last_error ?? "", /no longer differs from origin\/main/i);
+  assert.equal(updated.last_runtime_error, originalRuntimeFailureContext.summary);
+  assert.equal(updated.last_runtime_failure_kind, "timeout");
+  assert.deepEqual(updated.last_runtime_failure_context, originalRuntimeFailureContext);
+  assert.equal(updated.stale_stabilizing_no_pr_recovery_count, 0);
+  assert.equal(
+    updated.last_recovery_reason,
+    "failed_no_pr_manual_review: blocked issue #366 after failed no-PR recovery found an open issue with no authoritative completion signal",
+  );
+  assert.ok(updated.last_recovery_at);
+  assert.equal(saveCalls, 1);
+});
+
 test("reconcileStaleFailedIssueStates blocks already-satisfied failed no-PR issues for manual review when runtime evidence is not allowlisted", async () => {
   const { repoPath, workspaceRoot, baseHead } = await createRepositoryWithOrigin();
   const workspacePath = await createIssueWorktree({


### PR DESCRIPTION
Closes #1614
This PR was opened by codex-supervisor.
Latest Codex summary:

Adjusted the failed no-PR transient auto-requeue path so timeout evidence only qualifies when the canonical timeout retry budget still allows another retry. `provider-capacity` keeps the existing one-shot transient behavior. I also added the focused exhausted-budget regression in [src/supervisor/supervisor-recovery-reconciliation.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1614/src/supervisor/supervisor-recovery-reconciliation.test.ts) and updated the enforcement in [src/recovery-no-pr-reconciliation.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1614/src/recovery-no-pr-reconciliation.ts). The issue journal is updated, and I committed the change as `35f8903` (`Respect timeout retry budget in no-PR auto-requeue`).

Local verification passed:
`npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
`npm run build`

There are still unrelated untracked supervisor runtime artifacts in `.codex-supervisor/pre-merge/`, `.codex-supervisor/replay/`, and `.codex-supervisor/turn-in-progress.json`; I left them untouched.

Summary: Timeout-based failed no-PR `already_satisfied_on_main` auto-requeue now respects `timeoutRetryLimit`, with a focused exhausted-budget regression test added and committed as `35f8903`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/supervisor/su...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timeout-based recovery behavior to properly respect retry budget limits, preventing automatic requeuing after the configured retry limit is exhausted.

* **Tests**
  * Added regression test coverage for timeout recovery budget exhaustion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->