### PR TITLE
Split doctor diagnostics into operator tiers

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -697,6 +697,35 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
       "github_auth: Authentication needs refresh.",
     ],
   );
+
+  assert.deepEqual(
+    buildAttentionItems({
+      status: {
+        blockedIssues: [],
+        runnableIssues: [],
+      },
+      doctor: {
+        overallStatus: "fail",
+        decisionSummary: {
+          action: "stop",
+          summary: "2 active risk(s) require operator attention before continuing.",
+        },
+        diagnosticTiers: {
+          active_risk: [
+            { source: "github_auth", detail: "GitHub CLI authentication is unavailable." },
+            { source: "github_auth", detail: "Run gh auth status." },
+          ],
+          maintenance: [],
+          informational: [],
+        },
+        checks: [{ name: "github_auth", status: "fail", summary: "GitHub CLI authentication is unavailable." }],
+      },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    ["Doctor decision: 2 active risk(s) require operator attention before continuing."],
+  );
 });
 
 test("describeFreshnessState distinguishes fresh, refreshing, stale, and first-load states", () => {

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -121,9 +121,21 @@ export interface DashboardDoctorCheckLike {
   summary?: string | null;
 }
 
+export interface DashboardDoctorDecisionLike {
+  action?: string | null;
+  summary?: string | null;
+}
+
+export interface DashboardDoctorTierItemLike {
+  source?: string | null;
+  detail?: string | null;
+}
+
 export interface DashboardDoctorLike {
   overallStatus?: string | null;
   checks?: DashboardDoctorCheckLike[] | null;
+  decisionSummary?: DashboardDoctorDecisionLike | null;
+  diagnosticTiers?: Record<string, DashboardDoctorTierItemLike[] | null | undefined> | null;
 }
 
 export interface DashboardIssueShortcut {
@@ -720,6 +732,7 @@ export function buildAttentionItems(args: {
   const runnableIssues = Array.isArray(args.status?.runnableIssues) ? args.status.runnableIssues : [];
   const inventoryStatus = args.status?.inventoryStatus ?? null;
   const doctorChecks = Array.isArray(args.doctor?.checks) ? args.doctor.checks : [];
+  const doctorDecision = args.doctor?.decisionSummary ?? null;
   const statusWarning = args.status?.warning?.message ?? null;
   const reconciliationWarning = args.status?.reconciliationWarning ?? null;
   const loopOffTrackedWorkBlocker = describeLoopOffTrackedWorkBlocker(args.status);
@@ -762,8 +775,17 @@ export function buildAttentionItems(args: {
     items.push(String(runnableIssues.length) + " runnable issue(s) are available.");
   }
 
-  for (const check of failingChecks.slice(0, 3)) {
-    items.push((check.name || "check") + ": " + (check.summary || check.status || "needs attention"));
+  if (
+    doctorDecision &&
+    (doctorDecision.action === "stop" || doctorDecision.action === "maintenance") &&
+    typeof doctorDecision.summary === "string" &&
+    doctorDecision.summary.trim().length > 0
+  ) {
+    items.push("Doctor decision: " + doctorDecision.summary);
+  } else {
+    for (const check of failingChecks.slice(0, 3)) {
+      items.push((check.name || "check") + ": " + (check.summary || check.status || "needs attention"));
+    }
   }
 
   if (statusWarning) {

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -182,6 +182,8 @@ export function renderDashboardBrowserScript(): string {
         trackedHistoryLines: document.getElementById("tracked-history-lines"),
         trackedHistoryToggle: document.getElementById("tracked-history-toggle"),
         doctorOverall: document.getElementById("doctor-overall"),
+        doctorDecision: document.getElementById("doctor-decision"),
+        doctorTiers: document.getElementById("doctor-tiers"),
         doctorChecks: document.getElementById("doctor-checks"),
         issueSummary: document.getElementById("issue-summary"),
         issueMetrics: document.getElementById("issue-metrics"),
@@ -946,6 +948,28 @@ export function renderDashboardBrowserScript(): string {
         if (elements.doctorOverall) {
           setText(elements.doctorOverall, doctor.overallStatus);
           elements.doctorOverall.className = "metric " + metricClass(doctor.overallStatus);
+        }
+        if (elements.doctorDecision) {
+          const decision = doctor.decisionSummary || {};
+          const action = typeof decision.action === "string" ? decision.action : "unknown";
+          const summaryText = typeof decision.summary === "string" ? decision.summary : "Decision summary is unavailable.";
+          setText(elements.doctorDecision, action + ": " + summaryText);
+          elements.doctorDecision.className = "status-line " + metricClass(action === "stop" ? "fail" : action === "maintenance" ? "warn" : "pass");
+        }
+        if (elements.doctorTiers) {
+          elements.doctorTiers.innerHTML = "";
+          const tiers = doctor.diagnosticTiers || {};
+          for (const tierName of ["active_risk", "maintenance", "informational"]) {
+            const entries = Array.isArray(tiers[tierName]) ? tiers[tierName] : [];
+            const tone = entries.length > 0
+              ? tierName === "active_risk"
+                ? "fail"
+                : tierName === "maintenance"
+                  ? "warn"
+                  : "info"
+              : "info";
+            appendChip(elements.doctorTiers, tierName + " " + entries.length, tone);
+          }
         }
         const checks = doctor.checks || [];
         if (!elements.doctorChecks) {

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -950,25 +950,38 @@ export function renderDashboardBrowserScript(): string {
           elements.doctorOverall.className = "metric " + metricClass(doctor.overallStatus);
         }
         if (elements.doctorDecision) {
-          const decision = doctor.decisionSummary || {};
-          const action = typeof decision.action === "string" ? decision.action : "unknown";
-          const summaryText = typeof decision.summary === "string" ? decision.summary : "Decision summary is unavailable.";
-          setText(elements.doctorDecision, action + ": " + summaryText);
-          elements.doctorDecision.className = "status-line " + metricClass(action === "stop" ? "fail" : action === "maintenance" ? "warn" : "pass");
+          const decision = doctor.decisionSummary && typeof doctor.decisionSummary === "object"
+            ? doctor.decisionSummary
+            : null;
+          const action = typeof decision?.action === "string" ? decision.action : null;
+          const summaryText = typeof decision?.summary === "string" ? decision.summary : "Decision summary is unavailable.";
+          const decisionTone = action === "stop"
+            ? "fail"
+            : action === "maintenance"
+              ? "warn"
+              : action === "continue"
+                ? "pass"
+                : "";
+          setText(elements.doctorDecision, (action || "unknown") + ": " + summaryText);
+          elements.doctorDecision.className = ["status-line", metricClass(decisionTone)].filter(Boolean).join(" ");
         }
         if (elements.doctorTiers) {
           elements.doctorTiers.innerHTML = "";
-          const tiers = doctor.diagnosticTiers || {};
-          for (const tierName of ["active_risk", "maintenance", "informational"]) {
-            const entries = Array.isArray(tiers[tierName]) ? tiers[tierName] : [];
-            const tone = entries.length > 0
-              ? tierName === "active_risk"
-                ? "fail"
-                : tierName === "maintenance"
-                  ? "warn"
-                  : "info"
-              : "info";
-            appendChip(elements.doctorTiers, tierName + " " + entries.length, tone);
+          const tiers = doctor.diagnosticTiers && typeof doctor.diagnosticTiers === "object"
+            ? doctor.diagnosticTiers
+            : null;
+          if (tiers) {
+            for (const tierName of ["active_risk", "maintenance", "informational"]) {
+              const entries = Array.isArray(tiers[tierName]) ? tiers[tierName] : [];
+              const tone = entries.length > 0
+                ? tierName === "active_risk"
+                  ? "fail"
+                  : tierName === "maintenance"
+                    ? "warn"
+                    : "info"
+                : "info";
+              appendChip(elements.doctorTiers, tierName + " " + entries.length, tone);
+            }
           }
         }
         const checks = doctor.checks || [];

--- a/src/backend/webui-dashboard-panel-layout.ts
+++ b/src/backend/webui-dashboard-panel-layout.ts
@@ -131,6 +131,11 @@ export const DASHBOARD_PANEL_REGISTRY = [
     headerMetaMarkup: '<span id="doctor-overall" class="metric">…</span>',
     bodyClassName: "stack",
     bodyMarkup: `              <div class="row">
+                <div class="row-label">Decision</div>
+                <div id="doctor-decision" class="status-line panel-empty-state">Loading /api/doctor…</div>
+                <div id="doctor-tiers" class="chip-row"></div>
+              </div>
+              <div class="row">
                 <div class="row-label">Checks</div>
                 <ul id="doctor-checks" class="list">
                   <li class="panel-empty-state">Loading /api/doctor…</li>

--- a/src/backend/webui-dashboard-test-fixtures.ts
+++ b/src/backend/webui-dashboard-test-fixtures.ts
@@ -441,6 +441,15 @@ export function createDashboardStatusFixture(args: {
 export function createDashboardDoctorFixture() {
   return {
     overallStatus: "pass",
+    decisionSummary: {
+      action: "continue",
+      summary: "No active risk or maintenance blocker was detected; continue normal supervisor operation.",
+    },
+    diagnosticTiers: {
+      active_risk: [],
+      maintenance: [],
+      informational: [],
+    },
     checks: [{ name: "github_auth", status: "pass", summary: "GitHub auth ok." }],
   };
 }

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -144,6 +144,7 @@ test("dashboard page frames a summary-first shell and a collapsible details area
   );
   assert.match(html, /id="loop-state-summary"/u);
   assert.match(html, /id="selected-issue-summary-metrics"[\s\S]*id="selected-issue-summary-notes"/u);
+  assert.match(html, /id="doctor-decision"[\s\S]*id="doctor-tiers"[\s\S]*id="doctor-checks"/u);
   assert.match(
     html,
     /<details id="details-disclosure" class="details-disclosure">[\s\S]*<div class="details-body">[\s\S]*<h2 id="overview-heading">Advanced queue context<\/h2>[\s\S]*<div id="overview-grid" class="overview-grid" aria-label="overview" data-panel-grid="overview">/u,

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -318,6 +318,35 @@ test("dashboard derives the selected issue from typed status fields without pars
   assert.equal(harness.remainingFetches.length, 0);
 });
 
+test("dashboard does not render missing doctor decision or tier metadata as healthy", async () => {
+  const harness = createDashboardHarness([
+    ...dashboardServer.page({
+      doctor: jsonResponse({
+        overallStatus: "fail",
+        checks: [{ name: "github_auth", status: "fail", summary: "GitHub auth failed." }],
+      }),
+    }),
+  ]);
+  await harness.flush();
+
+  const doctorOverall = harness.document.getElementById("doctor-overall");
+  const doctorDecision = harness.document.getElementById("doctor-decision");
+  const doctorTiers = harness.document.getElementById("doctor-tiers");
+  const doctorChecks = harness.document.getElementById("doctor-checks");
+  assert.ok(doctorOverall);
+  assert.ok(doctorDecision);
+  assert.ok(doctorTiers);
+  assert.ok(doctorChecks);
+
+  assert.equal(doctorOverall.className, "metric fail");
+  assert.equal(doctorDecision.textContent, "unknown: Decision summary is unavailable.");
+  assert.equal(doctorDecision.className, "status-line");
+  assert.equal(doctorTiers.children.length, 0);
+  assert.match(doctorChecks.textContent, /github_auth GitHub auth failed\./u);
+  assert.match(doctorChecks.textContent, /fail/u);
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
 test("dashboard does not claim loop mode is off while typed runtime status reports the loop is running", async () => {
   const harness = createDashboardHarness([
     ...dashboardServer.page({

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1298,6 +1298,54 @@ test("renderDoctorReport surfaces merge-critical recheck cadence visibility", ()
   assert.match(report, /doctor_local_ci configured=true source=config command=npm run ci:local summary=Repo-owned local CI contract is configured\./);
 });
 
+test("renderDoctorReport starts with decision summary and tiers active risks, maintenance, and informational details", () => {
+  const report = renderDoctorReport({
+    overallStatus: "fail",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: null,
+      configWarning: null,
+    },
+    checks: [
+      {
+        name: "github_auth",
+        status: "fail",
+        summary: "GitHub CLI authentication is unavailable.",
+        details: ["Run `gh auth status --hostname github.com` to inspect the current login state."],
+      },
+      {
+        name: "worktrees",
+        status: "warn",
+        summary: "orphaned prune candidates=1 eligible=1 locked=0 recent=0 unsafe_target=0",
+        details: [
+          "issue_host_paths issue=#177 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required",
+          "orphan_prune_candidate issue_number=201 eligibility=eligible workspace=<workspace-root>/issue-201 branch=codex/issue-201 modified_at=2026-03-01T00:00:00.000Z reason=done_state_missing_from_supervisor_state",
+        ],
+      },
+    ],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  const lines = report.split("\n");
+  assert.match(lines[0], /^doctor_decision action=stop summary=/);
+  assert.equal(lines[1], "doctor_tier tier=active_risk count=2");
+  assert.equal(lines[4], "doctor_tier tier=maintenance count=2");
+  assert.equal(lines[7], "doctor_tier tier=informational count=1");
+  assert.match(report, /^doctor_tier_item tier=active_risk source=github_auth detail=GitHub CLI authentication is unavailable\.$/m);
+  assert.match(report, /^doctor_tier_item tier=maintenance source=worktrees detail=orphaned prune candidates=1 eligible=1 locked=0 recent=0 unsafe_target=0$/m);
+  assert.match(report, /^doctor_tier_item tier=informational source=worktrees detail=issue_host_paths issue=#177 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m);
+  assert.match(report, /^doctor_check name=github_auth status=fail summary=GitHub CLI authentication is unavailable\.$/m);
+  assert.match(report, /^doctor_detail name=worktrees detail=orphan_prune_candidate issue_number=201 eligibility=eligible /m);
+});
+
 test("renderDoctorReport surfaces absent workspace preparation posture when no repo-owned contract exists", () => {
   const report = renderDoctorReport({
     overallStatus: "pass",

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -41,6 +41,8 @@ import { buildTrustAndConfigWarnings, buildWarning, renderDoctorWarningLine } fr
 import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "./reconciliation-backlog-diagnostics";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
+export type DoctorDecisionAction = "stop" | "maintenance" | "continue";
+export type DoctorDiagnosticTier = "active_risk" | "maintenance" | "informational";
 
 export interface DoctorCheck {
   name: "github_auth" | "codex_cli" | "state_file" | "worktrees";
@@ -49,9 +51,23 @@ export interface DoctorCheck {
   details: string[];
 }
 
+export interface DoctorDecisionSummary {
+  action: DoctorDecisionAction;
+  summary: string;
+}
+
+export interface DoctorTierItem {
+  source: string;
+  detail: string;
+}
+
+export type DoctorTieredDiagnostics = Record<DoctorDiagnosticTier, DoctorTierItem[]>;
+
 export interface DoctorDiagnostics {
   overallStatus: DoctorCheckStatus;
   checks: DoctorCheck[];
+  decisionSummary?: DoctorDecisionSummary;
+  diagnosticTiers?: DoctorTieredDiagnostics;
   codexModelPolicyLines?: string[];
   reconciliationBacklogLine?: string | null;
   trustDiagnostics: TrustDiagnosticsSummary;
@@ -144,6 +160,86 @@ function overallStatusForChecks(checks: DoctorCheck[]): DoctorCheckStatus {
   }
 
   return "pass";
+}
+
+function emptyDoctorDiagnosticTiers(): DoctorTieredDiagnostics {
+  return {
+    active_risk: [],
+    maintenance: [],
+    informational: [],
+  };
+}
+
+function isInformationalDoctorDetail(detail: string): boolean {
+  return /^issue_host_paths\b/.test(detail) ||
+    /^issue_journal_state\b/.test(detail) ||
+    /\bguidance=no_manual_action_required\b/.test(detail);
+}
+
+function buildDoctorDiagnosticTiers(checks: DoctorCheck[]): DoctorTieredDiagnostics {
+  const tiers = emptyDoctorDiagnosticTiers();
+
+  for (const check of checks) {
+    if (check.status === "fail") {
+      tiers.active_risk.push({ source: check.name, detail: check.summary });
+      for (const detail of check.details) {
+        tiers.active_risk.push({ source: check.name, detail });
+      }
+      continue;
+    }
+
+    if (check.status === "warn") {
+      tiers.maintenance.push({ source: check.name, detail: check.summary });
+      for (const detail of check.details) {
+        if (isInformationalDoctorDetail(detail)) {
+          tiers.informational.push({ source: check.name, detail });
+        } else {
+          tiers.maintenance.push({ source: check.name, detail });
+        }
+      }
+      continue;
+    }
+
+    for (const detail of check.details) {
+      tiers.informational.push({ source: check.name, detail });
+    }
+  }
+
+  return tiers;
+}
+
+function buildDoctorDecisionSummary(
+  overallStatus: DoctorCheckStatus,
+  diagnosticTiers: DoctorTieredDiagnostics,
+): DoctorDecisionSummary {
+  if (overallStatus === "fail" || diagnosticTiers.active_risk.length > 0) {
+    return {
+      action: "stop",
+      summary: `${diagnosticTiers.active_risk.length} active risk(s) require operator attention before continuing.`,
+    };
+  }
+
+  if (overallStatus === "warn" || diagnosticTiers.maintenance.length > 0) {
+    return {
+      action: "maintenance",
+      summary: `${diagnosticTiers.maintenance.length} maintenance item(s) should be handled, but no stop-now risk was detected.`,
+    };
+  }
+
+  return {
+    action: "continue",
+    summary: "No active risk or maintenance blocker was detected; continue normal supervisor operation.",
+  };
+}
+
+function buildDoctorDecisionSurface(
+  diagnostics: Pick<DoctorDiagnostics, "overallStatus" | "checks" | "decisionSummary" | "diagnosticTiers">,
+): { decisionSummary: DoctorDecisionSummary; diagnosticTiers: DoctorTieredDiagnostics } {
+  const diagnosticTiers = diagnostics.diagnosticTiers ?? buildDoctorDiagnosticTiers(diagnostics.checks);
+  const decisionSummary = diagnostics.decisionSummary ??
+    buildDoctorDecisionSummary(diagnostics.overallStatus, diagnosticTiers);
+
+  return { decisionSummary, diagnosticTiers };
 }
 
 function withReconciliationBacklogStateReadFailure(
@@ -713,9 +809,14 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     finalChecks = withReconciliationBacklogStateReadFailure(checks, args.config, error);
   }
 
+  const overallStatus = overallStatusForChecks(finalChecks);
+  const diagnosticTiers = buildDoctorDiagnosticTiers(finalChecks);
+
   return {
-    overallStatus: overallStatusForChecks(finalChecks),
+    overallStatus,
     checks: finalChecks,
+    decisionSummary: buildDoctorDecisionSummary(overallStatus, diagnosticTiers),
+    diagnosticTiers,
     codexModelPolicyLines,
     reconciliationBacklogLine: state === null
       ? null
@@ -788,6 +889,7 @@ export async function diagnoseBootstrapReadiness(
 }
 
 export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
+  const decisionSurface = buildDoctorDecisionSurface(diagnostics);
   const workspacePreparationContract =
     diagnostics.workspacePreparationContract
     ?? summarizeWorkspacePreparationContract({ workspacePreparationCommand: undefined, localCiCommand: undefined });
@@ -815,6 +917,13 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     .filter((line) => line.trim().length > 0);
 
   return [
+    `doctor_decision action=${decisionSurface.decisionSummary.action} summary=${sanitizeDoctorValue(decisionSurface.decisionSummary.summary)}`,
+    ...(["active_risk", "maintenance", "informational"] as const).flatMap((tier) => [
+      `doctor_tier tier=${tier} count=${decisionSurface.diagnosticTiers[tier].length}`,
+      ...decisionSurface.diagnosticTiers[tier].map((item) =>
+        `doctor_tier_item tier=${tier} source=${item.source} detail=${sanitizeDoctorValue(item.detail)}`
+      ),
+    ]),
     `doctor overall=${diagnostics.overallStatus} checks=${diagnostics.checks.length}`,
     `doctor_posture trust_mode=${diagnostics.trustDiagnostics.trustMode} execution_safety_mode=${diagnostics.trustDiagnostics.executionSafetyMode}`,
     `doctor_cadence poll_interval_seconds=${diagnostics.cadenceDiagnostics.pollIntervalSeconds} merge_critical_recheck_seconds=${mergeCriticalRecheckSeconds} merge_critical_effective_seconds=${diagnostics.cadenceDiagnostics.mergeCriticalEffectiveSeconds} enabled=${diagnostics.cadenceDiagnostics.mergeCriticalRecheckEnabled}`,


### PR DESCRIPTION
## Summary
- add a top-of-report doctor decision line plus active risk, maintenance, and informational tier summaries
- include structured decisionSummary and diagnosticTiers on doctor diagnostics while preserving raw checks/details
- surface the doctor decision and tier counts in the WebUI doctor panel and attention summary

## Verification
- npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/backend/webui-dashboard.test.ts
- npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts
- npm run build
- npm run verify:paths

## Manual check
- node dist/index.js doctor --config supervisor.config.coderabbit.json currently exits before doctor logic because supervisor.config.coderabbit.json has placeholder repoSlug=REPLACE_ME, which fails config parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Doctor decision summary added to the dashboard with explicit action status and tone-based styling.
  * Diagnostic data shown as tiered chips (active risks, maintenance, informational) with counts and severity tones.
  * Dashboard doctor panel includes a decision row and tier chips area, with graceful fallbacks when metadata is missing.

* **Tests**
  * Added tests covering decision summary rendering, tier counts/items, and dashboard doctor UI structure and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->