### PR TITLE
Strengthen docs-task prompt guidance for repo-relative supervisor commands and placeholders (#1628)

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -252,6 +252,14 @@ test("buildCodexPrompt teaches implementation turns to avoid raw workstation-loc
     prompt,
     /Avoid raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior\./,
   );
+  assert.match(
+    prompt,
+    /For publishable Markdown, validation plans, and docs-oriented task output, prefer repo-relative supervisor commands, documented env vars, and explicit placeholders over host absolute paths\./,
+  );
+  assert.match(
+    prompt,
+    /Prefer command forms such as `node dist\/index\.js .*`, `CODEX_SUPERVISOR_CONFIG`, `<supervisor-config-path>`, and `<codex-supervisor-root>` when the same guidance does not require a host-specific absolute path\./,
+  );
 });
 
 test("buildCodexPrompt renders on-demand memory files even without always-read files", () => {

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -492,6 +492,8 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     "",
     "Path-literal hygiene:",
     "- Avoid raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, prompts, or durable artifacts when fragment assembly or placeholders would verify the same behavior.",
+    "- For publishable Markdown, validation plans, and docs-oriented task output, prefer repo-relative supervisor commands, documented env vars, and explicit placeholders over host absolute paths.",
+    "- Prefer command forms such as `node dist/index.js ...`, `CODEX_SUPERVISOR_CONFIG`, `<supervisor-config-path>`, and `<codex-supervisor-root>` when the same guidance does not require a host-specific absolute path.",
     "",
     ...failClosedReviewHeuristics,
     "",

--- a/src/local-review/prompt.test.ts
+++ b/src/local-review/prompt.test.ts
@@ -177,6 +177,14 @@ test("buildRolePrompt teaches reviewer to avoid drift-prone line coupling unless
     prompt,
     /Do not object to exact line assertions when source location itself is the intended contract\./,
   );
+  assert.match(
+    prompt,
+    /For docs-heavy diffs, validation plans, and command examples, prefer repo-relative supervisor commands, documented env vars, and explicit placeholders over host absolute paths unless a real host path is the behavior under review\./,
+  );
+  assert.match(
+    prompt,
+    /Examples to prefer include `node dist\/index\.js .*`, `CODEX_SUPERVISOR_CONFIG`, `<supervisor-config-path>`, and `<codex-supervisor-root>`\./,
+  );
 });
 
 test("buildRolePrompt teaches reviewer to anchor findings to the actual behavioral boundary", () => {

--- a/src/local-review/prompt.ts
+++ b/src/local-review/prompt.ts
@@ -241,6 +241,8 @@ function roleGoal(role: string): string[] {
         "- Do not treat a raised exception or returned error as sufficient proof when durable state might already have been mutated.",
         "- Flag transactions that stay open across network hops, queued work, adapter dispatch, or other remote waits; require the boundary to commit/roll back before crossing it.",
         "- Flag raw workstation-local absolute path literals rooted in a user home directory or Windows user-profile directory in tests, fixtures, docs, prompts, or committed examples as a path-hygiene regression when a fragment-based or placeholder-based fixture would verify the same behavior.",
+        "- For docs-heavy diffs, validation plans, and command examples, prefer repo-relative supervisor commands, documented env vars, and explicit placeholders over host absolute paths unless a real host path is the behavior under review.",
+        "- Examples to prefer include `node dist/index.js ...`, `CODEX_SUPERVISOR_CONFIG`, `<supervisor-config-path>`, and `<codex-supervisor-root>`.",
         "- Ignore style nits unless they could hide a bug or maintenance trap.",
       ];
     case "docs_researcher":


### PR DESCRIPTION
Closes #1628
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the Codex start prompt and local-review reviewer prompt so docs-heavy and validation-oriented tasks now explicitly prefer repo-relative supervisor commands, `CODEX_SUPERVISOR_CONFIG`, and placeholders like `<supervisor-config-path>` / `<codex-supervisor-root>` over host absolute paths. Added focused prompt assertions for both surfaces, updated the issue journal, and checkpointed the branch at `9df6517` (`Tighten docs prompt path guidance`).

Summary: Added narrow docs/validation prompt guidance for repo-relative supervisor commands and placeholders in Codex and reviewer prompt surfaces, with focused regression tests and a checkpoint commit.
State hint: draft_pr
Blocked reason: none
Tests: `npx tsx --test src/codex/codex-prompt.test.ts src/local-review/prompt.test.ts`; `npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-1628` with commit `9df6517`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test assertions to validate improved path-literal hygiene guidance.

* **Improvements**
  * Refined code generation and review guidance to recommend repo-relative supervisor commands and documented configuration placeholders instead of host-specific absolute paths, improving portability of generated documentation and command examples. Host paths remain available when necessary for behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->