### PR TITLE
Add skeleton guard config posture metadata

### DIFF
--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1758,6 +1758,20 @@ test("setup shell renders required fields first and separates advanced and dange
                   summary: "Configured-bot stale-thread reply or resolve behavior.",
                 },
               },
+              {
+                key: "approvedTrackedTopLevelEntries",
+                label: "Approved tracked top level entries",
+                state: "configured",
+                value: "README.md, src",
+                message: "Approved tracked top level entries is configured.",
+                required: false,
+                metadata: { source: "config", editable: true, valueType: "text" },
+                posture: {
+                  field: "approvedTrackedTopLevelEntries",
+                  tier: "dangerous_explicit_opt_in",
+                  summary: "Approved tracked top-level repository skeleton entries.",
+                },
+              },
             ],
           },
         ],
@@ -1771,6 +1785,8 @@ test("setup shell renders required fields first and separates advanced and dange
   assert.match(fieldsText, /Recommended setup contracts.*Workspace preparation command \[Missing\]/u);
   assert.match(fieldsText, /Advanced settings.*Bounded repair model strategy \[Missing\]/u);
   assert.match(fieldsText, /Dangerous explicit opt-in settings.*Stale configured bot review policy \[Missing\]/u);
+  assert.match(fieldsText, /Dangerous explicit opt-in settings.*Approved tracked top level entries \[Configured\]/u);
+  assert.match(fieldsText, /Current value: README\.md, src/u);
   assert.ok(fieldsText.indexOf("Required setup decisions") < fieldsText.indexOf("Advanced settings"));
   assert.ok(fieldsText.indexOf("Advanced settings") < fieldsText.indexOf("Dangerous explicit opt-in settings"));
   assert.match(fieldsText, /Dangerous explicit opt-in settings.*Dangerous settings are never routine defaults\./u);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -118,6 +118,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       "localReviewFollowUpIssueCreationEnabled",
       "localReviewHighSeverityAction",
       "staleConfiguredBotReviewPolicy",
+      "approvedTrackedTopLevelEntries",
     ].map((field) => [field, getConfigFieldPostureMetadata(field)?.tier]),
     [
       ["localReviewFollowUpRepairEnabled", "dangerous_explicit_opt_in"],
@@ -125,6 +126,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       ["localReviewFollowUpIssueCreationEnabled", "dangerous_explicit_opt_in"],
       ["localReviewHighSeverityAction", "dangerous_explicit_opt_in"],
       ["staleConfiguredBotReviewPolicy", "dangerous_explicit_opt_in"],
+      ["approvedTrackedTopLevelEntries", "dangerous_explicit_opt_in"],
     ],
   );
 });

--- a/src/core/config-field-posture.ts
+++ b/src/core/config-field-posture.ts
@@ -116,6 +116,7 @@ const CONFIG_FIELD_POSTURE_METADATA_ENTRIES = [
   dangerousExplicitOptIn("localReviewFollowUpIssueCreationEnabled", "Automated local-review follow-up issue creation opt-in."),
   dangerousExplicitOptIn("localReviewHighSeverityAction", "High-severity local-review autonomous action posture."),
   dangerousExplicitOptIn("staleConfiguredBotReviewPolicy", "Configured-bot stale-thread reply or resolve behavior."),
+  dangerousExplicitOptIn("approvedTrackedTopLevelEntries", "Approved tracked top-level repository skeleton entries."),
 ] as const;
 
 const CONFIG_FIELD_POSTURE_METADATA_BY_FIELD: Partial<

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -33,6 +33,7 @@ function buildConfigDocument(args: {
   workspacePreparationCommand: unknown;
   includeTrustPosture?: boolean;
   localReviewPosture?: string;
+  approvedTrackedTopLevelEntries?: string[];
 }): Record<string, unknown> {
   return {
     repoPath: args.repoPath,
@@ -45,6 +46,9 @@ function buildConfigDocument(args: {
     reviewBotLogins: ["chatgpt-codex-connector"],
     workspacePreparationCommand: args.workspacePreparationCommand,
     ...(args.localReviewPosture ? { localReviewPosture: args.localReviewPosture } : {}),
+    ...(args.approvedTrackedTopLevelEntries
+      ? { approvedTrackedTopLevelEntries: args.approvedTrackedTopLevelEntries }
+      : {}),
     ...(args.includeTrustPosture === false
       ? {}
       : {
@@ -334,6 +338,12 @@ test("diagnoseSetupReadiness groups config fields by setup posture tier", async 
   assert.equal(staleBotPolicy?.state, "missing");
   assert.equal(staleBotPolicy?.required, false);
   assert.match(staleBotPolicy?.message ?? "", /dangerous explicit opt-in/i);
+  const skeletonGuard = dangerousGroup?.fields.find((field) => field.key === "approvedTrackedTopLevelEntries");
+  assert.equal(skeletonGuard?.state, "missing");
+  assert.equal(skeletonGuard?.required, false);
+  assert.equal(skeletonGuard?.value, null);
+  assert.match(skeletonGuard?.message ?? "", /conservative behavior remains in effect/i);
+  assert.equal(skeletonGuard?.posture.summary, "Approved tracked top-level repository skeleton entries.");
 
   assert.equal(
     summary.blockers.some((blocker) => blocker.fieldKeys.includes("boundedRepairModelStrategy")),
@@ -343,6 +353,47 @@ test("diagnoseSetupReadiness groups config fields by setup posture tier", async 
     summary.blockers.some((blocker) => blocker.fieldKeys.includes("staleConfiguredBotReviewPolicy")),
     false,
   );
+  assert.equal(
+    summary.blockers.some((blocker) => blocker.fieldKeys.includes("approvedTrackedTopLevelEntries")),
+    false,
+  );
+});
+
+test("diagnoseSetupReadiness exposes configured approved tracked top-level entries in posture groups", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+        approvedTrackedTopLevelEntries: ["README.md", "src"],
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  const dangerousGroup = summary.configPostureGroups?.find((group) => group.tier === "dangerous_explicit_opt_in");
+  const skeletonGuard = dangerousGroup?.fields.find((field) => field.key === "approvedTrackedTopLevelEntries");
+  assert.equal(skeletonGuard?.state, "configured");
+  assert.equal(skeletonGuard?.required, false);
+  assert.equal(skeletonGuard?.value, "README.md, src");
+  assert.match(skeletonGuard?.message ?? "", /Approved tracked top level entries is configured/i);
 });
 
 test("diagnoseSetupReadiness reuses review provider validation for reviewBotLogins posture", async (t) => {


### PR DESCRIPTION
## Summary
- classify approvedTrackedTopLevelEntries as dangerous explicit opt-in posture metadata
- surface the skeleton guard in setup-readiness posture groups when configured or unset
- cover WebUI posture-group rendering for the configured skeleton guard field

## Verification
- npx tsx --test src/config.test.ts src/setup-readiness.test.ts src/backend/webui-dashboard.test.ts
- npm run build

Closes #1676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for configuration field posture classification and WebUI dashboard rendering.

* **Chores**
  * Added support for a new advanced configuration field that requires explicit opt-in to enable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->