### PR TITLE
Detect duplicate supervisor loop processes

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -522,6 +522,14 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
       pid: 4242,
       startedAt: "2026-03-25T00:00:00.000Z",
       detail: "supervisor-loop-runtime",
+      duplicateLoopDiagnostic: {
+        kind: "duplicate_loop_processes",
+        status: "duplicate",
+        matchingProcessCount: 2,
+        matchingPids: [4242, 4243],
+        configPath: "/tmp/supervisor.config.json",
+        stateFile: "/tmp/state.json",
+      },
     },
     loopHostWarning:
       "macOS loop runtime is active outside tmux. Restart it with ./scripts/start-loop-tmux.sh and stop unsupported direct hosts before relying on steady-state automation.",
@@ -530,6 +538,10 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
   assert.match(
     report,
     /doctor_loop_runtime state=running host_mode=direct pid=4242 started_at=2026-03-25T00:00:00.000Z detail=supervisor-loop-runtime/,
+  );
+  assert.match(
+    report,
+    /doctor_loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=\/tmp\/supervisor.config.json state_file=\/tmp\/state.json/,
   );
   assert.match(
     report,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -100,6 +100,7 @@ export interface BootstrapReadinessSummary {
 
 interface DiagnoseSupervisorHostArgs {
   config: SupervisorConfig;
+  configPath?: string;
   authStatus?: () => Promise<{ ok: boolean; message: string | null }>;
   loadState?: () => Promise<SupervisorStateFile>;
   github?: {
@@ -136,6 +137,23 @@ function withDoctorLoadFindings(state: SupervisorStateFile, findings: StateLoadF
 
 function sanitizeDoctorValue(value: string): string {
   return value.replace(/\r?\n/g, "\\n");
+}
+
+function renderDoctorDuplicateLoopDiagnosticLine(loopRuntime: SupervisorLoopRuntimeDto): string | null {
+  const diagnostic = loopRuntime.duplicateLoopDiagnostic;
+  if (!diagnostic) {
+    return null;
+  }
+
+  return [
+    "doctor_loop_runtime_diagnostic",
+    `kind=${diagnostic.kind}`,
+    `status=${diagnostic.status}`,
+    `matching_processes=${diagnostic.matchingProcessCount}`,
+    `pids=${diagnostic.matchingPids.join(",")}`,
+    `config_path=${sanitizeDoctorValue(diagnostic.configPath)}`,
+    `state_file=${sanitizeDoctorValue(diagnostic.stateFile)}`,
+  ].join(" ");
 }
 
 function formatOrphanPolicySummary(config: SupervisorConfig): string {
@@ -790,7 +808,7 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     diagnoseStateFile(args.config),
     diagnoseWorktrees(args.config, loadState, github),
   ]);
-  const loopRuntime = await readSupervisorLoopRuntime(args.config.stateFile);
+  const loopRuntime = await readSupervisorLoopRuntime(args.config.stateFile, { configPath: args.configPath });
   const candidateDiscoveryWarning = formatCandidateDiscoveryWarningDetail(
     await github.getCandidateDiscoveryDiagnostics().catch(() => null),
   );
@@ -910,6 +928,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     startedAt: null,
     detail: null,
   };
+  const duplicateLoopDiagnosticLine = renderDoctorDuplicateLoopDiagnosticLine(loopRuntime);
   const workspacePreparationWarning = workspacePreparationContract.warning ?? localCiContract.warning ?? null;
   const configWarnings = workspacePreparationWarning === null ? [] : [renderDoctorWarningLine(buildWarning("config", workspacePreparationWarning)!, sanitizeDoctorValue)];
   const codexModelPolicyLines = (diagnostics.codexModelPolicyLines ?? [])
@@ -931,6 +950,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     ...codexModelPolicyLines,
     ...(diagnostics.reconciliationBacklogLine ? [diagnostics.reconciliationBacklogLine] : []),
     `doctor_loop_runtime state=${loopRuntime.state} host_mode=${loopRuntime.hostMode} pid=${loopRuntime.pid === null ? "none" : String(loopRuntime.pid)} started_at=${loopRuntime.startedAt ?? "none"} detail=${sanitizeDoctorValue(loopRuntime.detail ?? "none")}`,
+    ...(duplicateLoopDiagnosticLine ? [duplicateLoopDiagnosticLine] : []),
     ...(diagnostics.orphanPolicySummary ? [diagnostics.orphanPolicySummary] : []),
     `doctor_workspace_preparation configured=${workspacePreparationContract.configured} source=${workspacePreparationContract.source} command=${sanitizeDoctorValue(workspacePreparationContract.command ?? "none")} summary=${sanitizeDoctorValue(workspacePreparationContract.summary)}`,
     `doctor_local_ci configured=${localCiContract.configured} source=${localCiContract.source} command=${sanitizeDoctorValue(localCiContract.command ?? "none")} summary=${sanitizeDoctorValue(localCiContract.summary)}`,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -432,6 +432,14 @@ test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens
       pid: 4242,
       startedAt: "2026-03-27T00:15:00.000Z\nlegacy",
       detail: "supervisor-loop-runtime",
+      duplicateLoopDiagnostic: {
+        kind: "duplicate_loop_processes",
+        status: "duplicate",
+        matchingProcessCount: 2,
+        matchingPids: [4242, 4243],
+        configPath: "/tmp/supervisor.config.json",
+        stateFile: "/tmp/state.json",
+      },
     },
     activeIssue: null,
     selectionSummary: null,
@@ -449,6 +457,10 @@ test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens
   assert.match(
     status,
     /^loop_runtime state=running host_mode=direct\\nlegacy pid=4242 started_at=2026-03-27T00:15:00.000Z\\nlegacy detail=supervisor-loop-runtime$/m,
+  );
+  assert.match(
+    status,
+    /^loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=\/tmp\/supervisor.config.json state_file=\/tmp\/state.json$/m,
   );
 });
 

--- a/src/supervisor/supervisor-loop-runtime-state.test.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.test.ts
@@ -41,3 +41,62 @@ test("legacy live loop locks without launcher metadata stay unknown and avoid ma
   });
   assert.equal(buildMacOsLoopHostWarning(runtime, "darwin"), null);
 });
+
+test("readSupervisorLoopRuntime detects duplicate loop processes for the same resolved config and state target", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-loop-runtime-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const configPath = path.join(root, "supervisor.config.json");
+  const stateFile = path.join(root, "state.json");
+  const otherConfigPath = path.join(root, "other.supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    `${JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "workspaces",
+      stateFile: "state.json",
+      codexBinary: process.execPath,
+      branchPrefix: "codex/issue-",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    otherConfigPath,
+    `${JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "other-workspaces",
+      stateFile: "other-state.json",
+      codexBinary: process.execPath,
+      branchPrefix: "codex/issue-",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const runtime = await readSupervisorLoopRuntime(stateFile, {
+    configPath,
+    listProcesses: async () => [
+      { pid: 101, command: `node ./dist/index.js loop --config ${configPath}` },
+      { pid: 102, command: `node ./dist/index.js loop --config=${configPath}` },
+      { pid: 103, command: `node ./dist/index.js loop --config ${otherConfigPath}` },
+      { pid: 104, command: `node ./dist/index.js status --config ${configPath}` },
+      { pid: 105, command: "node ./dist/index.js loop" },
+      { pid: 106, command: `grep loop --config ${configPath}` },
+    ],
+  });
+
+  assert.deepEqual(runtime.duplicateLoopDiagnostic, {
+    kind: "duplicate_loop_processes",
+    status: "duplicate",
+    matchingProcessCount: 2,
+    matchingPids: [101, 102],
+    configPath,
+    stateFile,
+  });
+  assert.equal(runtime.state, "off");
+});

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -1,9 +1,21 @@
+import { execFile } from "node:child_process";
 import path from "node:path";
+import { promisify } from "node:util";
+import { loadConfigSummary, resolveConfigPath } from "../core/config";
 import { acquireFileLock, inspectFileLock, type ExistingLockState, type LockHandle } from "../core/lock";
 import type { RunState } from "../core/types";
 import { isLoopAdvanceableState } from "../core/utils";
 
 export type SupervisorLoopHostMode = "tmux" | "direct" | "unknown";
+
+export interface SupervisorDuplicateLoopDiagnostic {
+  kind: "duplicate_loop_processes";
+  status: "duplicate";
+  matchingProcessCount: number;
+  matchingPids: number[];
+  configPath: string;
+  stateFile: string;
+}
 
 export interface SupervisorLoopRuntimeDto {
   state: "running" | "off" | "unknown";
@@ -11,6 +23,7 @@ export interface SupervisorLoopRuntimeDto {
   pid: number | null;
   startedAt: string | null;
   detail: string | null;
+  duplicateLoopDiagnostic?: SupervisorDuplicateLoopDiagnostic;
 }
 
 export interface LoopOffTrackedWorkLike {
@@ -19,7 +32,18 @@ export interface LoopOffTrackedWorkLike {
   prNumber: number | null;
 }
 
+export interface SupervisorLoopProcessSnapshot {
+  pid: number;
+  command: string;
+}
+
+export interface ReadSupervisorLoopRuntimeOptions {
+  configPath?: string;
+  listProcesses?: () => Promise<SupervisorLoopProcessSnapshot[]>;
+}
+
 const LOOP_RUNTIME_LOCK_LABEL = "supervisor-loop-runtime";
+const execFileAsync = promisify(execFile);
 
 export function supervisorLoopRuntimeLockPath(stateFile: string): string {
   return path.resolve(path.dirname(stateFile), "locks", "supervisor", "loop-runtime.lock");
@@ -105,33 +129,204 @@ export function buildLoopOffTrackedWorkBlocker(args: {
   };
 }
 
-export async function readSupervisorLoopRuntime(stateFile: string): Promise<SupervisorLoopRuntimeDto> {
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+
+  for (const character of command) {
+    if (escaping) {
+      current += character;
+      escaping = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote !== null) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === "\"") {
+      quote = character;
+      continue;
+    }
+
+    if (/\s/u.test(character)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+function isSupervisorLoopEntrypointToken(token: string): boolean {
+  const normalized = token.replace(/\\/g, "/");
+  return normalized === "dist/index.js" ||
+    normalized.endsWith("/dist/index.js") ||
+    normalized === "src/index.ts" ||
+    normalized.endsWith("/src/index.ts");
+}
+
+function parseLoopConfigPath(command: string): string | null {
+  const tokens = tokenizeCommand(command);
+  const loopIndex = tokens.indexOf("loop");
+  if (loopIndex === -1 || !tokens.some(isSupervisorLoopEntrypointToken)) {
+    return null;
+  }
+
+  for (let index = loopIndex + 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--config") {
+      return tokens[index + 1] ?? null;
+    }
+    if (token.startsWith("--config=")) {
+      return token.slice("--config=".length) || null;
+    }
+  }
+
+  return null;
+}
+
+async function listProcessSnapshots(): Promise<SupervisorLoopProcessSnapshot[]> {
+  const { stdout } = await execFileAsync("ps", ["-axo", "pid=,command="], { maxBuffer: 1024 * 1024 });
+  return stdout
+    .split(/\r?\n/u)
+    .map((line) => {
+      const match = line.match(/^\s*(\d+)\s+([\s\S]+)$/u);
+      if (!match) {
+        return null;
+      }
+      return {
+        pid: Number(match[1]),
+        command: match[2],
+      };
+    })
+    .filter((entry): entry is SupervisorLoopProcessSnapshot => entry !== null && Number.isInteger(entry.pid));
+}
+
+async function resolveLoopProcessStateFile(configPath: string): Promise<string | null> {
+  try {
+    const summary = loadConfigSummary(configPath);
+    return summary.config === null ? null : path.resolve(summary.config.stateFile);
+  } catch {
+    return null;
+  }
+}
+
+async function detectDuplicateLoopProcesses(
+  stateFile: string,
+  options: ReadSupervisorLoopRuntimeOptions,
+): Promise<SupervisorDuplicateLoopDiagnostic | null> {
+  const currentConfigPath = path.resolve(options.configPath ?? resolveConfigPath(undefined));
+  const currentStateFile = path.resolve(stateFile);
+  const listProcesses = options.listProcesses ?? listProcessSnapshots;
+  let snapshots: SupervisorLoopProcessSnapshot[];
+  try {
+    snapshots = await listProcesses();
+  } catch {
+    return null;
+  }
+
+  const matchingPids: number[] = [];
+  for (const snapshot of snapshots) {
+    const candidateConfigPath = parseLoopConfigPath(snapshot.command);
+    if (candidateConfigPath === null) {
+      continue;
+    }
+
+    const resolvedCandidateConfigPath = path.resolve(candidateConfigPath);
+    if (resolvedCandidateConfigPath !== currentConfigPath) {
+      continue;
+    }
+
+    const candidateStateFile = await resolveLoopProcessStateFile(resolvedCandidateConfigPath);
+    if (candidateStateFile !== currentStateFile) {
+      continue;
+    }
+
+    matchingPids.push(snapshot.pid);
+  }
+
+  const uniquePids = [...new Set(matchingPids)].sort((left, right) => left - right);
+  if (uniquePids.length <= 1) {
+    return null;
+  }
+
+  return {
+    kind: "duplicate_loop_processes",
+    status: "duplicate",
+    matchingProcessCount: uniquePids.length,
+    matchingPids: uniquePids,
+    configPath: currentConfigPath,
+    stateFile: currentStateFile,
+  };
+}
+
+function withDuplicateLoopDiagnostic(
+  runtime: SupervisorLoopRuntimeDto,
+  diagnostic: SupervisorDuplicateLoopDiagnostic | null,
+): SupervisorLoopRuntimeDto {
+  return diagnostic === null
+    ? runtime
+    : {
+      ...runtime,
+      duplicateLoopDiagnostic: diagnostic,
+    };
+}
+
+export async function readSupervisorLoopRuntime(
+  stateFile: string,
+  options: ReadSupervisorLoopRuntimeOptions = {},
+): Promise<SupervisorLoopRuntimeDto> {
   const runtimeLock = await inspectSupervisorLoopRuntimeLock(stateFile);
+  const duplicateLoopDiagnostic = await detectDuplicateLoopProcesses(stateFile, options);
   if (runtimeLock.status === "live") {
-    return {
+    return withDuplicateLoopDiagnostic({
       state: "running",
       hostMode: inferLoopHostMode(runtimeLock),
       pid: runtimeLock.payload?.pid ?? null,
       startedAt: runtimeLock.payload?.acquired_at ?? null,
       detail: runtimeLock.payload?.label ?? LOOP_RUNTIME_LOCK_LABEL,
-    };
+    }, duplicateLoopDiagnostic);
   }
 
   if (runtimeLock.status === "ambiguous_owner") {
-    return {
+    return withDuplicateLoopDiagnostic({
       state: "unknown",
       hostMode: inferLoopHostMode(runtimeLock),
       pid: runtimeLock.payload?.pid ?? null,
       startedAt: runtimeLock.payload?.acquired_at ?? null,
       detail: runtimeLock.payload?.label ?? LOOP_RUNTIME_LOCK_LABEL,
-    };
+    }, duplicateLoopDiagnostic);
   }
 
-  return {
+  return withDuplicateLoopDiagnostic({
     state: "off",
     hostMode: "unknown",
     pid: null,
     startedAt: null,
     detail: null,
-  };
+  }, duplicateLoopDiagnostic);
 }

--- a/src/supervisor/supervisor-read-only-reporting-boundary.test.ts
+++ b/src/supervisor/supervisor-read-only-reporting-boundary.test.ts
@@ -33,7 +33,7 @@ test("Supervisor read-only reporting methods remain thin delegators", async () =
 
   assert.match(
     extractMethodBody(source, 'async statusReport(options: Pick<CliOptions, "why"> = { why: false }): Promise<SupervisorStatusDto>'),
-    /^return buildSupervisorStatusReport\(\{\s*config: this\.config,\s*github: this\.github,\s*stateStore: this\.stateStore,\s*options,\s*\}\);$/s,
+    /^return buildSupervisorStatusReport\(\{\s*config: this\.config,\s*configPath: this\.configPath,\s*github: this\.github,\s*stateStore: this\.stateStore,\s*options,\s*\}\);$/s,
   );
   assert.match(
     extractMethodBody(source, "async explainReport(issueNumber: number): Promise<SupervisorExplainDto>"),
@@ -41,7 +41,7 @@ test("Supervisor read-only reporting methods remain thin delegators", async () =
   );
   assert.match(
     extractMethodBody(source, "async doctorReport()"),
-    /^return buildSupervisorDoctorReport\(\{\s*config: this\.config,\s*github: this\.github,\s*\}\);$/s,
+    /^return buildSupervisorDoctorReport\(\{\s*config: this\.config,\s*configPath: this\.configPath,\s*github: this\.github,\s*\}\);$/s,
   );
   assert.match(
     extractMethodBody(source, "async setupReadinessReport()"),

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -155,6 +155,7 @@ async function loadGitHubRateLimitStatus(github: GitHubClient) {
 
 export async function buildSupervisorStatusReport(args: {
   config: SupervisorConfig;
+  configPath?: string;
   github: GitHubClient;
   stateStore: StateStore;
   options: Pick<CliOptions, "why">;
@@ -166,7 +167,7 @@ export async function buildSupervisorStatusReport(args: {
   const cadenceDiagnostics = summarizeCadenceDiagnostics(config);
   const candidateDiscoverySummary = formatCandidateDiscoveryBehaviorLine(config);
   const localCiContract = summarizeLocalCiContract(config);
-  const loopRuntime = await readSupervisorLoopRuntime(config.stateFile);
+  const loopRuntime = await readSupervisorLoopRuntime(config.stateFile, { configPath: args.configPath });
   const loopHostWarning = buildMacOsLoopHostWarning(loopRuntime);
   const gsdSummary = await describeGsdIntegration(config);
   const statusRecords = summarizeSupervisorStatusRecords(state);
@@ -533,10 +534,12 @@ export async function buildSupervisorExplainReport(args: {
 
 export async function buildSupervisorDoctorReport(args: {
   config: SupervisorConfig;
+  configPath?: string;
   github: Pick<GitHubClient, "authStatus">;
 }): Promise<DoctorDiagnostics> {
   return diagnoseSupervisorHost({
     config: args.config,
+    configPath: args.configPath,
     authStatus: () => args.github.authStatus(),
     loadState: () => loadStateReadonlyForDoctor(args.config),
   });

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -521,7 +521,7 @@ test("buildDetailedStatusSummaryLines shapes optional summaries and artifact pat
     }),
     [
       "handoff_summary=blocked\\nneeds reproduction",
-      "pre_merge_evaluation status=blocked outcome=fix_blocked head=current must_fix=1 manual_review=0 follow_up=0 reason=must_fix_residuals=1 ran_at=2026-03-24T00:11:00Z summary_path=owner-repo/issue-58/local-review-summary.md artifact_path=owner-repo/issue-58/local-review-summary.json",
+      "pre_merge_evaluation status=blocked outcome=fix_blocked repair=none head=current must_fix=1 manual_review=0 follow_up=0 reason=must_fix_residuals=1 ran_at=2026-03-24T00:11:00Z summary_path=owner-repo/issue-58/local-review-summary.md artifact_path=owner-repo/issue-58/local-review-summary.json",
       "local_review_routing generic=inherit->gpt-5-codex(1) specialists=gpt-5-codex(1) verifier=gpt-5-codex",
       "change_classes=backend, docs, tests",
       "durable_guardrails verifier=committed:.codex/verifier-guardrails.json#1 external_review=none",

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -92,6 +92,23 @@ export function renderLoopRuntimeLine(loopRuntime: SupervisorLoopRuntimeDto): st
   ].join(" ");
 }
 
+function renderDuplicateLoopDiagnosticLine(loopRuntime: SupervisorLoopRuntimeDto): string | null {
+  const diagnostic = loopRuntime.duplicateLoopDiagnostic;
+  if (!diagnostic) {
+    return null;
+  }
+
+  return [
+    "loop_runtime_diagnostic",
+    `kind=${diagnostic.kind}`,
+    `status=${diagnostic.status}`,
+    `matching_processes=${diagnostic.matchingProcessCount}`,
+    `pids=${diagnostic.matchingPids.join(",")}`,
+    `config_path=${sanitizeStatusValue(diagnostic.configPath)}`,
+    `state_file=${sanitizeStatusValue(diagnostic.stateFile)}`,
+  ].join(" ");
+}
+
 export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
   const localCiContract = dto.localCiContract ?? {
     configured: false,
@@ -125,10 +142,12 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
       ].filter((line) => !dto.detailedStatusLines.includes(line));
   const trustWarnings = buildTrustAndConfigWarnings(trustDiagnostics);
   const statusWarning = dto.warning === null ? null : buildWarning(dto.warning.kind, dto.warning.message);
+  const duplicateLoopDiagnosticLine = renderDuplicateLoopDiagnosticLine(dto.loopRuntime);
   const lines = [
     ...dto.detailedStatusLines,
     ...githubRateLimitLines,
     renderLoopRuntimeLine(dto.loopRuntime),
+    ...(duplicateLoopDiagnosticLine ? [duplicateLoopDiagnosticLine] : []),
     `trust_mode=${trustDiagnostics.trustMode}`,
     `execution_safety_mode=${trustDiagnostics.executionSafetyMode}`,
     ...trustWarnings.map((warning) => renderStatusWarningLine(warning, sanitizeStatusValue)),

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -951,6 +951,7 @@ export class Supervisor {
   async statusReport(options: Pick<CliOptions, "why"> = { why: false }): Promise<SupervisorStatusDto> {
     return buildSupervisorStatusReport({
       config: this.config,
+      configPath: this.configPath,
       github: this.github,
       stateStore: this.stateStore,
       options,
@@ -1004,6 +1005,7 @@ export class Supervisor {
   async doctorReport() {
     return buildSupervisorDoctorReport({
       config: this.config,
+      configPath: this.configPath,
       github: this.github,
     });
   }


### PR DESCRIPTION
## Summary
- add typed duplicate-loop diagnostics to loop runtime state
- detect duplicates by matching supervisor loop entrypoint processes against the resolved config path and config-resolved state file
- pass config path into status/doctor runtime reads and render compact duplicate diagnostics when present

## Verification
- npx tsx --test src/supervisor/supervisor-loop-runtime-state.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts src/doctor.test.ts src/supervisor/supervisor-read-only-reporting-boundary.test.ts
- npm run build
- npm run verify:paths

Part of #1650