### PR TITLE
Add explicit setup trust posture selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,4 +264,4 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Issue metadata](./docs/issue-metadata.md): canonical issue-body fields, sequencing rules, and execution-ready examples
 - [GSD to GitHub issues](./docs/examples/gsd-to-github-issues.md): how to hand planning output into execution-ready issues
 - [Atlas example](./docs/examples/atlaspm.md): a concrete config and workflow example
-- [Release readiness checklist](./docs/validation-checklist.md): advisory minimum, recommended, and sufficient release-readiness checks
+- [Validation checklist](./docs/validation-checklist.md): advisory minimum, recommended, and sufficient release-readiness checks

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -422,6 +422,8 @@ Diagnostics that matter here:
 - `codexReasoningEffortByState`
 - `codexReasoningEscalateOnRepeatedFailure`
 
+Choose `trustMode` and `executionSafetyMode` explicitly during first-run setup. `trusted_repo_and_authors` plus `unsandboxed_autonomous` is the trusted solo-lane posture: it is appropriate only when the operator trusts the repository and the GitHub authors who can write issue bodies, PR comments, and review text that become execution inputs. For untrusted or mixed-author repositories, use `untrusted_or_mixed` or keep execution behind `operator_gated`; the supervisor keeps the existing fail-closed execution guard instead of silently treating those inputs as safe.
+
 ### Durable memory and planning
 
 - `sharedMemoryFiles`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -422,7 +422,7 @@ Diagnostics that matter here:
 - `codexReasoningEffortByState`
 - `codexReasoningEscalateOnRepeatedFailure`
 
-Choose `trustMode` and `executionSafetyMode` explicitly during first-run setup. `trusted_repo_and_authors` plus `unsandboxed_autonomous` is the trusted solo-lane posture: it is appropriate only when the operator trusts the repository and the GitHub authors who can write issue bodies, PR comments, and review text that become execution inputs. For untrusted or mixed-author repositories, use `untrusted_or_mixed` or keep execution behind `operator_gated`; the supervisor keeps the existing fail-closed execution guard instead of silently treating those inputs as safe.
+Choose `trustMode` and `executionSafetyMode` explicitly during first-run setup. `trusted_repo_and_authors` plus `unsandboxed_autonomous` is the trusted solo-lane posture: it is appropriate only when the operator trusts the repository and the GitHub authors who can write issue bodies, PR comments, and review text that become execution inputs. For untrusted or mixed-author repositories, set `executionSafetyMode: "operator_gated"`; setting only `trustMode: "untrusted_or_mixed"` does not force fail-closed execution because `unsandboxed_autonomous` remains an explicit override. Once execution is gated, `trustMode` is the secondary policy that decides whether trusted repo/authors are enough or whether `untrusted_or_mixed` requires an explicit trusted-input signal.
 
 ### Durable memory and planning
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -289,6 +289,8 @@ type SetupReadinessFieldKey =
   | "codexBinary"
   | "branchPrefix"
   | "localCiCommand"
+  | "trustMode"
+  | "executionSafetyMode"
   | "reviewProvider";
 type SetupReadinessFieldValueType =
   | "directory_path"
@@ -297,6 +299,8 @@ type SetupReadinessFieldValueType =
   | "file_path"
   | "executable_path"
   | "text"
+  | "trust_mode"
+  | "execution_safety_mode"
   | "review_provider";
 type SetupReadinessRemediationKind =
   | "edit_config"
@@ -347,6 +351,7 @@ Minimum rules for that contract:
 - `blockers` lists only the conditions that still prevent a safe first run
 - each blocker carries typed remediation guidance so the browser does not have to reverse-engineer next actions from free-form text
 - the setup flow and WebUI should surface whether the repo-owned local CI contract is configured so operators know whether PR publication depends on a canonical repo-owned pre-PR command or on issue-level verification guidance
+- the setup flow and WebUI should surface `trustMode` and `executionSafetyMode` as explicit first-run decisions; inferred runtime defaults remain compatibility behavior, not a completed setup decision
 - `ready` becomes `true` only when no first-run blockers remain
 - ongoing diagnostics such as GitHub auth details, corrupted state-file findings, orphaned worktree candidates, and other repair-oriented host checks stay in `doctor`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,13 +85,17 @@ Then choose the review provider profile that matches your PR review flow. The ac
 
 Either copy one of those files over `supervisor.config.json` as a starting point, copy it to a separate profile such as `supervisor.config.local.json`, or copy only its `reviewBotLogins` into your active config.
 
-At minimum, set these fields before the first run:
+At minimum, set these first-run fields before the first run:
 
 - `repoPath`
 - `repoSlug`
 - `workspaceRoot`
 - `codexBinary`
+- `trustMode`
+- `executionSafetyMode`
 - provider-specific review settings you expect the supervisor to watch
+
+The setup/readiness report stays `ready: false` until these required first-run blockers, including the explicit trust posture decisions, are resolved.
 
 The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so operators must replace it before the first run.
 

--- a/src/backend/setup-test-fixtures.ts
+++ b/src/backend/setup-test-fixtures.ts
@@ -202,6 +202,30 @@ const DEFAULT_SETUP_FIELD_FIXTURES: Record<SetupReadinessFieldKey, Omit<SetupRea
       valueType: "text",
     },
   },
+  trustMode: {
+    label: "Trust mode",
+    state: "configured",
+    value: "trusted_repo_and_authors",
+    message: "Trust mode is explicitly configured.",
+    required: true,
+    metadata: {
+      source: "config",
+      editable: true,
+      valueType: "trust_mode",
+    },
+  },
+  executionSafetyMode: {
+    label: "Execution safety mode",
+    state: "configured",
+    value: "unsandboxed_autonomous",
+    message: "Execution safety mode is explicitly configured.",
+    required: true,
+    metadata: {
+      source: "config",
+      editable: true,
+      valueType: "execution_safety_mode",
+    },
+  },
   reviewProvider: {
     label: "Review provider",
     state: "missing",
@@ -301,8 +325,11 @@ export function createSetupTrustPosture(
   return {
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
-    warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
-    summary: "Trusted inputs with unsandboxed autonomous execution.",
+    configured: true,
+    warning:
+      "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
+    summary:
+      "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
     ...overrides,
   };
 }

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -734,9 +734,12 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
     },
     trustPosture: {
       trustMode: "trusted_repo_and_authors",
+      configured: true,
       executionSafetyMode: "unsandboxed_autonomous",
-      warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
-      summary: "Trusted inputs with unsandboxed autonomous execution.",
+      warning:
+        "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
+      summary:
+        "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
     },
     modelRoutingPosture: {
       summary: "Model routing follows the host Codex default model unless you opt into a per-target override.",
@@ -1355,9 +1358,12 @@ test("createSupervisorHttpServer accepts narrow setup config writes and returns 
       },
       trustPosture: {
         trustMode: "trusted_repo_and_authors",
+        configured: true,
         executionSafetyMode: "unsandboxed_autonomous",
-        warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
-        summary: "Trusted inputs with unsandboxed autonomous execution.",
+        warning:
+          "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
+        summary:
+          "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
       },
       modelRoutingPosture: {
         summary: "Model routing follows the host Codex default model unless you opt into a per-target override.",
@@ -1609,9 +1615,12 @@ test("createSupervisorHttpServer surfaces no-op setup config writes without a re
           },
           trustPosture: {
             trustMode: "trusted_repo_and_authors",
+            configured: true,
             executionSafetyMode: "unsandboxed_autonomous",
-            warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
-            summary: "Trusted inputs with unsandboxed autonomous execution.",
+            warning:
+              "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
+            summary:
+              "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
           },
         },
       },
@@ -1677,9 +1686,12 @@ test("createSupervisorHttpServer surfaces no-op setup config writes without a re
       },
       trustPosture: {
         trustMode: "trusted_repo_and_authors",
+        configured: true,
         executionSafetyMode: "unsandboxed_autonomous",
-        warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
-        summary: "Trusted inputs with unsandboxed autonomous execution.",
+        warning:
+          "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
+        summary:
+          "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
       },
     },
   });
@@ -2022,7 +2034,8 @@ test("createSupervisorHttpServer keeps root on the operator dashboard after setu
         trustMode: "trusted_repo_and_authors",
         executionSafetyMode: "unsandboxed_autonomous",
         warning: null,
-        summary: "Trusted inputs with unsandboxed autonomous execution.",
+        summary:
+          "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
       },
     },
   };

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -2362,6 +2362,118 @@ test("setup shell saves through the narrow setup config API and revalidates read
   assert.equal(harness.remainingFetches.length, 0);
 });
 
+test("setup shell does not persist missing trust posture selects during unrelated saves", async () => {
+  const harness = createSetupHarness([
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse(createSetupReadinessReport({
+        ready: false,
+        overallStatus: "missing",
+        configPath: "/tmp/supervisor.config.json",
+        fields: [
+          createSetupField("repoPath", {
+            state: "missing",
+            value: null,
+            message: "Repository path is required before first-run setup is complete.",
+          }),
+          createSetupField("trustMode", {
+            state: "missing",
+            value: null,
+            message: "Trust mode needs an explicit first-run setup decision.",
+          }),
+          createSetupField("executionSafetyMode", {
+            state: "missing",
+            value: null,
+            message: "Execution safety mode needs an explicit first-run setup decision.",
+          }),
+          createSetupField("reviewProvider", {
+            state: "configured",
+            value: "chatgpt-codex-connector",
+            message: "Review provider posture is configured.",
+          }),
+        ],
+        blockers: [],
+        providerPosture: createSetupProviderPosture({
+          profile: "codex",
+          provider: "codex",
+          reviewers: ["chatgpt-codex-connector"],
+          signalSource: "reviewBotLogins",
+          configured: true,
+          summary: "Review provider posture uses codex via reviewBotLogins.",
+        }),
+        trustPosture: createSetupTrustPosture({
+          configured: false,
+          summary: "Trust posture needs an explicit first-run setup decision.",
+        }),
+      })),
+    },
+    {
+      path: "/api/setup-config",
+      method: "POST",
+      body: JSON.stringify({
+        changes: {
+          repoPath: "/tmp/repo",
+          reviewProvider: "codex",
+        },
+      }),
+      response: jsonResponse(createSetupConfigUpdateResult({
+        updatedFields: ["repoPath", "reviewProvider"],
+        restartRequired: true,
+        restartScope: "supervisor",
+        restartTriggeredByFields: ["repoPath", "reviewProvider"],
+      })),
+    },
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse(createSetupReadinessReport()),
+    },
+  ]);
+  await harness.flush();
+
+  const repoPathInput = harness.document.getElementById("setup-input-repoPath");
+  const trustModeInput = harness.document.getElementById("setup-input-trustMode");
+  const executionSafetyModeInput = harness.document.getElementById("setup-input-executionSafetyMode");
+  const setupForm = harness.document.getElementById("setup-form");
+  assert.ok(repoPathInput);
+  assert.ok(trustModeInput);
+  assert.ok(executionSafetyModeInput);
+  assert.ok(setupForm);
+  assert.equal(trustModeInput.value, "");
+  assert.equal(executionSafetyModeInput.value, "");
+  assert.deepEqual(
+    trustModeInput.children.map((child) => [child.value, child.textContent]),
+    [
+      ["", "Select an option"],
+      ["untrusted_or_mixed", "Untrusted or mixed authors"],
+      ["trusted_repo_and_authors", "Trusted repo and authors"],
+    ],
+  );
+
+  repoPathInput.value = "/tmp/repo";
+  await setupForm.dispatch("submit", {
+    preventDefault() {},
+  });
+  await harness.flush();
+
+  assert.deepEqual(
+    harness.fetchCalls.map((call) => ({ path: call.path, method: call.method, body: call.body })),
+    [
+      { path: "/api/setup-readiness", method: "GET", body: null },
+      {
+        path: "/api/setup-config",
+        method: "POST",
+        body: JSON.stringify({
+          changes: {
+            repoPath: "/tmp/repo",
+            reviewProvider: "codex",
+          },
+        }),
+      },
+      { path: "/api/setup-readiness", method: "GET", body: null },
+    ],
+  );
+});
+
 test("setup shell warns when localCiCommand is configured without workspacePreparationCommand", async () => {
   const harness = createSetupHarness([
     {

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1613,7 +1613,10 @@ test("setup shell loads typed setup readiness without mixing in dashboard status
     harness.document.getElementById("setup-model-routing-details")?.textContent ?? "",
     /Bounded repair override \[Inherit\].*Leave boundedRepairModelStrategy unset or use `"inherit"` to keep following the default Codex route\./u,
   );
-  assert.match(harness.document.getElementById("setup-trust-details")?.textContent ?? "", /Trust mode: Trusted Repo And Authors.*Execution safety: Unsandboxed Autonomous.*Warning: Unsandboxed autonomous execution assumes trusted GitHub-authored inputs\./u);
+  assert.match(
+    harness.document.getElementById("setup-trust-details")?.textContent ?? "",
+    /Trust mode: Trusted Repo And Authors.*Execution safety: Unsandboxed Autonomous.*Explicit setup decision: configured.*Warning: Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution\./u,
+  );
   assert.match(harness.document.getElementById("setup-local-ci-summary")?.textContent ?? "", /No repo-owned local CI contract is configured\./u);
   assert.match(
     harness.document.getElementById("setup-local-ci-details")?.textContent ?? "",
@@ -2028,6 +2031,32 @@ test("setup shell saves through the narrow setup config API and revalidates read
               valueType: "review_provider",
             },
           },
+          {
+            key: "trustMode",
+            label: "Trust mode",
+            state: "missing",
+            value: null,
+            message: "Trust mode needs an explicit first-run setup decision.",
+            required: true,
+            metadata: {
+              source: "config",
+              editable: true,
+              valueType: "trust_mode",
+            },
+          },
+          {
+            key: "executionSafetyMode",
+            label: "Execution safety mode",
+            state: "missing",
+            value: null,
+            message: "Execution safety mode needs an explicit first-run setup decision.",
+            required: true,
+            metadata: {
+              source: "config",
+              editable: true,
+              valueType: "execution_safety_mode",
+            },
+          },
         ],
         blockers: [
           {
@@ -2050,6 +2079,26 @@ test("setup shell saves through the narrow setup config API and revalidates read
               fieldKeys: ["reviewProvider"],
             },
           },
+          {
+            code: "missing_trust_mode",
+            message: "Trust mode needs an explicit first-run setup decision.",
+            fieldKeys: ["trustMode"],
+            remediation: {
+              kind: "edit_config",
+              summary: "Trust mode needs an explicit first-run setup decision.",
+              fieldKeys: ["trustMode"],
+            },
+          },
+          {
+            code: "missing_execution_safety_mode",
+            message: "Execution safety mode needs an explicit first-run setup decision.",
+            fieldKeys: ["executionSafetyMode"],
+            remediation: {
+              kind: "edit_config",
+              summary: "Execution safety mode needs an explicit first-run setup decision.",
+              fieldKeys: ["executionSafetyMode"],
+            },
+          },
         ],
         hostReadiness: {
           overallStatus: "pass",
@@ -2066,8 +2115,10 @@ test("setup shell saves through the narrow setup config API and revalidates read
         trustPosture: {
           trustMode: "trusted_repo_and_authors",
           executionSafetyMode: "unsandboxed_autonomous",
-          warning: null,
-          summary: "Trusted inputs with unsandboxed autonomous execution.",
+          configured: false,
+          warning:
+            "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
+          summary: "Trust posture needs an explicit first-run setup decision.",
         },
         localCiContract: {
           configured: false,
@@ -2083,6 +2134,8 @@ test("setup shell saves through the narrow setup config API and revalidates read
       body: JSON.stringify({
         changes: {
           repoPath: "/tmp/repo",
+          trustMode: "untrusted_or_mixed",
+          executionSafetyMode: "operator_gated",
           reviewProvider: "codex",
         },
       }),
@@ -2097,6 +2150,8 @@ test("setup shell saves through the narrow setup config API and revalidates read
 
   const repoPathInput = harness.document.getElementById("setup-input-repoPath");
   const reviewProviderInput = harness.document.getElementById("setup-input-reviewProvider");
+  const trustModeInput = harness.document.getElementById("setup-input-trustMode");
+  const executionSafetyModeInput = harness.document.getElementById("setup-input-executionSafetyMode");
   const setupForm = harness.document.getElementById("setup-form");
   const saveButton = harness.document.getElementById("setup-save-button");
   const saveStatus = harness.document.getElementById("setup-save-status");
@@ -2104,6 +2159,8 @@ test("setup shell saves through the narrow setup config API and revalidates read
   const restartDetails = harness.document.getElementById("setup-restart-details");
   assert.ok(repoPathInput);
   assert.ok(reviewProviderInput);
+  assert.ok(trustModeInput);
+  assert.ok(executionSafetyModeInput);
   assert.ok(setupForm);
   assert.ok(saveButton);
   assert.ok(saveStatus);
@@ -2111,6 +2168,8 @@ test("setup shell saves through the narrow setup config API and revalidates read
   assert.ok(restartDetails);
 
   repoPathInput.value = "/tmp/repo";
+  trustModeInput.value = "untrusted_or_mixed";
+  executionSafetyModeInput.value = "operator_gated";
   reviewProviderInput.value = "codex";
   const submitPromise = setupForm.dispatch("submit", {
     preventDefault() {},
@@ -2125,12 +2184,14 @@ test("setup shell saves through the narrow setup config API and revalidates read
     managedRestart: unavailableManagedRestart,
     configPath: "/tmp/supervisor.config.json",
     backupPath: null,
-    updatedFields: ["repoPath", "reviewProvider"],
+    updatedFields: ["repoPath", "trustMode", "executionSafetyMode", "reviewProvider"],
     restartRequired: true,
     restartScope: "supervisor",
-    restartTriggeredByFields: ["repoPath", "reviewProvider"],
+    restartTriggeredByFields: ["repoPath", "trustMode", "executionSafetyMode", "reviewProvider"],
     document: {
       repoPath: "/tmp/repo",
+      trustMode: "untrusted_or_mixed",
+      executionSafetyMode: "operator_gated",
       reviewBotLogins: ["chatgpt-codex-connector"],
     },
     readiness: {
@@ -2151,10 +2212,11 @@ test("setup shell saves through the narrow setup config API and revalidates read
         summary: "Codex Connector is configured.",
       },
       trustPosture: {
-        trustMode: "trusted_repo_and_authors",
-        executionSafetyMode: "unsandboxed_autonomous",
+        trustMode: "untrusted_or_mixed",
+        executionSafetyMode: "operator_gated",
+        configured: true,
         warning: null,
-        summary: "Trusted inputs with unsandboxed autonomous execution.",
+        summary: "Trust posture avoids the default unsandboxed trusted-input assumption.",
       },
       localCiContract: {
         configured: true,
@@ -2202,6 +2264,32 @@ test("setup shell saves through the narrow setup config API and revalidates read
           valueType: "review_provider",
         },
       },
+      {
+        key: "trustMode",
+        label: "Trust mode",
+        state: "configured",
+        value: "untrusted_or_mixed",
+        message: "Trust mode is explicitly configured.",
+        required: true,
+        metadata: {
+          source: "config",
+          editable: true,
+          valueType: "trust_mode",
+        },
+      },
+      {
+        key: "executionSafetyMode",
+        label: "Execution safety mode",
+        state: "configured",
+        value: "operator_gated",
+        message: "Execution safety mode is explicitly configured.",
+        required: true,
+        metadata: {
+          source: "config",
+          editable: true,
+          valueType: "execution_safety_mode",
+        },
+      },
     ],
     blockers: [],
     hostReadiness: {
@@ -2217,10 +2305,11 @@ test("setup shell saves through the narrow setup config API and revalidates read
       summary: "Codex Connector is configured.",
     },
     trustPosture: {
-      trustMode: "trusted_repo_and_authors",
-      executionSafetyMode: "unsandboxed_autonomous",
+      trustMode: "untrusted_or_mixed",
+      executionSafetyMode: "operator_gated",
+      configured: true,
       warning: null,
-      summary: "Trusted inputs with unsandboxed autonomous execution.",
+      summary: "Trust posture avoids the default unsandboxed trusted-input assumption.",
     },
     localCiContract: {
       configured: true,
@@ -2243,6 +2332,8 @@ test("setup shell saves through the narrow setup config API and revalidates read
         body: JSON.stringify({
           changes: {
             repoPath: "/tmp/repo",
+            trustMode: "untrusted_or_mixed",
+            executionSafetyMode: "operator_gated",
             reviewProvider: "codex",
           },
         }),
@@ -2251,11 +2342,15 @@ test("setup shell saves through the narrow setup config API and revalidates read
     ],
   );
   assert.equal(saveButton.disabled, false);
-  assert.match(saveStatus.textContent, /Saved 2 setup fields\./u);
+  assert.match(saveStatus.textContent, /Saved 4 setup fields\./u);
   assert.match(restartStatus.textContent ?? "", /Restart required/u);
   assert.match(
     restartDetails.textContent ?? "",
-    /Saved changes to repoPath, reviewProvider require a supervisor restart before they take effect\..*Restart now is unavailable for this unmanaged WebUI session\..*Restart the supervisor manually and then refresh this page\./u,
+    /Saved changes to repoPath, trustMode, executionSafetyMode, reviewProvider require a supervisor restart before they take effect\..*Restart now is unavailable for this unmanaged WebUI session\..*Restart the supervisor manually and then refresh this page\./u,
+  );
+  assert.match(
+    harness.document.getElementById("setup-trust-posture")?.textContent ?? "",
+    /Trust posture avoids the default unsandboxed trusted-input assumption\./u,
   );
   assert.match(harness.document.getElementById("setup-overall-status")?.textContent ?? "", /configured/u);
   assert.match(harness.document.getElementById("setup-blocker-summary")?.textContent ?? "", /No blocking setup conditions remain\./u);

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -71,6 +71,8 @@ export function renderSetupBrowserScript(): string {
         "codexBinary",
         "branchPrefix",
         "localCiCommand",
+        "trustMode",
+        "executionSafetyMode",
         "reviewProvider",
       ];
       const reviewProviderOptions = [
@@ -78,6 +80,14 @@ export function renderSetupBrowserScript(): string {
         { value: "copilot", label: "GitHub Copilot" },
         { value: "codex", label: "Codex Connector" },
         { value: "coderabbit", label: "CodeRabbit" },
+      ];
+      const trustModeOptions = [
+        { value: "untrusted_or_mixed", label: "Untrusted or mixed authors" },
+        { value: "trusted_repo_and_authors", label: "Trusted repo and authors" },
+      ];
+      const executionSafetyModeOptions = [
+        { value: "operator_gated", label: "Operator gated" },
+        { value: "unsandboxed_autonomous", label: "Unsandboxed autonomous" },
       ];
       let currentReport = null;
       let latestSaveResult = null;
@@ -195,6 +205,10 @@ export function renderSetupBrowserScript(): string {
         return reviewProviderOptions.some((option) => option.value === profile) ? profile : "none";
       }
 
+      function normalizeSelectValue(options, value, fallback) {
+        return options.some((option) => option.value === value) ? value : fallback;
+      }
+
       function createFieldInput(field, report) {
         if (field.key === "reviewProvider") {
           const select = document.createElement("select");
@@ -208,6 +222,22 @@ export function renderSetupBrowserScript(): string {
             select.appendChild(optionElement);
           }
           select.value = normalizeReviewProviderValue(report);
+          return select;
+        }
+
+        if (field.key === "trustMode" || field.key === "executionSafetyMode") {
+          const options = field.key === "trustMode" ? trustModeOptions : executionSafetyModeOptions;
+          const select = document.createElement("select");
+          select.id = "setup-input-" + field.key;
+          select.className = "field-editor__input";
+          select.disabled = saveInFlight;
+          for (const option of options) {
+            const optionElement = document.createElement("option");
+            optionElement.value = option.value;
+            optionElement.textContent = option.label;
+            select.appendChild(optionElement);
+          }
+          select.value = normalizeSelectValue(options, field.value, options[0].value);
           return select;
         }
 
@@ -557,9 +587,12 @@ export function renderSetupBrowserScript(): string {
           report.trustPosture
             ? [{
               title: "Trust mode: " + formatStatus(report.trustPosture.trustMode),
-              tone: "",
+              tone: report.trustPosture.configured === false ? "blocker" : "",
               meta: ["Execution safety: " + formatStatus(report.trustPosture.executionSafetyMode)],
-              notes: [report.trustPosture.warning ? "Warning: " + report.trustPosture.warning : "Warning: none"],
+              notes: [
+                "Explicit setup decision: " + (report.trustPosture.configured === false ? "needed" : "configured"),
+                report.trustPosture.warning ? "Warning: " + report.trustPosture.warning : "Warning: none",
+              ],
             }]
             : [],
           "No trust posture details reported.",
@@ -606,6 +639,12 @@ export function renderSetupBrowserScript(): string {
               changes.localCiCommand = rawValue;
             } else if (field.value !== null) {
               changes.localCiCommand = null;
+            }
+            continue;
+          }
+          if (field.key === "trustMode" || field.key === "executionSafetyMode") {
+            if (rawValue !== "") {
+              changes[field.key] = rawValue;
             }
             continue;
           }

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -205,8 +205,8 @@ export function renderSetupBrowserScript(): string {
         return reviewProviderOptions.some((option) => option.value === profile) ? profile : "none";
       }
 
-      function normalizeSelectValue(options, value, fallback) {
-        return options.some((option) => option.value === value) ? value : fallback;
+      function normalizeSelectValue(options, value) {
+        return options.some((option) => option.value === value) ? value : "";
       }
 
       function createFieldInput(field, report) {
@@ -227,17 +227,25 @@ export function renderSetupBrowserScript(): string {
 
         if (field.key === "trustMode" || field.key === "executionSafetyMode") {
           const options = field.key === "trustMode" ? trustModeOptions : executionSafetyModeOptions;
+          const currentValue = typeof field.value === "string" ? field.value : "";
+          const selectedValue = normalizeSelectValue(options, currentValue);
           const select = document.createElement("select");
           select.id = "setup-input-" + field.key;
           select.className = "field-editor__input";
           select.disabled = saveInFlight;
+          if (selectedValue === "") {
+            const placeholder = document.createElement("option");
+            placeholder.value = "";
+            placeholder.textContent = "Select an option";
+            select.appendChild(placeholder);
+          }
           for (const option of options) {
             const optionElement = document.createElement("option");
             optionElement.value = option.value;
             optionElement.textContent = option.label;
             select.appendChild(optionElement);
           }
-          select.value = normalizeSelectValue(options, field.value, options[0].value);
+          select.value = selectedValue;
           return select;
         }
 
@@ -643,8 +651,11 @@ export function renderSetupBrowserScript(): string {
             continue;
           }
           if (field.key === "trustMode" || field.key === "executionSafetyMode") {
-            if (rawValue !== "") {
-              changes[field.key] = rawValue;
+            const currentValue = typeof field.value === "string" ? field.value : "";
+            const options = field.key === "trustMode" ? trustModeOptions : executionSafetyModeOptions;
+            const normalizedValue = normalizeSelectValue(options, rawValue);
+            if (normalizedValue !== "" && normalizedValue !== currentValue) {
+              changes[field.key] = normalizedValue;
             }
             continue;
           }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -158,7 +158,8 @@ test("loadConfigSummary surfaces the default trust diagnostics posture", async (
   assert.deepEqual(summary.trustDiagnostics, {
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
-    warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    warning:
+      "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
     configWarning: null,
   });
 });
@@ -1832,6 +1833,52 @@ test("updateSetupConfig accepts localCiCommand through the setup-owned write sur
     warning:
       "localCiCommand is configured but workspacePreparationCommand is unset. Configure a repo-owned workspacePreparationCommand so preserved issue worktrees can prepare toolchains before host-local CI runs. GitHub checks can stay green while host-local CI still blocks tracked PR progress.",
   });
+});
+
+test("updateSetupConfig accepts trust posture through the setup-owned write surface", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-trust-posture-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        repoPath: ".",
+        repoSlug: "owner/repo",
+        defaultBranch: "main",
+        workspaceRoot: "./worktrees",
+        stateFile: "./state.json",
+        codexBinary: process.execPath,
+        branchPrefix: "codex/issue-",
+        reviewBotLogins: ["chatgpt-codex-connector"],
+        experimentalFlag: true,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const result = await updateSetupConfig({
+    configPath,
+    changes: {
+      trustMode: "untrusted_or_mixed",
+      executionSafetyMode: "operator_gated",
+    },
+  });
+
+  const updatedDocument = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
+  assert.deepEqual(result.updatedFields, ["trustMode", "executionSafetyMode"]);
+  assert.equal(result.restartRequired, true);
+  assert.equal(result.restartScope, "supervisor");
+  assert.deepEqual(result.restartTriggeredByFields, ["trustMode", "executionSafetyMode"]);
+  assert.equal(updatedDocument.trustMode, "untrusted_or_mixed");
+  assert.equal(updatedDocument.executionSafetyMode, "operator_gated");
+  assert.equal(updatedDocument.experimentalFlag, true);
+  assert.equal(result.readiness.trustPosture.configured, true);
+  assert.equal(result.readiness.trustPosture.warning, null);
 });
 
 test("updateSetupConfig clears localCiCommand back to the unset state", async (t) => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1881,6 +1881,49 @@ test("updateSetupConfig accepts trust posture through the setup-owned write surf
   assert.equal(result.readiness.trustPosture.warning, null);
 });
 
+test("updateSetupConfig restart detection treats trust posture values as exact enums", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-trust-posture-exact-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        repoPath: ".",
+        repoSlug: "owner/repo",
+        defaultBranch: "main",
+        workspaceRoot: "./worktrees",
+        stateFile: "./state.json",
+        codexBinary: process.execPath,
+        branchPrefix: "codex/issue-",
+        reviewBotLogins: ["chatgpt-codex-connector"],
+        trustMode: " untrusted_or_mixed ",
+        executionSafetyMode: " operator_gated ",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const result = await updateSetupConfig({
+    configPath,
+    changes: {
+      trustMode: "untrusted_or_mixed",
+      executionSafetyMode: "operator_gated",
+    },
+  });
+
+  const updatedDocument = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
+  assert.deepEqual(result.updatedFields, ["trustMode", "executionSafetyMode"]);
+  assert.equal(result.restartRequired, true);
+  assert.deepEqual(result.restartTriggeredByFields, ["trustMode", "executionSafetyMode"]);
+  assert.equal(updatedDocument.trustMode, "untrusted_or_mixed");
+  assert.equal(updatedDocument.executionSafetyMode, "operator_gated");
+});
+
 test("updateSetupConfig clears localCiCommand back to the unset state", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-update-local-ci-clear-"));
   t.after(async () => {

--- a/src/core/config-diagnostics.ts
+++ b/src/core/config-diagnostics.ts
@@ -40,7 +40,7 @@ export function summarizeTrustDiagnostics(
     executionSafetyMode,
     warning:
       trustMode === "trusted_repo_and_authors" && executionSafetyMode === "unsandboxed_autonomous"
-        ? "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs."
+        ? "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution."
         : null,
     configWarning:
       issueJournalRelativePath === LEGACY_SHARED_ISSUE_JOURNAL_RELATIVE_PATH

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -81,7 +81,7 @@ test("diagnoseSupervisorHost reports representative auth, state, and workspace f
   );
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_warning kind=execution_safety detail=Unsandboxed autonomous execution assumes trusted GitHub-authored inputs\./,
+    /doctor_warning kind=execution_safety detail=Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution\./,
   );
   assert.match(
     renderDoctorReport(diagnostics),
@@ -834,18 +834,45 @@ test("diagnoseSetupReadiness returns typed first-run setup state distinct from d
       ["branchPrefix", "configured", "config", true, "text"],
       ["workspacePreparationCommand", "missing", "config", true, "text"],
       ["localCiCommand", "missing", "config", true, "text"],
+      ["trustMode", "missing", "config", true, "trust_mode"],
+      ["executionSafetyMode", "missing", "config", true, "execution_safety_mode"],
       ["reviewProvider", "missing", "config", true, "review_provider"],
     ],
   );
-  assert.deepEqual(summary.blockers, [
-    {
-      code: "missing_review_provider",
-      message: "Configure at least one review provider before first-run setup is complete.",
+  assert.deepEqual(summary.blockers.map((blocker) => blocker.code), [
+    "missing_trust_mode",
+    "missing_execution_safety_mode",
+    "missing_review_provider",
+  ]);
+  assert.deepEqual(summary.blockers.at(-1), {
+    code: "missing_review_provider",
+    message: "Configure at least one review provider before first-run setup is complete.",
+    fieldKeys: ["reviewProvider"],
+    remediation: {
+      kind: "configure_review_provider",
+      summary: "Configure at least one review provider before first-run setup is complete.",
       fieldKeys: ["reviewProvider"],
+    },
+  });
+  assert.deepEqual(summary.blockers.slice(0, 2), [
+    {
+      code: "missing_trust_mode",
+      message: "Trust mode needs an explicit first-run setup decision.",
+      fieldKeys: ["trustMode"],
       remediation: {
-        kind: "configure_review_provider",
-        summary: "Configure at least one review provider before first-run setup is complete.",
-        fieldKeys: ["reviewProvider"],
+        kind: "edit_config",
+        summary: "Trust mode needs an explicit first-run setup decision.",
+        fieldKeys: ["trustMode"],
+      },
+    },
+    {
+      code: "missing_execution_safety_mode",
+      message: "Execution safety mode needs an explicit first-run setup decision.",
+      fieldKeys: ["executionSafetyMode"],
+      remediation: {
+        kind: "edit_config",
+        summary: "Execution safety mode needs an explicit first-run setup decision.",
+        fieldKeys: ["executionSafetyMode"],
       },
     },
   ]);
@@ -867,9 +894,11 @@ test("diagnoseSetupReadiness returns typed first-run setup state distinct from d
   assert.deepEqual(summary.trustPosture, {
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
-    warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    warning:
+      "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
     configWarning: null,
-    summary: "Trusted inputs with unsandboxed autonomous execution.",
+    configured: false,
+    summary: "Trust posture needs an explicit first-run setup decision.",
   });
   assert.deepEqual(summary.localCiContract, {
     configured: false,
@@ -914,6 +943,8 @@ test("diagnoseSetupReadiness recommends a repo-owned local CI candidate when loc
       stateFile: path.join(root, "state.json"),
       codexBinary: process.execPath,
       branchPrefix: "codex/issue-",
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
       reviewBotLogins: ["chatgpt-codex-connector"],
     }),
     "utf8",
@@ -1023,6 +1054,8 @@ test("diagnoseSetupReadiness prefers the configured local CI command over repo-o
       stateFile: path.join(root, "state.json"),
       codexBinary: process.execPath,
       branchPrefix: "codex/issue-",
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
       reviewBotLogins: ["chatgpt-codex-connector"],
       localCiCommand: "npm run ci:local",
     }),
@@ -1068,6 +1101,8 @@ test("diagnoseSetupReadiness warns when localCiCommand is configured without wor
       stateFile: path.join(root, "state.json"),
       codexBinary: process.execPath,
       branchPrefix: "codex/issue-",
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
       reviewBotLogins: ["chatgpt-codex-connector"],
       localCiCommand: "npm run ci:local",
     }),
@@ -1113,6 +1148,8 @@ test("diagnoseSetupReadiness surfaces a structured local CI command as configure
       stateFile: path.join(root, "state.json"),
       codexBinary: process.execPath,
       branchPrefix: "codex/issue-",
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
       reviewBotLogins: ["chatgpt-codex-connector"],
       localCiCommand: {
         mode: "structured",

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -97,6 +97,9 @@ test("getting-started defines setup readiness as a typed first-run contract dist
   );
   assert.match(content, /localCiContract\?: LocalCiContractSummary/);
   assert.match(content, /setup flow and WebUI should surface whether the repo-owned local CI contract is configured/i);
+  assert.match(content, /At minimum, set these first-run fields before the first run:[\s\S]*`trustMode`[\s\S]*`executionSafetyMode`/i);
+  assert.match(content, /`ready: false` until these required first-run blockers/i);
+  assert.match(content, /explicit trust posture decisions/i);
 });
 
 test("getting-started defines the repo-owned local CI contract for pre-PR verification", async () => {

--- a/src/setup-config-preview.ts
+++ b/src/setup-config-preview.ts
@@ -125,6 +125,8 @@ const SETUP_FIELD_LABELS: Record<SetupConfigPreviewFieldKey, string> = {
   stateFile: "State file",
   codexBinary: "Codex binary",
   branchPrefix: "Branch prefix",
+  trustMode: "Trust mode",
+  executionSafetyMode: "Execution safety mode",
   reviewProvider: "Review provider",
 };
 const SUPPORTED_REVIEW_PROVIDER_PROFILES: SetupConfigPreviewSupportedProfile[] = [
@@ -234,6 +236,8 @@ function buildFieldChanges(args: {
     "stateFile",
     "codexBinary",
     "branchPrefix",
+    "trustMode",
+    "executionSafetyMode",
     "reviewProvider",
   ];
 

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -9,6 +9,7 @@ import {
 } from "./core/config";
 import { reviewProviderProfileFromConfig } from "./core/review-providers";
 import { isValidGitRefName, parseJson, resolveMaybeRelative, writeJsonAtomic } from "./core/utils";
+import type { ExecutionSafetyMode, TrustMode } from "./core/types";
 import type { SetupConfigPreviewSelectableReviewProviderProfile } from "./setup-config-preview";
 import { diagnoseSetupReadiness, type SetupReadinessFieldKey, type SetupReadinessReport } from "./setup-readiness";
 
@@ -22,6 +23,8 @@ export interface SetupConfigChanges {
   branchPrefix?: string;
   workspacePreparationCommand?: string | null;
   localCiCommand?: string | null;
+  trustMode?: TrustMode;
+  executionSafetyMode?: ExecutionSafetyMode;
   localCiCandidateDismissed?: boolean;
   reviewProvider?: SetupConfigPreviewSelectableReviewProviderProfile;
 }
@@ -55,6 +58,8 @@ const CONFIGURABLE_FIELDS: SetupConfigWritableFieldKey[] = [
   "branchPrefix",
   "workspacePreparationCommand",
   "localCiCommand",
+  "trustMode",
+  "executionSafetyMode",
   "localCiCandidateDismissed",
   "reviewProvider",
 ];
@@ -100,6 +105,22 @@ function assertReviewProvider(value: unknown): SetupConfigPreviewSelectableRevie
   }
 
   throw new Error("reviewProvider must be one of none, copilot, codex, or coderabbit.");
+}
+
+function assertTrustMode(value: unknown): TrustMode {
+  if (value === "trusted_repo_and_authors" || value === "untrusted_or_mixed") {
+    return value;
+  }
+
+  throw new Error("trustMode must be one of trusted_repo_and_authors or untrusted_or_mixed.");
+}
+
+function assertExecutionSafetyMode(value: unknown): ExecutionSafetyMode {
+  if (value === "unsandboxed_autonomous" || value === "operator_gated") {
+    return value;
+  }
+
+  throw new Error("executionSafetyMode must be one of unsandboxed_autonomous or operator_gated.");
 }
 
 function assertBoolean(value: unknown, fieldName: string): boolean {
@@ -182,6 +203,12 @@ function normalizeSetupChanges(changes: unknown): SetupConfigChanges {
   }
   if ("localCiCommand" in raw) {
     normalized.localCiCommand = normalizeLocalCiCommand(raw.localCiCommand);
+  }
+  if ("trustMode" in raw) {
+    normalized.trustMode = assertTrustMode(raw.trustMode);
+  }
+  if ("executionSafetyMode" in raw) {
+    normalized.executionSafetyMode = assertExecutionSafetyMode(raw.executionSafetyMode);
   }
   if ("localCiCandidateDismissed" in raw) {
     normalized.localCiCandidateDismissed = assertBoolean(raw.localCiCandidateDismissed, "localCiCandidateDismissed");
@@ -267,6 +294,12 @@ function applySetupChanges(document: Record<string, unknown>, changes: SetupConf
       delete nextDocument.localCiCandidateDismissed;
     }
   }
+  if (changes.trustMode !== undefined) {
+    nextDocument.trustMode = changes.trustMode;
+  }
+  if (changes.executionSafetyMode !== undefined) {
+    nextDocument.executionSafetyMode = changes.executionSafetyMode;
+  }
   if ("localCiCandidateDismissed" in changes) {
     if (changes.localCiCandidateDismissed) {
       nextDocument.localCiCandidateDismissed = true;
@@ -341,6 +374,10 @@ function currentSemanticFieldValue(args: {
     return effectiveDismissed ? "true" : "false";
   }
 
+  if (field === "trustMode" || field === "executionSafetyMode") {
+    return displayStringValue(existingDocument[field]);
+  }
+
   if (resolvedConfig !== null) {
     return displayStringValue(resolvedConfig[field]);
   }
@@ -370,6 +407,10 @@ function nextSemanticFieldValue(field: SetupConfigWritableFieldKey, changes: Set
       return changes.localCiCommand ?? null;
     case "localCiCandidateDismissed":
       return changes.localCiCandidateDismissed === true ? "true" : "false";
+    case "trustMode":
+      return changes.trustMode ?? null;
+    case "executionSafetyMode":
+      return changes.executionSafetyMode ?? null;
     case "reviewProvider":
       return changes.reviewProvider ?? null;
   }

--- a/src/setup-config-write.ts
+++ b/src/setup-config-write.ts
@@ -323,6 +323,10 @@ function displayStringValue(value: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+function displayExactStringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
 function currentSemanticFieldValue(args: {
   configSummary: ReturnType<typeof loadConfigSummary>;
   existingDocument: Record<string, unknown>;
@@ -375,7 +379,7 @@ function currentSemanticFieldValue(args: {
   }
 
   if (field === "trustMode" || field === "executionSafetyMode") {
-    return displayStringValue(existingDocument[field]);
+    return displayExactStringValue(existingDocument[field]);
   }
 
   if (resolvedConfig !== null) {

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -31,6 +31,7 @@ function buildConfigDocument(args: {
   workspaceRoot: string;
   stateFile: string;
   workspacePreparationCommand: unknown;
+  includeTrustPosture?: boolean;
 }): Record<string, unknown> {
   return {
     repoPath: args.repoPath,
@@ -42,6 +43,12 @@ function buildConfigDocument(args: {
     branchPrefix: "codex/issue-",
     reviewBotLogins: ["chatgpt-codex-connector"],
     workspacePreparationCommand: args.workspacePreparationCommand,
+    ...(args.includeTrustPosture === false
+      ? {}
+      : {
+        trustMode: "trusted_repo_and_authors",
+        executionSafetyMode: "unsandboxed_autonomous",
+      }),
   };
 }
 
@@ -211,6 +218,59 @@ test("diagnoseSetupReadiness suggests a repo-native workspace preparation comman
   const field = summary.fields.find((entry) => entry.key === "workspacePreparationCommand");
   assert.equal(field?.state, "missing");
   assert.match(field?.message ?? "", /recommended repo-native command: npm ci/i);
+});
+
+test("diagnoseSetupReadiness requires explicit trust posture decisions", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+        includeTrustPosture: false,
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "missing");
+  assert.equal(summary.trustPosture.configured, false);
+  assert.match(summary.trustPosture.summary, /needs an explicit first-run setup decision/i);
+  assert.deepEqual(
+    summary.fields
+      .filter((field) => field.key === "trustMode" || field.key === "executionSafetyMode")
+      .map((field) => [field.key, field.state, field.value, field.required, field.metadata.valueType]),
+    [
+      ["trustMode", "missing", null, true, "trust_mode"],
+      ["executionSafetyMode", "missing", null, true, "execution_safety_mode"],
+    ],
+  );
+  assert.deepEqual(
+    summary.blockers
+      .filter((blocker) => blocker.code === "missing_trust_mode" || blocker.code === "missing_execution_safety_mode")
+      .map((blocker) => [blocker.code, blocker.fieldKeys]),
+    [
+      ["missing_trust_mode", ["trustMode"]],
+      ["missing_execution_safety_mode", ["executionSafetyMode"]],
+    ],
+  );
 });
 
 test("diagnoseSetupReadiness fails closed when fixed model routing is missing an explicit model value", async (t) => {

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -273,6 +273,60 @@ test("diagnoseSetupReadiness requires explicit trust posture decisions", async (
   );
 });
 
+test("diagnoseSetupReadiness validates trust posture fields as exact raw strings", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      ...buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+        includeTrustPosture: false,
+      }),
+      trustMode: " trusted_repo_and_authors ",
+      executionSafetyMode: ["operator_gated"],
+    }),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "invalid");
+  assert.equal(summary.trustPosture.configured, false);
+  assert.deepEqual(
+    summary.fields
+      .filter((field) => field.key === "trustMode" || field.key === "executionSafetyMode")
+      .map((field) => [field.key, field.state, field.value]),
+    [
+      ["trustMode", "invalid", " trusted_repo_and_authors "],
+      ["executionSafetyMode", "invalid", null],
+    ],
+  );
+  assert.deepEqual(
+    summary.blockers
+      .filter((blocker) => blocker.code === "invalid_trust_mode" || blocker.code === "invalid_execution_safety_mode")
+      .map((blocker) => [blocker.code, blocker.fieldKeys]),
+    [
+      ["invalid_trust_mode", ["trustMode"]],
+      ["invalid_execution_safety_mode", ["executionSafetyMode"]],
+    ],
+  );
+});
+
 test("diagnoseSetupReadiness fails closed when fixed model routing is missing an explicit model value", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
   t.after(async () => {

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -216,6 +216,26 @@ function displayValue(value: unknown): string | null {
   return null;
 }
 
+function readExactSetupStringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function trustPostureFieldState(args: {
+  key: "trustMode" | "executionSafetyMode";
+  rawValue: unknown;
+}): SetupFieldState {
+  const { key, rawValue } = args;
+  if (rawValue === undefined || rawValue === null || rawValue === "") {
+    return "missing";
+  }
+  if (key === "trustMode") {
+    return typeof rawValue === "string" && VALID_TRUST_MODES.has(rawValue as TrustMode) ? "configured" : "invalid";
+  }
+  return typeof rawValue === "string" && VALID_EXECUTION_SAFETY_MODES.has(rawValue as ExecutionSafetyMode)
+    ? "configured"
+    : "invalid";
+}
+
 function tryNormalizeLocalCiCommand(value: unknown): ReturnType<typeof normalizeLocalCiCommand> {
   try {
     return normalizeLocalCiCommand(value);
@@ -299,22 +319,15 @@ function buildConfigFields(args: {
   const resolvedConfig = configSummary.config;
   const fields = SETUP_FIELD_DEFINITIONS.map(({ key, label, required }) => {
     const rawValue = rawConfig?.[key];
-    const explicitValue = displayValue(rawValue);
+    const explicitValue =
+      key === "trustMode" || key === "executionSafetyMode"
+        ? readExactSetupStringValue(rawValue)
+        : displayValue(rawValue);
     const resolvedValue = key === "trustMode" || key === "executionSafetyMode"
       ? explicitValue
       : resolvedConfig !== null ? displayValue(resolvedConfig[key]) : explicitValue;
-    const state: SetupFieldState = key === "trustMode"
-      ? explicitValue === null
-        ? "missing"
-        : VALID_TRUST_MODES.has(explicitValue as TrustMode)
-          ? "configured"
-          : "invalid"
-      : key === "executionSafetyMode"
-        ? explicitValue === null
-          ? "missing"
-          : VALID_EXECUTION_SAFETY_MODES.has(explicitValue as ExecutionSafetyMode)
-            ? "configured"
-            : "invalid"
+    const state: SetupFieldState = key === "trustMode" || key === "executionSafetyMode"
+      ? trustPostureFieldState({ key, rawValue })
         : key === "workspacePreparationCommand" && workspacePreparationWarning !== null
       ? "invalid"
       : configSummary.missingRequiredFields.includes(key)

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -13,6 +13,7 @@ import {
 import type { CodexModelStrategy, LocalCiContractSummary, TrustDiagnosticsSummary } from "./core/types";
 import { diagnoseSupervisorHost, type DoctorCheck, type DoctorCheckStatus } from "./doctor";
 import { reviewProviderProfileFromConfig } from "./core/review-providers";
+import type { ExecutionSafetyMode, TrustMode } from "./core/types";
 
 export type SetupFieldState = "configured" | "missing" | "invalid";
 export type SetupReadinessOverallStatus = "configured" | "missing" | "invalid";
@@ -26,6 +27,8 @@ export type SetupReadinessFieldKey =
   | "branchPrefix"
   | "workspacePreparationCommand"
   | "localCiCommand"
+  | "trustMode"
+  | "executionSafetyMode"
   | "reviewProvider";
 export type SetupReadinessConfigFieldKey =
   | SetupReadinessFieldKey
@@ -43,6 +46,8 @@ export type SetupReadinessFieldValueType =
   | "file_path"
   | "executable_path"
   | "text"
+  | "trust_mode"
+  | "execution_safety_mode"
   | "review_provider";
 
 export interface SetupReadinessFieldMetadata {
@@ -98,6 +103,7 @@ export interface SetupReadinessProviderPosture {
 }
 
 export interface SetupReadinessTrustPosture extends TrustDiagnosticsSummary {
+  configured?: boolean;
   summary: string;
 }
 
@@ -157,6 +163,8 @@ const SETUP_FIELD_DEFINITIONS: Array<{
   { key: "branchPrefix", label: "Branch prefix", required: true },
   { key: "workspacePreparationCommand", label: "Workspace preparation command", required: false },
   { key: "localCiCommand", label: "Local CI command", required: false },
+  { key: "trustMode", label: "Trust mode", required: true },
+  { key: "executionSafetyMode", label: "Execution safety mode", required: true },
 ];
 
 const SETUP_FIELD_METADATA: Record<SetupReadinessFieldKey, SetupReadinessFieldMetadata> = {
@@ -169,8 +177,13 @@ const SETUP_FIELD_METADATA: Record<SetupReadinessFieldKey, SetupReadinessFieldMe
   branchPrefix: { source: "config", editable: true, valueType: "text" },
   workspacePreparationCommand: { source: "config", editable: true, valueType: "text" },
   localCiCommand: { source: "config", editable: true, valueType: "text" },
+  trustMode: { source: "config", editable: true, valueType: "trust_mode" },
+  executionSafetyMode: { source: "config", editable: true, valueType: "execution_safety_mode" },
   reviewProvider: { source: "config", editable: true, valueType: "review_provider" },
 };
+
+const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untrusted_or_mixed"]);
+const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
 
 function readRawConfigDocument(configPath: string): RawConfigDocument {
   if (!fs.existsSync(configPath)) {
@@ -241,6 +254,26 @@ function buildFieldMessage(args: {
     return "Local CI command is optional until you opt in to the repo-owned contract.";
   }
 
+  if (field.key === "trustMode") {
+    if (field.state === "configured") {
+      return "Trust mode is explicitly configured.";
+    }
+    if (field.state === "missing") {
+      return "Trust mode needs an explicit first-run setup decision.";
+    }
+    return "Trust mode must be trusted_repo_and_authors or untrusted_or_mixed.";
+  }
+
+  if (field.key === "executionSafetyMode") {
+    if (field.state === "configured") {
+      return "Execution safety mode is explicitly configured.";
+    }
+    if (field.state === "missing") {
+      return "Execution safety mode needs an explicit first-run setup decision.";
+    }
+    return "Execution safety mode must be unsandboxed_autonomous or operator_gated.";
+  }
+
   if (field.state === "configured") {
     return `${field.label} is configured.`;
   }
@@ -265,8 +298,24 @@ function buildConfigFields(args: {
   const { rawConfig, configSummary, workspacePreparationWarning, recommendedWorkspacePreparationCommand } = args;
   const resolvedConfig = configSummary.config;
   const fields = SETUP_FIELD_DEFINITIONS.map(({ key, label, required }) => {
-    const resolvedValue = resolvedConfig !== null ? displayValue(resolvedConfig[key]) : displayValue(rawConfig?.[key]);
-    const state: SetupFieldState = key === "workspacePreparationCommand" && workspacePreparationWarning !== null
+    const rawValue = rawConfig?.[key];
+    const explicitValue = displayValue(rawValue);
+    const resolvedValue = key === "trustMode" || key === "executionSafetyMode"
+      ? explicitValue
+      : resolvedConfig !== null ? displayValue(resolvedConfig[key]) : explicitValue;
+    const state: SetupFieldState = key === "trustMode"
+      ? explicitValue === null
+        ? "missing"
+        : VALID_TRUST_MODES.has(explicitValue as TrustMode)
+          ? "configured"
+          : "invalid"
+      : key === "executionSafetyMode"
+        ? explicitValue === null
+          ? "missing"
+          : VALID_EXECUTION_SAFETY_MODES.has(explicitValue as ExecutionSafetyMode)
+            ? "configured"
+            : "invalid"
+        : key === "workspacePreparationCommand" && workspacePreparationWarning !== null
       ? "invalid"
       : configSummary.missingRequiredFields.includes(key)
       ? "missing"
@@ -348,7 +397,17 @@ function buildProviderPosture(
   };
 }
 
-function buildTrustPosture(config: ReturnType<typeof loadConfigSummary>["config"]): SetupReadinessTrustPosture {
+function buildTrustPostureFromRaw(
+  rawConfig: RawConfigDocument,
+  config: ReturnType<typeof loadConfigSummary>["config"],
+): SetupReadinessTrustPosture {
+  const rawTrustMode = rawConfig?.trustMode;
+  const rawExecutionSafetyMode = rawConfig?.executionSafetyMode;
+  const configured =
+    typeof rawTrustMode === "string" &&
+    VALID_TRUST_MODES.has(rawTrustMode as TrustMode) &&
+    typeof rawExecutionSafetyMode === "string" &&
+    VALID_EXECUTION_SAFETY_MODES.has(rawExecutionSafetyMode as ExecutionSafetyMode);
   const trust = summarizeTrustDiagnostics(
     config ?? {
       trustMode: "trusted_repo_and_authors",
@@ -359,10 +418,13 @@ function buildTrustPosture(config: ReturnType<typeof loadConfigSummary>["config"
 
   return {
     ...trust,
+    configured,
     summary:
-      trust.warning === null
+      !configured
+        ? "Trust posture needs an explicit first-run setup decision."
+        : trust.warning === null
         ? "Trust posture avoids the default unsandboxed trusted-input assumption."
-        : "Trusted inputs with unsandboxed autonomous execution.",
+        : "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors.",
   };
 }
 
@@ -687,7 +749,7 @@ export async function diagnoseSetupReadiness(
     blockers,
     hostReadiness,
     providerPosture: buildProviderPosture(configSummary.config),
-    trustPosture: buildTrustPosture(configSummary.config),
+    trustPosture: buildTrustPostureFromRaw(rawConfig, configSummary.config),
     modelRoutingPosture,
     localCiContract: summarizeLocalCiContract(localCiContractConfig),
   };

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -105,7 +105,8 @@ test("status surfaces the default trust posture and execution-safety warning", a
   assert.deepEqual(report.trustDiagnostics, {
     trustMode: "trusted_repo_and_authors",
     executionSafetyMode: "unsandboxed_autonomous",
-    warning: "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs.",
+    warning:
+      "Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution.",
     configWarning:
       "Active config still uses legacy shared issue journal path .codex-supervisor/issue-journal.md; prefer .codex-supervisor/issues/{issueNumber}/issue-journal.md.",
   });
@@ -113,7 +114,10 @@ test("status surfaces the default trust posture and execution-safety warning", a
   const status = await supervisor.status();
   assert.match(status, /trust_mode=trusted_repo_and_authors/);
   assert.match(status, /execution_safety_mode=unsandboxed_autonomous/);
-  assert.match(status, /execution_safety_warning=Unsandboxed autonomous execution assumes trusted GitHub-authored inputs\./);
+  assert.match(
+    status,
+    /execution_safety_warning=Unsandboxed autonomous execution assumes trusted GitHub-authored inputs; confirm this explicit setup trust posture before starting autonomous execution\./,
+  );
   assert.match(
     status,
     /config_warning=Active config still uses legacy shared issue journal path \.codex-supervisor\/issue-journal\.md; prefer \.codex-supervisor\/issues\/\{issueNumber\}\/issue-journal\.md\./,

--- a/supervisor.config.coderabbit.json
+++ b/supervisor.config.coderabbit.json
@@ -7,6 +7,8 @@
   "stateFile": "./.local/state.json",
   "stateBootstrapFile": "",
   "codexBinary": "codex",
+  "trustMode": "trusted_repo_and_authors",
+  "executionSafetyMode": "unsandboxed_autonomous",
   "codexModelStrategy": "inherit",
   "codexModel": "",
   "boundedRepairModelStrategy": "",

--- a/supervisor.config.codex.json
+++ b/supervisor.config.codex.json
@@ -7,6 +7,8 @@
   "stateFile": "./.local/state.json",
   "stateBootstrapFile": "",
   "codexBinary": "/absolute/path/to/codex",
+  "trustMode": "trusted_repo_and_authors",
+  "executionSafetyMode": "unsandboxed_autonomous",
   "codexModelStrategy": "inherit",
   "codexModel": "",
   "boundedRepairModelStrategy": "",

--- a/supervisor.config.copilot.json
+++ b/supervisor.config.copilot.json
@@ -7,6 +7,8 @@
   "stateFile": "./.local/state.json",
   "stateBootstrapFile": "",
   "codexBinary": "/absolute/path/to/codex",
+  "trustMode": "trusted_repo_and_authors",
+  "executionSafetyMode": "unsandboxed_autonomous",
   "codexModelStrategy": "inherit",
   "codexModel": "",
   "boundedRepairModelStrategy": "",

--- a/supervisor.config.example.json
+++ b/supervisor.config.example.json
@@ -7,6 +7,8 @@
   "stateFile": "./.local/state.json",
   "stateBootstrapFile": "",
   "codexBinary": "/absolute/path/to/codex",
+  "trustMode": "untrusted_or_mixed",
+  "executionSafetyMode": "operator_gated",
   "codexModelStrategy": "inherit",
   "codexModel": "",
   "boundedRepairModelStrategy": "",


### PR DESCRIPTION
## Summary
- require setup/readiness to treat trust posture as explicit first-run decisions
- allow WebUI/setup config writes for trustMode and executionSafetyMode
- update doctor warning, profile configs, and docs for trusted solo-lane vs gated/mixed-author posture

## Verification
- npx tsx --test src/doctor.test.ts src/config.test.ts src/backend/webui-dashboard.test.ts src/getting-started-docs.test.ts
- npx tsx --test src/setup-readiness.test.ts src/backend/setup-test-fixtures.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * First-run setup now requires explicit configuration of trust mode and execution safety mode settings before autonomous execution.
  * WebUI setup flow now includes interactive prompts for trust settings.

* **Documentation**
  * Updated configuration guidance clarifying when to use trusted vs. gated execution modes.
  * Enhanced setup documentation with new trust configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->