### PR TITLE
Show setup fields by config posture

### DIFF
--- a/src/backend/setup-test-fixtures.ts
+++ b/src/backend/setup-test-fixtures.ts
@@ -8,6 +8,8 @@ import type {
 import type { SetupConfigUpdateResult } from "../setup-config-write";
 import type {
   SetupReadinessBlocker,
+  SetupReadinessConfigPostureField,
+  SetupReadinessConfigPostureGroup,
   SetupReadinessField,
   SetupReadinessFieldKey,
   SetupReadinessHostSummary,
@@ -383,6 +385,108 @@ export function createSetupModelRoutingPosture(
   };
 }
 
+export function createSetupConfigPostureField(
+  overrides: Partial<SetupReadinessConfigPostureField> = {},
+): SetupReadinessConfigPostureField {
+  return {
+    key: "repoPath",
+    label: "Repository path",
+    state: "configured",
+    value: "/tmp/repo",
+    message: "Repository path is configured.",
+    required: true,
+    metadata: {
+      source: "config",
+      editable: true,
+      valueType: "directory_path",
+    },
+    posture: {
+      field: "repoPath",
+      tier: "required",
+      summary: "Managed repository path.",
+      requirementScope: "parser_required",
+    },
+    ...overrides,
+  };
+}
+
+export function createSetupConfigPostureGroups(
+  overrides: Partial<Record<SetupReadinessConfigPostureGroup["tier"], SetupReadinessConfigPostureField[]>> = {},
+): SetupReadinessConfigPostureGroup[] {
+  return [
+    {
+      tier: "required",
+      label: "Required setup decisions",
+      summary: "Missing or invalid required setup decisions are first-run blockers.",
+      fields: overrides.required ?? [
+        createSetupConfigPostureField(),
+        createSetupConfigPostureField({
+          key: "reviewBotLogins",
+          label: "Review provider",
+          state: "missing",
+          value: null,
+          message: "Configure at least one review provider before first-run setup is complete.",
+          required: true,
+          metadata: { source: "config", editable: true, valueType: "review_provider" },
+          posture: {
+            field: "reviewBotLogins",
+            tier: "required",
+            summary: "Review provider identity source.",
+            requirementScope: "first_run_setup",
+          },
+        }),
+      ],
+    },
+    {
+      tier: "recommended",
+      label: "Recommended setup contracts",
+      summary: "Recommended fields improve repeatability without blocking first-run setup.",
+      fields: overrides.recommended ?? [
+        createSetupConfigPostureField({
+          key: "workspacePreparationCommand",
+          label: "Workspace preparation command",
+          state: "missing",
+          value: null,
+          message: "Workspace preparation command is optional until you opt in to the repo-owned contract.",
+          required: false,
+          metadata: { source: "config", editable: true, valueType: "text" },
+          posture: {
+            field: "workspacePreparationCommand",
+            tier: "recommended",
+            summary: "Repo-owned workspace setup contract.",
+          },
+        }),
+        createSetupConfigPostureField({
+          key: "localCiCommand",
+          label: "Local CI command",
+          state: "missing",
+          value: null,
+          message: "Local CI command is optional until you opt in to the repo-owned contract.",
+          required: false,
+          metadata: { source: "config", editable: true, valueType: "text" },
+          posture: {
+            field: "localCiCommand",
+            tier: "recommended",
+            summary: "Repo-owned local CI contract.",
+          },
+        }),
+      ],
+    },
+    {
+      tier: "advanced",
+      label: "Advanced settings",
+      summary: "Advanced settings stay separate from first-run work until explicitly reviewed.",
+      fields: overrides.advanced ?? [],
+    },
+    {
+      tier: "dangerous_explicit_opt_in",
+      label: "Dangerous explicit opt-in settings",
+      summary: "Dangerous explicit opt-in settings are never presented as routine defaults or required next steps.",
+      fields: overrides.dangerous_explicit_opt_in ?? [],
+    },
+  ];
+}
+
 export function createSetupReadinessReport(
   overrides: Partial<SetupReadinessReport> = {},
 ): SetupReadinessReport {
@@ -397,6 +501,7 @@ export function createSetupReadinessReport(
       createSetupField("workspaceRoot"),
       createSetupField("reviewProvider"),
     ],
+    configPostureGroups: createSetupConfigPostureGroups(),
     blockers: [createMissingReviewProviderBlocker()],
     hostReadiness: createSetupHostReadiness(),
     providerPosture: createSetupProviderPosture(),

--- a/src/backend/setup-test-fixtures.ts
+++ b/src/backend/setup-test-fixtures.ts
@@ -501,7 +501,6 @@ export function createSetupReadinessReport(
       createSetupField("workspaceRoot"),
       createSetupField("reviewProvider"),
     ],
-    configPostureGroups: createSetupConfigPostureGroups(),
     blockers: [createMissingReviewProviderBlocker()],
     hostReadiness: createSetupHostReadiness(),
     providerPosture: createSetupProviderPosture(),

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1667,6 +1667,115 @@ test("setup shell loads typed setup readiness without mixing in dashboard status
   assert.equal(harness.remainingFetches.length, 0);
 });
 
+test("setup shell renders required fields first and separates advanced and dangerous posture tiers", async () => {
+  const harness = createSetupHarness([
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse(withManagedRestart(createSetupReadinessReport({
+        fields: [
+          createSetupField("trustMode", {
+            state: "missing",
+            value: null,
+            message: "Trust mode needs an explicit first-run setup decision.",
+          }),
+          createSetupField("workspacePreparationCommand"),
+        ],
+        configPostureGroups: [
+          {
+            tier: "required",
+            label: "Required setup decisions",
+            summary: "Missing or invalid required setup decisions are first-run blockers.",
+            fields: [
+              {
+                ...createSetupField("trustMode", {
+                  state: "missing",
+                  value: null,
+                  message: "Trust mode needs an explicit first-run setup decision.",
+                }),
+                key: "trustMode",
+                posture: {
+                  field: "trustMode",
+                  tier: "required",
+                  summary: "Explicit first-run trust posture decision.",
+                  requirementScope: "first_run_setup",
+                },
+              },
+            ],
+          },
+          {
+            tier: "recommended",
+            label: "Recommended setup contracts",
+            summary: "Recommended fields improve repeatability without blocking first-run setup.",
+            fields: [
+              {
+                ...createSetupField("workspacePreparationCommand"),
+                key: "workspacePreparationCommand",
+                posture: {
+                  field: "workspacePreparationCommand",
+                  tier: "recommended",
+                  summary: "Repo-owned workspace setup contract.",
+                },
+              },
+            ],
+          },
+          {
+            tier: "advanced",
+            label: "Advanced settings",
+            summary: "Advanced settings stay collapsed until explicitly reviewed.",
+            fields: [
+              {
+                key: "boundedRepairModelStrategy",
+                label: "Bounded repair model strategy",
+                state: "missing",
+                value: null,
+                message: "Advanced setting is unset; inherited defaults remain in effect.",
+                required: false,
+                metadata: { source: "config", editable: true, valueType: "text" },
+                posture: {
+                  field: "boundedRepairModelStrategy",
+                  tier: "advanced",
+                  summary: "Bounded repair model routing override.",
+                },
+              },
+            ],
+          },
+          {
+            tier: "dangerous_explicit_opt_in",
+            label: "Dangerous explicit opt-in settings",
+            summary: "Dangerous settings are never routine defaults.",
+            fields: [
+              {
+                key: "staleConfiguredBotReviewPolicy",
+                label: "Stale configured bot review policy",
+                state: "missing",
+                value: null,
+                message: "Dangerous explicit opt-in setting is unset; conservative behavior remains in effect.",
+                required: false,
+                metadata: { source: "config", editable: true, valueType: "text" },
+                posture: {
+                  field: "staleConfiguredBotReviewPolicy",
+                  tier: "dangerous_explicit_opt_in",
+                  summary: "Configured-bot stale-thread reply or resolve behavior.",
+                },
+              },
+            ],
+          },
+        ],
+      }), unavailableManagedRestart)),
+    },
+  ]);
+  await harness.flush();
+
+  const fieldsText = harness.document.getElementById("setup-fields")?.textContent ?? "";
+  assert.match(fieldsText, /Required setup decisions.*Trust mode \[Missing\]/u);
+  assert.match(fieldsText, /Recommended setup contracts.*Workspace preparation command \[Missing\]/u);
+  assert.match(fieldsText, /Advanced settings.*Bounded repair model strategy \[Missing\]/u);
+  assert.match(fieldsText, /Dangerous explicit opt-in settings.*Stale configured bot review policy \[Missing\]/u);
+  assert.ok(fieldsText.indexOf("Required setup decisions") < fieldsText.indexOf("Advanced settings"));
+  assert.ok(fieldsText.indexOf("Advanced settings") < fieldsText.indexOf("Dangerous explicit opt-in settings"));
+  assert.match(fieldsText, /Dangerous explicit opt-in settings.*Dangerous settings are never routine defaults\./u);
+});
+
 test("setup shell highlights a repo-owned local CI candidate when localCiCommand is unset", async () => {
   const harness = createSetupHarness([
     {

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -158,6 +158,51 @@ export function renderSetupBrowserScript(): string {
         }
       }
 
+      function fieldChecklistEntry(field) {
+        const posture = field.posture && field.posture.tier ? formatToken(field.posture.tier) : null;
+        const meta = [
+          "Current value: " + (field.value ?? "Unset"),
+          "Required: " + (field.required ? "yes" : "no") + " | Source: " + formatToken(field.metadata && field.metadata.source ? field.metadata.source : "unknown") + " | Type: " + formatToken(field.metadata && field.metadata.valueType ? field.metadata.valueType : "unknown"),
+        ];
+        if (posture) {
+          meta.push("Posture tier: " + posture);
+        }
+        return {
+          title: field.label + " [" + formatStatus(field.state) + "]",
+          tone: field.state === "invalid" ? "blocker" : "",
+          meta,
+          notes: [
+            field.posture && field.posture.summary ? "Posture: " + field.posture.summary : null,
+            field.message,
+          ].filter(Boolean),
+        };
+      }
+
+      function postureGroupChecklistEntries(report) {
+        const groups = Array.isArray(report.configPostureGroups) ? report.configPostureGroups : [];
+        if (groups.length === 0) {
+          return (report.fields || []).map(fieldChecklistEntry);
+        }
+
+        const entries = [];
+        for (const group of groups) {
+          const fields = Array.isArray(group.fields) ? group.fields : [];
+          entries.push({
+            title: group.label || formatStatus(group.tier),
+            tone: group.tier === "dangerous_explicit_opt_in" ? "danger" : "",
+            meta: [
+              "Posture tier: " + formatToken(group.tier),
+              "Fields: " + fields.length,
+            ],
+            notes: [group.summary || ""].filter(Boolean),
+          });
+          for (const field of fields) {
+            entries.push(fieldChecklistEntry(field));
+          }
+        }
+        return entries;
+      }
+
       async function readJson(path, init) {
         const response = await fetch(path, init || { headers: { Accept: "application/json" } });
         if (!response.ok) {
@@ -529,16 +574,7 @@ export function renderSetupBrowserScript(): string {
         setText(elements.fieldSummary, summarizeFields(report.fields));
         renderChecklist(
           elements.fields,
-          (report.fields || []).map(
-            (field) => ({
-              title: field.label + " [" + formatStatus(field.state) + "]",
-              meta: [
-                "Current value: " + (field.value ?? "Unset"),
-                "Required: " + (field.required ? "yes" : "no") + " | Source: " + formatToken(field.metadata && field.metadata.source ? field.metadata.source : "unknown") + " | Type: " + formatToken(field.metadata && field.metadata.valueType ? field.metadata.valueType : "unknown"),
-              ],
-              notes: [field.message],
-            }),
-          ),
+          postureGroupChecklistEntries(report),
           "No setup fields reported.",
         );
         setText(elements.hostSummary, summarizeHostReadiness(report));

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -345,6 +345,45 @@ test("diagnoseSetupReadiness groups config fields by setup posture tier", async 
   );
 });
 
+test("diagnoseSetupReadiness reuses review provider validation for reviewBotLogins posture", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      ...buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+      }),
+      reviewBotLogins: [123],
+    }),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  const reviewProvider = summary.fields.find((field) => field.key === "reviewProvider");
+  assert.equal(reviewProvider?.state, "missing");
+
+  const requiredGroup = summary.configPostureGroups?.find((group) => group.tier === "required");
+  const reviewBotLogins = requiredGroup?.fields.find((field) => field.key === "reviewBotLogins");
+  assert.equal(reviewBotLogins?.state, "missing");
+  assert.equal(reviewBotLogins?.value, null);
+  assert.match(reviewBotLogins?.message ?? "", /configure at least one review provider/i);
+});
+
 test("diagnoseSetupReadiness reports the selected local review posture preset", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
   t.after(async () => {
@@ -545,6 +584,7 @@ test("diagnoseSetupReadiness surfaces unsupported raw model strategies as invali
         workspacePreparationCommand: undefined,
       }),
       codexModelStrategy: "fiixed",
+      boundedRepairModelStrategy: "fiixed",
     }),
     "utf8",
   );
@@ -567,6 +607,20 @@ test("diagnoseSetupReadiness surfaces unsupported raw model strategies as invali
   assert.equal(codexTarget?.missingExplicitModel, false);
   assert.match(codexTarget?.summary ?? "", /unsupported fiixed routing/i);
   assert.match(codexTarget?.guidance ?? "", /codexModelStrategy=fiixed is unsupported/i);
+  const boundedRepairTarget = summary.modelRoutingPosture.targets.find((target) => target.key === "bounded_repair");
+  assert.equal(boundedRepairTarget?.strategy, "fiixed");
+  assert.equal(boundedRepairTarget?.invalidStrategy, true);
+  assert.match(boundedRepairTarget?.guidance ?? "", /boundedRepairModelStrategy=fiixed is unsupported/i);
+  const recommendedGroup = summary.configPostureGroups?.find((group) => group.tier === "recommended");
+  const codexStrategy = recommendedGroup?.fields.find((field) => field.key === "codexModelStrategy");
+  assert.equal(codexStrategy?.state, "invalid");
+  assert.equal(codexStrategy?.value, "fiixed");
+  assert.match(codexStrategy?.message ?? "", /codexModelStrategy=fiixed is unsupported/i);
+  const advancedGroup = summary.configPostureGroups?.find((group) => group.tier === "advanced");
+  const boundedRepairStrategy = advancedGroup?.fields.find((field) => field.key === "boundedRepairModelStrategy");
+  assert.equal(boundedRepairStrategy?.state, "invalid");
+  assert.equal(boundedRepairStrategy?.value, "fiixed");
+  assert.match(boundedRepairStrategy?.message ?? "", /boundedRepairModelStrategy=fiixed is unsupported/i);
   const blocker = summary.blockers.find((entry) => entry.code === "invalid_codex_model_strategy");
   assert.ok(blocker);
   assert.deepEqual(blocker.fieldKeys, ["codexModelStrategy"]);

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -275,6 +275,76 @@ test("diagnoseSetupReadiness requires explicit trust posture decisions", async (
   );
 });
 
+test("diagnoseSetupReadiness groups config fields by setup posture tier", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+        includeTrustPosture: false,
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  const configPostureGroups = summary.configPostureGroups ?? [];
+  assert.deepEqual(
+    configPostureGroups.map((group) => group.tier),
+    ["required", "recommended", "advanced", "dangerous_explicit_opt_in"],
+  );
+
+  const requiredGroup = configPostureGroups.find((group) => group.tier === "required");
+  const recommendedGroup = configPostureGroups.find((group) => group.tier === "recommended");
+  const advancedGroup = configPostureGroups.find((group) => group.tier === "advanced");
+  const dangerousGroup = configPostureGroups.find((group) => group.tier === "dangerous_explicit_opt_in");
+
+  const trustMode = requiredGroup?.fields.find((field) => field.key === "trustMode");
+  assert.equal(trustMode?.state, "missing");
+  assert.equal(trustMode?.required, true);
+  assert.equal(trustMode?.posture.summary, "Explicit first-run trust posture decision.");
+
+  const workspacePreparation = recommendedGroup?.fields.find((field) => field.key === "workspacePreparationCommand");
+  assert.equal(workspacePreparation?.state, "missing");
+  assert.equal(workspacePreparation?.required, false);
+  assert.match(workspacePreparation?.message ?? "", /optional until you opt in/i);
+
+  const boundedRepairStrategy = advancedGroup?.fields.find((field) => field.key === "boundedRepairModelStrategy");
+  assert.equal(boundedRepairStrategy?.state, "missing");
+  assert.equal(boundedRepairStrategy?.required, false);
+  assert.match(boundedRepairStrategy?.message ?? "", /advanced setting/i);
+
+  const staleBotPolicy = dangerousGroup?.fields.find((field) => field.key === "staleConfiguredBotReviewPolicy");
+  assert.equal(staleBotPolicy?.state, "missing");
+  assert.equal(staleBotPolicy?.required, false);
+  assert.match(staleBotPolicy?.message ?? "", /dangerous explicit opt-in/i);
+
+  assert.equal(
+    summary.blockers.some((blocker) => blocker.fieldKeys.includes("boundedRepairModelStrategy")),
+    false,
+  );
+  assert.equal(
+    summary.blockers.some((blocker) => blocker.fieldKeys.includes("staleConfiguredBotReviewPolicy")),
+    false,
+  );
+});
+
 test("diagnoseSetupReadiness reports the selected local review posture preset", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
   t.after(async () => {

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+  CONFIG_FIELD_POSTURE_METADATA,
+  CONFIG_FIELD_POSTURE_TIERS,
+  type ConfigFieldName,
+  type ConfigFieldPostureMetadata,
+  type ConfigFieldPostureTier,
   displayLocalCiCommand,
   findRepoOwnedWorkspacePreparationCandidate,
   loadConfigSummary,
@@ -33,6 +38,7 @@ export type SetupReadinessFieldKey =
   | "reviewProvider";
 export type SetupReadinessConfigFieldKey =
   | SetupReadinessFieldKey
+  | ConfigFieldName
   | "codexModelStrategy"
   | "codexModel"
   | "boundedRepairModelStrategy"
@@ -65,6 +71,24 @@ export interface SetupReadinessField {
   message: string;
   required: boolean;
   metadata: SetupReadinessFieldMetadata;
+}
+
+export interface SetupReadinessConfigPostureField {
+  key: ConfigFieldName;
+  label: string;
+  state: SetupFieldState;
+  value: string | null;
+  message: string;
+  required: boolean;
+  metadata: SetupReadinessFieldMetadata;
+  posture: ConfigFieldPostureMetadata;
+}
+
+export interface SetupReadinessConfigPostureGroup {
+  tier: ConfigFieldPostureTier;
+  label: string;
+  summary: string;
+  fields: SetupReadinessConfigPostureField[];
 }
 
 export type SetupReadinessRemediationKind =
@@ -135,6 +159,7 @@ export interface SetupReadinessReport {
   overallStatus: SetupReadinessOverallStatus;
   configPath: string;
   fields: SetupReadinessField[];
+  configPostureGroups?: SetupReadinessConfigPostureGroup[];
   blockers: SetupReadinessBlocker[];
   hostReadiness: SetupReadinessHostSummary;
   providerPosture: SetupReadinessProviderPosture;
@@ -186,6 +211,19 @@ const SETUP_FIELD_METADATA: Record<SetupReadinessFieldKey, SetupReadinessFieldMe
 
 const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untrusted_or_mixed"]);
 const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
+const SETUP_POSTURE_GROUP_LABELS: Record<ConfigFieldPostureTier, string> = {
+  required: "Required setup decisions",
+  recommended: "Recommended setup contracts",
+  advanced: "Advanced settings",
+  dangerous_explicit_opt_in: "Dangerous explicit opt-in settings",
+};
+const SETUP_POSTURE_GROUP_SUMMARIES: Record<ConfigFieldPostureTier, string> = {
+  required: "Missing or invalid required setup decisions are first-run blockers.",
+  recommended: "Recommended fields improve repeatability without blocking first-run setup.",
+  advanced: "Advanced settings stay separate from first-run work until explicitly reviewed.",
+  dangerous_explicit_opt_in:
+    "Dangerous explicit opt-in settings are never presented as routine defaults or required next steps.",
+};
 
 function readRawConfigDocument(configPath: string): RawConfigDocument {
   if (!fs.existsSync(configPath)) {
@@ -215,6 +253,36 @@ function displayValue(value: unknown): string | null {
     return rendered.length > 0 ? rendered : null;
   }
 
+  return null;
+}
+
+function displayConfigFieldLabel(field: string): string {
+  return field
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\b([a-z])/g, (match) => match.toUpperCase());
+}
+
+function displayPostureConfigValue(value: unknown): string | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    const rendered = value
+      .map((entry) => displayPostureConfigValue(entry))
+      .filter((entry): entry is string => entry !== null)
+      .join(", ");
+    return rendered.length > 0 ? rendered : null;
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
   return null;
 }
 
@@ -380,6 +448,76 @@ function buildConfigFields(args: {
           : "Configure at least one review provider before first-run setup is complete.",
     },
   ];
+}
+
+function buildMissingPostureMessage(posture: ConfigFieldPostureMetadata): string {
+  if (posture.tier === "required") {
+    return posture.requirementScope === "first_run_setup"
+      ? `${displayConfigFieldLabel(posture.field)} needs an explicit first-run setup decision.`
+      : `${displayConfigFieldLabel(posture.field)} is required before first-run setup is complete.`;
+  }
+  if (posture.tier === "recommended") {
+    return `${displayConfigFieldLabel(posture.field)} is recommended, but setup can continue until you opt in.`;
+  }
+  if (posture.tier === "advanced") {
+    return "Advanced setting is unset; inherited defaults remain in effect.";
+  }
+  return "Dangerous explicit opt-in setting is unset; conservative behavior remains in effect.";
+}
+
+function metadataForPostureField(field: ConfigFieldName): SetupReadinessFieldMetadata {
+  const existing = SETUP_FIELD_METADATA[field as SetupReadinessFieldKey];
+  return existing ?? { source: "config", editable: true, valueType: "text" };
+}
+
+function buildConfigPostureGroups(args: {
+  rawConfig: RawConfigDocument;
+  configSummary: ReturnType<typeof loadConfigSummary>;
+  fields: SetupReadinessField[];
+}): SetupReadinessConfigPostureGroup[] {
+  const fieldByKey = new Map(args.fields.map((field) => [field.key, field]));
+  const resolvedConfig = args.configSummary.config;
+  const rawConfig = args.rawConfig ?? {};
+  const postureFields = Object.values(CONFIG_FIELD_POSTURE_METADATA)
+    .filter((entry): entry is ConfigFieldPostureMetadata => Boolean(entry))
+    .map((posture): SetupReadinessConfigPostureField => {
+      const existing = fieldByKey.get(posture.field as SetupReadinessFieldKey);
+      if (existing) {
+        return {
+          ...existing,
+          key: posture.field,
+          posture,
+        };
+      }
+
+      const hasRawValue = Object.prototype.hasOwnProperty.call(rawConfig, posture.field);
+      const value = displayPostureConfigValue(
+        hasRawValue
+          ? rawConfig[posture.field]
+          : posture.tier === "required"
+            ? resolvedConfig?.[posture.field]
+            : undefined,
+      );
+      return {
+        key: posture.field,
+        label: displayConfigFieldLabel(posture.field),
+        state: (value === null ? "missing" : "configured") as SetupFieldState,
+        value,
+        message: value === null
+          ? buildMissingPostureMessage(posture)
+          : `${displayConfigFieldLabel(posture.field)} is configured.`,
+        required: posture.tier === "required",
+        metadata: metadataForPostureField(posture.field),
+        posture,
+      };
+    });
+
+  return CONFIG_FIELD_POSTURE_TIERS.map((tier) => ({
+    tier,
+    label: SETUP_POSTURE_GROUP_LABELS[tier],
+    summary: SETUP_POSTURE_GROUP_SUMMARIES[tier],
+    fields: postureFields.filter((field) => field.posture.tier === tier),
+  }));
 }
 
 function buildProviderPosture(
@@ -742,6 +880,11 @@ export async function diagnoseSetupReadiness(
     workspacePreparationWarning,
     recommendedWorkspacePreparationCommand,
   });
+  const configPostureGroups = buildConfigPostureGroups({
+    rawConfig,
+    configSummary,
+    fields,
+  });
   const modelRoutingPosture = buildModelRoutingPosture({
     rawConfig,
     config: configSummary.config,
@@ -761,6 +904,7 @@ export async function diagnoseSetupReadiness(
     overallStatus: overallStatusFromFields(fields, modelRoutingPosture),
     configPath,
     fields,
+    configPostureGroups,
     blockers,
     hostReadiness,
     providerPosture: buildProviderPosture(configSummary.config),

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -224,6 +224,9 @@ const SETUP_POSTURE_GROUP_SUMMARIES: Record<ConfigFieldPostureTier, string> = {
   dangerous_explicit_opt_in:
     "Dangerous explicit opt-in settings are never presented as routine defaults or required next steps.",
 };
+const POSTURE_FIELD_ALIASES: Partial<Record<ConfigFieldName, SetupReadinessFieldKey>> = {
+  reviewBotLogins: "reviewProvider",
+};
 
 function readRawConfigDocument(configPath: string): RawConfigDocument {
   if (!fs.existsSync(configPath)) {
@@ -474,6 +477,7 @@ function buildConfigPostureGroups(args: {
   rawConfig: RawConfigDocument;
   configSummary: ReturnType<typeof loadConfigSummary>;
   fields: SetupReadinessField[];
+  modelRoutingPosture: SetupReadinessModelRoutingPosture;
 }): SetupReadinessConfigPostureGroup[] {
   const fieldByKey = new Map(args.fields.map((field) => [field.key, field]));
   const resolvedConfig = args.configSummary.config;
@@ -481,7 +485,8 @@ function buildConfigPostureGroups(args: {
   const postureFields = Object.values(CONFIG_FIELD_POSTURE_METADATA)
     .filter((entry): entry is ConfigFieldPostureMetadata => Boolean(entry))
     .map((posture): SetupReadinessConfigPostureField => {
-      const existing = fieldByKey.get(posture.field as SetupReadinessFieldKey);
+      const existingKey = POSTURE_FIELD_ALIASES[posture.field] ?? (posture.field as SetupReadinessFieldKey);
+      const existing = fieldByKey.get(existingKey);
       if (existing) {
         return {
           ...existing,
@@ -498,14 +503,26 @@ function buildConfigPostureGroups(args: {
             ? resolvedConfig?.[posture.field]
             : undefined,
       );
+      const invalidModelRoutingTarget = args.modelRoutingPosture.targets.find(
+        (target) => target.strategyField === posture.field && target.invalidStrategy,
+      );
+      const state: SetupFieldState = invalidModelRoutingTarget || args.configSummary.invalidFields.includes(posture.field)
+        ? "invalid"
+        : value === null
+          ? "missing"
+          : "configured";
       return {
         key: posture.field,
         label: displayConfigFieldLabel(posture.field),
-        state: (value === null ? "missing" : "configured") as SetupFieldState,
+        state,
         value,
-        message: value === null
-          ? buildMissingPostureMessage(posture)
-          : `${displayConfigFieldLabel(posture.field)} is configured.`,
+        message: invalidModelRoutingTarget
+          ? invalidModelRoutingTarget.guidance
+          : state === "invalid"
+            ? `${displayConfigFieldLabel(posture.field)} is present but invalid.`
+            : value === null
+              ? buildMissingPostureMessage(posture)
+              : `${displayConfigFieldLabel(posture.field)} is configured.`,
         required: posture.tier === "required",
         metadata: metadataForPostureField(posture.field),
         posture,
@@ -880,14 +897,15 @@ export async function diagnoseSetupReadiness(
     workspacePreparationWarning,
     recommendedWorkspacePreparationCommand,
   });
+  const modelRoutingPosture = buildModelRoutingPosture({
+    rawConfig,
+    config: configSummary.config,
+  });
   const configPostureGroups = buildConfigPostureGroups({
     rawConfig,
     configSummary,
     fields,
-  });
-  const modelRoutingPosture = buildModelRoutingPosture({
-    rawConfig,
-    config: configSummary.config,
+    modelRoutingPosture,
   });
   const hostDiagnostics = configSummary.config
     ? await diagnoseSupervisorHost({


### PR DESCRIPTION
## Summary
- expose setup readiness config posture groups from Phase 3 metadata
- render required/recommended/advanced/dangerous setup groups in the WebUI field inventory
- add focused setup readiness and WebUI regression coverage

Part of #1666
Addresses #1670

## Verification
- npx tsx --test src/setup-readiness.test.ts src/backend/webui-dashboard.test.ts
- npm run build

Note: the issue verification command references src/backend/webui-setup.test.ts, but that file does not exist in this checkout; the setup WebUI coverage is in src/backend/webui-dashboard.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup readiness view now organizes configuration fields into tiered categories (Required setup decisions, Advanced settings, Dangerous explicit opt-in settings) with tier-specific guidance and status indicators.

* **Tests**
  * Added comprehensive test coverage for setup readiness tier organization and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->