### PR TITLE
Align WebUI run mode docs with runtime state

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,16 @@ Before the first run, keep the [Configuration guide](./docs/configuration.md) op
    node dist/index.js web --config /path/to/supervisor.config.json
    ```
 
+   The WebUI is an operator surface over the same supervisor service. It does not own the background loop or create a loop run mode; use `status` or `doctor` to inspect the observable loop runtime marker.
+
 ## WebUI
 
 The local WebUI gives you two operator-facing routes on the same supervisor service:
 
 - `/setup` for first-run setup, typed readiness, and guided config edits
 - `/dashboard` for steady-state issue, queue, and diagnostics monitoring
+
+It observes and mutates through the supervisor service boundary, but it is not the loop owner. A launcher-managed WebUI restart only relaunches the WebUI process; the background loop remains owned by the supported tmux or systemd loop host.
 
 Start it with:
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -217,6 +217,8 @@ host ごとの loop 運用ルール:
 
 WebUI は CLI と同じ `SupervisorService` を使い、typed な `status`、`doctor`、`explain`、`issue-lint` を読みます。現在の safe command surface は `run-once`、`requeue`、`prune-orphaned-workspaces`、`reset-corrupt-json-state` です。
 
+WebUI は operator surface であり、loop run mode ではありません。`status` と `doctor` が表示する loop runtime は、WebUI process ではなく観測可能な loop runtime marker に基づきます。launcher-managed WebUI restart は WebUI process だけを対象にし、background loop の所有権を意味しません。
+
 通常運用では、supervisor は次を繰り返します。
 
 1. GitHub とローカル state を再取得する

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -418,11 +418,10 @@ Supported run-mode vocabulary:
 - `one_shot_manual`: a manually invoked CLI command such as `run-once`, `status`, or `doctor`; it does not own a background loop and has no safe automatic restart action.
 - `macos_tmux_loop`: the macOS loop hosted by `./scripts/start-loop-tmux.sh`; safe recovery is to stop it with `./scripts/stop-loop-tmux.sh`, inspect any ambiguous direct loop PIDs reported by diagnostics, and restart with the same `CODEX_SUPERVISOR_CONFIG`.
 - `linux_systemd_loop`: the Linux user service installed by `./scripts/install-systemd.sh`; safe recovery is through `systemctl --user status|restart codex-supervisor.service` after confirming `status` or `doctor` points at the intended config.
-- `webui_attached`: a local WebUI session launched through `node dist/index.js web --config <supervisor-config-path>` or the dedicated WebUI launchers; it exposes operator actions but does not own or restart the background loop unless the WebUI launcher explicitly reports managed restart capability.
 
-`status` and `doctor` report `run_mode=...` next to the loop runtime marker fields when the mode can be inferred from launcher metadata. If diagnostics show `run_mode=unknown`, `ownership_confidence=ambiguous_owner`, or duplicate loop processes, inspect the marker and listed PIDs instead of deleting marker files or killing processes automatically.
+`status` and `doctor` report `run_mode=...` next to the loop runtime marker fields when the mode can be inferred from the loop's own runtime marker. If diagnostics show `run_mode=unknown`, `ownership_confidence=ambiguous_owner`, or duplicate loop processes, inspect the marker and listed PIDs instead of deleting marker files or killing processes automatically.
 
-The WebUI uses the same `SupervisorService` boundary as the CLI. It reads the same typed status, doctor, explain, and issue-lint data, and it only exposes the current safe command set: `run-once`, `requeue`, `prune-orphaned-workspaces`, and `reset-corrupt-json-state`.
+The WebUI uses the same `SupervisorService` boundary as the CLI. It reads the same typed status, doctor, explain, and issue-lint data, and it only exposes the current safe command set: `run-once`, `requeue`, `prune-orphaned-workspaces`, and `reset-corrupt-json-state`. A WebUI session is an operator surface, not a loop run mode; launcher-backed WebUI restart capability applies to the WebUI process only and does not imply ownership of the background loop.
 
 In normal operation, the supervisor will:
 

--- a/docs/operator-dashboard.md
+++ b/docs/operator-dashboard.md
@@ -4,6 +4,8 @@ Use this guide when you want the local WebUI for `codex-supervisor`.
 
 The dashboard is an operator surface over the same `SupervisorService` boundary that the CLI uses. It is not a separate backend, and it is not allowed to read the state file, worktrees, `gh`, or `codex` directly from the browser.
 
+The WebUI does not own the background loop and does not create a loop run mode. Status and doctor panels show the observable loop runtime marker for the configured supervisor service; launcher-backed WebUI restart support applies only to the WebUI process.
+
 ## Start the WebUI
 
 Run the local server against the same supervisor config you use for `run-once`, `loop`, and `status`:

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -174,10 +174,13 @@ test("getting-started documents tmux as the supported macOS loop host and keeps 
   assert.match(gettingStarted, /`\.\/scripts\/install-launchd\.sh` now fails closed/i);
   assert.match(gettingStarted, /If you want a launcher-managed background loop on Linux, use `\.\/scripts\/install-systemd\.sh`/);
   assert.match(gettingStarted, /For a launcher-managed WebUI on macOS, use `\.\/scripts\/install-launchd-web\.sh`/);
+  assert.match(gettingStarted, /A WebUI session is an operator surface, not a loop run mode/i);
+  assert.doesNotMatch(gettingStarted, /webui_attached/);
 
   assert.match(japaneseGettingStarted, /macOS でサポートしている常駐 loop host は `tmux`/);
   assert.match(japaneseGettingStarted, /`\.\/scripts\/start-loop-tmux\.sh`/);
   assert.match(japaneseGettingStarted, /`\.\/scripts\/stop-loop-tmux\.sh`/);
+  assert.match(japaneseGettingStarted, /WebUI は operator surface であり、loop run mode ではありません/);
 });
 
 test("japanese docs keep overview and getting-started responsibilities separate", async () => {

--- a/src/supervisor/supervisor-loop-runtime-state.test.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.test.ts
@@ -82,6 +82,35 @@ test("readSupervisorLoopRuntime names tmux and manual run modes without broadeni
   assert.equal(tmuxRuntime.runMode, "macos_tmux_loop");
 });
 
+test("readSupervisorLoopRuntime does not promote WebUI launcher metadata to a loop run mode", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-loop-runtime-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const stateFile = path.join(root, "state.json");
+  const lockPath = supervisorLoopRuntimeLockPath(stateFile);
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.writeFile(
+    lockPath,
+    `${JSON.stringify({
+      pid: process.pid,
+      label: "supervisor-loop-runtime",
+      acquired_at: "2026-03-25T00:00:00.000Z",
+      host: "fixture-host",
+      owner: "fixture-owner",
+      launcher: "webui",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const runtime = await readSupervisorLoopRuntime(stateFile);
+
+  assert.equal(runtime.state, "running");
+  assert.equal(runtime.hostMode, "direct");
+  assert.equal(runtime.runMode, "unknown");
+});
+
 test("readSupervisorLoopRuntime detects duplicate loop processes for the same resolved config and state target", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-loop-runtime-"));
   t.after(async () => {

--- a/src/supervisor/supervisor-loop-runtime-state.ts
+++ b/src/supervisor/supervisor-loop-runtime-state.ts
@@ -11,7 +11,6 @@ export type SupervisorRunMode =
   | "one_shot_manual"
   | "macos_tmux_loop"
   | "linux_systemd_loop"
-  | "webui_attached"
   | "unknown";
 export type SupervisorLoopOwnershipConfidence =
   | "none"
@@ -115,10 +114,6 @@ function inferRunMode(runtimeLock: ExistingLockState): SupervisorRunMode {
   if (normalizedLauncher === "systemd") {
     return "linux_systemd_loop";
   }
-  if (normalizedLauncher === "webui") {
-    return "webui_attached";
-  }
-
   return "unknown";
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable `webui_attached` loop run mode from runtime inference
- document WebUI as an operator surface rather than a loop owner
- add focused runtime/docs regressions so status and doctor vocabulary stays tied to observable loop markers

## Verification
- `npx tsx --test src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-loop-runtime-state.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/doctor.test.ts src/getting-started-docs.test.ts`
- `npm run build`

Part of #1677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified WebUI as an operator surface, not a loop run mode.
  * Defined WebUI restart scope to affect only the WebUI process, leaving the background loop unchanged.
  * Updated runtime semantics: Status/Doctor panels now source data from loop runtime markers.

* **Tests**
  * Added validation tests for documentation consistency and WebUI launcher metadata handling.

* **Bug Fixes**
  * Removed `webui_attached` as a recognized run mode designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->