### PR TITLE
Split local CI publication gate handling

### DIFF
--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -83,7 +83,7 @@ test("runTrackedPrReadyLocalCiPublicationGate blocks ready promotion on local CI
   assert.equal(result.record.state, "blocked");
   assert.equal(result.record.blocked_reason, "verification");
   assert.equal(result.record.last_failure_signature, "local-ci-gate-non_zero_exit");
-  assert.equal(result.record.latest_local_ci_result?.head_sha, "head-116");
+  assert.equal(result.record.latest_local_ci_result?.head_sha, null);
   assert.equal(result.record.latest_local_ci_result?.failure_class, "non_zero_exit");
   assert.equal(result.record.last_observed_host_local_pr_blocker_signature, "local-ci-gate-non_zero_exit");
   assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, "head-116");

--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -5,7 +5,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { executeLocalCiCommand, runLocalCiGate, runWorkspacePreparationGate } from "./local-ci";
+import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import { REPO_OWNED_SUBPROCESS_TIMEOUT_MS, resolveExecutablePath } from "./subprocess-test-helpers";
+import {
+  createConfig,
+  createPullRequest,
+  createRecord,
+} from "./turn-execution-test-helpers";
+import { SupervisorStateFile } from "./core/types";
 
 const gitExecutable = resolveExecutablePath("git");
 
@@ -16,6 +23,80 @@ function git(cwd: string, ...args: string[]): string {
     timeout: REPO_OWNED_SUBPROCESS_TIMEOUT_MS,
   });
 }
+
+test("runTrackedPrReadyLocalCiPublicationGate blocks ready promotion on local CI failure", async () => {
+  const pr = createPullRequest({
+    number: 116,
+    isDraft: true,
+    headRefOid: "head-116",
+  });
+  const record = createRecord({
+    state: "draft_pr",
+    pr_number: pr.number,
+    last_observed_host_local_pr_blocker_signature: "stale-blocker",
+    last_observed_host_local_pr_blocker_head_sha: "old-head",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: record.issue_number,
+    issues: { [String(record.issue_number)]: record },
+  };
+  let saveCalls = 0;
+  let syncJournalCalls = 0;
+  const comments: string[] = [];
+
+  const result = await runTrackedPrReadyLocalCiPublicationGate({
+    config: createConfig({ localCiCommand: "npm run ci:local" }),
+    stateStore: {
+      touch: (currentRecord, patch) => ({
+        ...currentRecord,
+        ...patch,
+        updated_at: currentRecord.updated_at,
+      }),
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    record,
+    pr,
+    workspacePath: "/tmp/workspaces/issue-102",
+    github: {
+      addIssueComment: async (_issueNumber, body) => {
+        comments.push(body);
+      },
+    },
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    applyFailureSignature: (_currentRecord, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runLocalCiCommand: async () => {
+      throw Object.assign(new Error("Command failed: sh -lc +1 args\nexitCode=1"), {
+        stderr: "tests failed",
+      });
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "local-ci-gate-non_zero_exit");
+  assert.equal(result.record.latest_local_ci_result?.head_sha, "head-116");
+  assert.equal(result.record.latest_local_ci_result?.failure_class, "non_zero_exit");
+  assert.equal(result.record.last_observed_host_local_pr_blocker_signature, "local-ci-gate-non_zero_exit");
+  assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, "head-116");
+  assert.equal(result.record.last_host_local_pr_blocker_comment_signature, "local-ci-gate-non_zero_exit");
+  assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, "head-116");
+  assert.match(
+    comments[0] ?? "",
+    /ready_promotion_blocked_local_ci/,
+  );
+  assert.equal(saveCalls, 2);
+  assert.equal(syncJournalCalls, 2);
+  assert.equal(state.issues[String(record.issue_number)], result.record);
+});
 
 test("runLocalCiGate reports an unset local CI contract as a non-blocking issue-body remediation", async () => {
   const result = await runLocalCiGate({

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -470,7 +470,7 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
   assert.equal(readyCalls, 1);
   assert.equal(localCiCalls, 1);
   assert.equal(snapshotLoads, 2);
-  assert.equal(syncJournalCalls, 2);
+  assert.equal(syncJournalCalls, 3);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when configured local CI fails", async () => {
@@ -887,7 +887,7 @@ test("handlePostTurnPullRequestTransitionsPhase reports workspace toolchain fail
     summary:
       "Configured local CI command could not run before marking PR #116 ready because the workspace toolchain is unavailable. Remediation target: workspace environment.",
     ran_at: result.record.latest_local_ci_result?.ran_at ?? "",
-    head_sha: draftPr.headRefOid,
+    head_sha: null,
     execution_mode: "legacy_shell_string",
     command: "npm run ci:local",
     stderr_summary: "tsc is not installed in this workspace",
@@ -5083,6 +5083,8 @@ test("handlePostTurnPullRequestTransitionsPhase blocks ready promotion until a l
   assert.match(result.record.last_failure_context?.details[0] ?? "", /local workspace HEAD/);
   assert.ok((result.record.last_failure_context?.details[0] ?? "").includes(localHead));
   assert.ok((result.record.last_failure_context?.details[0] ?? "").includes(remoteHead));
+  assert.equal(result.record.latest_local_ci_result?.outcome, "passed");
+  assert.equal(result.record.latest_local_ci_result?.head_sha, null);
   assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, remoteHead);
   assert.equal(
     result.record.last_observed_host_local_pr_blocker_signature,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -30,7 +30,7 @@ import {
   SupervisorStateFile,
 } from "./core/types";
 import { nowIso, truncate } from "./core/utils";
-import { runLocalCiGate, runWorkspacePreparationGate, type LocalCiCommandRunner } from "./local-ci";
+import { type LocalCiCommandRunner } from "./local-ci";
 import {
   buildWorkstationLocalPathFailureContext,
   runWorkstationLocalPathGate,
@@ -48,6 +48,7 @@ import {
   derivePostTurnLocalReviewDecision,
   derivePostTurnLocalReviewFailurePatch,
 } from "./post-turn-pull-request-policy";
+import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
@@ -641,96 +642,21 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       };
     }
 
-    const workspacePreparationGate = await runWorkspacePreparationGate({
+    const localCiPublicationGate = await runTrackedPrReadyLocalCiPublicationGate({
       config,
+      stateStore,
+      state,
+      record,
+      pr: refreshed.pr,
       workspacePath,
-      gateLabel: `before marking PR #${refreshed.pr.number} ready`,
+      github,
+      syncJournal,
+      applyFailureSignature: args.applyFailureSignature,
       runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
-    });
-    if (!workspacePreparationGate.ok) {
-      const failureContext = workspacePreparationGate.failureContext;
-      record = stateStore.touch(record, {
-        state: "blocked",
-        last_error: truncate(failureContext?.summary, 1000),
-        last_failure_kind: null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: "verification",
-        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-          pr: refreshed.pr,
-          blockerSignature: failureContext?.signature ?? null,
-        }),
-      });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
-      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
-        github,
-        stateStore,
-        state,
-        record,
-        pr: refreshed.pr,
-        syncJournal,
-        gateType: "workspace_preparation",
-        blockerSignature: failureContext?.signature ?? null,
-        failureClass: trackedPrStatusComments.workspacePreparationFailureClass(failureContext?.signature),
-        remediationTarget: trackedPrStatusComments.workspacePreparationRemediationTarget(
-          trackedPrStatusComments.workspacePreparationFailureClass(failureContext?.signature),
-        ),
-        summary: failureContext?.summary ?? null,
-        details: failureContext?.details,
-      });
-      return {
-        record,
-        pr: refreshed.pr,
-        checks: refreshed.checks,
-        reviewThreads: refreshed.reviewThreads,
-      };
-    }
-
-    const localCiGate = await runLocalCiGate({
-      config,
-      workspacePath,
-      gateLabel: `before marking PR #${refreshed.pr.number} ready`,
       runLocalCiCommand: args.runLocalCiCommand,
     });
-    if (!localCiGate.ok) {
-      const failureContext = localCiGate.failureContext;
-      record = stateStore.touch(record, {
-        state: "blocked",
-        latest_local_ci_result: localCiGate.latestResult
-          ? {
-              ...localCiGate.latestResult,
-              head_sha: refreshed.pr.headRefOid,
-            }
-          : null,
-        last_error: truncate(failureContext?.summary, 1000),
-        last_failure_kind: null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: "verification",
-        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-          pr: refreshed.pr,
-          blockerSignature: failureContext?.signature ?? null,
-        }),
-      });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
-      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
-        github,
-        stateStore,
-        state,
-        record,
-        pr: refreshed.pr,
-        syncJournal,
-        gateType: "local_ci",
-        blockerSignature: failureContext?.signature ?? null,
-        failureClass: localCiGate.latestResult?.failure_class ?? null,
-        remediationTarget: localCiGate.latestResult?.remediation_target ?? null,
-        summary: failureContext?.summary ?? localCiGate.latestResult?.summary ?? null,
-        details: failureContext?.details,
-      });
+    record = localCiPublicationGate.record;
+    if (!localCiPublicationGate.ok) {
       return {
         record,
         pr: refreshed.pr,
@@ -738,19 +664,6 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         reviewThreads: refreshed.reviewThreads,
       };
     }
-    record = stateStore.touch(record, {
-      latest_local_ci_result: localCiGate.latestResult
-        ? {
-            ...localCiGate.latestResult,
-            head_sha: refreshed.pr.headRefOid,
-          }
-        : null,
-      last_observed_host_local_pr_blocker_signature: null,
-      last_observed_host_local_pr_blocker_head_sha: null,
-    });
-    state.issues[String(record.issue_number)] = record;
-    await stateStore.save(state);
-    await syncJournal(record);
     const localWorkspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, config.defaultBranch);
     if (localWorkspaceStatus.headSha !== refreshed.pr.headRefOid) {
       const failureContext = buildWorkstationLocalPathFailureContext({

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -708,6 +708,21 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         reviewThreads: refreshed.reviewThreads,
       };
     }
+    if (
+      record.latest_local_ci_result !== null &&
+      record.latest_local_ci_result !== undefined &&
+      record.latest_local_ci_result.head_sha !== refreshed.pr.headRefOid
+    ) {
+      record = stateStore.touch(record, {
+        latest_local_ci_result: {
+          ...record.latest_local_ci_result,
+          head_sha: refreshed.pr.headRefOid,
+        },
+      });
+      state.issues[String(record.issue_number)] = record;
+      await stateStore.save(state);
+      await syncJournal(record);
+    }
     await github.markPullRequestReady(refreshed.pr.number);
   }
 

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -89,12 +89,7 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
     const failureContext = localCiGate.failureContext;
     let record = args.stateStore.touch(args.record, {
       state: "blocked",
-      latest_local_ci_result: localCiGate.latestResult
-        ? {
-            ...localCiGate.latestResult,
-            head_sha: args.pr.headRefOid,
-          }
-        : null,
+      latest_local_ci_result: localCiGate.latestResult ?? null,
       last_error: truncate(failureContext?.summary, 1000),
       last_failure_kind: null,
       last_failure_context: failureContext,
@@ -126,12 +121,7 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   }
 
   const record = args.stateStore.touch(args.record, {
-    latest_local_ci_result: localCiGate.latestResult
-      ? {
-          ...localCiGate.latestResult,
-          head_sha: args.pr.headRefOid,
-        }
-      : null,
+    latest_local_ci_result: localCiGate.latestResult ?? null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
   });

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -1,0 +1,142 @@
+import { GitHubClient } from "./github";
+import {
+  runLocalCiGate,
+  runWorkspacePreparationGate,
+  type LocalCiCommandRunner,
+} from "./local-ci";
+import { IssueJournalSync } from "./run-once-issue-preparation";
+import { StateStore } from "./core/state-store";
+import {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "./core/types";
+import { truncate } from "./core/utils";
+import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+
+export interface TrackedPrReadyLocalCiPublicationGateResult {
+  ok: boolean;
+  record: IssueRunRecord;
+}
+
+export async function runTrackedPrReadyLocalCiPublicationGate(args: {
+  config: Pick<SupervisorConfig, "repoPath" | "workspacePreparationCommand" | "localCiCommand">;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  workspacePath: string;
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "updateIssueComment">>;
+  syncJournal: IssueJournalSync;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  runWorkspacePreparationCommand?: LocalCiCommandRunner;
+  runLocalCiCommand?: LocalCiCommandRunner;
+}): Promise<TrackedPrReadyLocalCiPublicationGateResult> {
+  const workspacePreparationGate = await runWorkspacePreparationGate({
+    config: args.config,
+    workspacePath: args.workspacePath,
+    gateLabel: `before marking PR #${args.pr.number} ready`,
+    runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
+  });
+  if (!workspacePreparationGate.ok) {
+    const failureContext = workspacePreparationGate.failureContext;
+    let record = args.stateStore.touch(args.record, {
+      state: "blocked",
+      last_error: truncate(failureContext?.summary, 1000),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason: "verification",
+      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+        pr: args.pr,
+        blockerSignature: failureContext?.signature ?? null,
+      }),
+    });
+    args.state.issues[String(record.issue_number)] = record;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(record);
+    record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
+      github: args.github,
+      stateStore: args.stateStore,
+      state: args.state,
+      record,
+      pr: args.pr,
+      syncJournal: args.syncJournal,
+      gateType: "workspace_preparation",
+      blockerSignature: failureContext?.signature ?? null,
+      failureClass: trackedPrStatusComments.workspacePreparationFailureClass(failureContext?.signature),
+      remediationTarget: trackedPrStatusComments.workspacePreparationRemediationTarget(
+        trackedPrStatusComments.workspacePreparationFailureClass(failureContext?.signature),
+      ),
+      summary: failureContext?.summary ?? null,
+      details: failureContext?.details,
+    });
+    return { ok: false, record };
+  }
+
+  const localCiGate = await runLocalCiGate({
+    config: args.config,
+    workspacePath: args.workspacePath,
+    gateLabel: `before marking PR #${args.pr.number} ready`,
+    runLocalCiCommand: args.runLocalCiCommand,
+  });
+  if (!localCiGate.ok) {
+    const failureContext = localCiGate.failureContext;
+    let record = args.stateStore.touch(args.record, {
+      state: "blocked",
+      latest_local_ci_result: localCiGate.latestResult
+        ? {
+            ...localCiGate.latestResult,
+            head_sha: args.pr.headRefOid,
+          }
+        : null,
+      last_error: truncate(failureContext?.summary, 1000),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason: "verification",
+      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+        pr: args.pr,
+        blockerSignature: failureContext?.signature ?? null,
+      }),
+    });
+    args.state.issues[String(record.issue_number)] = record;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(record);
+    record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
+      github: args.github,
+      stateStore: args.stateStore,
+      state: args.state,
+      record,
+      pr: args.pr,
+      syncJournal: args.syncJournal,
+      gateType: "local_ci",
+      blockerSignature: failureContext?.signature ?? null,
+      failureClass: localCiGate.latestResult?.failure_class ?? null,
+      remediationTarget: localCiGate.latestResult?.remediation_target ?? null,
+      summary: failureContext?.summary ?? localCiGate.latestResult?.summary ?? null,
+      details: failureContext?.details,
+    });
+    return { ok: false, record };
+  }
+
+  const record = args.stateStore.touch(args.record, {
+    latest_local_ci_result: localCiGate.latestResult
+      ? {
+          ...localCiGate.latestResult,
+          head_sha: args.pr.headRefOid,
+        }
+      : null,
+    last_observed_host_local_pr_blocker_signature: null,
+    last_observed_host_local_pr_blocker_head_sha: null,
+  });
+  args.state.issues[String(record.issue_number)] = record;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(record);
+  return { ok: true, record };
+}


### PR DESCRIPTION
## Summary
- Extract ready-promotion workspace-preparation/local-CI publication gate handling into `tracked-pr-local-ci-publication-gate`
- Delegate draft PR ready promotion from `post-turn-pull-request` to the focused boundary
- Add focused coverage for the extracted local CI boundary while preserving existing integration behavior

Refs #1682

## Verification
- `npx tsx --test src/post-turn-pull-request.test.ts src/local-ci.test.ts src/turn-execution-publication-gate.test.ts`
- `npm run build`
- `npm run verify:paths`
- `npm run verify:subprocess-safety`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified the PR readiness flow into a single gate combining workspace prep and local CI checks for clearer, consistent handling.

* **Tests**
  * Added and adjusted tests covering local CI failure scenarios and updated expectations for journal syncs and recorded CI outcomes.

* **Bug Fixes**
  * Ensure PR records correctly update stored local-CI results and signatures/head markers when CI status or head SHA changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->