### PR TITLE
Add CLI help output

### DIFF
--- a/src/cli/entrypoint.test.ts
+++ b/src/cli/entrypoint.test.ts
@@ -3,6 +3,52 @@ import test from "node:test";
 import type { CliIo } from "./replay-corpus-command";
 import { isDirectExecution, runCli, runCliMain } from "./entrypoint";
 
+test("runCli prints help without checking runtime freshness or constructing services", async () => {
+  const stdout: string[] = [];
+  let checkedFreshness = false;
+  let createdSupervisorService = false;
+
+  await runCli(["--help"], {
+    assertRuntimeFreshness: async () => {
+      checkedFreshness = true;
+      throw new Error("unexpected freshness check");
+    },
+    createSupervisorService: () => {
+      createdSupervisorService = true;
+      throw new Error("unexpected createSupervisorService");
+    },
+    writeStdout: (line) => {
+      stdout.push(line);
+    },
+  });
+
+  assert.equal(checkedFreshness, false);
+  assert.equal(createdSupervisorService, false);
+  assert.match(stdout.join("\n"), /Usage:/);
+  assert.match(stdout.join("\n"), /node dist\/index\.js help/);
+  assert.match(stdout.join("\n"), /First run:/);
+  assert.match(stdout.join("\n"), /Inspect commands:/);
+  assert.match(stdout.join("\n"), /issue-lint <issue-number>/);
+  assert.match(stdout.join("\n"), /Maintenance commands:/);
+  assert.match(stdout.join("\n"), /Web-oriented commands:/);
+});
+
+test("runCli prints help for the help command", async () => {
+  const stdout: string[] = [];
+
+  await runCli(["help"], {
+    assertRuntimeFreshness: async () => {
+      throw new Error("unexpected freshness check");
+    },
+    writeStdout: (line) => {
+      stdout.push(line);
+    },
+  });
+
+  assert.match(stdout.join("\n"), /Usage:/);
+  assert.match(stdout.join("\n"), /Run commands:/);
+});
+
 test("runCli routes replay commands through the replay handler and stdout boundary", async () => {
   const stdout: string[] = [];
   let replayedSnapshotPath: string | undefined;

--- a/src/cli/entrypoint.ts
+++ b/src/cli/entrypoint.ts
@@ -13,6 +13,7 @@ import {
   handleReplayCorpusCommand,
   handleReplayCorpusPromoteCommand,
 } from "./replay-corpus-command";
+import { renderCliHelp } from "./help";
 import { isSupervisorRuntimeCommand, runSupervisorCommand } from "./supervisor-runtime";
 import { assertRuntimeFreshness } from "../build-freshness";
 
@@ -53,6 +54,10 @@ export interface CliMainDependencies {
   exit?: (code: number) => void;
 }
 
+function isExactHelpRequest(argv: string[]): boolean {
+  return argv.length === 1 && (argv[0] === "--help" || argv[0] === "help");
+}
+
 export async function runCli(
   argv: string[],
   dependencies: CliEntrypointDependencies = {},
@@ -72,8 +77,18 @@ export async function runCli(
   const supervisorCommandRunner = dependencies.runSupervisorCommand ?? runSupervisorCommand;
   const writeStdout = dependencies.writeStdout ?? ((line: string) => console.log(line));
 
+  if (isExactHelpRequest(argv)) {
+    writeStdout(renderCliHelp());
+    return;
+  }
+
   await runtimeFreshnessGuard();
   const options = parseCliArgs(argv);
+  if (options.command === "help") {
+    writeStdout(renderCliHelp());
+    return;
+  }
+
   if (options.command === "replay") {
     writeStdout(await replayCommandHandler(options));
     return;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,47 @@
+export function renderCliHelp(): string {
+  return `Usage:
+  node dist/index.js [command] [options]
+  node dist/index.js --help
+  node dist/index.js help
+
+Common flags:
+  --config <supervisor-config-path>  Use an explicit supervisor config file.
+  --dry-run                         Plan the next run-once or loop action without executing Codex.
+  --why                             Include status decision details. Supported with status only.
+
+First run:
+  1. node dist/index.js doctor --config <supervisor-config-path>
+  2. node dist/index.js status --config <supervisor-config-path> --why
+  3. node dist/index.js run-once --config <supervisor-config-path> --dry-run
+  4. node dist/index.js run-once --config <supervisor-config-path>
+  5. node dist/index.js loop --config <supervisor-config-path>
+
+Run commands:
+  run-once                          Run one supervisor cycle.
+  loop                              Keep running supervisor cycles until stopped.
+
+Inspect commands:
+  status [--why]                    Show queue, PR, CI, review, and loop state.
+  doctor                            Check local configuration and repository prerequisites.
+  explain <issue-number>            Explain supervisor readiness for one issue.
+  issue-lint <issue-number>         Validate an execution-ready issue body.
+
+Repair commands:
+  requeue <issue-number>            Requeue a blocked or failed issue.
+  reset-corrupt-json-state          Move corrupt JSON state aside after inspection.
+
+Maintenance commands:
+  rollup-execution-metrics          Summarize execution metrics from durable state.
+  summarize-post-merge-audits       Summarize post-merge audit patterns.
+  prune-orphaned-workspaces         Remove orphaned managed workspaces.
+
+Replay commands:
+  replay <snapshot-path>            Replay one decision snapshot.
+  replay-corpus [corpus-path]       Run checked-in replay corpus cases.
+  replay-corpus-promote <snapshot-path> [case-id] [corpus-path]
+                                    Promote a snapshot into the replay corpus.
+
+Web-oriented commands:
+  web                               Start the operator dashboard.
+`;
+}

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -2,6 +2,32 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { parseArgs } from "./parse-args";
 
+test("parseArgs accepts --help as the help command", () => {
+  assert.deepEqual(parseArgs(["--help"]), {
+    command: "help",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
+test("parseArgs accepts help as a command", () => {
+  assert.deepEqual(parseArgs(["help"]), {
+    command: "help",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
 test("parseArgs accepts doctor as a command", () => {
   assert.deepEqual(parseArgs(["doctor"]), {
     command: "doctor",
@@ -207,6 +233,13 @@ test("parseArgs requires an issue number for requeue", () => {
   assert.throws(
     () => parseArgs(["requeue"]),
     /The requeue command requires one issue number\./,
+  );
+});
+
+test("parseArgs still rejects command-scoped --help as an unknown argument", () => {
+  assert.throws(
+    () => parseArgs(["issue-lint", "--help"]),
+    /Unknown argument: --help/,
   );
 });
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -42,12 +42,14 @@ export function parseArgs(argv: string[]): CliOptions {
       token === "web" ||
       token === "replay" ||
       token === "replay-corpus" ||
-      token === "replay-corpus-promote"
+      token === "replay-corpus-promote" ||
+      token === "help" ||
+      (token === "--help" && !commandSeen)
     ) {
       if (commandSeen) {
         throw new Error(`Unexpected second command: ${token}`);
       }
-      command = token;
+      command = token === "--help" ? "help" : token;
       commandSeen = true;
       continue;
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -554,7 +554,8 @@ export interface CliOptions {
     | "web"
     | "replay"
     | "replay-corpus"
-    | "replay-corpus-promote";
+    | "replay-corpus-promote"
+    | "help";
   configPath?: string;
   dryRun: boolean;
   why: boolean;


### PR DESCRIPTION
## Summary
- add `help` and `--help` handling to the CLI
- render grouped usage output for run, inspect, repair, maintenance, replay, and web commands
- keep command-scoped required-argument failures fail-closed

## Verification
- `npx tsx --test src/cli/parse-args.test.ts src/cli/entrypoint.test.ts`
- `npm run build`
- `npm run verify:paths`
- `node dist/index.js --help`
- `node dist/index.js help`
- `node dist/index.js issue-lint`

Part of #1635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added help functionality to the CLI. Users can now invoke the `--help` flag or use the `help` command to display comprehensive usage information and guidance. The help output includes a complete list of supported commands organized by category, common flags such as `--config`, `--dry-run`, and `--why`, and practical example first-run invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->