### PR TITLE
Block supervisor-local durable artifacts before they enter checkpoint commits (#1621)

### DIFF
--- a/.codex-supervisor/issue-journal.md
+++ b/.codex-supervisor/issue-journal.md
@@ -1,47 +1,33 @@
-# Issue #1619: Narrow loop-off tracked-work blockers to loop-advanceable states
+# Issue #1621: Block supervisor-local durable artifacts before they enter checkpoint commits
 
 ## Supervisor Snapshot
-- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1619
-- Branch: codex/issue-1619
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1621
+- Branch: codex/issue-1621
 - Workspace: .
 - Journal: .codex-supervisor/issue-journal.md
-- Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 77fda093dc21b6e75e8a1b3e8f8ffc5adedf7d3b
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 09030f69df191789c4fe6d9470c0ff423fe49f25
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORgvdZ858hx8x
-- Repeated failure signature count: 1
-- Updated at: 2026-04-21T14:29:21.059Z
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-21T22:24:20.741Z
 
 ## Latest Codex Summary
-Narrowed the loop-off blocker so only loop-advanceable tracked states trigger the restart-the-loop message. The shared selector now excludes `blocked` and `failed`, and the dashboard/browser logic matches that policy. I also tightened the focused regressions so blocked-only tracked sets stay visible without claiming the loop can resume them, while mixed tracked sets still point at the first advanceable issue. Checkpoint commit: `77fda09` (`Narrow loop-off tracked-work blockers`).
-
-Verification passed with `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts` and `npm run build`. The worktree still has untracked supervisor runtime artifacts under `.codex-supervisor/` that I left untouched.
-
-Summary: Narrowed loop-off tracked-work blockers to loop-advanceable states, added blocked-only/mixed-state regressions across status, explain, and WebUI, and committed the checkpoint.
-State hint: draft_pr
-Blocked reason: none
-Tests: `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts`; `npm run build`
-Next action: Open or update the draft PR from `codex/issue-1619` using commit `77fda09`.
-Failure signature: PRRT_kwDORgvdZ858hx8x
+- None yet.
 
 ## Active Failure Context
-- Category: review
-- Summary: 1 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1620#discussion_r3118162345
-- Details:
-  - src/backend/webui-dashboard-browser-logic.ts:342 summary=_⚠️ Potential issue_ | _🟠 Major_ **Blocked tracked issues are being hidden globally, not just excluded from loop-restart messaging.** This change affects all `collectTrackedIss... url=https://github.com/TommyKammy/codex-supervisor/pull/1620#discussion_r3118162345
+- None recorded.
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The CodeRabbit finding was valid on the branch because `collectTrackedIssues()` was filtering out `blocked` and `failed` globally in browser logic; loop-off restart guidance needed its own narrower filter while tracked history and shortcuts kept those entries visible.
-- What changed: Restored `collectTrackedIssues()` in `src/backend/webui-dashboard-browser-logic.ts` to hide only `done` by default, narrowed `describeLoopOffTrackedWorkBlocker()` with an inline loop-advanceable filter, and expanded browser/dashboard tests so blocked tracked items stay visible in history/shortcuts while blocked-only loop-off sets do not advertise restart-loop guidance.
-- Current blocker: none
-- Next exact step: commit the review fix on `codex/issue-1619`, push the branch, and resolve/respond to PR thread `PRRT_kwDORgvdZ858hx8x`.
-- Verification gap: none for the requested local bundle; targeted regressions and `npm run build` passed after the browser-script serialization fix.
-- Files touched: `.codex-supervisor/issue-journal.md`; `src/backend/webui-dashboard-browser-logic.ts`; `src/backend/webui-dashboard-browser-logic.test.ts`; `src/backend/webui-dashboard.test.ts`
-- Rollback concern: The dashboard browser script inlines helper source strings, so future browser-logic changes cannot depend on cross-module helpers unless those helpers are also injected into `src/backend/webui-dashboard-browser-script.ts`.
-- Last focused command: `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts src/backend/webui-dashboard.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts && npm run build`
+- Hypothesis: PR publication should fail closed as soon as tracked supervisor-local `.codex-supervisor` artifacts are present, before path hygiene normalization, workspace preparation, or local CI can continue.
+- What changed: Added an early tracked supervisor-artifact scan in the publication gate using the existing ignored-artifact path classifier; blocked tracked issue journals, replay/pre-merge/execution-metrics, and turn-in-progress artifacts with a precise remediation message; updated focused publication tests to cover tracked issue-journal and replay cases plus sparse-tracked journal blocking.
+- Current blocker: none.
+- Next exact step: commit the publication-gate changes on `codex/issue-1621`, then open or update the draft PR if needed.
+- Verification gap: none for the requested local scope; focused tests and `npm run build` passed.
+- Files touched: src/core/workspace.ts, src/turn-execution-publication-gate.ts, src/turn-execution-publication-gate.test.ts, .codex-supervisor/issue-journal.md
+- Rollback concern: blocking current tracked issue-journal paths is stricter than the prior normalization behavior, so any workflow still relying on tracked live journals reaching draft PR publication will now stop earlier and require untracking/removal first.
+- Last focused command: npm run build
 ### Scratchpad
-- Intermediate failure while fixing review thread: dashboard DOM tests initially threw `ReferenceError: import_utils is not defined` because the injected browser script serialized `describeLoopOffTrackedWorkBlocker()` with a cross-module helper reference. Resolved by keeping the restart-only predicate inline inside `webui-dashboard-browser-logic.ts`.
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/src/core/git-workspace-helpers.test.ts
+++ b/src/core/git-workspace-helpers.test.ts
@@ -46,6 +46,23 @@ test("isIgnoredSupervisorArtifactPath matches supervisor-owned artifacts and pre
   assert.equal(isIgnoredSupervisorArtifactPath("src/user-change.ts", ".codex-supervisor/issues/1359/issue-journal.md"), false);
 });
 
+test("isIgnoredSupervisorArtifactPath matches configured templated issue journal paths", () => {
+  assert.equal(
+    isIgnoredSupervisorArtifactPath(
+      ".codex-supervisor/custom/issue-2468.md",
+      ".codex-supervisor/custom/issue-{issueNumber}.md",
+    ),
+    true,
+  );
+  assert.equal(
+    isIgnoredSupervisorArtifactPath(
+      ".codex-supervisor/custom/issue-not-a-number.md",
+      ".codex-supervisor/custom/issue-{issueNumber}.md",
+    ),
+    false,
+  );
+});
+
 test("parseGitWorktreePaths returns only normalized worktree entries", () => {
   const worktreeEntries = parseGitWorktreePaths([
     "worktree .",

--- a/src/core/git-workspace-helpers.test.ts
+++ b/src/core/git-workspace-helpers.test.ts
@@ -61,6 +61,20 @@ test("isIgnoredSupervisorArtifactPath matches configured templated issue journal
     ),
     false,
   );
+  assert.equal(
+    isIgnoredSupervisorArtifactPath(
+      ".codex-supervisor/2468/issue-2468.md",
+      ".codex-supervisor/{issueNumber}/issue-{issueNumber}.md",
+    ),
+    true,
+  );
+  assert.equal(
+    isIgnoredSupervisorArtifactPath(
+      ".codex-supervisor/2468/issue-not-a-number.md",
+      ".codex-supervisor/{issueNumber}/issue-{issueNumber}.md",
+    ),
+    false,
+  );
 });
 
 test("parseGitWorktreePaths returns only normalized worktree entries", () => {

--- a/src/core/git-workspace-helpers.ts
+++ b/src/core/git-workspace-helpers.ts
@@ -8,11 +8,29 @@ export type GitStatusPorcelainV1Entry = {
 
 const ISSUE_JOURNAL_RELATIVE_PATH_REGEX = /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/u;
 
+function matchesConfiguredIssueJournalPath(relativePath: string, journalRelativePath?: string): boolean {
+  if (!journalRelativePath) {
+    return false;
+  }
+
+  if (relativePath === journalRelativePath) {
+    return true;
+  }
+
+  if (!journalRelativePath.includes("{issueNumber}")) {
+    return false;
+  }
+
+  const escapedTemplate = journalRelativePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const templatePattern = new RegExp(`^${escapedTemplate.replace("\\{issueNumber\\}", "\\d+")}$`, "u");
+  return templatePattern.test(relativePath);
+}
+
 export function isIgnoredSupervisorArtifactPath(
   relativePath: string,
   journalRelativePath?: string,
 ): boolean {
-  return relativePath === journalRelativePath
+  return matchesConfiguredIssueJournalPath(relativePath, journalRelativePath)
     || relativePath === ".codex-supervisor/issue-journal.md"
     || ISSUE_JOURNAL_RELATIVE_PATH_REGEX.test(relativePath)
     || relativePath === ".codex-supervisor/turn-in-progress.json"

--- a/src/core/git-workspace-helpers.ts
+++ b/src/core/git-workspace-helpers.ts
@@ -22,7 +22,8 @@ function matchesConfiguredIssueJournalPath(relativePath: string, journalRelative
   }
 
   const escapedTemplate = journalRelativePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const templatePattern = new RegExp(`^${escapedTemplate.replace("\\{issueNumber\\}", "\\d+")}$`, "u");
+  const patternSource = escapedTemplate.replaceAll("\\{issueNumber\\}", "\\d+");
+  const templatePattern = new RegExp(`^${patternSource}$`, "u");
   return templatePattern.test(relativePath);
 }
 

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -455,6 +455,22 @@ export async function filterPresentTrackedFilePaths(workspacePath: string, fileP
   return presentPaths.filter((filePath): filePath is string => filePath !== null);
 }
 
+export async function listTrackedSupervisorArtifactPaths(
+  workspacePath: string,
+  journalRelativePath?: string,
+): Promise<string[]> {
+  if (!fs.existsSync(path.join(workspacePath, ".git"))) {
+    return [];
+  }
+  const trackedPathsResult = await runCommand("git", ["-C", workspacePath, "ls-files", "-z", "--", ".codex-supervisor"]);
+  return trackedPathsResult.stdout
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => isIgnoredSupervisorArtifactPath(entry, journalRelativePath))
+    .sort((left, right) => left.localeCompare(right));
+}
+
 export async function cleanupWorkspace(
   repoPath: string,
   workspacePath: string,

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -227,6 +227,8 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
       }),
     },
   };
+  const initialLastHeadSha = state.issues["102"]!.last_head_sha;
+  const workspaceHeadSha = git(workspacePath, "rev-parse", "HEAD").trim();
 
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({
@@ -243,7 +245,7 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
     workspacePath,
     workspaceStatus: {
       branch: "codex/issue-102",
-      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      headSha: workspaceHeadSha,
       hasUncommittedChanges: false,
       baseAhead: 1,
       baseBehind: 0,
@@ -291,7 +293,8 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
   assert.equal(createPullRequestCalls, 0);
   assert.equal(runWorkspacePreparationCalls, 0);
   assert.equal(runLocalCiCalls, 0);
-  assert.equal(result.record.last_head_sha, "head-116");
+  assert.equal(result.record.last_head_sha, initialLastHeadSha);
+  assert.notEqual(result.record.last_head_sha, workspaceHeadSha);
   assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed cross-issue journal leak");
   assert.equal(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102").trim(), "");
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -297,6 +297,99 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 
+test("applyCodexTurnPublicationGate blocks tracked supervisor journals for custom templated journal layouts", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "custom", "issue-102.md");
+  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "custom", "issue-181.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(otherJournalPath, "# Issue #181\n", "utf8");
+  git(workspacePath, "add", ".codex-supervisor/custom/issue-102.md", ".codex-supervisor/custom/issue-181.md");
+  git(workspacePath, "commit", "-m", "seed custom journal leak");
+
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+  const issue = createIssue({ title: "Gate custom journal layouts before publication" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      issueJournalRelativePath: ".codex-supervisor/custom/issue-{issueNumber}.md",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected path hygiene call");
+    },
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.match(result.message, /\.codex-supervisor\/custom\/issue-102\.md/);
+  assert.match(result.message, /\.codex-supervisor\/custom\/issue-181\.md/);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
+  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed custom journal leak");
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+});
+
 test("applyCodexTurnPublicationGate persists trusted generated artifact normalization before PR creation", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -165,9 +165,9 @@ test("applyCodexTurnPublicationGate forwards publishable allowlist markers to th
       getUnresolvedReviewThreads: async () => [],
     },
     syncJournal: async () => undefined,
-    applyFailureSignature: () => ({
-      last_failure_signature: null,
-      repeated_failure_signature_count: 0,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
     }),
     runWorkstationLocalPathGate: async (args) => {
       observedCalls.push(args.publishablePathAllowlistMarkers);
@@ -184,7 +184,7 @@ test("applyCodexTurnPublicationGate forwards publishable allowlist markers to th
   assert.deepEqual(observedCalls, [["publishable-path-hygiene: allowlist"]]);
 });
 
-test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journals before publication", async (t) => {
+test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals before publication", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {
     await fs.rm(workspacePath, { recursive: true, force: true });
@@ -212,6 +212,8 @@ test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journal
   git(workspacePath, "commit", "-m", "seed cross-issue journal leak");
 
   let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
   const issue = createIssue({ title: "Gate draft PR creation on cross-issue journal hygiene" });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
@@ -253,28 +255,45 @@ test("applyCodexTurnPublicationGate redacts supervisor-owned cross-issue journal
       resolvePullRequestForBranch: async () => null,
       createPullRequest: async () => {
         createPullRequestCalls += 1;
-        return createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });
+        throw new Error("unexpected createPullRequest call");
       },
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
     },
     syncJournal: async () => undefined,
-    applyFailureSignature: () => ({
-      last_failure_signature: null,
-      repeated_failure_signature_count: 0,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
     }),
-    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected path hygiene call");
+    },
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
     syncExecutionMetricsRunSummary: async () => undefined,
   });
 
-  assert.equal(result.kind, "ready");
-  assert.equal(createPullRequestCalls, 1);
-  assert.equal(result.record.last_head_sha, git(workspacePath, "rev-parse", "HEAD").trim());
-  const redactedJournal = await fs.readFile(otherJournalPath, "utf8");
-  assert.doesNotMatch(redactedJournal, new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-  assert.match(redactedJournal, /<redacted-local-path>/);
-  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
-  assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102"), /refs\/heads\/codex\/issue-102/);
+  assert.equal(result.kind, "blocked");
+  assert.match(
+    result.message,
+    /Tracked supervisor-local durable artifacts blocked pull request creation for issue #102\./,
+  );
+  assert.match(result.message, /\.codex-supervisor\/issues\/102\/issue-journal\.md/);
+  assert.match(result.message, /\.codex-supervisor\/issues\/181\/issue-journal\.md/);
+  assert.match(result.message, /Remove or unstage these tracked paths before publishing checkpoint commits:/);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
+  assert.equal(result.record.last_head_sha, "head-116");
+  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed cross-issue journal leak");
+  assert.equal(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102").trim(), "");
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 
@@ -303,7 +322,7 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
     ].join("\n"),
     "utf8",
   );
-  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md", "docs/guide.md", "docs/generated-summary.md");
+  git(workspacePath, "add", "docs/guide.md", "docs/generated-summary.md");
   git(workspacePath, "commit", "-m", "seed trusted generated artifact leak");
 
   let createPullRequestCalls = 0;
@@ -354,9 +373,9 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
       getUnresolvedReviewThreads: async () => [],
     },
     syncJournal: async () => undefined,
-    applyFailureSignature: () => ({
-      last_failure_signature: null,
-      repeated_failure_signature_count: 0,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
     }),
     runLocalCiCommand: async () => undefined,
     syncExecutionMetricsRunSummary: async () => undefined,
@@ -378,7 +397,7 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 
-test("applyCodexTurnPublicationGate tolerates sparse-present tracked cross-issue journals outside the sparse checkout", async (t) => {
+test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue journals outside the sparse checkout", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {
     await fs.rm(workspacePath, { recursive: true, force: true });
@@ -429,6 +448,8 @@ test("applyCodexTurnPublicationGate tolerates sparse-present tracked cross-issue
   await fs.access(otherJournalPath);
 
   let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
   const issue = createIssue({ title: "Gate sparse cross-issue journal hygiene without blocking publication" });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
@@ -470,26 +491,124 @@ test("applyCodexTurnPublicationGate tolerates sparse-present tracked cross-issue
       resolvePullRequestForBranch: async () => null,
       createPullRequest: async () => {
         createPullRequestCalls += 1;
-        return createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });
+        throw new Error("unexpected createPullRequest call");
       },
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
     },
     syncJournal: async () => undefined,
-    applyFailureSignature: () => ({
-      last_failure_signature: null,
-      repeated_failure_signature_count: 0,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
     }),
-    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected path hygiene call");
+    },
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
     syncExecutionMetricsRunSummary: async () => undefined,
   });
 
-  assert.equal(result.kind, "ready");
-  assert.equal(createPullRequestCalls, 1);
-  assert.equal(result.record.state, "stabilizing");
-  assert.equal(result.record.last_failure_signature, null);
+  assert.equal(result.kind, "blocked");
+  assert.match(result.message, /\.codex-supervisor\/issues\/181\/issue-journal\.md/);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
   assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed sparse cross-issue journal leak");
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "M .codex-supervisor/issues/181/issue-journal.md");
+});
+
+test("applyCodexTurnPublicationGate blocks tracked supervisor replay artifacts before workspace preparation and local CI", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const replayArtifactPath = path.join(workspacePath, ".codex-supervisor", "replay", "decision-cycle-snapshot.json");
+  await fs.mkdir(path.dirname(replayArtifactPath), { recursive: true });
+  await fs.writeFile(replayArtifactPath, "{\n  \"kind\": \"replay\"\n}\n", "utf8");
+  git(workspacePath, "add", ".codex-supervisor/replay/decision-cycle-snapshot.json");
+  git(workspacePath, "commit", "-m", "seed replay artifact leak");
+
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+  const issue = createIssue({ title: "Gate draft PR creation on supervisor replay artifact" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      workspacePreparationCommand: "npm ci",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected path hygiene call");
+    },
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.match(result.message, /\.codex-supervisor\/replay\/decision-cycle-snapshot\.json/);
+  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
+  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed replay artifact leak");
 });
 
 test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails", async () => {

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -390,6 +390,100 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for custo
   assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
 });
 
+test("applyCodexTurnPublicationGate blocks tracked supervisor journals for repeated-placeholder layouts", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "102", "issue-102.md");
+  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "181", "issue-181.md");
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  await fs.writeFile(otherJournalPath, "# Issue #181\n", "utf8");
+  git(workspacePath, "add", ".codex-supervisor/102/issue-102.md", ".codex-supervisor/181/issue-181.md");
+  git(workspacePath, "commit", "-m", "seed repeated placeholder journal leak");
+
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+  const issue = createIssue({ title: "Gate repeated-placeholder journal layouts before publication" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      issueJournalRelativePath: ".codex-supervisor/{issueNumber}/issue-{issueNumber}.md",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected path hygiene call");
+    },
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.match(result.message, /\.codex-supervisor\/102\/issue-102\.md/);
+  assert.match(result.message, /\.codex-supervisor\/181\/issue-181\.md/);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
+  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed repeated placeholder journal leak");
+  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+});
+
 test("applyCodexTurnPublicationGate persists trusted generated artifact normalization before PR creation", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -19,7 +19,12 @@ import {
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
 } from "./workstation-local-path-gate";
-import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
+import {
+  commitAndPushTrackedFiles,
+  filterPresentTrackedFilePaths,
+  getWorkspaceStatus,
+  listTrackedSupervisorArtifactPaths,
+} from "./core/workspace";
 
 function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
@@ -47,6 +52,28 @@ export type CodexTurnPublicationGateResult =
   | CodexTurnPublicationGateReadyResult;
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
+const SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE = "supervisor-local-durable-artifacts-tracked-before-publication";
+
+function buildSupervisorLocalArtifactFailureContext(
+  trackedPaths: string[],
+  issueNumber: number,
+): FailureContext {
+  const listedPaths = trackedPaths.join(", ");
+  return {
+    category: "blocked",
+    summary:
+      `Tracked supervisor-local durable artifacts blocked pull request creation for issue #${issueNumber}. `
+      + `Remove or unstage these tracked paths before publishing checkpoint commits: ${listedPaths}.`,
+    signature: SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE,
+    command: "git ls-files -- .codex-supervisor",
+    details: [
+      "Supervisor-local durable artifacts must not be committed into issue-branch publication checkpoints.",
+      ...trackedPaths.map((trackedPath) => `tracked supervisor-local artifact: ${trackedPath}`),
+    ],
+    url: null,
+    updated_at: new Date().toISOString(),
+  };
+}
 
 export async function applyCodexTurnPublicationGate(args: {
   config: Pick<
@@ -54,6 +81,7 @@ export async function applyCodexTurnPublicationGate(args: {
     | "repoPath"
     | "defaultBranch"
     | "draftPrAfterAttempt"
+    | "issueJournalRelativePath"
     | "workspacePreparationCommand"
     | "localCiCommand"
     | "publishablePathAllowlistMarkers"
@@ -94,6 +122,38 @@ export async function applyCodexTurnPublicationGate(args: {
     !workspaceStatus.hasUncommittedChanges &&
     record.implementation_attempt_count >= args.config.draftPrAfterAttempt
   ) {
+    const trackedSupervisorArtifactPaths = await listTrackedSupervisorArtifactPaths(
+      args.workspacePath,
+      args.config.issueJournalRelativePath,
+    );
+    if (trackedSupervisorArtifactPaths.length > 0) {
+      const failureContext = buildSupervisorLocalArtifactFailureContext(
+        trackedSupervisorArtifactPaths,
+        record.issue_number,
+      );
+      record = args.stateStore.touch(record, {
+        state: "blocked",
+        last_error: truncate(failureContext.summary, 1000),
+        last_failure_kind: null,
+        last_failure_context: failureContext,
+        ...args.applyFailureSignature(record, failureContext),
+        blocked_reason: "verification",
+        ...issueDefinitionFreshnessPatch(args.issue),
+      });
+      args.state.issues[String(record.issue_number)] = record;
+      await args.stateStore.save(args.state);
+      await args.syncExecutionMetricsRunSummary(record);
+      await args.syncJournal(record);
+      return {
+        kind: "blocked",
+        message: failureContext.summary,
+        record,
+        pr: null,
+        checks: [],
+        reviewThreads: [],
+      };
+    }
+
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({
       workspacePath: args.workspacePath,
       gateLabel: "before publication",


### PR DESCRIPTION
Closes #1621
This PR was opened by codex-supervisor.
Latest Codex summary:

Added an early publication blocker that scans tracked `.codex-supervisor` files before path hygiene, workspace prep, or local CI. It now hard-blocks tracked live issue journals plus replay, pre-merge, execution-metrics, and `turn-in-progress` artifacts with an operator-facing remediation message, while keeping trusted generated artifact normalization intact. Checkpoint commit: `6a87f03` (`Block tracked supervisor-local publication artifacts`).

Verification passed with `npx tsx --test src/turn-execution-publication-gate.test.ts src/run-once-issue-preparation.test.ts` and `npm run build`. I left the existing untracked supervisor runtime artifacts under `.codex-supervisor/` untouched.

Summary: Added a fail-closed pre-publication guard for tracked supervisor-local durable artifacts and committed it as `6a87f03`.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/turn-execution-publication-gate.test.ts src/run-once-issue-preparation.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1621` from commit `6a87f03`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publication gate now blocks PR creation when tracked supervisor-local durable artifacts are present, halting workspace prep and local CI and recording a failure signature.
  * New utility to detect tracked supervisor artifact paths with support for configurable templated journal path patterns.

* **Tests**
  * Added/updated tests for blocked scenarios, templated journal patterns, sparse-checkout, replay artifacts, and trusted-artifact normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->