### PR TITLE
Add provider-outage review diagnostics

### DIFF
--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -176,7 +176,7 @@ export function buildActiveDetailedStatusLines(
       `review_bot_profile profile=${reviewBotProfile.profile} provider=${reviewBotProfile.provider} reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} signal_source=${reviewBotProfile.signalSource}`,
     );
     lines.push(
-      `review_bot_diagnostics status=${reviewBotStatus.status} observed_review=${reviewBotStatus.observedReview} expected_reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} next_check=${reviewBotStatus.nextCheck}`,
+      `review_bot_diagnostics status=${reviewBotStatus.status} observed_review=${reviewBotStatus.observedReview} expected_reviewers=${reviewBotProfile.reviewers.length > 0 ? reviewBotProfile.reviewers.join(",") : "none"} next_check=${reviewBotStatus.nextCheck}${reviewBotStatus.recentObservation ? ` recent_observation=${sanitizeStatusValue(reviewBotStatus.recentObservation)}` : ""}`,
     );
     const externalSignalReadiness = externalSignalReadinessDiagnostics(
       config,

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -454,6 +454,51 @@ test("buildDetailedStatusModel explains when CodeRabbit is re-waiting after a dr
   }
 });
 
+test("buildDetailedStatusModel reports stale provider signal diagnostics with recent observation context", () => {
+  const lines = buildDetailedStatusModel({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    }),
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "waiting_ci",
+      blocked_reason: null,
+      last_error: null,
+      external_review_head_sha: "head-old",
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr: createPullRequest({
+      headRefOid: "head-new",
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+    }),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+    manualReviewThreads,
+    configuredBotReviewThreads,
+    pendingBotReviewThreads: (innerConfig, innerRecord, innerPr, innerReviewThreads) =>
+      configuredBotReviewThreads(innerConfig, innerReviewThreads).filter(
+        (thread) =>
+          !innerRecord.processed_review_thread_ids.includes(thread.id) &&
+          innerRecord.last_head_sha === innerPr.headRefOid,
+      ),
+    summarizeChecks: (checks) => ({
+      allPassing: checks.every((check) => check.bucket === "pass"),
+      hasPending: checks.some((check) => check.bucket === "pending" || check.bucket === "cancel"),
+      hasFailing: checks.some((check) => check.bucket === "fail"),
+    }),
+    mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
+  });
+
+  assert.ok(
+    lines.includes(
+      "review_bot_diagnostics status=stale_provider_signal observed_review=stale_external_review_record expected_reviewers=chatgpt-codex-connector next_check=wait_for_current_head_signal recent_observation=external_review_record:head-old->head-new",
+    ),
+  );
+});
+
 test("buildDetailedStatusSummaryLines shapes optional summaries and artifact paths", () => {
   const config = createConfig({
     localReviewArtifactDir: "/tmp/reviews",

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -200,9 +200,10 @@ test("reviewBotDiagnostics tracks observed review signal precedence", () => {
   assert.deepEqual(
     reviewBotDiagnostics(config, createRecord(), pr, [createThread()], configuredBotReviewThreads),
     {
-      status: "review_signal_observed",
+      status: "actionable_provider_review",
       observedReview: "review_thread",
-      nextCheck: "none",
+      nextCheck: "address_review",
+      recentObservation: "unresolved_threads:1",
     },
   );
 
@@ -241,6 +242,63 @@ test("reviewBotDiagnostics tracks observed review signal precedence", () => {
     observedReview: "none",
     nextCheck: "provider_setup_or_delivery",
   });
+});
+
+test("reviewBotDiagnostics separates stale provider signal from missing provider signal", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const pr = createPr({ headRefOid: "head-new" });
+
+  assert.deepEqual(
+    reviewBotDiagnostics(
+      config,
+      createRecord({ external_review_head_sha: "head-old" }),
+      pr,
+      [],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "stale_provider_signal",
+      observedReview: "stale_external_review_record",
+      nextCheck: "wait_for_current_head_signal",
+      recentObservation: "external_review_record:head-old->head-new",
+    },
+  );
+});
+
+test("reviewBotDiagnostics flags suspected provider outage after current-head signal wait expires", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:20:01.000Z");
+
+  try {
+    assert.deepEqual(
+      reviewBotDiagnostics(
+        createConfig({
+          reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+          configuredBotRequireCurrentHeadSignal: true,
+          configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+        }),
+        createRecord({
+          state: "blocked",
+          blocked_reason: "stale_review_bot",
+          last_failure_signature: "stale-configured-bot-review",
+        }),
+        createPr({
+          currentHeadCiGreenAt: "2026-03-16T00:10:00.000Z",
+          configuredBotCurrentHeadObservedAt: null,
+        }),
+        [],
+        configuredBotReviewThreads,
+      ),
+      {
+        status: "provider_outage_suspected",
+        observedReview: "none",
+        nextCheck: "wait_or_provider_setup_or_manual_review",
+        recentObservation: "required_checks_green:2026-03-16T00:10:00.000Z recoverability=provider_outage_suspected",
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("reviewBotDiagnostics does not expect configured provider review while a draft PR is waiting for ready-for-review", () => {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -301,6 +301,40 @@ test("reviewBotDiagnostics flags suspected provider outage after current-head si
   }
 });
 
+test("reviewBotDiagnostics honors draft-skip rewait grace before suspecting provider outage", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:10:45.000Z");
+
+  try {
+    assert.deepEqual(
+      reviewBotDiagnostics(
+        createConfig({
+          reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+          configuredBotInitialGraceWaitSeconds: 90,
+        }),
+        createRecord({
+          review_wait_started_at: "2026-03-16T00:10:30.000Z",
+          review_wait_head_sha: "head-sha",
+        }),
+        createPr({
+          currentHeadCiGreenAt: "2026-03-16T00:00:00.000Z",
+          configuredBotCurrentHeadObservedAt: null,
+          configuredBotDraftSkipAt: "2026-03-15T23:59:00.000Z",
+        }),
+        [],
+        configuredBotReviewThreads,
+      ),
+      {
+        status: "missing_provider_signal",
+        observedReview: "none",
+        nextCheck: "provider_setup_or_delivery",
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("reviewBotDiagnostics does not expect configured provider review while a draft PR is waiting for ready-for-review", () => {
   assert.deepEqual(
     reviewBotDiagnostics(

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -9,6 +9,7 @@ import {
 } from "../core/review-providers";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
+import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
@@ -88,6 +89,7 @@ export interface ReviewBotDiagnostics {
   status: string;
   observedReview: string;
   nextCheck: string;
+  recentObservation?: string;
 }
 
 export interface ExternalSignalReadinessDiagnostics {
@@ -389,6 +391,28 @@ export function summarizeObservedReviewSignal(
   return { observedReview: "none", hasSignal: false };
 }
 
+function staleProviderSignalObservation(activeRecord: IssueRunRecord, pr: GitHubPullRequest): string | null {
+  if (activeRecord.external_review_head_sha && activeRecord.external_review_head_sha !== pr.headRefOid) {
+    return `external_review_record:${activeRecord.external_review_head_sha}->${pr.headRefOid}`;
+  }
+
+  return null;
+}
+
+function providerOutageObservation(config: SupervisorConfig, pr: GitHubPullRequest): string | null {
+  const currentHeadSignalWait = configuredBotCurrentHeadSignalWaitWindow(config, pr);
+  if (currentHeadSignalWait.status === "expired" && currentHeadSignalWait.observedAt) {
+    return `${currentHeadSignalWait.recentObservation}:${currentHeadSignalWait.observedAt}`;
+  }
+
+  const initialGraceWait = configuredBotInitialGraceWaitWindow(config, pr);
+  if (initialGraceWait.status === "expired" && initialGraceWait.observedAt) {
+    return `${initialGraceWait.recentObservation}:${initialGraceWait.observedAt}`;
+  }
+
+  return null;
+}
+
 export function reviewBotDiagnostics(
   config: SupervisorConfig,
   activeRecord: IssueRunRecord,
@@ -412,6 +436,22 @@ export function reviewBotDiagnostics(
     };
   }
 
+  const unresolvedConfiguredThreads = configuredBotReviewThreads(config, reviewThreads).filter(
+    (thread) => !thread.isResolved && !thread.isOutdated,
+  );
+  const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
+  if (unresolvedConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking") {
+    return {
+      status: "actionable_provider_review",
+      observedReview: unresolvedConfiguredThreads.length > 0 ? "review_thread" : "top_level_review",
+      nextCheck: "address_review",
+      recentObservation:
+        unresolvedConfiguredThreads.length > 0
+          ? `unresolved_threads:${unresolvedConfiguredThreads.length}`
+          : `top_level_review:${pr.configuredBotTopLevelReviewSubmittedAt ?? "unknown"}`,
+    };
+  }
+
   const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
   if (observed.hasSignal) {
     return {
@@ -421,11 +461,36 @@ export function reviewBotDiagnostics(
     };
   }
 
+  const staleProviderObservation = staleProviderSignalObservation(activeRecord, pr);
+  if (staleProviderObservation) {
+    return {
+      status: "stale_provider_signal",
+      observedReview: "stale_external_review_record",
+      nextCheck: "wait_for_current_head_signal",
+      recentObservation: staleProviderObservation,
+    };
+  }
+
   if (observed.observedReview === "copilot_requested") {
     return {
       status: "waiting_for_provider_review",
       observedReview: observed.observedReview,
       nextCheck: "provider_delivery",
+    };
+  }
+
+  const providerOutageRecentObservation = providerOutageObservation(config, pr);
+  if (providerOutageRecentObservation) {
+    const staleReviewBotRecoverability = classifyStaleReviewBotRecoverability(activeRecord, config);
+    const recoverability =
+      staleReviewBotRecoverability === "provider_outage_suspected"
+        ? recoverabilityStatusToken(staleReviewBotRecoverability)
+        : recoverabilityStatusToken("provider_outage_suspected");
+    return {
+      status: "provider_outage_suspected",
+      observedReview: "none",
+      nextCheck: "wait_or_provider_setup_or_manual_review",
+      recentObservation: `${providerOutageRecentObservation} ${recoverability}`,
     };
   }
 

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -399,13 +399,17 @@ function staleProviderSignalObservation(activeRecord: IssueRunRecord, pr: GitHub
   return null;
 }
 
-function providerOutageObservation(config: SupervisorConfig, pr: GitHubPullRequest): string | null {
+function providerOutageObservation(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  activeRecord: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">,
+): string | null {
   const currentHeadSignalWait = configuredBotCurrentHeadSignalWaitWindow(config, pr);
   if (currentHeadSignalWait.status === "expired" && currentHeadSignalWait.observedAt) {
     return `${currentHeadSignalWait.recentObservation}:${currentHeadSignalWait.observedAt}`;
   }
 
-  const initialGraceWait = configuredBotInitialGraceWaitWindow(config, pr);
+  const initialGraceWait = configuredBotInitialGraceWaitWindow(config, pr, activeRecord);
   if (initialGraceWait.status === "expired" && initialGraceWait.observedAt) {
     return `${initialGraceWait.recentObservation}:${initialGraceWait.observedAt}`;
   }
@@ -436,9 +440,7 @@ export function reviewBotDiagnostics(
     };
   }
 
-  const unresolvedConfiguredThreads = configuredBotReviewThreads(config, reviewThreads).filter(
-    (thread) => !thread.isResolved && !thread.isOutdated,
-  );
+  const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
   if (unresolvedConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking") {
     return {
@@ -479,7 +481,7 @@ export function reviewBotDiagnostics(
     };
   }
 
-  const providerOutageRecentObservation = providerOutageObservation(config, pr);
+  const providerOutageRecentObservation = providerOutageObservation(config, pr, activeRecord);
   if (providerOutageRecentObservation) {
     const staleReviewBotRecoverability = classifyStaleReviewBotRecoverability(activeRecord, config);
     const recoverability =
@@ -515,9 +517,7 @@ export function externalSignalReadinessDiagnostics(
   const hasFailingChecks = checks.some((check) => check.bucket === "fail");
   const hasPendingChecks = checks.some((check) => check.bucket === "pending" || check.bucket === "cancel");
   const hasPassingChecks = checks.some((check) => check.bucket === "pass" || check.bucket === "skipping");
-  const unresolvedConfiguredThreads = configuredBotReviewThreads(config, reviewThreads).filter(
-    (thread) => !thread.isResolved && !thread.isOutdated,
-  );
+  const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
   const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
   const hasExternalProviderActivity = hasAuthoritativeExternalProviderActivity(


### PR DESCRIPTION
## Summary
- classify review-bot diagnostics as actionable provider review, stale provider signal, missing signal, or suspected provider outage
- include recent observation context in status output when a provider diagnostic has usable evidence
- keep provider availability diagnostic-only; merge gating behavior is unchanged

## Verification
- npx tsx --test src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/github/github-review-signals.test.ts
- npm run build

Part of #1649
Closes #1654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review bot diagnostics now include a recent observation field for clearer, contextual status messages
  * Improved detection of stale provider signals and automated scheduling to wait for current-head signals
  * New handling that flags actionable provider reviews when unresolved review threads exist and surfaces guidance for next steps
  * Added logic to detect suspected provider outages and assess recoverability

* **Tests**
  * Added unit tests covering stale-signal, unresolved-thread, and provider-outage scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->