### PR TITLE
Add explicit local CI candidate dismissal flow

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -519,11 +519,14 @@ Operational notes:
 - the repo is the source of truth for the command contents, and the supervisor should only run the configured entrypoint and observe its exit status
 - `No repo-owned local CI contract is configured.` means no canonical repo-owned local gate is active
 - `Repo-owned local CI candidate exists but localCiCommand is unset.` means setup or readiness found a repo script candidate, but codex-supervisor will not run it until localCiCommand is configured. This warning is advisory only.
+- `Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking.` means an operator acknowledged the detected candidate without adopting it, so setup and doctor should stop treating the candidate as unresolved first-run noise.
 - `Repo-owned local CI contract is configured.` means the configured command is active and fail-closed, so when configured local CI fails, PR publication stays blocked until the command passes again
 
 Operator rule:
 
 - keep the command defined in the managed repo
+- adopt the candidate by saving it as `localCiCommand` only when that repo-owned command is intended to become the fail-closed publication gate
+- dismiss a candidate only as an explicit acknowledgement that the repo script should stay non-blocking for this supervisor profile
 - let the supervisor execute it
 - do not ask the supervisor to infer CI behavior from workflow YAML
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -376,9 +376,10 @@ Steady-state posture to read after setup:
 
 - `No repo-owned local CI contract is configured.` That means no canonical repo-owned pre-PR command is active, so PR publication does not depend on `localCiCommand` yet.
 - `Repo-owned local CI candidate exists but localCiCommand is unset.` That means the repo already exposes a likely script candidate, but the supervisor has not opted into it yet. This warning is advisory only. Setup readiness stays unchanged until you configure `localCiCommand`, and codex-supervisor will not run the candidate just because it exists.
+- `Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking.` That means an operator acknowledged the recommendation and chose not to make it the publication gate for this profile. The dismissed candidate is still reported for visibility, but it should not keep appearing as an unresolved setup ambiguity.
 - `Repo-owned local CI contract is configured.` That means the configured command is the active fail-closed gate before PR publication or ready-for-review promotion.
 
-Operator impact: when configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again. Setup/readiness and WebUI guidance should make that visible so operators can tell the difference between a missing contract and a failing configured contract.
+Operator impact: candidate detection is advisory, dismissal is an explicit non-blocking acknowledgement, and adoption is the point where local CI becomes a fail-closed gate. When configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again. Setup/readiness and WebUI guidance should make that visible so operators can tell the difference between a missing contract, a dismissed candidate, and a failing configured contract.
 
 Explicit non-goal: `codex-supervisor` does not infer or reconstruct workflow logic from GitHub Actions YAML, other workflow YAML, or changed-file heuristics as a substitute for this contract. If a repo wants a canonical pre-PR local verification command, the repo must expose that command directly.
 

--- a/docs/operator-dashboard.md
+++ b/docs/operator-dashboard.md
@@ -92,6 +92,7 @@ Read the local CI posture the same way:
 
 - `No repo-owned local CI contract is configured.` No canonical repo-owned local gate is active, so local CI is not blocking PR publication yet.
 - `Repo-owned local CI candidate exists but localCiCommand is unset.` The repo already defines a likely entrypoint, but codex-supervisor will not run it until `localCiCommand` is configured. This warning is advisory only.
+- `Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking.` An operator acknowledged the detected candidate and intentionally left local CI unset for this profile.
 - `Repo-owned local CI contract is configured.` The configured command is now the active fail-closed gate. When configured local CI fails, PR publication stays blocked and ready-for-review promotion stays blocked until the repo-owned command passes again.
 
 If local CI is configured, remember that the config can now use either:
@@ -165,6 +166,7 @@ Use that same split when local CI is involved:
 
 - If `Issue details` is red because `issue-lint` reports missing sections or malformed metadata, fix the GitHub issue body first.
 - If `Issue details` is clean but `Doctor` or setup/readiness shows `Repo-owned local CI candidate exists but localCiCommand is unset.`, decide whether to adopt the repo script by updating supervisor config; this is not an issue-authoring failure.
+- If setup/readiness shows `Repo-owned local CI candidate was intentionally dismissed`, leave it alone unless you now want to adopt the repo command as the fail-closed local CI gate.
 - If `Issue details` is clean and the configured local CI gate fails, repair the repo or host until the configured command passes again.
 
 ## Browser smoke suite

--- a/src/backend/webui-browser-script-helpers.ts
+++ b/src/backend/webui-browser-script-helpers.ts
@@ -88,6 +88,7 @@ export function buildBrowserLocalCiChecklistEntries(
   localCiContract: BrowserLocalCiContractLike | null | undefined,
 ): BrowserChecklistEntry[] {
   const normalized = normalizeBrowserLocalCiContract(localCiContract);
+  const dismissed = normalized.source === "dismissed_repo_script_candidate";
   return [{
     title: "Configured: " + (normalized.configured ? "yes" : "no"),
     tone: "",
@@ -106,6 +107,11 @@ export function buildBrowserLocalCiChecklistEntries(
         "This repo-owned command is the canonical local verification step before PR publication or update.",
         "When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again.",
       ]
+      : dismissed
+        ? [
+          "This repo-owned local CI candidate was intentionally dismissed, so localCiCommand remains unset and non-blocking.",
+          "codex-supervisor will not run the dismissed candidate unless you opt in later by configuring localCiCommand.",
+        ]
       : normalized.recommendedCommand
         ? [
           "This repo already defines a repo-owned local CI entrypoint, but codex-supervisor will not run it until localCiCommand is configured.",
@@ -123,7 +129,16 @@ export function canAdoptBrowserLocalCiRecommendedCommand(
   hasInput: boolean,
 ): boolean {
   const normalized = normalizeBrowserLocalCiContract(localCiContract);
-  return Boolean(normalized.recommendedCommand) && hasInput;
+  return Boolean(normalized.recommendedCommand) && normalized.source !== "dismissed_repo_script_candidate" && hasInput;
+}
+
+export function canDismissBrowserLocalCiRecommendedCommand(
+  localCiContract: BrowserLocalCiContractLike | null | undefined,
+): boolean {
+  const normalized = normalizeBrowserLocalCiContract(localCiContract);
+  return Boolean(normalized.recommendedCommand) &&
+    !normalized.configured &&
+    normalized.source !== "dismissed_repo_script_candidate";
 }
 
 export function readStoredMutationAuthToken(host: BrowserHostLike, storageKey: string): string | null {

--- a/src/backend/webui-dashboard-test-fixtures.ts
+++ b/src/backend/webui-dashboard-test-fixtures.ts
@@ -365,7 +365,7 @@ export function createDashboardStatusFixture(args: {
     configured: boolean;
     command: string | null;
     recommendedCommand?: string | null;
-    source: "config" | "repo_script_candidate";
+    source: "config" | "repo_script_candidate" | "dismissed_repo_script_candidate";
     summary: string;
   } | null;
   loopRuntime?: {

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1830,6 +1830,165 @@ test("setup shell lets operators adopt the recommended local CI command and save
   );
 });
 
+test("setup shell lets operators dismiss the recommended local CI command", async () => {
+  const setupConfigResponse = createDeferred<MockResponseLike>();
+  const setupReadinessRefreshResponse = createDeferred<MockResponseLike>();
+  const harness = createSetupHarness([
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse(withManagedRestart(createSetupReadinessReport({
+        ready: true,
+        overallStatus: "configured",
+        fields: [
+          createSetupField("localCiCommand"),
+        ],
+        blockers: [],
+        hostReadiness: { overallStatus: "pass", checks: [] },
+        providerPosture: createSetupProviderPosture({
+          profile: "codex",
+          provider: "codex",
+          reviewers: ["chatgpt-codex-connector"],
+          signalSource: "review_bot_logins",
+          configured: true,
+          summary: "Codex Connector is configured.",
+        }),
+        trustPosture: createSetupTrustPosture({ warning: null }),
+        localCiContract: {
+          configured: false,
+          command: null,
+          recommendedCommand: "npm run verify:pre-pr",
+          source: "repo_script_candidate",
+          summary:
+            "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
+        },
+      }), unavailableManagedRestart)),
+    },
+    {
+      path: "/api/setup-config",
+      method: "POST",
+      body: JSON.stringify({
+        changes: {
+          localCiCandidateDismissed: true,
+        },
+      }),
+      response: setupConfigResponse.promise,
+    },
+    {
+      path: "/api/setup-readiness",
+      response: setupReadinessRefreshResponse.promise,
+    },
+  ]);
+  await harness.flush();
+
+  const dismissButton = harness.document.getElementById("setup-local-ci-dismiss-recommended");
+  const adoptButton = harness.document.getElementById("setup-local-ci-adopt-recommended");
+  const saveStatus = harness.document.getElementById("setup-save-status");
+  assert.ok(dismissButton);
+  assert.ok(adoptButton);
+  assert.ok(saveStatus);
+  assert.equal(dismissButton.hidden, false);
+  assert.equal(dismissButton.disabled, false);
+  assert.equal(adoptButton.hidden, false);
+
+  const dismissPromise = dismissButton.dispatch("click");
+  await harness.flush();
+  assert.match(saveStatus.textContent ?? "", /Dismissing recommended local CI command/u);
+
+  setupConfigResponse.resolve(jsonResponse(withManagedRestart(createSetupConfigUpdateResult({
+    backupPath: null,
+    updatedFields: ["localCiCandidateDismissed"],
+    restartTriggeredByFields: ["localCiCandidateDismissed"],
+    document: {
+      localCiCandidateDismissed: true,
+    },
+    readiness: createSetupReadinessReport({
+      ready: true,
+      overallStatus: "configured",
+      fields: [
+        createSetupField("localCiCommand"),
+      ],
+      blockers: [],
+      hostReadiness: { overallStatus: "pass", checks: [] },
+      providerPosture: createSetupProviderPosture({
+        profile: "codex",
+        provider: "codex",
+        reviewers: ["chatgpt-codex-connector"],
+        signalSource: "review_bot_logins",
+        configured: true,
+        summary: "Codex Connector is configured.",
+      }),
+      trustPosture: createSetupTrustPosture({ warning: null }),
+      localCiContract: {
+        configured: false,
+        command: null,
+        recommendedCommand: "npm run verify:pre-pr",
+        source: "dismissed_repo_script_candidate",
+        summary:
+          "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
+      },
+    }),
+  }), unavailableManagedRestart)));
+  await harness.flush();
+
+  setupReadinessRefreshResponse.resolve(jsonResponse(withManagedRestart(createSetupReadinessReport({
+    ready: true,
+    overallStatus: "configured",
+    fields: [
+      createSetupField("localCiCommand"),
+    ],
+    blockers: [],
+    hostReadiness: { overallStatus: "pass", checks: [] },
+    providerPosture: createSetupProviderPosture({
+      profile: "codex",
+      provider: "codex",
+      reviewers: ["chatgpt-codex-connector"],
+      signalSource: "review_bot_logins",
+      configured: true,
+      summary: "Codex Connector is configured.",
+    }),
+    trustPosture: createSetupTrustPosture({ warning: null }),
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: "npm run verify:pre-pr",
+      source: "dismissed_repo_script_candidate",
+      summary:
+        "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
+    },
+  }), unavailableManagedRestart)));
+
+  await dismissPromise;
+  await harness.flush();
+
+  assert.deepEqual(
+    harness.fetchCalls.map((call) => ({ path: call.path, method: call.method, body: call.body })),
+    [
+      { path: "/api/setup-readiness", method: "GET", body: null },
+      {
+        path: "/api/setup-config",
+        method: "POST",
+        body: JSON.stringify({
+          changes: {
+            localCiCandidateDismissed: true,
+          },
+        }),
+      },
+      { path: "/api/setup-readiness", method: "GET", body: null },
+    ],
+  );
+  assert.match(saveStatus.textContent ?? "", /Dismissed the recommended local CI command/u);
+  assert.match(
+    harness.document.getElementById("setup-local-ci-summary")?.textContent ?? "",
+    /Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking\./u,
+  );
+  assert.match(
+    harness.document.getElementById("setup-local-ci-details")?.textContent ?? "",
+    /Configured: no.*Source: dismissed repo script candidate.*codex-supervisor will not run the dismissed candidate unless you opt in later by configuring localCiCommand\./u,
+  );
+  assert.equal(harness.document.getElementById("setup-local-ci-dismiss-recommended")?.hidden, true);
+  assert.equal(harness.document.getElementById("setup-local-ci-adopt-recommended")?.hidden, true);
+});
+
 test("setup shell saves through the narrow setup config API and revalidates readiness after the write", async () => {
   const setupConfigResponse = createDeferred<MockResponseLike>();
   const setupReadinessRefreshResponse = createDeferred<MockResponseLike>();

--- a/src/backend/webui-local-ci-browser-helpers.test.ts
+++ b/src/backend/webui-local-ci-browser-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildLocalCiContractChecklistItems,
   buildLocalCiContractStatusLines,
   canAdoptRecommendedLocalCiCommand,
+  canDismissRecommendedLocalCiCommand,
 } from "./webui-local-ci-browser-helpers";
 
 test("local CI browser helpers summarize a repo-owned candidate contract consistently", () => {
@@ -35,6 +36,38 @@ test("local CI browser helpers summarize a repo-owned candidate contract consist
   }]);
   assert.equal(canAdoptRecommendedLocalCiCommand(contract, true), true);
   assert.equal(canAdoptRecommendedLocalCiCommand(contract, false), false);
+  assert.equal(canDismissRecommendedLocalCiCommand(contract), true);
+});
+
+test("local CI browser helpers summarize an explicitly dismissed candidate", () => {
+  const contract = {
+    configured: false,
+    command: null,
+    recommendedCommand: "npm run verify:pre-pr",
+    source: "dismissed_repo_script_candidate",
+    summary:
+      "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
+  };
+
+  assert.deepEqual(buildLocalCiContractStatusLines(contract), [
+    "local ci configured=no source=dismissed repo script candidate command=none recommended command=npm run verify:pre-pr warning=none",
+    "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
+  ]);
+  assert.deepEqual(buildLocalCiContractChecklistItems(contract), [{
+    title: "Configured: no",
+    tone: "",
+    meta: [
+      "Command: none",
+      "Source: dismissed repo script candidate",
+      "Recommended command: npm run verify:pre-pr",
+    ],
+    notes: [
+      "This repo-owned local CI candidate was intentionally dismissed, so localCiCommand remains unset and non-blocking.",
+      "codex-supervisor will not run the dismissed candidate unless you opt in later by configuring localCiCommand.",
+    ],
+  }]);
+  assert.equal(canAdoptRecommendedLocalCiCommand(contract, true), false);
+  assert.equal(canDismissRecommendedLocalCiCommand(contract), false);
 });
 
 test("local CI browser helpers preserve configured and fallback contract guidance", () => {

--- a/src/backend/webui-local-ci-browser-helpers.ts
+++ b/src/backend/webui-local-ci-browser-helpers.ts
@@ -2,6 +2,7 @@ import {
   buildBrowserLocalCiChecklistEntries,
   buildBrowserLocalCiStatusLines,
   canAdoptBrowserLocalCiRecommendedCommand,
+  canDismissBrowserLocalCiRecommendedCommand,
   formatBrowserToken,
   normalizeBrowserLocalCiContract,
   type BrowserChecklistEntry,
@@ -33,6 +34,12 @@ export function canAdoptRecommendedLocalCiCommand(
   hasLocalCiInput: boolean,
 ): boolean {
   return canAdoptBrowserLocalCiRecommendedCommand(contract, hasLocalCiInput);
+}
+
+export function canDismissRecommendedLocalCiCommand(
+  contract: BrowserLocalCiContractLike | null | undefined,
+): boolean {
+  return canDismissBrowserLocalCiRecommendedCommand(contract);
 }
 
 export function buildLocalCiContractChecklistItems(

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -3,6 +3,7 @@ import {
   buildBrowserLocalCiChecklistEntries,
   buildMutationHeaders,
   canAdoptBrowserLocalCiRecommendedCommand,
+  canDismissBrowserLocalCiRecommendedCommand,
   formatBrowserToken,
   normalizeBrowserLocalCiContract,
   postMutationJsonWithAuth,
@@ -19,6 +20,7 @@ export function renderSetupBrowserScript(): string {
         normalizeBrowserLocalCiContract,
         buildBrowserLocalCiChecklistEntries,
         canAdoptBrowserLocalCiRecommendedCommand,
+        canDismissBrowserLocalCiRecommendedCommand,
         readStoredMutationAuthToken,
         writeStoredMutationAuthToken,
         promptForMutationAuthToken,
@@ -58,6 +60,7 @@ export function renderSetupBrowserScript(): string {
         localCiActions: document.getElementById("setup-local-ci-actions"),
         localCiDetails: document.getElementById("setup-local-ci-details"),
         localCiAdoptRecommended: document.getElementById("setup-local-ci-adopt-recommended"),
+        localCiDismissRecommended: document.getElementById("setup-local-ci-dismiss-recommended"),
       };
       const editableFieldOrder = [
         "repoPath",
@@ -288,6 +291,13 @@ export function renderSetupBrowserScript(): string {
               normalizedLocalCiContract,
               Boolean(document.getElementById("setup-input-localCiCommand")),
             );
+        }
+        if (elements.localCiDismissRecommended) {
+          const normalizedLocalCiContract = normalizeBrowserLocalCiContract(currentReport && currentReport.localCiContract);
+          elements.localCiDismissRecommended.disabled =
+            disabled ||
+            elements.localCiDismissRecommended.hidden ||
+            !canDismissBrowserLocalCiRecommendedCommand(normalizedLocalCiContract);
         }
         syncRestartButton();
         for (const field of editableFields(currentReport || {})) {
@@ -564,6 +574,11 @@ export function renderSetupBrowserScript(): string {
           elements.localCiAdoptRecommended.hidden = !canAdoptRecommended;
           elements.localCiAdoptRecommended.disabled = saveInFlight || !canAdoptRecommended;
         }
+        if (elements.localCiDismissRecommended) {
+          const canDismissRecommended = canDismissBrowserLocalCiRecommendedCommand(localCiContract);
+          elements.localCiDismissRecommended.hidden = !canDismissRecommended;
+          elements.localCiDismissRecommended.disabled = saveInFlight || !canDismissRecommended;
+        }
         renderChecklist(
           elements.localCiDetails,
           buildBrowserLocalCiChecklistEntries(localCiContract),
@@ -693,12 +708,36 @@ export function renderSetupBrowserScript(): string {
         setSaveStatus("Recommended local CI command copied into the setup field. Save to opt in.");
       }
 
+      async function handleDismissRecommendedLocalCiClick() {
+        if (!currentReport || !canDismissBrowserLocalCiRecommendedCommand(currentReport.localCiContract)) {
+          return;
+        }
+
+        setFormDisabled(true);
+        setSaveStatus("Dismissing recommended local CI command...");
+        try {
+          const result = await writeJson("/api/setup-config", { changes: { localCiCandidateDismissed: true } });
+          setSaveStatus("Revalidating setup readiness...");
+          await refreshSetupReadiness();
+          renderRestartOutcome(result);
+          setSaveStatus("Dismissed the recommended local CI command. localCiCommand remains unset.");
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          setSaveStatus("Local CI dismissal failed: " + message);
+        } finally {
+          setFormDisabled(false);
+        }
+      }
+
       async function bootstrap() {
         if (elements.form) {
           elements.form.addEventListener("submit", handleSetupSubmit);
         }
         if (elements.localCiAdoptRecommended) {
           elements.localCiAdoptRecommended.addEventListener("click", handleAdoptRecommendedLocalCiClick);
+        }
+        if (elements.localCiDismissRecommended) {
+          elements.localCiDismissRecommended.addEventListener("click", handleDismissRecommendedLocalCiClick);
         }
         if (elements.restartButton) {
           elements.restartButton.addEventListener("click", handleManagedRestartClick);

--- a/src/backend/webui-setup-page.ts
+++ b/src/backend/webui-setup-page.ts
@@ -770,6 +770,7 @@ ${renderSetupNavigation()}
                     <p id="setup-local-ci-summary" class="hint">Loading typed local CI contract…</p>
                     <div id="setup-local-ci-actions" class="actions">
                       <button id="setup-local-ci-adopt-recommended" class="button" type="button" hidden disabled>Use recommended command</button>
+                      <button id="setup-local-ci-dismiss-recommended" class="button button--secondary" type="button" hidden disabled>Dismiss recommendation</button>
                     </div>
                     <ul id="setup-local-ci-details" class="list list--plain checklist-grid">
                       <li>Loading local CI contract details…</li>

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1896,6 +1896,64 @@ test("updateSetupConfig clears localCiCommand back to the unset state", async (t
   });
 });
 
+test("updateSetupConfig records an explicit local CI candidate dismissal", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-dismiss-local-ci-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  const repoPath = path.join(tempDir, "repo");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "package.json"),
+    JSON.stringify({
+      scripts: {
+        "verify:pre-pr": "npm test",
+      },
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        repoPath,
+        repoSlug: "owner/repo",
+        defaultBranch: "main",
+        workspaceRoot: path.join(tempDir, "worktrees"),
+        stateFile: path.join(tempDir, "state.json"),
+        codexBinary: process.execPath,
+        branchPrefix: "codex/issue-",
+        reviewBotLogins: ["chatgpt-codex-connector"],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const result = await updateSetupConfig({
+    configPath,
+    changes: {
+      localCiCandidateDismissed: true,
+    },
+  });
+
+  const updatedDocument = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
+  assert.equal(updatedDocument.localCiCandidateDismissed, true);
+  assert.deepEqual(result.updatedFields, ["localCiCandidateDismissed"]);
+  assert.deepEqual(result.restartTriggeredByFields, ["localCiCandidateDismissed"]);
+  assert.deepEqual(result.readiness.localCiContract, {
+    configured: false,
+    command: null,
+    recommendedCommand: "npm run verify:pre-pr",
+    source: "dismissed_repo_script_candidate",
+    summary:
+      "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
+    warning: null,
+  });
+});
+
 test("updateSetupConfig rejects invalid setup field values before touching the config file", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-invalid-"));
   t.after(async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1954,6 +1954,43 @@ test("updateSetupConfig records an explicit local CI candidate dismissal", async
   });
 });
 
+test("updateSetupConfig rejects conflicting local CI adoption and dismissal before touching the config file", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-local-ci-conflict-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  const originalDocument = {
+    repoPath: ".",
+    repoSlug: "owner/repo",
+    defaultBranch: "main",
+    workspaceRoot: "./worktrees",
+    stateFile: "./state.json",
+    codexBinary: process.execPath,
+    branchPrefix: "codex/issue-",
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    experimentalFlag: true,
+  };
+  await fs.writeFile(configPath, JSON.stringify(originalDocument, null, 2), "utf8");
+  const before = await fs.readFile(configPath, "utf8");
+
+  await assert.rejects(
+    () =>
+      updateSetupConfig({
+        configPath,
+        changes: {
+          localCiCommand: "npm run verify:pre-pr",
+          localCiCandidateDismissed: true,
+        },
+      }),
+    /localCiCommand and localCiCandidateDismissed=true cannot be set in the same update\./u,
+  );
+
+  const after = await fs.readFile(configPath, "utf8");
+  assert.equal(after, before);
+  await assert.rejects(fs.access(`${configPath}.bak`));
+});
+
 test("updateSetupConfig rejects invalid setup field values before touching the config file", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-invalid-"));
   t.after(async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1991,6 +1991,68 @@ test("updateSetupConfig rejects conflicting local CI adoption and dismissal befo
   await assert.rejects(fs.access(`${configPath}.bak`));
 });
 
+test("updateSetupConfig reports restart when dismissal resolves a malformed configured local CI state", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-local-ci-effective-dismiss-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  const repoPath = path.join(tempDir, "repo");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "package.json"),
+    JSON.stringify({
+      scripts: {
+        "verify:pre-pr": "npm test",
+      },
+    }),
+    "utf8",
+  );
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        repoPath,
+        repoSlug: "owner/repo",
+        defaultBranch: "main",
+        workspaceRoot: path.join(tempDir, "worktrees"),
+        stateFile: path.join(tempDir, "state.json"),
+        codexBinary: process.execPath,
+        branchPrefix: "codex/issue-",
+        reviewBotLogins: ["chatgpt-codex-connector"],
+        localCiCommand: "npm run ci:local",
+        localCiCandidateDismissed: true,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const result = await updateSetupConfig({
+    configPath,
+    changes: {
+      localCiCandidateDismissed: true,
+    },
+  });
+
+  const updatedDocument = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
+  assert.ok(!("localCiCommand" in updatedDocument));
+  assert.equal(updatedDocument.localCiCandidateDismissed, true);
+  assert.equal(result.restartRequired, true);
+  assert.equal(result.restartScope, "supervisor");
+  assert.deepEqual(result.restartTriggeredByFields, ["localCiCandidateDismissed"]);
+  assert.deepEqual(result.readiness.localCiContract, {
+    configured: false,
+    command: null,
+    recommendedCommand: "npm run verify:pre-pr",
+    source: "dismissed_repo_script_candidate",
+    summary:
+      "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
+    warning: null,
+  });
+});
+
 test("updateSetupConfig rejects invalid setup field values before touching the config file", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-invalid-"));
   t.after(async () => {

--- a/src/core/config-diagnostics.ts
+++ b/src/core/config-diagnostics.ts
@@ -69,7 +69,7 @@ export function summarizeCadenceDiagnostics(
 }
 
 export function summarizeLocalCiContract(
-  config: Pick<SupervisorConfig, "localCiCommand" | "workspacePreparationCommand"> & { repoPath?: string },
+  config: Pick<SupervisorConfig, "localCiCommand" | "workspacePreparationCommand" | "localCiCandidateDismissed"> & { repoPath?: string },
 ): LocalCiContractSummary {
   const command = displayLocalCiCommand(config.localCiCommand);
   const recommendedCommand = findRepoOwnedLocalCiCandidate(config.repoPath);
@@ -83,6 +83,18 @@ export function summarizeLocalCiContract(
       source: "config",
       summary: "Repo-owned local CI contract is configured.",
       warning,
+    };
+  }
+
+  if (recommendedCommand !== null && config.localCiCandidateDismissed === true) {
+    return {
+      configured: false,
+      command: null,
+      recommendedCommand,
+      source: "dismissed_repo_script_candidate",
+      summary:
+        `Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: ${recommendedCommand}.`,
+      warning: null,
     };
   }
 

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -415,6 +415,7 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
     issueSearch: typeof raw.issueSearch === "string" ? raw.issueSearch : undefined,
     workspacePreparationCommand: normalizeLocalCiCommand(raw.workspacePreparationCommand),
     localCiCommand: normalizeLocalCiCommand(raw.localCiCommand),
+    localCiCandidateDismissed: raw.localCiCandidateDismissed === true,
     candidateDiscoveryFetchWindow:
       typeof raw.candidateDiscoveryFetchWindow === "number" &&
       Number.isFinite(raw.candidateDiscoveryFetchWindow) &&

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -82,7 +82,7 @@ export interface LocalCiContractSummary {
   configured: boolean;
   command: string | null;
   recommendedCommand: string | null;
-  source: "config" | "repo_script_candidate";
+  source: "config" | "repo_script_candidate" | "dismissed_repo_script_candidate";
   summary: string;
   warning?: string | null;
 }
@@ -185,6 +185,7 @@ export interface SupervisorConfig {
   issueSearch?: string;
   workspacePreparationCommand?: LocalCiCommandConfig;
   localCiCommand?: LocalCiCommandConfig;
+  localCiCandidateDismissed?: boolean;
   candidateDiscoveryFetchWindow?: number;
   skipTitlePrefixes: string[];
   branchPrefix: string;

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1421,6 +1421,41 @@ test("renderDoctorReport surfaces advisory local CI posture when a repo-owned ca
   );
 });
 
+test("renderDoctorReport surfaces explicitly dismissed local CI candidate posture", () => {
+  const report = renderDoctorReport({
+    overallStatus: "pass",
+    trustDiagnostics: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+      configWarning: null,
+    },
+    checks: [],
+    cadenceDiagnostics: {
+      pollIntervalSeconds: 120,
+      mergeCriticalRecheckSeconds: null,
+      mergeCriticalEffectiveSeconds: 120,
+      mergeCriticalRecheckEnabled: false,
+    },
+    candidateDiscoverySummary: "doctor_candidate_discovery fetch_window=100 strategy=paginated",
+    candidateDiscoveryWarning: null,
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: "npm run verify:supervisor-pre-pr",
+      source: "dismissed_repo_script_candidate",
+      summary:
+        "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:supervisor-pre-pr.",
+      warning: null,
+    },
+  } as Awaited<ReturnType<typeof diagnoseSupervisorHost>>);
+
+  assert.match(
+    report,
+    /doctor_local_ci configured=false source=dismissed_repo_script_candidate command=none summary=Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking\. Dismissed candidate: npm run verify:supervisor-pre-pr\./,
+  );
+});
+
 test("renderDoctorReport warns when localCiCommand is configured without workspacePreparationCommand", () => {
   const report = renderDoctorReport({
     overallStatus: "pass",

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -329,10 +329,16 @@ function currentSemanticFieldValue(args: {
   }
 
   if (field === "localCiCandidateDismissed") {
-    const value = resolvedConfig !== null
-      ? resolvedConfig.localCiCandidateDismissed
-      : existingDocument.localCiCandidateDismissed;
-    return value === true ? "true" : "false";
+    const currentLocalCiCommand =
+      resolvedConfig !== null
+        ? displayLocalCiCommand(resolvedConfig.localCiCommand)
+        : displayStringValue(existingDocument.localCiCommand);
+    const dismissedValue =
+      resolvedConfig !== null
+        ? resolvedConfig.localCiCandidateDismissed
+        : existingDocument.localCiCandidateDismissed;
+    const effectiveDismissed = currentLocalCiCommand === null && dismissedValue === true;
+    return effectiveDismissed ? "true" : "false";
   }
 
   if (resolvedConfig !== null) {

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -122,6 +122,12 @@ function normalizeLocalCiCommand(value: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+function assertNoConflictingLocalCiIntent(changes: SetupConfigChanges): void {
+  if (changes.localCiCandidateDismissed === true && typeof changes.localCiCommand === "string") {
+    throw new Error("localCiCommand and localCiCandidateDismissed=true cannot be set in the same update.");
+  }
+}
+
 function validateProspectiveSetupDocument(configPath: string, nextDocument: Record<string, unknown>): void {
   const configDir = path.dirname(configPath);
   const repoPath =
@@ -188,6 +194,8 @@ function normalizeSetupChanges(changes: unknown): SetupConfigChanges {
     throw new Error("changes must include at least one supported setup field.");
   }
 
+  assertNoConflictingLocalCiIntent(normalized);
+
   return normalized;
 }
 
@@ -220,6 +228,8 @@ async function readExistingConfigDocument(configPath: string): Promise<{
 }
 
 function applySetupChanges(document: Record<string, unknown>, changes: SetupConfigChanges): Record<string, unknown> {
+  assertNoConflictingLocalCiIntent(changes);
+
   const nextDocument = { ...document };
   if (changes.repoPath !== undefined) {
     nextDocument.repoPath = changes.repoPath;

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -22,6 +22,7 @@ export interface SetupConfigChanges {
   branchPrefix?: string;
   workspacePreparationCommand?: string | null;
   localCiCommand?: string | null;
+  localCiCandidateDismissed?: boolean;
   reviewProvider?: SetupConfigPreviewSelectableReviewProviderProfile;
 }
 
@@ -34,15 +35,17 @@ export interface SetupConfigUpdateResult {
   kind: "setup_config_update";
   configPath: string;
   backupPath: string | null;
-  updatedFields: SetupReadinessFieldKey[];
+  updatedFields: SetupConfigWritableFieldKey[];
   restartRequired: boolean;
   restartScope: "supervisor" | null;
-  restartTriggeredByFields: SetupReadinessFieldKey[];
+  restartTriggeredByFields: SetupConfigWritableFieldKey[];
   document: Record<string, unknown>;
   readiness: SetupReadinessReport;
 }
 
-const CONFIGURABLE_FIELDS: SetupReadinessFieldKey[] = [
+type SetupConfigWritableFieldKey = SetupReadinessFieldKey | "localCiCandidateDismissed";
+
+const CONFIGURABLE_FIELDS: SetupConfigWritableFieldKey[] = [
   "repoPath",
   "repoSlug",
   "defaultBranch",
@@ -52,10 +55,11 @@ const CONFIGURABLE_FIELDS: SetupReadinessFieldKey[] = [
   "branchPrefix",
   "workspacePreparationCommand",
   "localCiCommand",
+  "localCiCandidateDismissed",
   "reviewProvider",
 ];
 
-const RESTART_REQUIRED_FIELDS = new Set<SetupReadinessFieldKey>(CONFIGURABLE_FIELDS);
+const RESTART_REQUIRED_FIELDS = new Set<SetupConfigWritableFieldKey>(CONFIGURABLE_FIELDS);
 
 const REVIEW_PROVIDER_LOGIN_MAP: Record<SetupConfigPreviewSelectableReviewProviderProfile, string[]> = {
   none: [],
@@ -98,6 +102,14 @@ function assertReviewProvider(value: unknown): SetupConfigPreviewSelectableRevie
   throw new Error("reviewProvider must be one of none, copilot, codex, or coderabbit.");
 }
 
+function assertBoolean(value: unknown, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${fieldName} must be a boolean.`);
+  }
+
+  return value;
+}
+
 function normalizeLocalCiCommand(value: unknown): string | null {
   if (value === null) {
     return null;
@@ -132,7 +144,7 @@ function normalizeSetupChanges(changes: unknown): SetupConfigChanges {
   }
 
   const raw = changes as Record<string, unknown>;
-  const unknownFields = Object.keys(raw).filter((key) => !CONFIGURABLE_FIELDS.includes(key as SetupReadinessFieldKey));
+  const unknownFields = Object.keys(raw).filter((key) => !CONFIGURABLE_FIELDS.includes(key as SetupConfigWritableFieldKey));
   if (unknownFields.length > 0) {
     throw new Error(`Unsupported setup config field: ${unknownFields[0]}`);
   }
@@ -164,6 +176,9 @@ function normalizeSetupChanges(changes: unknown): SetupConfigChanges {
   }
   if ("localCiCommand" in raw) {
     normalized.localCiCommand = normalizeLocalCiCommand(raw.localCiCommand);
+  }
+  if ("localCiCandidateDismissed" in raw) {
+    normalized.localCiCandidateDismissed = assertBoolean(raw.localCiCandidateDismissed, "localCiCandidateDismissed");
   }
   if ("reviewProvider" in raw) {
     normalized.reviewProvider = assertReviewProvider(raw.reviewProvider);
@@ -239,6 +254,15 @@ function applySetupChanges(document: Record<string, unknown>, changes: SetupConf
       delete nextDocument.localCiCommand;
     } else {
       nextDocument.localCiCommand = changes.localCiCommand;
+      delete nextDocument.localCiCandidateDismissed;
+    }
+  }
+  if ("localCiCandidateDismissed" in changes) {
+    if (changes.localCiCandidateDismissed) {
+      nextDocument.localCiCandidateDismissed = true;
+      delete nextDocument.localCiCommand;
+    } else {
+      delete nextDocument.localCiCandidateDismissed;
     }
   }
   if (changes.reviewProvider !== undefined) {
@@ -259,7 +283,7 @@ function displayStringValue(value: unknown): string | null {
 function currentSemanticFieldValue(args: {
   configSummary: ReturnType<typeof loadConfigSummary>;
   existingDocument: Record<string, unknown>;
-  field: SetupReadinessFieldKey;
+  field: SetupConfigWritableFieldKey;
 }): string | null {
   const { configSummary, existingDocument, field } = args;
   const resolvedConfig = configSummary.config;
@@ -294,6 +318,13 @@ function currentSemanticFieldValue(args: {
     return displayStringValue(existingDocument.workspacePreparationCommand);
   }
 
+  if (field === "localCiCandidateDismissed") {
+    const value = resolvedConfig !== null
+      ? resolvedConfig.localCiCandidateDismissed
+      : existingDocument.localCiCandidateDismissed;
+    return value === true ? "true" : "false";
+  }
+
   if (resolvedConfig !== null) {
     return displayStringValue(resolvedConfig[field]);
   }
@@ -301,7 +332,7 @@ function currentSemanticFieldValue(args: {
   return displayStringValue(existingDocument[field]);
 }
 
-function nextSemanticFieldValue(field: SetupReadinessFieldKey, changes: SetupConfigChanges): string | null {
+function nextSemanticFieldValue(field: SetupConfigWritableFieldKey, changes: SetupConfigChanges): string | null {
   switch (field) {
     case "repoPath":
       return changes.repoPath ?? null;
@@ -321,6 +352,8 @@ function nextSemanticFieldValue(field: SetupReadinessFieldKey, changes: SetupCon
       return changes.workspacePreparationCommand ?? null;
     case "localCiCommand":
       return changes.localCiCommand ?? null;
+    case "localCiCandidateDismissed":
+      return changes.localCiCandidateDismissed === true ? "true" : "false";
     case "reviewProvider":
       return changes.reviewProvider ?? null;
   }
@@ -330,7 +363,7 @@ function determineRestartTriggeredFields(args: {
   configSummary: ReturnType<typeof loadConfigSummary>;
   existingDocument: Record<string, unknown>;
   changes: SetupConfigChanges;
-}): SetupReadinessFieldKey[] {
+}): SetupConfigWritableFieldKey[] {
   const { configSummary, existingDocument, changes } = args;
   const updatedFields = CONFIGURABLE_FIELDS.filter((field) => field in changes);
   return updatedFields.filter((field) => {

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -654,6 +654,7 @@ export async function diagnoseSetupReadiness(
   const localCiContractConfig = configSummary.config ?? {
     localCiCommand: tryNormalizeLocalCiCommand(rawConfigDocument.localCiCommand),
     workspacePreparationCommand: tryNormalizeLocalCiCommand(rawConfigDocument.workspacePreparationCommand),
+    localCiCandidateDismissed: rawConfigDocument.localCiCandidateDismissed === true,
     repoPath: fallbackRepoPath,
   };
   const workspacePreparationWarning = validateWorkspacePreparationCommandForWorktrees(localCiContractConfig);


### PR DESCRIPTION
## Summary
- add a durable localCiCandidateDismissed config flag and setup-owned write path
- distinguish configured, detected, dismissed, and absent local CI states in setup/readiness, doctor, and WebUI
- document the safety difference between detected candidates, explicit dismissal, and adopted fail-closed local CI

## Verification
- npx tsx --test src/doctor.test.ts src/config.test.ts src/backend/webui-dashboard.test.ts src/local-ci.test.ts
- npm run build
- npx tsx --test src/getting-started-docs.test.ts src/readme-docs.test.ts src/agent-instructions-docs.test.ts
- npm run verify:paths

Part of #1637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can explicitly dismiss a detected repo-owned local CI candidate from the setup UI; dismissal is persisted, keeps the candidate non-blocking, and hides adopt/dismiss controls once applied.
  * New secondary button in the Local CI diagnostics to perform dismissal.

* **Documentation**
  * Clarified operator guidance distinguishing adopting (fail-closed) vs dismissing (non-blocking) local CI candidates and updated readiness/dashboard messaging.

* **Tests**
  * Added coverage for dismissal flows, UX states, and adopt/dismiss validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->