### PR TITLE
Start domain-specific type export extraction

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,19 @@
+import type { GitHubIssue } from "../github/types";
 import type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "../local-review/types";
 
+export type {
+  CopilotReviewState,
+  ExternalReviewActor,
+  GitHubIssue,
+  GitHubLabel,
+  GitHubPullRequest,
+  IssueComment,
+  PullRequestCheck,
+  PullRequestHydrationProvenance,
+  PullRequestReview,
+  ReviewThread,
+  ReviewThreadComment,
+} from "../github/types";
 export type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "../local-review/types";
 
 export type RunState =
@@ -37,8 +51,6 @@ export type LocalReviewPosturePreset =
   | "repair_high_severity"
   | "follow_up_issue_creation";
 export type StaleConfiguredBotReviewPolicy = "diagnose_only" | "reply_only" | "reply_and_resolve";
-export type CopilotReviewState = "not_requested" | "requested" | "arrived";
-export type PullRequestHydrationProvenance = "fresh" | "cached";
 export type CopilotReviewTimeoutAction = "continue" | "block";
 export type ConfiguredReviewProviderKind = "copilot" | "codex" | "coderabbit" | "custom";
 export type ConfiguredReviewSignalSource = "copilot_lifecycle" | "review_threads";
@@ -425,102 +437,6 @@ export interface SupervisorStateFile {
   last_successful_inventory_snapshot?: LastSuccessfulInventorySnapshot;
   load_findings?: StateLoadFinding[];
   json_state_quarantine?: JsonStateQuarantine;
-}
-
-export interface GitHubLabel {
-  name: string;
-}
-
-export interface GitHubIssue {
-  number: number;
-  title: string;
-  body: string;
-  createdAt: string;
-  updatedAt: string;
-  url: string;
-  labels?: GitHubLabel[];
-  state?: string;
-}
-
-export interface GitHubPullRequest {
-  number: number;
-  title: string;
-  url: string;
-  state: string;
-  createdAt: string;
-  updatedAt?: string;
-  isDraft: boolean;
-  reviewDecision: string | null;
-  mergeStateStatus: string | null;
-  mergeable?: string | null;
-  headRefName: string;
-  headRefOid: string;
-  copilotReviewState?: CopilotReviewState | null;
-  copilotReviewRequestedAt?: string | null;
-  copilotReviewArrivedAt?: string | null;
-  configuredBotCurrentHeadObservedAt?: string | null;
-  configuredBotCurrentHeadStatusState?: string | null;
-  currentHeadCiGreenAt?: string | null;
-  configuredBotRateLimitedAt?: string | null;
-  configuredBotDraftSkipAt?: string | null;
-  configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
-  configuredBotTopLevelReviewSubmittedAt?: string | null;
-  hydrationProvenance?: PullRequestHydrationProvenance | null;
-  mergedAt?: string | null;
-}
-
-export interface PullRequestCheck {
-  name: string;
-  state: string;
-  bucket: "pass" | "fail" | "pending" | "skipping" | "cancel" | string;
-  workflow?: string;
-  link?: string;
-}
-
-export interface ReviewThreadComment {
-  id: string;
-  body: string;
-  createdAt: string;
-  url: string;
-  author: {
-    login: string | null;
-    typeName: string | null;
-  } | null;
-}
-
-export interface ExternalReviewActor {
-  login: string | null;
-  typeName: string | null;
-}
-
-export interface ReviewThread {
-  id: string;
-  isResolved: boolean;
-  isOutdated: boolean;
-  path: string | null;
-  line: number | null;
-  comments: {
-    nodes: ReviewThreadComment[];
-  };
-}
-
-export interface PullRequestReview {
-  id: string;
-  body: string | null;
-  submittedAt: string | null;
-  url: string | null;
-  state: string | null;
-  author: ExternalReviewActor | null;
-}
-
-export interface IssueComment {
-  id: string;
-  databaseId?: number | null;
-  body: string;
-  createdAt: string;
-  url: string | null;
-  author: ExternalReviewActor | null;
-  viewerDidAuthor?: boolean | null;
 }
 
 export interface WorkspaceStatus {

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -3,7 +3,7 @@ import {
   ConfiguredBotReviewSummary,
   CopilotReviewLifecycleFacts,
 } from "./github-review-signals";
-import { GitHubPullRequest, PullRequestCheck } from "../core/types";
+import type { GitHubPullRequest, PullRequestCheck } from "./types";
 
 export interface PullRequestStatusCheckRollupResponse {
   statusCheckRollup?: Array<{

--- a/src/github/github-inventory.ts
+++ b/src/github/github-inventory.ts
@@ -2,12 +2,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   CandidateDiscoveryDiagnostics,
-  GitHubIssue,
   InventoryRefreshDiagnosticEntry,
   GitHubRateLimitBudget,
   GitHubRateLimitTelemetry,
   SupervisorConfig,
 } from "../core/types";
+import type { GitHubIssue } from "./types";
 import { DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW } from "../core/config";
 import { CommandResult } from "../core/command";
 import { isGitHubRateLimitFailure } from "./github-transport";

--- a/src/github/github-mutations.ts
+++ b/src/github/github-mutations.ts
@@ -1,6 +1,7 @@
-import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../core/types";
+import { IssueRunRecord, SupervisorConfig } from "../core/types";
 import { CommandResult } from "../core/command";
 import { parseJson, truncate } from "../core/utils";
+import type { GitHubIssue, GitHubPullRequest } from "./types";
 
 const POST_CREATE_PR_LOOKUP_RETRY_LIMIT = 2;
 const POST_CREATE_PR_LOOKUP_BASE_DELAY_MS = 200;

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -5,8 +5,9 @@ import {
   PullRequestCopilotReviewLifecycleResponse,
 } from "./github-hydration";
 import { ConfiguredBotReviewSummary } from "./github-review-signals";
-import { CopilotReviewState, GitHubPullRequest, SupervisorConfig } from "../core/types";
+import { SupervisorConfig } from "../core/types";
 import { parseJson, truncate } from "../core/utils";
+import type { CopilotReviewState, GitHubPullRequest } from "./types";
 
 const COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS = 30_000;
 const COPILOT_REVIEW_CACHE_MAX_ENTRIES = 128;

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -6,7 +6,7 @@ import {
   isRateLimitReviewText,
 } from "../external-review/external-review-signal-heuristics";
 import { normalizeReviewBotLogins } from "../core/review-providers";
-import { CopilotReviewState } from "../core/types";
+import type { CopilotReviewState } from "./types";
 
 export interface CopilotReviewLifecycleFacts {
   reviewRequests: string[];

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -1,12 +1,8 @@
 import {
-  GitHubPullRequest,
-  IssueComment,
-  PullRequestCheck,
-  PullRequestReview,
-  ReviewThread,
   SupervisorConfig,
 } from "../core/types";
 import { CommandOptions, CommandResult } from "../core/command";
+import type { GitHubPullRequest, IssueComment, PullRequestCheck, PullRequestReview, ReviewThread } from "./types";
 import {
   normalizeRollupChecks,
   PullRequestStatusCheckRollupResponse,

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -1,13 +1,7 @@
 import {
   CandidateDiscoveryDiagnostics,
-  GitHubIssue,
-  GitHubPullRequest,
   GitHubRateLimitTelemetry,
-  IssueComment,
   IssueRunRecord,
-  PullRequestCheck,
-  PullRequestReview,
-  ReviewThread,
   SupervisorConfig,
 } from "../core/types";
 import { CommandOptions, runCommand } from "../core/command";
@@ -19,12 +13,26 @@ import {
   PullRequestReviewSurfaceOptions,
 } from "./github-review-surface";
 import { GitHubTransport, isGitHubRateLimitFailure } from "./github-transport";
+import type { GitHubIssue, GitHubPullRequest, IssueComment, PullRequestCheck, PullRequestReview, ReviewThread } from "./types";
 
 export { isTransientGitHubCommandFailure } from "./github-transport";
 export { isGitHubRateLimitFailure } from "./github-transport";
 export { inferCopilotReviewLifecycle } from "./github-review-signals";
 export type { GitHubCommandRunner } from "./github-transport";
 export { GitHubInventoryRefreshError } from "./github-inventory";
+export type {
+  CopilotReviewState,
+  ExternalReviewActor,
+  GitHubIssue,
+  GitHubLabel,
+  GitHubPullRequest,
+  IssueComment,
+  PullRequestCheck,
+  PullRequestHydrationProvenance,
+  PullRequestReview,
+  ReviewThread,
+  ReviewThreadComment,
+} from "./types";
 
 export class GitHubClient {
   private readonly inventory: GitHubInventoryClient;

--- a/src/github/types.test.ts
+++ b/src/github/types.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const rootDir = process.cwd();
+
+test("GitHub DTO types are owned by the GitHub domain module and compatibility-reexported from core types", async () => {
+  const [githubTypesSource, coreTypesSource] = await Promise.all([
+    fs.readFile(path.join(rootDir, "src", "github", "types.ts"), "utf8"),
+    fs.readFile(path.join(rootDir, "src", "core", "types.ts"), "utf8"),
+  ]);
+
+  assert.match(githubTypesSource, /export interface GitHubIssue\b/);
+  assert.match(githubTypesSource, /export interface GitHubPullRequest\b/);
+  assert.match(githubTypesSource, /export interface ReviewThread\b/);
+  assert.match(coreTypesSource, /export type \{[\s\S]*GitHubIssue[\s\S]*\} from "\.\.\/github\/types";/);
+  assert.doesNotMatch(coreTypesSource, /export interface GitHubIssue\b/);
+  assert.doesNotMatch(coreTypesSource, /export interface GitHubPullRequest\b/);
+  assert.doesNotMatch(coreTypesSource, /export interface ReviewThread\b/);
+});

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -1,0 +1,98 @@
+export type CopilotReviewState = "not_requested" | "requested" | "arrived";
+export type PullRequestHydrationProvenance = "fresh" | "cached";
+
+export interface GitHubLabel {
+  name: string;
+}
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  labels?: GitHubLabel[];
+  state?: string;
+}
+
+export interface GitHubPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  createdAt: string;
+  updatedAt?: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  mergeStateStatus: string | null;
+  mergeable?: string | null;
+  headRefName: string;
+  headRefOid: string;
+  copilotReviewState?: CopilotReviewState | null;
+  copilotReviewRequestedAt?: string | null;
+  copilotReviewArrivedAt?: string | null;
+  configuredBotCurrentHeadObservedAt?: string | null;
+  configuredBotCurrentHeadStatusState?: string | null;
+  currentHeadCiGreenAt?: string | null;
+  configuredBotRateLimitedAt?: string | null;
+  configuredBotDraftSkipAt?: string | null;
+  configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
+  configuredBotTopLevelReviewSubmittedAt?: string | null;
+  hydrationProvenance?: PullRequestHydrationProvenance | null;
+  mergedAt?: string | null;
+}
+
+export interface PullRequestCheck {
+  name: string;
+  state: string;
+  bucket: "pass" | "fail" | "pending" | "skipping" | "cancel" | string;
+  workflow?: string;
+  link?: string;
+}
+
+export interface ReviewThreadComment {
+  id: string;
+  body: string;
+  createdAt: string;
+  url: string;
+  author: {
+    login: string | null;
+    typeName: string | null;
+  } | null;
+}
+
+export interface ExternalReviewActor {
+  login: string | null;
+  typeName: string | null;
+}
+
+export interface ReviewThread {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string | null;
+  line: number | null;
+  comments: {
+    nodes: ReviewThreadComment[];
+  };
+}
+
+export interface PullRequestReview {
+  id: string;
+  body: string | null;
+  submittedAt: string | null;
+  url: string | null;
+  state: string | null;
+  author: ExternalReviewActor | null;
+}
+
+export interface IssueComment {
+  id: string;
+  databaseId?: number | null;
+  body: string;
+  createdAt: string;
+  url: string | null;
+  author: ExternalReviewActor | null;
+  viewerDidAuthor?: boolean | null;
+}


### PR DESCRIPTION
## Summary
- extract GitHub issue/PR/check/review DTO types from `src/core/types.ts` into `src/github/types.ts`
- keep compatibility re-exports from `src/core/types.ts` so existing public imports continue to work
- update GitHub-owned modules to import the new domain type module directly

## Verification
- `npx tsx --test src/github/types.test.ts`
- `npx tsx --test src/config.test.ts src/doctor.test.ts src/supervisor/supervisor-loop-runtime-state.test.ts src/github/types.test.ts`
- `npm run build`
- `git diff --check`

Closes #1685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized GitHub-related type definitions into a dedicated module for improved code organization and maintainability.
  * Types are re-exported from the core module to maintain backward compatibility.
  
* **Tests**
  * Added validation tests to verify type ownership and compatibility across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->