### PR TITLE
Classify stale diagnostics by recoverability

### DIFF
--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -647,7 +647,7 @@ test("dashboard status panel surfaces tracked PR host-local CI blockers", async 
         createStatus({
           includeWhyLines: false,
           detailedStatusLines: [
-            "tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=verification stale_local_blocker=yes",
+            "tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=verification stale_local_blocker=yes",
             "tracked_pr_host_local_ci issue=#171 pr=#271 github_checks=green head_sha=head-ready-271 outcome=failed failure_class=workspace_toolchain_missing remediation_target=workspace_environment head=current summary=Configured local CI command could not run before marking PR #271 ready because the workspace toolchain is unavailable. Remediation target: workspace environment.",
             `tracked_pr_host_local_ci_gap issue=#171 pr=#271 workspace_preparation_command=unset gap=missing_workspace_prerequisite_visibility likely_cause=${MISSING_WORKSPACE_PREPARATION_CONTRACT_WARNING}`,
           ],

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1932,7 +1932,7 @@ test("diagnoseSupervisorHost exposes tracked PR mismatches when GitHub is ready 
   );
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes/,
   );
   assert.match(
     renderDoctorReport(diagnostics),
@@ -2040,7 +2040,7 @@ test("diagnoseSupervisorHost skips tracked PR hydration for historical done reco
   assert.equal(getPullRequestIfExistsCalls, 1);
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes/,
   );
 });
 
@@ -2120,7 +2120,7 @@ test("diagnoseSupervisorHost exposes stale_review_bot tracked PR mismatches when
   assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#172 pr=#272 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_mismatch issue=#172 pr=#272 recoverability=stale_already_handled github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes/,
   );
   assert.match(
     renderDoctorReport(diagnostics),
@@ -2215,7 +2215,7 @@ test("diagnoseSupervisorHost preserves draft tracked PR verification blockers in
   assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#174 pr=#274 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#174 pr=#274 recoverability=manual_attention_required github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
   );
   assert.match(
     renderDoctorReport(diagnostics),
@@ -2319,7 +2319,7 @@ test("diagnoseSupervisorHost marks old-head ready-promotion blockers as stale", 
   assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#175 pr=#275 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#175 pr=#275 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
   );
   assert.match(
     renderDoctorReport(diagnostics),
@@ -2426,7 +2426,7 @@ test("diagnoseSupervisorHost marks same-head ready-promotion blockers as stale w
   assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#176 pr=#276 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#176 pr=#276 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
   );
   assert.match(
     renderDoctorReport(diagnostics),
@@ -2535,7 +2535,7 @@ test("diagnoseSupervisorHost keeps same-head host-local ready-promotion blockers
   assert.equal(diagnostics.checks.find((check) => check.name === "worktrees")?.status, "warn");
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#177 pr=#277 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
+    /doctor_detail name=worktrees detail=tracked_pr_ready_promotion_blocked issue=#177 pr=#277 recoverability=manual_attention_required github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes/,
   );
   assert.match(
     renderDoctorReport(diagnostics),

--- a/src/no-pull-request-state.ts
+++ b/src/no-pull-request-state.ts
@@ -1,4 +1,8 @@
 import { IssueRunRecord, RunState, SupervisorConfig, WorkspaceStatus } from "./core/types";
+import {
+  classifyStaleNoPrRecoverability,
+  recoverabilityStatusToken,
+} from "./supervisor/stale-diagnostic-recoverability";
 
 export const STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE = "stale-stabilizing-no-pr-recovery-loop";
 
@@ -84,6 +88,7 @@ export function buildStaleStabilizingNoPrRecoveryWarningLine(
     "stale_recovery_warning",
     `issue=#${record.issue_number}`,
     `status=${status}`,
+    recoverabilityStatusToken(classifyStaleNoPrRecoverability(status)),
     `state=${record.state}`,
     `repeat_count=${repeatedCount}/${repeatLimit}`,
     "tracked_pr=none",

--- a/src/supervisor/stale-diagnostic-recoverability.ts
+++ b/src/supervisor/stale-diagnostic-recoverability.ts
@@ -1,0 +1,81 @@
+import type { BlockedReason, RunState } from "../core/types";
+import type { IssueRunRecord, SupervisorConfig } from "../core/types";
+import { shouldAutoRecoverStaleReviewBot } from "./supervisor-execution-policy";
+
+export type StaleDiagnosticRecoverability =
+  | "stale_but_recoverable"
+  | "stale_already_handled"
+  | "manual_attention_required"
+  | "provider_outage_suspected";
+
+export function recoverabilityStatusToken(recoverability: StaleDiagnosticRecoverability): string {
+  return `recoverability=${recoverability}`;
+}
+
+export function classifyStaleNoPrRecoverability(status: "retrying" | "manual_review_required"): StaleDiagnosticRecoverability {
+  return status === "retrying" ? "stale_but_recoverable" : "manual_attention_required";
+}
+
+export function classifyTrackedPrMismatchRecoverability(args: {
+  githubState: RunState;
+  githubBlockedReason: BlockedReason | null;
+  localBlockedReason: BlockedReason | null;
+  staleLocalBlocker: boolean;
+}): StaleDiagnosticRecoverability {
+  if (!args.staleLocalBlocker) {
+    return "manual_attention_required";
+  }
+
+  if (args.localBlockedReason === "stale_review_bot" && args.githubBlockedReason === null) {
+    return "stale_already_handled";
+  }
+
+  if (args.localBlockedReason === "stale_review_bot" && args.githubBlockedReason === "stale_review_bot") {
+    return "provider_outage_suspected";
+  }
+
+  if (args.githubState === "ready_to_merge" || args.githubState === "draft_pr" || args.githubState === "addressing_review") {
+    return "stale_but_recoverable";
+  }
+
+  return "manual_attention_required";
+}
+
+export function classifyReadyPromotionRecoverability(args: {
+  staleLocalBlocker: boolean;
+  blockerHasFreshCurrentHeadEvidence: boolean;
+}): StaleDiagnosticRecoverability {
+  if (!args.staleLocalBlocker || args.blockerHasFreshCurrentHeadEvidence) {
+    return "manual_attention_required";
+  }
+
+  return "stale_but_recoverable";
+}
+
+function staleReviewBotRecoverySignature(record: Pick<IssueRunRecord, "last_failure_signature">): string {
+  return record.last_failure_signature ?? "stale_review_bot";
+}
+
+export function classifyStaleReviewBotRecoverability(
+  record: IssueRunRecord,
+  config: SupervisorConfig,
+): StaleDiagnosticRecoverability | null {
+  if (record.state !== "blocked" || record.blocked_reason !== "stale_review_bot") {
+    return null;
+  }
+
+  if (shouldAutoRecoverStaleReviewBot(record, config)) {
+    return "stale_but_recoverable";
+  }
+
+  const currentHeadSha = record.last_head_sha ?? null;
+  if (
+    currentHeadSha &&
+    record.last_stale_review_bot_reply_head_sha === currentHeadSha &&
+    record.last_stale_review_bot_reply_signature === staleReviewBotRecoverySignature(record)
+  ) {
+    return "stale_already_handled";
+  }
+
+  return record.pr_number === null ? "manual_attention_required" : "provider_outage_suspected";
+}

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -627,6 +627,7 @@ test("explain reports stale configured-bot blockers distinctly from generic manu
         branch: branchName(fixture.config, 98),
         workspace: path.join(fixture.workspaceRoot, "issue-98"),
         journal_path: null,
+        pr_number: 198,
         blocked_reason: "stale_review_bot",
         last_error: "configured bot review stayed stale on the current head",
       }),
@@ -667,6 +668,7 @@ Show stale configured-bot review blockers distinctly in explain output.
   assert.match(explanation, /^state=blocked$/m);
   assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
   assert.match(explanation, /^runnable=no$/m);
+  assert.match(explanation, /^stale_diagnostic kind=stale_review_bot recoverability=provider_outage_suspected$/m);
   assert.match(explanation, /^reason_1=manual_block stale_review_bot$/m);
   assert.match(explanation, /^reason_2=local_state blocked$/m);
 });
@@ -864,6 +866,7 @@ Show recoverable stale configured-bot review blockers as runnable when auto-hand
   assert.match(explanation, /^state=blocked$/m);
   assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
   assert.match(explanation, /^runnable=yes$/m);
+  assert.match(explanation, /^stale_diagnostic kind=stale_review_bot recoverability=stale_but_recoverable$/m);
   assert.doesNotMatch(explanation, /^reason_1=manual_block stale_review_bot$/m);
   assert.match(explanation, /^selection_reason=ready execution_ready=yes depends_on=none execution_order=none predecessors=none retry_state=stale_review_bot_recovery:reply_and_resolve$/m);
 });
@@ -925,6 +928,7 @@ Keep already-handled stale configured-bot blockers out of the runnable queue.
   assert.match(explanation, /^state=blocked$/m);
   assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
   assert.match(explanation, /^runnable=no$/m);
+  assert.match(explanation, /^stale_diagnostic kind=stale_review_bot recoverability=stale_already_handled$/m);
   assert.match(explanation, /^reason_1=manual_block stale_review_bot$/m);
   assert.doesNotMatch(explanation, /retry_state=stale_review_bot_recovery:/m);
 });
@@ -993,7 +997,7 @@ Expose stale tracked PR mismatch diagnostics.
   assert.match(explanation, /^blocked_reason=manual_review$/m);
   assert.match(
     explanation,
-    /^tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
+    /^tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
   );
   assert.match(
     explanation,
@@ -1079,7 +1083,7 @@ test("explain marks same-head ready-promotion blockers as stale when fresh block
 
   assert.match(
     explanation,
-    /^tracked_pr_ready_promotion_blocked issue=#176 pr=#276 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#176 pr=#276 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     explanation,
@@ -1180,7 +1184,7 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
 
   assert.match(
     explanation,
-    /^tracked_pr_ready_promotion_blocked issue=#177 pr=#277 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#177 pr=#277 recoverability=manual_attention_required github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     explanation,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1682,7 +1682,7 @@ test("status surfaces repeated stale cleanup risk before the stale recovery loop
   });
   assert.match(
     status,
-    /stale_recovery_warning issue=#366 status=retrying state=queued repeat_count=1\/3 tracked_pr=none action=confirm_whether_the_change_already_landed_or_retarget_the_issue_manually/,
+    /stale_recovery_warning issue=#366 status=retrying recoverability=stale_but_recoverable state=queued repeat_count=1\/3 tracked_pr=none action=confirm_whether_the_change_already_landed_or_retarget_the_issue_manually/,
   );
   assert.match(
     status,
@@ -3016,7 +3016,7 @@ test("status surfaces tracked PR mismatches when GitHub is ready but local state
   const report = await supervisor.statusReport();
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
+    /^tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
@@ -3026,7 +3026,7 @@ test("status surfaces tracked PR mismatches when GitHub is ready but local state
   const status = await supervisor.status();
   assert.match(
     status,
-    /^tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
+    /^tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
   );
   assert.match(
     status,
@@ -3109,7 +3109,7 @@ test("status skips tracked PR hydration for historical done records", async () =
   assert.equal(getPullRequestIfExistsCalls, 1);
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^tracked_pr_mismatch issue=#171 pr=#271 github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
+    /^tracked_pr_mismatch issue=#171 pr=#271 recoverability=stale_but_recoverable github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=manual_review stale_local_blocker=yes$/m,
   );
 });
 
@@ -3182,7 +3182,7 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   const report = await supervisor.statusReport();
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^tracked_pr_ready_promotion_blocked issue=#174 pr=#274 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#174 pr=#274 recoverability=manual_attention_required github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
@@ -3205,7 +3205,7 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   const status = await supervisor.status();
   assert.match(
     status,
-    /^tracked_pr_ready_promotion_blocked issue=#174 pr=#274 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#174 pr=#274 recoverability=manual_attention_required github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     status,
@@ -3292,7 +3292,7 @@ test("status marks old-head ready-promotion blockers as stale in recovery guidan
   const report = await supervisor.statusReport();
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^tracked_pr_ready_promotion_blocked issue=#175 pr=#275 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#175 pr=#275 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
@@ -3377,7 +3377,7 @@ test("status marks same-head ready-promotion blockers as stale when fresh blocke
   const report = await supervisor.statusReport();
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^tracked_pr_ready_promotion_blocked issue=#176 pr=#276 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#176 pr=#276 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
@@ -3464,7 +3464,7 @@ test("status keeps same-head host-local ready-promotion blockers current when th
   const report = await supervisor.statusReport();
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^tracked_pr_ready_promotion_blocked issue=#177 pr=#277 github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+    /^tracked_pr_ready_promotion_blocked issue=#177 pr=#277 recoverability=manual_attention_required github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -1044,7 +1044,7 @@ test("buildIssueExplainSummary surfaces repeated stale cleanup risk for no-PR re
 
   assert.ok(
     lines.includes(
-      "stale_recovery_warning issue=#608 status=retrying state=queued repeat_count=1/3 tracked_pr=none action=confirm_whether_the_change_already_landed_or_retarget_the_issue_manually",
+      "stale_recovery_warning issue=#608 status=retrying recoverability=stale_but_recoverable state=queued repeat_count=1/3 tracked_pr=none action=confirm_whether_the_change_already_landed_or_retarget_the_issue_manually",
     ),
   );
   assert.ok(

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -57,6 +57,10 @@ import {
 } from "./supervisor-operator-activity-context";
 import { formatPreMergeEvaluationStatusLine, loadPreMergeEvaluationDto } from "./supervisor-pre-merge-evaluation";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
+import {
+  classifyStaleReviewBotRecoverability,
+  recoverabilityStatusToken,
+} from "./stale-diagnostic-recoverability";
 
 export type ExplainIssueGitHub =
   Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
@@ -79,6 +83,7 @@ export interface SupervisorExplainDto {
   latestRecoverySummary: string | null;
   staleRecoveryWarningSummary: string | null;
   activityContext: SupervisorIssueActivityContextDto | null;
+  staleDiagnosticSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
   trackedPrMismatchSummary: string | null;
   externalSignalReadinessSummary?: string | null;
@@ -474,6 +479,14 @@ export async function buildIssueExplainDto(
         preMergeEvaluation,
       })
       : null,
+    staleDiagnosticSummary: record && record.blocked_reason === "stale_review_bot"
+      ? (() => {
+        const recoverability = classifyStaleReviewBotRecoverability(record, config);
+        return recoverability === null
+          ? null
+          : ["stale_diagnostic", "kind=stale_review_bot", recoverabilityStatusToken(recoverability)].join(" ");
+      })()
+      : null,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary
         ? [
@@ -515,6 +528,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.journalStateSummary ? [dto.journalStateSummary] : []),
     ...(preMergeEvaluationLine ? [preMergeEvaluationLine] : []),
     ...(localCiStatusLine ? [localCiStatusLine] : []),
+    ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),
     ...(dto.externalSignalReadinessSummary ? [dto.externalSignalReadinessSummary] : []),

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -14,6 +14,12 @@ import {
 } from "../core/config";
 import { projectTrackedPrLifecycle } from "../tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "../tracked-pr-ready-promotion-blocker";
+import {
+  classifyReadyPromotionRecoverability,
+  classifyTrackedPrMismatchRecoverability,
+  recoverabilityStatusToken,
+  type StaleDiagnosticRecoverability,
+} from "./stale-diagnostic-recoverability";
 
 export interface TrackedPrMismatch {
   issueNumber: number;
@@ -23,6 +29,7 @@ export interface TrackedPrMismatch {
   localState: RunState;
   localBlockedReason: BlockedReason | null;
   staleLocalBlocker: boolean;
+  recoverability: StaleDiagnosticRecoverability;
   summaryLine: string;
   guidanceLine: string;
   detailLines: string[];
@@ -252,6 +259,10 @@ export function buildTrackedPrMismatch(
   if (record.state === "blocked" && record.blocked_reason === "verification" && githubState === "draft_pr" && pr.isDraft) {
     const readyPromotionGate = readyPromotionGateSummary(config, record, pr, checks);
     const blockerHasFreshCurrentHeadEvidence = hasFreshTrackedPrReadyPromotionBlockerEvidence(record, pr);
+    const recoverability = classifyReadyPromotionRecoverability({
+      staleLocalBlocker,
+      blockerHasFreshCurrentHeadEvidence,
+    });
     return {
       issueNumber: record.issue_number,
       prNumber: pr.number,
@@ -260,10 +271,12 @@ export function buildTrackedPrMismatch(
       localState: record.state,
       localBlockedReason: record.blocked_reason,
       staleLocalBlocker,
+      recoverability,
       summaryLine: [
         "tracked_pr_ready_promotion_blocked",
         `issue=#${record.issue_number}`,
         `pr=#${pr.number}`,
+        recoverabilityStatusToken(recoverability),
         `github_state=${githubState}`,
         `local_state=${record.state}`,
         `local_blocked_reason=${record.blocked_reason ?? "none"}`,
@@ -279,6 +292,13 @@ export function buildTrackedPrMismatch(
     };
   }
 
+  const recoverability = classifyTrackedPrMismatchRecoverability({
+    githubState,
+    githubBlockedReason,
+    localBlockedReason: record.blocked_reason,
+    staleLocalBlocker,
+  });
+
   return {
     issueNumber: record.issue_number,
     prNumber: pr.number,
@@ -287,10 +307,12 @@ export function buildTrackedPrMismatch(
     localState: record.state,
     localBlockedReason: record.blocked_reason,
     staleLocalBlocker,
+    recoverability,
     summaryLine: [
       "tracked_pr_mismatch",
       `issue=#${record.issue_number}`,
       `pr=#${pr.number}`,
+      recoverabilityStatusToken(recoverability),
       `github_state=${githubState}`,
       `github_blocked_reason=${githubBlockedReason ?? "none"}`,
       `local_state=${record.state}`,


### PR DESCRIPTION
## Summary
- add typed stale diagnostic recoverability categories
- surface recoverability in stale no-PR warnings, tracked PR mismatch/ready-promotion diagnostics, and stale configured-bot explain output
- update exact-output tests for status, explain, doctor, and WebUI fixtures

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/run-once-cycle-prelude.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts src/backend/webui-dashboard.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Diagnostic output now includes recoverability status information, indicating whether stale issues can be automatically recovered, were already handled, require manual intervention, or suspect provider outages.

* **Tests**
  * Updated test assertions across multiple scenarios to validate the new recoverability status field in diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->