### PR TITLE
Split doctor raw diagnostics boundary

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -8,7 +8,15 @@ import test from "node:test";
 import { StateStore } from "./core/state-store";
 import { MISSING_WORKSPACE_PREPARATION_CONTRACT_WARNING } from "./core/config";
 import { createConfig, createPullRequest, createRecord } from "./turn-execution-test-helpers";
-import { diagnoseBootstrapReadiness, diagnoseSupervisorHost, loadStateReadonlyForDoctor, renderDoctorReport } from "./doctor";
+import {
+  buildDoctorOperatorDecisionSurface,
+  collectDoctorRawHostDiagnostics,
+  collectDoctorRawDiagnostics,
+  diagnoseBootstrapReadiness,
+  diagnoseSupervisorHost,
+  loadStateReadonlyForDoctor,
+  renderDoctorReport,
+} from "./doctor";
 import { type SupervisorStateFile } from "./core/types";
 import { diagnoseSetupReadiness } from "./setup-readiness";
 
@@ -1451,6 +1459,89 @@ test("renderDoctorReport starts with decision summary and tiers active risks, ma
   assert.match(report, /^doctor_tier_item tier=informational source=worktrees detail=issue_host_paths issue=#177 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m);
   assert.match(report, /^doctor_check name=github_auth status=fail summary=GitHub CLI authentication is unavailable\.$/m);
   assert.match(report, /^doctor_detail name=worktrees detail=orphan_prune_candidate issue_number=201 eligibility=eligible /m);
+});
+
+test("doctor raw diagnostics stay separate from operator decision summary rendering", () => {
+  const rawDiagnostics = collectDoctorRawDiagnostics([
+    {
+      name: "github_auth",
+      status: "fail",
+      summary: "GitHub CLI authentication is unavailable.",
+      details: ["Run `gh auth status --hostname github.com` to inspect the current login state."],
+    },
+    {
+      name: "worktrees",
+      status: "warn",
+      summary: "orphaned prune candidates=1 eligible=1 locked=0 recent=0 unsafe_target=0",
+      details: [
+        "issue_host_paths issue=#177 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required",
+        "orphan_prune_candidate issue_number=201 eligibility=eligible workspace=<workspace-root>/issue-201 branch=codex/issue-201 modified_at=2026-03-01T00:00:00.000Z reason=done_state_missing_from_supervisor_state",
+      ],
+    },
+  ]);
+
+  assert.equal(rawDiagnostics.overallStatus, "fail");
+  assert.deepEqual(
+    rawDiagnostics.checks.map((check) => ({ name: check.name, status: check.status })),
+    [
+      { name: "github_auth", status: "fail" },
+      { name: "worktrees", status: "warn" },
+    ],
+  );
+  assert.equal("decisionSummary" in rawDiagnostics, false);
+  assert.equal("diagnosticTiers" in rawDiagnostics, false);
+
+  const decisionSurface = buildDoctorOperatorDecisionSurface(rawDiagnostics);
+  assert.deepEqual(decisionSurface.decisionSummary, {
+    action: "stop",
+    summary: "2 active risk(s) require operator attention before continuing.",
+  });
+  assert.equal(decisionSurface.diagnosticTiers.active_risk.length, 2);
+  assert.equal(decisionSurface.diagnosticTiers.maintenance.length, 2);
+  assert.equal(decisionSurface.diagnosticTiers.informational.length, 1);
+});
+
+test("doctor raw host diagnostics collector returns checks without operator decision fields", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-raw-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+
+  const rawDiagnostics = await collectDoctorRawHostDiagnostics({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary: process.execPath,
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({
+      activeIssueNumber: null,
+      issues: {},
+    }),
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 100,
+        observedMatchingOpenIssues: 0,
+        truncated: false,
+      }),
+    },
+  });
+
+  assert.equal(rawDiagnostics.overallStatus, "pass");
+  assert.deepEqual(
+    rawDiagnostics.checks.map((check) => check.name),
+    ["github_auth", "codex_cli", "state_file", "worktrees"],
+  );
+  assert.equal("decisionSummary" in rawDiagnostics, false);
+  assert.equal("diagnosticTiers" in rawDiagnostics, false);
 });
 
 test("renderDoctorReport surfaces absent workspace preparation posture when no repo-owned contract exists", () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -65,6 +65,16 @@ export interface DoctorTierItem {
 
 export type DoctorTieredDiagnostics = Record<DoctorDiagnosticTier, DoctorTierItem[]>;
 
+export interface DoctorRawDiagnostics {
+  overallStatus: DoctorCheckStatus;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorOperatorDecisionSurface {
+  decisionSummary: DoctorDecisionSummary;
+  diagnosticTiers: DoctorTieredDiagnostics;
+}
+
 export interface DoctorDiagnostics {
   overallStatus: DoctorCheckStatus;
   checks: DoctorCheck[];
@@ -101,7 +111,7 @@ export interface BootstrapReadinessSummary {
   };
 }
 
-interface DiagnoseSupervisorHostArgs {
+export interface DiagnoseSupervisorHostArgs {
   config: SupervisorConfig;
   configPath?: string;
   authStatus?: () => Promise<{ ok: boolean; message: string | null }>;
@@ -192,6 +202,16 @@ function overallStatusForChecks(checks: DoctorCheck[]): DoctorCheckStatus {
   return "pass";
 }
 
+export function collectDoctorRawDiagnostics(checks: DoctorCheck[]): DoctorRawDiagnostics {
+  return {
+    overallStatus: overallStatusForChecks(checks),
+    checks: checks.map((check) => ({
+      ...check,
+      details: [...check.details],
+    })),
+  };
+}
+
 function emptyDoctorDiagnosticTiers(): DoctorTieredDiagnostics {
   return {
     active_risk: [],
@@ -262,9 +282,9 @@ function buildDoctorDecisionSummary(
   };
 }
 
-function buildDoctorDecisionSurface(
-  diagnostics: Pick<DoctorDiagnostics, "overallStatus" | "checks" | "decisionSummary" | "diagnosticTiers">,
-): { decisionSummary: DoctorDecisionSummary; diagnosticTiers: DoctorTieredDiagnostics } {
+export function buildDoctorOperatorDecisionSurface(
+  diagnostics: DoctorRawDiagnostics & Partial<Pick<DoctorDiagnostics, "decisionSummary" | "diagnosticTiers">>,
+): DoctorOperatorDecisionSurface {
   const diagnosticTiers = diagnostics.diagnosticTiers ?? buildDoctorDiagnosticTiers(diagnostics.checks);
   const decisionSummary = diagnostics.decisionSummary ??
     buildDoctorDecisionSummary(diagnostics.overallStatus, diagnosticTiers);
@@ -803,7 +823,7 @@ async function diagnoseWorktrees(
   }
 }
 
-export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): Promise<DoctorDiagnostics> {
+export async function collectDoctorRawHostDiagnostics(args: DiagnoseSupervisorHostArgs): Promise<DoctorRawDiagnostics> {
   const authStatus =
     args.authStatus ??
     (() => new GitHubClient(args.config).authStatus());
@@ -814,12 +834,23 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     args.github ??
     new GitHubClient(args.config);
 
-  const checks: DoctorCheck[] = await Promise.all([
+  return collectDoctorRawDiagnostics(await Promise.all([
     diagnoseGitHubAuth(authStatus),
     diagnoseCodexCli(args.config),
     diagnoseStateFile(args.config),
     diagnoseWorktrees(args.config, loadState, github),
-  ]);
+  ]));
+}
+
+export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): Promise<DoctorDiagnostics> {
+  const loadState =
+    args.loadState ??
+    (() => loadStateReadonlyForDoctor(args.config));
+  const github =
+    args.github ??
+    new GitHubClient(args.config);
+
+  const rawDiagnostics = await collectDoctorRawHostDiagnostics({ ...args, loadState, github });
   const loopRuntime = await readSupervisorLoopRuntime(args.config.stateFile, { configPath: args.configPath });
   const candidateDiscoveryWarning = formatCandidateDiscoveryWarningDetail(
     await github.getCandidateDiscoveryDiagnostics().catch(() => null),
@@ -832,21 +863,20 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
     }),
   );
   let state: SupervisorStateFile | null = null;
-  let finalChecks = checks;
+  let finalRawDiagnostics = rawDiagnostics;
   try {
     state = await loadState();
   } catch (error) {
-    finalChecks = withReconciliationBacklogStateReadFailure(checks, args.config, error);
+    finalRawDiagnostics = collectDoctorRawDiagnostics(
+      withReconciliationBacklogStateReadFailure(rawDiagnostics.checks, args.config, error),
+    );
   }
 
-  const overallStatus = overallStatusForChecks(finalChecks);
-  const diagnosticTiers = buildDoctorDiagnosticTiers(finalChecks);
+  const decisionSurface = buildDoctorOperatorDecisionSurface(finalRawDiagnostics);
 
   return {
-    overallStatus,
-    checks: finalChecks,
-    decisionSummary: buildDoctorDecisionSummary(overallStatus, diagnosticTiers),
-    diagnosticTiers,
+    ...finalRawDiagnostics,
+    ...decisionSurface,
     codexModelPolicyLines,
     reconciliationBacklogLine: state === null
       ? null
@@ -920,7 +950,7 @@ export async function diagnoseBootstrapReadiness(
 }
 
 export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
-  const decisionSurface = buildDoctorDecisionSurface(diagnostics);
+  const decisionSurface = buildDoctorOperatorDecisionSurface(diagnostics);
   const workspacePreparationContract =
     diagnostics.workspacePreparationContract
     ?? summarizeWorkspacePreparationContract({ workspacePreparationCommand: undefined, localCiCommand: undefined });


### PR DESCRIPTION
## Summary
- split doctor raw diagnostics collection from operator decision summary/tier rendering
- add typed raw and operator decision boundary helpers
- cover raw check and raw host collector boundaries with focused doctor tests

## Verification
- npx tsx --test src/doctor.test.ts src/setup-readiness.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Part of #1684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal diagnostics architecture by separating raw diagnostic data from decision analysis, enhancing reporting clarity and system maintainability.

* **Tests**
  * Added comprehensive test coverage for diagnostic collectors and decision-surface components, including integration-style verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->