### PR TITLE
Add one bounded same-turn repair retry for publishable path hygiene failures (#1627)

### DIFF
--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -7,11 +7,18 @@ import {
   normalizeGitPath,
   parseGitStatusPorcelainV1Paths,
 } from "./git-workspace-helpers";
-import { EnsuredWorkspace, SupervisorConfig, WorkspaceRestoreMetadata, WorkspaceStatus } from "./types";
+import {
+  EnsuredWorkspace,
+  SupervisorConfig,
+  WorkspaceRestoreMetadata,
+  WorkspaceStatus,
+} from "./types";
 import { ensureDir, isValidGitRefName } from "./utils";
 
-const LIVE_ISSUE_JOURNAL_PATH_GLOB = ".codex-supervisor/issues/[0-9]*/issue-journal.md";
-const LIVE_ISSUE_JOURNAL_PATH_REGEX = /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/u;
+const LIVE_ISSUE_JOURNAL_PATH_GLOB =
+  ".codex-supervisor/issues/[0-9]*/issue-journal.md";
+const LIVE_ISSUE_JOURNAL_PATH_REGEX =
+  /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/u;
 
 function assertIssueNumber(issueNumber: number): void {
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
@@ -19,7 +26,10 @@ function assertIssueNumber(issueNumber: number): void {
   }
 }
 
-export function branchNameForIssue(config: SupervisorConfig, issueNumber: number): string {
+export function branchNameForIssue(
+  config: SupervisorConfig,
+  issueNumber: number,
+): string {
   assertIssueNumber(issueNumber);
   const branch = `${config.branchPrefix}${issueNumber}`;
   if (!isValidGitRefName(branch)) {
@@ -29,12 +39,18 @@ export function branchNameForIssue(config: SupervisorConfig, issueNumber: number
   return branch;
 }
 
-export function workspacePathForIssue(config: SupervisorConfig, issueNumber: number): string {
+export function workspacePathForIssue(
+  config: SupervisorConfig,
+  issueNumber: number,
+): string {
   assertIssueNumber(issueNumber);
   return path.join(config.workspaceRoot, `issue-${issueNumber}`);
 }
 
-async function branchExists(repoPath: string, branch: string): Promise<boolean> {
+async function branchExists(
+  repoPath: string,
+  branch: string,
+): Promise<boolean> {
   const result = await runCommand(
     "git",
     ["-C", repoPath, "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
@@ -43,10 +59,20 @@ async function branchExists(repoPath: string, branch: string): Promise<boolean> 
   return result.exitCode === 0;
 }
 
-async function remoteTrackingRefExists(gitPath: string, branch: string): Promise<boolean> {
+async function remoteTrackingRefExists(
+  gitPath: string,
+  branch: string,
+): Promise<boolean> {
   const result = await runCommand(
     "git",
-    ["-C", gitPath, "show-ref", "--verify", "--quiet", `refs/remotes/origin/${branch}`],
+    [
+      "-C",
+      gitPath,
+      "show-ref",
+      "--verify",
+      "--quiet",
+      `refs/remotes/origin/${branch}`,
+    ],
     { allowExitCodes: [0, 1] },
   );
   return result.exitCode === 0;
@@ -61,7 +87,10 @@ async function gitRefExists(gitPath: string, ref: string): Promise<boolean> {
   return result.exitCode === 0;
 }
 
-async function listDefaultBranchCandidateRefs(repoPath: string, defaultBranch: string): Promise<string[]> {
+async function listDefaultBranchCandidateRefs(
+  repoPath: string,
+  defaultBranch: string,
+): Promise<string[]> {
   const candidates = new Set<string>();
   const localRef = `refs/heads/${defaultBranch}`;
   if (await gitRefExists(repoPath, localRef)) {
@@ -69,7 +98,10 @@ async function listDefaultBranchCandidateRefs(repoPath: string, defaultBranch: s
   }
 
   const remotes = await runCommand("git", ["-C", repoPath, "remote"]);
-  for (const remote of remotes.stdout.split("\n").map((line) => line.trim()).filter(Boolean)) {
+  for (const remote of remotes.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)) {
     const remoteRef = `refs/remotes/${remote}/${defaultBranch}`;
     if (await gitRefExists(repoPath, remoteRef)) {
       candidates.add(`${remote}/${defaultBranch}`);
@@ -79,7 +111,11 @@ async function listDefaultBranchCandidateRefs(repoPath: string, defaultBranch: s
   return [...candidates];
 }
 
-async function isAncestorRef(repoPath: string, ancestor: string, descendant: string): Promise<boolean> {
+async function isAncestorRef(
+  repoPath: string,
+  ancestor: string,
+  descendant: string,
+): Promise<boolean> {
   const result = await runCommand(
     "git",
     ["-C", repoPath, "merge-base", "--is-ancestor", ancestor, descendant],
@@ -93,7 +129,10 @@ async function revParse(repoPath: string, ref: string): Promise<string> {
   return result.stdout.trim();
 }
 
-function preferredBootstrapBaseRef(defaultBranch: string, refs: string[]): string {
+function preferredBootstrapBaseRef(
+  defaultBranch: string,
+  refs: string[],
+): string {
   const preferredOrder = [`origin/${defaultBranch}`, defaultBranch];
   for (const preferredRef of preferredOrder) {
     if (refs.includes(preferredRef)) {
@@ -104,14 +143,25 @@ function preferredBootstrapBaseRef(defaultBranch: string, refs: string[]): strin
   return [...refs].sort()[0] ?? `origin/${defaultBranch}`;
 }
 
-async function resolveBootstrapBaseRef(repoPath: string, defaultBranch: string): Promise<string> {
-  const candidateRefs = await listDefaultBranchCandidateRefs(repoPath, defaultBranch);
+async function resolveBootstrapBaseRef(
+  repoPath: string,
+  defaultBranch: string,
+): Promise<string> {
+  const candidateRefs = await listDefaultBranchCandidateRefs(
+    repoPath,
+    defaultBranch,
+  );
   if (candidateRefs.length === 0) {
-    throw new Error(`No available default-branch refs found for ${defaultBranch}`);
+    throw new Error(
+      `No available default-branch refs found for ${defaultBranch}`,
+    );
   }
 
-  const remoteCandidateRefs = candidateRefs.filter((ref) => ref !== defaultBranch);
-  const refsToCompare = remoteCandidateRefs.length > 0 ? remoteCandidateRefs : candidateRefs;
+  const remoteCandidateRefs = candidateRefs.filter(
+    (ref) => ref !== defaultBranch,
+  );
+  const refsToCompare =
+    remoteCandidateRefs.length > 0 ? remoteCandidateRefs : candidateRefs;
   const candidateShas = new Map<string, string>();
   for (const ref of refsToCompare) {
     candidateShas.set(ref, await revParse(repoPath, ref));
@@ -150,7 +200,10 @@ async function resolveBootstrapBaseRef(repoPath: string, defaultBranch: string):
   return preferredBootstrapBaseRef(defaultBranch, maximalRefs);
 }
 
-async function originBranchExists(gitPath: string, branch: string): Promise<boolean> {
+async function originBranchExists(
+  gitPath: string,
+  branch: string,
+): Promise<boolean> {
   const result = await runCommand(
     "git",
     ["-C", gitPath, "ls-remote", "--exit-code", "--heads", "origin", branch],
@@ -159,18 +212,25 @@ async function originBranchExists(gitPath: string, branch: string): Promise<bool
   return result.exitCode === 0;
 }
 
-async function fetchIssueRemoteTrackingRef(repoPath: string, branch: string): Promise<boolean> {
+async function fetchIssueRemoteTrackingRef(
+  repoPath: string,
+  branch: string,
+): Promise<boolean> {
   const remoteRef = `refs/remotes/origin/${branch}`;
   if (!(await originBranchExists(repoPath, branch))) {
-    await runCommand(
-      "git",
-      ["-C", repoPath, "update-ref", "-d", remoteRef],
-      { allowExitCodes: [0, 1] },
-    );
+    await runCommand("git", ["-C", repoPath, "update-ref", "-d", remoteRef], {
+      allowExitCodes: [0, 1],
+    });
     return false;
   }
 
-  await runCommand("git", ["-C", repoPath, "fetch", "origin", `+refs/heads/${branch}:${remoteRef}`]);
+  await runCommand("git", [
+    "-C",
+    repoPath,
+    "fetch",
+    "origin",
+    `+refs/heads/${branch}:${remoteRef}`,
+  ]);
   return true;
 }
 
@@ -184,11 +244,17 @@ function buildEnsuredWorkspace(
   };
 }
 
-async function protectTrackedLiveIssueJournals(workspacePath: string): Promise<void> {
-  const trackedPathsResult = await runCommand(
-    "git",
-    ["-C", workspacePath, "ls-files", "-z", "--", LIVE_ISSUE_JOURNAL_PATH_GLOB],
-  );
+async function protectTrackedLiveIssueJournals(
+  workspacePath: string,
+): Promise<void> {
+  const trackedPathsResult = await runCommand("git", [
+    "-C",
+    workspacePath,
+    "ls-files",
+    "-z",
+    "--",
+    LIVE_ISSUE_JOURNAL_PATH_GLOB,
+  ]);
   const trackedPaths = trackedPathsResult.stdout
     .split("\0")
     .map((entry) => entry.trim())
@@ -199,69 +265,77 @@ async function protectTrackedLiveIssueJournals(workspacePath: string): Promise<v
     return;
   }
 
-  await runCommand("git", ["-C", workspacePath, "update-index", "--skip-worktree", "--", ...trackedPaths]);
+  await runCommand("git", [
+    "-C",
+    workspacePath,
+    "update-index",
+    "--skip-worktree",
+    "--",
+    ...trackedPaths,
+  ]);
 }
 
-function toGitRelativePath(workspacePath: string, absolutePath: string): string {
+function toGitRelativePath(
+  workspacePath: string,
+  absolutePath: string,
+): string {
   const relativePath = path.relative(workspacePath, absolutePath);
   return relativePath.split(path.sep).join("/");
 }
 
-async function worktreeLocalExcludePath(workspacePath: string): Promise<string> {
-  const excludePath = (await runCommand(
-    "git",
-    ["-C", workspacePath, "rev-parse", "--path-format=absolute", "--git-path", "info/exclude"],
-  )).stdout.trim();
+async function worktreeLocalExcludePath(
+  workspacePath: string,
+): Promise<string> {
+  const excludePath = (
+    await runCommand("git", [
+      "-C",
+      workspacePath,
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-path",
+      "info/exclude",
+    ])
+  ).stdout.trim();
   if (!excludePath) {
-    throw new Error(`Could not resolve git exclude path for workspace: ${workspacePath}`);
+    throw new Error(
+      `Could not resolve git exclude path for workspace: ${workspacePath}`,
+    );
   }
 
   return excludePath;
 }
 
-function wildcardConfiguredIssueJournalPath(journalRelativePath: string): string {
-  return journalRelativePath.includes("{issueNumber}")
-    ? journalRelativePath.replaceAll("{issueNumber}", "*")
-    : journalRelativePath;
-}
-
-function managedSupervisorArtifactExcludeEntries(
+async function installWorktreeLocalExcludes(
   config: Pick<SupervisorConfig, "issueJournalRelativePath">,
   workspacePath: string,
-  issueNumber?: number,
-): string[] {
-  const journalEntries = new Set<string>();
-  if (issueNumber === undefined) {
-    journalEntries.add(wildcardConfiguredIssueJournalPath(config.issueJournalRelativePath));
-    journalEntries.add(".codex-supervisor/issue-journal.md");
-    journalEntries.add(".codex-supervisor/issues/*/issue-journal.md");
-  } else {
-    const journalPath = issueJournalPath(workspacePath, config.issueJournalRelativePath, issueNumber);
-    journalEntries.add(toGitRelativePath(workspacePath, journalPath));
-  }
+  issueNumber: number,
+): Promise<void> {
+  const excludePath = await worktreeLocalExcludePath(workspacePath);
+  await ensureDir(path.dirname(excludePath));
 
-  return [
-    ...journalEntries,
+  const journalPath = issueJournalPath(
+    workspacePath,
+    config.issueJournalRelativePath,
+    issueNumber,
+  );
+  const managedEntries = [
+    toGitRelativePath(workspacePath, journalPath),
     ".codex-supervisor/execution-metrics/*",
     ".codex-supervisor/pre-merge/*",
     ".codex-supervisor/replay/*",
     ".codex-supervisor/turn-in-progress.json",
   ];
-}
-
-async function installGitLocalExcludes(
-  config: Pick<SupervisorConfig, "issueJournalRelativePath">,
-  workspacePath: string,
-  issueNumber?: number,
-): Promise<void> {
-  const excludePath = await worktreeLocalExcludePath(workspacePath);
-  await ensureDir(path.dirname(excludePath));
-
-  const managedEntries = managedSupervisorArtifactExcludeEntries(config, workspacePath, issueNumber);
-  const existingContent = fs.existsSync(excludePath) ? fs.readFileSync(excludePath, "utf8") : "";
-  const existingLines = existingContent.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
+  const existingContent = fs.existsSync(excludePath)
+    ? fs.readFileSync(excludePath, "utf8")
+    : "";
+  const existingLines = existingContent
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
   const existingEntries = new Set(existingLines);
-  const missingEntries = managedEntries.filter((entry) => !existingEntries.has(entry));
+  const missingEntries = managedEntries.filter(
+    (entry) => !existingEntries.has(entry),
+  );
 
   if (missingEntries.length === 0) {
     return;
@@ -271,31 +345,18 @@ async function installGitLocalExcludes(
   fs.appendFileSync(excludePath, appendedBlock, "utf8");
 }
 
-async function installWorktreeLocalExcludes(
+async function finalizeWorkspaceSetup(
   config: Pick<SupervisorConfig, "issueJournalRelativePath">,
   workspacePath: string,
   issueNumber: number,
 ): Promise<void> {
-  await installGitLocalExcludes(config, workspacePath, issueNumber);
-}
-
-async function installRepoLocalExcludes(
-  config: Pick<SupervisorConfig, "repoPath" | "issueJournalRelativePath">,
-): Promise<void> {
-  await installGitLocalExcludes(config, config.repoPath);
-}
-
-async function finalizeWorkspaceSetup(
-  config: Pick<SupervisorConfig, "issueJournalRelativePath" | "repoPath">,
-  workspacePath: string,
-  issueNumber: number,
-): Promise<void> {
-  await installRepoLocalExcludes(config);
   await installWorktreeLocalExcludes(config, workspacePath, issueNumber);
   await protectTrackedLiveIssueJournals(workspacePath);
 }
 
-export function formatWorkspaceRestoreStatusLine(restore: WorkspaceRestoreMetadata): string {
+export function formatWorkspaceRestoreStatusLine(
+  restore: WorkspaceRestoreMetadata,
+): string {
   return `workspace_restore source=${restore.source} ref=${restore.ref}`;
 }
 
@@ -347,13 +408,21 @@ async function assertReusableExistingWorkspace(
   branch: string,
 ): Promise<void> {
   const resolvedWorkspacePath = normalizeGitPath(workspacePath);
-  const worktreeList = await runCommand("git", ["-C", config.repoPath, "worktree", "list", "--porcelain"]);
+  const worktreeList = await runCommand("git", [
+    "-C",
+    config.repoPath,
+    "worktree",
+    "list",
+    "--porcelain",
+  ]);
   const worktreeEntry = parseGitWorktreeList(worktreeList.stdout).find(
     (entry) => entry.worktreePath === resolvedWorkspacePath,
   );
 
   if (!worktreeEntry) {
-    throw new Error(`Existing workspace is not a registered worktree for repository ${config.repoPath}: ${workspacePath}`);
+    throw new Error(
+      `Existing workspace is not a registered worktree for repository ${config.repoPath}: ${workspacePath}`,
+    );
   }
 
   const headBranch = await runCommand(
@@ -362,12 +431,16 @@ async function assertReusableExistingWorkspace(
     { allowExitCodes: [0, 1] },
   );
   if (headBranch.exitCode !== 0) {
-    throw new Error(`Existing workspace is on a detached HEAD; expected branch ${branch}: ${workspacePath}`);
+    throw new Error(
+      `Existing workspace is on a detached HEAD; expected branch ${branch}: ${workspacePath}`,
+    );
   }
 
   const actualBranch = headBranch.stdout.trim();
   if (actualBranch !== branch) {
-    throw new Error(`Existing workspace is on branch ${actualBranch}; expected branch ${branch}: ${workspacePath}`);
+    throw new Error(
+      `Existing workspace is on branch ${actualBranch}; expected branch ${branch}: ${workspacePath}`,
+    );
   }
 
   if (worktreeEntry.branchRef !== `refs/heads/${branch}`) {
@@ -385,8 +458,17 @@ export async function ensureWorkspace(
   assertIssueNumber(issueNumber);
   const workspacePath = workspacePathForIssue(config, issueNumber);
   await ensureDir(config.workspaceRoot);
-  await runCommand("git", ["-C", config.repoPath, "fetch", "origin", config.defaultBranch]);
-  const remoteBranchExists = await fetchIssueRemoteTrackingRef(config.repoPath, branch);
+  await runCommand("git", [
+    "-C",
+    config.repoPath,
+    "fetch",
+    "origin",
+    config.defaultBranch,
+  ]);
+  const remoteBranchExists = await fetchIssueRemoteTrackingRef(
+    config.repoPath,
+    branch,
+  );
 
   if (fs.existsSync(path.join(workspacePath, ".git"))) {
     await assertReusableExistingWorkspace(config, workspacePath, branch);
@@ -397,12 +479,24 @@ export async function ensureWorkspace(
     });
   }
 
-  if (fs.existsSync(workspacePath) && !fs.existsSync(path.join(workspacePath, ".git"))) {
-    throw new Error(`Workspace path exists but is not a git worktree: ${workspacePath}`);
+  if (
+    fs.existsSync(workspacePath) &&
+    !fs.existsSync(path.join(workspacePath, ".git"))
+  ) {
+    throw new Error(
+      `Workspace path exists but is not a git worktree: ${workspacePath}`,
+    );
   }
 
   if (await branchExists(config.repoPath, branch)) {
-    await runCommand("git", ["-C", config.repoPath, "worktree", "add", workspacePath, branch]);
+    await runCommand("git", [
+      "-C",
+      config.repoPath,
+      "worktree",
+      "add",
+      workspacePath,
+      branch,
+    ]);
     await finalizeWorkspaceSetup(config, workspacePath, issueNumber);
     return buildEnsuredWorkspace(workspacePath, {
       source: "local_branch",
@@ -411,7 +505,16 @@ export async function ensureWorkspace(
   }
 
   if (remoteBranchExists) {
-    await runCommand("git", ["-C", config.repoPath, "worktree", "add", "-b", branch, workspacePath, `origin/${branch}`]);
+    await runCommand("git", [
+      "-C",
+      config.repoPath,
+      "worktree",
+      "add",
+      "-b",
+      branch,
+      workspacePath,
+      `origin/${branch}`,
+    ]);
     await finalizeWorkspaceSetup(config, workspacePath, issueNumber);
     return buildEnsuredWorkspace(workspacePath, {
       source: "remote_branch",
@@ -419,7 +522,10 @@ export async function ensureWorkspace(
     });
   }
 
-  const bootstrapBaseRef = await resolveBootstrapBaseRef(config.repoPath, config.defaultBranch);
+  const bootstrapBaseRef = await resolveBootstrapBaseRef(
+    config.repoPath,
+    config.defaultBranch,
+  );
   await runCommand("git", [
     "-C",
     config.repoPath,
@@ -445,26 +551,69 @@ export async function getWorkspaceStatus(
 ): Promise<WorkspaceStatus> {
   const defaultBranchRef = `refs/remotes/origin/${defaultBranch}`;
   const remoteBranchRef = `refs/remotes/origin/${branch}`;
-  const [headResult, branchResult, statusResult, baseResult, remoteExistsResult] = await Promise.all([
+  const [
+    headResult,
+    branchResult,
+    statusResult,
+    baseResult,
+    remoteExistsResult,
+  ] = await Promise.all([
     runCommand("git", ["-C", workspacePath, "rev-parse", "HEAD"]),
-    runCommand("git", ["-C", workspacePath, "rev-parse", "--abbrev-ref", "HEAD"]),
-    runCommand("git", ["-C", workspacePath, "status", "--porcelain=v1", "-z", "--untracked-files=all"]),
-    runCommand("git", ["-C", workspacePath, "rev-list", "--left-right", "--count", `${defaultBranchRef}...HEAD`]),
+    runCommand("git", [
+      "-C",
+      workspacePath,
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ]),
+    runCommand("git", [
+      "-C",
+      workspacePath,
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+    ]),
+    runCommand("git", [
+      "-C",
+      workspacePath,
+      "rev-list",
+      "--left-right",
+      "--count",
+      `${defaultBranchRef}...HEAD`,
+    ]),
     runCommand(
       "git",
-      ["-C", workspacePath, "ls-remote", "--exit-code", "--heads", "origin", branch],
+      [
+        "-C",
+        workspacePath,
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        "origin",
+        branch,
+      ],
       { allowExitCodes: [0, 2] },
     ),
   ]);
 
-  const [baseBehind, baseAhead] = baseResult.stdout.trim().split(/\s+/).map((value) => Number(value));
+  const [baseBehind, baseAhead] = baseResult.stdout
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number(value));
   const remoteBranchExists = remoteExistsResult.exitCode === 0;
 
   let remoteBehind = 0;
   let remoteAhead = 0;
   if (remoteBranchExists) {
     if (!(await remoteTrackingRefExists(workspacePath, branch))) {
-      await runCommand("git", ["-C", workspacePath, "fetch", "origin", `${branch}:${remoteBranchRef}`]);
+      await runCommand("git", [
+        "-C",
+        workspacePath,
+        "fetch",
+        "origin",
+        `${branch}:${remoteBranchRef}`,
+      ]);
     }
 
     const remoteResult = await runCommand("git", [
@@ -481,8 +630,13 @@ export async function getWorkspaceStatus(
       .map((value) => Number(value));
   }
 
-  const hasMeaningfulUncommittedChanges = parseGitStatusPorcelainV1Paths(statusResult.stdout)
-    .some((paths) => paths.some((relativePath) => !isIgnoredSupervisorArtifactPath(relativePath)));
+  const hasMeaningfulUncommittedChanges = parseGitStatusPorcelainV1Paths(
+    statusResult.stdout,
+  ).some((paths) =>
+    paths.some(
+      (relativePath) => !isIgnoredSupervisorArtifactPath(relativePath),
+    ),
+  );
 
   return {
     branch: branchResult.stdout.trim(),
@@ -496,13 +650,24 @@ export async function getWorkspaceStatus(
   };
 }
 
-export async function pushBranch(workspacePath: string, branch: string, remoteBranchExists: boolean): Promise<void> {
+export async function pushBranch(
+  workspacePath: string,
+  branch: string,
+  remoteBranchExists: boolean,
+): Promise<void> {
   if (remoteBranchExists) {
     await runCommand("git", ["-C", workspacePath, "push", "origin", branch]);
     return;
   }
 
-  await runCommand("git", ["-C", workspacePath, "push", "-u", "origin", branch]);
+  await runCommand("git", [
+    "-C",
+    workspacePath,
+    "push",
+    "-u",
+    "origin",
+    branch,
+  ]);
 }
 
 export async function commitAndPushTrackedFiles(args: {
@@ -512,27 +677,57 @@ export async function commitAndPushTrackedFiles(args: {
   filePaths: string[];
   commitMessage: string;
 }): Promise<boolean> {
-  const filePaths = [...new Set(args.filePaths.map((filePath) => filePath.trim()).filter(Boolean))];
+  const filePaths = [
+    ...new Set(
+      args.filePaths.map((filePath) => filePath.trim()).filter(Boolean),
+    ),
+  ];
   if (filePaths.length === 0) {
     return false;
   }
 
-  await runCommand("git", ["-C", args.workspacePath, "add", "--", ...filePaths]);
+  await runCommand("git", [
+    "-C",
+    args.workspacePath,
+    "add",
+    "--",
+    ...filePaths,
+  ]);
   const stagedDiff = await runCommand(
     "git",
-    ["-C", args.workspacePath, "diff", "--cached", "--quiet", "--exit-code", "--", ...filePaths],
+    [
+      "-C",
+      args.workspacePath,
+      "diff",
+      "--cached",
+      "--quiet",
+      "--exit-code",
+      "--",
+      ...filePaths,
+    ],
     { allowExitCodes: [0, 1] },
   );
   if (stagedDiff.exitCode === 0) {
     return false;
   }
 
-  await runCommand("git", ["-C", args.workspacePath, "commit", "-m", args.commitMessage, "--", ...filePaths]);
+  await runCommand("git", [
+    "-C",
+    args.workspacePath,
+    "commit",
+    "-m",
+    args.commitMessage,
+    "--",
+    ...filePaths,
+  ]);
   await pushBranch(args.workspacePath, args.branch, args.remoteBranchExists);
   return true;
 }
 
-async function isIndexUpdatableTrackedFilePath(workspacePath: string, filePath: string): Promise<boolean> {
+async function isIndexUpdatableTrackedFilePath(
+  workspacePath: string,
+  filePath: string,
+): Promise<boolean> {
   if (!fs.existsSync(path.join(workspacePath, filePath))) {
     return false;
   }
@@ -545,12 +740,46 @@ async function isIndexUpdatableTrackedFilePath(workspacePath: string, filePath: 
   return result.exitCode === 0;
 }
 
-export async function filterPresentTrackedFilePaths(workspacePath: string, filePaths: string[]): Promise<string[]> {
-  const uniquePaths = [...new Set(filePaths.map((filePath) => filePath.trim()).filter(Boolean))];
+export async function filterPresentTrackedFilePaths(
+  workspacePath: string,
+  filePaths: string[],
+): Promise<string[]> {
+  const uniquePaths = [
+    ...new Set(filePaths.map((filePath) => filePath.trim()).filter(Boolean)),
+  ];
   const presentPaths = await Promise.all(
-    uniquePaths.map(async (filePath) => (await isIndexUpdatableTrackedFilePath(workspacePath, filePath) ? filePath : null)),
+    uniquePaths.map(async (filePath) =>
+      (await isIndexUpdatableTrackedFilePath(workspacePath, filePath))
+        ? filePath
+        : null,
+    ),
   );
-  return presentPaths.filter((filePath): filePath is string => filePath !== null);
+  return presentPaths.filter(
+    (filePath): filePath is string => filePath !== null,
+  );
+}
+
+export async function listChangedTrackedFilesBetween(
+  workspacePath: string,
+  fromRef: string,
+  toRef = "HEAD",
+): Promise<string[]> {
+  const result = await runCommand("git", [
+    "-C",
+    workspacePath,
+    "diff",
+    "--name-only",
+    "--diff-filter=ACMR",
+    "-z",
+    fromRef,
+    toRef,
+    "--",
+  ]);
+  return result.stdout
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => normalizeGitPath(entry));
 }
 
 export async function listTrackedSupervisorArtifactPaths(
@@ -560,12 +789,21 @@ export async function listTrackedSupervisorArtifactPaths(
   if (!fs.existsSync(path.join(workspacePath, ".git"))) {
     return [];
   }
-  const trackedPathsResult = await runCommand("git", ["-C", workspacePath, "ls-files", "-z", "--", ".codex-supervisor"]);
+  const trackedPathsResult = await runCommand("git", [
+    "-C",
+    workspacePath,
+    "ls-files",
+    "-z",
+    "--",
+    ".codex-supervisor",
+  ]);
   return trackedPathsResult.stdout
     .split("\0")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0)
-    .filter((entry) => isIgnoredSupervisorArtifactPath(entry, journalRelativePath))
+    .filter((entry) =>
+      isIgnoredSupervisorArtifactPath(entry, journalRelativePath),
+    )
     .sort((left, right) => left.localeCompare(right));
 }
 
@@ -582,12 +820,12 @@ export async function cleanupWorkspace(
     );
   }
 
-  await runCommand("git", ["-C", repoPath, "worktree", "prune"], { allowExitCodes: [0] });
-  await runCommand(
-    "git",
-    ["-C", repoPath, "branch", "-D", branch],
-    { allowExitCodes: [0, 1] },
-  );
+  await runCommand("git", ["-C", repoPath, "worktree", "prune"], {
+    allowExitCodes: [0],
+  });
+  await runCommand("git", ["-C", repoPath, "branch", "-D", branch], {
+    allowExitCodes: [0, 1],
+  });
 }
 
 export function isSafeCleanupTarget(

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -5,9 +5,24 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { executeCodexTurnPhase } from "./run-once-turn-execution";
-import { FailureContextCategory, GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorStateFile } from "./core/types";
-import { createCodexTurnContext, createWorkspaceStatus } from "./orchestration-test-helpers";
-import { createConfig, createIssue, createPullRequest, createRecord, createReviewThread } from "./turn-execution-test-helpers";
+import {
+  FailureContextCategory,
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  SupervisorStateFile,
+} from "./core/types";
+import {
+  createCodexTurnContext,
+  createWorkspaceStatus,
+} from "./orchestration-test-helpers";
+import {
+  createConfig,
+  createIssue,
+  createPullRequest,
+  createRecord,
+  createReviewThread,
+} from "./turn-execution-test-helpers";
 import { AgentRunner, AgentTurnRequest } from "./supervisor/agent-runner";
 import { interruptedTurnMarkerPath } from "./interrupted-turn-marker";
 
@@ -21,7 +36,9 @@ function git(cwd: string, ...args: string[]): string {
 }
 
 async function createTrackedRepo(): Promise<string> {
-  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "run-once-turn-path-hygiene-"));
+  const repoPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), "run-once-turn-path-hygiene-"),
+  );
   git(repoPath, "init", "-b", "main");
   git(repoPath, "config", "user.name", "Codex Supervisor");
   git(repoPath, "config", "user.email", "codex@example.test");
@@ -46,7 +63,10 @@ function createSuccessfulAgentRunner(
   };
 }
 
-async function withTempWorkspace<T>(prefix: string, run: (workspacePath: string) => Promise<T>): Promise<T> {
+async function withTempWorkspace<T>(
+  prefix: string,
+  run: (workspacePath: string) => Promise<T>,
+): Promise<T> {
   const workspacePath = await fs.mkdtemp(path.join("/tmp", prefix));
   try {
     return await run(workspacePath);
@@ -57,7 +77,9 @@ async function withTempWorkspace<T>(prefix: string, run: (workspacePath: string)
 
 test("executeCodexTurnPhase does not mark review threads processed for a refreshed PR head it did not evaluate", async () => {
   const config = createConfig();
-  const issue: GitHubIssue = createIssue({ title: "Avoid attributing review processing to a refreshed head" });
+  const issue: GitHubIssue = createIssue({
+    title: "Avoid attributing review processing to a refreshed head",
+  });
   const initialPr: GitHubPullRequest = createPullRequest({
     title: "Address review threads",
     reviewDecision: "CHANGES_REQUESTED",
@@ -99,7 +121,11 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
   const result = await executeCodexTurnPhase({
     config,
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -157,7 +183,8 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b" }),
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b" }),
     pushBranch: async () => {
       throw new Error("unexpected pushBranch call");
     },
@@ -180,7 +207,8 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
     agentRunner: createSuccessfulAgentRunner(async () => ({
       exitCode: 0,
       sessionId: "session-102",
-      supervisorMessage: "Reviewed the configured bot thread on the current head.",
+      supervisorMessage:
+        "Reviewed the configured bot thread on the current head.",
       stderr: "",
       stdout: "",
       structuredResult: null,
@@ -191,8 +219,12 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
 
   assert.equal(result.kind, "completed");
   assert.equal(state.issues["102"]?.last_head_sha, "head-b");
-  assert.deepEqual(state.issues["102"]?.processed_review_thread_ids, ["thread-1@head-a"]);
-  assert.deepEqual(state.issues["102"]?.processed_review_thread_fingerprints, ["thread-1@head-a#comment-1"]);
+  assert.deepEqual(state.issues["102"]?.processed_review_thread_ids, [
+    "thread-1@head-a",
+  ]);
+  assert.deepEqual(state.issues["102"]?.processed_review_thread_fingerprints, [
+    "thread-1@head-a#comment-1",
+  ]);
   assert.deepEqual(resolvePurposes, ["action"]);
 });
 
@@ -203,8 +235,18 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
-  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issue-journal.md",
+  );
+  const otherJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "181",
+    "issue-journal.md",
+  );
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
   await fs.writeFile(
@@ -241,17 +283,28 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
     ].join("\n"),
     "utf8",
   );
-  git(workspacePath, "add", ".codex-supervisor/issue-journal.md", ".codex-supervisor/issues/181/issue-journal.md");
+  git(
+    workspacePath,
+    "add",
+    ".codex-supervisor/issue-journal.md",
+    ".codex-supervisor/issues/181/issue-journal.md",
+  );
   git(workspacePath, "commit", "-m", "seed cross-issue journal leak");
   git(workspacePath, "push", "-u", "origin", "codex/issue-102");
 
   const remoteHead = git(workspacePath, "rev-parse", "HEAD").trim();
-  await fs.appendFile(path.join(workspacePath, "README.md"), "implementation change\n", "utf8");
+  await fs.appendFile(
+    path.join(workspacePath, "README.md"),
+    "implementation change\n",
+    "utf8",
+  );
   git(workspacePath, "add", "README.md");
   git(workspacePath, "commit", "-m", "local implementation change");
   const preNormalizationHead = git(workspacePath, "rev-parse", "HEAD").trim();
 
-  const issue = createIssue({ title: "Refresh review bookkeeping after supervisor normalization" });
+  const issue = createIssue({
+    title: "Refresh review bookkeeping after supervisor normalization",
+  });
   const reviewThreads = [createReviewThread()];
   let pathGateCalls = 0;
   const state: SupervisorStateFile = {
@@ -291,9 +344,15 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
   });
 
   const result = await executeCodexTurnPhase({
-    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -354,15 +413,18 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
       pathGateCalls += 1;
       await fs.writeFile(
         otherJournalPath,
-        (
-          await fs.readFile(otherJournalPath, "utf8")
-        ).replaceAll(SAMPLE_MACOS_WORKSTATION_PATH, "<redacted-local-path>"),
+        (await fs.readFile(otherJournalPath, "utf8")).replaceAll(
+          SAMPLE_MACOS_WORKSTATION_PATH,
+          "<redacted-local-path>",
+        ),
         "utf8",
       );
       return {
         ok: true,
         failureContext: null,
-        rewrittenJournalPaths: [".codex-supervisor/issues/181/issue-journal.md"],
+        rewrittenJournalPaths: [
+          ".codex-supervisor/issues/181/issue-journal.md",
+        ],
       };
     },
     derivePullRequestLifecycleSnapshot: (record) => ({
@@ -431,20 +493,28 @@ test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned 
   assert.equal(result.kind, "completed");
   assert.notEqual(normalizedHead, preNormalizationHead);
   assert.equal(state.issues["102"]?.last_head_sha, normalizedHead);
-  assert.deepEqual(state.issues["102"]?.processed_review_thread_ids, [`thread-1@${normalizedHead}`]);
-  assert.deepEqual(
-    state.issues["102"]?.processed_review_thread_fingerprints,
-    [`thread-1@${normalizedHead}#comment-1`],
+  assert.deepEqual(state.issues["102"]?.processed_review_thread_ids, [
+    `thread-1@${normalizedHead}`,
+  ]);
+  assert.deepEqual(state.issues["102"]?.processed_review_thread_fingerprints, [
+    `thread-1@${normalizedHead}#comment-1`,
+  ]);
+  assert.match(
+    git(workspacePath, "log", "-1", "--pretty=%s"),
+    /Normalize trusted durable artifacts for path hygiene/,
   );
-  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
   assert.doesNotMatch(
     await fs.readFile(otherJournalPath, "utf8"),
-    new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    new RegExp(
+      SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+    ),
   );
 });
 
 test("executeCodexTurnPhase skips prompt preparation side effects when the session lock is unavailable", async () => {
-  const issue = createIssue({ title: "Skip prompt preparation when the session lock is unavailable" });
+  const issue = createIssue({
+    title: "Skip prompt preparation when the session lock is unavailable",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -480,7 +550,11 @@ test("executeCodexTurnPhase skips prompt preparation side effects when the sessi
   const result = await executeCodexTurnPhase({
     config: createConfig(),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -531,7 +605,8 @@ test("executeCodexTurnPhase skips prompt preparation side effects when the sessi
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    readIssueJournal: async () => "## Codex Working Notes\n### Current Handoff\n- Hypothesis: wait for the lock.\n",
+    readIssueJournal: async () =>
+      "## Codex Working Notes\n### Current Handoff\n- Hypothesis: wait for the lock.\n",
     agentRunner: createSuccessfulAgentRunner(async () => {
       throw new Error("unexpected agentRunner.runTurn call");
     }),
@@ -580,7 +655,11 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
   const result = await executeCodexTurnPhase({
     config: createConfig({ localCiCommand: "npm run ci:local" }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -635,7 +714,12 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b", baseAhead: 1 }),
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({
+        branch: "codex/issue-102",
+        headSha: "head-b",
+        baseAhead: 1,
+      }),
     pushBranch: async () => undefined,
     readIssueJournal: (() => {
       let readCount = 0;
@@ -660,7 +744,9 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
       failureContext: null,
     }),
     runLocalCiCommand: async () => {
-      throw new Error("Command failed: sh -lc +1 args\nexitCode=1\nlocal ci failed");
+      throw new Error(
+        "Command failed: sh -lc +1 args\nexitCode=1\nlocal ci failed",
+      );
     },
     agentRunner: createSuccessfulAgentRunner(async () => ({
       exitCode: 0,
@@ -696,7 +782,10 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
   assert.equal(syncJournalCalls, 1);
   assert.equal(state.issues["102"]?.state, "blocked");
   assert.equal(state.issues["102"]?.blocked_reason, "verification");
-  assert.equal(state.issues["102"]?.last_failure_signature, "local-ci-gate-non_zero_exit");
+  assert.equal(
+    state.issues["102"]?.last_failure_signature,
+    "local-ci-gate-non_zero_exit",
+  );
   assert.match(
     state.issues["102"]?.last_error ?? "",
     /Configured local CI command failed before opening a pull request\. Remediation target: repo-owned command\./,
@@ -704,7 +793,9 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
 });
 
 test("executeCodexTurnPhase blocks branch publication when workstation-local path hygiene fails", async () => {
-  const issue = createIssue({ title: "Gate branch publication on path hygiene" });
+  const issue = createIssue({
+    title: "Gate branch publication on path hygiene",
+  });
   const pr = createPullRequest({ isDraft: true, headRefOid: "head-b" });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
@@ -741,7 +832,11 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
       publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -795,7 +890,13 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
     recoverUnexpectedCodexTurnFailure: async () => {
       throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
     },
-    getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-b", remoteAhead: 1 }),
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({
+        branch: "codex/issue-102",
+        headSha: "head-b",
+        remoteAhead: 1,
+      }),
+    listChangedTrackedFilesBetween: async () => ["docs/guide.md"],
     pushBranch: async () => {
       pushBranchCalls += 1;
     },
@@ -823,10 +924,13 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
         ok: false,
         failureContext: {
           category: "blocked",
-          summary: "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+          summary:
+            "Tracked durable artifacts failed workstation-local path hygiene before publication.",
           signature: "workstation-local-path-hygiene-failed",
           command: "npm run verify:paths",
-          details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
+          details: [
+            `docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`,
+          ],
           url: null,
           updated_at: "2026-03-13T06:20:00Z",
         },
@@ -860,15 +964,243 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
 
   assert.deepEqual(result, {
     kind: "returned",
-    message: "Workstation-local path hygiene blocked publication for issue #102.",
+    message:
+      "Workstation-local path hygiene blocked publication for issue #102.",
   });
-  assert.deepEqual(observedAllowlistMarkers, [["publishable-path-hygiene: allowlist"]]);
+  assert.deepEqual(observedAllowlistMarkers, [
+    ["publishable-path-hygiene: allowlist"],
+  ]);
   assert.equal(pushBranchCalls, 0);
   assert.equal(syncJournalCalls, 1);
   assert.equal(state.issues["102"]?.state, "blocked");
   assert.equal(state.issues["102"]?.blocked_reason, "verification");
-  assert.equal(state.issues["102"]?.last_failure_signature, "workstation-local-path-hygiene-failed");
-  assert.match(state.issues["102"]?.last_failure_context?.details[0] ?? "", /docs\/guide\.md:1/);
+  assert.equal(
+    state.issues["102"]?.last_failure_signature,
+    "workstation-local-path-hygiene-failed",
+  );
+  assert.match(
+    state.issues["102"]?.last_failure_context?.details[0] ?? "",
+    /docs\/guide\.md:1/,
+  );
+});
+
+test("executeCodexTurnPhase retries once in the same turn when changed publishable files fail path hygiene and the repair clears it", async () => {
+  const issue = createIssue({
+    title:
+      "Retry one same-turn publication repair for changed publishable files",
+  });
+  const pr = createPullRequest({ isDraft: true, headRefOid: "head-b" });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: pr.number,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  let agentRunCount = 0;
+  let pushBranchCalls = 0;
+  let syncJournalCalls = 0;
+  let pathGateCalls = 0;
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-a",
+    },
+    pr,
+    checks: [],
+    reviewThreads: [],
+  });
+
+  const result = await executeCodexTurnPhase({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => pr,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context,
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-13T06:20:00Z",
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    inferStateWithoutPullRequest: () => "draft_pr",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({
+        branch: "codex/issue-102",
+        headSha: agentRunCount >= 2 ? "head-c" : "head-b",
+        remoteAhead: 1,
+      }),
+    listChangedTrackedFilesBetween: async () => ["docs/guide.md"],
+    pushBranch: async () => {
+      pushBranchCalls += 1;
+    },
+    readIssueJournal: (() => {
+      let readCount = 0;
+      return async () => {
+        readCount += 1;
+        return readCount === 1
+          ? [
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: update the existing PR.",
+            ].join("\n")
+          : readCount === 2
+            ? [
+                "## Codex Working Notes",
+                "### Current Handoff",
+                "- Hypothesis: update the existing PR.",
+                "- What changed: completed the first implementation pass.",
+              ].join("\n")
+            : readCount === 3
+              ? [
+                  "## Codex Working Notes",
+                  "### Current Handoff",
+                  "- Hypothesis: update the existing PR.",
+                  "- What changed: completed the first implementation pass.",
+                ].join("\n")
+              : [
+                  "## Codex Working Notes",
+                  "### Current Handoff",
+                  "- Hypothesis: update the existing PR.",
+                  "- What changed: repaired the publishable path leak and completed the retry.",
+                ].join("\n");
+      };
+    })(),
+    runWorkstationLocalPathGate: async () => {
+      pathGateCalls += 1;
+      return pathGateCalls === 1
+        ? {
+            ok: false,
+            failureContext: {
+              category: "blocked",
+              summary:
+                "Tracked durable artifacts failed workstation-local path hygiene before publication. Edit tracked publishable content to remove workstation-local paths. First fix: docs/guide.md (1 match, linux_home).",
+              signature: "workstation-local-path-hygiene-failed",
+              command: "npm run verify:paths",
+              details: [
+                `docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`,
+              ],
+              url: null,
+              updated_at: "2026-03-13T06:20:00Z",
+            },
+            actionablePublishableFilePaths: ["docs/guide.md"],
+          }
+        : {
+            ok: true,
+            failureContext: null,
+            actionablePublishableFilePaths: [],
+          };
+    },
+    agentRunner: createSuccessfulAgentRunner(async (request) => {
+      agentRunCount += 1;
+      if (agentRunCount === 2) {
+        assert.equal(request.kind, "resume");
+        assert.match(
+          request.failureContext?.summary ?? "",
+          /Tracked durable artifacts failed workstation-local path hygiene before publication/,
+        );
+      }
+      return {
+        exitCode: 0,
+        sessionId: "session-102",
+        supervisorMessage: [
+          `Summary: ${agentRunCount === 1 ? "implementation complete" : "publishable path repaired"}`,
+          "State hint: draft_pr",
+          "Blocked reason: none",
+          "Tests: not run",
+          "Failure signature: none",
+          `Next action: ${agentRunCount === 1 ? "repair the publishable path finding" : "push the branch update"}`,
+        ].join("\n"),
+        stderr: "",
+        stdout: "",
+        structuredResult: {
+          summary:
+            agentRunCount === 1
+              ? "implementation complete"
+              : "publishable path repaired",
+          stateHint: "draft_pr",
+          blockedReason: null,
+          failureSignature: null,
+          nextAction:
+            agentRunCount === 1
+              ? "repair the publishable path finding"
+              : "push the branch update",
+          tests: "not run",
+        },
+        failureKind: null,
+        failureContext: null,
+      };
+    }),
+  });
+
+  assert.equal(result.kind, "completed");
+  assert.equal(agentRunCount, 2);
+  assert.equal(pathGateCalls, 2);
+  assert.equal(pushBranchCalls, 1);
+  assert.equal(syncJournalCalls, 2);
+  assert.equal(state.issues["102"]?.state, "draft_pr");
+  assert.equal(state.issues["102"]?.blocked_reason, null);
+  assert.equal(state.issues["102"]?.last_failure_context, null);
 });
 
 test("executeCodexTurnPhase routes start and resume turns through the shared agent runner contract", async () => {
@@ -877,7 +1209,8 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
     requests.push(request);
     return {
       exitCode: 0,
-      sessionId: request.kind === "resume" ? request.sessionId : "session-started",
+      sessionId:
+        request.kind === "resume" ? request.sessionId : "session-started",
       supervisorMessage: [
         "Summary: completed via agent runner",
         "State hint: stabilizing",
@@ -900,8 +1233,12 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
       failureContext: null,
     };
   });
-  const issue: GitHubIssue = createIssue({ title: "Use the agent runner contract" });
-  const pr: GitHubPullRequest = createPullRequest({ title: "Agent runner turn execution" });
+  const issue: GitHubIssue = createIssue({
+    title: "Use the agent runner contract",
+  });
+  const pr: GitHubPullRequest = createPullRequest({
+    title: "Agent runner turn execution",
+  });
 
   const createContext = (record = createRecord({ codex_session_id: null })) => {
     const state: SupervisorStateFile = {
@@ -918,7 +1255,11 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
       previousCodexSummary: null,
       previousError: null,
       workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
+      journalPath: path.join(
+        "/tmp/workspaces/issue-102",
+        ".codex-supervisor",
+        "issue-journal.md",
+      ),
       syncJournal: async () => undefined,
       memoryArtifacts: {
         alwaysReadFiles: [],
@@ -967,7 +1308,11 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
     context,
     acquireSessionLock: async () => null,
     classifyFailure: () => "command_error" as const,
-    buildCodexFailureContext: (category: FailureContextCategory, summary: string, details: string[]) => ({
+    buildCodexFailureContext: (
+      category: FailureContextCategory,
+      summary: string,
+      details: string[],
+    ) => ({
       category,
       summary,
       signature: `${category}:${summary}`,
@@ -1033,7 +1378,9 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
   const startResult = await executeCodexTurnPhase(createArgs(startContext));
   assert.equal(startResult.kind, "completed");
 
-  const resumeContext = createContext(createRecord({ codex_session_id: "session-existing" }));
+  const resumeContext = createContext(
+    createRecord({ codex_session_id: "session-existing" }),
+  );
   const resumeResult = await executeCodexTurnPhase(createArgs(resumeContext));
   assert.equal(resumeResult.kind, "completed");
 
@@ -1044,284 +1391,345 @@ test("executeCodexTurnPhase routes start and resume turns through the shared age
 });
 
 test("executeCodexTurnPhase rehydrates a missing local journal before resuming a tracked turn", async () => {
-  await withTempWorkspace("codex-turn-missing-journal-", async (workspacePath) => {
-    const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
-    const state: SupervisorStateFile = {
-      activeIssueNumber: 102,
-      issues: {
-        "102": createRecord({
-          state: "stabilizing",
-          codex_session_id: "session-existing",
-          workspace: workspacePath,
-          journal_path: journalPath,
-          pr_number: 116,
-        }),
-      },
-    };
-
-    let syncJournalCalls = 0;
-    let journalExistedDuringRun = false;
-
-    const result = await executeCodexTurnPhase({
-      config: createConfig({
-        issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
-      }),
-      stateStore: {
-        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-26T01:00:01.000Z" }),
-        save: async () => undefined,
-      },
-      github: {
-        resolvePullRequestForBranch: async () => createPullRequest({ number: 116, headRefOid: "head-116" }),
-        createPullRequest: async () => {
-          throw new Error("unexpected createPullRequest call");
-        },
-        getChecks: async () => [],
-        getUnresolvedReviewThreads: async () => [],
-        getExternalReviewSurface: async () => {
-          throw new Error("unexpected getExternalReviewSurface call");
-        },
-      },
-      context: {
-        state,
-        record: state.issues["102"]!,
-        issue: createIssue({ number: 102, title: "Rehydrate missing journal before resume" }),
-        previousCodexSummary: null,
-        previousError: null,
+  await withTempWorkspace(
+    "codex-turn-missing-journal-",
+    async (workspacePath) => {
+      const journalPath = path.join(
         workspacePath,
-        journalPath,
-        syncJournal: async () => {
-          syncJournalCalls += 1;
-          await fs.mkdir(path.dirname(journalPath), { recursive: true });
-          await fs.writeFile(
+        ".codex-supervisor",
+        "issues",
+        "102",
+        "issue-journal.md",
+      );
+      const state: SupervisorStateFile = {
+        activeIssueNumber: 102,
+        issues: {
+          "102": createRecord({
+            state: "stabilizing",
+            codex_session_id: "session-existing",
+            workspace: workspacePath,
+            journal_path: journalPath,
+            pr_number: 116,
+          }),
+        },
+      };
+
+      let syncJournalCalls = 0;
+      let journalExistedDuringRun = false;
+
+      const result = await executeCodexTurnPhase({
+        config: createConfig({
+          issueJournalRelativePath:
+            ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+        }),
+        stateStore: {
+          touch: (record, patch) => ({
+            ...record,
+            ...patch,
+            updated_at: "2026-03-26T01:00:01.000Z",
+          }),
+          save: async () => undefined,
+        },
+        github: {
+          resolvePullRequestForBranch: async () =>
+            createPullRequest({ number: 116, headRefOid: "head-116" }),
+          createPullRequest: async () => {
+            throw new Error("unexpected createPullRequest call");
+          },
+          getChecks: async () => [],
+          getUnresolvedReviewThreads: async () => [],
+          getExternalReviewSurface: async () => {
+            throw new Error("unexpected getExternalReviewSurface call");
+          },
+        },
+        context: {
+          state,
+          record: state.issues["102"]!,
+          issue: createIssue({
+            number: 102,
+            title: "Rehydrate missing journal before resume",
+          }),
+          previousCodexSummary: null,
+          previousError: null,
+          workspacePath,
+          journalPath,
+          syncJournal: async () => {
+            syncJournalCalls += 1;
+            await fs.mkdir(path.dirname(journalPath), { recursive: true });
+            await fs.writeFile(
+              journalPath,
+              [
+                "# Issue #102: Rehydrate missing journal before resume",
+                "",
+                "## Codex Working Notes",
+                "### Current Handoff",
+                "- Hypothesis: restore the missing journal before the resume turn runs.",
+                "- What changed: journal was rehydrated on this host because the local-only copy was missing.",
+                "- Current blocker:",
+                "- Next exact step: resume the tracked PR follow-up safely.",
+                "- Verification gap:",
+                "- Files touched:",
+                "- Rollback concern:",
+                "- Last focused command:",
+                "",
+                "### Scratchpad",
+                "- Keep this section short. The supervisor may compact older notes automatically.",
+                "",
+              ].join("\n"),
+              "utf8",
+            );
+          },
+          memoryArtifacts: {
+            alwaysReadFiles: [],
+            onDemandFiles: [],
+            contextIndexPath: "/tmp/context-index.md",
+            agentsPath: "/tmp/AGENTS.generated.md",
+          },
+          workspaceStatus: createWorkspaceStatus({
+            branch: "codex/issue-102",
+            headSha: "head-116",
+          }),
+          pr: createPullRequest({ number: 116, headRefOid: "head-116" }),
+          checks: [],
+          reviewThreads: [],
+          options: { dryRun: false },
+        },
+        acquireSessionLock: async () => null,
+        classifyFailure: () => "command_error",
+        buildCodexFailureContext: (category, summary, details) => ({
+          category,
+          summary,
+          signature: `${category}:${summary}`,
+          command: null,
+          details,
+          url: null,
+          updated_at: "2026-03-26T01:00:01.000Z",
+        }),
+        applyFailureSignature: () => ({
+          last_failure_signature: null,
+          repeated_failure_signature_count: 0,
+        }),
+        normalizeBlockerSignature: () => null,
+        isVerificationBlockedMessage: () => false,
+        derivePullRequestLifecycleSnapshot: (record) => ({
+          recordForState: record,
+          nextState: "stabilizing",
+          failureContext: null,
+          reviewWaitPatch: {},
+          copilotRequestObservationPatch: {},
+          mergeLatencyVisibilityPatch: {
+            provider_success_observed_at: null,
+            provider_success_head_sha: null,
+            merge_readiness_last_evaluated_at: null,
+          },
+          copilotTimeoutPatch: {
+            copilot_review_timed_out_at: null,
+            copilot_review_timeout_action: null,
+            copilot_review_timeout_reason: null,
+          },
+        }),
+        inferStateWithoutPullRequest: () => "stabilizing",
+        blockedReasonFromReviewState: () => null,
+        recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+          throw error instanceof Error ? error : new Error(String(error));
+        },
+        getWorkspaceStatus: async () =>
+          createWorkspaceStatus({
+            branch: "codex/issue-102",
+            headSha: "head-116",
+          }),
+        pushBranch: async () => {
+          throw new Error("unexpected pushBranch call");
+        },
+        agentRunner: createSuccessfulAgentRunner(async (request) => {
+          assert.equal(request.kind, "resume");
+          await fs.access(journalPath);
+          journalExistedDuringRun = true;
+          await fs.appendFile(
             journalPath,
-            [
-              "# Issue #102: Rehydrate missing journal before resume",
-              "",
-              "## Codex Working Notes",
-              "### Current Handoff",
-              "- Hypothesis: restore the missing journal before the resume turn runs.",
-              "- What changed: journal was rehydrated on this host because the local-only copy was missing.",
-              "- Current blocker:",
-              "- Next exact step: resume the tracked PR follow-up safely.",
-              "- Verification gap:",
-              "- Files touched:",
-              "- Rollback concern:",
-              "- Last focused command:",
-              "",
-              "### Scratchpad",
-              "- Keep this section short. The supervisor may compact older notes automatically.",
-              "",
-            ].join("\n"),
+            "- What changed: resume turn completed after journal rehydration.\n",
             "utf8",
           );
-        },
-        memoryArtifacts: {
-          alwaysReadFiles: [],
-          onDemandFiles: [],
-          contextIndexPath: "/tmp/context-index.md",
-          agentsPath: "/tmp/AGENTS.generated.md",
-        },
-        workspaceStatus: createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
-        pr: createPullRequest({ number: 116, headRefOid: "head-116" }),
-        checks: [],
-        reviewThreads: [],
-        options: { dryRun: false },
-      },
-      acquireSessionLock: async () => null,
-      classifyFailure: () => "command_error",
-      buildCodexFailureContext: (category, summary, details) => ({
-        category,
-        summary,
-        signature: `${category}:${summary}`,
-        command: null,
-        details,
-        url: null,
-        updated_at: "2026-03-26T01:00:01.000Z",
-      }),
-      applyFailureSignature: () => ({
-        last_failure_signature: null,
-        repeated_failure_signature_count: 0,
-      }),
-      normalizeBlockerSignature: () => null,
-      isVerificationBlockedMessage: () => false,
-      derivePullRequestLifecycleSnapshot: (record) => ({
-        recordForState: record,
-        nextState: "stabilizing",
-        failureContext: null,
-        reviewWaitPatch: {},
-        copilotRequestObservationPatch: {},
-        mergeLatencyVisibilityPatch: {
-          provider_success_observed_at: null,
-          provider_success_head_sha: null,
-          merge_readiness_last_evaluated_at: null,
-        },
-        copilotTimeoutPatch: {
-          copilot_review_timed_out_at: null,
-          copilot_review_timeout_action: null,
-          copilot_review_timeout_reason: null,
-        },
-      }),
-      inferStateWithoutPullRequest: () => "stabilizing",
-      blockedReasonFromReviewState: () => null,
-      recoverUnexpectedCodexTurnFailure: async ({ error }) => {
-        throw error instanceof Error ? error : new Error(String(error));
-      },
-      getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
-      pushBranch: async () => {
-        throw new Error("unexpected pushBranch call");
-      },
-      agentRunner: createSuccessfulAgentRunner(async (request) => {
-        assert.equal(request.kind, "resume");
-        await fs.access(journalPath);
-        journalExistedDuringRun = true;
-        await fs.appendFile(journalPath, "- What changed: resume turn completed after journal rehydration.\n", "utf8");
-        return {
-          exitCode: 0,
-          sessionId: "session-existing",
-          supervisorMessage: "Paused on the resumed head after rehydrating the missing journal.",
-          stderr: "",
-          stdout: "",
-          structuredResult: {
-            summary: "Paused on the resumed head after rehydrating the missing journal.",
-            stateHint: "blocked",
-            blockedReason: "manual_review",
-            failureSignature: null,
-            nextAction: "continue from the recreated journal",
-            tests: "not run",
-          },
-          failureKind: null,
-          failureContext: null,
-        };
-      }),
-    });
+          return {
+            exitCode: 0,
+            sessionId: "session-existing",
+            supervisorMessage:
+              "Paused on the resumed head after rehydrating the missing journal.",
+            stderr: "",
+            stdout: "",
+            structuredResult: {
+              summary:
+                "Paused on the resumed head after rehydrating the missing journal.",
+              stateHint: "blocked",
+              blockedReason: "manual_review",
+              failureSignature: null,
+              nextAction: "continue from the recreated journal",
+              tests: "not run",
+            },
+            failureKind: null,
+            failureContext: null,
+          };
+        }),
+      });
 
-    assert.equal(result.kind, "returned");
-    assert.match(result.message, /Codex reported blocked/);
-    assert.ok(syncJournalCalls >= 1);
-    assert.equal(journalExistedDuringRun, true);
-    const journalContent = await fs.readFile(journalPath, "utf8");
-    assert.match(journalContent, /local-only copy was missing/);
-  });
+      assert.equal(result.kind, "returned");
+      assert.match(result.message, /Codex reported blocked/);
+      assert.ok(syncJournalCalls >= 1);
+      assert.equal(journalExistedDuringRun, true);
+      const journalContent = await fs.readFile(journalPath, "utf8");
+      assert.match(journalContent, /local-only copy was missing/);
+    },
+  );
 });
 
 test("executeCodexTurnPhase does not rehydrate a missing local journal when the resume lock is unavailable", async () => {
-  await withTempWorkspace("codex-turn-missing-journal-locked-", async (workspacePath) => {
-    const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
-    const state: SupervisorStateFile = {
-      activeIssueNumber: 102,
-      issues: {
-        "102": createRecord({
-          state: "stabilizing",
-          codex_session_id: "session-existing",
-          workspace: workspacePath,
-          journal_path: journalPath,
-          pr_number: 116,
-        }),
-      },
-    };
-
-    let syncJournalCalls = 0;
-    let journalReadCalls = 0;
-
-    const result = await executeCodexTurnPhase({
-      config: createConfig({
-        issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
-      }),
-      stateStore: {
-        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-26T01:00:01.000Z" }),
-        save: async () => undefined,
-      },
-      github: {
-        resolvePullRequestForBranch: async () => createPullRequest({ number: 116, headRefOid: "head-116" }),
-        createPullRequest: async () => {
-          throw new Error("unexpected createPullRequest call");
-        },
-        getChecks: async () => [],
-        getUnresolvedReviewThreads: async () => [],
-        getExternalReviewSurface: async () => {
-          throw new Error("unexpected getExternalReviewSurface call");
-        },
-      },
-      context: {
-        state,
-        record: state.issues["102"]!,
-        issue: createIssue({ number: 102, title: "Skip missing journal rehydration when the resume lock is unavailable" }),
-        previousCodexSummary: null,
-        previousError: null,
+  await withTempWorkspace(
+    "codex-turn-missing-journal-locked-",
+    async (workspacePath) => {
+      const journalPath = path.join(
         workspacePath,
-        journalPath,
-        syncJournal: async () => {
-          syncJournalCalls += 1;
+        ".codex-supervisor",
+        "issues",
+        "102",
+        "issue-journal.md",
+      );
+      const state: SupervisorStateFile = {
+        activeIssueNumber: 102,
+        issues: {
+          "102": createRecord({
+            state: "stabilizing",
+            codex_session_id: "session-existing",
+            workspace: workspacePath,
+            journal_path: journalPath,
+            pr_number: 116,
+          }),
         },
-        memoryArtifacts: {
-          alwaysReadFiles: [],
-          onDemandFiles: [],
-          contextIndexPath: "/tmp/context-index.md",
-          agentsPath: "/tmp/AGENTS.generated.md",
-        },
-        workspaceStatus: createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
-        pr: createPullRequest({ number: 116, headRefOid: "head-116" }),
-        checks: [],
-        reviewThreads: [],
-        options: { dryRun: false },
-      },
-      acquireSessionLock: async () => ({
-        sessionId: "session-existing",
-        acquired: false,
-        reason: "session already locked elsewhere",
-        release: async () => undefined,
-      }),
-      classifyFailure: () => "command_error",
-      buildCodexFailureContext: (category, summary, details) => ({
-        category,
-        summary,
-        signature: `${category}:${summary}`,
-        command: null,
-        details,
-        url: null,
-        updated_at: "2026-03-26T01:00:01.000Z",
-      }),
-      applyFailureSignature: () => ({
-        last_failure_signature: null,
-        repeated_failure_signature_count: 0,
-      }),
-      normalizeBlockerSignature: () => null,
-      isVerificationBlockedMessage: () => false,
-      derivePullRequestLifecycleSnapshot: () => {
-        throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
-      },
-      inferStateWithoutPullRequest: () => "stabilizing",
-      blockedReasonFromReviewState: () => null,
-      recoverUnexpectedCodexTurnFailure: async ({ error }) => {
-        throw error instanceof Error ? error : new Error(String(error));
-      },
-      getWorkspaceStatus: async () => createWorkspaceStatus({ branch: "codex/issue-102", headSha: "head-116" }),
-      pushBranch: async () => {
-        throw new Error("unexpected pushBranch call");
-      },
-      readIssueJournal: async () => {
-        journalReadCalls += 1;
-        return null;
-      },
-      agentRunner: createSuccessfulAgentRunner(async () => {
-        throw new Error("unexpected agentRunner.runTurn call");
-      }),
-    });
+      };
 
-    assert.deepEqual(result, {
-      kind: "returned",
-      message: "Skipped issue #102: session already locked elsewhere.",
-    });
-    assert.equal(syncJournalCalls, 0);
-    assert.equal(journalReadCalls, 0);
-  });
+      let syncJournalCalls = 0;
+      let journalReadCalls = 0;
+
+      const result = await executeCodexTurnPhase({
+        config: createConfig({
+          issueJournalRelativePath:
+            ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+        }),
+        stateStore: {
+          touch: (record, patch) => ({
+            ...record,
+            ...patch,
+            updated_at: "2026-03-26T01:00:01.000Z",
+          }),
+          save: async () => undefined,
+        },
+        github: {
+          resolvePullRequestForBranch: async () =>
+            createPullRequest({ number: 116, headRefOid: "head-116" }),
+          createPullRequest: async () => {
+            throw new Error("unexpected createPullRequest call");
+          },
+          getChecks: async () => [],
+          getUnresolvedReviewThreads: async () => [],
+          getExternalReviewSurface: async () => {
+            throw new Error("unexpected getExternalReviewSurface call");
+          },
+        },
+        context: {
+          state,
+          record: state.issues["102"]!,
+          issue: createIssue({
+            number: 102,
+            title:
+              "Skip missing journal rehydration when the resume lock is unavailable",
+          }),
+          previousCodexSummary: null,
+          previousError: null,
+          workspacePath,
+          journalPath,
+          syncJournal: async () => {
+            syncJournalCalls += 1;
+          },
+          memoryArtifacts: {
+            alwaysReadFiles: [],
+            onDemandFiles: [],
+            contextIndexPath: "/tmp/context-index.md",
+            agentsPath: "/tmp/AGENTS.generated.md",
+          },
+          workspaceStatus: createWorkspaceStatus({
+            branch: "codex/issue-102",
+            headSha: "head-116",
+          }),
+          pr: createPullRequest({ number: 116, headRefOid: "head-116" }),
+          checks: [],
+          reviewThreads: [],
+          options: { dryRun: false },
+        },
+        acquireSessionLock: async () => ({
+          sessionId: "session-existing",
+          acquired: false,
+          reason: "session already locked elsewhere",
+          release: async () => undefined,
+        }),
+        classifyFailure: () => "command_error",
+        buildCodexFailureContext: (category, summary, details) => ({
+          category,
+          summary,
+          signature: `${category}:${summary}`,
+          command: null,
+          details,
+          url: null,
+          updated_at: "2026-03-26T01:00:01.000Z",
+        }),
+        applyFailureSignature: () => ({
+          last_failure_signature: null,
+          repeated_failure_signature_count: 0,
+        }),
+        normalizeBlockerSignature: () => null,
+        isVerificationBlockedMessage: () => false,
+        derivePullRequestLifecycleSnapshot: () => {
+          throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
+        },
+        inferStateWithoutPullRequest: () => "stabilizing",
+        blockedReasonFromReviewState: () => null,
+        recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+          throw error instanceof Error ? error : new Error(String(error));
+        },
+        getWorkspaceStatus: async () =>
+          createWorkspaceStatus({
+            branch: "codex/issue-102",
+            headSha: "head-116",
+          }),
+        pushBranch: async () => {
+          throw new Error("unexpected pushBranch call");
+        },
+        readIssueJournal: async () => {
+          journalReadCalls += 1;
+          return null;
+        },
+        agentRunner: createSuccessfulAgentRunner(async () => {
+          throw new Error("unexpected agentRunner.runTurn call");
+        }),
+      });
+
+      assert.deepEqual(result, {
+        kind: "returned",
+        message: "Skipped issue #102: session already locked elsewhere.",
+      });
+      assert.equal(syncJournalCalls, 0);
+      assert.equal(journalReadCalls, 0);
+    },
+  );
 });
 
 test("executeCodexTurnPhase writes a durable interrupted-turn marker before runTurn and clears it after success", async () => {
   await withTempWorkspace("codex-turn-marker-", async (workspacePath) => {
     const markerPath = interruptedTurnMarkerPath(workspacePath);
-    const issue: GitHubIssue = createIssue({ title: "Persist interrupted turn marker" });
-    const pr: GitHubPullRequest = createPullRequest({ title: "Interrupted turn marker lifecycle" });
+    const issue: GitHubIssue = createIssue({
+      title: "Persist interrupted turn marker",
+    });
+    const pr: GitHubPullRequest = createPullRequest({
+      title: "Interrupted turn marker lifecycle",
+    });
     const state: SupervisorStateFile = {
       activeIssueNumber: 102,
       issues: {
@@ -1329,7 +1737,11 @@ test("executeCodexTurnPhase writes a durable interrupted-turn marker before runT
           state: "implementing",
           codex_session_id: null,
           workspace: workspacePath,
-          journal_path: path.join(workspacePath, ".codex-supervisor", "issue-journal.md"),
+          journal_path: path.join(
+            workspacePath,
+            ".codex-supervisor",
+            "issue-journal.md",
+          ),
         }),
       },
     };
@@ -1338,7 +1750,11 @@ test("executeCodexTurnPhase writes a durable interrupted-turn marker before runT
     const result = await executeCodexTurnPhase({
       config: createConfig(),
       stateStore: {
-        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-26T01:00:01.000Z" }),
+        touch: (record, patch) => ({
+          ...record,
+          ...patch,
+          updated_at: "2026-03-26T01:00:01.000Z",
+        }),
         save: async () => undefined,
       },
       github: {
@@ -1359,7 +1775,11 @@ test("executeCodexTurnPhase writes a durable interrupted-turn marker before runT
         previousCodexSummary: null,
         previousError: null,
         workspacePath,
-        journalPath: path.join(workspacePath, ".codex-supervisor", "issue-journal.md"),
+        journalPath: path.join(
+          workspacePath,
+          ".codex-supervisor",
+          "issue-journal.md",
+        ),
         syncJournal: async () => undefined,
         memoryArtifacts: {
           alwaysReadFiles: [],
@@ -1522,7 +1942,9 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
 
   try {
     const config = createConfig({ localCiCommand: "npm run ci:local" });
-    const issue: GitHubIssue = createIssue({ title: "Keep local CI blocked despite metrics failures" });
+    const issue: GitHubIssue = createIssue({
+      title: "Keep local CI blocked despite metrics failures",
+    });
     const state: SupervisorStateFile = {
       activeIssueNumber: 102,
       issues: {
@@ -1530,7 +1952,8 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
           state: "implementing",
           implementation_attempt_count: 1,
           workspace: "/tmp/workspaces/issue-102",
-          journal_path: "/tmp/workspaces/issue-102/.codex-supervisor/issue-journal.md",
+          journal_path:
+            "/tmp/workspaces/issue-102/.codex-supervisor/issue-journal.md",
           updated_at: "not-an-iso-timestamp",
         }),
       },
@@ -1542,7 +1965,11 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
     const result = await executeCodexTurnPhase({
       config,
       stateStore: {
-        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-24T03:10:00Z" }),
+        touch: (record, patch) => ({
+          ...record,
+          ...patch,
+          updated_at: "2026-03-24T03:10:00Z",
+        }),
         save: async () => undefined,
       },
       github: {
@@ -1563,7 +1990,8 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
         previousCodexSummary: null,
         previousError: null,
         workspacePath: "/tmp/workspaces/issue-102",
-        journalPath: "/tmp/workspaces/issue-102/.codex-supervisor/issue-journal.md",
+        journalPath:
+          "/tmp/workspaces/issue-102/.codex-supervisor/issue-journal.md",
         syncJournal: async () => undefined,
         memoryArtifacts: {
           alwaysReadFiles: [],
@@ -1644,7 +2072,9 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
         failureContext: null,
       }),
       runLocalCiCommand: async () => {
-        throw new Error("Command failed: sh -lc +1 args\nexitCode=1\nlocal ci failed");
+        throw new Error(
+          "Command failed: sh -lc +1 args\nexitCode=1\nlocal ci failed",
+        );
       },
       agentRunner: createSuccessfulAgentRunner(async () => ({
         exitCode: 0,
@@ -1679,7 +2109,10 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
     assert.equal(recoverCalls, 0, String(recoveredError));
     assert.equal(state.issues["102"]?.state, "blocked");
     assert.equal(state.issues["102"]?.blocked_reason, "verification");
-    assert.equal(state.issues["102"]?.last_failure_signature, "local-ci-gate-non_zero_exit");
+    assert.equal(
+      state.issues["102"]?.last_failure_signature,
+      "local-ci-gate-non_zero_exit",
+    );
     assert.equal(consoleWarnings.length, 1);
     assert.match(
       String(consoleWarnings[0]?.[0] ?? ""),
@@ -1690,7 +2123,10 @@ test("executeCodexTurnPhase keeps local-CI blocked outcomes isolated from execut
       terminalState: "blocked",
       updatedAt: "2026-03-24T03:10:00Z",
     });
-    assert.match(String(consoleWarnings[0]?.[2] ?? ""), /startedAt must be an ISO-8601 timestamp/u);
+    assert.match(
+      String(consoleWarnings[0]?.[2] ?? ""),
+      /startedAt must be an ISO-8601 timestamp/u,
+    );
   } finally {
     console.warn = originalWarn;
   }
@@ -1729,7 +2165,9 @@ test("executeCodexTurnPhase falls back to a fresh start when the agent runner ca
     title: "Fallback to a fresh start turn",
     body: "## Summary\nFresh sessions still need the full issue prompt.",
   });
-  const pr: GitHubPullRequest = createPullRequest({ title: "Agent runner compatibility fallback" });
+  const pr: GitHubPullRequest = createPullRequest({
+    title: "Agent runner compatibility fallback",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -1743,7 +2181,11 @@ test("executeCodexTurnPhase falls back to a fresh start when the agent runner ca
   const result = await executeCodexTurnPhase({
     config: createConfig(),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -1764,7 +2206,11 @@ test("executeCodexTurnPhase falls back to a fresh start when the agent runner ca
       previousCodexSummary: null,
       previousError: null,
       workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
+      journalPath: path.join(
+        "/tmp/workspaces/issue-102",
+        ".codex-supervisor",
+        "issue-journal.md",
+      ),
       syncJournal: async () => undefined,
       memoryArtifacts: {
         alwaysReadFiles: [],
@@ -1869,8 +2315,14 @@ test("executeCodexTurnPhase falls back to a fresh start when the agent runner ca
   assert.equal(sessionLockCalls, 0);
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.kind, "start");
-  assert.equal(requests[0]?.issue.body, "## Summary\nFresh sessions still need the full issue prompt.");
-  assert.equal(requests[0]?.journalExcerpt?.includes("restart from the issue body."), true);
+  assert.equal(
+    requests[0]?.issue.body,
+    "## Summary\nFresh sessions still need the full issue prompt.",
+  );
+  assert.equal(
+    requests[0]?.journalExcerpt?.includes("restart from the issue body."),
+    true,
+  );
   assert.equal(state.issues["102"]?.state, "stabilizing");
 });
 
@@ -1926,7 +2378,11 @@ test("executeCodexTurnPhase does not take a session lock when the turn must rest
   const result = await executeCodexTurnPhase({
     config: createConfig(),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -1947,7 +2403,11 @@ test("executeCodexTurnPhase does not take a session lock when the turn must rest
       previousCodexSummary: "Previous review turn summary.",
       previousError: null,
       workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
+      journalPath: path.join(
+        "/tmp/workspaces/issue-102",
+        ".codex-supervisor",
+        "issue-journal.md",
+      ),
       syncJournal: async () => undefined,
       memoryArtifacts: {
         alwaysReadFiles: [],
@@ -2057,7 +2517,10 @@ test("executeCodexTurnPhase does not take a session lock when the turn must rest
   assert.equal(sessionLockCalls, 0);
   assert.equal(requests.length, 1);
   assert.equal(requests[0]?.kind, "start");
-  assert.equal(requests[0]?.issue.body, "## Summary\nAddressing review should restart from a fresh prompt.");
+  assert.equal(
+    requests[0]?.issue.body,
+    "## Summary\nAddressing review should restart from a fresh prompt.",
+  );
   assert.equal(state.issues["102"]?.state, "stabilizing");
 });
 
@@ -2096,7 +2559,11 @@ test("executeCodexTurnPhase preserves stale stabilizing no-PR recovery tracking 
   const result = await executeCodexTurnPhase({
     config: createConfig(),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     github: {
@@ -2117,7 +2584,11 @@ test("executeCodexTurnPhase preserves stale stabilizing no-PR recovery tracking 
       previousCodexSummary: null,
       previousError: null,
       workspacePath: path.join("/tmp/workspaces", "issue-102"),
-      journalPath: path.join("/tmp/workspaces/issue-102", ".codex-supervisor", "issue-journal.md"),
+      journalPath: path.join(
+        "/tmp/workspaces/issue-102",
+        ".codex-supervisor",
+        "issue-journal.md",
+      ),
       syncJournal: async () => undefined,
       memoryArtifacts: {
         alwaysReadFiles: [],
@@ -2241,18 +2712,37 @@ test("executeCodexTurnPhase preserves stale stabilizing no-PR recovery tracking 
   assert.equal(result.kind, "completed");
   assert.equal(state.issues["102"]?.state, "stabilizing");
   assert.equal(state.issues["102"]?.pr_number, null);
-  assert.equal(state.issues["102"]?.last_error, staleNoPrFailureContext.summary);
-  assert.equal(state.issues["102"]?.last_failure_context, staleNoPrFailureContext);
-  assert.equal(state.issues["102"]?.last_failure_signature, staleNoPrFailureContext.signature);
+  assert.equal(
+    state.issues["102"]?.last_error,
+    staleNoPrFailureContext.summary,
+  );
+  assert.equal(
+    state.issues["102"]?.last_failure_context,
+    staleNoPrFailureContext,
+  );
+  assert.equal(
+    state.issues["102"]?.last_failure_signature,
+    staleNoPrFailureContext.signature,
+  );
   assert.equal(state.issues["102"]?.repeated_failure_signature_count, 0);
   assert.equal(state.issues["102"]?.stale_stabilizing_no_pr_recovery_count, 1);
 });
 
 test("executeCodexTurnPhase normalizes workstation-local paths from a journal-only direct rewrite before post-run persistence", async () => {
   await withTempWorkspace("journal-direct-rewrite-", async (workspacePath) => {
-    const journalPath = path.join(workspacePath, ".codex-supervisor", "issue-journal.md");
+    const journalPath = path.join(
+      workspacePath,
+      ".codex-supervisor",
+      "issue-journal.md",
+    );
     const repoFilePath = path.join(workspacePath, "src", "review-fix.ts");
-    const hostOnlyPath = path.posix.join("/", "home", "alice", ".codex", "history.log");
+    const hostOnlyPath = path.posix.join(
+      "/",
+      "home",
+      "alice",
+      ".codex",
+      "history.log",
+    );
     await fs.mkdir(path.dirname(journalPath), { recursive: true });
     await fs.mkdir(path.dirname(repoFilePath), { recursive: true });
     await fs.writeFile(
@@ -2284,7 +2774,11 @@ test("executeCodexTurnPhase normalizes workstation-local paths from a journal-on
     const result = await executeCodexTurnPhase({
       config: createConfig(),
       stateStore: {
-        touch: (record, patch) => ({ ...record, ...patch, updated_at: "2026-03-27T09:00:00.000Z" }),
+        touch: (record, patch) => ({
+          ...record,
+          ...patch,
+          updated_at: "2026-03-27T09:00:00.000Z",
+        }),
         save: async () => undefined,
       },
       github: {
@@ -2301,7 +2795,9 @@ test("executeCodexTurnPhase normalizes workstation-local paths from a journal-on
       context: {
         state,
         record: state.issues["102"]!,
-        issue: createIssue({ title: "Normalize journal-only review-fix rewrites" }),
+        issue: createIssue({
+          title: "Normalize journal-only review-fix rewrites",
+        }),
         previousCodexSummary: null,
         previousError: null,
         workspacePath,
@@ -2421,8 +2917,14 @@ test("executeCodexTurnPhase normalizes workstation-local paths from a journal-on
 
     assert.equal(result.kind, "completed");
     const content = await fs.readFile(journalPath, "utf8");
-    assert.doesNotMatch(content, new RegExp(workspacePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-    assert.doesNotMatch(content, new RegExp(hostOnlyPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(
+      content,
+      new RegExp(workspacePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+    assert.doesNotMatch(
+      content,
+      new RegExp(hostOnlyPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
     assert.match(content, /src\/review-fix\.ts/);
     assert.match(content, /<redacted-local-path>/);
   });

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -1004,6 +1004,7 @@ test("executeCodexTurnPhase retries once in the same turn when changed publishab
   let pushBranchCalls = 0;
   let syncJournalCalls = 0;
   let pathGateCalls = 0;
+  const requests: AgentTurnRequest[] = [];
   const context = createCodexTurnContext({
     state,
     record: state.issues["102"]!,
@@ -1152,11 +1153,16 @@ test("executeCodexTurnPhase retries once in the same turn when changed publishab
           };
     },
     agentRunner: createSuccessfulAgentRunner(async (request) => {
+      requests.push(request);
       agentRunCount += 1;
       if (agentRunCount === 2) {
         assert.equal(request.kind, "resume");
         assert.match(
           request.failureContext?.summary ?? "",
+          /Tracked durable artifacts failed workstation-local path hygiene before publication/,
+        );
+        assert.match(
+          request.previousError ?? "",
           /Tracked durable artifacts failed workstation-local path hygiene before publication/,
         );
       }
@@ -1198,9 +1204,309 @@ test("executeCodexTurnPhase retries once in the same turn when changed publishab
   assert.equal(pathGateCalls, 2);
   assert.equal(pushBranchCalls, 1);
   assert.equal(syncJournalCalls, 2);
+  assert.match(requests[1]?.previousSummary ?? "", /implementation complete/);
   assert.equal(state.issues["102"]?.state, "draft_pr");
   assert.equal(state.issues["102"]?.blocked_reason, null);
   assert.equal(state.issues["102"]?.last_failure_context, null);
+});
+
+test("executeCodexTurnPhase persists rewritten tracked paths before continuing a same-turn repair retry", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const journalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issue-journal.md",
+  );
+  const publishableGuidePath = path.join(workspacePath, "docs", "guide.md");
+  const trustedArtifactPath = path.join(
+    workspacePath,
+    "docs",
+    "generated-summary.md",
+  );
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.mkdir(path.dirname(publishableGuidePath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    [
+      "# Issue #102",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      "- Hypothesis: persist supervisor-owned rewrites before retrying the publishable path fix.",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    publishableGuidePath,
+    `Guide path: ${SAMPLE_MACOS_WORKSTATION_PATH}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    trustedArtifactPath,
+    `Trusted artifact path: ${SAMPLE_MACOS_WORKSTATION_PATH}\n`,
+    "utf8",
+  );
+  git(workspacePath, "add", "docs/guide.md", "docs/generated-summary.md");
+  git(workspacePath, "commit", "-m", "seed same-turn repair fixture");
+
+  const initialHeadSha = git(workspacePath, "rev-parse", "HEAD").trim();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: journalPath,
+        branch: "codex/issue-102",
+        last_head_sha: initialHeadSha,
+      }),
+    },
+  };
+  const issue = createIssue({
+    title: "Persist rewritten tracked paths before same-turn retry",
+  });
+  const requests: AgentTurnRequest[] = [];
+  let pathGateCalls = 0;
+
+  const result = await executeCodexTurnPhase({
+    config: createConfig(),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () =>
+        createPullRequest({
+          number: 200,
+          isDraft: true,
+          headRefOid: git(workspacePath, "rev-parse", "HEAD").trim(),
+        }),
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      previousCodexSummary: null,
+      previousError: null,
+      workspacePath,
+      journalPath,
+      syncJournal: async () => undefined,
+      memoryArtifacts: {
+        alwaysReadFiles: [],
+        onDemandFiles: [],
+        contextIndexPath: "/tmp/context-index.md",
+        agentsPath: "/tmp/AGENTS.generated.md",
+      },
+      workspaceStatus: {
+        branch: "codex/issue-102",
+        headSha: initialHeadSha,
+        hasUncommittedChanges: false,
+        baseAhead: 1,
+        baseBehind: 0,
+        remoteBranchExists: false,
+        remoteAhead: 0,
+        remoteBehind: 0,
+      },
+      pr: null,
+      checks: [],
+      reviewThreads: [],
+      options: { dryRun: false },
+    },
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-27T09:00:00.000Z",
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "draft_pr",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    inferStateWithoutPullRequest: () => "draft_pr",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    getWorkspaceStatus: (() => {
+      let statusCalls = 0;
+      return async () => {
+        statusCalls += 1;
+        return createWorkspaceStatus({
+          branch: "codex/issue-102",
+          headSha:
+            statusCalls === 1
+              ? "head-after-turn-1"
+              : git(workspacePath, "rev-parse", "HEAD").trim(),
+          baseAhead: statusCalls === 1 ? 1 : 2,
+          remoteBranchExists: statusCalls !== 1,
+        });
+      };
+    })(),
+    listChangedTrackedFilesBetween: async () => ["docs/guide.md"],
+    readIssueJournal: (() => {
+      let readCount = 0;
+      return async () => {
+        readCount += 1;
+        return readCount === 1
+          ? [
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: persist supervisor-owned rewrites before retrying the publishable path fix.",
+            ].join("\n")
+          : readCount === 2
+            ? [
+                "## Codex Working Notes",
+                "### Current Handoff",
+                "- Hypothesis: persist supervisor-owned rewrites before retrying the publishable path fix.",
+                "- What changed: completed the first implementation pass.",
+              ].join("\n")
+            : readCount === 3
+              ? [
+                  "## Codex Working Notes",
+                  "### Current Handoff",
+                  "- Hypothesis: persist supervisor-owned rewrites before retrying the publishable path fix.",
+                  "- What changed: completed the first implementation pass.",
+                ].join("\n")
+              : [
+                  "## Codex Working Notes",
+                  "### Current Handoff",
+                  "- Hypothesis: persist supervisor-owned rewrites before retrying the publishable path fix.",
+                  "- What changed: repaired the publishable path finding after the normalization commit.",
+                ].join("\n");
+      };
+    })(),
+    runWorkstationLocalPathGate: async () => {
+      pathGateCalls += 1;
+      if (pathGateCalls === 1) {
+        await fs.writeFile(
+          trustedArtifactPath,
+          "Trusted artifact path: <workstation-local>\n",
+          "utf8",
+        );
+        return {
+          ok: false,
+          failureContext: {
+            category: "blocked",
+            summary:
+              "Tracked durable artifacts failed workstation-local path hygiene before publication. Edit tracked publishable content to remove workstation-local paths. First fix: docs/guide.md (1 match, macos_home).",
+            signature: "workstation-local-path-hygiene-failed",
+            command: "npm run verify:paths",
+            details: [
+              `docs/guide.md:1 matched /${"Users"}/ via "${SAMPLE_MACOS_WORKSTATION_PATH}"`,
+            ],
+            url: null,
+            updated_at: "2026-03-27T09:00:00.000Z",
+          },
+          actionablePublishableFilePaths: ["docs/guide.md"],
+          rewrittenTrustedGeneratedArtifactPaths: ["docs/generated-summary.md"],
+        };
+      }
+
+      return {
+        ok: true,
+        failureContext: null,
+        actionablePublishableFilePaths: [],
+      };
+    },
+    agentRunner: createSuccessfulAgentRunner(async (request) => {
+      requests.push(request);
+      if (requests.length === 2) {
+        assert.equal(request.kind, "resume");
+        assert.match(
+          request.previousError ?? "",
+          /Tracked durable artifacts failed workstation-local path hygiene before publication/,
+        );
+      }
+      return {
+        exitCode: 0,
+        sessionId: "session-102",
+        supervisorMessage: [
+          `Summary: ${requests.length === 1 ? "implementation complete" : "publishable path repaired"}`,
+          "State hint: draft_pr",
+          "Blocked reason: none",
+          "Tests: not run",
+          "Failure signature: none",
+          "Next action: continue",
+        ].join("\n"),
+        stderr: "",
+        stdout: "",
+        structuredResult: {
+          summary:
+            requests.length === 1
+              ? "implementation complete"
+              : "publishable path repaired",
+          stateHint: "draft_pr",
+          blockedReason: null,
+          failureSignature: null,
+          nextAction: "continue",
+          tests: "not run",
+        },
+        failureKind: null,
+        failureContext: null,
+      };
+    }),
+  });
+
+  assert.equal(result.kind, "completed");
+  assert.equal(pathGateCalls, 2);
+  assert.equal(requests.length, 2);
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "Normalize trusted durable artifacts for path hygiene",
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "",
+  );
+  assert.equal(
+    git(workspacePath, "rev-parse", "HEAD").trim(),
+    git(workspacePath, "rev-parse", "origin/codex/issue-102").trim(),
+  );
+  assert.equal(
+    await fs.readFile(trustedArtifactPath, "utf8"),
+    "Trusted artifact path: <workstation-local>\n",
+  );
 });
 
 test("executeCodexTurnPhase routes start and resume turns through the shared agent runner contract", async () => {

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -12,12 +12,12 @@ import {
   persistHintedCodexTurnState,
   persistMissingCodexJournalHandoff,
 } from "./turn-execution-failure-helpers";
+import {} from "./review-handling";
+import { PullRequestLifecycleSnapshot } from "./post-turn-pull-request";
 import {
-} from "./review-handling";
-import {
-  PullRequestLifecycleSnapshot,
-} from "./post-turn-pull-request";
-import { IssueJournalSync, MemoryArtifacts } from "./run-once-issue-preparation";
+  IssueJournalSync,
+  MemoryArtifacts,
+} from "./run-once-issue-preparation";
 import { type LocalCiCommandRunner } from "./local-ci";
 import {
   buildWorkstationLocalPathFailureContext,
@@ -48,7 +48,13 @@ import {
   WorkspaceStatus,
 } from "./core/types";
 import { truncate } from "./core/utils";
-import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus, pushBranch } from "./core/workspace";
+import {
+  commitAndPushTrackedFiles,
+  filterPresentTrackedFilePaths,
+  getWorkspaceStatus,
+  listChangedTrackedFilesBetween,
+  pushBranch,
+} from "./core/workspace";
 import { AgentRunner, createCodexAgentRunner } from "./supervisor/agent-runner";
 import {
   executionMetricsRetentionRootPath,
@@ -96,7 +102,8 @@ export interface CodexTurnResult {
   reviewThreads: ReviewThread[];
 }
 
-const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
+const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
+  "Normalize trusted durable artifacts for path hygiene";
 
 export interface CodexTurnShortCircuit {
   kind: "returned";
@@ -111,8 +118,14 @@ interface RecoverUnexpectedCodexTurnFailureArgs {
   issue: GitHubIssue;
   journalSync: (record: IssueRunRecord) => Promise<void>;
   error: unknown;
-  workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha"> | null;
-  pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "createdAt" | "mergedAt"> | null;
+  workspaceStatus: Pick<
+    WorkspaceStatus,
+    "hasUncommittedChanges" | "headSha"
+  > | null;
+  pr: Pick<
+    GitHubPullRequest,
+    "number" | "headRefOid" | "createdAt" | "mergedAt"
+  > | null;
 }
 
 interface ExecuteCodexTurnPhaseArgs {
@@ -120,12 +133,18 @@ interface ExecuteCodexTurnPhaseArgs {
   stateStore: Pick<StateStore, "touch" | "save">;
   github: Pick<
     GitHubClient,
-    "resolvePullRequestForBranch" | "createPullRequest" | "getChecks" | "getUnresolvedReviewThreads" | "getExternalReviewSurface"
+    | "resolvePullRequestForBranch"
+    | "createPullRequest"
+    | "getChecks"
+    | "getUnresolvedReviewThreads"
+    | "getExternalReviewSurface"
   >;
   context: CodexTurnContext;
   sessionLock?: LockHandle | null;
   acquireSessionLock: (sessionId: string) => Promise<LockHandle | null>;
-  classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+  classifyFailure: (
+    message: string | null | undefined,
+  ) => "timeout" | "command_error";
   buildCodexFailureContext: (
     category: FailureContext["category"],
     summary: string,
@@ -134,8 +153,13 @@ interface ExecuteCodexTurnPhaseArgs {
   applyFailureSignature: (
     record: IssueRunRecord,
     failureContext: FailureContext | null,
-  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
-  normalizeBlockerSignature: (message: string | null | undefined) => string | null;
+  ) => Pick<
+    IssueRunRecord,
+    "last_failure_signature" | "repeated_failure_signature_count"
+  >;
+  normalizeBlockerSignature: (
+    message: string | null | undefined,
+  ) => string | null;
   isVerificationBlockedMessage: (message: string | null | undefined) => boolean;
   derivePullRequestLifecycleSnapshot: (
     record: IssueRunRecord,
@@ -144,7 +168,10 @@ interface ExecuteCodexTurnPhaseArgs {
     reviewThreads: ReviewThread[],
     recordPatch?: Partial<IssueRunRecord>,
   ) => PullRequestLifecycleSnapshot;
-  inferStateWithoutPullRequest: (record: IssueRunRecord, workspaceStatus: WorkspaceStatus) => RunState;
+  inferStateWithoutPullRequest: (
+    record: IssueRunRecord,
+    workspaceStatus: WorkspaceStatus,
+  ) => RunState;
   blockedReasonFromReviewState: (
     record: IssueRunRecord,
     pr: GitHubPullRequest,
@@ -162,7 +189,9 @@ interface ExecuteCodexTurnPhaseArgs {
     syncJournal: (record: IssueRunRecord) => Promise<void>;
     issueNumber: number;
     error: unknown;
-    classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+    classifyFailure: (
+      message: string | null | undefined,
+    ) => "timeout" | "command_error";
     buildCodexFailureContext: (
       category: FailureContext["category"],
       summary: string,
@@ -171,7 +200,10 @@ interface ExecuteCodexTurnPhaseArgs {
     applyFailureSignature: (
       record: IssueRunRecord,
       failureContext: FailureContext | null,
-    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    ) => Pick<
+      IssueRunRecord,
+      "last_failure_signature" | "repeated_failure_signature_count"
+    >;
     retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   persistCodexTurnExitFailure?: (args: {
@@ -181,8 +213,13 @@ interface ExecuteCodexTurnPhaseArgs {
     issue: Pick<GitHubIssue, "createdAt">;
     syncJournal: (record: IssueRunRecord) => Promise<void>;
     issueNumber: number;
-    codexResult: Pick<import("./core/types").CodexTurnResult, "lastMessage" | "stderr" | "stdout">;
-    classifyFailure: (message: string | null | undefined) => "timeout" | "command_error";
+    codexResult: Pick<
+      import("./core/types").CodexTurnResult,
+      "lastMessage" | "stderr" | "stdout"
+    >;
+    classifyFailure: (
+      message: string | null | undefined,
+    ) => "timeout" | "command_error";
     buildCodexFailureContext: (
       category: FailureContext["category"],
       summary: string,
@@ -191,7 +228,10 @@ interface ExecuteCodexTurnPhaseArgs {
     applyFailureSignature: (
       record: IssueRunRecord,
       failureContext: FailureContext | null,
-    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    ) => Pick<
+      IssueRunRecord,
+      "last_failure_signature" | "repeated_failure_signature_count"
+    >;
     retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   persistMissingCodexJournalHandoff?: (args: {
@@ -209,7 +249,10 @@ interface ExecuteCodexTurnPhaseArgs {
     applyFailureSignature: (
       record: IssueRunRecord,
       failureContext: FailureContext | null,
-    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+    ) => Pick<
+      IssueRunRecord,
+      "last_failure_signature" | "repeated_failure_signature_count"
+    >;
     retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   persistHintedCodexTurnState?: (args: {
@@ -231,12 +274,20 @@ interface ExecuteCodexTurnPhaseArgs {
     applyFailureSignature: (
       record: IssueRunRecord,
       failureContext: FailureContext | null,
-    ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
-    normalizeBlockerSignature: (message: string | null | undefined) => string | null;
-    isVerificationBlockedMessage: (message: string | null | undefined) => boolean;
+    ) => Pick<
+      IssueRunRecord,
+      "last_failure_signature" | "repeated_failure_signature_count"
+    >;
+    normalizeBlockerSignature: (
+      message: string | null | undefined,
+    ) => string | null;
+    isVerificationBlockedMessage: (
+      message: string | null | undefined,
+    ) => boolean;
     retentionRootPath?: string;
   }) => Promise<IssueRunRecord>;
   getWorkspaceStatus?: typeof getWorkspaceStatus;
+  listChangedTrackedFilesBetween?: typeof listChangedTrackedFilesBetween;
   pushBranch?: typeof pushBranch;
   readIssueJournal?: typeof readIssueJournal;
   agentRunner?: AgentRunner;
@@ -252,16 +303,20 @@ export async function executeCodexTurnPhase(
   args: ExecuteCodexTurnPhaseArgs,
 ): Promise<CodexTurnResult | CodexTurnShortCircuit> {
   const getWorkspaceStatusImpl = args.getWorkspaceStatus ?? getWorkspaceStatus;
+  const listChangedTrackedFilesBetweenImpl =
+    args.listChangedTrackedFilesBetween ?? listChangedTrackedFilesBetween;
   const pushBranchImpl = args.pushBranch ?? pushBranch;
   const readIssueJournalImpl = args.readIssueJournal ?? readIssueJournal;
   const persistCodexTurnExecutionFailureImpl =
     args.persistCodexTurnExecutionFailure ?? persistCodexTurnExecutionFailure;
-  const persistCodexTurnExitFailureImpl = args.persistCodexTurnExitFailure ?? persistCodexTurnExitFailure;
+  const persistCodexTurnExitFailureImpl =
+    args.persistCodexTurnExitFailure ?? persistCodexTurnExitFailure;
   const persistMissingCodexJournalHandoffImpl =
     args.persistMissingCodexJournalHandoff ?? persistMissingCodexJournalHandoff;
   const persistHintedCodexTurnStateImpl =
     args.persistHintedCodexTurnState ?? persistHintedCodexTurnState;
-  const runWorkstationLocalPathGateImpl = args.runWorkstationLocalPathGate ?? runWorkstationLocalPathGate;
+  const runWorkstationLocalPathGateImpl =
+    args.runWorkstationLocalPathGate ?? runWorkstationLocalPathGate;
   const agentRunner =
     args.agentRunner ??
     createCodexAgentRunner({
@@ -270,9 +325,21 @@ export async function executeCodexTurnPhase(
       buildFailureContextImpl: args.buildCodexFailureContext,
     });
   const { config, stateStore, github } = args;
-  const { state, issue, previousCodexSummary, previousError, workspacePath, journalPath, syncJournal, memoryArtifacts, options } = args.context;
+  const {
+    state,
+    issue,
+    previousCodexSummary,
+    previousError,
+    workspacePath,
+    journalPath,
+    syncJournal,
+    memoryArtifacts,
+    options,
+  } = args.context;
   let { record, workspaceStatus, pr, checks, reviewThreads } = args.context;
   let turnMarkerWritten = false;
+  const turnStartHeadSha = workspaceStatus.headSha;
+  let usedSameTurnPathRepairRetry = false;
 
   try {
     if (options.dryRun) {
@@ -299,232 +366,250 @@ export async function executeCodexTurnPhase(
       };
     }
 
-    let journalContent = await readIssueJournalImpl(journalPath);
-    if (journalContent === null) {
-      await syncJournal(record);
-      journalContent = await readIssueJournalImpl(journalPath);
-    }
-    const effectiveJournalContent = journalContent ?? "";
-
     try {
-      const preparedTurn = await prepareCodexTurnPrompt({
-        config,
-        stateStore,
-        state,
-        record,
-        issue,
-        previousCodexSummary,
-        previousError,
-        workspacePath,
-        journalPath,
-        journalContent: effectiveJournalContent,
-        syncJournal,
-        memoryArtifacts,
-        pr,
-        checks,
-        reviewThreads,
-        github,
-        agentRunnerCapabilities: agentRunner.capabilities,
-      });
-      record = preparedTurn.record;
-      const { turnContext, reviewThreadsToProcess } = preparedTurn;
-      const preRunJournalFingerprint = await captureIssueJournalFingerprint(journalPath);
-      await writeInterruptedTurnMarker({
-        workspacePath,
-        issueNumber: record.issue_number,
-        state: record.state,
-        journalFingerprint: preRunJournalFingerprint,
-      });
-      turnMarkerWritten = true;
-      const turnResult = await agentRunner.runTurn(turnContext);
-      const structuredResult = agentRunner.capabilities.supportsStructuredResult ? turnResult.structuredResult : null;
-      const hintedState = structuredResult?.stateHint ?? null;
-      const hintedBlockedReason = structuredResult?.blockedReason ?? null;
-      const hintedFailureSignature = structuredResult?.failureSignature ?? null;
-      const preTurnFailureContext = record.last_failure_context;
-      const preTurnFailureSignature = record.last_failure_signature;
-      const preTurnStaleNoPrRecoveryCount = getStaleStabilizingNoPrRecoveryCount(record);
-      const preTurnLastError = record.last_error;
-      const journalAfterRun = await readIssueJournalImpl(journalPath);
-      const normalizedJournalAfterRun =
-        journalAfterRun === null
-          ? null
-          : await normalizeCommittedIssueJournal({
-              journalPath,
-              workspacePath,
-            });
-      const effectiveJournalAfterRun = normalizedJournalAfterRun ?? journalAfterRun;
-      record = stateStore.touch(record, {
-        codex_session_id: turnResult.sessionId,
-        last_codex_summary: truncate(turnResult.supervisorMessage),
-        last_failure_kind: turnResult.failureKind,
-        last_error:
-          turnResult.exitCode === 0
-            ? null
-            : truncate([turnResult.stderr.trim(), turnResult.stdout.trim()].filter(Boolean).join("\n")),
-      });
-
-      if (
-        turnResult.exitCode === 0 &&
-        (!effectiveJournalAfterRun ||
-          effectiveJournalAfterRun === effectiveJournalContent ||
-          !hasMeaningfulJournalHandoff(effectiveJournalAfterRun))
-      ) {
-        record = await persistMissingCodexJournalHandoffImpl({
-          stateStore,
-          state,
-          record,
-          issue,
-          syncJournal,
-          issueNumber: record.issue_number,
-          buildCodexFailureContext: args.buildCodexFailureContext,
-          applyFailureSignature: args.applyFailureSignature,
-          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-        });
-        return {
-          kind: "returned",
-          message: `Codex turn for issue #${record.issue_number} was rejected because no journal handoff was written.`,
-        };
-      }
-
-      if (turnResult.failureKind === "timeout" || turnResult.failureKind === "command_error") {
-        const message =
-          turnResult.stderr.trim() ||
-          turnResult.stdout.trim() ||
-          turnResult.supervisorMessage.trim() ||
-          "Unknown failure";
-        record = await persistCodexTurnExecutionFailureImpl({
-          stateStore,
-          state,
-          record,
-          issue,
-          syncJournal,
-          issueNumber: record.issue_number,
-          error: new Error(message),
-          classifyFailure: args.classifyFailure,
-          buildCodexFailureContext: args.buildCodexFailureContext,
-          applyFailureSignature: args.applyFailureSignature,
-          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-        });
-        return {
-          kind: "returned",
-          message: `Codex turn failed for issue #${record.issue_number}.`,
-        };
-      }
-
-      if (turnResult.exitCode !== 0) {
-        record = await persistCodexTurnExitFailureImpl({
-          stateStore,
-          state,
-          record,
-          issue,
-          syncJournal,
-          issueNumber: record.issue_number,
-          codexResult: {
-            lastMessage: turnResult.supervisorMessage,
-            stderr: turnResult.stderr,
-            stdout: turnResult.stdout,
-          },
-          classifyFailure: args.classifyFailure,
-          buildCodexFailureContext: args.buildCodexFailureContext,
-          applyFailureSignature: args.applyFailureSignature,
-          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-        });
-        return {
-          kind: "returned",
-          message: `Codex turn failed for issue #${record.issue_number}.`,
-        };
-      }
-
-      if (hintedState === "blocked" || hintedState === "failed") {
-        record = await persistHintedCodexTurnStateImpl({
-          stateStore,
-          state,
-          record,
-          issue,
-          syncJournal,
-          issueNumber: record.issue_number,
-          lastMessage: turnResult.supervisorMessage,
-          hintedState,
-          hintedBlockedReason,
-          hintedFailureSignature,
-          buildCodexFailureContext: args.buildCodexFailureContext,
-          applyFailureSignature: args.applyFailureSignature,
-          normalizeBlockerSignature: args.normalizeBlockerSignature,
-          isVerificationBlockedMessage: args.isVerificationBlockedMessage,
-          retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-        });
-        return {
-          kind: "returned",
-          message: `Codex reported ${hintedState} for issue #${record.issue_number}.`,
-        };
-      }
-
-      workspaceStatus = await getWorkspaceStatusImpl(workspacePath, record.branch, config.defaultBranch);
-      record = stateStore.touch(record, { last_head_sha: workspaceStatus.headSha });
-      let evaluatedReviewHeadSha = workspaceStatus.headSha;
-
-      if ((workspaceStatus.remoteAhead > 0 || !workspaceStatus.remoteBranchExists) && !workspaceStatus.hasUncommittedChanges) {
-        const pathHygieneGate = await runWorkstationLocalPathGateImpl({
-          workspacePath,
-          gateLabel: "before publication",
-          publishablePathAllowlistMarkers: config.publishablePathAllowlistMarkers,
-        });
-        if (!pathHygieneGate.ok) {
-          const failureContext = pathHygieneGate.failureContext;
-          record = stateStore.touch(record, {
-            state: "blocked",
-            last_error: truncate(
-              failureContext?.summary ?? "Tracked durable artifacts failed workstation-local path hygiene before publication.",
-              1000,
-            ),
-            last_failure_kind: null,
-            last_failure_context: failureContext,
-            ...args.applyFailureSignature(record, failureContext),
-            blocked_reason: "verification",
-            ...issueDefinitionFreshnessPatch(issue),
-          });
-          state.issues[String(record.issue_number)] = record;
-          await stateStore.save(state);
-          await syncExecutionMetricsRunSummarySafely({
-            previousRecord: args.context.record,
-            nextRecord: record,
-            issue,
-            pullRequest: pr,
-            retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-            warningContext: "persisting",
-          });
+      while (true) {
+        let journalContent = await readIssueJournalImpl(journalPath);
+        if (journalContent === null) {
           await syncJournal(record);
+          journalContent = await readIssueJournalImpl(journalPath);
+        }
+        const effectiveJournalContent = journalContent ?? "";
+
+        const preparedTurn = await prepareCodexTurnPrompt({
+          config,
+          stateStore,
+          state,
+          record,
+          issue,
+          previousCodexSummary,
+          previousError,
+          workspacePath,
+          journalPath,
+          journalContent: effectiveJournalContent,
+          syncJournal,
+          memoryArtifacts,
+          pr,
+          checks,
+          reviewThreads,
+          github,
+          agentRunnerCapabilities: agentRunner.capabilities,
+        });
+        record = preparedTurn.record;
+        const { turnContext, reviewThreadsToProcess } = preparedTurn;
+        const preRunJournalFingerprint =
+          await captureIssueJournalFingerprint(journalPath);
+        await writeInterruptedTurnMarker({
+          workspacePath,
+          issueNumber: record.issue_number,
+          state: record.state,
+          journalFingerprint: preRunJournalFingerprint,
+        });
+        turnMarkerWritten = true;
+        const turnResult = await agentRunner.runTurn(turnContext);
+        const structuredResult = agentRunner.capabilities
+          .supportsStructuredResult
+          ? turnResult.structuredResult
+          : null;
+        const hintedState = structuredResult?.stateHint ?? null;
+        const hintedBlockedReason = structuredResult?.blockedReason ?? null;
+        const hintedFailureSignature =
+          structuredResult?.failureSignature ?? null;
+        const preTurnFailureContext = record.last_failure_context;
+        const preTurnFailureSignature = record.last_failure_signature;
+        const preTurnStaleNoPrRecoveryCount =
+          getStaleStabilizingNoPrRecoveryCount(record);
+        const preTurnLastError = record.last_error;
+        const journalAfterRun = await readIssueJournalImpl(journalPath);
+        const normalizedJournalAfterRun =
+          journalAfterRun === null
+            ? null
+            : await normalizeCommittedIssueJournal({
+                journalPath,
+                workspacePath,
+              });
+        const effectiveJournalAfterRun =
+          normalizedJournalAfterRun ?? journalAfterRun;
+        record = stateStore.touch(record, {
+          codex_session_id: turnResult.sessionId,
+          last_codex_summary: truncate(turnResult.supervisorMessage),
+          last_failure_kind: turnResult.failureKind,
+          last_error:
+            turnResult.exitCode === 0
+              ? null
+              : truncate(
+                  [turnResult.stderr.trim(), turnResult.stdout.trim()]
+                    .filter(Boolean)
+                    .join("\n"),
+                ),
+        });
+
+        if (
+          turnResult.exitCode === 0 &&
+          (!effectiveJournalAfterRun ||
+            effectiveJournalAfterRun === effectiveJournalContent ||
+            !hasMeaningfulJournalHandoff(effectiveJournalAfterRun))
+        ) {
+          record = await persistMissingCodexJournalHandoffImpl({
+            stateStore,
+            state,
+            record,
+            issue,
+            syncJournal,
+            issueNumber: record.issue_number,
+            buildCodexFailureContext: args.buildCodexFailureContext,
+            applyFailureSignature: args.applyFailureSignature,
+            retentionRootPath: executionMetricsRetentionRootPath(
+              args.config.stateFile,
+            ),
+          });
           return {
             kind: "returned",
-            message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
+            message: `Codex turn for issue #${record.issue_number} was rejected because no journal handoff was written.`,
           };
         }
-        const rewrittenTrackedPaths = [
-          ...(pathHygieneGate.rewrittenJournalPaths ?? []),
-          ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
-        ];
-        const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenTrackedPaths);
-        if (presentRewrittenTrackedPaths.length > 0) {
-          try {
-            await commitAndPushTrackedFiles({
-              workspacePath,
-              branch: record.branch,
-              remoteBranchExists: workspaceStatus.remoteBranchExists,
-              filePaths: presentRewrittenTrackedPaths,
-              commitMessage: TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
-            });
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            const failureContext = buildWorkstationLocalPathFailureContext({
-              gateLabel: "before publication",
-              details: [
-                `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
-              ],
-            });
+
+        if (
+          turnResult.failureKind === "timeout" ||
+          turnResult.failureKind === "command_error"
+        ) {
+          const message =
+            turnResult.stderr.trim() ||
+            turnResult.stdout.trim() ||
+            turnResult.supervisorMessage.trim() ||
+            "Unknown failure";
+          record = await persistCodexTurnExecutionFailureImpl({
+            stateStore,
+            state,
+            record,
+            issue,
+            syncJournal,
+            issueNumber: record.issue_number,
+            error: new Error(message),
+            classifyFailure: args.classifyFailure,
+            buildCodexFailureContext: args.buildCodexFailureContext,
+            applyFailureSignature: args.applyFailureSignature,
+            retentionRootPath: executionMetricsRetentionRootPath(
+              args.config.stateFile,
+            ),
+          });
+          return {
+            kind: "returned",
+            message: `Codex turn failed for issue #${record.issue_number}.`,
+          };
+        }
+
+        if (turnResult.exitCode !== 0) {
+          record = await persistCodexTurnExitFailureImpl({
+            stateStore,
+            state,
+            record,
+            issue,
+            syncJournal,
+            issueNumber: record.issue_number,
+            codexResult: {
+              lastMessage: turnResult.supervisorMessage,
+              stderr: turnResult.stderr,
+              stdout: turnResult.stdout,
+            },
+            classifyFailure: args.classifyFailure,
+            buildCodexFailureContext: args.buildCodexFailureContext,
+            applyFailureSignature: args.applyFailureSignature,
+            retentionRootPath: executionMetricsRetentionRootPath(
+              args.config.stateFile,
+            ),
+          });
+          return {
+            kind: "returned",
+            message: `Codex turn failed for issue #${record.issue_number}.`,
+          };
+        }
+
+        if (hintedState === "blocked" || hintedState === "failed") {
+          record = await persistHintedCodexTurnStateImpl({
+            stateStore,
+            state,
+            record,
+            issue,
+            syncJournal,
+            issueNumber: record.issue_number,
+            lastMessage: turnResult.supervisorMessage,
+            hintedState,
+            hintedBlockedReason,
+            hintedFailureSignature,
+            buildCodexFailureContext: args.buildCodexFailureContext,
+            applyFailureSignature: args.applyFailureSignature,
+            normalizeBlockerSignature: args.normalizeBlockerSignature,
+            isVerificationBlockedMessage: args.isVerificationBlockedMessage,
+            retentionRootPath: executionMetricsRetentionRootPath(
+              args.config.stateFile,
+            ),
+          });
+          return {
+            kind: "returned",
+            message: `Codex reported ${hintedState} for issue #${record.issue_number}.`,
+          };
+        }
+
+        workspaceStatus = await getWorkspaceStatusImpl(
+          workspacePath,
+          record.branch,
+          config.defaultBranch,
+        );
+        record = stateStore.touch(record, {
+          last_head_sha: workspaceStatus.headSha,
+        });
+        let evaluatedReviewHeadSha = workspaceStatus.headSha;
+        const changedFilesInCurrentTurn =
+          workspaceStatus.headSha === turnStartHeadSha
+            ? []
+            : await listChangedTrackedFilesBetweenImpl(
+                workspacePath,
+                turnStartHeadSha,
+                workspaceStatus.headSha,
+              );
+
+        if (
+          (workspaceStatus.remoteAhead > 0 ||
+            !workspaceStatus.remoteBranchExists) &&
+          !workspaceStatus.hasUncommittedChanges
+        ) {
+          const pathHygieneGate = await runWorkstationLocalPathGateImpl({
+            workspacePath,
+            gateLabel: "before publication",
+            publishablePathAllowlistMarkers:
+              config.publishablePathAllowlistMarkers,
+          });
+          if (!pathHygieneGate.ok) {
+            const failureContext = pathHygieneGate.failureContext;
+            const actionablePublishableFilePaths =
+              pathHygieneGate.actionablePublishableFilePaths ?? [];
+            const sameTurnRepairEligible =
+              !usedSameTurnPathRepairRetry &&
+              failureContext !== null &&
+              actionablePublishableFilePaths.length > 0 &&
+              actionablePublishableFilePaths.every((filePath) =>
+                changedFilesInCurrentTurn.includes(filePath),
+              );
+            if (sameTurnRepairEligible) {
+              usedSameTurnPathRepairRetry = true;
+              record = stateStore.touch(record, {
+                last_error: truncate(failureContext.summary, 1000),
+                last_failure_kind: null,
+                last_failure_context: failureContext,
+                ...args.applyFailureSignature(record, failureContext),
+              });
+              state.issues[String(record.issue_number)] = record;
+              await stateStore.save(state);
+              await syncJournal(record);
+              continue;
+            }
             record = stateStore.touch(record, {
               state: "blocked",
-              last_error: truncate(failureContext.summary, 1000),
+              last_error: truncate(
+                failureContext?.summary ??
+                  "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+                1000,
+              ),
               last_failure_kind: null,
               last_failure_context: failureContext,
               ...args.applyFailureSignature(record, failureContext),
@@ -538,7 +623,9 @@ export async function executeCodexTurnPhase(
               nextRecord: record,
               issue,
               pullRequest: pr,
-              retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
+              retentionRootPath: executionMetricsRetentionRootPath(
+                args.config.stateFile,
+              ),
               warningContext: "persisting",
             });
             await syncJournal(record);
@@ -547,143 +634,256 @@ export async function executeCodexTurnPhase(
               message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
             };
           }
-          workspaceStatus = await getWorkspaceStatusImpl(workspacePath, record.branch, config.defaultBranch);
-          evaluatedReviewHeadSha = workspaceStatus.headSha;
-          record = stateStore.touch(record, { last_head_sha: evaluatedReviewHeadSha });
+          const rewrittenTrackedPaths = [
+            ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+            ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+          ];
+          const presentRewrittenTrackedPaths =
+            await filterPresentTrackedFilePaths(
+              workspacePath,
+              rewrittenTrackedPaths,
+            );
+          if (presentRewrittenTrackedPaths.length > 0) {
+            try {
+              await commitAndPushTrackedFiles({
+                workspacePath,
+                branch: record.branch,
+                remoteBranchExists: workspaceStatus.remoteBranchExists,
+                filePaths: presentRewrittenTrackedPaths,
+                commitMessage:
+                  TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
+              });
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              const failureContext = buildWorkstationLocalPathFailureContext({
+                gateLabel: "before publication",
+                details: [
+                  `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
+                ],
+              });
+              record = stateStore.touch(record, {
+                state: "blocked",
+                last_error: truncate(failureContext.summary, 1000),
+                last_failure_kind: null,
+                last_failure_context: failureContext,
+                ...args.applyFailureSignature(record, failureContext),
+                blocked_reason: "verification",
+                ...issueDefinitionFreshnessPatch(issue),
+              });
+              state.issues[String(record.issue_number)] = record;
+              await stateStore.save(state);
+              await syncExecutionMetricsRunSummarySafely({
+                previousRecord: args.context.record,
+                nextRecord: record,
+                issue,
+                pullRequest: pr,
+                retentionRootPath: executionMetricsRetentionRootPath(
+                  args.config.stateFile,
+                ),
+                warningContext: "persisting",
+              });
+              await syncJournal(record);
+              return {
+                kind: "returned",
+                message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
+              };
+            }
+            workspaceStatus = await getWorkspaceStatusImpl(
+              workspacePath,
+              record.branch,
+              config.defaultBranch,
+            );
+            evaluatedReviewHeadSha = workspaceStatus.headSha;
+            record = stateStore.touch(record, {
+              last_head_sha: evaluatedReviewHeadSha,
+            });
+          }
+          if (
+            workspaceStatus.remoteAhead > 0 ||
+            !workspaceStatus.remoteBranchExists
+          ) {
+            await pushBranchImpl(
+              workspacePath,
+              record.branch,
+              workspaceStatus.remoteBranchExists,
+            );
+            workspaceStatus = await getWorkspaceStatusImpl(
+              workspacePath,
+              record.branch,
+              config.defaultBranch,
+            );
+            evaluatedReviewHeadSha = workspaceStatus.headSha;
+            record = stateStore.touch(record, {
+              last_head_sha: evaluatedReviewHeadSha,
+            });
+          }
         }
-        if (workspaceStatus.remoteAhead > 0 || !workspaceStatus.remoteBranchExists) {
-          await pushBranchImpl(workspacePath, record.branch, workspaceStatus.remoteBranchExists);
-          workspaceStatus = await getWorkspaceStatusImpl(workspacePath, record.branch, config.defaultBranch);
-          evaluatedReviewHeadSha = workspaceStatus.headSha;
-          record = stateStore.touch(record, { last_head_sha: evaluatedReviewHeadSha });
-        }
-      }
 
-      const publicationGate = await applyCodexTurnPublicationGate({
-        config,
-        stateStore,
-        state,
-        record,
-        issue,
-        workspacePath,
-        workspaceStatus,
-        github,
-        syncJournal,
-        applyFailureSignature: args.applyFailureSignature,
-        runLocalCiCommand: args.runLocalCiCommand,
-        runWorkstationLocalPathGate: args.runWorkstationLocalPathGate,
-        syncExecutionMetricsRunSummary: async (blockedRecord) => {
-          await syncExecutionMetricsRunSummarySafely({
-            previousRecord: args.context.record,
-            nextRecord: blockedRecord,
-            issue,
-            retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-            warningContext: "persisting",
+        const publicationGate = await applyCodexTurnPublicationGate({
+          config,
+          stateStore,
+          state,
+          record,
+          issue,
+          workspacePath,
+          workspaceStatus,
+          github,
+          syncJournal,
+          applyFailureSignature: args.applyFailureSignature,
+          runLocalCiCommand: args.runLocalCiCommand,
+          runWorkstationLocalPathGate: args.runWorkstationLocalPathGate,
+          allowSameTurnPathRepairRetry: !usedSameTurnPathRepairRetry,
+          changedFilesInCurrentTurn,
+          syncExecutionMetricsRunSummary: async (blockedRecord) => {
+            await syncExecutionMetricsRunSummarySafely({
+              previousRecord: args.context.record,
+              nextRecord: blockedRecord,
+              issue,
+              retentionRootPath: executionMetricsRetentionRootPath(
+                args.config.stateFile,
+              ),
+              warningContext: "persisting",
+            });
+          },
+        });
+        record = publicationGate.record;
+        if (publicationGate.kind === "same_turn_repair") {
+          usedSameTurnPathRepairRetry = true;
+          record = stateStore.touch(record, {
+            last_error: truncate(publicationGate.failureContext.summary, 1000),
+            last_failure_kind: null,
+            last_failure_context: publicationGate.failureContext,
+            ...args.applyFailureSignature(
+              record,
+              publicationGate.failureContext,
+            ),
           });
-        },
-      });
-      record = publicationGate.record;
-      pr = publicationGate.pr;
-      checks = publicationGate.checks;
-      reviewThreads = publicationGate.reviewThreads;
-      if (publicationGate.kind === "blocked") {
-        return {
-          kind: "returned",
-          message: publicationGate.message,
-        };
-      }
+          state.issues[String(record.issue_number)] = record;
+          await stateStore.save(state);
+          await syncJournal(record);
+          continue;
+        }
+        pr = publicationGate.pr;
+        checks = publicationGate.checks;
+        reviewThreads = publicationGate.reviewThreads;
+        if (publicationGate.kind === "blocked") {
+          return {
+            kind: "returned",
+            message: publicationGate.message,
+          };
+        }
 
-      const processedReviewThreadPatch = nextProcessedReviewThreadPatch({
-        preRunState,
-        record,
-        currentPr: pr,
-        evaluatedReviewHeadSha,
-        reviewThreadsToProcess,
-      });
-      const reviewFollowUpPatch = nextReviewFollowUpPatch({
-        config,
-        preRunState,
-        record,
-        currentPr: pr,
-        evaluatedReviewHeadSha,
-        preRunReviewThreads: args.context.reviewThreads,
-        postRunReviewThreads: reviewThreads,
-      });
-      const postRunSnapshot = pr
-        ? args.derivePullRequestLifecycleSnapshot(
+        const processedReviewThreadPatch = nextProcessedReviewThreadPatch({
+          preRunState,
+          record,
+          currentPr: pr,
+          evaluatedReviewHeadSha,
+          reviewThreadsToProcess,
+        });
+        const reviewFollowUpPatch = nextReviewFollowUpPatch({
+          config,
+          preRunState,
+          record,
+          currentPr: pr,
+          evaluatedReviewHeadSha,
+          preRunReviewThreads: args.context.reviewThreads,
+          postRunReviewThreads: reviewThreads,
+        });
+        const postRunSnapshot = pr
+          ? args.derivePullRequestLifecycleSnapshot(
+              record,
+              pr,
+              checks,
+              reviewThreads,
+              {
+                ...processedReviewThreadPatch,
+                ...reviewFollowUpPatch,
+              },
+            )
+          : null;
+        const postRunState = postRunSnapshot
+          ? postRunSnapshot.nextState
+          : (hintedState ??
+            args.inferStateWithoutPullRequest(record, workspaceStatus));
+        const preserveStaleNoPrRecoveryTracking =
+          pr === null &&
+          postRunSnapshot === null &&
+          shouldPreserveStaleStabilizingNoPrRecoveryTracking(
             record,
-            pr,
-            checks,
-            reviewThreads,
-            {
-              ...processedReviewThreadPatch,
-              ...reviewFollowUpPatch,
-            },
-          )
-        : null;
-      const postRunState = postRunSnapshot
-        ? postRunSnapshot.nextState
-        : hintedState ?? args.inferStateWithoutPullRequest(record, workspaceStatus);
-      const preserveStaleNoPrRecoveryTracking =
-        pr === null && postRunSnapshot === null && shouldPreserveStaleStabilizingNoPrRecoveryTracking(record, postRunState);
-      record = stateStore.touch(record, {
-        pr_number: pr?.number ?? null,
-        ...(postRunSnapshot?.reviewWaitPatch ?? {}),
-        ...(postRunSnapshot?.copilotRequestObservationPatch ?? {}),
-        ...(postRunSnapshot?.copilotTimeoutPatch ?? {}),
-        ...processedReviewThreadPatch,
-        ...reviewFollowUpPatch,
-        blocked_verification_retry_count: pr ? 0 : record.blocked_verification_retry_count,
-        repeated_blocker_count: 0,
-        last_blocker_signature: null,
-        stale_stabilizing_no_pr_recovery_count: preserveStaleNoPrRecoveryTracking
-          ? preTurnStaleNoPrRecoveryCount
-          : 0,
-        last_error:
-          preserveStaleNoPrRecoveryTracking
+            postRunState,
+          );
+        record = stateStore.touch(record, {
+          pr_number: pr?.number ?? null,
+          ...(postRunSnapshot?.reviewWaitPatch ?? {}),
+          ...(postRunSnapshot?.copilotRequestObservationPatch ?? {}),
+          ...(postRunSnapshot?.copilotTimeoutPatch ?? {}),
+          ...processedReviewThreadPatch,
+          ...reviewFollowUpPatch,
+          blocked_verification_retry_count: pr
+            ? 0
+            : record.blocked_verification_retry_count,
+          repeated_blocker_count: 0,
+          last_blocker_signature: null,
+          stale_stabilizing_no_pr_recovery_count:
+            preserveStaleNoPrRecoveryTracking
+              ? preTurnStaleNoPrRecoveryCount
+              : 0,
+          last_error: preserveStaleNoPrRecoveryTracking
             ? preTurnLastError
             : postRunState === "blocked" && postRunSnapshot?.failureContext
-            ? truncate(postRunSnapshot.failureContext.summary, 1000)
-            : record.last_error,
-        last_failure_context:
-          preserveStaleNoPrRecoveryTracking ? preTurnFailureContext : postRunSnapshot?.failureContext ?? null,
-        ...(
-          preserveStaleNoPrRecoveryTracking
+              ? truncate(postRunSnapshot.failureContext.summary, 1000)
+              : record.last_error,
+          last_failure_context: preserveStaleNoPrRecoveryTracking
+            ? preTurnFailureContext
+            : (postRunSnapshot?.failureContext ?? null),
+          ...(preserveStaleNoPrRecoveryTracking
             ? {
                 last_failure_signature: preTurnFailureSignature,
                 repeated_failure_signature_count: 0,
               }
-            : args.applyFailureSignature(record, postRunSnapshot?.failureContext ?? null)
-        ),
-        blocked_reason:
-          pr && postRunState === "blocked"
-            ? args.blockedReasonFromReviewState(postRunSnapshot?.recordForState ?? record, pr, checks, reviewThreads)
-            : null,
-        state: postRunState,
-        ...((pr === null && (postRunState === "blocked" || postRunState === "failed"))
-          ? issueDefinitionFreshnessPatch(issue)
-          : {}),
-      });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncExecutionMetricsRunSummarySafely({
-        previousRecord: args.context.record,
-        nextRecord: record,
-        issue,
-        pullRequest: pr,
-        retentionRootPath: executionMetricsRetentionRootPath(args.config.stateFile),
-        warningContext: "persisting",
-      });
-      await syncJournal(record);
+            : args.applyFailureSignature(
+                record,
+                postRunSnapshot?.failureContext ?? null,
+              )),
+          blocked_reason:
+            pr && postRunState === "blocked"
+              ? args.blockedReasonFromReviewState(
+                  postRunSnapshot?.recordForState ?? record,
+                  pr,
+                  checks,
+                  reviewThreads,
+                )
+              : null,
+          state: postRunState,
+          ...(pr === null &&
+          (postRunState === "blocked" || postRunState === "failed")
+            ? issueDefinitionFreshnessPatch(issue)
+            : {}),
+        });
+        state.issues[String(record.issue_number)] = record;
+        await stateStore.save(state);
+        await syncExecutionMetricsRunSummarySafely({
+          previousRecord: args.context.record,
+          nextRecord: record,
+          issue,
+          pullRequest: pr,
+          retentionRootPath: executionMetricsRetentionRootPath(
+            args.config.stateFile,
+          ),
+          warningContext: "persisting",
+        });
+        await syncJournal(record);
 
-      return {
-        kind: "completed",
-        record,
-        workspaceStatus,
-        pr,
-        checks,
-        reviewThreads,
-      };
+        return {
+          kind: "completed",
+          record,
+          workspaceStatus,
+          pr,
+          checks,
+          reviewThreads,
+        };
+      }
     } finally {
       await sessionLock?.release();
     }

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -328,8 +328,6 @@ export async function executeCodexTurnPhase(
   const {
     state,
     issue,
-    previousCodexSummary,
-    previousError,
     workspacePath,
     journalPath,
     syncJournal,
@@ -374,6 +372,8 @@ export async function executeCodexTurnPhase(
           journalContent = await readIssueJournalImpl(journalPath);
         }
         const effectiveJournalContent = journalContent ?? "";
+        const previousCodexSummary = record.last_codex_summary;
+        const previousError = record.last_error;
 
         const preparedTurn = await prepareCodexTurnPrompt({
           config,
@@ -591,6 +591,78 @@ export async function executeCodexTurnPhase(
                 changedFilesInCurrentTurn.includes(filePath),
               );
             if (sameTurnRepairEligible) {
+              const rewrittenTrackedPaths = [
+                ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+                ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ??
+                  []),
+              ];
+              const presentRewrittenTrackedPaths =
+                await filterPresentTrackedFilePaths(
+                  workspacePath,
+                  rewrittenTrackedPaths,
+                );
+              if (presentRewrittenTrackedPaths.length > 0) {
+                try {
+                  await commitAndPushTrackedFiles({
+                    workspacePath,
+                    branch: record.branch,
+                    remoteBranchExists: workspaceStatus.remoteBranchExists,
+                    filePaths: presentRewrittenTrackedPaths,
+                    commitMessage:
+                      TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
+                  });
+                } catch (error) {
+                  const message =
+                    error instanceof Error ? error.message : String(error);
+                  const retryPersistenceFailureContext =
+                    buildWorkstationLocalPathFailureContext({
+                      gateLabel: "before publication",
+                      details: [
+                        `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
+                      ],
+                    });
+                  record = stateStore.touch(record, {
+                    state: "blocked",
+                    last_error: truncate(
+                      retryPersistenceFailureContext.summary,
+                      1000,
+                    ),
+                    last_failure_kind: null,
+                    last_failure_context: retryPersistenceFailureContext,
+                    ...args.applyFailureSignature(
+                      record,
+                      retryPersistenceFailureContext,
+                    ),
+                    blocked_reason: "verification",
+                    ...issueDefinitionFreshnessPatch(issue),
+                  });
+                  state.issues[String(record.issue_number)] = record;
+                  await stateStore.save(state);
+                  await syncExecutionMetricsRunSummarySafely({
+                    previousRecord: args.context.record,
+                    nextRecord: record,
+                    issue,
+                    pullRequest: pr,
+                    retentionRootPath: executionMetricsRetentionRootPath(
+                      args.config.stateFile,
+                    ),
+                    warningContext: "persisting",
+                  });
+                  await syncJournal(record);
+                  return {
+                    kind: "returned",
+                    message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
+                  };
+                }
+                workspaceStatus = await getWorkspaceStatusImpl(
+                  workspacePath,
+                  record.branch,
+                  config.defaultBranch,
+                );
+                record = stateStore.touch(record, {
+                  last_head_sha: workspaceStatus.headSha,
+                });
+              }
               usedSameTurnPathRepairRetry = true;
               record = stateStore.touch(record, {
                 last_error: truncate(failureContext.summary, 1000),
@@ -749,6 +821,72 @@ export async function executeCodexTurnPhase(
         });
         record = publicationGate.record;
         if (publicationGate.kind === "same_turn_repair") {
+          const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(
+            workspacePath,
+            publicationGate.rewrittenTrackedPaths,
+          );
+          if (presentRewrittenTrackedPaths.length > 0) {
+            try {
+              await commitAndPushTrackedFiles({
+                workspacePath,
+                branch: record.branch,
+                remoteBranchExists: workspaceStatus.remoteBranchExists,
+                filePaths: presentRewrittenTrackedPaths,
+                commitMessage:
+                  TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
+              });
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              const retryPersistenceFailureContext =
+                buildWorkstationLocalPathFailureContext({
+                  gateLabel: "before publication",
+                  details: [
+                    `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
+                  ],
+                });
+              record = stateStore.touch(record, {
+                state: "blocked",
+                last_error: truncate(
+                  retryPersistenceFailureContext.summary,
+                  1000,
+                ),
+                last_failure_kind: null,
+                last_failure_context: retryPersistenceFailureContext,
+                ...args.applyFailureSignature(
+                  record,
+                  retryPersistenceFailureContext,
+                ),
+                blocked_reason: "verification",
+                ...issueDefinitionFreshnessPatch(issue),
+              });
+              state.issues[String(record.issue_number)] = record;
+              await stateStore.save(state);
+              await syncExecutionMetricsRunSummarySafely({
+                previousRecord: args.context.record,
+                nextRecord: record,
+                issue,
+                pullRequest: pr,
+                retentionRootPath: executionMetricsRetentionRootPath(
+                  args.config.stateFile,
+                ),
+                warningContext: "persisting",
+              });
+              await syncJournal(record);
+              return {
+                kind: "returned",
+                message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
+              };
+            }
+            workspaceStatus = await getWorkspaceStatusImpl(
+              workspacePath,
+              record.branch,
+              config.defaultBranch,
+            );
+            record = stateStore.touch(record, {
+              last_head_sha: workspaceStatus.headSha,
+            });
+          }
           usedSameTurnPathRepairRetry = true;
           record = stateStore.touch(record, {
             last_error: truncate(publicationGate.failureContext.summary, 1000),

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -229,6 +229,91 @@ test("applyCodexTurnPublicationGate keeps the existing verification block once s
   );
 });
 
+test("applyCodexTurnPublicationGate preserves rewritten tracked paths when requesting a same-turn repair retry", async () => {
+  const issue = createIssue({
+    title: "Preserve rewritten tracked paths across same-turn publication repair",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({ localCiCommand: "npm run ci:local" }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath: "/tmp/workspaces/issue-102",
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-102",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: false,
+      failureContext: {
+        category: "blocked",
+        summary:
+          "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+        signature: "workstation-local-path-hygiene-failed",
+        command: "npm run verify:paths",
+        details: [
+          'docs/guide.md:1 matched <workstation-local> via "<workstation-local>/private-repo"',
+        ],
+        url: null,
+        updated_at: "2026-03-27T00:00:00Z",
+      },
+      actionablePublishableFilePaths: ["docs/guide.md"],
+      rewrittenJournalPaths: [".codex-supervisor/issue-journal.md"],
+      rewrittenTrustedGeneratedArtifactPaths: ["docs/generated-summary.md"],
+    }),
+    allowSameTurnPathRepairRetry: true,
+    changedFilesInCurrentTurn: ["docs/guide.md"],
+    runLocalCiCommand: async () => {
+      throw new Error("unexpected runLocalCiCommand call");
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "same_turn_repair");
+  assert.deepEqual(result.rewrittenTrackedPaths, [
+    ".codex-supervisor/issue-journal.md",
+    "docs/generated-summary.md",
+  ]);
+});
+
 test("applyCodexTurnPublicationGate forwards publishable allowlist markers to the path hygiene gate", async () => {
   const issue = createIssue({
     title: "Honor publishable allowlist markers before PR creation",

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -6,7 +6,12 @@ import os from "node:os";
 import path from "node:path";
 import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate";
 import { SupervisorStateFile } from "./core/types";
-import { createConfig, createIssue, createPullRequest, createRecord } from "./turn-execution-test-helpers";
+import {
+  createConfig,
+  createIssue,
+  createPullRequest,
+  createRecord,
+} from "./turn-execution-test-helpers";
 
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
 const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
@@ -19,7 +24,9 @@ function git(cwd: string, ...args: string[]): string {
 }
 
 async function createTrackedRepo(): Promise<string> {
-  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "publication-gate-path-hygiene-"));
+  const repoPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), "publication-gate-path-hygiene-"),
+  );
   git(repoPath, "init", "-b", "main");
   git(repoPath, "config", "user.name", "Codex Supervisor");
   git(repoPath, "config", "user.email", "codex@example.test");
@@ -33,7 +40,9 @@ async function createTrackedRepo(): Promise<string> {
 }
 
 test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene fails", async () => {
-  const issue = createIssue({ title: "Gate draft PR creation on path hygiene" });
+  const issue = createIssue({
+    title: "Gate draft PR creation on path hygiene",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -53,7 +62,11 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene f
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({ localCiCommand: "npm run ci:local" }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => {
         saveCalls += 1;
       },
@@ -92,10 +105,13 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene f
       ok: false,
       failureContext: {
         category: "blocked",
-        summary: "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+        summary:
+          "Tracked durable artifacts failed workstation-local path hygiene before publication.",
         signature: "workstation-local-path-hygiene-failed",
         command: "npm run verify:paths",
-        details: ['docs/guide.md:1 matched <workstation-local> via "<workstation-local>/private-repo"'],
+        details: [
+          'docs/guide.md:1 matched <workstation-local> via "<workstation-local>/private-repo"',
+        ],
         url: null,
         updated_at: "2026-03-27T00:00:00Z",
       },
@@ -109,10 +125,16 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene f
   });
 
   assert.equal(result.kind, "blocked");
-  assert.equal(result.message, "Workstation-local path hygiene blocked pull request creation for issue #102.");
+  assert.equal(
+    result.message,
+    "Workstation-local path hygiene blocked pull request creation for issue #102.",
+  );
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
-  assert.equal(result.record.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(
+    result.record.last_failure_signature,
+    "workstation-local-path-hygiene-failed",
+  );
   assert.equal(result.pr, null);
   assert.equal(saveCalls, 1);
   assert.equal(syncJournalCalls, 1);
@@ -121,8 +143,11 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene f
   assert.equal(runLocalCiCalls, 0);
 });
 
-test("applyCodexTurnPublicationGate forwards publishable allowlist markers to the path hygiene gate", async () => {
-  const issue = createIssue({ title: "Honor publishable allowlist markers before PR creation" });
+test("applyCodexTurnPublicationGate keeps the existing verification block once same-turn path repair retry is exhausted", async () => {
+  const issue = createIssue({
+    title:
+      "Keep publication blocked after exhausting same-turn path repair retry",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -133,15 +158,15 @@ test("applyCodexTurnPublicationGate forwards publishable allowlist markers to th
       }),
     },
   };
-  const observedCalls: Array<readonly string[] | undefined> = [];
 
   const result = await applyCodexTurnPublicationGate({
-    config: createConfig({
-      localCiCommand: "npm run ci:local",
-      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
-    }),
+    config: createConfig({ localCiCommand: "npm run ci:local" }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -160,7 +185,101 @@ test("applyCodexTurnPublicationGate forwards publishable allowlist markers to th
     },
     github: {
       resolvePullRequestForBranch: async () => null,
-      createPullRequest: async () => createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" }),
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: false,
+      failureContext: {
+        category: "blocked",
+        summary:
+          "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+        signature: "workstation-local-path-hygiene-failed",
+        command: "npm run verify:paths",
+        details: [
+          'docs/guide.md:1 matched <workstation-local> via "<workstation-local>/private-repo"',
+        ],
+        url: null,
+        updated_at: "2026-03-27T00:00:00Z",
+      },
+      actionablePublishableFilePaths: ["docs/guide.md"],
+    }),
+    allowSameTurnPathRepairRetry: false,
+    changedFilesInCurrentTurn: ["docs/guide.md"],
+    runLocalCiCommand: async () => {
+      throw new Error("unexpected runLocalCiCommand call");
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(
+    result.record.last_failure_signature,
+    "workstation-local-path-hygiene-failed",
+  );
+});
+
+test("applyCodexTurnPublicationGate forwards publishable allowlist markers to the path hygiene gate", async () => {
+  const issue = createIssue({
+    title: "Honor publishable allowlist markers before PR creation",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  const observedCalls: Array<readonly string[] | undefined> = [];
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      publishablePathAllowlistMarkers: ["publishable-path-hygiene: allowlist"],
+    }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath: "/tmp/workspaces/issue-102",
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-102",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () =>
+        createPullRequest({
+          number: 200,
+          isDraft: true,
+          headRefOid: "head-102",
+        }),
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
     },
@@ -191,8 +310,20 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
-  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "102",
+    "issue-journal.md",
+  );
+  const otherJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "181",
+    "issue-journal.md",
+  );
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
   await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
@@ -208,13 +339,20 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
     ].join("\n"),
     "utf8",
   );
-  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md", ".codex-supervisor/issues/181/issue-journal.md");
+  git(
+    workspacePath,
+    "add",
+    ".codex-supervisor/issues/102/issue-journal.md",
+    ".codex-supervisor/issues/181/issue-journal.md",
+  );
   git(workspacePath, "commit", "-m", "seed cross-issue journal leak");
 
   let createPullRequestCalls = 0;
   let runWorkspacePreparationCalls = 0;
   let runLocalCiCalls = 0;
-  const issue = createIssue({ title: "Gate draft PR creation on cross-issue journal hygiene" });
+  const issue = createIssue({
+    title: "Gate draft PR creation on cross-issue journal hygiene",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -233,10 +371,15 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({
       localCiCommand: "npm run ci:local",
-      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+      issueJournalRelativePath:
+        ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -284,20 +427,47 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals bef
     result.message,
     /Tracked supervisor-local durable artifacts blocked pull request creation for issue #102\./,
   );
-  assert.match(result.message, /\.codex-supervisor\/issues\/102\/issue-journal\.md/);
-  assert.match(result.message, /\.codex-supervisor\/issues\/181\/issue-journal\.md/);
-  assert.match(result.message, /Remove or unstage these tracked paths before publishing checkpoint commits:/);
+  assert.match(
+    result.message,
+    /\.codex-supervisor\/issues\/102\/issue-journal\.md/,
+  );
+  assert.match(
+    result.message,
+    /\.codex-supervisor\/issues\/181\/issue-journal\.md/,
+  );
+  assert.match(
+    result.message,
+    /Remove or unstage these tracked paths before publishing checkpoint commits:/,
+  );
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
-  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(
+    result.record.last_failure_signature,
+    "supervisor-local-durable-artifacts-tracked-before-publication",
+  );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(runWorkspacePreparationCalls, 0);
   assert.equal(runLocalCiCalls, 0);
   assert.equal(result.record.last_head_sha, initialLastHeadSha);
   assert.notEqual(result.record.last_head_sha, workspaceHeadSha);
-  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed cross-issue journal leak");
-  assert.equal(git(workspacePath, "ls-remote", "--heads", "origin", "codex/issue-102").trim(), "");
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "seed cross-issue journal leak",
+  );
+  assert.equal(
+    git(
+      workspacePath,
+      "ls-remote",
+      "--heads",
+      "origin",
+      "codex/issue-102",
+    ).trim(),
+    "",
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "",
+  );
 });
 
 test("applyCodexTurnPublicationGate blocks tracked supervisor journals for custom templated journal layouts", async (t) => {
@@ -307,18 +477,35 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for custo
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "custom", "issue-102.md");
-  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "custom", "issue-181.md");
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "custom",
+    "issue-102.md",
+  );
+  const otherJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "custom",
+    "issue-181.md",
+  );
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
   await fs.writeFile(otherJournalPath, "# Issue #181\n", "utf8");
-  git(workspacePath, "add", ".codex-supervisor/custom/issue-102.md", ".codex-supervisor/custom/issue-181.md");
+  git(
+    workspacePath,
+    "add",
+    ".codex-supervisor/custom/issue-102.md",
+    ".codex-supervisor/custom/issue-181.md",
+  );
   git(workspacePath, "commit", "-m", "seed custom journal leak");
 
   let createPullRequestCalls = 0;
   let runWorkspacePreparationCalls = 0;
   let runLocalCiCalls = 0;
-  const issue = createIssue({ title: "Gate custom journal layouts before publication" });
+  const issue = createIssue({
+    title: "Gate custom journal layouts before publication",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -335,10 +522,15 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for custo
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({
       localCiCommand: "npm run ci:local",
-      issueJournalRelativePath: ".codex-supervisor/custom/issue-{issueNumber}.md",
+      issueJournalRelativePath:
+        ".codex-supervisor/custom/issue-{issueNumber}.md",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -385,12 +577,21 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for custo
   assert.match(result.message, /\.codex-supervisor\/custom\/issue-102\.md/);
   assert.match(result.message, /\.codex-supervisor\/custom\/issue-181\.md/);
   assert.equal(result.record.state, "blocked");
-  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(
+    result.record.last_failure_signature,
+    "supervisor-local-durable-artifacts-tracked-before-publication",
+  );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(runWorkspacePreparationCalls, 0);
   assert.equal(runLocalCiCalls, 0);
-  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed custom journal leak");
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "seed custom journal leak",
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "",
+  );
 });
 
 test("applyCodexTurnPublicationGate blocks tracked supervisor journals for repeated-placeholder layouts", async (t) => {
@@ -400,19 +601,36 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for repea
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "102", "issue-102.md");
-  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "181", "issue-181.md");
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "102",
+    "issue-102.md",
+  );
+  const otherJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "181",
+    "issue-181.md",
+  );
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
   await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
   await fs.writeFile(otherJournalPath, "# Issue #181\n", "utf8");
-  git(workspacePath, "add", ".codex-supervisor/102/issue-102.md", ".codex-supervisor/181/issue-181.md");
+  git(
+    workspacePath,
+    "add",
+    ".codex-supervisor/102/issue-102.md",
+    ".codex-supervisor/181/issue-181.md",
+  );
   git(workspacePath, "commit", "-m", "seed repeated placeholder journal leak");
 
   let createPullRequestCalls = 0;
   let runWorkspacePreparationCalls = 0;
   let runLocalCiCalls = 0;
-  const issue = createIssue({ title: "Gate repeated-placeholder journal layouts before publication" });
+  const issue = createIssue({
+    title: "Gate repeated-placeholder journal layouts before publication",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -429,10 +647,15 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for repea
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({
       localCiCommand: "npm run ci:local",
-      issueJournalRelativePath: ".codex-supervisor/{issueNumber}/issue-{issueNumber}.md",
+      issueJournalRelativePath:
+        ".codex-supervisor/{issueNumber}/issue-{issueNumber}.md",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -479,12 +702,21 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor journals for repea
   assert.match(result.message, /\.codex-supervisor\/102\/issue-102\.md/);
   assert.match(result.message, /\.codex-supervisor\/181\/issue-181\.md/);
   assert.equal(result.record.state, "blocked");
-  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(
+    result.record.last_failure_signature,
+    "supervisor-local-durable-artifacts-tracked-before-publication",
+  );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(runWorkspacePreparationCalls, 0);
   assert.equal(runLocalCiCalls, 0);
-  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed repeated placeholder journal leak");
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "seed repeated placeholder journal leak",
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "",
+  );
 });
 
 test("applyCodexTurnPublicationGate persists trusted generated artifact normalization before PR creation", async (t) => {
@@ -494,9 +726,19 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "102",
+    "issue-journal.md",
+  );
   const repoOwnedAbsolutePath = path.join(workspacePath, "docs", "guide.md");
-  const trustedArtifactPath = path.join(workspacePath, "docs", "generated-summary.md");
+  const trustedArtifactPath = path.join(
+    workspacePath,
+    "docs",
+    "generated-summary.md",
+  );
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.mkdir(path.dirname(repoOwnedAbsolutePath), { recursive: true });
   await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
@@ -516,7 +758,9 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
   git(workspacePath, "commit", "-m", "seed trusted generated artifact leak");
 
   let createPullRequestCalls = 0;
-  const issue = createIssue({ title: "Normalize trusted generated artifacts before publication" });
+  const issue = createIssue({
+    title: "Normalize trusted generated artifacts before publication",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -533,10 +777,15 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({
       localCiCommand: "npm run ci:local",
-      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+      issueJournalRelativePath:
+        ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -557,7 +806,11 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
       resolvePullRequestForBranch: async () => null,
       createPullRequest: async () => {
         createPullRequestCalls += 1;
-        return createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });
+        return createPullRequest({
+          number: 200,
+          isDraft: true,
+          headRefOid: "head-102",
+        });
       },
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
@@ -573,18 +826,35 @@ test("applyCodexTurnPublicationGate persists trusted generated artifact normaliz
 
   assert.equal(result.kind, "ready");
   assert.equal(createPullRequestCalls, 1);
-  assert.equal(result.record.last_head_sha, git(workspacePath, "rev-parse", "HEAD").trim());
+  assert.equal(
+    result.record.last_head_sha,
+    git(workspacePath, "rev-parse", "HEAD").trim(),
+  );
   const normalizedArtifact = await fs.readFile(trustedArtifactPath, "utf8");
   assert.match(normalizedArtifact, /Repo note: docs\/guide\.md/);
   assert.match(normalizedArtifact, /Host note: <redacted-local-path>/);
-  assert.doesNotMatch(normalizedArtifact, new RegExp(repoOwnedAbsolutePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.doesNotMatch(
     normalizedArtifact,
-    new RegExp(SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    new RegExp(repoOwnedAbsolutePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
   );
-  assert.match(git(workspacePath, "log", "-1", "--pretty=%s"), /Normalize trusted durable artifacts for path hygiene/);
-  assert.match(git(workspacePath, "ls-remote", "--heads", "origin", "codex\/issue-102"), /refs\/heads\/codex\/issue-102/);
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "");
+  assert.doesNotMatch(
+    normalizedArtifact,
+    new RegExp(
+      SAMPLE_MACOS_WORKSTATION_PATH.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+    ),
+  );
+  assert.match(
+    git(workspacePath, "log", "-1", "--pretty=%s"),
+    /Normalize trusted durable artifacts for path hygiene/,
+  );
+  assert.match(
+    git(workspacePath, "ls-remote", "--heads", "origin", "codex\/issue-102"),
+    /refs\/heads\/codex\/issue-102/,
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "",
+  );
 });
 
 test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue journals outside the sparse checkout", async (t) => {
@@ -594,8 +864,20 @@ test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue jo
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");
-  const otherJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "181", "issue-journal.md");
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "102",
+    "issue-journal.md",
+  );
+  const otherJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "181",
+    "issue-journal.md",
+  );
   await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
   await fs.mkdir(path.dirname(otherJournalPath), { recursive: true });
   await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
@@ -611,7 +893,12 @@ test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue jo
     ].join("\n"),
     "utf8",
   );
-  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md", ".codex-supervisor/issues/181/issue-journal.md");
+  git(
+    workspacePath,
+    "add",
+    ".codex-supervisor/issues/102/issue-journal.md",
+    ".codex-supervisor/issues/181/issue-journal.md",
+  );
   git(workspacePath, "commit", "-m", "seed sparse cross-issue journal leak");
 
   git(workspacePath, "sparse-checkout", "init", "--no-cone");
@@ -640,7 +927,10 @@ test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue jo
   let createPullRequestCalls = 0;
   let runWorkspacePreparationCalls = 0;
   let runLocalCiCalls = 0;
-  const issue = createIssue({ title: "Gate sparse cross-issue journal hygiene without blocking publication" });
+  const issue = createIssue({
+    title:
+      "Gate sparse cross-issue journal hygiene without blocking publication",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -657,10 +947,15 @@ test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue jo
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({
       localCiCommand: "npm run ci:local",
-      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+      issueJournalRelativePath:
+        ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -704,14 +999,26 @@ test("applyCodexTurnPublicationGate blocks sparse-present tracked cross-issue jo
   });
 
   assert.equal(result.kind, "blocked");
-  assert.match(result.message, /\.codex-supervisor\/issues\/181\/issue-journal\.md/);
+  assert.match(
+    result.message,
+    /\.codex-supervisor\/issues\/181\/issue-journal\.md/,
+  );
   assert.equal(result.record.state, "blocked");
-  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.equal(
+    result.record.last_failure_signature,
+    "supervisor-local-durable-artifacts-tracked-before-publication",
+  );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(runWorkspacePreparationCalls, 0);
   assert.equal(runLocalCiCalls, 0);
-  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed sparse cross-issue journal leak");
-  assert.equal(git(workspacePath, "status", "--short", "--untracked-files=no").trim(), "M .codex-supervisor/issues/181/issue-journal.md");
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "seed sparse cross-issue journal leak",
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "M .codex-supervisor/issues/181/issue-journal.md",
+  );
 });
 
 test("applyCodexTurnPublicationGate blocks tracked supervisor replay artifacts before workspace preparation and local CI", async (t) => {
@@ -721,16 +1028,27 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor replay artifacts b
   });
   git(workspacePath, "checkout", "-b", "codex/issue-102");
 
-  const replayArtifactPath = path.join(workspacePath, ".codex-supervisor", "replay", "decision-cycle-snapshot.json");
+  const replayArtifactPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "replay",
+    "decision-cycle-snapshot.json",
+  );
   await fs.mkdir(path.dirname(replayArtifactPath), { recursive: true });
-  await fs.writeFile(replayArtifactPath, "{\n  \"kind\": \"replay\"\n}\n", "utf8");
-  git(workspacePath, "add", ".codex-supervisor/replay/decision-cycle-snapshot.json");
+  await fs.writeFile(replayArtifactPath, '{\n  "kind": "replay"\n}\n', "utf8");
+  git(
+    workspacePath,
+    "add",
+    ".codex-supervisor/replay/decision-cycle-snapshot.json",
+  );
   git(workspacePath, "commit", "-m", "seed replay artifact leak");
 
   let createPullRequestCalls = 0;
   let runWorkspacePreparationCalls = 0;
   let runLocalCiCalls = 0;
-  const issue = createIssue({ title: "Gate draft PR creation on supervisor replay artifact" });
+  const issue = createIssue({
+    title: "Gate draft PR creation on supervisor replay artifact",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -749,7 +1067,11 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor replay artifacts b
       workspacePreparationCommand: "npm ci",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -793,12 +1115,21 @@ test("applyCodexTurnPublicationGate blocks tracked supervisor replay artifacts b
   });
 
   assert.equal(result.kind, "blocked");
-  assert.match(result.message, /\.codex-supervisor\/replay\/decision-cycle-snapshot\.json/);
-  assert.equal(result.record.last_failure_signature, "supervisor-local-durable-artifacts-tracked-before-publication");
+  assert.match(
+    result.message,
+    /\.codex-supervisor\/replay\/decision-cycle-snapshot\.json/,
+  );
+  assert.equal(
+    result.record.last_failure_signature,
+    "supervisor-local-durable-artifacts-tracked-before-publication",
+  );
   assert.equal(createPullRequestCalls, 0);
   assert.equal(runWorkspacePreparationCalls, 0);
   assert.equal(runLocalCiCalls, 0);
-  assert.equal(git(workspacePath, "log", "-1", "--pretty=%s").trim(), "seed replay artifact leak");
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "seed replay artifact leak",
+  );
 });
 
 test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails", async () => {
@@ -820,7 +1151,11 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({ localCiCommand: "npm run ci:local" }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => {
         saveCalls += 1;
       },
@@ -866,10 +1201,16 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when local CI fails
   });
 
   assert.equal(result.kind, "blocked");
-  assert.equal(result.message, "Local CI gate blocked pull request creation for issue #102.");
+  assert.equal(
+    result.message,
+    "Local CI gate blocked pull request creation for issue #102.",
+  );
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
-  assert.equal(result.record.last_failure_signature, "local-ci-gate-non_zero_exit");
+  assert.equal(
+    result.record.last_failure_signature,
+    "local-ci-gate-non_zero_exit",
+  );
   assert.equal(result.pr, null);
   assert.equal(saveCalls, 1);
   assert.equal(syncJournalCalls, 1);
@@ -896,7 +1237,11 @@ test("applyCodexTurnPublicationGate runs workspace preparation before local CI",
       localCiCommand: "npm run ci:local",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -915,7 +1260,12 @@ test("applyCodexTurnPublicationGate runs workspace preparation before local CI",
     },
     github: {
       resolvePullRequestForBranch: async () => null,
-      createPullRequest: async () => createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" }),
+      createPullRequest: async () =>
+        createPullRequest({
+          number: 200,
+          isDraft: true,
+          headRefOid: "head-102",
+        }),
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
     },
@@ -945,7 +1295,9 @@ test("applyCodexTurnPublicationGate runs workspace preparation before local CI",
 });
 
 test("applyCodexTurnPublicationGate blocks draft PR creation when workspace preparation fails", async () => {
-  const issue = createIssue({ title: "Gate draft PR creation on workspace preparation" });
+  const issue = createIssue({
+    title: "Gate draft PR creation on workspace preparation",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -964,7 +1316,11 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when workspace prep
       localCiCommand: "npm run ci:local",
     }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => undefined,
     },
     state,
@@ -999,7 +1355,9 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when workspace prep
       failureContext: null,
     }),
     runWorkspacePreparationCommand: async () => {
-      throw new Error("Command failed: sh -lc +1 args\nexitCode=1\nnpm error missing node_modules");
+      throw new Error(
+        "Command failed: sh -lc +1 args\nexitCode=1\nnpm error missing node_modules",
+      );
     },
     runLocalCiCommand: async () => {
       runLocalCiCalls += 1;
@@ -1008,17 +1366,27 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when workspace prep
   });
 
   assert.equal(result.kind, "blocked");
-  assert.equal(result.message, "Workspace preparation blocked pull request creation for issue #102.");
+  assert.equal(
+    result.message,
+    "Workspace preparation blocked pull request creation for issue #102.",
+  );
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
-  assert.equal(result.record.last_failure_signature, "workspace-preparation-gate-non_zero_exit");
+  assert.equal(
+    result.record.last_failure_signature,
+    "workspace-preparation-gate-non_zero_exit",
+  );
   assert.match(result.record.last_error ?? "", /workspace environment/i);
   assert.equal(runLocalCiCalls, 0);
 });
 
 test("applyCodexTurnPublicationGate opens a draft PR after the gate passes", async () => {
   const issue = createIssue({ title: "Open draft PR" });
-  const draftPr = createPullRequest({ number: 200, isDraft: true, headRefOid: "head-102" });
+  const draftPr = createPullRequest({
+    number: 200,
+    isDraft: true,
+    headRefOid: "head-102",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -1036,7 +1404,11 @@ test("applyCodexTurnPublicationGate opens a draft PR after the gate passes", asy
   const result = await applyCodexTurnPublicationGate({
     config: createConfig({ localCiCommand: "npm run ci:local" }),
     stateStore: {
-      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
       save: async () => {
         saveCalls += 1;
       },

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -51,6 +51,7 @@ export interface CodexTurnPublicationGateSameTurnRepairResult {
   record: IssueRunRecord;
   failureContext: FailureContext;
   actionablePublishableFilePaths: string[];
+  rewrittenTrackedPaths: string[];
 }
 
 export interface CodexTurnPublicationGateReadyResult {
@@ -200,6 +201,10 @@ export async function applyCodexTurnPublicationGate(args: {
       const failureContext = pathHygieneGate.failureContext;
       const actionablePublishableFilePaths =
         pathHygieneGate.actionablePublishableFilePaths ?? [];
+      const rewrittenTrackedPaths = [
+        ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+        ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+      ];
       const changedFilesInCurrentTurn = new Set(
         args.changedFilesInCurrentTurn ?? [],
       );
@@ -217,6 +222,7 @@ export async function applyCodexTurnPublicationGate(args: {
           record,
           failureContext,
           actionablePublishableFilePaths,
+          rewrittenTrackedPaths,
         };
       }
       record = args.stateStore.touch(record, {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -1,5 +1,9 @@
 import { GitHubClient } from "./github";
-import { runLocalCiGate, runWorkspacePreparationGate, type LocalCiCommandRunner } from "./local-ci";
+import {
+  runLocalCiGate,
+  runWorkspacePreparationGate,
+  type LocalCiCommandRunner,
+} from "./local-ci";
 import { StateStore } from "./core/state-store";
 import {
   FailureContext,
@@ -26,7 +30,9 @@ import {
   listTrackedSupervisorArtifactPaths,
 } from "./core/workspace";
 
-function isOpenPullRequest(pr: GitHubPullRequest | null): pr is GitHubPullRequest {
+function isOpenPullRequest(
+  pr: GitHubPullRequest | null,
+): pr is GitHubPullRequest {
   return pr !== null && pr.state === "OPEN" && !pr.mergedAt;
 }
 
@@ -39,6 +45,14 @@ export interface CodexTurnPublicationGateBlockedResult {
   reviewThreads: [];
 }
 
+export interface CodexTurnPublicationGateSameTurnRepairResult {
+  kind: "same_turn_repair";
+  message: string;
+  record: IssueRunRecord;
+  failureContext: FailureContext;
+  actionablePublishableFilePaths: string[];
+}
+
 export interface CodexTurnPublicationGateReadyResult {
   kind: "ready";
   record: IssueRunRecord;
@@ -49,10 +63,13 @@ export interface CodexTurnPublicationGateReadyResult {
 
 export type CodexTurnPublicationGateResult =
   | CodexTurnPublicationGateBlockedResult
+  | CodexTurnPublicationGateSameTurnRepairResult
   | CodexTurnPublicationGateReadyResult;
 
-const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
-const SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE = "supervisor-local-durable-artifacts-tracked-before-publication";
+const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
+  "Normalize trusted durable artifacts for path hygiene";
+const SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE =
+  "supervisor-local-durable-artifacts-tracked-before-publication";
 
 function buildSupervisorLocalArtifactFailureContext(
   trackedPaths: string[],
@@ -62,13 +79,15 @@ function buildSupervisorLocalArtifactFailureContext(
   return {
     category: "blocked",
     summary:
-      `Tracked supervisor-local durable artifacts blocked pull request creation for issue #${issueNumber}. `
-      + `Remove or unstage these tracked paths before publishing checkpoint commits: ${listedPaths}.`,
+      `Tracked supervisor-local durable artifacts blocked pull request creation for issue #${issueNumber}. ` +
+      `Remove or unstage these tracked paths before publishing checkpoint commits: ${listedPaths}.`,
     signature: SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE,
     command: "git ls-files -- .codex-supervisor",
     details: [
       "Supervisor-local durable artifacts must not be committed into issue-branch publication checkpoints.",
-      ...trackedPaths.map((trackedPath) => `tracked supervisor-local artifact: ${trackedPath}`),
+      ...trackedPaths.map(
+        (trackedPath) => `tracked supervisor-local artifact: ${trackedPath}`,
+      ),
     ],
     url: null,
     updated_at: new Date().toISOString(),
@@ -89,18 +108,27 @@ export async function applyCodexTurnPublicationGate(args: {
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
   record: IssueRunRecord;
-  issue: Pick<GitHubIssue, "number" | "createdAt" | "title" | "body" | "updatedAt" | "url" | "state">;
+  issue: Pick<
+    GitHubIssue,
+    "number" | "createdAt" | "title" | "body" | "updatedAt" | "url" | "state"
+  >;
   workspacePath: string;
   workspaceStatus: WorkspaceStatus;
   github: Pick<
     GitHubClient,
-    "resolvePullRequestForBranch" | "createPullRequest" | "getChecks" | "getUnresolvedReviewThreads"
+    | "resolvePullRequestForBranch"
+    | "createPullRequest"
+    | "getChecks"
+    | "getUnresolvedReviewThreads"
   >;
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   applyFailureSignature: (
     record: IssueRunRecord,
     failureContext: FailureContext | null,
-  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  ) => Pick<
+    IssueRunRecord,
+    "last_failure_signature" | "repeated_failure_signature_count"
+  >;
   runWorkspacePreparationCommand?: LocalCiCommandRunner;
   runLocalCiCommand?: LocalCiCommandRunner;
   runWorkstationLocalPathGate?: (args: {
@@ -108,12 +136,19 @@ export async function applyCodexTurnPublicationGate(args: {
     gateLabel: string;
     publishablePathAllowlistMarkers?: readonly string[];
   }) => Promise<WorkstationLocalPathGateResult>;
+  allowSameTurnPathRepairRetry?: boolean;
+  changedFilesInCurrentTurn?: readonly string[];
   syncExecutionMetricsRunSummary: (record: IssueRunRecord) => Promise<void>;
 }): Promise<CodexTurnPublicationGateResult> {
   let record = args.record;
   let workspaceStatus = args.workspaceStatus;
-  const runWorkstationLocalPathGateImpl = args.runWorkstationLocalPathGate ?? runWorkstationLocalPathGate;
-  const resolvedPr = await args.github.resolvePullRequestForBranch(record.branch, record.pr_number, { purpose: "action" });
+  const runWorkstationLocalPathGateImpl =
+    args.runWorkstationLocalPathGate ?? runWorkstationLocalPathGate;
+  const resolvedPr = await args.github.resolvePullRequestForBranch(
+    record.branch,
+    record.pr_number,
+    { purpose: "action" },
+  );
   let pr = isOpenPullRequest(resolvedPr) ? resolvedPr : null;
 
   if (
@@ -122,10 +157,11 @@ export async function applyCodexTurnPublicationGate(args: {
     !workspaceStatus.hasUncommittedChanges &&
     record.implementation_attempt_count >= args.config.draftPrAfterAttempt
   ) {
-    const trackedSupervisorArtifactPaths = await listTrackedSupervisorArtifactPaths(
-      args.workspacePath,
-      args.config.issueJournalRelativePath,
-    );
+    const trackedSupervisorArtifactPaths =
+      await listTrackedSupervisorArtifactPaths(
+        args.workspacePath,
+        args.config.issueJournalRelativePath,
+      );
     if (trackedSupervisorArtifactPaths.length > 0) {
       const failureContext = buildSupervisorLocalArtifactFailureContext(
         trackedSupervisorArtifactPaths,
@@ -157,14 +193,37 @@ export async function applyCodexTurnPublicationGate(args: {
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({
       workspacePath: args.workspacePath,
       gateLabel: "before publication",
-      publishablePathAllowlistMarkers: args.config.publishablePathAllowlistMarkers,
+      publishablePathAllowlistMarkers:
+        args.config.publishablePathAllowlistMarkers,
     });
     if (!pathHygieneGate.ok) {
       const failureContext = pathHygieneGate.failureContext;
+      const actionablePublishableFilePaths =
+        pathHygieneGate.actionablePublishableFilePaths ?? [];
+      const changedFilesInCurrentTurn = new Set(
+        args.changedFilesInCurrentTurn ?? [],
+      );
+      const sameTurnRepairEligible =
+        args.allowSameTurnPathRepairRetry === true &&
+        failureContext !== null &&
+        actionablePublishableFilePaths.length > 0 &&
+        actionablePublishableFilePaths.every((filePath) =>
+          changedFilesInCurrentTurn.has(filePath),
+        );
+      if (sameTurnRepairEligible) {
+        return {
+          kind: "same_turn_repair",
+          message: `Workstation-local path hygiene requested a same-turn repair retry for issue #${record.issue_number}.`,
+          record,
+          failureContext,
+          actionablePublishableFilePaths,
+        };
+      }
       record = args.stateStore.touch(record, {
         state: "blocked",
         last_error: truncate(
-          failureContext?.summary ?? "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+          failureContext?.summary ??
+            "Tracked durable artifacts failed workstation-local path hygiene before publication.",
           1000,
         ),
         last_failure_kind: null,
@@ -190,7 +249,10 @@ export async function applyCodexTurnPublicationGate(args: {
       ...(pathHygieneGate.rewrittenJournalPaths ?? []),
       ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
     ];
-    const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(args.workspacePath, rewrittenTrackedPaths);
+    const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(
+      args.workspacePath,
+      rewrittenTrackedPaths,
+    );
     if (presentRewrittenTrackedPaths.length > 0) {
       try {
         await commitAndPushTrackedFiles({
@@ -230,8 +292,14 @@ export async function applyCodexTurnPublicationGate(args: {
           reviewThreads: [],
         };
       }
-      workspaceStatus = await getWorkspaceStatus(args.workspacePath, record.branch, args.config.defaultBranch);
-      record = args.stateStore.touch(record, { last_head_sha: workspaceStatus.headSha });
+      workspaceStatus = await getWorkspaceStatus(
+        args.workspacePath,
+        record.branch,
+        args.config.defaultBranch,
+      );
+      record = args.stateStore.touch(record, {
+        last_head_sha: workspaceStatus.headSha,
+      });
     }
 
     const workspacePreparationGate = await runWorkspacePreparationGate({
@@ -313,7 +381,9 @@ export async function applyCodexTurnPublicationGate(args: {
     args.state.issues[String(record.issue_number)] = record;
     await args.stateStore.save(args.state);
     await args.syncJournal(record);
-    pr = await args.github.createPullRequest(args.issue, record, { draft: true });
+    pr = await args.github.createPullRequest(args.issue, record, {
+      draft: true,
+    });
   }
 
   return {
@@ -321,6 +391,8 @@ export async function applyCodexTurnPublicationGate(args: {
     record,
     pr,
     checks: pr ? await args.github.getChecks(pr.number) : [],
-    reviewThreads: pr ? await args.github.getUnresolvedReviewThreads(pr.number) : [],
+    reviewThreads: pr
+      ? await args.github.getUnresolvedReviewThreads(pr.number)
+      : [],
   };
 }

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -16,33 +16,43 @@ import {
   type WorkstationLocalPathMatch,
 } from "./workstation-local-paths";
 
-export const WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE = "workstation-local-path-hygiene-failed";
+export const WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE =
+  "workstation-local-path-hygiene-failed";
 
 export interface WorkstationLocalPathGateResult {
   ok: boolean;
   failureContext: FailureContext | null;
   rewrittenJournalPaths?: string[];
   rewrittenTrustedGeneratedArtifactPaths?: string[];
+  actionablePublishableFilePaths?: string[];
 }
 
 function normalizeRepoRelativePath(filePath: string): string {
-  return path.posix.normalize(filePath.replace(/\\/g, "/")).replace(/^(?:\.\/)+/, "");
+  return path.posix
+    .normalize(filePath.replace(/\\/g, "/"))
+    .replace(/^(?:\.\/)+/, "");
 }
 
 function isSupervisorOwnedDurableJournalPath(filePath: string): boolean {
   const normalizedPath = normalizeRepoRelativePath(filePath);
   return (
-    normalizedPath === LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH
-    || /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/.test(normalizedPath)
+    normalizedPath === LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH ||
+    /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/.test(normalizedPath)
   );
 }
 
-function formatJournalNormalizationFailureDetail(journalPath: string, error: unknown): string {
+function formatJournalNormalizationFailureDetail(
+  journalPath: string,
+  error: unknown,
+): string {
   const message = error instanceof Error ? error.message : String(error);
   return `journal normalization failed for ${journalPath}: ${message}`;
 }
 
-function formatTrustedGeneratedArtifactNormalizationFailureDetail(filePath: string, error: unknown): string {
+function formatTrustedGeneratedArtifactNormalizationFailureDetail(
+  filePath: string,
+  error: unknown,
+): string {
   const message = error instanceof Error ? error.message : String(error);
   return `trusted durable artifact normalization failed for ${filePath}: ${message}`;
 }
@@ -55,8 +65,8 @@ export function buildWorkstationLocalPathFailureContext(args: {
   return {
     category: "blocked",
     summary:
-      args.summary
-      ?? `Tracked durable artifacts failed workstation-local path hygiene ${args.gateLabel}.`,
+      args.summary ??
+      `Tracked durable artifacts failed workstation-local path hygiene ${args.gateLabel}.`,
     signature: WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE,
     command: "npm run verify:paths",
     details: args.details,
@@ -78,7 +88,10 @@ function summarizeWorkstationLocalPathMatches(
     const existing = countsByFile.get(finding.filePath);
     if (existing) {
       existing.count += 1;
-      existing.reasons.set(finding.reason, (existing.reasons.get(finding.reason) ?? 0) + 1);
+      existing.reasons.set(
+        finding.reason,
+        (existing.reasons.get(finding.reason) ?? 0) + 1,
+      );
       continue;
     }
 
@@ -96,21 +109,30 @@ function summarizeWorkstationLocalPathMatches(
     return left[0].localeCompare(right[0]);
   });
 
-  const visibleFiles = sortedFiles.slice(0, limit).map(([filePath, summary]) => {
-    const dominantReason = [...summary.reasons.entries()].sort((left, right) => {
-      if (right[1] !== left[1]) {
-        return right[1] - left[1];
-      }
+  const visibleFiles = sortedFiles
+    .slice(0, limit)
+    .map(([filePath, summary]) => {
+      const dominantReason = [...summary.reasons.entries()].sort(
+        (left, right) => {
+          if (right[1] !== left[1]) {
+            return right[1] - left[1];
+          }
 
-      return left[0].localeCompare(right[0]);
-    })[0]?.[0];
+          return left[0].localeCompare(right[0]);
+        },
+      )[0]?.[0];
 
-    return `${filePath} (${summary.count} match${summary.count === 1 ? "" : "es"}${dominantReason ? `, ${dominantReason}` : ""})`;
-  });
+      return `${filePath} (${summary.count} match${summary.count === 1 ? "" : "es"}${dominantReason ? `, ${dominantReason}` : ""})`;
+    });
 
   const remainingCount = sortedFiles.length - visibleFiles.length;
-  const tail = remainingCount > 0 ? `; +${remainingCount} more file${remainingCount === 1 ? "" : "s"}` : "";
-  return visibleFiles.length > 0 ? `First fix: ${visibleFiles.join("; ")}${tail}.` : "";
+  const tail =
+    remainingCount > 0
+      ? `; +${remainingCount} more file${remainingCount === 1 ? "" : "s"}`
+      : "";
+  return visibleFiles.length > 0
+    ? `First fix: ${visibleFiles.join("; ")}${tail}.`
+    : "";
 }
 
 async function categorizeWorkstationLocalArtifact(
@@ -120,8 +142,14 @@ async function categorizeWorkstationLocalArtifact(
   const repoRelativePath = normalizeRepoRelativePath(filePath);
 
   try {
-    const contents = await fs.readFile(path.join(workspacePath, repoRelativePath), "utf8");
-    return classifyWorkstationLocalArtifact({ filePath: repoRelativePath, contents });
+    const contents = await fs.readFile(
+      path.join(workspacePath, repoRelativePath),
+      "utf8",
+    );
+    return classifyWorkstationLocalArtifact({
+      filePath: repoRelativePath,
+      contents,
+    });
   } catch {
     // Fail closed into generic publishable content when the trusted signal cannot be read.
     return classifyWorkstationLocalArtifact({ filePath: repoRelativePath });
@@ -136,7 +164,10 @@ async function summarizeCategoryMatches(
   const categorizedFindings = await Promise.all(
     findings.map(async (finding) => ({
       finding,
-      category: await categorizeWorkstationLocalArtifact(workspacePath, finding.filePath),
+      category: await categorizeWorkstationLocalArtifact(
+        workspacePath,
+        finding.filePath,
+      ),
     })),
   );
   return summarizeWorkstationLocalPathMatches(
@@ -164,7 +195,11 @@ async function summarizeWorkstationLocalPathRemediation(args: {
   }
 
   if (args.journalNormalizationErrors.length > 0) {
-    const journalSummary = await summarizeCategoryMatches(args.workspacePath, args.findings, "supervisor_owned_journal");
+    const journalSummary = await summarizeCategoryMatches(
+      args.workspacePath,
+      args.findings,
+      "supervisor_owned_journal",
+    );
     parts.push(
       journalSummary
         ? `Supervisor-owned issue journal auto-normalization still needs attention. ${journalSummary}`
@@ -197,7 +232,9 @@ async function summarizeWorkstationLocalPathRemediation(args: {
     "expected_local_durable_artifact",
   );
   if (expectedLocalSummary) {
-    parts.push(`Review repo policy or exclusions for expected-local durable artifacts. ${expectedLocalSummary}`);
+    parts.push(
+      `Review repo policy or exclusions for expected-local durable artifacts. ${expectedLocalSummary}`,
+    );
   }
 
   const trustedGeneratedSummary = await summarizeCategoryMatches(
@@ -206,12 +243,20 @@ async function summarizeWorkstationLocalPathRemediation(args: {
     "trusted_generated_durable_artifact",
   );
   if (trustedGeneratedSummary) {
-    parts.push(`Review trusted generated durable artifacts before supervisor-managed path rewriting. ${trustedGeneratedSummary}`);
+    parts.push(
+      `Review trusted generated durable artifacts before supervisor-managed path rewriting. ${trustedGeneratedSummary}`,
+    );
   }
 
-  const publishableSummary = await summarizeCategoryMatches(args.workspacePath, args.findings, "publishable_tracked_content");
+  const publishableSummary = await summarizeCategoryMatches(
+    args.workspacePath,
+    args.findings,
+    "publishable_tracked_content",
+  );
   if (publishableSummary) {
-    parts.push(`Edit tracked publishable content to remove workstation-local paths. ${publishableSummary}`);
+    parts.push(
+      `Edit tracked publishable content to remove workstation-local paths. ${publishableSummary}`,
+    );
   }
 
   if (parts.length === 0) {
@@ -225,7 +270,13 @@ async function redactSupervisorOwnedJournalLeaks(
   workspacePath: string,
   findings: Awaited<ReturnType<typeof findForbiddenWorkstationLocalPaths>>,
 ): Promise<{ rewrittenJournalPaths: string[]; normalizationErrors: string[] }> {
-  const journalPaths = [...new Set(findings.map((finding) => finding.filePath).filter(isSupervisorOwnedDurableJournalPath))];
+  const journalPaths = [
+    ...new Set(
+      findings
+        .map((finding) => finding.filePath)
+        .filter(isSupervisorOwnedDurableJournalPath),
+    ),
+  ];
   const settledResults = await Promise.allSettled(
     journalPaths.map(async (journalPath) => {
       const absoluteJournalPath = path.join(workspacePath, journalPath);
@@ -234,7 +285,10 @@ async function redactSupervisorOwnedJournalLeaks(
         journalPath: absoluteJournalPath,
         workspacePath,
       });
-      return { journalPath, rewritten: existing !== null && normalized !== existing };
+      return {
+        journalPath,
+        rewritten: existing !== null && normalized !== existing,
+      };
     }),
   );
 
@@ -249,7 +303,9 @@ async function redactSupervisorOwnedJournalLeaks(
     }
 
     const journalPath = journalPaths[index] ?? "<unknown-journal>";
-    normalizationErrors.push(formatJournalNormalizationFailureDetail(journalPath, result.reason));
+    normalizationErrors.push(
+      formatJournalNormalizationFailureDetail(journalPath, result.reason),
+    );
   }
 
   return { rewrittenJournalPaths, normalizationErrors };
@@ -258,14 +314,21 @@ async function redactSupervisorOwnedJournalLeaks(
 async function redactTrustedGeneratedArtifactLeaks(
   workspacePath: string,
   findings: Awaited<ReturnType<typeof findForbiddenWorkstationLocalPaths>>,
-): Promise<{ rewrittenTrustedGeneratedArtifactPaths: string[]; normalizationErrors: string[] }> {
+): Promise<{
+  rewrittenTrustedGeneratedArtifactPaths: string[];
+  normalizationErrors: string[];
+}> {
   const artifactPaths = [
     ...new Set(
       await Promise.all(
-        findings.map(async (finding) => (
-          await categorizeWorkstationLocalArtifact(workspacePath, finding.filePath)) === "trusted_generated_durable_artifact"
-          ? finding.filePath
-          : null),
+        findings.map(async (finding) =>
+          (await categorizeWorkstationLocalArtifact(
+            workspacePath,
+            finding.filePath,
+          )) === "trusted_generated_durable_artifact"
+            ? finding.filePath
+            : null,
+        ),
       ),
     ),
   ].filter((value): value is string => value !== null);
@@ -274,7 +337,10 @@ async function redactTrustedGeneratedArtifactLeaks(
     artifactPaths.map(async (artifactPath) => {
       const absoluteArtifactPath = path.join(workspacePath, artifactPath);
       const existing = await fs.readFile(absoluteArtifactPath, "utf8");
-      const normalized = normalizeDurableTrackedArtifactContent(existing, workspacePath);
+      const normalized = normalizeDurableTrackedArtifactContent(
+        existing,
+        workspacePath,
+      );
       if (normalized !== existing) {
         await fs.writeFile(absoluteArtifactPath, normalized, "utf8");
       }
@@ -293,7 +359,12 @@ async function redactTrustedGeneratedArtifactLeaks(
     }
 
     const artifactPath = artifactPaths[index] ?? "<unknown-artifact>";
-    normalizationErrors.push(formatTrustedGeneratedArtifactNormalizationFailureDetail(artifactPath, result.reason));
+    normalizationErrors.push(
+      formatTrustedGeneratedArtifactNormalizationFailureDetail(
+        artifactPath,
+        result.reason,
+      ),
+    );
   }
 
   return { rewrittenTrustedGeneratedArtifactPaths, normalizationErrors };
@@ -304,41 +375,89 @@ export async function runWorkstationLocalPathGate(args: {
   gateLabel: string;
   publishablePathAllowlistMarkers?: readonly string[];
 }): Promise<WorkstationLocalPathGateResult> {
-  const detectorOptions = { publishablePathAllowlistMarkers: args.publishablePathAllowlistMarkers ?? [] };
-  let findings = await findForbiddenWorkstationLocalPaths(args.workspacePath, undefined, detectorOptions);
+  const detectorOptions = {
+    publishablePathAllowlistMarkers: args.publishablePathAllowlistMarkers ?? [],
+  };
+  let findings = await findForbiddenWorkstationLocalPaths(
+    args.workspacePath,
+    undefined,
+    detectorOptions,
+  );
   let journalNormalizationErrors: string[] = [];
   let rewrittenJournalPaths: string[] = [];
   let trustedGeneratedArtifactNormalizationErrors: string[] = [];
   let rewrittenTrustedGeneratedArtifactPaths: string[] = [];
-  if (findings.some((finding) => isSupervisorOwnedDurableJournalPath(finding.filePath))) {
-    const redactionResult = await redactSupervisorOwnedJournalLeaks(args.workspacePath, findings);
+  if (
+    findings.some((finding) =>
+      isSupervisorOwnedDurableJournalPath(finding.filePath),
+    )
+  ) {
+    const redactionResult = await redactSupervisorOwnedJournalLeaks(
+      args.workspacePath,
+      findings,
+    );
     journalNormalizationErrors = redactionResult.normalizationErrors;
     rewrittenJournalPaths = redactionResult.rewrittenJournalPaths;
-    findings = await findForbiddenWorkstationLocalPaths(args.workspacePath, undefined, detectorOptions);
+    findings = await findForbiddenWorkstationLocalPaths(
+      args.workspacePath,
+      undefined,
+      detectorOptions,
+    );
   }
   if (findings.length > 0) {
-    const redactionResult = await redactTrustedGeneratedArtifactLeaks(args.workspacePath, findings);
-    trustedGeneratedArtifactNormalizationErrors = redactionResult.normalizationErrors;
-    rewrittenTrustedGeneratedArtifactPaths = redactionResult.rewrittenTrustedGeneratedArtifactPaths;
+    const redactionResult = await redactTrustedGeneratedArtifactLeaks(
+      args.workspacePath,
+      findings,
+    );
+    trustedGeneratedArtifactNormalizationErrors =
+      redactionResult.normalizationErrors;
+    rewrittenTrustedGeneratedArtifactPaths =
+      redactionResult.rewrittenTrustedGeneratedArtifactPaths;
     if (
-      rewrittenTrustedGeneratedArtifactPaths.length > 0
-      || trustedGeneratedArtifactNormalizationErrors.length > 0
+      rewrittenTrustedGeneratedArtifactPaths.length > 0 ||
+      trustedGeneratedArtifactNormalizationErrors.length > 0
     ) {
-      findings = await findForbiddenWorkstationLocalPaths(args.workspacePath, undefined, detectorOptions);
+      findings = await findForbiddenWorkstationLocalPaths(
+        args.workspacePath,
+        undefined,
+        detectorOptions,
+      );
     }
   }
   if (
-    findings.length === 0
-    && journalNormalizationErrors.length === 0
-    && trustedGeneratedArtifactNormalizationErrors.length === 0
+    findings.length === 0 &&
+    journalNormalizationErrors.length === 0 &&
+    trustedGeneratedArtifactNormalizationErrors.length === 0
   ) {
     return {
       ok: true,
       failureContext: null,
       rewrittenJournalPaths,
       rewrittenTrustedGeneratedArtifactPaths,
+      actionablePublishableFilePaths: [],
     };
   }
+
+  const categorizedFindings = await Promise.all(
+    findings.map(async (finding) => ({
+      filePath: finding.filePath,
+      category: await categorizeWorkstationLocalArtifact(
+        args.workspacePath,
+        finding.filePath,
+      ),
+    })),
+  );
+  const actionablePublishableFilePaths =
+    journalNormalizationErrors.length === 0 &&
+    trustedGeneratedArtifactNormalizationErrors.length === 0 &&
+    categorizedFindings.length > 0 &&
+    categorizedFindings.every(
+      (entry) => entry.category === "publishable_tracked_content",
+    )
+      ? [...new Set(categorizedFindings.map((entry) => entry.filePath))].sort(
+          (left, right) => left.localeCompare(right),
+        )
+      : [];
 
   const remediationSummary = summarizeWorkstationLocalPathMatches(findings);
   return {
@@ -351,7 +470,7 @@ export async function runWorkstationLocalPathGate(args: {
         ...findings.map(formatWorkstationLocalPathMatch),
       ],
       summary:
-        await summarizeWorkstationLocalPathRemediation({
+        (await summarizeWorkstationLocalPathRemediation({
           workspacePath: args.workspacePath,
           gateLabel: args.gateLabel,
           findings,
@@ -359,12 +478,13 @@ export async function runWorkstationLocalPathGate(args: {
           trustedGeneratedArtifactNormalizationErrors,
           rewrittenJournalPaths,
           rewrittenTrustedGeneratedArtifactPaths,
-        })
-        ?? (remediationSummary
+        })) ??
+        (remediationSummary
           ? `Tracked durable artifacts failed workstation-local path hygiene ${args.gateLabel}. ${remediationSummary}`
           : undefined),
     }),
     rewrittenJournalPaths,
     rewrittenTrustedGeneratedArtifactPaths,
+    actionablePublishableFilePaths,
   };
 }


### PR DESCRIPTION
Closes #1627
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the bounded same-turn publication repair path for workstation-local publishable-path findings. The gate now exposes retry-eligible publishable files, `executeCodexTurnPhase` compares them against files changed since the turn started, and Codex gets at most one immediate same-session retry before the existing verification block remains in place. I also added focused coverage for the successful one-retry repair path and the exhausted-still-blocked fallback, updated the issue journal, and committed the checkpoint as `21936c5` (`Add one same-turn path hygiene repair retry`).

Verification passed with `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts` and `npm run build`.

Summary: Added a single bounded same-turn repair retry for publication-time publishable path hygiene failures, with fail-closed gating and focused regression coverage.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1627` with commit `21936c5` and move into review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Same-turn automatic repair & retry for path-hygiene failures so publish attempts can continue after eligible fixes.
  * Ability to detect changed tracked files between refs to drive retry decisions.

* **Bug Fixes**
  * Better handling of workstation-local path hygiene—persists repair context and clears blocks when fixes succeed.

* **Tests**
  * Added tests covering retry behavior, persistence of repaired artifacts, and publication-gate outcomes.

* **Chores**
  * Formatting and structural refactors for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->