### PR TITLE
Make configured local CI blockers actionable

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -133,8 +133,11 @@ export interface LatestLocalCiResult {
   ran_at: string;
   head_sha: string | null;
   execution_mode: LocalCiExecutionMode | null;
+  command?: string | null;
+  stderr_summary?: string | null;
   failure_class: LocalCiFailureClass | null;
   remediation_target: LocalCiRemediationTarget | null;
+  verifier_drift_hint?: string | null;
 }
 
 export interface SupervisorConfig {

--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -32,8 +32,11 @@ test("runLocalCiGate reports an unset local CI contract as a non-blocking issue-
     ran_at: result.latestResult?.ran_at ?? "",
     head_sha: null,
     execution_mode: null,
+    command: null,
+    stderr_summary: null,
     failure_class: "unset_contract",
     remediation_target: "issue_body",
+    verifier_drift_hint: null,
   });
 });
 
@@ -84,6 +87,32 @@ test("runLocalCiGate classifies non-zero exits as repo-owned-command remediation
   );
   assert.equal(result.latestResult?.failure_class, "non_zero_exit");
   assert.equal(result.latestResult?.remediation_target, "repo_owned_command");
+  assert.equal(result.latestResult?.command, "npm run ci:local");
+  assert.equal(result.latestResult?.stderr_summary, "tests failed");
+});
+
+test("runLocalCiGate surfaces likely repo-owned verifier drift as a distinct hint", async () => {
+  const failure = Object.assign(new Error("Command failed: sh -lc +1 args\nexitCode=1"), {
+    stderr: "docs/configuration.md contract drift: changed doc contract no longer matches repo-owned verifier expectation",
+  });
+
+  const result = await runLocalCiGate({
+    config: { localCiCommand: "npm run verify:pre-pr" },
+    workspacePath: "/tmp/workspaces/issue-102",
+    gateLabel: "before opening a pull request",
+    runLocalCiCommand: async () => {
+      throw failure;
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.latestResult?.command, "npm run verify:pre-pr");
+  assert.equal(
+    result.latestResult?.stderr_summary,
+    "docs/configuration.md contract drift: changed doc contract no longer matches repo-owned verifier expectation",
+  );
+  assert.match(result.latestResult?.verifier_drift_hint ?? "", /^repo_owned_verifier_drift:/);
+  assert.match(result.failureContext?.details.join("\n") ?? "", /repo_owned_verifier_drift:/);
 });
 
 test("runLocalCiGate keeps nested missing binaries inside the configured command as non-zero exits", async () => {

--- a/src/local-ci.ts
+++ b/src/local-ci.ts
@@ -302,6 +302,27 @@ function renderFailureOutput(label: "stdout" | "stderr", output: string | undefi
   return `${label}:\n${truncatePreservingStartAndEnd(trimmed, 1500) ?? trimmed}`;
 }
 
+function summarizeCommandStderr(error: unknown): string | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  const outputError = error as ErrorWithOutput;
+  if (typeof outputError.stderr !== "string") {
+    return null;
+  }
+
+  const firstLine = outputError.stderr
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find((line) => line !== "");
+  if (!firstLine) {
+    return null;
+  }
+
+  return truncatePreservingStartAndEnd(firstLine, 300) ?? firstLine;
+}
+
 function collectCommandErrorLines(error: unknown): string[] {
   if (!(error instanceof Error)) {
     return [String(error)];
@@ -373,6 +394,21 @@ function buildTargetedStaticAnalysisGuidance(error: unknown): string[] {
       .map((code) => RUFF_REMEDIATION_HINTS.get(code))
       .filter((hint): hint is string => typeof hint === "string"),
   ];
+}
+
+function buildRepoOwnedVerifierDriftHint(error: unknown): string | null {
+  const output = collectCommandErrorLines(error).join("\n");
+  if (!/\b(?:doc|docs|documentation|contract)\b/i.test(output)) {
+    return null;
+  }
+  if (!/\b(?:verifier|verify|expectation|expected)\b/i.test(output)) {
+    return null;
+  }
+  if (!/\b(?:drift|mismatch|no longer matches?|changed)\b/i.test(output)) {
+    return null;
+  }
+
+  return "repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI.";
 }
 
 function buildFailureDetails(error: unknown, executionMode: LocalCiExecutionMode | null): string[] {
@@ -568,8 +604,11 @@ export async function runLocalCiGate(args: {
         ran_at: ranAt,
         head_sha: null,
         execution_mode: null,
+        command: null,
+        stderr_summary: null,
         failure_class: "unset_contract",
         remediation_target: remediationTargetForFailureClass("unset_contract"),
+        verifier_drift_hint: null,
       },
     };
   }
@@ -585,13 +624,17 @@ export async function runLocalCiGate(args: {
         ran_at: ranAt,
         head_sha: null,
         execution_mode: command.executionMode,
+        command: command.displayCommand,
+        stderr_summary: null,
         failure_class: null,
         remediation_target: null,
+        verifier_drift_hint: null,
       },
     };
   } catch (error) {
     const failureClass = classifyLocalCiFailure(error, command.displayCommand);
     const summary = buildSummary({ failureClass, gateLabel: args.gateLabel, passed: false });
+    const verifierDriftHint = failureClass === "non_zero_exit" ? buildRepoOwnedVerifierDriftHint(error) : null;
     return {
       ok: false,
       failureContext: {
@@ -599,7 +642,10 @@ export async function runLocalCiGate(args: {
         summary,
         signature: localCiFailureSignature(failureClass),
         command: command.displayCommand,
-        details: buildFailureDetails(error, command.executionMode),
+        details: [
+          ...buildFailureDetails(error, command.executionMode),
+          ...(verifierDriftHint ? [verifierDriftHint] : []),
+        ],
         url: null,
         updated_at: ranAt,
       },
@@ -609,8 +655,11 @@ export async function runLocalCiGate(args: {
         ran_at: ranAt,
         head_sha: null,
         execution_mode: command.executionMode,
+        command: command.displayCommand,
+        stderr_summary: summarizeCommandStderr(error),
         failure_class: failureClass,
         remediation_target: remediationTargetForFailureClass(failureClass),
+        verifier_drift_hint: verifierDriftHint,
       },
     };
   }

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -461,8 +461,11 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
     ran_at: result.record.latest_local_ci_result?.ran_at ?? "",
     head_sha: headSha,
     execution_mode: "legacy_shell_string",
+    command: "npm run ci:local",
+    stderr_summary: null,
     failure_class: null,
     remediation_target: null,
+    verifier_drift_hint: null,
   });
   assert.equal(readyCalls, 1);
   assert.equal(localCiCalls, 1);
@@ -886,8 +889,11 @@ test("handlePostTurnPullRequestTransitionsPhase reports workspace toolchain fail
     ran_at: result.record.latest_local_ci_result?.ran_at ?? "",
     head_sha: draftPr.headRefOid,
     execution_mode: "legacy_shell_string",
+    command: "npm run ci:local",
+    stderr_summary: "tsc is not installed in this workspace",
     failure_class: "workspace_toolchain_missing",
     remediation_target: "workspace_environment",
+    verifier_drift_hint: null,
   });
   assert.match(
     result.record.last_error ?? "",

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1104,11 +1104,11 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
         journal_path: null,
         pr_number: prNumber,
         blocked_reason: "verification",
-        last_error: "Tracked durable artifacts failed workstation-local path hygiene before marking PR #277 ready.",
+        last_error: "Configured local CI command failed before marking PR #277 ready.",
         last_head_sha: "head-draft-277",
-        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_failure_signature: "local-ci-gate-non_zero_exit",
         last_observed_host_local_pr_blocker_head_sha: "head-draft-277",
-        last_observed_host_local_pr_blocker_signature: "workstation-local-path-hygiene-failed",
+        last_observed_host_local_pr_blocker_signature: "local-ci-gate-non_zero_exit",
         last_tracked_pr_progress_snapshot: JSON.stringify({
           headRefOid: "head-old-277",
           reviewDecision: null,
@@ -1126,7 +1126,19 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
           checks: ["build:pass:SUCCESS:CI"],
           unresolvedReviewThreadIds: [],
         }),
-        latest_local_ci_result: null,
+        latest_local_ci_result: {
+          outcome: "failed",
+          summary: "Configured local CI command failed before marking PR #277 ready.",
+          ran_at: "2026-03-13T00:10:00Z",
+          head_sha: "head-draft-277",
+          execution_mode: "legacy_shell_string",
+          command: "npm run verify:paths",
+          stderr_summary: "docs/configuration.md contract drift: changed doc contract no longer matches repo-owned verifier expectation",
+          failure_class: "non_zero_exit",
+          remediation_target: "repo_owned_command",
+          verifier_drift_hint:
+            "repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI.",
+        },
         last_host_local_pr_blocker_comment_signature: null,
         last_host_local_pr_blocker_comment_head_sha: null,
       }),
@@ -1173,6 +1185,10 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
   assert.match(
     explanation,
     /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
+  );
+  assert.match(
+    explanation,
+    /^local_ci_result outcome=failed context=blocking failure_class=non_zero_exit remediation_target=repo_owned_command head=current head_sha=head-draft-277 ran_at=2026-03-13T00:10:00Z summary=Configured local CI command failed before marking PR #277 ready\. command=npm run verify:paths stderr_summary=docs\/configuration\.md contract drift: changed doc contract no longer matches repo-owned verifier expectation hint=repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI\.$/m,
   );
   assert.doesNotMatch(
     explanation,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1505,8 +1505,11 @@ Expose typed operator-facing issue detail fields.
       headSha: "head-new-58",
       headStatus: "current",
       context: "warning",
+      command: null,
+      stderrSummary: null,
       failureClass: "non_zero_exit",
       remediationTarget: "repo_owned_command",
+      verifierDriftHint: null,
     },
     latestRecovery: {
       issueNumber,
@@ -3097,8 +3100,12 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
           ran_at: "2026-03-13T00:10:00Z",
           head_sha: "head-draft-274",
           execution_mode: "legacy_shell_string",
+          command: "npm run verify:paths",
+          stderr_summary: "docs/configuration.md contract drift: changed doc contract no longer matches repo-owned verifier expectation",
           failure_class: "non_zero_exit",
           remediation_target: "repo_owned_command",
+          verifier_drift_hint:
+            "repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI.",
         },
       }),
     },
@@ -3145,6 +3152,14 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
+    /^tracked_pr_host_local_ci issue=#174 pr=#274 github_checks=green head_sha=head-draft-274 outcome=failed failure_class=non_zero_exit remediation_target=repo_owned_command head=current summary=Configured local CI command failed before marking PR #274 ready\. command=npm run verify:paths stderr_summary=docs\/configuration\.md contract drift: changed doc contract no longer matches repo-owned verifier expectation$/m,
+  );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^tracked_pr_host_local_ci_hint issue=#174 pr=#274 kind=repo_owned_verifier_drift summary=repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI\.$/m,
+  );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
     /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
   );
   assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^tracked_pr_mismatch /m);
@@ -3157,6 +3172,14 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   assert.match(
     status,
     /^tracked_pr_ready_promotion_gate issue=#174 pr=#274 gate=local_ci summary=Configured local CI command failed before marking PR #274 ready\.$/m,
+  );
+  assert.match(
+    status,
+    /^tracked_pr_host_local_ci issue=#174 pr=#274 github_checks=green head_sha=head-draft-274 outcome=failed failure_class=non_zero_exit remediation_target=repo_owned_command head=current summary=Configured local CI command failed before marking PR #274 ready\. command=npm run verify:paths stderr_summary=docs\/configuration\.md contract drift: changed doc contract no longer matches repo-owned verifier expectation$/m,
+  );
+  assert.match(
+    status,
+    /^tracked_pr_host_local_ci_hint issue=#174 pr=#274 kind=repo_owned_verifier_drift summary=repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI\.$/m,
   );
   assert.match(
     status,

--- a/src/supervisor/supervisor-operator-activity-context.ts
+++ b/src/supervisor/supervisor-operator-activity-context.ts
@@ -82,8 +82,11 @@ export interface SupervisorLocalCiStatusDto {
   headSha: string | null;
   headStatus: "current" | "stale" | "unknown";
   context: "blocking" | "warning" | "notice";
+  command: string | null;
+  stderrSummary: string | null;
   failureClass: LatestLocalCiResult["failure_class"];
   remediationTarget: LatestLocalCiResult["remediation_target"];
+  verifierDriftHint: string | null;
 }
 
 function isLocalCiBlockingFailureSignature(signature: string | null): boolean {
@@ -185,6 +188,11 @@ export function formatLocalCiStatusLine(
     `head_sha=${localCiStatus.headSha ?? "none"}`,
     `ran_at=${localCiStatus.ranAt}`,
     `summary=${localCiStatus.summary.replace(/\r?\n/g, "\\n")}`,
+    ...(localCiStatus.command ? [`command=${localCiStatus.command}`] : []),
+    ...(localCiStatus.stderrSummary ? [`stderr_summary=${localCiStatus.stderrSummary.replace(/\r?\n/g, "\\n")}`] : []),
+    ...(localCiStatus.verifierDriftHint
+      ? [`hint=${localCiStatus.verifierDriftHint.replace(/\r?\n/g, "\\n")}`]
+      : []),
   ].join(" ");
 }
 
@@ -240,8 +248,11 @@ function buildLocalCiStatusDto(
     headSha: result.head_sha,
     headStatus,
     context,
+    command: result.command ?? null,
+    stderrSummary: result.stderr_summary ?? null,
     failureClass: result.failure_class,
     remediationTarget: result.remediation_target,
+    verifierDriftHint: result.verifier_drift_hint ?? null,
   };
 }
 

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -407,8 +407,11 @@ test("buildIssueExplainDto exposes typed operator activity context", async () =>
       headSha: "head-new-605",
       headStatus: "current",
       context: "warning",
+      command: null,
+      stderrSummary: null,
       failureClass: "non_zero_exit",
       remediationTarget: "repo_owned_command",
+      verifierDriftHint: null,
     },
     latestRecovery: {
       issueNumber,

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -82,8 +82,22 @@ function buildTrackedPrHostLocalCiDetailLines(
       `remediation_target=${result.remediation_target ?? "none"}`,
       `head=${localCiHeadStatus(record, pr, result)}`,
       `summary=${result.summary.replace(/\r?\n/g, "\\n")}`,
+      ...(result.command ? [`command=${result.command}`] : []),
+      ...(result.stderr_summary ? [`stderr_summary=${result.stderr_summary.replace(/\r?\n/g, "\\n")}`] : []),
     ].join(" "),
   ];
+
+  if (result.verifier_drift_hint) {
+    detailLines.push(
+      [
+        "tracked_pr_host_local_ci_hint",
+        `issue=#${record.issue_number}`,
+        `pr=#${pr.number}`,
+        "kind=repo_owned_verifier_drift",
+        `summary=${result.verifier_drift_hint.replace(/\r?\n/g, "\\n")}`,
+      ].join(" "),
+    );
+  }
 
   if (result.failure_class === "workspace_toolchain_missing" && !config.workspacePreparationCommand) {
     const warning =


### PR DESCRIPTION
## Summary
- record the configured local CI command, concise stderr summary, and likely verifier-drift hint in durable local CI results
- render those fields in status/explain local CI diagnostics and tracked PR host-local blocker detail lines
- keep local CI gates fail-closed while preserving compatibility with older persisted records

## Verification
- npx tsx --test src/local-ci.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-operator-activity-context.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build
- npm run verify:paths

## Known gap
- Full issue-requested test command still fails in src/supervisor/supervisor-execution-orchestration.test.ts on pre-existing stale no-PR/reconciliation expectation failures unrelated to this local CI diagnostics slice.