### PR TITLE
Make explain detect tracked PR numbers and report owning issue context (#1610)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,17 +1,17 @@
-# Issue #1614: Respect timeout retry budget in failed no-PR transient auto-requeue
+# Issue #1610: Make explain detect tracked PR numbers and report owning issue context
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1614
-- Branch: codex/issue-1614
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1610
+- Branch: codex/issue-1610
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 0b9daef8d8590529bee4dfc162ab65f430a52f1e
+- Last head SHA: 37458be151d9ef6a82eb5fc9bc447f2700d71ced
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-21T08:22:50.897Z
+- Updated at: 2026-04-21T12:53:29.674Z
 
 ## Latest Codex Summary
 - None yet.
@@ -21,13 +21,13 @@
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: Failed no-PR `already_satisfied_on_main` transient auto-requeue was treating timeout runtime evidence as always allowlisted, so exhausted timeout budgets still received one extra retry outside `shouldAutoRetryTimeout()`.
-- What changed: Added an exhausted-timeout regression test and tightened the no-PR transient runtime classifier so `timeout` only stays allowlisted when the timeout retry budget still permits another retry; non-timeout `provider-capacity` behavior remains one-shot.
-- Current blocker: none
-- Next exact step: Stage only the issue journal and source/test changes, then create a checkpoint commit on `codex/issue-1614`.
-- Verification gap: none for the issue scope; requested reconciliation/diagnostic tests and `npm run build` passed locally.
-- Files touched: .codex-supervisor/issue-journal.md; src/recovery-no-pr-reconciliation.ts; src/supervisor/supervisor-recovery-reconciliation.test.ts
-- Rollback concern: Low; the change only narrows timeout-based no-PR auto-requeue eligibility to the existing canonical timeout retry policy.
-- Last focused command: npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
+- Hypothesis: `explain <number>` should resolve through the authoritative tracked record when `<number>` matches `record.pr_number`, then render the owning issue context instead of treating the PR body as a schedulable issue.
+- What changed: Added tracked-PR explain regressions in the helper and end-to-end diagnostics tests, then taught `buildIssueExplainDto` to map PR-number lookups to the owning issue and emit a `lookup_target=tracked_pr ...` diagnostic with branch, tracked state, blocked reason, and PR state.
+- Current blocker: None for the issue scope. The repo's `npm test -- src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts` wrapper still expands to the full suite and currently fails in unrelated `supervisor-status-model-supervisor.test.ts` pre-merge evaluation expectations.
+- Next exact step: Commit the explain-path change on `codex/issue-1610`; if the supervisor requires the exact npm wrapper to be green, investigate the unrelated `repair=none` expectation drift in `src/supervisor/supervisor-status-model-supervisor.test.ts`.
+- Verification gap: Focused explain regressions and `npm run build` are green. The exact npm wrapper command is not a clean focused gate in this repo and currently fails outside this issue's changed area.
+- Files touched: .codex-supervisor/issue-journal.md; src/supervisor/supervisor-selection-issue-explain.ts; src/supervisor/supervisor-selection-issue-explain.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts
+- Rollback concern: Low. The new lookup branch only activates when a requested number matches exactly one tracked `pr_number`; normal issue-number explain behavior is unchanged.
+- Last focused command: npm run build
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -155,6 +155,73 @@ test("explain reports candidate filtering for a non-candidate issue", async () =
   assert.match(explanation, /^reason_1=candidate filtered_by_candidate_list$/m);
 });
 
+test("explain resolves tracked PR numbers to the owning issue context", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 155;
+  const prNumber = 655;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "manual_review",
+        last_error: "waiting on review feedback",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const owningIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Owning issue for tracked PR explain",
+    body: executionReadyBody("Explain should resolve tracked PR numbers to the owning issue context."),
+    createdAt: "2026-03-13T00:05:00Z",
+    updatedAt: "2026-03-13T00:05:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async (requestedIssueNumber: number) => {
+      assert.equal(requestedIssueNumber, issueNumber);
+      return owningIssue;
+    },
+    listAllIssues: async () => [owningIssue],
+    listCandidateIssues: async () => [owningIssue],
+    getPullRequestIfExists: async (requestedPrNumber: number) => {
+      assert.equal(requestedPrNumber, prNumber);
+      return createPullRequest({
+        number: prNumber,
+        headRefName: branch,
+        headRefOid: "head-655",
+        isDraft: true,
+      });
+    },
+  };
+
+  const explanation = await supervisor.explain(prNumber);
+
+  assert.match(
+    explanation,
+    new RegExp(
+      `^lookup_target=tracked_pr query=#${prNumber} owner_issue=#${issueNumber} branch=${branch} tracked_state=blocked tracked_blocked_reason=manual_review pr_state=draft$`,
+      "m",
+    ),
+  );
+  assert.match(explanation, new RegExp(`^issue=#${issueNumber}$`, "m"));
+  assert.match(explanation, /^state=blocked$/m);
+  assert.match(explanation, /^blocked_reason=manual_review$/m);
+  assert.doesNotMatch(explanation, /candidate filtered_by_candidate_list/);
+});
+
 test("explain surfaces degraded full inventory refresh without requiring a fresh full issue list", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -12,7 +12,14 @@ import {
   buildNonRunnableLocalStateReasons,
   renderIssueExplainDto,
 } from "./supervisor-selection-issue-explain";
-import { branchName, createConfig, createRecord, createSupervisorFixture, createSupervisorState } from "./supervisor-test-helpers";
+import {
+  branchName,
+  createConfig,
+  createPullRequest,
+  createRecord,
+  createSupervisorFixture,
+  createSupervisorState,
+} from "./supervisor-test-helpers";
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -206,6 +213,75 @@ Parallelizable: No`,
   assert.ok(lines.some((line) => line.includes("retry_state=timeout_retry:1/2")));
   assert.ok(lines.includes("runtime_failure_kind=timeout"));
   assert.ok(lines.includes("runtime_failure_summary=Supervisor failed while recovering a Codex turn for issue #604."));
+});
+
+test("buildIssueExplainSummary resolves tracked PR numbers to the owning issue context", async () => {
+  const config = createConfig();
+  const issueNumber = 611;
+  const prNumber = 655;
+  const branch = branchName(config, issueNumber);
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Explain tracked PR ownership",
+    body: `## Summary
+Resolve tracked PR explain lookups through the owning issue.
+
+## Scope
+- detect tracked PR numbers before treating them like runnable issues
+
+## Acceptance criteria
+- explain reports the owning issue context for tracked PR numbers
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Execution order: 1 of 1
+Parallelizable: No`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        blocked_reason: null,
+        last_error: null,
+        branch,
+        pr_number: prNumber,
+      }),
+    },
+  };
+
+  const lines = await buildIssueExplainSummary(
+    {
+      getIssue: async (requestedIssueNumber) => {
+        assert.equal(requestedIssueNumber, issueNumber);
+        return issue;
+      },
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+      getPullRequestIfExists: async (requestedPrNumber) => {
+        assert.equal(requestedPrNumber, prNumber);
+        return createPullRequest({
+          number: prNumber,
+          headRefName: branch,
+          isDraft: true,
+        });
+      },
+    },
+    config,
+    state,
+    prNumber,
+  );
+
+  assert.ok(
+    lines.includes(
+      `lookup_target=tracked_pr query=#${prNumber} owner_issue=#${issueNumber} branch=${branch} tracked_state=addressing_review tracked_blocked_reason=none pr_state=draft`,
+    ),
+  );
+  assert.ok(lines.includes(`issue=#${issueNumber}`));
+  assert.ok(lines.includes("state=addressing_review"));
 });
 
 test("buildIssueExplainDto exposes typed operator activity context", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -58,12 +58,15 @@ import {
 import { formatPreMergeEvaluationStatusLine, loadPreMergeEvaluationDto } from "./supervisor-pre-merge-evaluation";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
 
-export type ExplainIssueGitHub = Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
+export type ExplainIssueGitHub =
+  Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
+  Partial<Pick<GitHubClient, "getPullRequestIfExists">> &
   Partial<ActiveStatusGitHub>;
 
 export interface SupervisorExplainDto {
   issueNumber: number;
   title: string;
+  lookupTargetSummary?: string | null;
   state: RunState | "untracked";
   blockedReason: BlockedReason | "none";
   runnable: boolean;
@@ -135,6 +138,78 @@ async function buildExplainExternalReviewFollowUpSummary(args: {
     activeRecord: args.record,
     currentHeadSha: pr?.headRefOid ?? args.record.last_head_sha,
   });
+}
+
+function formatTrackedPrState(pr: GitHubPullRequest | null): string {
+  if (pr === null) {
+    return "missing";
+  }
+
+  if (pr.mergedAt) {
+    return "merged";
+  }
+
+  if (pr.state !== "OPEN") {
+    return pr.state.toLowerCase();
+  }
+
+  return pr.isDraft ? "draft" : "open";
+}
+
+async function resolveExplainLookupTarget(args: {
+  github: ExplainIssueGitHub;
+  state: SupervisorStateFile;
+  requestedNumber: number;
+}): Promise<{
+  issue: GitHubIssue;
+  record: IssueRunRecord | undefined;
+  lookupTargetSummary: string | null;
+}> {
+  const trackedPrOwners = Object.values(args.state.issues).filter((candidate) => candidate.pr_number === args.requestedNumber);
+  if (trackedPrOwners.length !== 1) {
+    const issue = await args.github.getIssue(args.requestedNumber);
+    return {
+      issue,
+      record: args.state.issues[String(issue.number)],
+      lookupTargetSummary: null,
+    };
+  }
+
+  const record = trackedPrOwners[0];
+  const issue = await args.github.getIssue(record.issue_number);
+  let trackedPr: GitHubPullRequest | null = null;
+  let prLookup = "unavailable";
+
+  if (args.github.getPullRequestIfExists) {
+    try {
+      trackedPr = await args.github.getPullRequestIfExists(args.requestedNumber, { purpose: "status" });
+      if (trackedPr === null) {
+        prLookup = "not_found";
+      } else if (trackedPr.headRefName !== record.branch) {
+        trackedPr = null;
+        prLookup = "branch_mismatch";
+      } else {
+        prLookup = "ok";
+      }
+    } catch {
+      prLookup = "degraded";
+    }
+  }
+
+  return {
+    issue,
+    record,
+    lookupTargetSummary: [
+      "lookup_target=tracked_pr",
+      `query=#${args.requestedNumber}`,
+      `owner_issue=#${issue.number}`,
+      `branch=${record.branch}`,
+      `tracked_state=${record.state}`,
+      `tracked_blocked_reason=${record.blocked_reason ?? "none"}`,
+      `pr_state=${formatTrackedPrState(trackedPr)}`,
+      ...(prLookup === "ok" ? [] : [`pr_lookup=${prLookup}`]),
+    ].join(" "),
+  };
 }
 
 export function buildNonRunnableLocalStateReasons(record: IssueRunRecord, config: SupervisorConfig): string[] {
@@ -212,13 +287,16 @@ export async function buildIssueExplainDto(
   issueNumber: number,
 ): Promise<SupervisorExplainDto> {
   const inventoryRefreshDegraded = state.inventory_refresh_failure !== undefined;
-  const [issue, loadedIssues, candidateIssues] = await Promise.all([
-    github.getIssue(issueNumber),
+  const [{ issue, record, lookupTargetSummary }, loadedIssues, candidateIssues] = await Promise.all([
+    resolveExplainLookupTarget({
+      github,
+      state,
+      requestedNumber: issueNumber,
+    }),
     inventoryRefreshDegraded ? Promise.resolve(null) : github.listAllIssues(),
     github.listCandidateIssues(),
   ]);
   const issues = loadedIssues ?? [issue];
-  const record = state.issues[String(issue.number)];
   const labelsAvailable = hasAvailableIssueLabels(issue);
   const readiness = labelsAvailable ? lintExecutionReadyIssueBody(issue) : null;
   const clarificationBlock = findHighRiskBlockingAmbiguity(issue);
@@ -372,6 +450,7 @@ export async function buildIssueExplainDto(
   return {
     issueNumber: issue.number,
     title: issue.title,
+    lookupTargetSummary,
     state: record?.state ?? "untracked",
     blockedReason: record?.blocked_reason ?? "none",
     runnable,
@@ -423,6 +502,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
   const lines = [
     `issue=#${dto.issueNumber}`,
     `title=${dto.title}`,
+    ...(dto.lookupTargetSummary ? [dto.lookupTargetSummary] : []),
     `state=${dto.state}`,
     `blocked_reason=${dto.blockedReason}`,
     `runnable=${dto.runnable ? "yes" : "no"}`,


### PR DESCRIPTION
Closes #1610
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the explain-path fix in commit `db4668d` so `explain <pr-number>` now resolves through the authoritative tracked record when the number matches `record.pr_number`, then reports the owning issue context plus a `lookup_target=tracked_pr ...` diagnostic with the owner issue, branch, tracked state, blocked reason, and current PR state. I added focused regressions in both [src/supervisor/supervisor-selection-issue-explain.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1610/src/supervisor/supervisor-selection-issue-explain.test.ts) and [src/supervisor/supervisor-diagnostics-explain.test.ts](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1610/src/supervisor/supervisor-diagnostics-explain.test.ts), and updated the journal in [.codex-supervisor/issue-journal.md](/Users/tomoakikawada/Dev/codex-supervisor-self/.local/worktrees/issue-1610/.codex-supervisor/issue-journal.md).

`npm run build` passed. The exact requested `npm test -- src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts` command is not a focused gate in this repo and expands to the full suite; it currently fails in unrelated `src/supervisor/supervisor-status-model-supervisor.test.ts` because the expected `pre_merge_evaluation` line is missing `repair=none` while the runtime output includes it.

Summary: explain now detects tracked PR numbers and renders the owning issue context instead of misclass...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `explain` command now detects and resolves tracked PR numbers to their owning GitHub issues, providing comprehensive issue context including state, branch information, and ownership details.
  * Enhanced diagnostic output with lookup target metadata when resolving tracked pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->