### PR TITLE
Narrow loop-off tracked-work blockers to loop-advanceable states (#1619)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,33 +1,33 @@
-# Issue #1612: Classify no-actionable current-head configured-bot reviews as stale review blockers
+# Issue #1619: Narrow loop-off tracked-work blockers to loop-advanceable states
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1612
-- Branch: codex/issue-1612
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1619
+- Branch: codex/issue-1619
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
 - Current phase: reproducing
 - Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: d3d579515c2c6c696e9fae33a4cef7446edeb66a
+- Last head SHA: 78f53be1b6b3be1d5bc0482c6c6b1d5d6419e530
 - Blocked reason: none
 - Last failure signature: none
 - Repeated failure signature count: 0
-- Updated at: 2026-04-21T13:43:55.881Z
+- Updated at: 2026-04-21T14:15:56.778Z
 
 ## Latest Codex Summary
-- Reclassified same-head configured-bot threads with an explicit current-head no-actionable signal into the `stale_review_bot` path, then tightened regression coverage across selector, policy, tracked-PR persistence, and explain surfaces.
+- Narrowed the loop-off tracked-work blocker to loop-advanceable states only, then added focused regressions for blocked-only and mixed tracked-work sets across status, explain, and WebUI surfaces.
 
 ## Active Failure Context
-- Resolved: stale same-head configured-bot blockers with a current-head informational success signal were staying on the generic non-actionable `manual_review` path.
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: When the configured bot reports an explicit current-head success/no-actionable signal, lingering bot-owned same-head unresolved threads should route through stale-review recovery instead of the generic non-actionable manual-review bucket.
-- What changed: `staleConfiguredBotReviewThreads` now considers configured-bot threads stale when the current head has an explicit no-actionable signal (`configuredBotCurrentHeadObservedAt` + `configuredBotCurrentHeadStatusState=SUCCESS` + no top-level actionable strength), and failure-context selection now prefers the stale-review context before the generic non-actionable manual-review context.
+- Hypothesis: The loop-off blocker was too broad because it treated every non-`done` tracked issue as restartable background work; `blocked` and `failed` tracked records should stay visible but should not trigger the restart-the-loop message.
+- What changed: Added `isLoopAdvanceableState()` in `src/core/utils.ts`, switched `buildLoopOffTrackedWorkBlocker()` to use it, and tightened WebUI tracked-work filtering so blocked-only/failed-only tracked sets no longer produce loop-restart messaging while mixed sets still point at the first loop-advanceable issue. Added focused regressions in status, explain, dashboard browser logic, and dashboard rendering tests.
 - Current blocker: none
-- Next exact step: open or update the PR for `codex/issue-1612` if the supervisor wants an early draft PR checkpoint.
-- Verification gap: none for the requested local bundle; targeted regressions and `npm run build` both passed.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/review-thread-reporting.ts`; `src/supervisor/supervisor-failure-context.ts`; `src/review-thread-reporting.test.ts`; `src/pull-request-state-policy.test.ts`; `src/supervisor/supervisor-pr-review-blockers.test.ts`; `src/supervisor/supervisor-diagnostics-explain.test.ts`
-- Rollback concern: The new stale path intentionally stays fail-closed unless the PR has an explicit current-head success observation with no actionable top-level configured-bot signal; if that inference is too broad, revert the `staleConfiguredBotReviewThreads` expansion.
-- Last focused command: `npx tsx --test src/github/github-review-signals.test.ts src/pull-request-state-policy.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`
+- Next exact step: commit this checkpoint on `codex/issue-1619` and proceed with PR/update flow if requested by the supervisor.
+- Verification gap: none for the requested local bundle; targeted regressions and `npm run build` passed.
+- Files touched: `.codex-supervisor/issue-journal.md`; `src/core/utils.ts`; `src/supervisor/supervisor-loop-runtime-state.ts`; `src/backend/webui-dashboard-browser-logic.ts`; `src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `src/supervisor/supervisor-diagnostics-explain.test.ts`; `src/backend/webui-dashboard-browser-logic.test.ts`; `src/backend/webui-dashboard.test.ts`
+- Rollback concern: If loop-off guidance is later meant to include a specific blocked subtype, the shared loop-advanceable predicate is now the enforcement point for both CLI/reporting and WebUI surfaces.
+- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -5,29 +5,43 @@
 - Branch: codex/issue-1619
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 78f53be1b6b3be1d5bc0482c6c6b1d5d6419e530
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 77fda093dc21b6e75e8a1b3e8f8ffc5adedf7d3b
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-21T14:15:56.778Z
+- Last failure signature: PRRT_kwDORgvdZ858hx8x
+- Repeated failure signature count: 1
+- Updated at: 2026-04-21T14:29:21.059Z
 
 ## Latest Codex Summary
-- Narrowed the loop-off tracked-work blocker to loop-advanceable states only, then added focused regressions for blocked-only and mixed tracked-work sets across status, explain, and WebUI surfaces.
+Narrowed the loop-off blocker so only loop-advanceable tracked states trigger the restart-the-loop message. The shared selector now excludes `blocked` and `failed`, and the dashboard/browser logic matches that policy. I also tightened the focused regressions so blocked-only tracked sets stay visible without claiming the loop can resume them, while mixed tracked sets still point at the first advanceable issue. Checkpoint commit: `77fda09` (`Narrow loop-off tracked-work blockers`).
+
+Verification passed with `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts` and `npm run build`. The worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/` that I left untouched.
+
+Summary: Narrowed loop-off tracked-work blockers to loop-advanceable states, added blocked-only/mixed-state regressions across status, explain, and WebUI, and committed the checkpoint.
+State hint: draft_pr
+Blocked reason: none
+Tests: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts`; `npm run build`
+Next action: Open or update the draft PR from `codex/issue-1619` using commit `77fda09`.
+Failure signature: PRRT_kwDORgvdZ858hx8x
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1620#discussion_r3118162345
+- Details:
+  - src/backend/webui-dashboard-browser-logic.ts:342 summary=_⚠️ Potential issue_ | _🟠 Major_ **Blocked tracked issues are being hidden globally, not just excluded from loop-restart messaging.** This change affects all `collectTrackedIss... url=https://github.com/TommyKammy/codex-supervisor/pull/1620#discussion_r3118162345
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The loop-off blocker was too broad because it treated every non-`done` tracked issue as restartable background work; `blocked` and `failed` tracked records should stay visible but should not trigger the restart-the-loop message.
-- What changed: Added `isLoopAdvanceableState()` in `src/core/utils.ts`, switched `buildLoopOffTrackedWorkBlocker()` to use it, and tightened WebUI tracked-work filtering so blocked-only/failed-only tracked sets no longer produce loop-restart messaging while mixed sets still point at the first loop-advanceable issue. Added focused regressions in status, explain, dashboard browser logic, and dashboard rendering tests.
+- Hypothesis: The CodeRabbit finding was valid on the branch because `collectTrackedIssues()` was filtering out `blocked` and `failed` globally in browser logic; loop-off restart guidance needed its own narrower filter while tracked history and shortcuts kept those entries visible.
+- What changed: Restored `collectTrackedIssues()` in `src/backend/webui-dashboard-browser-logic.ts` to hide only `done` by default, narrowed `describeLoopOffTrackedWorkBlocker()` with an inline loop-advanceable filter, and expanded browser/dashboard tests so blocked tracked items stay visible in history/shortcuts while blocked-only loop-off sets do not advertise restart-loop guidance.
 - Current blocker: none
-- Next exact step: commit this checkpoint on `codex/issue-1619` and proceed with PR/update flow if requested by the supervisor.
-- Verification gap: none for the requested local bundle; targeted regressions and `npm run build` passed.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/core/utils.ts`; `src/supervisor/supervisor-loop-runtime-state.ts`; `src/backend/webui-dashboard-browser-logic.ts`; `src/supervisor/supervisor-diagnostics-status-selection.test.ts`; `src/supervisor/supervisor-diagnostics-explain.test.ts`; `src/backend/webui-dashboard-browser-logic.test.ts`; `src/backend/webui-dashboard.test.ts`
-- Rollback concern: If loop-off guidance is later meant to include a specific blocked subtype, the shared loop-advanceable predicate is now the enforcement point for both CLI/reporting and WebUI surfaces.
-- Last focused command: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts`
+- Next exact step: commit the review fix on `codex/issue-1619`, push the branch, and resolve/respond to PR thread `PRRT_kwDORgvdZ858hx8x`.
+- Verification gap: none for the requested local bundle; targeted regressions and `npm run build` passed after the browser-script serialization fix.
+- Files touched: `.codex-supervisor/issue-journal.md`; `src/backend/webui-dashboard-browser-logic.ts`; `src/backend/webui-dashboard-browser-logic.test.ts`; `src/backend/webui-dashboard.test.ts`
+- Rollback concern: The dashboard browser script inlines helper source strings, so future browser-logic changes cannot depend on cross-module helpers unless those helpers are also injected into `src/backend/webui-dashboard-browser-script.ts`.
+- Last focused command: `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts src/backend/webui-dashboard.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts && npm run build`
 ### Scratchpad
+- Intermediate failure while fixing review thread: dashboard DOM tests initially threw `ReferenceError: import_utils is not defined` because the injected browser script serialized `describeLoopOffTrackedWorkBlocker()` with a cross-module helper reference. Resolved by keeping the restart-only predicate inline inside `webui-dashboard-browser-logic.ts`.
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -10,6 +10,7 @@ import {
   collectIssueShortcuts,
   describeCommandSelectionChange,
   describeConnectionHealth,
+  describeLoopOffTrackedWorkBlocker,
   describeTimelineCommandResult,
   describeFreshnessState,
   describeTimelineEvent,
@@ -172,6 +173,61 @@ test("dashboard summaries treat loop-off tracked work as an active blocker", () 
       hasSuccessfulRefresh: true,
     }),
     ["Tracked work is active for #58, but the supervisor loop is off. Restart the loop to resume background execution."],
+  );
+});
+
+test("dashboard summaries ignore blocked-only tracked work when the loop is off", () => {
+  const status: DashboardStatusLike = {
+    trackedIssues: [
+      {
+        issueNumber: 58,
+        state: "blocked",
+        branch: "codex/issue-58",
+        prNumber: 58,
+        blockedReason: "manual_review",
+      },
+    ],
+    loopRuntime: {
+      state: "off",
+      hostMode: "unknown",
+      pid: null,
+      startedAt: null,
+      detail: null,
+    },
+    blockedIssues: [],
+    runnableIssues: [],
+  };
+
+  assert.equal(describeLoopOffTrackedWorkBlocker(status), null);
+  assert.doesNotMatch(
+    buildOverviewSummary({
+      status,
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }).detail,
+    /Restart the loop to resume background execution/u,
+  );
+  assert.doesNotMatch(
+    buildPrimaryActionSummary({
+      status,
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }).detail,
+    /Background execution will not advance until the loop restarts/u,
+  );
+  assert.deepEqual(
+    buildAttentionItems({
+      status,
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    ["No immediate attention items are reported."],
   );
 });
 

--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -243,6 +243,13 @@ test("formatTrackedIssues defaults to non-done history and can reveal done issue
           blockedReason: "requirements:verification",
         },
         {
+          issueNumber: 43,
+          state: "blocked",
+          branch: "codex/issue-43",
+          prNumber: 543,
+          blockedReason: "manual_review",
+        },
+        {
           issueNumber: 42,
           state: "done",
           branch: "codex/issue-42",
@@ -251,7 +258,10 @@ test("formatTrackedIssues defaults to non-done history and can reveal done issue
         },
       ],
     }),
-    ["tracked issue #41 [queued] branch=codex/issue-41 pr=none blocked_reason=requirements:verification"],
+    [
+      "tracked issue #41 [queued] branch=codex/issue-41 pr=none blocked_reason=requirements:verification",
+      "tracked issue #43 [blocked] branch=codex/issue-43 pr=#543 blocked_reason=manual_review",
+    ],
   );
 
   assert.deepEqual(
@@ -266,6 +276,13 @@ test("formatTrackedIssues defaults to non-done history and can reveal done issue
             blockedReason: "requirements:verification",
           },
           {
+            issueNumber: 43,
+            state: "blocked",
+            branch: "codex/issue-43",
+            prNumber: 543,
+            blockedReason: "manual_review",
+          },
+          {
             issueNumber: 42,
             state: "done",
             branch: "codex/issue-42",
@@ -278,7 +295,38 @@ test("formatTrackedIssues defaults to non-done history and can reveal done issue
     ),
     [
       "tracked issue #41 [queued] branch=codex/issue-41 pr=none blocked_reason=requirements:verification",
+      "tracked issue #43 [blocked] branch=codex/issue-43 pr=#543 blocked_reason=manual_review",
       "tracked issue #42 [done] branch=codex/issue-42 pr=#512 blocked_reason=none",
+    ],
+  );
+});
+
+test("collectIssueShortcuts keeps tracked blocked issues visible when no typed blocked issue exists", () => {
+  assert.deepEqual(
+    collectIssueShortcuts({
+      trackedIssues: [
+        {
+          issueNumber: 93,
+          state: "blocked",
+          branch: "codex/issue-93",
+          prNumber: 193,
+          blockedReason: "manual_review",
+        },
+        {
+          issueNumber: 12,
+          state: "done",
+          branch: "codex/issue-12",
+          prNumber: 12,
+          blockedReason: null,
+        },
+      ],
+    }),
+    [
+      {
+        issueNumber: 93,
+        label: "tracked blocked",
+        detail: "codex/issue-93 pr=#193",
+      },
     ],
   );
 });

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -336,7 +336,10 @@ export function collectTrackedIssues(
   if (options.includeDone) {
     return trackedIssues;
   }
-  return trackedIssues.filter((issue) => issue.state?.toLowerCase() !== "done");
+  return trackedIssues.filter((issue) => {
+    const normalized = issue.state?.toLowerCase();
+    return normalized !== "done" && normalized !== "blocked" && normalized !== "failed";
+  });
 }
 
 export function formatTrackedIssues(

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -101,7 +101,10 @@ export function describeLoopOffTrackedWorkBlocker(status: DashboardStatusLike | 
     return null;
   }
 
-  const activeTrackedIssues = collectTrackedIssues(status);
+  const activeTrackedIssues = collectTrackedIssues(status).filter((issue) => {
+    const normalized = issue.state?.toLowerCase();
+    return Boolean(normalized) && normalized !== "done" && normalized !== "blocked" && normalized !== "failed";
+  });
   if (activeTrackedIssues.length === 0) {
     return null;
   }
@@ -336,10 +339,7 @@ export function collectTrackedIssues(
   if (options.includeDone) {
     return trackedIssues;
   }
-  return trackedIssues.filter((issue) => {
-    const normalized = issue.state?.toLowerCase();
-    return normalized !== "done" && normalized !== "blocked" && normalized !== "failed";
-  });
+  return trackedIssues.filter((issue) => issue.state?.toLowerCase() !== "done");
 }
 
 export function formatTrackedIssues(

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -447,6 +447,38 @@ test("dashboard treats loop-off tracked work as an active blocker instead of idl
   assert.equal(harness.remainingFetches.length, 0);
 });
 
+test("dashboard does not tell the operator to restart the loop for blocked-only tracked work", async () => {
+  const harness = createDashboardHarness([
+    ...dashboardServer.page({
+      status: createStatus({
+        trackedIssues: [
+          {
+            issueNumber: 58,
+            state: "blocked",
+            branch: "codex/issue-58",
+            prNumber: 58,
+            blockedReason: "manual_review",
+          },
+        ],
+        loopRuntime: {
+          state: "off",
+          hostMode: "unknown",
+          pid: null,
+          startedAt: null,
+          detail: null,
+        },
+        warning: null,
+      }),
+    }),
+  ]);
+  await harness.flush();
+
+  const attentionList = harness.document.getElementById("attention-list");
+  assert.ok(attentionList);
+  assert.doesNotMatch(joinChildText(attentionList), /Restart the loop to resume background execution/u);
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
 test("dashboard keeps Summary focused on current state and only shows tracked issue count", async () => {
   const harness = createDashboardHarness([
     {

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -611,6 +611,13 @@ test("dashboard moves tracked history into a dedicated panel with non-done defau
               blockedReason: "requirements:verification",
             },
             {
+              issueNumber: 59,
+              state: "blocked",
+              branch: "codex/issue-59",
+              prNumber: 159,
+              blockedReason: "manual_review",
+            },
+            {
               issueNumber: 12,
               state: "done",
               branch: "codex/issue-12",
@@ -634,21 +641,26 @@ test("dashboard moves tracked history into a dedicated panel with non-done defau
   assert.ok(trackedHistorySummary);
   assert.ok(trackedHistoryToggle);
 
-  assert.match(statusLines.textContent, /tracked issues=2/u);
+  assert.match(statusLines.textContent, /tracked issues=3/u);
   assert.doesNotMatch(statusLines.textContent, /tracked issue #58/u);
-  assert.match(trackedHistorySummary.textContent, /showing 1 of 2 tracked issues/u);
+  assert.match(trackedHistorySummary.textContent, /showing 2 of 3 tracked issues/u);
   assert.match(trackedHistoryLines.textContent, /#58/u);
   assert.match(trackedHistoryLines.textContent, /queued/u);
   assert.match(trackedHistoryLines.textContent, /pr #58/u);
   assert.match(trackedHistoryLines.textContent, /requirements:verification/u);
+  assert.match(trackedHistoryLines.textContent, /#59/u);
+  assert.match(trackedHistoryLines.textContent, /blocked/u);
+  assert.match(trackedHistoryLines.textContent, /pr #159/u);
+  assert.match(trackedHistoryLines.textContent, /manual_review/u);
   assert.doesNotMatch(trackedHistoryLines.textContent, /codex\/issue-58/u);
+  assert.doesNotMatch(trackedHistoryLines.textContent, /codex\/issue-59/u);
   assert.doesNotMatch(trackedHistoryLines.textContent, /#12/u);
   assert.match(trackedHistoryToggle.textContent, /Show done issues/u);
 
   await trackedHistoryToggle.dispatch("click");
   await harness.flush();
 
-  assert.match(trackedHistorySummary.textContent, /showing 2 of 2 tracked issues/u);
+  assert.match(trackedHistorySummary.textContent, /showing 3 of 3 tracked issues/u);
   assert.match(trackedHistoryLines.textContent, /#12/u);
   assert.match(trackedHistoryLines.textContent, /done/u);
   assert.match(trackedHistoryLines.textContent, /pr #12/u);

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -95,6 +95,14 @@ export function isTerminalState(state: string): boolean {
   return state === "done" || state === "blocked" || state === "failed";
 }
 
+export function isLoopAdvanceableState(state: string | null | undefined): boolean {
+  if (!state) {
+    return false;
+  }
+
+  return !isTerminalState(state);
+}
+
 export function resolveMaybeRelative(baseDir: string, inputPath: string): string {
   return path.isAbsolute(inputPath) ? inputPath : path.resolve(baseDir, inputPath);
 }

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -321,14 +321,59 @@ test("explain loop-off blocker summarizes all tracked work even when the explain
   const report = await supervisor.explainReport(explainedIssueNumber);
   assert.equal(
     report.loopRuntimeBlockerSummary,
-    "loop_runtime_blocker state=off active_tracked_issues=2 first_issue=#150 first_state=blocked first_pr=none action=restart_loop",
+    "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#189 first_state=queued first_pr=#289 action=restart_loop",
   );
 
   const explanation = await supervisor.explain(explainedIssueNumber);
   assert.match(
     explanation,
-    /^loop_runtime_blocker state=off active_tracked_issues=2 first_issue=#150 first_state=blocked first_pr=none action=restart_loop$/m,
+    /^loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#189 first_state=queued first_pr=#289 action=restart_loop$/m,
   );
+});
+
+test("explain omits the loop-off blocker when tracked work is blocked-only", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 191;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        branch,
+        pr_number: 291,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain blocked-only tracked issue without loop restart hint",
+    body: executionReadyBody("Blocked-only tracked work should not emit the shared loop-off restart blocker."),
+    createdAt: "2026-03-25T00:00:00Z",
+    updatedAt: "2026-03-25T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+  };
+
+  const report = await supervisor.explainReport(issueNumber);
+  assert.equal(report.loopRuntimeBlockerSummary, null);
+
+  const explanation = await supervisor.explain(issueNumber);
+  assert.doesNotMatch(explanation, /^loop_runtime_blocker /m);
 });
 
 test("explain surfaces degraded full inventory refresh without requiring a fresh full issue list", async () => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1161,6 +1161,58 @@ test("status surfaces loop-off as a blocker when tracked work is still active", 
   );
 });
 
+test("status does not emit the loop-off restart blocker for blocked-only tracked work", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 188;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        branch: branchName(fixture.config, issueNumber),
+        pr_number: 288,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Blocked tracked issue should not advertise loop restart",
+    body: executionReadyBody("Blocked-only tracked work should not be treated as loop-advanceable."),
+    createdAt: "2026-03-25T00:00:00Z",
+    updatedAt: "2026-03-25T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport();
+  assert.equal(report.warning?.message ?? null, null);
+  assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^loop_runtime_blocker /m);
+
+  const status = await supervisor.status();
+  assert.doesNotMatch(status, /^loop_runtime_blocker /m);
+  assert.doesNotMatch(status, /^status_warning=Tracked work is active for issue #188, but the supervisor loop is off\./m);
+});
+
 test("acquireSupervisorLock fails closed on ambiguous-owner run locks", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { acquireFileLock, inspectFileLock, type ExistingLockState, type LockHandle } from "../core/lock";
 import type { RunState } from "../core/types";
+import { isLoopAdvanceableState } from "../core/utils";
 
 export type SupervisorLoopHostMode = "tmux" | "direct" | "unknown";
 
@@ -78,7 +79,7 @@ export function buildLoopOffTrackedWorkBlocker(args: {
     return null;
   }
 
-  const activeTrackedIssues = args.trackedIssues.filter((issue) => issue.state !== "done");
+  const activeTrackedIssues = args.trackedIssues.filter((issue) => isLoopAdvanceableState(issue.state));
   if (activeTrackedIssues.length === 0) {
     return null;
   }


### PR DESCRIPTION
Closes #1619
This PR was opened by codex-supervisor.
Latest Codex summary:

Narrowed the loop-off blocker so only loop-advanceable tracked states trigger the restart-the-loop message. The shared selector now excludes `blocked` and `failed`, and the dashboard/browser logic matches that policy. I also tightened the focused regressions so blocked-only tracked sets stay visible without claiming the loop can resume them, while mixed tracked sets still point at the first advanceable issue. Checkpoint commit: `77fda09` (`Narrow loop-off tracked-work blockers`).

Verification passed with `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts` and `npm run build`. The worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/` that I left untouched.

Summary: Narrowed loop-off tracked-work blockers to loop-advanceable states, added blocked-only/mixed-state regressions across status, explain, and WebUI, and committed the checkpoint.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR from `codex/issue-1619` using commit `77fda09`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed misleading “restart loop” and “background will not advance” messages when the supervisor loop is off and tracked work is only in a blocked/terminal state.
  * Status outputs and diagnostics no longer report a loop blocker for blocked-only tracked work.

* **New Features**
  * Centralized logic to classify advanceable vs. terminal/blocked states for more accurate UI and status behavior.

* **Tests**
  * Added tests covering blocked-only tracked work, formatted tracked-issue output, and shortcut/diagnostic behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->