### PR TITLE
Require fresh bot signal for same-head follow-up

### DIFF
--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -251,7 +251,7 @@ test("nextReviewFollowUpPatch does not grant a follow-up when no configured-bot 
   });
 });
 
-test("nextReviewFollowUpPatch grants one same-head follow-up for a narrow actionable bot thread set even when thread counts do not shrink", () => {
+test("nextReviewFollowUpPatch does not grant a same-head follow-up for unchanged narrow actionable bot guidance", () => {
   const patch = nextReviewFollowUpPatch({
     config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
     preRunState: "addressing_review",
@@ -341,6 +341,75 @@ test("nextReviewFollowUpPatch grants one same-head follow-up for a narrow action
         },
       }),
     ],
+  });
+
+  assert.deepEqual(patch, {
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+  });
+});
+
+test("nextReviewFollowUpPatch grants one same-head follow-up for fresh narrow actionable bot guidance", () => {
+  const preRunThread = createReviewThread({
+    id: "thread-1",
+    path: "src/a.ts",
+    line: 10,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Guard the nullable payload before accessing nested properties here.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const postRunThread = createReviewThread({
+    id: "thread-1",
+    path: "src/a.ts",
+    line: 10,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Guard the nullable payload before accessing nested properties here.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-2",
+          body: "The nullable payload still needs an explicit guard before this access path can be considered safe.",
+          createdAt: "2026-03-11T00:10:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const patch = nextReviewFollowUpPatch({
+    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
+    preRunState: "addressing_review",
+    record: {
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    currentPr: { headRefOid: "head-a" },
+    evaluatedReviewHeadSha: "head-a",
+    preRunReviewThreads: [preRunThread],
+    postRunReviewThreads: [postRunThread],
   });
 
   assert.deepEqual(patch, {

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -350,6 +350,14 @@ export function nextReviewFollowUpPatch(args: {
   }
 
   const postRunActionableConfiguredThreads = unresolvedActionableConfiguredBotThreads(args.postRunReviewThreads);
+  const preRunActionableFingerprintKeys = new Set(
+    unresolvedActionableConfiguredBotThreads(args.preRunReviewThreads)
+      .map((thread) => {
+        const fingerprint = latestReviewThreadCommentFingerprint(thread);
+        return fingerprint ? `${thread.id}#${fingerprint}` : null;
+      })
+      .filter((key): key is string => key !== null),
+  );
 
   if (
     args.record.review_follow_up_head_sha === args.evaluatedReviewHeadSha &&
@@ -383,8 +391,13 @@ export function nextReviewFollowUpPatch(args: {
         latestComment.body.trim().split(/\s+/).length >= 6
       );
     });
+  const hasFreshActionableBotSignal = postRunActionableConfiguredThreads.some((thread) => {
+    const fingerprint = latestReviewThreadCommentFingerprint(thread);
+    return Boolean(fingerprint && !preRunActionableFingerprintKeys.has(`${thread.id}#${fingerprint}`));
+  });
 
-  return (madeProgress && postRunActionableConfiguredThreads.length > 0) || hasNarrowActionableThreadSet
+  return (madeProgress && postRunActionableConfiguredThreads.length > 0) ||
+    (hasNarrowActionableThreadSet && hasFreshActionableBotSignal)
     ? {
         review_follow_up_head_sha: args.evaluatedReviewHeadSha,
         review_follow_up_remaining: 1,


### PR DESCRIPTION
## Summary
- tighten same-head configured-bot follow-up repair so unchanged narrow guidance does not blindly re-arm a retry
- allow one extra same-head follow-up only when there is actual configured-bot progress or a fresh actionable configured-bot latest-comment fingerprint on the current head
- add focused regression coverage for unchanged versus fresh narrow bot guidance

## Verification
- `npx tsx --test src/turn-execution-orchestration.test.ts`
- `npm run build`
- `npm run verify:paths`

## Known verification gap
- `npx tsx --test src/post-turn-pull-request.test.ts src/review-handling.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/turn-execution-orchestration.test.ts` currently fails in `src/supervisor/supervisor-execution-orchestration.test.ts` on unrelated stale-state cleanup and workspace fixture expectations. The review-thread and turn-execution portions pass before the same orchestration failures reproduce when that file is run alone.

Part of #1625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined automatic review follow-up logic to only trigger when fresh actionable feedback is detected, eliminating unnecessary follow-ups for unchanged guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->