### PR TITLE
Add loop ownership recovery guidance

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -48,6 +48,7 @@ export interface DashboardLoopRuntimeLike {
   startedAt?: string | null;
   ownershipConfidence?: "none" | "live_lock" | "stale_lock" | "ambiguous_owner" | "duplicate_suspected" | null;
   detail?: string | null;
+  recoveryGuidance?: string | null;
   duplicateLoopDiagnostic?: {
     kind?: string | null;
     status?: string | null;
@@ -55,6 +56,7 @@ export interface DashboardLoopRuntimeLike {
     matchingPids?: number[] | null;
     configPath?: string | null;
     stateFile?: string | null;
+    recoveryGuidance?: string | null;
   } | null;
 }
 

--- a/src/backend/webui-dashboard-browser-view-model.test.ts
+++ b/src/backend/webui-dashboard-browser-view-model.test.ts
@@ -77,6 +77,8 @@ test("describeLoopRuntime summarizes running, off, and unknown states with host 
     state: "off",
     hostMode: "unknown",
     ownershipConfidence: "duplicate_suspected",
+    recoveryGuidance:
+      "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
     duplicateLoopDiagnostic: {
       kind: "duplicate_loop_processes",
       status: "duplicate",
@@ -84,11 +86,30 @@ test("describeLoopRuntime summarizes running, off, and unknown states with host 
       matchingPids: [4242, 4243],
       configPath: "/tmp/supervisor.config.json",
       stateFile: "/tmp/state.json",
+      recoveryGuidance:
+        "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
     },
   }), {
     modeBadge: "Mode: web + loop ambiguous",
-    summary: "Loop runtime ownership is ambiguous: 2 matching loop processes",
+    summary:
+      "Loop runtime ownership is ambiguous: 2 matching loop processes. Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
     chipLabel: "loop ownership ambiguous",
+    chipTone: "warn",
+  });
+
+  assert.deepEqual(describeLoopRuntime({
+    state: "unknown",
+    hostMode: "unknown",
+    ownershipConfidence: "ambiguous_owner",
+    pid: 4242,
+    configPath: "/tmp/supervisor.config.json",
+    recoveryGuidance:
+      "Safe recovery: verify marker PID 4242 owns config /tmp/supervisor.config.json before restarting automation; if ownership is still unclear, inspect the process and marker instead of deleting the marker or killing processes automatically.",
+  }), {
+    modeBadge: "Mode: local WebUI",
+    summary:
+      "Loop runtime marker ownership is ambiguous. Safe recovery: verify marker PID 4242 owns config /tmp/supervisor.config.json before restarting automation; if ownership is still unclear, inspect the process and marker instead of deleting the marker or killing processes automatically.",
+    chipLabel: "loop marker ambiguous",
     chipTone: "warn",
   });
 

--- a/src/backend/webui-dashboard-browser-view-model.ts
+++ b/src/backend/webui-dashboard-browser-view-model.ts
@@ -153,6 +153,15 @@ export function describeLoopRuntime(loopRuntime: DashboardLoopRuntimeLike | null
   const ownershipConfidence =
     typeof loopRuntime?.ownershipConfidence === "string" ? loopRuntime.ownershipConfidence : "none";
   const duplicateDiagnostic = loopRuntime?.duplicateLoopDiagnostic ?? null;
+  const recoveryGuidance =
+    typeof loopRuntime?.recoveryGuidance === "string" && loopRuntime.recoveryGuidance.trim() !== ""
+      ? loopRuntime.recoveryGuidance
+      : typeof duplicateDiagnostic?.recoveryGuidance === "string" && duplicateDiagnostic.recoveryGuidance.trim() !== ""
+        ? duplicateDiagnostic.recoveryGuidance
+        : null;
+  function appendRecoveryGuidance(summary: string): string {
+    return recoveryGuidance === null ? summary : summary + ". " + recoveryGuidance;
+  }
   const hasDuplicateSignal =
     ownershipConfidence === "duplicate_suspected" ||
     duplicateDiagnostic?.kind === "duplicate_loop_processes" ||
@@ -162,9 +171,9 @@ export function describeLoopRuntime(loopRuntime: DashboardLoopRuntimeLike | null
       typeof duplicateDiagnostic?.matchingProcessCount === "number" ? duplicateDiagnostic.matchingProcessCount : null;
     return {
       modeBadge: "Mode: web + loop ambiguous",
-      summary: matchingProcessCount === null
+      summary: appendRecoveryGuidance(matchingProcessCount === null
         ? "Loop runtime ownership is ambiguous"
-        : "Loop runtime ownership is ambiguous: " + String(matchingProcessCount) + " matching loop processes",
+        : "Loop runtime ownership is ambiguous: " + String(matchingProcessCount) + " matching loop processes"),
       chipLabel: "loop ownership ambiguous",
       chipTone: "warn",
     };
@@ -180,7 +189,7 @@ export function describeLoopRuntime(loopRuntime: DashboardLoopRuntimeLike | null
   if (ownershipConfidence === "ambiguous_owner") {
     return {
       modeBadge: "Mode: local WebUI",
-      summary: "Loop runtime marker ownership is ambiguous",
+      summary: appendRecoveryGuidance("Loop runtime marker ownership is ambiguous"),
       chipLabel: "loop marker ambiguous",
       chipTone: "warn",
     };

--- a/src/backend/webui-dashboard-test-fixtures.ts
+++ b/src/backend/webui-dashboard-test-fixtures.ts
@@ -378,6 +378,7 @@ export function createDashboardStatusFixture(args: {
     startedAt: string | null;
     ownershipConfidence?: "none" | "live_lock" | "stale_lock" | "ambiguous_owner" | "duplicate_suspected" | null;
     detail: string | null;
+    recoveryGuidance?: string | null;
     duplicateLoopDiagnostic?: {
       kind: string;
       status: string;
@@ -385,6 +386,7 @@ export function createDashboardStatusFixture(args: {
       matchingPids: number[];
       configPath: string;
       stateFile: string;
+      recoveryGuidance?: string | null;
     };
   } | null;
   trackedIssues?: Array<{

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -443,6 +443,8 @@ test("dashboard renders duplicate loop ownership as ambiguous instead of loop of
           startedAt: null,
           detail: null,
           ownershipConfidence: "duplicate_suspected",
+          recoveryGuidance:
+            "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
           duplicateLoopDiagnostic: {
             kind: "duplicate_loop_processes",
             status: "duplicate",
@@ -450,6 +452,8 @@ test("dashboard renders duplicate loop ownership as ambiguous instead of loop of
             matchingPids: [4242, 4243],
             configPath: "/tmp/supervisor.config.json",
             stateFile: "/tmp/state.json",
+            recoveryGuidance:
+              "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
           },
         },
       }),
@@ -465,6 +469,8 @@ test("dashboard renders duplicate loop ownership as ambiguous instead of loop of
   assert.match(loopModeBadge.textContent, /loop ambiguous/u);
   assert.doesNotMatch(loopModeBadge.textContent, /loop off/u);
   assert.match(loopStateSummary.textContent, /Loop runtime ownership is ambiguous: 2 matching loop processes/u);
+  assert.match(loopStateSummary.textContent, /inspect the listed direct loop PIDs before stopping any process/u);
+  assert.match(loopStateSummary.textContent, /\.\/scripts\/start-loop-tmux\.sh/u);
   assert.equal(harness.remainingFetches.length, 0);
 });
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -530,6 +530,8 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
       startedAt: "2026-03-25T00:00:00.000Z",
       ownershipConfidence: "duplicate_suspected",
       detail: "supervisor-loop-runtime",
+      recoveryGuidance:
+        "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
       duplicateLoopDiagnostic: {
         kind: "duplicate_loop_processes",
         status: "duplicate",
@@ -537,6 +539,8 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
         matchingPids: [4242, 4243],
         configPath: "/tmp/supervisor.config.json",
         stateFile: "/tmp/state.json",
+        recoveryGuidance:
+          "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
       },
     },
     loopHostWarning:
@@ -549,7 +553,11 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
   );
   assert.match(
     report,
-    /doctor_loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=\/tmp\/supervisor.config.json state_file=\/tmp\/state.json/,
+    /doctor_loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=\/tmp\/supervisor.config.json state_file=\/tmp\/state.json recovery=Safe recovery: for config \/tmp\/supervisor.config.json, stop the tmux-managed loop with \.\/scripts\/stop-loop-tmux\.sh, inspect the listed direct loop PIDs before stopping any process, then restart with \.\/scripts\/start-loop-tmux\.sh using the same config\./,
+  );
+  assert.match(
+    report,
+    /doctor_loop_runtime_recovery guidance=Safe recovery: for config \/tmp\/supervisor.config.json, stop the tmux-managed loop with \.\/scripts\/stop-loop-tmux\.sh, inspect the listed direct loop PIDs before stopping any process, then restart with \.\/scripts\/start-loop-tmux\.sh using the same config\./,
   );
   assert.match(
     report,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -153,7 +153,16 @@ function renderDoctorDuplicateLoopDiagnosticLine(loopRuntime: SupervisorLoopRunt
     `pids=${diagnostic.matchingPids.join(",")}`,
     `config_path=${sanitizeDoctorValue(diagnostic.configPath)}`,
     `state_file=${sanitizeDoctorValue(diagnostic.stateFile)}`,
+    `recovery=${sanitizeDoctorValue(diagnostic.recoveryGuidance ?? loopRuntime.recoveryGuidance ?? "none")}`,
   ].join(" ");
+}
+
+function renderDoctorLoopRuntimeRecoveryLine(loopRuntime: SupervisorLoopRuntimeDto): string | null {
+  if (!loopRuntime.recoveryGuidance) {
+    return null;
+  }
+
+  return `doctor_loop_runtime_recovery guidance=${sanitizeDoctorValue(loopRuntime.recoveryGuidance)}`;
 }
 
 function formatOrphanPolicySummary(config: SupervisorConfig): string {
@@ -938,6 +947,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
   const loopRuntimeOwnershipConfidence =
     ("ownershipConfidence" in loopRuntime ? loopRuntime.ownershipConfidence : null) ?? "none";
   const duplicateLoopDiagnosticLine = renderDoctorDuplicateLoopDiagnosticLine(loopRuntime);
+  const loopRuntimeRecoveryLine = renderDoctorLoopRuntimeRecoveryLine(loopRuntime);
   const workspacePreparationWarning = workspacePreparationContract.warning ?? localCiContract.warning ?? null;
   const configWarnings = workspacePreparationWarning === null ? [] : [renderDoctorWarningLine(buildWarning("config", workspacePreparationWarning)!, sanitizeDoctorValue)];
   const codexModelPolicyLines = (diagnostics.codexModelPolicyLines ?? [])
@@ -960,6 +970,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     ...(diagnostics.reconciliationBacklogLine ? [diagnostics.reconciliationBacklogLine] : []),
     `doctor_loop_runtime state=${loopRuntime.state} host_mode=${loopRuntime.hostMode} marker_path=${sanitizeDoctorValue(loopRuntimeMarkerPath)} config_path=${sanitizeDoctorValue(loopRuntimeConfigPath ?? "none")} state_file=${sanitizeDoctorValue(loopRuntimeStateFile)} pid=${loopRuntime.pid === null ? "none" : String(loopRuntime.pid)} started_at=${loopRuntime.startedAt ?? "none"} ownership_confidence=${loopRuntimeOwnershipConfidence} detail=${sanitizeDoctorValue(loopRuntime.detail ?? "none")}`,
     ...(duplicateLoopDiagnosticLine ? [duplicateLoopDiagnosticLine] : []),
+    ...(loopRuntimeRecoveryLine ? [loopRuntimeRecoveryLine] : []),
     ...(diagnostics.orphanPolicySummary ? [diagnostics.orphanPolicySummary] : []),
     `doctor_workspace_preparation configured=${workspacePreparationContract.configured} source=${workspacePreparationContract.source} command=${sanitizeDoctorValue(workspacePreparationContract.command ?? "none")} summary=${sanitizeDoctorValue(workspacePreparationContract.summary)}`,
     `doctor_local_ci configured=${localCiContract.configured} source=${localCiContract.source} command=${sanitizeDoctorValue(localCiContract.command ?? "none")} summary=${sanitizeDoctorValue(localCiContract.summary)}`,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -440,6 +440,8 @@ test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens
       startedAt: "2026-03-27T00:15:00.000Z\nlegacy",
       ownershipConfidence: "duplicate_suspected",
       detail: "supervisor-loop-runtime",
+      recoveryGuidance:
+        "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
       duplicateLoopDiagnostic: {
         kind: "duplicate_loop_processes",
         status: "duplicate",
@@ -447,6 +449,8 @@ test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens
         matchingPids: [4242, 4243],
         configPath: "/tmp/supervisor.config.json",
         stateFile: "/tmp/state.json",
+        recoveryGuidance:
+          "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
       },
     },
     activeIssue: null,
@@ -468,7 +472,11 @@ test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens
   );
   assert.match(
     status,
-    /^loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=\/tmp\/supervisor.config.json state_file=\/tmp\/state.json$/m,
+    /^loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=\/tmp\/supervisor.config.json state_file=\/tmp\/state.json recovery=Safe recovery: for config \/tmp\/supervisor.config.json, stop the tmux-managed loop with \.\/scripts\/stop-loop-tmux\.sh, inspect the listed direct loop PIDs before stopping any process, then restart with \.\/scripts\/start-loop-tmux\.sh using the same config\.$/m,
+  );
+  assert.match(
+    status,
+    /^loop_runtime_recovery guidance=Safe recovery: for config \/tmp\/supervisor.config.json, stop the tmux-managed loop with \.\/scripts\/stop-loop-tmux\.sh, inspect the listed direct loop PIDs before stopping any process, then restart with \.\/scripts\/start-loop-tmux\.sh using the same config\.$/m,
   );
 });
 
@@ -1327,6 +1335,8 @@ test("acquireLoopRuntimeLock fails closed on ambiguous-owner loop runtime locks 
     startedAt: "2026-03-20T00:00:00.000Z",
     ownershipConfidence: "ambiguous_owner",
     detail: "supervisor-loop-runtime",
+    recoveryGuidance:
+      "Safe recovery: verify marker PID 999999 owns the active supervisor config before restarting automation; if ownership is still unclear, inspect the process and marker instead of deleting the marker or killing processes automatically.",
   });
 });
 

--- a/src/supervisor/supervisor-loop-runtime-state.test.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.test.ts
@@ -101,10 +101,16 @@ test("readSupervisorLoopRuntime detects duplicate loop processes for the same re
     matchingPids: [101, 102],
     configPath,
     stateFile,
+    recoveryGuidance:
+      `Safe recovery: for config ${configPath}, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.`,
   });
   assert.equal(runtime.state, "off");
   assert.equal(runtime.markerPath, supervisorLoopRuntimeLockPath(stateFile));
   assert.equal(runtime.configPath, configPath);
   assert.equal(runtime.stateFile, stateFile);
   assert.equal(runtime.ownershipConfidence, "duplicate_suspected");
+  assert.equal(
+    runtime.recoveryGuidance,
+    `Safe recovery: for config ${configPath}, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.`,
+  );
 });

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -21,6 +21,7 @@ export interface SupervisorDuplicateLoopDiagnostic {
   matchingPids: number[];
   configPath: string;
   stateFile: string;
+  recoveryGuidance?: string;
 }
 
 export interface SupervisorLoopRuntimeDto {
@@ -34,6 +35,7 @@ export interface SupervisorLoopRuntimeDto {
   ownershipConfidence: SupervisorLoopOwnershipConfidence;
   detail: string | null;
   duplicateLoopDiagnostic?: SupervisorDuplicateLoopDiagnostic;
+  recoveryGuidance?: string;
 }
 
 export interface LoopOffTrackedWorkLike {
@@ -100,6 +102,30 @@ export function buildMacOsLoopHostWarning(
   }
 
   return "macOS loop runtime is active outside tmux. Restart it with ./scripts/start-loop-tmux.sh and stop unsupported direct hosts before relying on steady-state automation.";
+}
+
+function formatLoopConfigReference(configPath: string | null | undefined): string {
+  return configPath === null || configPath === undefined || configPath.trim() === ""
+    ? "the active supervisor config"
+    : `config ${configPath}`;
+}
+
+export function buildLoopRuntimeRecoveryGuidance(loopRuntime: Pick<
+  SupervisorLoopRuntimeDto,
+  "configPath" | "ownershipConfidence" | "pid" | "duplicateLoopDiagnostic"
+>): string | null {
+  if (loopRuntime.duplicateLoopDiagnostic) {
+    const configReference = formatLoopConfigReference(loopRuntime.duplicateLoopDiagnostic.configPath);
+    return `Safe recovery: for ${configReference}, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.`;
+  }
+
+  if (loopRuntime.ownershipConfidence === "ambiguous_owner") {
+    const configReference = formatLoopConfigReference(loopRuntime.configPath);
+    const pidReference = loopRuntime.pid === null ? "the marker PID" : `marker PID ${loopRuntime.pid}`;
+    return `Safe recovery: verify ${pidReference} owns ${configReference} before restarting automation; if ownership is still unclear, inspect the process and marker instead of deleting the marker or killing processes automatically.`;
+  }
+
+  return null;
 }
 
 export function buildLoopOffTrackedWorkBlocker(args: {
@@ -298,13 +324,30 @@ function withDuplicateLoopDiagnostic(
   runtime: SupervisorLoopRuntimeDto,
   diagnostic: SupervisorDuplicateLoopDiagnostic | null,
 ): SupervisorLoopRuntimeDto {
-  return diagnostic === null
+  const runtimeWithDiagnostic = diagnostic === null
     ? runtime
     : {
       ...runtime,
-      ownershipConfidence: "duplicate_suspected",
+      ownershipConfidence: "duplicate_suspected" as const,
       duplicateLoopDiagnostic: diagnostic,
     };
+  const recoveryGuidance = buildLoopRuntimeRecoveryGuidance(runtimeWithDiagnostic);
+  if (recoveryGuidance === null) {
+    return runtimeWithDiagnostic;
+  }
+
+  return {
+    ...runtimeWithDiagnostic,
+    recoveryGuidance,
+    ...(runtimeWithDiagnostic.duplicateLoopDiagnostic
+      ? {
+        duplicateLoopDiagnostic: {
+          ...runtimeWithDiagnostic.duplicateLoopDiagnostic,
+          recoveryGuidance,
+        },
+      }
+      : {}),
+  };
 }
 
 export async function readSupervisorLoopRuntime(

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -114,7 +114,16 @@ function renderDuplicateLoopDiagnosticLine(loopRuntime: SupervisorLoopRuntimeDto
     `pids=${diagnostic.matchingPids.join(",")}`,
     `config_path=${sanitizeStatusValue(diagnostic.configPath)}`,
     `state_file=${sanitizeStatusValue(diagnostic.stateFile)}`,
+    `recovery=${sanitizeStatusValue(diagnostic.recoveryGuidance ?? loopRuntime.recoveryGuidance ?? "none")}`,
   ].join(" ");
+}
+
+function renderLoopRuntimeRecoveryLine(loopRuntime: SupervisorLoopRuntimeDto): string | null {
+  if (!loopRuntime.recoveryGuidance) {
+    return null;
+  }
+
+  return `loop_runtime_recovery guidance=${sanitizeStatusValue(loopRuntime.recoveryGuidance)}`;
 }
 
 export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
@@ -151,11 +160,13 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
   const trustWarnings = buildTrustAndConfigWarnings(trustDiagnostics);
   const statusWarning = dto.warning === null ? null : buildWarning(dto.warning.kind, dto.warning.message);
   const duplicateLoopDiagnosticLine = renderDuplicateLoopDiagnosticLine(dto.loopRuntime);
+  const loopRuntimeRecoveryLine = renderLoopRuntimeRecoveryLine(dto.loopRuntime);
   const lines = [
     ...dto.detailedStatusLines,
     ...githubRateLimitLines,
     renderLoopRuntimeLine(dto.loopRuntime),
     ...(duplicateLoopDiagnosticLine ? [duplicateLoopDiagnosticLine] : []),
+    ...(loopRuntimeRecoveryLine ? [loopRuntimeRecoveryLine] : []),
     `trust_mode=${trustDiagnostics.trustMode}`,
     `execution_safety_mode=${trustDiagnostics.executionSafetyMode}`,
     ...trustWarnings.map((warning) => renderStatusWarningLine(warning, sanitizeStatusValue)),


### PR DESCRIPTION
## Summary
- Add typed recovery guidance for duplicate loop processes and ambiguous loop runtime markers
- Render the guidance in status and doctor output
- Reuse the typed guidance in the WebUI loop summary without adding automatic process or marker cleanup

Part of #1649
Closes #1652

## Verification
- npx tsx --test src/doctor.test.ts src/supervisor/supervisor-status-rendering.test.ts src/backend/webui-dashboard.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recovery guidance is now displayed throughout diagnostics, doctor output, and status reports to help users resolve issues.
  * When duplicate loop processes or ambiguous marker ownership is detected, the system displays actionable recovery instructions with specific steps to safely inspect and restart the loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->