### PR TITLE
Add tracked top-level publication guard

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -540,6 +540,60 @@ test("loadConfig rejects empty publishable path allowlist markers", async (t) =>
   assert.deepEqual(config.publishablePathAllowlistMarkers, ["publishable-path-hygiene: allowlist"]);
 });
 
+test("loadConfig accepts explicit approved tracked top-level entries", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      approvedTrackedTopLevelEntries: ["README.md", "src", ".github"],
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+  assert.deepEqual(config.approvedTrackedTopLevelEntries, ["README.md", "src", ".github"]);
+});
+
+test("loadConfig rejects nested approved tracked top-level entries", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      approvedTrackedTopLevelEntries: ["README.md", "docs/guide.md"],
+    }),
+    "utf8",
+  );
+
+  const summary = loadConfigSummary(configPath);
+  assert.equal(summary.status, "invalid_config");
+  assert.deepEqual(summary.invalidFields, ["approvedTrackedTopLevelEntries"]);
+  assert.match(summary.error ?? "", /approvedTrackedTopLevelEntries\[1\]/);
+});
+
 test("loadConfig accepts explicit local review follow-up issue creation opt-in", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -83,6 +83,29 @@ function normalizeStringArray(value: unknown, fieldName: string): string[] {
   });
 }
 
+function parseApprovedTrackedTopLevelEntries(value: unknown): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid config field: approvedTrackedTopLevelEntries (must be an array of top-level entry names)");
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry !== "string" || entry.trim() === "") {
+      throw new Error(`Invalid config field: approvedTrackedTopLevelEntries[${index}] (must be a non-empty string)`);
+    }
+
+    const normalized = entry.trim();
+    if (normalized === "." || normalized === ".." || normalized.includes("/") || normalized.includes("\\")) {
+      throw new Error(`Invalid config field: approvedTrackedTopLevelEntries[${index}] (must be a top-level entry name)`);
+    }
+
+    return normalized;
+  });
+}
+
 function parseStaleConfiguredBotReviewPolicy(value: unknown): StaleConfiguredBotReviewPolicy {
   if (typeof value === "undefined") {
     return "diagnose_only";
@@ -488,6 +511,7 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
           (value): value is string => typeof value === "string" && value.trim().length > 0,
         )
       : [],
+    approvedTrackedTopLevelEntries: parseApprovedTrackedTopLevelEntries(raw.approvedTrackedTopLevelEntries),
     staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
     reviewBotLogins: Array.isArray(raw.reviewBotLogins)
       ? raw.reviewBotLogins

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -195,6 +195,7 @@ export interface SupervisorConfig {
   localReviewFollowUpIssueCreationEnabled?: boolean;
   localReviewHighSeverityAction: LocalReviewHighSeverityAction;
   publishablePathAllowlistMarkers?: string[];
+  approvedTrackedTopLevelEntries?: string[];
   staleConfiguredBotReviewPolicy?: StaleConfiguredBotReviewPolicy;
   reviewBotLogins: string[];
   configuredReviewProviders?: ConfiguredReviewProvider[];

--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { SupervisorConfig } from "./types";
-import { ensureWorkspace } from "./workspace";
+import { ensureWorkspace, listTrackedTopLevelEntries } from "./workspace";
 import { DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH, issueJournalPath, syncIssueJournal } from "./journal";
 
 const execFileAsync = promisify(execFile);
@@ -210,6 +210,24 @@ async function createDivergedDefaultBranchFixture(): Promise<SupervisorConfig> {
 
   return config;
 }
+
+test("listTrackedTopLevelEntries preserves spaces in git path tokens", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-tracked-top-level-"));
+  const repoPath = path.join(root, "repo");
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(repoPath);
+  await git(repoPath, "init", "-b", "main");
+  await git(repoPath, "config", "user.name", "Codex Supervisor");
+  await git(repoPath, "config", "user.email", "codex@example.test");
+  await fs.writeFile(path.join(repoPath, " spaced top-level "), "fixture\n", "utf8");
+  await git(repoPath, "add", " spaced top-level ");
+  await git(repoPath, "commit", "-m", "seed spaced top-level entry");
+
+  assert.deepEqual(await listTrackedTopLevelEntries(repoPath), [" spaced top-level "]);
+});
 
 test("ensureWorkspace reports when a recreated workspace restores from an existing local branch", async () => {
   const config = await createRepositoryFixture();

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -784,6 +784,29 @@ export async function listChangedTrackedFilesBetween(
     .map((entry) => normalizeGitPath(entry));
 }
 
+export async function listTrackedTopLevelEntries(
+  workspacePath: string,
+): Promise<string[]> {
+  const result = await runCommand("git", [
+    "-C",
+    workspacePath,
+    "ls-files",
+    "-z",
+  ]);
+  const entries = new Set<string>();
+  for (const trackedPath of result.stdout
+    .split("\0")
+    .map((entry) => entry.trim().replaceAll("\\", "/"))
+    .filter(Boolean)) {
+    const [topLevelEntry] = trackedPath.split("/");
+    if (topLevelEntry) {
+      entries.add(topLevelEntry);
+    }
+  }
+
+  return [...entries].sort((left, right) => left.localeCompare(right));
+}
+
 export async function listTrackedSupervisorArtifactPaths(
   workspacePath: string,
   journalRelativePath?: string,

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -796,8 +796,8 @@ export async function listTrackedTopLevelEntries(
   const entries = new Set<string>();
   for (const trackedPath of result.stdout
     .split("\0")
-    .map((entry) => entry.trim().replaceAll("\\", "/"))
-    .filter(Boolean)) {
+    .filter((entry) => entry.length > 0)
+    .map((entry) => entry.replaceAll("\\", "/"))) {
     const [topLevelEntry] = trackedPath.split("/");
     if (topLevelEntry) {
       entries.add(topLevelEntry);

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -394,6 +394,209 @@ test("applyCodexTurnPublicationGate forwards publishable allowlist markers to th
   assert.deepEqual(observedCalls, [["publishable-path-hygiene: allowlist"]]);
 });
 
+test("applyCodexTurnPublicationGate blocks configured tracked top-level entry drift before workspace preparation", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+  await fs.writeFile(
+    path.join(workspacePath, ".coderabbit.yaml"),
+    "reviews:\n  profile: aegiops-style\n",
+    "utf8",
+  );
+  git(workspacePath, "add", ".coderabbit.yaml");
+  git(workspacePath, "commit", "-m", "seed inherited review config drift");
+
+  const issue = createIssue({
+    title: "Gate draft PR creation on tracked top-level skeleton drift",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+      }),
+    },
+  };
+  const config = {
+    ...createConfig({ localCiCommand: "npm run ci:local" }),
+    approvedTrackedTopLevelEntries: ["README.md"],
+  };
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+
+  const result = await applyCodexTurnPublicationGate({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(
+    result.record.last_failure_signature,
+    "tracked-top-level-entry-drift-before-publication",
+  );
+  assert.match(
+    result.record.last_failure_context?.summary ?? "",
+    /Tracked top-level entries drifted from the configured repository skeleton baseline/,
+  );
+  assert.match(
+    result.record.last_failure_context?.details.join("\n") ?? "",
+    /unexpected tracked top-level entry: \.coderabbit\.yaml/,
+  );
+  assert.equal(createPullRequestCalls, 0);
+  assert.equal(runWorkspacePreparationCalls, 0);
+  assert.equal(runLocalCiCalls, 0);
+});
+
+test("applyCodexTurnPublicationGate ignores tracked top-level drift when the skeleton guard is not configured", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+  await fs.writeFile(
+    path.join(workspacePath, ".coderabbit.yaml"),
+    "reviews:\n  profile: aegiops-style\n",
+    "utf8",
+  );
+  git(workspacePath, "add", ".coderabbit.yaml");
+  git(workspacePath, "commit", "-m", "seed inherited review config drift");
+
+  const issue = createIssue({
+    title: "Keep top-level skeleton guard opt-in",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+        workspace: workspacePath,
+      }),
+    },
+  };
+  let createPullRequestCalls = 0;
+  let runWorkspacePreparationCalls = 0;
+  let runLocalCiCalls = 0;
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({
+      workspacePreparationCommand: "npm run prepare",
+      localCiCommand: "npm run ci:local",
+    }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath,
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: git(workspacePath, "rev-parse", "HEAD").trim(),
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: false,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        createPullRequestCalls += 1;
+        return createPullRequest({
+          number: 200,
+          isDraft: true,
+          headRefOid: git(workspacePath, "rev-parse", "HEAD").trim(),
+        });
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runWorkspacePreparationCommand: async () => {
+      runWorkspacePreparationCalls += 1;
+    },
+    runLocalCiCommand: async () => {
+      runLocalCiCalls += 1;
+    },
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "ready");
+  assert.equal(createPullRequestCalls, 1);
+  assert.equal(runWorkspacePreparationCalls, 1);
+  assert.equal(runLocalCiCalls, 1);
+});
+
 test("applyCodexTurnPublicationGate self-heals a tracked current issue journal before draft PR creation", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -29,6 +29,7 @@ import {
   getWorkspaceStatus,
   isCurrentIssueJournalOnlyTrackedSupervisorArtifact,
   listTrackedSupervisorArtifactPaths,
+  listTrackedTopLevelEntries,
   untrackCurrentIssueJournalBeforePublication,
 } from "./core/workspace";
 
@@ -73,6 +74,8 @@ const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
   "Normalize trusted durable artifacts for path hygiene";
 const SUPERVISOR_LOCAL_DURABLE_ARTIFACT_SIGNATURE =
   "supervisor-local-durable-artifacts-tracked-before-publication";
+const TRACKED_TOP_LEVEL_ENTRY_DRIFT_SIGNATURE =
+  "tracked-top-level-entry-drift-before-publication";
 
 function buildSupervisorLocalArtifactFailureContext(
   trackedPaths: string[],
@@ -99,6 +102,62 @@ function buildSupervisorLocalArtifactFailureContext(
   };
 }
 
+function diffTrackedTopLevelEntries(args: {
+  approvedEntries: readonly string[] | undefined;
+  actualEntries: readonly string[];
+}): { unexpected: string[]; missing: string[] } | null {
+  if (!args.approvedEntries) {
+    return null;
+  }
+
+  const approved = new Set(args.approvedEntries);
+  const actual = new Set(args.actualEntries);
+  const unexpected = args.actualEntries.filter((entry) => !approved.has(entry));
+  const missing = args.approvedEntries.filter((entry) => !actual.has(entry));
+
+  if (unexpected.length === 0 && missing.length === 0) {
+    return null;
+  }
+
+  return { unexpected, missing };
+}
+
+function buildTrackedTopLevelEntryDriftFailureContext(args: {
+  issueNumber: number;
+  approvedEntries: readonly string[];
+  actualEntries: readonly string[];
+  unexpected: readonly string[];
+  missing: readonly string[];
+}): FailureContext {
+  const unexpectedSummary =
+    args.unexpected.length > 0
+      ? ` Unexpected: ${args.unexpected.join(", ")}.`
+      : "";
+  const missingSummary =
+    args.missing.length > 0 ? ` Missing: ${args.missing.join(", ")}.` : "";
+
+  return {
+    category: "blocked",
+    summary:
+      `Tracked top-level entries drifted from the configured repository skeleton baseline for issue #${args.issueNumber}.` +
+      unexpectedSummary +
+      missingSummary +
+      " Remove or reconcile the tracked top-level entries, or update approvedTrackedTopLevelEntries when the repository skeleton intentionally changes.",
+    signature: TRACKED_TOP_LEVEL_ENTRY_DRIFT_SIGNATURE,
+    command: "git ls-files -z",
+    details: [
+      `configured approved tracked top-level entries: ${args.approvedEntries.join(", ") || "(none)"}`,
+      `observed tracked top-level entries: ${args.actualEntries.join(", ") || "(none)"}`,
+      ...args.unexpected.map(
+        (entry) => `unexpected tracked top-level entry: ${entry}`,
+      ),
+      ...args.missing.map((entry) => `missing tracked top-level entry: ${entry}`),
+    ],
+    url: null,
+    updated_at: new Date().toISOString(),
+  };
+}
+
 export async function applyCodexTurnPublicationGate(args: {
   config: Pick<
     SupervisorConfig,
@@ -109,6 +168,7 @@ export async function applyCodexTurnPublicationGate(args: {
     | "workspacePreparationCommand"
     | "localCiCommand"
     | "publishablePathAllowlistMarkers"
+    | "approvedTrackedTopLevelEntries"
   >;
   stateStore: Pick<StateStore, "touch" | "save">;
   state: SupervisorStateFile;
@@ -285,6 +345,46 @@ export async function applyCodexTurnPublicationGate(args: {
         return {
           kind: "blocked",
           message: failureContext.summary,
+          record,
+          pr: null,
+          checks: [],
+          reviewThreads: [],
+        };
+      }
+    }
+
+    if (args.config.approvedTrackedTopLevelEntries) {
+      const trackedTopLevelEntries = await listTrackedTopLevelEntries(
+        args.workspacePath,
+      );
+      const trackedTopLevelDrift = diffTrackedTopLevelEntries({
+        approvedEntries: args.config.approvedTrackedTopLevelEntries,
+        actualEntries: trackedTopLevelEntries,
+      });
+      if (trackedTopLevelDrift) {
+        const failureContext = buildTrackedTopLevelEntryDriftFailureContext({
+          issueNumber: record.issue_number,
+          approvedEntries: args.config.approvedTrackedTopLevelEntries,
+          actualEntries: trackedTopLevelEntries,
+          unexpected: trackedTopLevelDrift.unexpected,
+          missing: trackedTopLevelDrift.missing,
+        });
+        record = args.stateStore.touch(record, {
+          state: "blocked",
+          last_error: truncate(failureContext.summary, 1000),
+          last_failure_kind: null,
+          last_failure_context: failureContext,
+          ...args.applyFailureSignature(record, failureContext),
+          blocked_reason: "verification",
+          ...issueDefinitionFreshnessPatch(args.issue),
+        });
+        args.state.issues[String(record.issue_number)] = record;
+        await args.stateStore.save(args.state);
+        await args.syncExecutionMetricsRunSummary(record);
+        await args.syncJournal(record);
+        return {
+          kind: "blocked",
+          message: `Tracked top-level entry guard blocked pull request creation for issue #${record.issue_number}.`,
           record,
           pr: null,
           checks: [],

--- a/src/turn-execution-test-helpers.ts
+++ b/src/turn-execution-test-helpers.ts
@@ -40,6 +40,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     localReviewFollowUpIssueCreationEnabled: false,
     localReviewHighSeverityAction: "retry",
     publishablePathAllowlistMarkers: [],
+    approvedTrackedTopLevelEntries: undefined,
     staleConfiguredBotReviewPolicy: "diagnose_only",
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,


### PR DESCRIPTION
## Summary
- add optional `approvedTrackedTopLevelEntries` config parsing for explicit tracked top-level skeleton baselines
- block draft PR publication when the issue worktree tracked top-level set has unexpected or missing entries
- cover the AegisOps-style `.coderabbit.yaml` drift case and the opt-out no-op case

## Verification
- `npx tsx --test src/turn-execution-publication-gate.test.ts src/config.test.ts`
- `npm run build`

Part of #1666
Implements #1623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New optional config field to declare approved tracked top-level entries.
  * Publication gate now blocks draft PR creation when repository top-level tracked entries differ from the approved list.

* **Validation**
  * Config values are validated and normalized; invalid nested entries produce clear error messages pointing to the offending list index.

* **Tests**
  * Added tests covering validation, listing of tracked top-level entries, and gate behavior with and without the guard configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->