### PR TITLE
Extract tracked PR status comment handling

### DIFF
--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -21,10 +21,8 @@ import { StateStore } from "./core/state-store";
 import {
   FailureContext,
   GitHubIssue,
-  IssueComment,
   GitHubPullRequest,
   IssueRunRecord,
-  LatestLocalCiResult,
   PullRequestCheck,
   ReviewThread,
   RunState,
@@ -43,7 +41,6 @@ import {
   maybeBuildReviewWaitChangedEvent,
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
-import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
 import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
 import { parseIssueMetadata } from "./issue-metadata";
 import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
@@ -51,7 +48,9 @@ import {
   derivePostTurnLocalReviewDecision,
   derivePostTurnLocalReviewFailurePatch,
 } from "./post-turn-pull-request-policy";
-import { configuredBotReviewThreads, latestReviewComment } from "./review-thread-reporting";
+import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+
+export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
 export interface PostTurnPullRequestContext {
   state: SupervisorStateFile;
@@ -89,894 +88,7 @@ export interface PullRequestLifecycleSnapshot {
   >;
 }
 
-type HostLocalTrackedPrBlockerGateType =
-  | "workspace_preparation"
-  | "local_ci"
-  | "workstation_local_path_hygiene";
-
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
-const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT = "stale_review_bot";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
-const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
-
-type TrackedPrStatusCommentKind = "status" | "host-local-blocker";
-
-function workspacePreparationFailureClass(
-  signature: string | null | undefined,
-): Exclude<LatestLocalCiResult["failure_class"], "unset_contract"> | null {
-  if (!signature?.startsWith("workspace-preparation-gate-")) {
-    return null;
-  }
-
-  const failureClass = signature.slice("workspace-preparation-gate-".length);
-  switch (failureClass) {
-    case "missing_command":
-    case "workspace_toolchain_missing":
-    case "worktree_helper_missing":
-    case "non_zero_exit":
-      return failureClass;
-    default:
-      return null;
-  }
-}
-
-function workspacePreparationRemediationTarget(
-  failureClass: Exclude<LatestLocalCiResult["failure_class"], "unset_contract"> | null,
-): string {
-  switch (failureClass) {
-    case "worktree_helper_missing":
-    case "missing_command":
-      return "supervisor_config";
-    case "workspace_toolchain_missing":
-    case "non_zero_exit":
-    default:
-      return "workspace_environment";
-  }
-}
-
-function buildTrackedPrHostLocalBlockerComment(args: {
-  pr: Pick<GitHubPullRequest, "headRefOid">;
-  gateType: HostLocalTrackedPrBlockerGateType;
-  blockerSignature: string;
-  failureClass: string | null;
-  remediationTarget: string | null;
-  summary: string;
-  details?: string[] | null;
-}): string {
-  if (args.gateType === "workstation_local_path_hygiene") {
-    return buildTrackedPrReadyPromotionPathHygieneComment(args);
-  }
-
-  return [
-    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
-    "",
-    `- reason code: \`${trackedPrReadyPromotionBlockedReasonCode(args.gateType)}\``,
-    `- gate type: \`${args.gateType}\``,
-    `- blocker signature: \`${args.blockerSignature}\``,
-    `- failure class: \`${args.failureClass ?? "unknown"}\``,
-    `- remediation target: \`${args.remediationTarget ?? "unknown"}\``,
-    `- summary: ${args.summary}`,
-    "- automatic retry: no",
-    "- next action: fix the tracked workspace blocker, then rerun the supervisor to retry ready-for-review promotion.",
-    "",
-    "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
-  ].join("\n");
-}
-
-function observedTrackedPrHostLocalBlockerPatch(args: {
-  pr: Pick<GitHubPullRequest, "headRefOid">;
-  blockerSignature: string | null;
-}): Pick<IssueRunRecord, "last_observed_host_local_pr_blocker_signature" | "last_observed_host_local_pr_blocker_head_sha"> {
-  return {
-    last_observed_host_local_pr_blocker_head_sha: args.pr.headRefOid,
-    last_observed_host_local_pr_blocker_signature: args.blockerSignature,
-  };
-}
-
-function summarizeWorkstationLocalPathFirstFix(details: string[] | null | undefined): string | null {
-  if (!details || details.length === 0) {
-    return null;
-  }
-
-  const countsByFile = new Map<string, number>();
-  for (const detail of details) {
-    const match = detail.match(/^-?\s*([^:\s][^:]*)\:\d+\s+matched\b/);
-    if (!match) {
-      continue;
-    }
-    const filePath = match[1]?.trim();
-    if (!filePath) {
-      continue;
-    }
-    countsByFile.set(filePath, (countsByFile.get(filePath) ?? 0) + 1);
-  }
-
-  if (countsByFile.size === 0) {
-    return null;
-  }
-
-  const sortedFiles = [...countsByFile.entries()].sort((left, right) => {
-    if (right[1] !== left[1]) {
-      return right[1] - left[1];
-    }
-    return left[0].localeCompare(right[0]);
-  });
-  const visibleFiles = sortedFiles
-    .slice(0, 3)
-    .map(([filePath, count]) => `${filePath} (${count} match${count === 1 ? "" : "es"})`);
-  const remainingCount = sortedFiles.length - visibleFiles.length;
-  const tail = remainingCount > 0 ? `; +${remainingCount} more file${remainingCount === 1 ? "" : "s"}` : "";
-  return `First fix: ${visibleFiles.join("; ")}${tail}.`;
-}
-
-function buildTrackedPrReadyPromotionPathHygieneComment(args: {
-  pr: Pick<GitHubPullRequest, "headRefOid">;
-  blockerSignature: string;
-  summary: string;
-  details?: string[] | null;
-}): string {
-  const firstFix = summarizeWorkstationLocalPathFirstFix(args.details);
-  const conciseSummary = args.summary.replace(/\s+First fix:.*$/i, "").trim();
-  return [
-    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
-    "",
-    `- reason code: \`${trackedPrReadyPromotionBlockedReasonCode("workstation_local_path_hygiene")}\``,
-    `- gate name: \`workstation_local_path_hygiene\``,
-    `- blocker signature: \`${args.blockerSignature}\``,
-    `- what failed: ${conciseSummary}`,
-    ...(firstFix ? [`- ${firstFix}`] : []),
-    "- automatic retry: no",
-    "- rerunning the supervisor alone will not help yet; fix the tracked workspace artifacts first, then rerun promotion.",
-    "",
-    "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
-  ].join("\n");
-}
-
-function trackedPrReadyPromotionBlockedReasonCode(gateType: HostLocalTrackedPrBlockerGateType): string {
-  return `ready_promotion_blocked_${gateType}`;
-}
-
-function buildTrackedPrDraftReviewSuppressedComment(args: {
-  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
-}): string {
-  return [
-    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because provider review is intentionally suppressed.`,
-    "",
-    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED}\``,
-    "- what is happening: configured provider review stays suppressed until this PR is ready for review.",
-    "- automatic retry: yes",
-    `- next action: keep the tracked workspace moving toward ready-for-review promotion for PR #${args.pr.number}; the supervisor will retry automatically on later cycles.`,
-    "",
-    "GitHub checks may still be pending because external review-provider work does not start while the PR remains draft.",
-  ].join("\n");
-}
-
-function compactEvidenceLines(details: string[] | null | undefined, limit = 3): string[] {
-  if (!details || details.length === 0) {
-    return [];
-  }
-
-  return details
-    .map((detail) => detail.replace(/\s+/g, " ").trim())
-    .filter((detail) => detail.length > 0)
-    .slice(0, limit);
-}
-
-function buildTrackedPrPersistentStatusComment(args: {
-  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
-  reasonCode: string;
-  summary: string;
-  evidence: string[];
-  nextAction: string;
-  automaticRetry: "yes" | "no";
-}): string {
-  return [
-    `Tracked PR head \`${args.pr.headRefOid}\` remains stopped near merge.`,
-    "",
-    `- reason code: \`${args.reasonCode}\``,
-    `- summary: ${args.summary}`,
-    ...args.evidence.map((detail) => `- evidence: ${detail}`),
-    `- automatic retry: ${args.automaticRetry}`,
-    `- next action: ${args.nextAction}`,
-  ].join("\n");
-}
-
-function isTrackedPrActiveStatusState(state: RunState): boolean {
-  switch (state) {
-    case "local_review":
-    case "local_review_fix":
-    case "stabilizing":
-    case "pr_open":
-    case "repairing_ci":
-    case "resolving_conflict":
-    case "waiting_ci":
-    case "addressing_review":
-    case "ready_to_merge":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function buildTrackedPrClearedStatusComment(args: {
-  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
-  state: RunState;
-}): string {
-  return [
-    `Tracked PR head \`${args.pr.headRefOid}\` blocker cleared; progress has resumed.`,
-    "",
-    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED}\``,
-    `- current supervisor state: \`${args.state}\``,
-    "- automatic retry: yes",
-    `- next action: continue the tracked PR workflow for PR #${args.pr.number} from the current active state.`,
-  ].join("\n");
-}
-
-function buildRequiredCheckMismatchEvidence(args: {
-  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable">;
-  checks: PullRequestCheck[];
-}): string[] {
-  const sortedChecks = [...args.checks]
-    .map((check) => `check=${check.name}:${check.bucket}:${check.state}`)
-    .sort();
-
-  return [
-    `merge_state=${args.pr.mergeStateStatus}`,
-    `mergeable=${args.pr.mergeable ?? "unknown"}`,
-    ...sortedChecks,
-  ];
-}
-
-function hasPersistentTrackedPrMergeStageSignal(args: {
-  record: Pick<IssueRunRecord, "merge_readiness_last_evaluated_at" | "provider_success_head_sha" | "provider_success_observed_at">;
-  pr: Pick<GitHubPullRequest, "headRefOid">;
-}): boolean {
-  return Boolean(
-    args.record.provider_success_observed_at &&
-      args.record.merge_readiness_last_evaluated_at &&
-      args.record.provider_success_head_sha === args.pr.headRefOid &&
-      args.record.merge_readiness_last_evaluated_at !== args.record.provider_success_observed_at,
-  );
-}
-
-function derivePersistentTrackedPrStatusComment(args: {
-  config: SupervisorConfig;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  failureContext: FailureContext | null;
-  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
-}): { blockerSignature: string; body: string } | null {
-  if (args.pr.isDraft) {
-    return null;
-  }
-
-  const checkSummary = args.summarizeChecks(args.checks);
-  if (checkSummary.hasPending || checkSummary.hasFailing) {
-    return null;
-  }
-
-  if (args.record.state === "blocked" && args.record.blocked_reason === "manual_review") {
-    const summary =
-      args.failureContext?.summary ?? "Unresolved manual or unconfigured review feedback still requires human attention.";
-    return {
-      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
-      body: buildTrackedPrPersistentStatusComment({
-        pr: args.pr,
-        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
-        summary,
-        evidence: compactEvidenceLines(args.failureContext?.details),
-        nextAction:
-          "Resolve the remaining manual review blocker or complete the required manual verification, then rerun the supervisor.",
-        automaticRetry: "no",
-      }),
-    };
-  }
-
-  if (args.record.state === "blocked" && args.record.blocked_reason === "stale_review_bot") {
-    const summary =
-      args.failureContext?.summary
-      ?? "Configured bot review state is stale on the current head and now requires manual attention.";
-    return {
-      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
-      body: buildTrackedPrPersistentStatusComment({
-        pr: args.pr,
-        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
-        summary,
-        evidence: compactEvidenceLines(args.failureContext?.details),
-        nextAction:
-          "Inspect the stale configured-bot review state on the current head, then rerun the supervisor after the blocker is cleared or explicitly resolved.",
-        automaticRetry: "no",
-      }),
-    };
-  }
-
-  if (!hasPersistentTrackedPrMergeStageSignal({ record: args.record, pr: args.pr })) {
-    return null;
-  }
-
-  const mismatch = buildTrackedPrMismatch(
-    args.config,
-    args.record,
-    args.pr,
-    args.checks,
-    args.reviewThreads,
-  );
-  if (mismatch) {
-    return {
-      blockerSignature: mismatch.summaryLine,
-      body: buildTrackedPrPersistentStatusComment({
-        pr: args.pr,
-        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH,
-        summary: mismatch.summaryLine,
-        evidence: mismatch.detailLines,
-        nextAction: mismatch.guidanceLine.replace(/^recovery_guidance=/, ""),
-        automaticRetry: "no",
-      }),
-    };
-  }
-
-  if (args.pr.mergeStateStatus === "BLOCKED") {
-    const fullEvidence = buildRequiredCheckMismatchEvidence({
-      pr: args.pr,
-      checks: args.checks,
-    });
-    const evidence = fullEvidence.slice(0, 4);
-    return {
-      blockerSignature:
-        `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}:${fullEvidence.join("|")}`,
-      body: buildTrackedPrPersistentStatusComment({
-        pr: args.pr,
-        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH,
-        summary:
-          "GitHub is not merge-ready even though the tracked PR has no failing or pending checks on the current head.",
-        evidence,
-        nextAction:
-          "Inspect required checks and branch protection for this PR, then rerun the supervisor after GitHub reports the PR as merge-ready.",
-        automaticRetry: "no",
-      }),
-    };
-  }
-
-  return null;
-}
-
-function buildTrackedPrStatusCommentMarker(args: {
-  issueNumber: number;
-  prNumber: number;
-  kind: TrackedPrStatusCommentKind;
-}): string {
-  return `<!-- ${TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX} issue=${args.issueNumber} pr=${args.prNumber} kind=${args.kind} -->`;
-}
-
-function findOwnedTrackedPrStatusComment(
-  issueComments: IssueComment[],
-  markers: string[],
-): IssueComment | null {
-  const matchingComments = issueComments.filter(
-    (comment) =>
-      markers.some((marker) => comment.body.includes(marker)) &&
-      comment.viewerDidAuthor === true &&
-      typeof comment.databaseId === "number",
-  );
-  if (matchingComments.length === 0) {
-    return null;
-  }
-
-  matchingComments.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
-  return matchingComments[0] ?? null;
-}
-
-async function publishTrackedPrStatusComment(args: {
-  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
-  issueNumber: number;
-  pr: GitHubPullRequest;
-  kind: TrackedPrStatusCommentKind;
-  body: string;
-}): Promise<void> {
-  if (!args.github.addIssueComment) {
-    return;
-  }
-
-  const marker = buildTrackedPrStatusCommentMarker({
-    issueNumber: args.issueNumber,
-    prNumber: args.pr.number,
-    kind: args.kind,
-  });
-  const bodyWithMarker = `${args.body}\n\n${marker}`;
-  const editableMarkers = [
-    marker,
-    buildTrackedPrStatusCommentMarker({
-      issueNumber: args.issueNumber,
-      prNumber: args.pr.number,
-      kind: args.kind === "status" ? "host-local-blocker" : "status",
-    }),
-  ];
-
-  if (args.github.getExternalReviewSurface && args.github.updateIssueComment) {
-    const surface = await args.github.getExternalReviewSurface(args.pr.number, {
-      purpose: "action",
-      headSha: args.pr.headRefOid,
-      reviewSurfaceVersion: args.pr.updatedAt,
-    });
-    const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, editableMarkers);
-    const existingCommentDatabaseId = existingComment?.databaseId;
-    if (typeof existingCommentDatabaseId === "number") {
-      await args.github.updateIssueComment(existingCommentDatabaseId, bodyWithMarker);
-      return;
-    }
-  }
-
-  await args.github.addIssueComment(args.pr.number, bodyWithMarker);
-}
-
-function buildStaleConfiguredBotReplyBody(args: {
-  pr: GitHubPullRequest;
-  thread: ReviewThread;
-  failureContext: FailureContext | null;
-  resolveAfterReply: boolean;
-}): string {
-  const latestComment = latestReviewComment(args.thread);
-  const location = `${args.thread.path ?? "unknown"}:${args.thread.line ?? "?"}`;
-  const evidenceLine =
-    args.failureContext?.details?.find((detail) => {
-      const fileMatch = detail.match(/\bfile=([^\s]+)/);
-      const lineMatch = detail.match(/\bline=(\d+)/);
-      return fileMatch?.[1] === (args.thread.path ?? "unknown") && lineMatch?.[1] === String(args.thread.line ?? "?");
-    }) ?? `location=${location} processed_on_current_head=yes`;
-  const sourceLink = latestComment?.url ?? args.failureContext?.url;
-  const sourceLine = sourceLink ? ` Source: ${sourceLink}` : "";
-  return [
-    `The supervisor reprocessed this configured-bot finding on the current head \`${args.pr.headRefOid}\` and classified it as stale.`,
-    `Evidence: ${evidenceLine}.${sourceLine}`,
-    args.resolveAfterReply
-      ? "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
-      : "Leaving thread resolution to a human operator.",
-  ].join("\n\n");
-}
-
-function staleConfiguredBotReplyThreadIds(signature: string | null | undefined): string[] {
-  if (!signature) {
-    return [];
-  }
-
-  return signature
-    .split("|")
-    .map((part) => part.trim())
-    .filter((part) => part.startsWith("stalled-bot:"))
-    .map((part) => part.slice("stalled-bot:".length).trim())
-    .filter((threadId) => threadId.length > 0);
-}
-
-function staleConfiguredBotReviewProgressKey(args: {
-  headSha: string;
-  signature: string;
-  threadId: string;
-  phase: "reply" | "resolve";
-}): string {
-  return `${args.phase}:${args.threadId}@${args.headSha}:${args.signature}`;
-}
-
-function appendBoundedUniqueStringEntry(existing: string[] | undefined, value: string): string[] {
-  return Array.from(new Set([...(existing ?? []).filter((entry) => entry !== value), value])).slice(-200);
-}
-
-async function persistStaleConfiguredBotReviewProgress(args: {
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  syncJournal: IssueJournalSync;
-  patch: Pick<IssueRunRecord, "stale_review_bot_reply_progress_keys" | "stale_review_bot_resolve_progress_keys">;
-}): Promise<IssueRunRecord> {
-  const updatedRecord = args.stateStore.touch(args.record, args.patch);
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
-async function maybeHandleTrackedPrStaleConfiguredBotReview(args: {
-  github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  reviewThreads: ReviewThread[];
-  syncJournal: IssueJournalSync;
-  config: SupervisorConfig;
-  failureContext: FailureContext | null;
-  resolveAfterReply: boolean;
-}): Promise<IssueRunRecord> {
-  if (!args.github.replyToReviewThread) {
-    return args.record;
-  }
-  if (args.resolveAfterReply && !args.github.resolveReviewThread) {
-    return args.record;
-  }
-
-  const blockerSignature = args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
-  if (
-    args.record.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
-    args.record.last_stale_review_bot_reply_signature === blockerSignature
-  ) {
-    return args.record;
-  }
-
-  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
-  const replyThreadIds = staleConfiguredBotReplyThreadIds(blockerSignature);
-  if (replyThreadIds.length === 0) {
-    return args.record;
-  }
-
-  const replyThreads = replyThreadIds
-    .map((threadId) => configuredThreads.find((thread) => thread.id === threadId) ?? null)
-    .filter((thread): thread is ReviewThread => thread !== null);
-  if (replyThreads.length !== replyThreadIds.length) {
-    return args.record;
-  }
-
-  let record = args.record;
-  const replyProgressKeys = new Set(record.stale_review_bot_reply_progress_keys ?? []);
-  const resolveProgressKeys = new Set(record.stale_review_bot_resolve_progress_keys ?? []);
-
-  try {
-    for (const replyThread of replyThreads) {
-      const replyKey = staleConfiguredBotReviewProgressKey({
-        headSha: args.pr.headRefOid,
-        signature: blockerSignature,
-        threadId: replyThread.id,
-        phase: "reply",
-      });
-      if (!replyProgressKeys.has(replyKey)) {
-        const replyBody = buildStaleConfiguredBotReplyBody({
-          pr: args.pr,
-          thread: replyThread,
-          failureContext: args.failureContext,
-          resolveAfterReply: args.resolveAfterReply,
-        });
-        await args.github.replyToReviewThread(replyThread.id, replyBody);
-        record = await persistStaleConfiguredBotReviewProgress({
-          stateStore: args.stateStore,
-          state: args.state,
-          record,
-          syncJournal: args.syncJournal,
-          patch: {
-            stale_review_bot_reply_progress_keys: appendBoundedUniqueStringEntry(
-              record.stale_review_bot_reply_progress_keys,
-              replyKey,
-            ),
-            stale_review_bot_resolve_progress_keys: record.stale_review_bot_resolve_progress_keys ?? [],
-          },
-        });
-        replyProgressKeys.add(replyKey);
-      }
-
-      if (args.resolveAfterReply) {
-        const resolveKey = staleConfiguredBotReviewProgressKey({
-          headSha: args.pr.headRefOid,
-          signature: blockerSignature,
-          threadId: replyThread.id,
-          phase: "resolve",
-        });
-        if (!resolveProgressKeys.has(resolveKey)) {
-          await args.github.resolveReviewThread?.(replyThread.id);
-          record = await persistStaleConfiguredBotReviewProgress({
-            stateStore: args.stateStore,
-            state: args.state,
-            record,
-            syncJournal: args.syncJournal,
-            patch: {
-              stale_review_bot_reply_progress_keys: record.stale_review_bot_reply_progress_keys ?? [],
-              stale_review_bot_resolve_progress_keys: appendBoundedUniqueStringEntry(
-                record.stale_review_bot_resolve_progress_keys,
-                resolveKey,
-              ),
-            },
-          });
-          resolveProgressKeys.add(resolveKey);
-        }
-      }
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(
-      `Failed to ${args.resolveAfterReply ? "reply-and-resolve" : "publish"} stale configured-bot reply for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
-    );
-    return record;
-  }
-
-  const updatedRecord = args.stateStore.touch(record, {
-    last_stale_review_bot_reply_head_sha: args.pr.headRefOid,
-    last_stale_review_bot_reply_signature: blockerSignature,
-  });
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
-async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
-  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  syncJournal: IssueJournalSync;
-  gateType: HostLocalTrackedPrBlockerGateType;
-  blockerSignature: string | null;
-  failureClass: string | null;
-  remediationTarget: string | null;
-  summary: string | null;
-  details?: string[] | null;
-}): Promise<IssueRunRecord> {
-  if (!args.github.addIssueComment) {
-    return args.record;
-  }
-
-  if (!args.blockerSignature || !args.failureClass || !args.remediationTarget || !args.summary) {
-    return args.record;
-  }
-
-  if (
-    args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
-    && args.record.last_host_local_pr_blocker_comment_signature === args.blockerSignature
-  ) {
-    return args.record;
-  }
-
-  try {
-    await publishTrackedPrStatusComment({
-      github: args.github,
-      issueNumber: args.record.issue_number,
-      pr: args.pr,
-      kind: "status",
-      body: buildTrackedPrHostLocalBlockerComment({
-        pr: args.pr,
-        gateType: args.gateType,
-        blockerSignature: args.blockerSignature,
-        failureClass: args.failureClass,
-        remediationTarget: args.remediationTarget,
-        summary: args.summary,
-        details: args.details,
-      }),
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(
-      `Failed to publish tracked PR host-local blocker comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
-    );
-    return args.record;
-  }
-
-  const updatedRecord = args.stateStore.touch(args.record, {
-    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
-    last_host_local_pr_blocker_comment_signature: args.blockerSignature,
-  });
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
-async function maybeCommentOnTrackedPrDraftReviewSuppressed(args: {
-  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  syncJournal: IssueJournalSync;
-}): Promise<IssueRunRecord> {
-  if (!args.github.addIssueComment) {
-    return args.record;
-  }
-
-  const blockerSignature = TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED;
-  if (
-    args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
-    && args.record.last_host_local_pr_blocker_comment_signature === blockerSignature
-  ) {
-    return args.record;
-  }
-
-  try {
-    await publishTrackedPrStatusComment({
-      github: args.github,
-      issueNumber: args.record.issue_number,
-      pr: args.pr,
-      kind: "status",
-      body: buildTrackedPrDraftReviewSuppressedComment({
-        pr: args.pr,
-      }),
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(
-      `Failed to publish tracked PR draft suppression status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
-    );
-    return args.record;
-  }
-
-  const updatedRecord = args.stateStore.touch(args.record, {
-    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
-    last_host_local_pr_blocker_comment_signature: blockerSignature,
-  });
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
-async function maybeCommentOnTrackedPrPersistentStatus(args: {
-  github: Partial<
-    Pick<
-      GitHubClient,
-      "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment" | "replyToReviewThread" | "resolveReviewThread"
-    >
-  >;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  manualReviewThreadCount: number;
-  syncJournal: IssueJournalSync;
-  config: SupervisorConfig;
-  failureContext: FailureContext | null;
-  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
-  skipAutoHandleStaleConfiguredBotReview?: boolean;
-}): Promise<IssueRunRecord> {
-  const comment = derivePersistentTrackedPrStatusComment({
-    config: args.config,
-    record: args.record,
-    pr: args.pr,
-    checks: args.checks,
-    reviewThreads: args.reviewThreads,
-    failureContext: args.failureContext,
-    summarizeChecks: args.summarizeChecks,
-  });
-
-  const canAutoHandleStaleConfiguredBotReview =
-    !args.skipAutoHandleStaleConfiguredBotReview &&
-    args.record.state === "blocked" &&
-    args.record.blocked_reason === "stale_review_bot" &&
-    comment &&
-    args.manualReviewThreadCount === 0 &&
-    !args.summarizeChecks(args.checks).hasPending &&
-    !args.summarizeChecks(args.checks).hasFailing &&
-    (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
-      args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve");
-
-  let currentRecord = args.record;
-  if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
-    const repliedRecord = await maybeHandleTrackedPrStaleConfiguredBotReview({
-      github: args.github,
-      stateStore: args.stateStore,
-      state: args.state,
-      record: args.record,
-      pr: args.pr,
-      reviewThreads: args.reviewThreads,
-      syncJournal: args.syncJournal,
-      config: args.config,
-      failureContext: args.failureContext,
-      resolveAfterReply: args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve",
-    });
-    currentRecord = repliedRecord;
-    const replyHandled =
-      repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
-      repliedRecord.last_stale_review_bot_reply_signature ===
-        (args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT);
-    if (replyHandled) {
-      return repliedRecord;
-    }
-  }
-
-  if (!args.github.addIssueComment) {
-    return currentRecord;
-  }
-
-  if (!comment) {
-    const previouslyPublishedCommentOnCurrentHead =
-      currentRecord.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
-      && currentRecord.last_host_local_pr_blocker_comment_signature != null;
-    if (!previouslyPublishedCommentOnCurrentHead || !isTrackedPrActiveStatusState(currentRecord.state)) {
-      return currentRecord;
-    }
-
-    const blockerSignature = `${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED}:${currentRecord.state}`;
-    if (currentRecord.last_host_local_pr_blocker_comment_signature === blockerSignature) {
-      return currentRecord;
-    }
-
-    try {
-      await publishTrackedPrStatusComment({
-        github: args.github,
-        issueNumber: currentRecord.issue_number,
-        pr: args.pr,
-        kind: "status",
-        body: buildTrackedPrClearedStatusComment({
-          pr: args.pr,
-          state: currentRecord.state,
-        }),
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(
-        `Failed to publish cleared tracked PR status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
-      );
-      return currentRecord;
-    }
-
-    const updatedRecord = args.stateStore.touch(currentRecord, {
-      last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
-      last_host_local_pr_blocker_comment_signature: blockerSignature,
-    });
-    args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-    await args.stateStore.save(args.state);
-    await args.syncJournal(updatedRecord);
-    return updatedRecord;
-  }
-
-  if (
-    currentRecord.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
-    && currentRecord.last_host_local_pr_blocker_comment_signature === comment.blockerSignature
-  ) {
-    return currentRecord;
-  }
-
-  try {
-    await publishTrackedPrStatusComment({
-      github: args.github,
-      issueNumber: currentRecord.issue_number,
-      pr: args.pr,
-      kind: "status",
-      body: comment.body,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(
-      `Failed to publish tracked PR merge-stage status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
-    );
-    return currentRecord;
-  }
-
-  const updatedRecord = args.stateStore.touch(currentRecord, {
-    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
-    last_host_local_pr_blocker_comment_signature: comment.blockerSignature,
-  });
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
-export async function syncTrackedPrPersistentStatusComment(args: {
-  github: Partial<
-    Pick<
-      GitHubClient,
-      "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment" | "replyToReviewThread" | "resolveReviewThread"
-    >
-  >;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  syncJournal: IssueJournalSync;
-  config: SupervisorConfig;
-  failureContext: FailureContext | null;
-  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
-  manualReviewThreadCount: number;
-  skipAutoHandleStaleConfiguredBotReview?: boolean;
-}): Promise<IssueRunRecord> {
-  return maybeCommentOnTrackedPrPersistentStatus(args);
-}
 
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -1402,7 +514,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
-        ...observedTrackedPrHostLocalBlockerPatch({
+        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
           pr: refreshed.pr,
           blockerSignature: failureContext?.signature ?? null,
         }),
@@ -1410,7 +522,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
-      record = await maybeCommentOnTrackedPrHostLocalBlocker({
+      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
         github,
         stateStore,
         state,
@@ -1461,7 +573,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           last_failure_context: failureContext,
           ...args.applyFailureSignature(record, failureContext),
           blocked_reason: "verification",
-          ...observedTrackedPrHostLocalBlockerPatch({
+          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
             pr: refreshed.pr,
             blockerSignature: failureContext.signature,
           }),
@@ -1490,7 +602,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           last_failure_context: failureContext,
           ...args.applyFailureSignature(record, failureContext),
           blocked_reason: "verification",
-          ...observedTrackedPrHostLocalBlockerPatch({
+          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
             pr: refreshed.pr,
             blockerSignature: failureContext.signature,
           }),
@@ -1544,7 +656,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
-        ...observedTrackedPrHostLocalBlockerPatch({
+        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
           pr: refreshed.pr,
           blockerSignature: failureContext?.signature ?? null,
         }),
@@ -1552,7 +664,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
-      record = await maybeCommentOnTrackedPrHostLocalBlocker({
+      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
         github,
         stateStore,
         state,
@@ -1561,8 +673,10 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         syncJournal,
         gateType: "workspace_preparation",
         blockerSignature: failureContext?.signature ?? null,
-        failureClass: workspacePreparationFailureClass(failureContext?.signature),
-        remediationTarget: workspacePreparationRemediationTarget(workspacePreparationFailureClass(failureContext?.signature)),
+        failureClass: trackedPrStatusComments.workspacePreparationFailureClass(failureContext?.signature),
+        remediationTarget: trackedPrStatusComments.workspacePreparationRemediationTarget(
+          trackedPrStatusComments.workspacePreparationFailureClass(failureContext?.signature),
+        ),
         summary: failureContext?.summary ?? null,
         details: failureContext?.details,
       });
@@ -1595,7 +709,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
-        ...observedTrackedPrHostLocalBlockerPatch({
+        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
           pr: refreshed.pr,
           blockerSignature: failureContext?.signature ?? null,
         }),
@@ -1603,7 +717,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
-      record = await maybeCommentOnTrackedPrHostLocalBlocker({
+      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
         github,
         stateStore,
         state,
@@ -1652,7 +766,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         last_failure_context: failureContext,
         ...args.applyFailureSignature(record, failureContext),
         blocked_reason: "verification",
-        ...observedTrackedPrHostLocalBlockerPatch({
+        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
           pr: refreshed.pr,
           blockerSignature: failureContext.signature,
         }),
@@ -1660,7 +774,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
-      record = await maybeCommentOnTrackedPrHostLocalBlocker({
+      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
         github,
         stateStore,
         state,
@@ -1726,7 +840,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   });
   record = lifecycleResult.record;
   let effectiveFailureContext = lifecycleResult.effectiveFailureContext;
-  record = await maybeCommentOnTrackedPrPersistentStatus({
+  record = await trackedPrStatusComments.maybeCommentOnTrackedPrPersistentStatus({
     github,
     stateStore,
     state,
@@ -1741,7 +855,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     summarizeChecks: args.summarizeChecks,
   });
   const staleReviewBotReplySignature =
-    effectiveFailureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
+    effectiveFailureContext?.signature ?? trackedPrStatusComments.TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
   const shouldRefreshAfterReplyAndResolve =
     config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
     record.state === "blocked" &&
@@ -1777,9 +891,9 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         record.state !== "blocked"
         || reconciledBlockedReason !== "stale_review_bot"
         || record.last_host_local_pr_blocker_comment_signature
-          !== (effectiveFailureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT)
+          !== (effectiveFailureContext?.signature ?? trackedPrStatusComments.TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT)
       ) {
-        record = await maybeCommentOnTrackedPrPersistentStatus({
+        record = await trackedPrStatusComments.maybeCommentOnTrackedPrPersistentStatus({
           github,
           stateStore,
           state,
@@ -1807,7 +921,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       args.configuredBotReviewThreads,
     ).status === "review_not_expected_while_draft"
   ) {
-    record = await maybeCommentOnTrackedPrDraftReviewSuppressed({
+    record = await trackedPrStatusComments.maybeCommentOnTrackedPrDraftReviewSuppressed({
       github,
       stateStore,
       state,

--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTrackedPrStatusCommentMarker } from "./tracked-pr-status-comment";
+
+test("buildTrackedPrStatusCommentMarker renders the stable sticky tracked PR marker", () => {
+  assert.equal(
+    buildTrackedPrStatusCommentMarker({
+      issueNumber: 102,
+      prNumber: 116,
+      kind: "status",
+    }),
+    "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+  );
+});

--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildTrackedPrStatusCommentMarker } from "./tracked-pr-status-comment";
+import {
+  buildTrackedPrStatusCommentMarker,
+  workspacePreparationRemediationTarget,
+} from "./tracked-pr-status-comment";
 
 test("buildTrackedPrStatusCommentMarker renders the stable sticky tracked PR marker", () => {
   assert.equal(
@@ -11,4 +14,11 @@ test("buildTrackedPrStatusCommentMarker renders the stable sticky tracked PR mar
     }),
     "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
   );
+});
+
+test("workspacePreparationRemediationTarget keeps generic preparation failures on workspace environment", () => {
+  assert.equal(workspacePreparationRemediationTarget("non_zero_exit"), "workspace_environment");
+  assert.equal(workspacePreparationRemediationTarget("workspace_toolchain_missing"), "workspace_environment");
+  assert.equal(workspacePreparationRemediationTarget("missing_command"), "supervisor_config");
+  assert.equal(workspacePreparationRemediationTarget("worktree_helper_missing"), "supervisor_config");
 });

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -12,6 +12,7 @@ import {
   SupervisorConfig,
   SupervisorStateFile,
   LatestLocalCiResult,
+  LocalCiRemediationTarget,
 } from "./core/types";
 import { truncate } from "./core/utils";
 import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
@@ -53,7 +54,8 @@ export function workspacePreparationFailureClass(
 
 export function workspacePreparationRemediationTarget(
   failureClass: Exclude<LatestLocalCiResult["failure_class"], "unset_contract"> | null,
-): string {
+): LocalCiRemediationTarget {
+  // Workspace preparation runs before the repo-owned verifier; generic command failures point at host setup.
   switch (failureClass) {
     case "worktree_helper_missing":
     case "missing_command":

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -1,0 +1,906 @@
+import { GitHubClient } from "./github";
+import { IssueJournalSync } from "./run-once-issue-preparation";
+import { StateStore } from "./core/state-store";
+import {
+  FailureContext,
+  GitHubPullRequest,
+  IssueComment,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  RunState,
+  SupervisorConfig,
+  SupervisorStateFile,
+  LatestLocalCiResult,
+} from "./core/types";
+import { truncate } from "./core/utils";
+import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
+import { configuredBotReviewThreads, latestReviewComment } from "./review-thread-reporting";
+
+export type HostLocalTrackedPrBlockerGateType =
+  | "workspace_preparation"
+  | "local_ci"
+  | "workstation_local_path_hygiene";
+
+const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
+export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT = "stale_review_bot";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
+
+export type TrackedPrStatusCommentKind = "status" | "host-local-blocker";
+
+export function workspacePreparationFailureClass(
+  signature: string | null | undefined,
+): Exclude<LatestLocalCiResult["failure_class"], "unset_contract"> | null {
+  if (!signature?.startsWith("workspace-preparation-gate-")) {
+    return null;
+  }
+
+  const failureClass = signature.slice("workspace-preparation-gate-".length);
+  switch (failureClass) {
+    case "missing_command":
+    case "workspace_toolchain_missing":
+    case "worktree_helper_missing":
+    case "non_zero_exit":
+      return failureClass;
+    default:
+      return null;
+  }
+}
+
+export function workspacePreparationRemediationTarget(
+  failureClass: Exclude<LatestLocalCiResult["failure_class"], "unset_contract"> | null,
+): string {
+  switch (failureClass) {
+    case "worktree_helper_missing":
+    case "missing_command":
+      return "supervisor_config";
+    case "workspace_toolchain_missing":
+    case "non_zero_exit":
+    default:
+      return "workspace_environment";
+  }
+}
+
+function buildTrackedPrHostLocalBlockerComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  gateType: HostLocalTrackedPrBlockerGateType;
+  blockerSignature: string;
+  failureClass: string | null;
+  remediationTarget: string | null;
+  summary: string;
+  details?: string[] | null;
+}): string {
+  if (args.gateType === "workstation_local_path_hygiene") {
+    return buildTrackedPrReadyPromotionPathHygieneComment(args);
+  }
+
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
+    "",
+    `- reason code: \`${trackedPrReadyPromotionBlockedReasonCode(args.gateType)}\``,
+    `- gate type: \`${args.gateType}\``,
+    `- blocker signature: \`${args.blockerSignature}\``,
+    `- failure class: \`${args.failureClass ?? "unknown"}\``,
+    `- remediation target: \`${args.remediationTarget ?? "unknown"}\``,
+    `- summary: ${args.summary}`,
+    "- automatic retry: no",
+    "- next action: fix the tracked workspace blocker, then rerun the supervisor to retry ready-for-review promotion.",
+    "",
+    "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
+  ].join("\n");
+}
+
+export function observedTrackedPrHostLocalBlockerPatch(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  blockerSignature: string | null;
+}): Pick<IssueRunRecord, "last_observed_host_local_pr_blocker_signature" | "last_observed_host_local_pr_blocker_head_sha"> {
+  return {
+    last_observed_host_local_pr_blocker_head_sha: args.pr.headRefOid,
+    last_observed_host_local_pr_blocker_signature: args.blockerSignature,
+  };
+}
+
+function summarizeWorkstationLocalPathFirstFix(details: string[] | null | undefined): string | null {
+  if (!details || details.length === 0) {
+    return null;
+  }
+
+  const countsByFile = new Map<string, number>();
+  for (const detail of details) {
+    const match = detail.match(/^-?\s*([^:\s][^:]*)\:\d+\s+matched\b/);
+    if (!match) {
+      continue;
+    }
+    const filePath = match[1]?.trim();
+    if (!filePath) {
+      continue;
+    }
+    countsByFile.set(filePath, (countsByFile.get(filePath) ?? 0) + 1);
+  }
+
+  if (countsByFile.size === 0) {
+    return null;
+  }
+
+  const sortedFiles = [...countsByFile.entries()].sort((left, right) => {
+    if (right[1] !== left[1]) {
+      return right[1] - left[1];
+    }
+    return left[0].localeCompare(right[0]);
+  });
+  const visibleFiles = sortedFiles
+    .slice(0, 3)
+    .map(([filePath, count]) => `${filePath} (${count} match${count === 1 ? "" : "es"})`);
+  const remainingCount = sortedFiles.length - visibleFiles.length;
+  const tail = remainingCount > 0 ? `; +${remainingCount} more file${remainingCount === 1 ? "" : "s"}` : "";
+  return `First fix: ${visibleFiles.join("; ")}${tail}.`;
+}
+
+function buildTrackedPrReadyPromotionPathHygieneComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  blockerSignature: string;
+  summary: string;
+  details?: string[] | null;
+}): string {
+  const firstFix = summarizeWorkstationLocalPathFirstFix(args.details);
+  const conciseSummary = args.summary.replace(/\s+First fix:.*$/i, "").trim();
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
+    "",
+    `- reason code: \`${trackedPrReadyPromotionBlockedReasonCode("workstation_local_path_hygiene")}\``,
+    `- gate name: \`workstation_local_path_hygiene\``,
+    `- blocker signature: \`${args.blockerSignature}\``,
+    `- what failed: ${conciseSummary}`,
+    ...(firstFix ? [`- ${firstFix}`] : []),
+    "- automatic retry: no",
+    "- rerunning the supervisor alone will not help yet; fix the tracked workspace artifacts first, then rerun promotion.",
+    "",
+    "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
+  ].join("\n");
+}
+
+function trackedPrReadyPromotionBlockedReasonCode(gateType: HostLocalTrackedPrBlockerGateType): string {
+  return `ready_promotion_blocked_${gateType}`;
+}
+
+function buildTrackedPrDraftReviewSuppressedComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` is still draft because provider review is intentionally suppressed.`,
+    "",
+    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED}\``,
+    "- what is happening: configured provider review stays suppressed until this PR is ready for review.",
+    "- automatic retry: yes",
+    `- next action: keep the tracked workspace moving toward ready-for-review promotion for PR #${args.pr.number}; the supervisor will retry automatically on later cycles.`,
+    "",
+    "GitHub checks may still be pending because external review-provider work does not start while the PR remains draft.",
+  ].join("\n");
+}
+
+function compactEvidenceLines(details: string[] | null | undefined, limit = 3): string[] {
+  if (!details || details.length === 0) {
+    return [];
+  }
+
+  return details
+    .map((detail) => detail.replace(/\s+/g, " ").trim())
+    .filter((detail) => detail.length > 0)
+    .slice(0, limit);
+}
+
+function buildTrackedPrPersistentStatusComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
+  reasonCode: string;
+  summary: string;
+  evidence: string[];
+  nextAction: string;
+  automaticRetry: "yes" | "no";
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` remains stopped near merge.`,
+    "",
+    `- reason code: \`${args.reasonCode}\``,
+    `- summary: ${args.summary}`,
+    ...args.evidence.map((detail) => `- evidence: ${detail}`),
+    `- automatic retry: ${args.automaticRetry}`,
+    `- next action: ${args.nextAction}`,
+  ].join("\n");
+}
+
+function isTrackedPrActiveStatusState(state: RunState): boolean {
+  switch (state) {
+    case "local_review":
+    case "local_review_fix":
+    case "stabilizing":
+    case "pr_open":
+    case "repairing_ci":
+    case "resolving_conflict":
+    case "waiting_ci":
+    case "addressing_review":
+    case "ready_to_merge":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function buildTrackedPrClearedStatusComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
+  state: RunState;
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` blocker cleared; progress has resumed.`,
+    "",
+    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED}\``,
+    `- current supervisor state: \`${args.state}\``,
+    "- automatic retry: yes",
+    `- next action: continue the tracked PR workflow for PR #${args.pr.number} from the current active state.`,
+  ].join("\n");
+}
+
+function buildRequiredCheckMismatchEvidence(args: {
+  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable">;
+  checks: PullRequestCheck[];
+}): string[] {
+  const sortedChecks = [...args.checks]
+    .map((check) => `check=${check.name}:${check.bucket}:${check.state}`)
+    .sort();
+
+  return [
+    `merge_state=${args.pr.mergeStateStatus}`,
+    `mergeable=${args.pr.mergeable ?? "unknown"}`,
+    ...sortedChecks,
+  ];
+}
+
+function hasPersistentTrackedPrMergeStageSignal(args: {
+  record: Pick<IssueRunRecord, "merge_readiness_last_evaluated_at" | "provider_success_head_sha" | "provider_success_observed_at">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+}): boolean {
+  return Boolean(
+    args.record.provider_success_observed_at &&
+      args.record.merge_readiness_last_evaluated_at &&
+      args.record.provider_success_head_sha === args.pr.headRefOid &&
+      args.record.merge_readiness_last_evaluated_at !== args.record.provider_success_observed_at,
+  );
+}
+
+function derivePersistentTrackedPrStatusComment(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  failureContext: FailureContext | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+}): { blockerSignature: string; body: string } | null {
+  if (args.pr.isDraft) {
+    return null;
+  }
+
+  const checkSummary = args.summarizeChecks(args.checks);
+  if (checkSummary.hasPending || checkSummary.hasFailing) {
+    return null;
+  }
+
+  if (args.record.state === "blocked" && args.record.blocked_reason === "manual_review") {
+    const summary =
+      args.failureContext?.summary ?? "Unresolved manual or unconfigured review feedback still requires human attention.";
+    return {
+      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
+        summary,
+        evidence: compactEvidenceLines(args.failureContext?.details),
+        nextAction:
+          "Resolve the remaining manual review blocker or complete the required manual verification, then rerun the supervisor.",
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  if (args.record.state === "blocked" && args.record.blocked_reason === "stale_review_bot") {
+    const summary =
+      args.failureContext?.summary
+      ?? "Configured bot review state is stale on the current head and now requires manual attention.";
+    return {
+      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
+        summary,
+        evidence: compactEvidenceLines(args.failureContext?.details),
+        nextAction:
+          "Inspect the stale configured-bot review state on the current head, then rerun the supervisor after the blocker is cleared or explicitly resolved.",
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  if (!hasPersistentTrackedPrMergeStageSignal({ record: args.record, pr: args.pr })) {
+    return null;
+  }
+
+  const mismatch = buildTrackedPrMismatch(
+    args.config,
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+  );
+  if (mismatch) {
+    return {
+      blockerSignature: mismatch.summaryLine,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH,
+        summary: mismatch.summaryLine,
+        evidence: mismatch.detailLines,
+        nextAction: mismatch.guidanceLine.replace(/^recovery_guidance=/, ""),
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  if (args.pr.mergeStateStatus === "BLOCKED") {
+    const fullEvidence = buildRequiredCheckMismatchEvidence({
+      pr: args.pr,
+      checks: args.checks,
+    });
+    const evidence = fullEvidence.slice(0, 4);
+    return {
+      blockerSignature:
+        `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}:${fullEvidence.join("|")}`,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH,
+        summary:
+          "GitHub is not merge-ready even though the tracked PR has no failing or pending checks on the current head.",
+        evidence,
+        nextAction:
+          "Inspect required checks and branch protection for this PR, then rerun the supervisor after GitHub reports the PR as merge-ready.",
+        automaticRetry: "no",
+      }),
+    };
+  }
+
+  return null;
+}
+
+export function buildTrackedPrStatusCommentMarker(args: {
+  issueNumber: number;
+  prNumber: number;
+  kind: TrackedPrStatusCommentKind;
+}): string {
+  return `<!-- ${TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX} issue=${args.issueNumber} pr=${args.prNumber} kind=${args.kind} -->`;
+}
+
+function findOwnedTrackedPrStatusComment(
+  issueComments: IssueComment[],
+  markers: string[],
+): IssueComment | null {
+  const matchingComments = issueComments.filter(
+    (comment) =>
+      markers.some((marker) => comment.body.includes(marker)) &&
+      comment.viewerDidAuthor === true &&
+      typeof comment.databaseId === "number",
+  );
+  if (matchingComments.length === 0) {
+    return null;
+  }
+
+  matchingComments.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  return matchingComments[0] ?? null;
+}
+
+async function publishTrackedPrStatusComment(args: {
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
+  issueNumber: number;
+  pr: GitHubPullRequest;
+  kind: TrackedPrStatusCommentKind;
+  body: string;
+}): Promise<void> {
+  if (!args.github.addIssueComment) {
+    return;
+  }
+
+  const marker = buildTrackedPrStatusCommentMarker({
+    issueNumber: args.issueNumber,
+    prNumber: args.pr.number,
+    kind: args.kind,
+  });
+  const bodyWithMarker = `${args.body}\n\n${marker}`;
+  const editableMarkers = [
+    marker,
+    buildTrackedPrStatusCommentMarker({
+      issueNumber: args.issueNumber,
+      prNumber: args.pr.number,
+      kind: args.kind === "status" ? "host-local-blocker" : "status",
+    }),
+  ];
+
+  if (args.github.getExternalReviewSurface && args.github.updateIssueComment) {
+    const surface = await args.github.getExternalReviewSurface(args.pr.number, {
+      purpose: "action",
+      headSha: args.pr.headRefOid,
+      reviewSurfaceVersion: args.pr.updatedAt,
+    });
+    const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, editableMarkers);
+    const existingCommentDatabaseId = existingComment?.databaseId;
+    if (typeof existingCommentDatabaseId === "number") {
+      await args.github.updateIssueComment(existingCommentDatabaseId, bodyWithMarker);
+      return;
+    }
+  }
+
+  await args.github.addIssueComment(args.pr.number, bodyWithMarker);
+}
+
+function buildStaleConfiguredBotReplyBody(args: {
+  pr: GitHubPullRequest;
+  thread: ReviewThread;
+  failureContext: FailureContext | null;
+  resolveAfterReply: boolean;
+}): string {
+  const latestComment = latestReviewComment(args.thread);
+  const location = `${args.thread.path ?? "unknown"}:${args.thread.line ?? "?"}`;
+  const evidenceLine =
+    args.failureContext?.details?.find((detail) => {
+      const fileMatch = detail.match(/\bfile=([^\s]+)/);
+      const lineMatch = detail.match(/\bline=(\d+)/);
+      return fileMatch?.[1] === (args.thread.path ?? "unknown") && lineMatch?.[1] === String(args.thread.line ?? "?");
+    }) ?? `location=${location} processed_on_current_head=yes`;
+  const sourceLink = latestComment?.url ?? args.failureContext?.url;
+  const sourceLine = sourceLink ? ` Source: ${sourceLink}` : "";
+  return [
+    `The supervisor reprocessed this configured-bot finding on the current head \`${args.pr.headRefOid}\` and classified it as stale.`,
+    `Evidence: ${evidenceLine}.${sourceLine}`,
+    args.resolveAfterReply
+      ? "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
+      : "Leaving thread resolution to a human operator.",
+  ].join("\n\n");
+}
+
+function staleConfiguredBotReplyThreadIds(signature: string | null | undefined): string[] {
+  if (!signature) {
+    return [];
+  }
+
+  return signature
+    .split("|")
+    .map((part) => part.trim())
+    .filter((part) => part.startsWith("stalled-bot:"))
+    .map((part) => part.slice("stalled-bot:".length).trim())
+    .filter((threadId) => threadId.length > 0);
+}
+
+function staleConfiguredBotReviewProgressKey(args: {
+  headSha: string;
+  signature: string;
+  threadId: string;
+  phase: "reply" | "resolve";
+}): string {
+  return `${args.phase}:${args.threadId}@${args.headSha}:${args.signature}`;
+}
+
+function appendBoundedUniqueStringEntry(existing: string[] | undefined, value: string): string[] {
+  return Array.from(new Set([...(existing ?? []).filter((entry) => entry !== value), value])).slice(-200);
+}
+
+async function persistStaleConfiguredBotReviewProgress(args: {
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: IssueJournalSync;
+  patch: Pick<IssueRunRecord, "stale_review_bot_reply_progress_keys" | "stale_review_bot_resolve_progress_keys">;
+}): Promise<IssueRunRecord> {
+  const updatedRecord = args.stateStore.touch(args.record, args.patch);
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+async function maybeHandleTrackedPrStaleConfiguredBotReview(args: {
+  github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+  syncJournal: IssueJournalSync;
+  config: SupervisorConfig;
+  failureContext: FailureContext | null;
+  resolveAfterReply: boolean;
+}): Promise<IssueRunRecord> {
+  if (!args.github.replyToReviewThread) {
+    return args.record;
+  }
+  if (args.resolveAfterReply && !args.github.resolveReviewThread) {
+    return args.record;
+  }
+
+  const blockerSignature = args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
+  if (
+    args.record.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
+    args.record.last_stale_review_bot_reply_signature === blockerSignature
+  ) {
+    return args.record;
+  }
+
+  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
+  const replyThreadIds = staleConfiguredBotReplyThreadIds(blockerSignature);
+  if (replyThreadIds.length === 0) {
+    return args.record;
+  }
+
+  const replyThreads = replyThreadIds
+    .map((threadId) => configuredThreads.find((thread) => thread.id === threadId) ?? null)
+    .filter((thread): thread is ReviewThread => thread !== null);
+  if (replyThreads.length !== replyThreadIds.length) {
+    return args.record;
+  }
+
+  let record = args.record;
+  const replyProgressKeys = new Set(record.stale_review_bot_reply_progress_keys ?? []);
+  const resolveProgressKeys = new Set(record.stale_review_bot_resolve_progress_keys ?? []);
+
+  try {
+    for (const replyThread of replyThreads) {
+      const replyKey = staleConfiguredBotReviewProgressKey({
+        headSha: args.pr.headRefOid,
+        signature: blockerSignature,
+        threadId: replyThread.id,
+        phase: "reply",
+      });
+      if (!replyProgressKeys.has(replyKey)) {
+        const replyBody = buildStaleConfiguredBotReplyBody({
+          pr: args.pr,
+          thread: replyThread,
+          failureContext: args.failureContext,
+          resolveAfterReply: args.resolveAfterReply,
+        });
+        await args.github.replyToReviewThread(replyThread.id, replyBody);
+        record = await persistStaleConfiguredBotReviewProgress({
+          stateStore: args.stateStore,
+          state: args.state,
+          record,
+          syncJournal: args.syncJournal,
+          patch: {
+            stale_review_bot_reply_progress_keys: appendBoundedUniqueStringEntry(
+              record.stale_review_bot_reply_progress_keys,
+              replyKey,
+            ),
+            stale_review_bot_resolve_progress_keys: record.stale_review_bot_resolve_progress_keys ?? [],
+          },
+        });
+        replyProgressKeys.add(replyKey);
+      }
+
+      if (args.resolveAfterReply) {
+        const resolveKey = staleConfiguredBotReviewProgressKey({
+          headSha: args.pr.headRefOid,
+          signature: blockerSignature,
+          threadId: replyThread.id,
+          phase: "resolve",
+        });
+        if (!resolveProgressKeys.has(resolveKey)) {
+          await args.github.resolveReviewThread?.(replyThread.id);
+          record = await persistStaleConfiguredBotReviewProgress({
+            stateStore: args.stateStore,
+            state: args.state,
+            record,
+            syncJournal: args.syncJournal,
+            patch: {
+              stale_review_bot_reply_progress_keys: record.stale_review_bot_reply_progress_keys ?? [],
+              stale_review_bot_resolve_progress_keys: appendBoundedUniqueStringEntry(
+                record.stale_review_bot_resolve_progress_keys,
+                resolveKey,
+              ),
+            },
+          });
+          resolveProgressKeys.add(resolveKey);
+        }
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to ${args.resolveAfterReply ? "reply-and-resolve" : "publish"} stale configured-bot reply for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return record;
+  }
+
+  const updatedRecord = args.stateStore.touch(record, {
+    last_stale_review_bot_reply_head_sha: args.pr.headRefOid,
+    last_stale_review_bot_reply_signature: blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+export async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  syncJournal: IssueJournalSync;
+  gateType: HostLocalTrackedPrBlockerGateType;
+  blockerSignature: string | null;
+  failureClass: string | null;
+  remediationTarget: string | null;
+  summary: string | null;
+  details?: string[] | null;
+}): Promise<IssueRunRecord> {
+  if (!args.github.addIssueComment) {
+    return args.record;
+  }
+
+  if (!args.blockerSignature || !args.failureClass || !args.remediationTarget || !args.summary) {
+    return args.record;
+  }
+
+  if (
+    args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+    && args.record.last_host_local_pr_blocker_comment_signature === args.blockerSignature
+  ) {
+    return args.record;
+  }
+
+  try {
+    await publishTrackedPrStatusComment({
+      github: args.github,
+      issueNumber: args.record.issue_number,
+      pr: args.pr,
+      kind: "status",
+      body: buildTrackedPrHostLocalBlockerComment({
+        pr: args.pr,
+        gateType: args.gateType,
+        blockerSignature: args.blockerSignature,
+        failureClass: args.failureClass,
+        remediationTarget: args.remediationTarget,
+        summary: args.summary,
+        details: args.details,
+      }),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to publish tracked PR host-local blocker comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return args.record;
+  }
+
+  const updatedRecord = args.stateStore.touch(args.record, {
+    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: args.blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+export async function maybeCommentOnTrackedPrDraftReviewSuppressed(args: {
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  syncJournal: IssueJournalSync;
+}): Promise<IssueRunRecord> {
+  if (!args.github.addIssueComment) {
+    return args.record;
+  }
+
+  const blockerSignature = TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED;
+  if (
+    args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+    && args.record.last_host_local_pr_blocker_comment_signature === blockerSignature
+  ) {
+    return args.record;
+  }
+
+  try {
+    await publishTrackedPrStatusComment({
+      github: args.github,
+      issueNumber: args.record.issue_number,
+      pr: args.pr,
+      kind: "status",
+      body: buildTrackedPrDraftReviewSuppressedComment({
+        pr: args.pr,
+      }),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to publish tracked PR draft suppression status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return args.record;
+  }
+
+  const updatedRecord = args.stateStore.touch(args.record, {
+    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+export async function maybeCommentOnTrackedPrPersistentStatus(args: {
+  github: Partial<
+    Pick<
+      GitHubClient,
+      "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment" | "replyToReviewThread" | "resolveReviewThread"
+    >
+  >;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  manualReviewThreadCount: number;
+  syncJournal: IssueJournalSync;
+  config: SupervisorConfig;
+  failureContext: FailureContext | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  skipAutoHandleStaleConfiguredBotReview?: boolean;
+}): Promise<IssueRunRecord> {
+  const comment = derivePersistentTrackedPrStatusComment({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+    failureContext: args.failureContext,
+    summarizeChecks: args.summarizeChecks,
+  });
+
+  const canAutoHandleStaleConfiguredBotReview =
+    !args.skipAutoHandleStaleConfiguredBotReview &&
+    args.record.state === "blocked" &&
+    args.record.blocked_reason === "stale_review_bot" &&
+    comment &&
+    args.manualReviewThreadCount === 0 &&
+    !args.summarizeChecks(args.checks).hasPending &&
+    !args.summarizeChecks(args.checks).hasFailing &&
+    (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
+      args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve");
+
+  let currentRecord = args.record;
+  if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
+    const repliedRecord = await maybeHandleTrackedPrStaleConfiguredBotReview({
+      github: args.github,
+      stateStore: args.stateStore,
+      state: args.state,
+      record: args.record,
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+      syncJournal: args.syncJournal,
+      config: args.config,
+      failureContext: args.failureContext,
+      resolveAfterReply: args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve",
+    });
+    currentRecord = repliedRecord;
+    const replyHandled =
+      repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
+      repliedRecord.last_stale_review_bot_reply_signature ===
+        (args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT);
+    if (replyHandled) {
+      return repliedRecord;
+    }
+  }
+
+  if (!args.github.addIssueComment) {
+    return currentRecord;
+  }
+
+  if (!comment) {
+    const previouslyPublishedCommentOnCurrentHead =
+      currentRecord.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+      && currentRecord.last_host_local_pr_blocker_comment_signature != null;
+    if (!previouslyPublishedCommentOnCurrentHead || !isTrackedPrActiveStatusState(currentRecord.state)) {
+      return currentRecord;
+    }
+
+    const blockerSignature = `${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED}:${currentRecord.state}`;
+    if (currentRecord.last_host_local_pr_blocker_comment_signature === blockerSignature) {
+      return currentRecord;
+    }
+
+    try {
+      await publishTrackedPrStatusComment({
+        github: args.github,
+        issueNumber: currentRecord.issue_number,
+        pr: args.pr,
+        kind: "status",
+        body: buildTrackedPrClearedStatusComment({
+          pr: args.pr,
+          state: currentRecord.state,
+        }),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `Failed to publish cleared tracked PR status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+      );
+      return currentRecord;
+    }
+
+    const updatedRecord = args.stateStore.touch(currentRecord, {
+      last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+      last_host_local_pr_blocker_comment_signature: blockerSignature,
+    });
+    args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(updatedRecord);
+    return updatedRecord;
+  }
+
+  if (
+    currentRecord.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
+    && currentRecord.last_host_local_pr_blocker_comment_signature === comment.blockerSignature
+  ) {
+    return currentRecord;
+  }
+
+  try {
+    await publishTrackedPrStatusComment({
+      github: args.github,
+      issueNumber: currentRecord.issue_number,
+      pr: args.pr,
+      kind: "status",
+      body: comment.body,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to publish tracked PR merge-stage status comment for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return currentRecord;
+  }
+
+  const updatedRecord = args.stateStore.touch(currentRecord, {
+    last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: comment.blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+export async function syncTrackedPrPersistentStatusComment(args: {
+  github: Partial<
+    Pick<
+      GitHubClient,
+      "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment" | "replyToReviewThread" | "resolveReviewThread"
+    >
+  >;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  syncJournal: IssueJournalSync;
+  config: SupervisorConfig;
+  failureContext: FailureContext | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  manualReviewThreadCount: number;
+  skipAutoHandleStaleConfiguredBotReview?: boolean;
+}): Promise<IssueRunRecord> {
+  return maybeCommentOnTrackedPrPersistentStatus(args);
+}


### PR DESCRIPTION
## Summary
- move tracked PR status comment construction, sticky marker handling, publish/update decisions, and dedupe bookkeeping into src/tracked-pr-status-comment.ts
- keep post-turn PR transitions delegating to the extracted boundary
- add focused module coverage for the stable tracked PR status comment marker

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/tracked-pr-status-comment.test.ts
- npm run build

Part of #1681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced automated PR status comments that notify about host-local blockers, draft-review suppression, stale configured-bot reviews, and other persistent blocked states.
  * Comments update intelligently to avoid redundant notifications, can reply to configured review threads and optionally resolve them, and persist progress to reduce noise.

* **Tests**
  * Added unit tests for stable comment marker generation and remediation-target logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->