### PR TITLE
Clean up rehydrated requirements test temp dir

### DIFF
--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -516,9 +516,12 @@ test("reconcileRecoverableBlockedIssueStates leaves closed issues blocked", asyn
   assert.equal(saveCalls, 0);
 });
 
-test("reconcileRecoverableBlockedIssueStates requeues requirements-blocked issues once metadata is execution-ready even with a rehydrated journal", async () => {
+test("reconcileRecoverableBlockedIssueStates requeues requirements-blocked issues once metadata is execution-ready even with a rehydrated journal", async (t) => {
   const config = createConfig();
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "requirements-rehydrated-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
   const workspacePath = path.join(tempDir, "workspaces", "issue-366");
   const journalPath = path.join(workspacePath, ".codex-supervisor", "issues", "366", "issue-journal.md");
   await fs.mkdir(path.dirname(journalPath), { recursive: true });


### PR DESCRIPTION
## Summary
- Register cleanup for the rehydrated requirements recovery test temp workspace.
- Keep the recovery regression scenario and production behavior unchanged.

## Verification
- npx tsx --test --test-name-pattern "rehydrated journal" src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npm run build

Closes #1662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test cleanup procedures to ensure temporary filesystem resources created during test execution are automatically removed after completion, improving test suite reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->