### PR TITLE
Add current issue journal publication self-heal (#1632)

### DIFF
--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -320,6 +320,8 @@ async function installWorktreeLocalExcludes(
   );
   const managedEntries = [
     toGitRelativePath(workspacePath, journalPath),
+    ".codex-supervisor/issues/*/issue-journal.md",
+    ".codex-supervisor/issue-journal.md",
     ".codex-supervisor/execution-metrics/*",
     ".codex-supervisor/pre-merge/*",
     ".codex-supervisor/replay/*",
@@ -805,6 +807,94 @@ export async function listTrackedSupervisorArtifactPaths(
       isIgnoredSupervisorArtifactPath(entry, journalRelativePath),
     )
     .sort((left, right) => left.localeCompare(right));
+}
+
+export function currentIssueJournalRelativePath(
+  workspacePath: string,
+  journalRelativePath: string,
+  issueNumber: number,
+): string {
+  return toGitRelativePath(
+    workspacePath,
+    issueJournalPath(workspacePath, journalRelativePath, issueNumber),
+  );
+}
+
+export function isCurrentIssueJournalOnlyTrackedSupervisorArtifact(args: {
+  workspacePath: string;
+  journalRelativePath: string;
+  issueNumber: number;
+  trackedPaths: readonly string[];
+}): boolean {
+  return (
+    args.trackedPaths.length === 1 &&
+    args.trackedPaths[0] ===
+      currentIssueJournalRelativePath(
+        args.workspacePath,
+        args.journalRelativePath,
+        args.issueNumber,
+      )
+  );
+}
+
+export async function untrackCurrentIssueJournalBeforePublication(args: {
+  workspacePath: string;
+  branch: string;
+  remoteBranchExists: boolean;
+  journalRelativePath: string;
+  issueNumber: number;
+}): Promise<string> {
+  const currentJournalPath = currentIssueJournalRelativePath(
+    args.workspacePath,
+    args.journalRelativePath,
+    args.issueNumber,
+  );
+  const trackedPaths = await listTrackedSupervisorArtifactPaths(
+    args.workspacePath,
+    args.journalRelativePath,
+  );
+  if (
+    !isCurrentIssueJournalOnlyTrackedSupervisorArtifact({
+      workspacePath: args.workspacePath,
+      journalRelativePath: args.journalRelativePath,
+      issueNumber: args.issueNumber,
+      trackedPaths,
+    })
+  ) {
+    throw new Error(
+      `Refusing current-issue journal self-heal because tracked supervisor-local artifacts are not exactly ${currentJournalPath}: ${trackedPaths.join(", ") || "none"}`,
+    );
+  }
+
+  await installWorktreeLocalExcludes(
+    { issueJournalRelativePath: args.journalRelativePath },
+    args.workspacePath,
+    args.issueNumber,
+  );
+  await runCommand("git", [
+    "-C",
+    args.workspacePath,
+    "rm",
+    "--cached",
+    "-q",
+    "--",
+    currentJournalPath,
+  ]);
+  await runCommand("git", [
+    "-C",
+    args.workspacePath,
+    "commit",
+    "-m",
+    "Untrack supervisor issue journal",
+  ]);
+  await pushBranch(args.workspacePath, args.branch, args.remoteBranchExists);
+  await installWorktreeLocalExcludes(
+    { issueJournalRelativePath: args.journalRelativePath },
+    args.workspacePath,
+    args.issueNumber,
+  );
+
+  return currentJournalPath;
 }
 
 export async function cleanupWorkspace(

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -384,8 +384,295 @@ test("applyCodexTurnPublicationGate forwards publishable allowlist markers to th
     syncExecutionMetricsRunSummary: async () => undefined,
   });
 
-  assert.equal(result.kind, "ready");
+  assert.equal(
+    result.kind,
+    "ready",
+    result.kind === "blocked"
+      ? `${result.message}\n${result.record.last_failure_context?.details.join("\n") ?? ""}`
+      : undefined,
+  );
   assert.deepEqual(observedCalls, [["publishable-path-hygiene: allowlist"]]);
+});
+
+test("applyCodexTurnPublicationGate self-heals a tracked current issue journal before draft PR creation", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "102",
+    "issue-journal.md",
+  );
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md");
+  git(workspacePath, "commit", "-m", "seed current issue journal leak");
+
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+  let syncJournalCalls = 0;
+  const issue = createIssue({
+    title: "Self-heal current issue journal hygiene",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      workspacePreparationCommand: "npm ci",
+      issueJournalRelativePath:
+        ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        return createPullRequest({
+          number: 200,
+          isDraft: true,
+          headRefOid: git(workspacePath, "rev-parse", "HEAD").trim(),
+        });
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(
+    result.kind,
+    "ready",
+    result.kind === "blocked"
+      ? `${result.message}\n${result.record.last_failure_context?.details.join("\n") ?? ""}`
+      : undefined,
+  );
+  assert.equal(createPullRequestCalls, 1);
+  assert.equal(runWorkspacePreparationCalls, 1);
+  assert.equal(runLocalCiCalls, 1);
+  assert.equal(syncJournalCalls, 2);
+  assert.equal(
+    git(workspacePath, "log", "-1", "--pretty=%s").trim(),
+    "Untrack supervisor issue journal",
+  );
+  assert.equal(
+    git(
+      workspacePath,
+      "ls-files",
+      "--",
+      ".codex-supervisor/issues/102/issue-journal.md",
+    ).trim(),
+    "",
+  );
+  assert.equal(await fs.readFile(currentJournalPath, "utf8"), "# Issue #102\n");
+  assert.match(
+    await fs.readFile(
+      git(
+        workspacePath,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+      ).trim(),
+      "utf8",
+    ),
+    /^\.codex-supervisor\/issues\/102\/issue-journal\.md$/mu,
+  );
+  assert.match(
+    git(workspacePath, "ls-remote", "--heads", "origin", "codex\/issue-102"),
+    /refs\/heads\/codex\/issue-102/,
+  );
+  assert.equal(
+    git(workspacePath, "status", "--short", "--untracked-files=no").trim(),
+    "",
+  );
+  assert.equal(
+    result.record.last_head_sha,
+    git(workspacePath, "rev-parse", "HEAD").trim(),
+  );
+});
+
+test("applyCodexTurnPublicationGate stays blocked when current issue journal self-heal cannot publish cleanup", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+
+  const currentJournalPath = path.join(
+    workspacePath,
+    ".codex-supervisor",
+    "issues",
+    "102",
+    "issue-journal.md",
+  );
+  await fs.mkdir(path.dirname(currentJournalPath), { recursive: true });
+  await fs.writeFile(currentJournalPath, "# Issue #102\n", "utf8");
+  git(workspacePath, "add", ".codex-supervisor/issues/102/issue-journal.md");
+  git(workspacePath, "commit", "-m", "seed current issue journal leak");
+  const originPath = path.join(workspacePath, "origin.git");
+  await fs.writeFile(
+    path.join(originPath, "hooks", "pre-receive"),
+    "#!/bin/sh\nprintf '%s\\n' 'cleanup push rejected' >&2\nexit 1\n",
+    { mode: 0o755 },
+  );
+
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+  let syncExecutionMetricsCalls = 0;
+  const issue = createIssue({
+    title: "Keep publication blocked when journal cleanup cannot publish",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+        journal_path: currentJournalPath,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      localCiCommand: "npm run ci:local",
+      issueJournalRelativePath:
+        ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => {
+      throw new Error("unexpected path hygiene call");
+    },
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => {
+      syncExecutionMetricsCalls += 1;
+    },
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(
+    result.record.last_failure_signature,
+    "supervisor-local-durable-artifacts-tracked-before-publication",
+  );
+  assert.match(
+    result.record.last_failure_context?.details.join("\n") ?? "",
+    /current-issue journal self-heal attempted and failed:/,
+  );
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
+  assert.equal(syncExecutionMetricsCalls, 1);
+  assert.equal(
+    git(
+      workspacePath,
+      "ls-files",
+      "--",
+      ".codex-supervisor/issues/102/issue-journal.md",
+    ).trim(),
+    "",
+  );
+  assert.equal(await fs.readFile(currentJournalPath, "utf8"), "# Issue #102\n");
 });
 
 test("applyCodexTurnPublicationGate blocks tracked supervisor issue journals before publication", async (t) => {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -27,7 +27,9 @@ import {
   commitAndPushTrackedFiles,
   filterPresentTrackedFilePaths,
   getWorkspaceStatus,
+  isCurrentIssueJournalOnlyTrackedSupervisorArtifact,
   listTrackedSupervisorArtifactPaths,
+  untrackCurrentIssueJournalBeforePublication,
 } from "./core/workspace";
 
 function isOpenPullRequest(
@@ -75,6 +77,7 @@ const SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE =
 function buildSupervisorLocalArtifactFailureContext(
   trackedPaths: string[],
   issueNumber: number,
+  extraDetails: string[] = [],
 ): FailureContext {
   const listedPaths = trackedPaths.join(", ");
   return {
@@ -86,6 +89,7 @@ function buildSupervisorLocalArtifactFailureContext(
     command: "git ls-files -- .codex-supervisor",
     details: [
       "Supervisor-local durable artifacts must not be committed into issue-branch publication checkpoints.",
+      ...extraDetails,
       ...trackedPaths.map(
         (trackedPath) => `tracked supervisor-local artifact: ${trackedPath}`,
       ),
@@ -164,31 +168,129 @@ export async function applyCodexTurnPublicationGate(args: {
         args.config.issueJournalRelativePath,
       );
     if (trackedSupervisorArtifactPaths.length > 0) {
-      const failureContext = buildSupervisorLocalArtifactFailureContext(
-        trackedSupervisorArtifactPaths,
-        record.issue_number,
-      );
-      record = args.stateStore.touch(record, {
-        state: "blocked",
-        last_error: truncate(failureContext.summary, 1000),
-        last_failure_kind: null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: "verification",
-        ...issueDefinitionFreshnessPatch(args.issue),
-      });
-      args.state.issues[String(record.issue_number)] = record;
-      await args.stateStore.save(args.state);
-      await args.syncExecutionMetricsRunSummary(record);
-      await args.syncJournal(record);
-      return {
-        kind: "blocked",
-        message: failureContext.summary,
-        record,
-        pr: null,
-        checks: [],
-        reviewThreads: [],
-      };
+      if (
+        isCurrentIssueJournalOnlyTrackedSupervisorArtifact({
+          workspacePath: args.workspacePath,
+          journalRelativePath: args.config.issueJournalRelativePath,
+          issueNumber: record.issue_number,
+          trackedPaths: trackedSupervisorArtifactPaths,
+        })
+      ) {
+        let cleanedPath: string | null = null;
+        try {
+          cleanedPath = await untrackCurrentIssueJournalBeforePublication({
+            workspacePath: args.workspacePath,
+            branch: record.branch,
+            remoteBranchExists: workspaceStatus.remoteBranchExists,
+            journalRelativePath: args.config.issueJournalRelativePath,
+            issueNumber: record.issue_number,
+          });
+          workspaceStatus = await getWorkspaceStatus(
+            args.workspacePath,
+            record.branch,
+            args.config.defaultBranch,
+          );
+          record = args.stateStore.touch(record, {
+            last_head_sha: workspaceStatus.headSha,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const failureContext = buildSupervisorLocalArtifactFailureContext(
+            trackedSupervisorArtifactPaths,
+            record.issue_number,
+            [
+              `current-issue journal self-heal attempted and failed: ${message}`,
+            ],
+          );
+          record = args.stateStore.touch(record, {
+            state: "blocked",
+            last_error: truncate(failureContext.summary, 1000),
+            last_failure_kind: null,
+            last_failure_context: failureContext,
+            ...args.applyFailureSignature(record, failureContext),
+            blocked_reason: "verification",
+            ...issueDefinitionFreshnessPatch(args.issue),
+          });
+          args.state.issues[String(record.issue_number)] = record;
+          await args.stateStore.save(args.state);
+          await args.syncExecutionMetricsRunSummary(record);
+          await args.syncJournal(record);
+          return {
+            kind: "blocked",
+            message: failureContext.summary,
+            record,
+            pr: null,
+            checks: [],
+            reviewThreads: [],
+          };
+        }
+
+        const remainingTrackedSupervisorArtifactPaths =
+          await listTrackedSupervisorArtifactPaths(
+            args.workspacePath,
+            args.config.issueJournalRelativePath,
+          );
+        if (remainingTrackedSupervisorArtifactPaths.length === 0) {
+          args.state.issues[String(record.issue_number)] = record;
+          await args.stateStore.save(args.state);
+          await args.syncJournal(record);
+        } else {
+          const failureContext = buildSupervisorLocalArtifactFailureContext(
+            remainingTrackedSupervisorArtifactPaths,
+            record.issue_number,
+            [
+              `current-issue journal self-heal removed ${cleanedPath ?? "unknown"} but supervisor-local artifacts still remain tracked`,
+            ],
+          );
+          record = args.stateStore.touch(record, {
+            state: "blocked",
+            last_error: truncate(failureContext.summary, 1000),
+            last_failure_kind: null,
+            last_failure_context: failureContext,
+            ...args.applyFailureSignature(record, failureContext),
+            blocked_reason: "verification",
+            ...issueDefinitionFreshnessPatch(args.issue),
+          });
+          args.state.issues[String(record.issue_number)] = record;
+          await args.stateStore.save(args.state);
+          await args.syncExecutionMetricsRunSummary(record);
+          await args.syncJournal(record);
+          return {
+            kind: "blocked",
+            message: failureContext.summary,
+            record,
+            pr: null,
+            checks: [],
+            reviewThreads: [],
+          };
+        }
+      } else {
+        const failureContext = buildSupervisorLocalArtifactFailureContext(
+          trackedSupervisorArtifactPaths,
+          record.issue_number,
+        );
+        record = args.stateStore.touch(record, {
+          state: "blocked",
+          last_error: truncate(failureContext.summary, 1000),
+          last_failure_kind: null,
+          last_failure_context: failureContext,
+          ...args.applyFailureSignature(record, failureContext),
+          blocked_reason: "verification",
+          ...issueDefinitionFreshnessPatch(args.issue),
+        });
+        args.state.issues[String(record.issue_number)] = record;
+        await args.stateStore.save(args.state);
+        await args.syncExecutionMetricsRunSummary(record);
+        await args.syncJournal(record);
+        return {
+          kind: "blocked",
+          message: failureContext.summary,
+          record,
+          pr: null,
+          checks: [],
+          reviewThreads: [],
+        };
+      }
     }
 
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({


### PR DESCRIPTION
Closes #1632

This PR adds a bounded publication-time self-heal for the case where the only tracked supervisor-local artifact is the current issue journal. It removes that journal from the branch index while leaving the local file in place, preserves local exclude protection, and then re-runs the supervisor-artifact publication gate once before continuing toward PR creation.

It also restores root-checkout exclude coverage for issue-scoped and legacy supervisor journals.

Verification:
- npx tsx --test src/turn-execution-publication-gate.test.ts src/core/workspace.test.ts
- npm run build
- npm run verify:paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publication gate now includes automatic self-healing capability to clean up tracked artifacts before publishing.

* **Bug Fixes**
  * Improved handling and validation of supervisor-local artifact tracking state.
  * Enhanced diagnostic information when publication fails, with detailed context on cleanup attempts.

* **Tests**
  * Added comprehensive tests for tracked artifact hygiene and publication gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->