### PR TITLE
Align release readiness checklist link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,4 +264,4 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Issue metadata](./docs/issue-metadata.md): canonical issue-body fields, sequencing rules, and execution-ready examples
 - [GSD to GitHub issues](./docs/examples/gsd-to-github-issues.md): how to hand planning output into execution-ready issues
 - [Atlas example](./docs/examples/atlaspm.md): a concrete config and workflow example
-- [Validation checklist](./docs/validation-checklist.md): advisory minimum, recommended, and sufficient release-readiness checks
+- [Release readiness checklist](./docs/validation-checklist.md): advisory minimum, recommended, and sufficient release-readiness checks

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1498,7 +1498,7 @@ test("README stays a lightweight landing page with provider profile guidance and
   assert.match(readme, /\[Architecture\]\(\.\/docs\/architecture\.md\)/i);
   assert.match(readme, /\[Issue metadata\]\(\.\/docs\/issue-metadata\.md\)/i);
   assert.match(readme, /\[GSD to GitHub issues\]\(\.\/docs\/examples\/gsd-to-github-issues\.md\)/i);
-  assert.match(readme, /\[Validation checklist\]\(\.\/docs\/validation-checklist\.md\)/i);
+  assert.match(readme, /\[Release readiness checklist\]\(\.\/docs\/validation-checklist\.md\)/i);
   assert.match(readme, /Copilot profile/i);
   assert.match(readme, /Codex Connector profile/i);
   assert.match(readme, /CodeRabbit profile/i);


### PR DESCRIPTION
## Summary
- update the README Docs Map checklist link text to `Release readiness checklist`
- update the existing README docs-map assertion to match the release-readiness discoverability contract

## Verification
- `npx tsx --test src/validation-checklist-docs.test.ts`
- `npx tsx --test src/config.test.ts`
- `npm run build`

Closes #1647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Docs Map" link label from "Validation checklist" to "Release readiness checklist"

* **Tests**
  * Updated test to verify the new documentation link label

<!-- end of auto-generated comment: release notes by coderabbit.ai -->