### PR TITLE
Disambiguate recoverable blocked prelude ordering test

### DIFF
--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -723,8 +723,8 @@ test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a
       };
       return [];
     },
-    reconcileRecoverableBlockedIssueStates: async () => {
-      calls.push("recoverable_blocked");
+    reconcileRecoverableBlockedIssueStates: async (_loadedState, _loadedIssues, options) => {
+      calls.push(`recoverable_blocked:${options?.onlyTrackedPrStates === true ? "tracked" : "all"}`);
       return [];
     },
     reconcileParentEpicClosures: async () => {
@@ -744,8 +744,8 @@ test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a
     "merged_closures",
     "stale_failed",
     "stale_done",
-    "recoverable_blocked",
-    "recoverable_blocked",
+    "recoverable_blocked:tracked",
+    "recoverable_blocked:all",
     "reserve:blocked",
     "parent_epics",
     "cleanup",


### PR DESCRIPTION
## Summary
- Tighten the stale-done prelude ordering test so the two recoverable-blocked passes record distinct labels.
- Prove the tracked-only pass runs before the all-records pass while stale done reconciliation still precedes reservation.

## Verification
- npx tsx --test --test-name-pattern "stale done no-PR" src/run-once-cycle-prelude.test.ts
- npx tsx --test src/run-once-cycle-prelude.test.ts
- npm run build

Closes #1663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to more precisely validate recovery scope tracking (tracked vs all scopes) during reconciliation operations, improving test accuracy and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->