### PR TITLE
Add regression coverage for rehydrated-journal requirements recovery

### DIFF
--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -514,8 +514,8 @@ test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving select
     reconcileStaleFailedIssueStates: async () => {
       calls.push("stale_failed");
     },
-    reconcileRecoverableBlockedIssueStates: async (loadedState) => {
-      calls.push("recoverable_blocked");
+    reconcileRecoverableBlockedIssueStates: async (loadedState, _loadedIssues, options) => {
+      calls.push(`recoverable_blocked:${options?.onlyTrackedPrStates === true ? "tracked" : "all"}`);
       loadedState.issues["77"] = {
         ...loadedState.issues["77"]!,
         state: "ready_to_merge",
@@ -539,11 +539,123 @@ test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving select
     "tracked_merged",
     "merged_closures",
     "stale_failed",
-    "recoverable_blocked",
+    "recoverable_blocked:tracked",
     "reserve:ready_to_merge",
     "parent_epics",
     "cleanup",
   ]);
+});
+
+test("runOnceCyclePrelude requeues rehydrated requirements-blocked no-PR records before reservation", async () => {
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "77": createRecord({
+        issue_number: 77,
+        state: "blocked",
+        pr_number: null,
+        blocked_reason: "requirements",
+        workspace: "/tmp/workspaces/issue-77",
+        journal_path: "/tmp/workspaces/issue-77/.codex-supervisor/issues/77/issue-journal.md",
+        last_error: "Missing required execution-ready metadata: scope, acceptance criteria, verification.",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Issue #77 is not execution-ready because it is missing: scope, acceptance criteria, verification.",
+          signature: "requirements:scope|acceptance criteria|verification",
+          command: null,
+          details: ["journal_state=rehydrated", "detail=prior_local_only_handoff_unavailable"],
+          url: "https://example.test/issues/77",
+          updated_at: "2026-03-26T00:00:00Z",
+        },
+        last_failure_signature: "requirements:scope|acceptance criteria|verification",
+        repeated_failure_signature_count: 2,
+      }),
+    },
+  };
+  const issues: GitHubIssue[] = [
+    {
+      number: 77,
+      title: "Requirements recovery after journal rehydration",
+      body: "",
+      createdAt: "2026-03-26T00:00:00Z",
+      updatedAt: "2026-03-26T00:05:00Z",
+      url: "https://example.test/issues/77",
+      state: "OPEN",
+    },
+  ];
+  const calls: string[] = [];
+  const recoveryEvent: RecoveryEvent = {
+    issueNumber: 77,
+    reason: "requirements_recovered: requeued issue #77 after execution-ready metadata was added",
+    at: "2026-03-26T00:06:00Z",
+  };
+
+  const result = await runOnceCyclePrelude({
+    stateStore: {
+      load: async () => state,
+      save: async () => {
+        calls.push("save");
+      },
+    },
+    carryoverRecoveryEvents: [],
+    reconcileStaleActiveIssueReservation: async () => [],
+    handleAuthFailure: async () => null,
+    listAllIssues: async () => issues,
+    reserveRunnableIssueSelection: async (loadedState) => {
+      calls.push(`reserve:${loadedState.issues["77"]?.state}:${loadedState.issues["77"]?.blocked_reason ?? "none"}`);
+      assert.equal(loadedState.issues["77"]?.last_error, null);
+      assert.equal(loadedState.issues["77"]?.last_failure_context, null);
+      assert.equal(loadedState.issues["77"]?.last_failure_signature, null);
+      return true;
+    },
+    reconcileTrackedMergedButOpenIssues: async () => {
+      calls.push("tracked_merged");
+      return [];
+    },
+    reconcileMergedIssueClosures: async () => {
+      calls.push("merged_closures");
+      return [];
+    },
+    reconcileStaleFailedIssueStates: async () => {
+      calls.push("stale_failed");
+    },
+    reconcileRecoverableBlockedIssueStates: async (loadedState, _loadedIssues, options) => {
+      calls.push(`recoverable_blocked:${options?.onlyTrackedPrStates === true ? "tracked" : "all"}`);
+      if (options?.onlyTrackedPrStates === true) {
+        return [];
+      }
+      loadedState.issues["77"] = {
+        ...loadedState.issues["77"]!,
+        state: "queued",
+        blocked_reason: null,
+        last_error: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        last_recovery_reason: recoveryEvent.reason,
+        last_recovery_at: recoveryEvent.at,
+      };
+      return [recoveryEvent];
+    },
+    reconcileParentEpicClosures: async () => {
+      throw new Error("unexpected reconcileParentEpicClosures call");
+    },
+    cleanupExpiredDoneWorkspaces: async () => {
+      throw new Error("unexpected cleanupExpiredDoneWorkspaces call");
+    },
+  });
+
+  assert.ok(!("kind" in result));
+  assert.deepEqual(calls, [
+    "save",
+    "tracked_merged",
+    "merged_closures",
+    "stale_failed",
+    "recoverable_blocked:tracked",
+    "recoverable_blocked:all",
+    "reserve:queued:none",
+  ]);
+  assert.deepEqual(result.recoveryEvents.map((event) => event.reason), [recoveryEvent.reason]);
 });
 
 test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a new issue", async () => {
@@ -633,8 +745,8 @@ test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a
     "stale_failed",
     "stale_done",
     "recoverable_blocked",
-    "reserve:blocked",
     "recoverable_blocked",
+    "reserve:blocked",
     "parent_epics",
     "cleanup",
   ]);

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -295,6 +295,13 @@ export async function runOnceCyclePrelude(
     recoveryEvents.push(...recoverableBlockedEvents);
     emitRecoveryEvents(recoverableBlockedEvents);
 
+    if (hasNonTrackedRecoverableBlockedStates(state)) {
+      await setReconciliationPhase("recoverable_blocked_issue_states");
+      const remainingRecoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues);
+      recoveryEvents.push(...remainingRecoverableBlockedEvents);
+      emitRecoveryEvents(remainingRecoverableBlockedEvents);
+    }
+
     if (
       state.activeIssueNumber === null &&
       await args.reserveRunnableIssueSelection?.(state) === true
@@ -303,13 +310,6 @@ export async function runOnceCyclePrelude(
         state,
         recoveryEvents,
       };
-    }
-
-    if (hasNonTrackedRecoverableBlockedStates(state)) {
-      await setReconciliationPhase("recoverable_blocked_issue_states");
-      const remainingRecoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues);
-      recoveryEvents.push(...remainingRecoverableBlockedEvents);
-      emitRecoveryEvents(remainingRecoverableBlockedEvents);
     }
 
     await setReconciliationPhase("parent_epic_closures");

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -516,11 +516,31 @@ test("reconcileRecoverableBlockedIssueStates leaves closed issues blocked", asyn
   assert.equal(saveCalls, 0);
 });
 
-test("reconcileRecoverableBlockedIssueStates requeues requirements-blocked issues once metadata is execution-ready", async () => {
+test("reconcileRecoverableBlockedIssueStates requeues requirements-blocked issues once metadata is execution-ready even with a rehydrated journal", async () => {
   const config = createConfig();
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "requirements-rehydrated-"));
+  const workspacePath = path.join(tempDir, "workspaces", "issue-366");
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "366", "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    `# Issue #366: P3: Add regression coverage
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker:
+- Next exact step: Continue after requirements recovery.
+
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+`,
+    "utf8",
+  );
   const original = createRecord({
     state: "blocked",
     blocked_reason: "requirements",
+    workspace: workspacePath,
+    journal_path: journalPath,
     last_error: "Missing required execution-ready metadata: scope, acceptance criteria, verification.",
     last_failure_kind: null,
     last_failure_context: {

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -765,6 +765,112 @@ test("buildIssueExplainSummary surfaces host-migration path repair and journal r
   );
 });
 
+test("buildIssueExplainSummary treats requirements-recovered rehydrated journals as runnable", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 610;
+  const workspacePath = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
+  const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", String(issueNumber), "issue-journal.md");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(path.join(workspacePath, ".git"), "gitdir: /tmp/fake\n", "utf8");
+  await fs.writeFile(
+    journalPath,
+    `# Issue #610: Requirements recovered explain
+
+## Supervisor Snapshot
+- Updated at: 2026-04-17T00:20:00Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Current blocker:
+- Next exact step: Continue after requirements recovery.
+
+### Scratchpad
+- Journal rehydration note: this journal was rehydrated on this host because the prior local-only handoff journal was unavailable.
+`,
+    "utf8",
+  );
+
+  const config = createConfig({
+    workspaceRoot: fixture.workspaceRoot,
+    stateFile: fixture.stateFile,
+    repoPath: fixture.repoPath,
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  });
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Requirements recovered explain",
+    body: `## Summary
+Cover requirements recovery after journal rehydration.
+
+## Scope
+- add explain coverage for recovered requirements blockers
+
+## Acceptance criteria
+- recovered issues are runnable
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "queued",
+        blocked_reason: null,
+        last_error: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        last_recovery_reason: `requirements_recovered: requeued issue #${issueNumber} after execution-ready metadata was added`,
+        last_recovery_at: "2026-04-17T00:21:00Z",
+        branch: branchName(config, issueNumber),
+        workspace: `/tmp/other-host/issue-${issueNumber}`,
+        journal_path: `/tmp/other-host/issue-${issueNumber}/.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
+      }),
+    },
+  };
+
+  const lines = await buildIssueExplainSummary(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+      resolvePullRequestForBranch: async () => null,
+    },
+    config,
+    state,
+    issueNumber,
+  );
+
+  const explanation = lines.join("\n");
+  assert.match(explanation, /^runnable=yes$/m);
+  assert.match(explanation, /^selection_reason=ready /m);
+  assert.match(
+    explanation,
+    /^latest_recovery issue=#610 at=2026-04-17T00:21:00Z reason=requirements_recovered detail=requeued issue #610 after execution-ready metadata was added$/m,
+  );
+  assert.match(
+    explanation,
+    /^issue_journal_state issue=#610 status=rehydrated guidance=no_manual_action_required detail=prior_local_only_handoff_unavailable$/m,
+  );
+  assert.doesNotMatch(explanation, /local_state blocked/);
+  assert.doesNotMatch(explanation, /requirements missing=/);
+  assert.doesNotMatch(explanation, /Missing required execution-ready metadata/);
+});
+
 test("buildIssueExplainDto surfaces preserved partial work for no-PR manual-review recovery", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 607;


### PR DESCRIPTION
## Summary
- Add rehydrated-journal regression coverage for requirements-blocked recovery.
- Run no-PR recoverable blocked reconciliation before reservation so fixed metadata can be selected in the same prelude cycle.
- Add explain coverage proving recovered rehydrated records render runnable and do not show stale requirements/local blocked output.

Closes #1600

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blocked issues that become eligible for recovery by ensuring they are properly re-queued with correct state.
  * Fixed issue state reconciliation timing to prevent blocked issues from being skipped during recovery processing.
  * Enhanced recognition of issues with saved execution state as runnable, preventing them from remaining incorrectly blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->