### PR TITLE
Install worktree-local excludes for supervisor-owned issue artifacts

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -359,6 +359,92 @@ test("ensureWorkspace hides tracked live issue journals while preserving intenti
   assert.doesNotMatch(workspaceStatus, /\.codex-supervisor\/issues\/811\/issue-journal\.md/u);
 });
 
+test("ensureWorkspace installs worktree-local excludes for supervisor artifacts in fresh linked worktrees", async () => {
+  const config = await createRepositoryFixture();
+  const issueNumber = 812;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+  const gitDir = await gitOutput(ensured.workspacePath, "rev-parse", "--absolute-git-dir");
+  const excludePath = await gitOutput(
+    ensured.workspacePath,
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-path",
+    "info/exclude",
+  );
+
+  await fs.mkdir(path.join(ensured.workspacePath, ".codex-supervisor", "execution-metrics"), { recursive: true });
+  await fs.mkdir(path.join(ensured.workspacePath, ".codex-supervisor", "pre-merge"), { recursive: true });
+  await fs.mkdir(path.join(ensured.workspacePath, ".codex-supervisor", "replay"), { recursive: true });
+  await fs.mkdir(path.join(ensured.workspacePath, ".codex-supervisor", "issues", String(issueNumber)), { recursive: true });
+  await fs.writeFile(path.join(ensured.workspacePath, ".codex-supervisor", "turn-in-progress.json"), "{}\n", "utf8");
+  await fs.writeFile(
+    path.join(ensured.workspacePath, ".codex-supervisor", "execution-metrics", "run-summary.json"),
+    "{}\n",
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(ensured.workspacePath, ".codex-supervisor", "pre-merge", "assessment-snapshot.json"),
+    "{}\n",
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(ensured.workspacePath, ".codex-supervisor", "replay", "decision-cycle-snapshot.json"),
+    "{}\n",
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(ensured.workspacePath, ".codex-supervisor", "issues", String(issueNumber), "issue-journal.md"),
+    "# local journal\n",
+    "utf8",
+  );
+
+  await git(ensured.workspacePath, "add", "-A");
+
+  const excludeFile = await fs.readFile(excludePath, "utf8");
+  const stagedPaths = await gitOutput(ensured.workspacePath, "diff", "--cached", "--name-only");
+
+  assert.match(gitDir, /\/worktrees\/issue-812$/u);
+  assert.match(excludePath, /\/\.git\/info\/exclude$/u);
+  assert.notEqual(excludePath, path.join(gitDir, "info", "exclude"));
+  assert.match(excludeFile, /^\.codex-supervisor\/issues\/812\/issue-journal\.md$/mu);
+  assert.match(excludeFile, /^\.codex-supervisor\/execution-metrics\/\*$/mu);
+  assert.match(excludeFile, /^\.codex-supervisor\/pre-merge\/\*$/mu);
+  assert.match(excludeFile, /^\.codex-supervisor\/replay\/\*$/mu);
+  assert.match(excludeFile, /^\.codex-supervisor\/turn-in-progress\.json$/mu);
+  assert.equal(stagedPaths, "");
+});
+
+test("ensureWorkspace reuses worktree-local excludes idempotently without clobbering operator entries", async () => {
+  const config = await createRepositoryFixture();
+  const issueNumber = 813;
+  const branch = `${config.branchPrefix}${issueNumber}`;
+
+  const ensured = await ensureWorkspace(config, issueNumber, branch);
+  const excludePath = await gitOutput(
+    ensured.workspacePath,
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-path",
+    "info/exclude",
+  );
+  await fs.appendFile(excludePath, "\n# operator-managed\ncustom-local.log\n", "utf8");
+
+  const reused = await ensureWorkspace(config, issueNumber, branch);
+  const excludeFile = await fs.readFile(excludePath, "utf8");
+  const excludeLines = excludeFile.split(/\r?\n/u).filter(Boolean);
+
+  assert.equal(reused.restore.source, "existing_workspace");
+  assert.equal(excludeLines.filter((line) => line === ".codex-supervisor/issues/813/issue-journal.md").length, 1);
+  assert.equal(excludeLines.filter((line) => line === ".codex-supervisor/execution-metrics/*").length, 1);
+  assert.equal(excludeLines.filter((line) => line === ".codex-supervisor/pre-merge/*").length, 1);
+  assert.equal(excludeLines.filter((line) => line === ".codex-supervisor/replay/*").length, 1);
+  assert.equal(excludeLines.filter((line) => line === ".codex-supervisor/turn-in-progress.json").length, 1);
+  assert.match(excludeFile, /^# operator-managed$/mu);
+  assert.match(excludeFile, /^custom-local\.log$/mu);
+});
+
 test("ensureWorkspace ignores similarly suffixed remote-tracking refs when bootstrapping", async () => {
   const config = await createRepositoryFixture();
   const issueNumber = 727;
@@ -444,7 +530,7 @@ test("ensureWorkspace rejects reusing an existing workspace on the wrong branch"
 
   await assert.rejects(
     () => ensureWorkspace(config, issueNumber, branch),
-    /not a registered worktree/i,
+    /unexpected-branch|not a registered worktree/i,
   );
 });
 
@@ -459,7 +545,7 @@ test("ensureWorkspace rejects reusing an existing workspace on a detached HEAD",
 
   await assert.rejects(
     () => ensureWorkspace(config, issueNumber, branch),
-    /not a registered worktree/i,
+    /detached HEAD|not a registered worktree/i,
   );
 });
 
@@ -644,10 +730,10 @@ test("issue-scoped journals do not manufacture merge conflicts between unrelated
   );
   assert.equal(
     await gitOutput(workspaceB.workspacePath, "ls-files", ".codex-supervisor/issues/801/issue-journal.md"),
-    ".codex-supervisor/issues/801/issue-journal.md",
+    "",
   );
   assert.equal(
     await gitOutput(workspaceB.workspacePath, "ls-files", ".codex-supervisor/issues/802/issue-journal.md"),
-    ".codex-supervisor/issues/802/issue-journal.md",
+    "",
   );
 });

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { runCommand } from "./command";
-import { isIgnoredSupervisorArtifactPath, parseGitStatusPorcelainV1Paths } from "./git-workspace-helpers";
+import { issueJournalPath } from "./journal";
+import {
+  isIgnoredSupervisorArtifactPath,
+  normalizeGitPath,
+  parseGitStatusPorcelainV1Paths,
+} from "./git-workspace-helpers";
 import { EnsuredWorkspace, SupervisorConfig, WorkspaceRestoreMetadata, WorkspaceStatus } from "./types";
 import { ensureDir, isValidGitRefName } from "./utils";
 
@@ -197,6 +202,61 @@ async function protectTrackedLiveIssueJournals(workspacePath: string): Promise<v
   await runCommand("git", ["-C", workspacePath, "update-index", "--skip-worktree", "--", ...trackedPaths]);
 }
 
+function toGitRelativePath(workspacePath: string, absolutePath: string): string {
+  const relativePath = path.relative(workspacePath, absolutePath);
+  return relativePath.split(path.sep).join("/");
+}
+
+async function worktreeLocalExcludePath(workspacePath: string): Promise<string> {
+  const excludePath = (await runCommand(
+    "git",
+    ["-C", workspacePath, "rev-parse", "--path-format=absolute", "--git-path", "info/exclude"],
+  )).stdout.trim();
+  if (!excludePath) {
+    throw new Error(`Could not resolve git exclude path for workspace: ${workspacePath}`);
+  }
+
+  return excludePath;
+}
+
+async function installWorktreeLocalExcludes(
+  config: Pick<SupervisorConfig, "issueJournalRelativePath">,
+  workspacePath: string,
+  issueNumber: number,
+): Promise<void> {
+  const excludePath = await worktreeLocalExcludePath(workspacePath);
+  await ensureDir(path.dirname(excludePath));
+
+  const journalPath = issueJournalPath(workspacePath, config.issueJournalRelativePath, issueNumber);
+  const managedEntries = [
+    toGitRelativePath(workspacePath, journalPath),
+    ".codex-supervisor/execution-metrics/*",
+    ".codex-supervisor/pre-merge/*",
+    ".codex-supervisor/replay/*",
+    ".codex-supervisor/turn-in-progress.json",
+  ];
+  const existingContent = fs.existsSync(excludePath) ? fs.readFileSync(excludePath, "utf8") : "";
+  const existingLines = existingContent.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
+  const existingEntries = new Set(existingLines);
+  const missingEntries = managedEntries.filter((entry) => !existingEntries.has(entry));
+
+  if (missingEntries.length === 0) {
+    return;
+  }
+
+  const appendedBlock = `${existingContent.length > 0 && !existingContent.endsWith("\n") ? "\n" : ""}${missingEntries.join("\n")}\n`;
+  fs.appendFileSync(excludePath, appendedBlock, "utf8");
+}
+
+async function finalizeWorkspaceSetup(
+  config: Pick<SupervisorConfig, "issueJournalRelativePath">,
+  workspacePath: string,
+  issueNumber: number,
+): Promise<void> {
+  await installWorktreeLocalExcludes(config, workspacePath, issueNumber);
+  await protectTrackedLiveIssueJournals(workspacePath);
+}
+
 export function formatWorkspaceRestoreStatusLine(restore: WorkspaceRestoreMetadata): string {
   return `workspace_restore source=${restore.source} ref=${restore.ref}`;
 }
@@ -225,7 +285,7 @@ function parseGitWorktreeList(stdout: string): GitWorktreeEntry[] {
         entries.push(current);
       }
       current = {
-        worktreePath: path.resolve(line.slice("worktree ".length).trim()),
+        worktreePath: normalizeGitPath(line.slice("worktree ".length).trim()),
         branchRef: null,
       };
       continue;
@@ -248,7 +308,7 @@ async function assertReusableExistingWorkspace(
   workspacePath: string,
   branch: string,
 ): Promise<void> {
-  const resolvedWorkspacePath = path.resolve(workspacePath);
+  const resolvedWorkspacePath = normalizeGitPath(workspacePath);
   const worktreeList = await runCommand("git", ["-C", config.repoPath, "worktree", "list", "--porcelain"]);
   const worktreeEntry = parseGitWorktreeList(worktreeList.stdout).find(
     (entry) => entry.worktreePath === resolvedWorkspacePath,
@@ -292,7 +352,7 @@ export async function ensureWorkspace(
 
   if (fs.existsSync(path.join(workspacePath, ".git"))) {
     await assertReusableExistingWorkspace(config, workspacePath, branch);
-    await protectTrackedLiveIssueJournals(workspacePath);
+    await finalizeWorkspaceSetup(config, workspacePath, issueNumber);
     return buildEnsuredWorkspace(workspacePath, {
       source: "existing_workspace",
       ref: branch,
@@ -305,7 +365,7 @@ export async function ensureWorkspace(
 
   if (await branchExists(config.repoPath, branch)) {
     await runCommand("git", ["-C", config.repoPath, "worktree", "add", workspacePath, branch]);
-    await protectTrackedLiveIssueJournals(workspacePath);
+    await finalizeWorkspaceSetup(config, workspacePath, issueNumber);
     return buildEnsuredWorkspace(workspacePath, {
       source: "local_branch",
       ref: branch,
@@ -314,7 +374,7 @@ export async function ensureWorkspace(
 
   if (remoteBranchExists) {
     await runCommand("git", ["-C", config.repoPath, "worktree", "add", "-b", branch, workspacePath, `origin/${branch}`]);
-    await protectTrackedLiveIssueJournals(workspacePath);
+    await finalizeWorkspaceSetup(config, workspacePath, issueNumber);
     return buildEnsuredWorkspace(workspacePath, {
       source: "remote_branch",
       ref: `origin/${branch}`,
@@ -332,7 +392,7 @@ export async function ensureWorkspace(
     workspacePath,
     bootstrapBaseRef,
   ]);
-  await protectTrackedLiveIssueJournals(workspacePath);
+  await finalizeWorkspaceSetup(config, workspacePath, issueNumber);
 
   return buildEnsuredWorkspace(workspacePath, {
     source: "bootstrap_default_branch",


### PR DESCRIPTION
Closes #1622

## Summary
- install supervisor-local exclude entries during workspace bootstrap through Git-resolved local exclude paths
- keep the exclude installation idempotent and preserve unrelated operator-managed entries
- normalize existing worktree path checks and update workspace tests around journal staging and reuse

## Verification
- npx tsx --test src/core/workspace.test.ts src/run-once-issue-preparation.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification for worktree-local ignore pattern configuration
  * Enhanced test coverage for workspace reuse scenarios

* **Improvements**
  * Enhanced workspace setup with automatic Git ignore pattern configuration for workspace-local artifacts
  * Improved worktree path handling for better cross-platform compatibility
  * Strengthened conflict prevention for shared tracked files across linked workspaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->