### PR TITLE
Clean up recovery boundary temp workspace

### DIFF
--- a/src/recovery-family-boundaries.test.ts
+++ b/src/recovery-family-boundaries.test.ts
@@ -43,8 +43,12 @@ function touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRu
   };
 }
 
-test("active recovery boundary clears a stale active reservation without loading aggregate reconciliation", async () => {
+test("active recovery boundary clears a stale active reservation without loading aggregate reconciliation", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-active-boundary-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
   const record = createRecord({
     issue_number: 366,
     state: "implementing",


### PR DESCRIPTION
## Summary
- register Node test cleanup for the active recovery boundary temp workspace
- keep recovery boundary assertions and production code unchanged

## Verification
- npx tsx --test src/recovery-family-boundaries.test.ts
- npm run build

Closes #1691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup procedures to ensure temporary test artifacts are properly removed after test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->