### PR TITLE
Classify no-actionable current-head configured-bot reviews as stale review blockers (#1612)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,42 +1,33 @@
-# Issue #1611: Surface loop-off as an active tracked-work blocker in status and explain
+# Issue #1612: Classify no-actionable current-head configured-bot reviews as stale review blockers
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1611
-- Branch: codex/issue-1611
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1612
+- Branch: codex/issue-1612
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 925c09f21f3692404f1b7bf983e76920ee1ca195
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d3d579515c2c6c696e9fae33a4cef7446edeb66a
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ858goN9
-- Repeated failure signature count: 1
-- Updated at: 2026-04-21T13:30:51.838Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-21T13:43:55.881Z
 
 ## Latest Codex Summary
-Added a shared loop-off tracked-work blocker across read-only surfaces. Status now emits a structured `loop_runtime_blocker` line plus a `status_warning` when non-done tracked work exists and the loop is off; explain now carries the same blocker; and the WebUI overview/action/attention summaries now treat that state as blocked instead of idle. I also updated the focused tests and made checkpoint commit `925c09f` (`Surface loop-off tracked-work blockers`).
-
-Verification used `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard-browser-logic.test.ts src/backend/webui-dashboard.test.ts` and `npm run build`. I also updated `.codex-supervisor/issue-journal.md`. The only remaining untracked files are supervisor runtime artifacts under `.codex-supervisor/`, not code changes.
-
-Summary: surfaced explicit loop-off blockers for active tracked work in status, explain, and WebUI summaries; added focused regression coverage; committed as `925c09f`
-State hint: implementing
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard-browser-logic.test.ts src/backend/webui-dashboard.test.ts`; `npm run build`
-Next action: open or update the draft PR for `codex/issue-1611` with commit `925c09f`
-Failure signature: PRRT_kwDORgvdZ858goN9
+- Reclassified same-head configured-bot threads with an explicit current-head no-actionable signal into the `stale_review_bot` path, then tightened regression coverage across selector, policy, tracked-PR persistence, and explain surfaces.
 
 ## Active Failure Context
-- None recorded.
+- Resolved: stale same-head configured-bot blockers with a current-head informational success signal were staying on the generic non-actionable `manual_review` path.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The remaining review miss was limited to explain-report aggregation: the shared loop-off blocker helper was correct, but `buildSupervisorExplainReport()` still passed only the explained record instead of the full tracked set.
-- What changed: Reused `buildTrackedIssueDtos(state)` inside `buildSupervisorExplainReport()` so explain now derives the loop-off blocker from all tracked records, matching status/WebUI behavior. Added a regression test covering an untracked explained issue while two tracked issues are stalled with the loop off. Committed the review fix as `206660b` (`Fix explain loop-off blocker aggregation`), pushed `codex/issue-1611`, and resolved the CodeRabbit thread on PR #1617.
+- Hypothesis: When the configured bot reports an explicit current-head success/no-actionable signal, lingering bot-owned same-head unresolved threads should route through stale-review recovery instead of the generic non-actionable manual-review bucket.
+- What changed: `staleConfiguredBotReviewThreads` now considers configured-bot threads stale when the current head has an explicit no-actionable signal (`configuredBotCurrentHeadObservedAt` + `configuredBotCurrentHeadStatusState=SUCCESS` + no top-level actionable strength), and failure-context selection now prefers the stale-review context before the generic non-actionable manual-review context.
 - Current blocker: none
-- Next exact step: Monitor PR #1617 for any new review or CI regressions; otherwise this branch is ready for normal review/merge flow.
-- Verification gap: none for the review fix; the targeted suite and full build both passed locally.
-- Files touched: .codex-supervisor/issue-journal.md; src/supervisor/supervisor-loop-runtime-state.ts; src/supervisor/supervisor-read-only-reporting.ts; src/supervisor/supervisor-selection-issue-explain.ts; src/supervisor/supervisor-diagnostics-status-selection.test.ts; src/supervisor/supervisor-diagnostics-explain.test.ts; src/backend/webui-dashboard-browser-logic.ts; src/backend/webui-dashboard-browser-logic.test.ts; src/backend/webui-dashboard-browser-script.ts; src/backend/webui-dashboard-browser-issue-details.ts; src/backend/webui-dashboard.test.ts
-- Rollback concern: Low. The main behavior change is additional loop-off blocker derivation on read-only surfaces when non-done tracked work exists; tests cover status, explain, and WebUI summaries.
-- Last focused command: gh api graphql -f query='mutation($threadId:ID!){ resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } } }' -f threadId='PRRT_kwDORgvdZ858goN9'
+- Next exact step: open or update the PR for `codex/issue-1612` if the supervisor wants an early draft PR checkpoint.
+- Verification gap: none for the requested local bundle; targeted regressions and `npm run build` both passed.
+- Files touched: `.codex-supervisor/issue-journal.md`; `src/review-thread-reporting.ts`; `src/supervisor/supervisor-failure-context.ts`; `src/review-thread-reporting.test.ts`; `src/pull-request-state-policy.test.ts`; `src/supervisor/supervisor-pr-review-blockers.test.ts`; `src/supervisor/supervisor-diagnostics-explain.test.ts`
+- Rollback concern: The new stale path intentionally stays fail-closed unless the PR has an explicit current-head success observation with no actionable top-level configured-bot signal; if that inference is too broad, revert the `staleConfiguredBotReviewThreads` expansion.
+- Last focused command: `npx tsx --test src/github/github-review-signals.test.ts src/pull-request-state-policy.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -314,6 +314,59 @@ test("blockedReasonFromReviewState keeps mixed unresolved human and configured-b
   assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), "manual_review");
 });
 
+test("blockedReasonFromReviewState classifies same-head configured-bot threads as stale after an explicit no-actionable current-head signal", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotCurrentHeadObservedAt: "2026-03-13T02:04:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "This configured-bot finding is now stale on the current head.",
+            createdAt: "2026-03-13T02:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "coderabbitai[bot]",
+              typeName: "Bot",
+            },
+          },
+          {
+            id: "comment-2",
+            body: "Handled manually elsewhere.",
+            createdAt: "2026-03-13T02:06:00Z",
+            url: "https://example.test/pr/44#discussion_r2",
+            author: {
+              login: "octocat",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), "stale_review_bot");
+});
+
 test("inferStateFromPullRequest still blocks a journal-only configured-bot thread when the PR is not otherwise green", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -166,3 +166,60 @@ test("staleConfiguredBotReviewThreads excludes same-head configured-bot threads 
 
   assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [nonActionableSameHeadThread]), []);
 });
+
+test("staleConfiguredBotReviewThreads treats non-actionable same-head configured-bot threads as stale when the current head has an explicit no-actionable configured-bot signal", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const pr: Pick<
+    GitHubPullRequest,
+    "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotCurrentHeadStatusState" | "configuredBotTopLevelReviewStrength"
+  > = {
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-03-11T00:15:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  };
+  const record: Pick<
+    IssueRunRecord,
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+    | "last_head_sha"
+    | "review_follow_up_head_sha"
+    | "review_follow_up_remaining"
+  > = {
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+    last_head_sha: "head123",
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+  };
+  const nonActionableSameHeadThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-2",
+          body: "Handled manually elsewhere.",
+          createdAt: "2026-03-11T00:10:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "octocat",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [nonActionableSameHeadThread]), [nonActionableSameHeadThread]);
+});

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -74,6 +74,19 @@ export function actionableConfiguredBotReviewThreads(
   );
 }
 
+function hasExplicitCurrentHeadNoActionableConfiguredBotSignal(
+  pr: Pick<
+    GitHubPullRequest,
+    "configuredBotCurrentHeadObservedAt" | "configuredBotCurrentHeadStatusState" | "configuredBotTopLevelReviewStrength"
+  >,
+): boolean {
+  return Boolean(
+    pr.configuredBotCurrentHeadObservedAt &&
+      pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
+      pr.configuredBotTopLevelReviewStrength === null,
+  );
+}
+
 export function pendingBotReviewThreads(
   config: SupervisorConfig,
   record: Pick<
@@ -138,13 +151,18 @@ export function staleConfiguredBotReviewThreads(
     | "processed_review_thread_ids"
     | "processed_review_thread_fingerprints"
     | "last_head_sha"
-    | "review_follow_up_head_sha"
-    | "review_follow_up_remaining"
+      | "review_follow_up_head_sha"
+      | "review_follow_up_remaining"
   >,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
+  pr: Pick<
+    GitHubPullRequest,
+    "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotCurrentHeadStatusState" | "configuredBotTopLevelReviewStrength"
+  >,
   reviewThreads: ReviewThread[],
 ): ReviewThread[] {
-  const configuredThreads = actionableConfiguredBotReviewThreads(config, reviewThreads);
+  const configuredThreads = hasExplicitCurrentHeadNoActionableConfiguredBotSignal(pr)
+    ? configuredBotReviewThreads(config, reviewThreads)
+    : actionableConfiguredBotReviewThreads(config, reviewThreads);
   if (configuredThreads.length === 0) {
     return [];
   }

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -696,6 +696,76 @@ Explain should keep non-actionable same-head configured-bot blockers on manual r
   assert.doesNotMatch(explanation, /^failure_details=.*processed_on_current_head=yes/m);
 });
 
+test("explain surfaces same-head no-actionable configured-bot blockers as stale review blockers", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 95;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "stale_review_bot",
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-1",
+          command: null,
+          details: [
+            "reviewer=octocat file=src/file.ts line=12 processed_on_current_head=yes",
+          ],
+          url: "https://example.test/pr/195#discussion_r2",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain same-head no-actionable configured bot blockers as stale",
+    body: `## Summary
+Explain should surface same-head no-actionable configured-bot blockers as stale review blockers.
+
+## Scope
+- distinguish explicit no-actionable current-head bot signals from generic manual review
+
+## Acceptance criteria
+- explain reports stale_review_bot and processed_on_current_head=yes for the blocker details
+
+## Verification
+- npm test -- src/supervisor/supervisor-diagnostics-explain.test.ts`,
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
+  assert.match(
+    explanation,
+    /^failure_summary=1 configured bot review thread\(s\) remain unresolved after processing on the current head without measurable progress and now require manual attention\.$/m,
+  );
+  assert.doesNotMatch(explanation, /^blocked_reason=manual_review$/m);
+});
+
 test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.staleConfiguredBotReviewPolicy = "reply_and_resolve";

--- a/src/supervisor/supervisor-failure-context.ts
+++ b/src/supervisor/supervisor-failure-context.ts
@@ -66,13 +66,6 @@ export function inferFailureContext(
         return reviewContext;
       }
 
-      const nonActionableConfiguredBotContext = buildNonActionableConfiguredBotReviewFailureContext(
-        nonActionableConfiguredBotReviewThreads(config, reviewThreads),
-      );
-      if (nonActionableConfiguredBotContext) {
-        return nonActionableConfiguredBotContext;
-      }
-
       const stalledBotReviewContext = buildStalledBotReviewFailureContext(
         staleConfiguredBotReviewThreads(config, record, pr, reviewThreads),
         configuredBotReviewFollowUpState(config, record, pr, configuredBotReviewThreads(config, reviewThreads)) === "exhausted"
@@ -81,6 +74,13 @@ export function inferFailureContext(
       );
       if (stalledBotReviewContext) {
         return stalledBotReviewContext;
+      }
+
+      const nonActionableConfiguredBotContext = buildNonActionableConfiguredBotReviewFailureContext(
+        nonActionableConfiguredBotReviewThreads(config, reviewThreads),
+      );
+      if (nonActionableConfiguredBotContext) {
+        return nonActionableConfiguredBotContext;
       }
 
       if (config.humanReviewBlocksMerge) {
@@ -115,13 +115,6 @@ export function inferFailureContext(
       return reviewContext;
     }
 
-    const nonActionableConfiguredBotContext = buildNonActionableConfiguredBotReviewFailureContext(
-      nonActionableConfiguredBotReviewThreads(config, reviewThreads),
-    );
-    if (nonActionableConfiguredBotContext) {
-      return nonActionableConfiguredBotContext;
-    }
-
     const stalledBotReviewContext = buildStalledBotReviewFailureContext(
       staleConfiguredBotReviewThreads(config, record, pr, reviewThreads),
       configuredBotReviewFollowUpState(config, record, pr, configuredBotReviewThreads(config, reviewThreads)) === "exhausted"
@@ -130,6 +123,13 @@ export function inferFailureContext(
     );
     if (stalledBotReviewContext) {
       return stalledBotReviewContext;
+    }
+
+    const nonActionableConfiguredBotContext = buildNonActionableConfiguredBotReviewFailureContext(
+      nonActionableConfiguredBotReviewThreads(config, reviewThreads),
+    );
+    if (nonActionableConfiguredBotContext) {
+      return nonActionableConfiguredBotContext;
     }
 
     if (localReviewHighSeverityNeedsBlock(config, record, pr)) {

--- a/src/supervisor/supervisor-pr-review-blockers.test.ts
+++ b/src/supervisor/supervisor-pr-review-blockers.test.ts
@@ -324,6 +324,168 @@ test("runOnce keeps same-head configured-bot blockers on manual review when the 
   );
 });
 
+test("runOnce classifies same-head configured-bot blockers as stale when the current head explicitly reports no actionable comments", async () => {
+  const fixture = await createSupervisorFixture({
+    codexScriptLines: [
+      "#!/bin/sh",
+      "set -eu",
+      "echo unexpected codex execution >&2",
+      "exit 42",
+      "",
+    ],
+  });
+  const issueNumber = 118;
+  const branch = branchName(fixture.config, issueNumber);
+  const runHeadSha = git(["rev-parse", "HEAD"], fixture.repoPath);
+  const config = createConfig({
+    ...fixture.config,
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "pr_open",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: issueNumber,
+        last_head_sha: runHeadSha,
+        processed_review_thread_ids: [`thread-1@${runHeadSha}`],
+        processed_review_thread_fingerprints: [`thread-1@${runHeadSha}#comment-1`],
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Classify explicit no-actionable current-head bot signals as stale blockers",
+    body: executionReadyBody("Classify explicit no-actionable current-head bot signals as stale blockers."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: issueNumber,
+    title: "Classify same-head no-actionable bot blockers as stale",
+    url: `https://example.test/pr/${issueNumber}`,
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-03-13T06:35:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    headRefName: branch,
+    headRefOid: runHeadSha,
+    mergedAt: null,
+  };
+  const reviewThreads = [
+    createReviewThread({
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Please address this.",
+            createdAt: "2026-03-13T06:20:00Z",
+            url: `https://example.test/pr/${issueNumber}#discussion_r1`,
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+          {
+            id: "comment-2",
+            body: "Handled manually elsewhere.",
+            createdAt: "2026-03-13T06:30:00Z",
+            url: `https://example.test/pr/${issueNumber}#discussion_r2`,
+            author: {
+              login: "octocat",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
+      assert.equal(branchName, branch);
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return reviewThreads;
+    },
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, issueNumber);
+      return pr;
+    },
+    getPullRequestIfExists: async () => null,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: false });
+  assert.match(message, /state=blocked/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "blocked");
+  assert.equal(record.last_head_sha, runHeadSha);
+  assert.equal(record.blocked_reason, "stale_review_bot");
+  assert.deepEqual(record.processed_review_thread_ids, [`thread-1@${runHeadSha}`]);
+  assert.deepEqual(record.processed_review_thread_fingerprints, [`thread-1@${runHeadSha}#comment-1`]);
+  assert.equal(record.last_failure_context?.category, "manual");
+  assert.match(
+    record.last_failure_context?.summary ?? "",
+    /configured bot review thread\(s\) remain unresolved after processing on the current head/,
+  );
+  assert.deepEqual(record.last_failure_context?.details, [
+    "reviewer=octocat file=src/file.ts line=12 processed_on_current_head=yes",
+  ]);
+
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: record,
+    latestRecord: record,
+    trackedIssueCount: 1,
+    pr,
+    checks: [],
+    reviewThreads,
+  });
+  assert.match(
+    status,
+    /failure_context category=manual summary=1 configured bot review thread\(s\) remain unresolved after processing on the current head without measurable progress and now require manual attention\./,
+  );
+  assert.match(
+    status,
+    /failure_details=reviewer=octocat file=src\/file\.ts line=12 processed_on_current_head=yes/,
+  );
+});
+
 test("runOnce clears stale same-head stalled review-thread blockers after GitHub reports the threads resolved", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 116;


### PR DESCRIPTION
Closes #1612
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed the stale-review classifier so same-head configured-bot threads can enter `stale_review_bot` when the PR has an explicit current-head success/no-actionable bot signal. I also updated the failure-context ordering so tracked PRs and explain surfaces reflect that reclassification, added focused regressions for the selector/policy/integration/explain paths, updated the issue journal, and committed the checkpoint as `8f5d328` (`Classify no-actionable bot signals as stale`).

Summary: Reclassified explicit no-actionable current-head configured-bot signals into the stale-review path, added focused regression coverage, updated the issue journal, and committed `8f5d328`.
State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/review-thread-reporting.test.ts`; `npx tsx --test src/pull-request-state-policy.test.ts`; `npx tsx --test src/supervisor/supervisor-pr-review-blockers.test.ts`; `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`; `npx tsx --test src/github/github-review-signals.test.ts src/pull-request-state-policy.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`; `npm run build`
Failure signature: none
Next action: open or update the PR for `codex/issue-1612` using commit `8f5d328`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved classification of review blockers to distinguish between stale configured-bot reviews and manual reviews.
  * Enhanced detection of stale reviews when the current PR head includes explicit signals with no actionable comments.

* **Tests**
  * Added comprehensive test coverage for stale review detection and blocker classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->