### PR TITLE
Add status and doctor operator action vocabulary

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1814,6 +1814,10 @@ test("renderDoctorReport surfaces absent local CI posture when no repo-owned con
     report,
     /doctor_local_ci configured=false source=config command=none summary=No repo-owned local CI contract is configured\./,
   );
+  assert.match(
+    report,
+    /^doctor_operator_action action=continue source=doctor priority=0 summary=No blocking doctor action was detected; continue normal supervisor operation\.$/m,
+  );
 });
 
 test("renderDoctorReport surfaces the selected local review posture preset", () => {

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -1451,9 +1451,10 @@ test("renderDoctorReport starts with decision summary and tiers active risks, ma
 
   const lines = report.split("\n");
   assert.match(lines[0], /^doctor_decision action=stop summary=/);
-  assert.equal(lines[1], "doctor_tier tier=active_risk count=2");
-  assert.equal(lines[4], "doctor_tier tier=maintenance count=2");
-  assert.equal(lines[7], "doctor_tier tier=informational count=1");
+  assert.match(lines[1], /^doctor_operator_action action=fix_config source=doctor_check priority=80 summary=/);
+  assert.equal(lines[2], "doctor_tier tier=active_risk count=2");
+  assert.equal(lines[5], "doctor_tier tier=maintenance count=2");
+  assert.equal(lines[8], "doctor_tier tier=informational count=1");
   assert.match(report, /^doctor_tier_item tier=active_risk source=github_auth detail=GitHub CLI authentication is unavailable\.$/m);
   assert.match(report, /^doctor_tier_item tier=maintenance source=worktrees detail=orphaned prune candidates=1 eligible=1 locked=0 recent=0 unsafe_target=0$/m);
   assert.match(report, /^doctor_tier_item tier=informational source=worktrees detail=issue_host_paths issue=#177 workspace=auto_repaired journal_path=auto_repaired guidance=no_manual_action_required$/m);
@@ -1617,6 +1618,10 @@ test("renderDoctorReport surfaces advisory local CI posture when a repo-owned ca
     report,
     /doctor_local_ci configured=false source=repo_script_candidate command=none summary=Repo-owned local CI candidate exists but localCiCommand is unset\. Recommended command: npm run verify:supervisor-pre-pr\./,
   );
+  assert.match(
+    report,
+    /^doctor_operator_action action=adopt_local_ci source=doctor_local_ci priority=55 summary=Repo-owned local CI candidate exists; adopt it in config or explicitly dismiss it before relying on local verification posture\.$/m,
+  );
 });
 
 test("renderDoctorReport surfaces explicitly dismissed local CI candidate posture", () => {
@@ -1651,6 +1656,10 @@ test("renderDoctorReport surfaces explicitly dismissed local CI candidate postur
   assert.match(
     report,
     /doctor_local_ci configured=false source=dismissed_repo_script_candidate command=none summary=Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking\. Dismissed candidate: npm run verify:supervisor-pre-pr\./,
+  );
+  assert.match(
+    report,
+    /^doctor_operator_action action=safe_to_ignore source=doctor_local_ci priority=10 summary=Repo-owned local CI candidate was intentionally dismissed; no local CI adoption action is required\.$/m,
   );
 });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -41,6 +41,7 @@ import {
 import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./supervisor/tracked-pr-mismatch";
 import { buildTrustAndConfigWarnings, buildWarning, renderDoctorWarningLine } from "./warning-formatting";
 import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "./reconciliation-backlog-diagnostics";
+import { renderOperatorActionLine, selectDoctorOperatorAction } from "./operator-actions";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
 export type DoctorDecisionAction = "stop" | "maintenance" | "continue";
@@ -997,9 +998,18 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
   const codexModelPolicyLines = (diagnostics.codexModelPolicyLines ?? [])
     .map((line) => sanitizeDoctorValue(line))
     .filter((line) => line.trim().length > 0);
+  const doctorOperatorActionLine = renderOperatorActionLine(
+    "doctor_operator_action",
+    selectDoctorOperatorAction({
+      overallStatus: diagnostics.overallStatus,
+      checks: diagnostics.checks,
+      localCiContract,
+    }),
+  );
 
   return [
     `doctor_decision action=${decisionSurface.decisionSummary.action} summary=${sanitizeDoctorValue(decisionSurface.decisionSummary.summary)}`,
+    doctorOperatorActionLine,
     ...(["active_risk", "maintenance", "informational"] as const).flatMap((tier) => [
       `doctor_tier tier=${tier} count=${decisionSurface.diagnosticTiers[tier].length}`,
       ...decisionSurface.diagnosticTiers[tier].map((item) =>

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -17,14 +17,23 @@ export interface OperatorAction {
   summary: string;
 }
 
-function chooseHighestPriority(actions: OperatorAction[]): OperatorAction {
-  return [...actions].sort((left, right) => right.priority - left.priority)[0] ?? {
-    action: "continue",
-    source: "status",
-    priority: 0,
-    summary: "No blocking operator action was detected; continue normal supervisor operation.",
-  };
+function chooseHighestPriority(actions: OperatorAction[], fallback: OperatorAction): OperatorAction {
+  return [...actions].sort((left, right) => right.priority - left.priority)[0] ?? fallback;
 }
+
+const statusFallbackOperatorAction: OperatorAction = {
+  action: "continue",
+  source: "status",
+  priority: 0,
+  summary: "No blocking operator action was detected; continue normal supervisor operation.",
+};
+
+const doctorFallbackOperatorAction: OperatorAction = {
+  action: "continue",
+  source: "doctor",
+  priority: 0,
+  summary: "No blocking doctor action was detected; continue normal supervisor operation.",
+};
 
 export function selectStatusOperatorAction(args: {
   detailedStatusLines: string[];
@@ -89,7 +98,7 @@ export function selectStatusOperatorAction(args: {
     }
   }
 
-  return chooseHighestPriority(actions);
+  return chooseHighestPriority(actions, statusFallbackOperatorAction);
 }
 
 export function selectDoctorOperatorAction(args: {
@@ -136,7 +145,7 @@ export function selectDoctorOperatorAction(args: {
     });
   }
 
-  return chooseHighestPriority(actions);
+  return chooseHighestPriority(actions, doctorFallbackOperatorAction);
 }
 
 export function renderOperatorActionLine(prefix: "operator_action" | "doctor_operator_action", action: OperatorAction): string {

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -1,0 +1,150 @@
+import type { LocalCiContractSummary } from "./core/types";
+
+export type OperatorActionToken =
+  | "continue"
+  | "restart_loop"
+  | "fix_config"
+  | "adopt_local_ci"
+  | "dismiss_local_ci"
+  | "manual_review"
+  | "provider_outage_suspected"
+  | "safe_to_ignore";
+
+export interface OperatorAction {
+  action: OperatorActionToken;
+  source: string;
+  priority: number;
+  summary: string;
+}
+
+function chooseHighestPriority(actions: OperatorAction[]): OperatorAction {
+  return [...actions].sort((left, right) => right.priority - left.priority)[0] ?? {
+    action: "continue",
+    source: "status",
+    priority: 0,
+    summary: "No blocking operator action was detected; continue normal supervisor operation.",
+  };
+}
+
+export function selectStatusOperatorAction(args: {
+  detailedStatusLines: string[];
+}): OperatorAction {
+  const actions: OperatorAction[] = [];
+
+  for (const line of args.detailedStatusLines) {
+    if (/^loop_runtime_blocker\b/.test(line)) {
+      actions.push({
+        action: "restart_loop",
+        source: "loop_runtime_blocker",
+        priority: 90,
+        summary: "Tracked work is active but the supervisor loop is off; restart the loop to resume background execution.",
+      });
+      continue;
+    }
+
+    if (/^tracked_pr_host_local_ci\b/.test(line) && /\bremediation_target=workspace_environment\b/.test(line)) {
+      actions.push({
+        action: "fix_config",
+        source: "tracked_pr_host_local_ci",
+        priority: 80,
+        summary:
+          "Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+      });
+      continue;
+    }
+
+    if (/^tracked_pr_host_local_ci_gap\b/.test(line)) {
+      actions.push({
+        action: "fix_config",
+        source: "tracked_pr_host_local_ci_gap",
+        priority: 75,
+        summary:
+          "Host-local CI visibility is incomplete; fix workspace preparation configuration before trusting the local CI posture.",
+      });
+      continue;
+    }
+
+    if (/^review_bot_diagnostics\b/.test(line) && /\bstatus=provider_outage_suspected\b/.test(line)) {
+      actions.push({
+        action: "provider_outage_suspected",
+        source: "review_bot_diagnostics",
+        priority: 70,
+        summary:
+          "The configured review provider has not reported on the current head after checks turned green; wait, verify provider delivery, or escalate to manual review.",
+      });
+      continue;
+    }
+
+    if (
+      /^blocked_partial_work\b/.test(line) ||
+      /^tracked_pr_mismatch\b/.test(line) && /\blocal_blocked_reason=manual_review\b/.test(line) ||
+      /^pre_merge_evaluation\b/.test(line) && /\bmanual_review=[1-9]\d*\b/.test(line)
+    ) {
+      actions.push({
+        action: "manual_review",
+        source: line.split(/\s/u, 1)[0] ?? "status",
+        priority: 65,
+        summary: "A tracked issue requires manual review before the supervisor should continue that path.",
+      });
+    }
+  }
+
+  return chooseHighestPriority(actions);
+}
+
+export function selectDoctorOperatorAction(args: {
+  overallStatus: "pass" | "warn" | "fail";
+  checks: Array<{ name: string; status: "pass" | "warn" | "fail" }>;
+  localCiContract: LocalCiContractSummary;
+}): OperatorAction {
+  const actions: OperatorAction[] = [];
+
+  if (args.checks.some((check) => check.status === "fail")) {
+    actions.push({
+      action: "fix_config",
+      source: "doctor_check",
+      priority: 80,
+      summary: "Doctor found a failing host prerequisite; fix the reported check before continuing supervisor operation.",
+    });
+  }
+
+  if (args.localCiContract.source === "repo_script_candidate") {
+    actions.push({
+      action: "adopt_local_ci",
+      source: "doctor_local_ci",
+      priority: 55,
+      summary:
+        "Repo-owned local CI candidate exists; adopt it in config or explicitly dismiss it before relying on local verification posture.",
+    });
+  }
+
+  if (args.localCiContract.source === "dismissed_repo_script_candidate") {
+    actions.push({
+      action: "safe_to_ignore",
+      source: "doctor_local_ci",
+      priority: 10,
+      summary: "Repo-owned local CI candidate was intentionally dismissed; no local CI adoption action is required.",
+    });
+  }
+
+  if (args.overallStatus === "warn") {
+    actions.push({
+      action: "manual_review",
+      source: "doctor_warning",
+      priority: 45,
+      summary: "Doctor found a warning that should be reviewed before relying on steady-state automation.",
+    });
+  }
+
+  return chooseHighestPriority(actions);
+}
+
+export function renderOperatorActionLine(prefix: "operator_action" | "doctor_operator_action", action: OperatorAction): string {
+  return [
+    prefix,
+    `action=${action.action}`,
+    `source=${action.source}`,
+    `priority=${action.priority}`,
+    `summary=${action.summary}`,
+  ].join(" ");
+}

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -426,6 +426,43 @@ test("renderSupervisorStatusDto appends canonical github rate-limit lines from d
   assert.match(status, /^github_rate_limit resource=graphql status=exhausted remaining=0 limit=5000 reset_at=2026-03-27T00:15:00.000Z$/m);
 });
 
+test("renderSupervisorStatusDto maps provider outage diagnostics to an operator action token", () => {
+  const status = renderSupervisorStatusDto({
+    gsdSummary: null,
+    candidateDiscovery: null,
+    loopRuntime: {
+      state: "running",
+      hostMode: "tmux",
+      runMode: "macos_tmux_loop",
+      markerPath: "/tmp/locks/supervisor/loop-runtime.lock",
+      configPath: "/tmp/supervisor.config.json",
+      stateFile: "/tmp/state.json",
+      pid: 4242,
+      startedAt: "2026-03-27T00:15:00.000Z",
+      ownershipConfidence: "live_lock",
+      detail: "supervisor-loop-runtime",
+    },
+    activeIssue: null,
+    selectionSummary: null,
+    trackedIssues: [],
+    runnableIssues: [],
+    blockedIssues: [],
+    detailedStatusLines: [
+      "review_bot_diagnostics status=provider_outage_suspected observed_review=none expected_reviewers=coderabbitai next_check=wait_or_provider_setup_or_manual_review recent_observation=required_checks_green:2026-03-16T00:10:00.000Z recoverability=provider_outage_suspected",
+    ],
+    reconciliationPhase: null,
+    reconciliationWarning: null,
+    readinessLines: [],
+    whyLines: [],
+    warning: null,
+  });
+
+  assert.match(
+    status,
+    /^operator_action action=provider_outage_suspected source=review_bot_diagnostics priority=70 summary=The configured review provider has not reported on the current head after checks turned green; wait, verify provider delivery, or escalate to manual review\.$/m,
+  );
+});
+
 test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
   const status = renderSupervisorStatusDto({
     gsdSummary: null,
@@ -1194,6 +1231,10 @@ test("status surfaces loop-off as a blocker when tracked work is still active", 
   );
   assert.match(
     status,
+    /^operator_action action=restart_loop source=loop_runtime_blocker priority=90 summary=Tracked work is active but the supervisor loop is off; restart the loop to resume background execution\.$/m,
+  );
+  assert.match(
+    status,
     /^status_warning=Tracked work is active for issue #188, but the supervisor loop is off\. Restart the loop to resume background execution\.$/m,
   );
 });
@@ -1248,6 +1289,10 @@ test("status does not emit the loop-off restart blocker for blocked-only tracked
   const status = await supervisor.status();
   assert.doesNotMatch(status, /^loop_runtime_blocker /m);
   assert.doesNotMatch(status, /^status_warning=Tracked work is active for issue #188, but the supervisor loop is off\./m);
+  assert.match(
+    status,
+    /^operator_action action=continue source=status priority=0 summary=No blocking operator action was detected; continue normal supervisor operation\.$/m,
+  );
 });
 
 test("acquireSupervisorLock fails closed on ambiguous-owner run locks", async (t) => {
@@ -3556,6 +3601,10 @@ test("status surfaces host-local CI blocker details for tracked PR mismatches", 
   assert.match(
     status,
     /^tracked_pr_host_local_ci issue=#171 pr=#271 github_checks=green head_sha=head-ready-271 outcome=failed failure_class=workspace_toolchain_missing remediation_target=workspace_environment head=current summary=Configured local CI command could not run before marking PR #271 ready because the workspace toolchain is unavailable\. Remediation target: workspace environment\.$/m,
+  );
+  assert.match(
+    status,
+    /^operator_action action=fix_config source=tracked_pr_host_local_ci priority=80 summary=Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing\.$/m,
   );
   assert.match(
     status,

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -22,6 +22,7 @@ import {
   formatLastSuccessfulInventorySnapshotStatusLine,
 } from "../inventory-refresh-state";
 import { buildTrustAndConfigWarnings, buildWarning, renderStatusWarningLine } from "../warning-formatting";
+import { renderOperatorActionLine, selectStatusOperatorAction } from "../operator-actions";
 
 export interface SupervisorStatusWarningDto {
   kind: "readiness" | "status";
@@ -162,8 +163,13 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
   const statusWarning = dto.warning === null ? null : buildWarning(dto.warning.kind, dto.warning.message);
   const duplicateLoopDiagnosticLine = renderDuplicateLoopDiagnosticLine(dto.loopRuntime);
   const loopRuntimeRecoveryLine = renderLoopRuntimeRecoveryLine(dto.loopRuntime);
+  const operatorActionLine = renderOperatorActionLine(
+    "operator_action",
+    selectStatusOperatorAction({ detailedStatusLines: dto.detailedStatusLines }),
+  );
   const lines = [
     ...dto.detailedStatusLines,
+    operatorActionLine,
     ...githubRateLimitLines,
     renderLoopRuntimeLine(dto.loopRuntime),
     ...(duplicateLoopDiagnosticLine ? [duplicateLoopDiagnosticLine] : []),


### PR DESCRIPTION
## Summary
- add a shared typed operator action selector for status and doctor surfaces
- render additive operator action lines while preserving existing raw diagnostics
- cover restart-loop, config-fix, provider-outage, local-CI adoption/dismissal, and continue cases

## Verification
- npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-loop-runtime-state.test.ts
- npm run build

Part of #1694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Report outputs now include operator action recommendations with priority levels to guide users on next steps (e.g., fix configuration, adopt local CI, restart loop, manual review).

* **Tests**
  * Added comprehensive test coverage for operator action selection and rendering across doctor and supervisor diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->