### PR TITLE
Add setup readiness next actions

### DIFF
--- a/src/backend/restartable-webui-shell-service.test.ts
+++ b/src/backend/restartable-webui-shell-service.test.ts
@@ -121,6 +121,16 @@ function createStubService(args?: {
     configPath: "/tmp/supervisor.config.json",
     fields: [],
     blockers: [],
+    nextActions: [
+      {
+        action: "continue",
+        source: "setup_readiness",
+        priority: 0,
+        required: false,
+        summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+        fieldKeys: [],
+      },
+    ],
     hostReadiness: {
       overallStatus: "pass",
       checks: [],

--- a/src/backend/setup-test-fixtures.test.ts
+++ b/src/backend/setup-test-fixtures.test.ts
@@ -18,6 +18,8 @@ test("createSetupReadinessReport builds the shared missing-provider fixture by d
   assert.equal(report.fields[0]?.key, "repoPath");
   assert.equal(report.fields.at(-1)?.key, "reviewProvider");
   assert.equal(report.blockers[0]?.code, "missing_review_provider");
+  assert.equal(report.nextActions[0]?.action, "fix_config");
+  assert.equal(report.nextActions[0]?.required, true);
   assert.equal(report.providerPosture.summary, "No review provider is configured.");
 });
 

--- a/src/backend/setup-test-fixtures.ts
+++ b/src/backend/setup-test-fixtures.ts
@@ -15,6 +15,7 @@ import type {
   SetupReadinessHostSummary,
   SetupReadinessModelRoutingPosture,
   SetupReadinessModelRoutingTarget,
+  SetupReadinessNextAction,
   SetupReadinessProviderPosture,
   SetupReadinessReport,
   SetupReadinessTrustPosture,
@@ -290,6 +291,20 @@ export function createMissingReviewProviderBlocker(
   };
 }
 
+export function createSetupNextAction(
+  overrides: Partial<SetupReadinessNextAction> = {},
+): SetupReadinessNextAction {
+  return {
+    action: "fix_config",
+    source: "missing_review_provider",
+    priority: 100,
+    required: true,
+    summary: "Configure at least one review provider before first-run setup is complete.",
+    fieldKeys: ["reviewProvider"],
+    ...overrides,
+  };
+}
+
 export function createSetupHostReadiness(
   overrides: Partial<SetupReadinessHostSummary> = {},
 ): SetupReadinessHostSummary {
@@ -502,6 +517,7 @@ export function createSetupReadinessReport(
       createSetupField("reviewProvider"),
     ],
     blockers: [createMissingReviewProviderBlocker()],
+    nextActions: [createSetupNextAction()],
     hostReadiness: createSetupHostReadiness(),
     providerPosture: createSetupProviderPosture(),
     trustPosture: createSetupTrustPosture(),

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -729,6 +729,16 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
         },
       },
     ],
+    nextActions: [
+      {
+        action: "fix_config",
+        source: "missing_review_provider",
+        priority: 100,
+        required: true,
+        summary: "Configure at least one review provider before first-run setup is complete.",
+        fieldKeys: ["reviewProvider"],
+      },
+    ],
     hostReadiness: {
       overallStatus: "pass",
       checks: [
@@ -1353,6 +1363,16 @@ test("createSupervisorHttpServer accepts narrow setup config writes and returns 
           },
         },
       ],
+      nextActions: [
+        {
+          action: "fix_config",
+          source: "missing_review_provider",
+          priority: 100,
+          required: true,
+          summary: "Configure at least one review provider before first-run setup is complete.",
+          fieldKeys: ["reviewProvider"],
+        },
+      ],
       hostReadiness: {
         overallStatus: "pass",
         checks: [
@@ -1701,6 +1721,16 @@ test("createSupervisorHttpServer surfaces no-op setup config writes without a re
       configPath: "/tmp/supervisor.config.json",
       fields: [],
       blockers: [],
+      nextActions: [
+        {
+          action: "continue",
+          source: "setup_readiness",
+          priority: 0,
+          required: false,
+          summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+          fieldKeys: [],
+        },
+      ],
       hostReadiness: { overallStatus: "pass", checks: [] },
       providerPosture: {
         profile: "codex",

--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -1620,6 +1620,16 @@ test("createSupervisorHttpServer surfaces no-op setup config writes without a re
           configPath: "/tmp/supervisor.config.json",
           fields: [],
           blockers: [],
+          nextActions: [
+            {
+              action: "continue",
+              source: "setup_readiness",
+              priority: 0,
+              required: false,
+              summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+              fieldKeys: [],
+            },
+          ],
           hostReadiness: { overallStatus: "pass", checks: [] },
           providerPosture: {
             profile: "codex",
@@ -2034,6 +2044,16 @@ test("createSupervisorHttpServer keeps root on the operator dashboard after setu
         },
       ],
       blockers: [],
+      nextActions: [
+        {
+          action: "continue",
+          source: "setup_readiness",
+          priority: 0,
+          required: false,
+          summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+          fieldKeys: [],
+        },
+      ],
       hostReadiness: {
         overallStatus: "pass",
         checks: [],

--- a/src/backend/webui-dashboard-browser-smoke.test.ts
+++ b/src/backend/webui-dashboard-browser-smoke.test.ts
@@ -462,6 +462,24 @@ function createFirstRunSetupService(args: {
         },
       },
     ],
+    nextActions: [
+      {
+        action: "fix_config",
+        source: "missing_repo_path",
+        priority: 100,
+        required: true,
+        summary: "Set repoPath in the supervisor config.",
+        fieldKeys: ["repoPath"],
+      },
+      {
+        action: "fix_config",
+        source: "missing_review_provider",
+        priority: 100,
+        required: true,
+        summary: "Configure at least one review provider before first-run setup is complete.",
+        fieldKeys: ["reviewProvider"],
+      },
+    ],
     hostReadiness: {
       overallStatus: "pass",
       checks: [

--- a/src/backend/webui-dashboard-browser-smoke.test.ts
+++ b/src/backend/webui-dashboard-browser-smoke.test.ts
@@ -658,6 +658,16 @@ function createFirstRunSetupService(args: {
             },
           ],
         blockers: [],
+        nextActions: [
+          {
+            action: "continue",
+            source: "setup_readiness",
+            priority: 0,
+            required: false,
+            summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+            fieldKeys: [],
+          },
+        ],
         providerPosture: {
           profile: "codex",
           provider: "codex",

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -1635,6 +1635,8 @@ test("setup shell loads typed setup readiness without mixing in dashboard status
   assert.match(harness.document.getElementById("setup-blockers")?.textContent ?? "", /Configure at least one review provider before first-run setup is complete\./u);
   assert.match(harness.document.getElementById("setup-blockers")?.textContent ?? "", /Blocker code: missing review provider/u);
   assert.match(harness.document.getElementById("setup-blockers")?.textContent ?? "", /Suggested remediation: Configure at least one review provider before first-run setup is complete\./u);
+  assert.match(harness.document.getElementById("setup-next-actions")?.textContent ?? "", /Configure at least one review provider before first-run setup is complete\./u);
+  assert.match(harness.document.getElementById("setup-next-actions")?.textContent ?? "", /Action: fix config.*Source: missing review provider.*Required: yes.*Priority: 100/u);
   assert.match(harness.document.getElementById("setup-field-summary")?.textContent ?? "", /1 of 2 required setup fields configured\./u);
   assert.match(harness.document.getElementById("setup-fields")?.textContent ?? "", /Repository path \[Configured\].*Current value: \/tmp\/repo.*Type: directory path.*Repository path is configured\./u);
   assert.match(harness.document.getElementById("setup-fields")?.textContent ?? "", /Review provider \[Missing\].*Current value: Unset.*Type: review provider.*Configure at least one review provider before first-run setup is complete\./u);

--- a/src/backend/webui-setup-browser-script.ts
+++ b/src/backend/webui-setup-browser-script.ts
@@ -46,6 +46,7 @@ export function renderSetupBrowserScript(): string {
         summary: document.getElementById("setup-summary"),
         blockerSummary: document.getElementById("setup-blocker-summary"),
         blockers: document.getElementById("setup-blockers"),
+        nextActions: document.getElementById("setup-next-actions"),
         fieldSummary: document.getElementById("setup-field-summary"),
         fields: document.getElementById("setup-fields"),
         hostSummary: document.getElementById("setup-host-summary"),
@@ -570,6 +571,23 @@ export function renderSetupBrowserScript(): string {
             ],
           })),
           "No setup blockers remain. Open /dashboard for steady-state operations.",
+        );
+        renderChecklist(
+          elements.nextActions,
+          (report.nextActions || []).map((action) => ({
+            title: action.summary,
+            tone: action.required ? "blocker" : "normal",
+            meta: [
+              "Action: " + formatToken(action.action),
+              "Source: " + formatToken(action.source),
+              "Required: " + (action.required ? "yes" : "no"),
+              "Priority: " + action.priority,
+            ],
+            notes: [
+              "Related fields: " + (action.fieldKeys && action.fieldKeys.length > 0 ? action.fieldKeys.join(", ") : "none"),
+            ],
+          })),
+          "No setup next actions reported.",
         );
         setText(elements.fieldSummary, summarizeFields(report.fields));
         renderChecklist(

--- a/src/backend/webui-setup-page.ts
+++ b/src/backend/webui-setup-page.ts
@@ -382,6 +382,10 @@ export function renderSupervisorSetupPage(): string {
         grid-column: span 8;
       }
 
+      .next-actions-card {
+        grid-column: span 12;
+      }
+
       .config-card,
       .fields-card {
         grid-column: span 6;
@@ -495,6 +499,7 @@ export function renderSupervisorSetupPage(): string {
       @media (max-width: 1160px) {
         .summary-card,
         .blockers-card,
+        .next-actions-card,
         .config-card,
         .fields-card,
         .diagnostic-card {
@@ -628,16 +633,16 @@ ${renderSetupNavigation()}
                 </div>
               </article>
 
-              <article id="setup-next-actions-card" class="panel">
+              <article id="setup-next-actions-card" class="panel next-actions-card">
                 <div class="panel-shell">
                   <div class="panel-header">
                     <h2>Next setup actions</h2>
                     <p class="panel-subtitle">Ordered setup decisions from the typed readiness contract.</p>
                   </div>
                   <div class="panel-body">
-                    <ul id="setup-next-actions" class="list list--plain checklist-grid">
+                    <ol id="setup-next-actions" class="list list--plain checklist-grid">
                       <li>Loading setup next actions…</li>
-                    </ul>
+                    </ol>
                   </div>
                 </div>
               </article>

--- a/src/backend/webui-setup-page.ts
+++ b/src/backend/webui-setup-page.ts
@@ -627,6 +627,20 @@ ${renderSetupNavigation()}
                   </div>
                 </div>
               </article>
+
+              <article id="setup-next-actions-card" class="panel">
+                <div class="panel-shell">
+                  <div class="panel-header">
+                    <h2>Next setup actions</h2>
+                    <p class="panel-subtitle">Ordered setup decisions from the typed readiness contract.</p>
+                  </div>
+                  <div class="panel-body">
+                    <ul id="setup-next-actions" class="list list--plain checklist-grid">
+                      <li>Loading setup next actions…</li>
+                    </ul>
+                  </div>
+                </div>
+              </article>
             </div>
           </section>
 

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -178,6 +178,16 @@ test("diagnoseSetupReadiness keeps a tracked repo-owned workspace preparation he
   assert.equal(field?.state, "configured");
   assert.equal(field?.value, "./scripts/prepare-workspace.sh");
   assert.match(field?.message ?? "", /workspace preparation command is configured/i);
+  assert.deepEqual(summary.nextActions, [
+    {
+      action: "continue",
+      source: "setup_readiness",
+      priority: 0,
+      required: false,
+      summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+      fieldKeys: [],
+    },
+  ]);
 });
 
 test("diagnoseSetupReadiness suggests a repo-native workspace preparation command when package-lock is present", async (t) => {
@@ -224,6 +234,13 @@ test("diagnoseSetupReadiness suggests a repo-native workspace preparation comman
   const field = summary.fields.find((entry) => entry.key === "workspacePreparationCommand");
   assert.equal(field?.state, "missing");
   assert.match(field?.message ?? "", /recommended repo-native command: npm ci/i);
+  assert.deepEqual(
+    summary.nextActions.map((action) => [action.action, action.source, action.required, action.fieldKeys]),
+    [
+      ["adopt_local_ci", "workspace_preparation_candidate", false, ["workspacePreparationCommand"]],
+    ],
+  );
+  assert.match(summary.nextActions[0]?.summary ?? "", /adopt the repo-owned workspace preparation command npm ci/i);
 });
 
 test("diagnoseSetupReadiness requires explicit trust posture decisions", async (t) => {
@@ -275,6 +292,15 @@ test("diagnoseSetupReadiness requires explicit trust posture decisions", async (
     [
       ["missing_trust_mode", ["trustMode"]],
       ["missing_execution_safety_mode", ["executionSafetyMode"]],
+    ],
+  );
+  assert.deepEqual(
+    summary.nextActions
+      .filter((action) => action.source === "missing_trust_mode" || action.source === "missing_execution_safety_mode")
+      .map((action) => [action.action, action.source, action.required, action.priority, action.fieldKeys]),
+    [
+      ["fix_config", "missing_trust_mode", true, 100, ["trustMode"]],
+      ["fix_config", "missing_execution_safety_mode", true, 100, ["executionSafetyMode"]],
     ],
   );
 });
@@ -394,6 +420,127 @@ test("diagnoseSetupReadiness exposes configured approved tracked top-level entri
   assert.equal(skeletonGuard?.required, false);
   assert.equal(skeletonGuard?.value, "README.md, src");
   assert.match(skeletonGuard?.message ?? "", /Approved tracked top level entries is configured/i);
+  const dangerousConfirmation = summary.nextActions.find(
+    (action) => action.source === "dangerous_explicit_opt_in:approvedTrackedTopLevelEntries",
+  );
+  assert.ok(dangerousConfirmation);
+  assert.equal(dangerousConfirmation.action, "manual_review");
+  assert.equal(dangerousConfirmation.required, false);
+  assert.deepEqual(dangerousConfirmation.fieldKeys, ["approvedTrackedTopLevelEntries"]);
+  assert.match(dangerousConfirmation.summary, /confirm approved tracked top level entries remains an intentional dangerous explicit opt-in/i);
+});
+
+test("diagnoseSetupReadiness summarizes advisory local CI adoption and dismissal decisions", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "package.json"),
+    JSON.stringify({ private: true, scripts: { "verify:pre-pr": "tsx --test" } }, null, 2),
+    "utf8",
+  );
+  execFileSync("git", ["add", "package.json"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "add local ci script"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, true);
+  assert.equal(summary.localCiContract?.source, "repo_script_candidate");
+  assert.deepEqual(
+    summary.nextActions.map((action) => [action.action, action.source, action.required, action.fieldKeys]),
+    [
+      ["adopt_local_ci", "local_ci_candidate", false, ["localCiCommand", "localCiCandidateDismissed"]],
+      ["dismiss_local_ci", "local_ci_candidate", false, ["localCiCandidateDismissed"]],
+    ],
+  );
+  assert.match(summary.nextActions[0]?.summary ?? "", /adopt the repo-owned local CI command npm run verify:pre-pr/i);
+  assert.match(summary.nextActions[1]?.summary ?? "", /dismiss the repo-owned local CI candidate npm run verify:pre-pr/i);
+});
+
+test("diagnoseSetupReadiness keeps dismissed local CI candidates visible as safe to ignore", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "package.json"),
+    JSON.stringify({ private: true, scripts: { "verify:pre-pr": "tsx --test" } }, null, 2),
+    "utf8",
+  );
+  execFileSync("git", ["add", "package.json"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "add local ci script"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      ...buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+      }),
+      localCiCandidateDismissed: true,
+    }),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, true);
+  assert.equal(summary.localCiContract?.source, "dismissed_repo_script_candidate");
+  assert.deepEqual(
+    summary.nextActions.map((action) => [action.action, action.source, action.required, action.fieldKeys]),
+    [
+      ["safe_to_ignore", "local_ci_candidate_dismissed", false, ["localCiCandidateDismissed"]],
+    ],
+  );
+  assert.match(summary.nextActions[0]?.summary ?? "", /intentionally dismissed/i);
 });
 
 test("diagnoseSetupReadiness reuses review provider validation for reviewBotLogins posture", async (t) => {
@@ -571,6 +718,12 @@ test("diagnoseSetupReadiness fails closed when fixed model routing is missing an
   assert.match(blocker.message, /codexModelStrategy=fixed requires an explicit codexModel value before execution can proceed/i);
   assert.deepEqual(blocker.fieldKeys, ["codexModel"]);
   assert.deepEqual(blocker.remediation.fieldKeys, ["codexModel"]);
+  assert.deepEqual(
+    summary.nextActions
+      .filter((action) => action.source === "missing_codex_model")
+      .map((action) => [action.action, action.required, action.fieldKeys]),
+    [["fix_config", true, ["codexModel"]]],
+  );
 });
 
 test("diagnoseSetupReadiness reports fully explicit model routing when every route is overridden", async (t) => {

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -144,7 +144,8 @@ test("diagnoseSetupReadiness keeps a tracked repo-owned workspace preparation he
   await fs.mkdir(path.join(repoPath, "scripts"), { recursive: true });
   await fs.mkdir(workspaceRoot, { recursive: true });
   await fs.writeFile(path.join(repoPath, "scripts", "prepare-workspace.sh"), "#!/bin/sh\nexit 0\n", "utf8");
-  execFileSync("git", ["add", "scripts/prepare-workspace.sh"], { cwd: repoPath });
+  await fs.writeFile(path.join(repoPath, "package-lock.json"), "{}\n", "utf8");
+  execFileSync("git", ["add", "scripts/prepare-workspace.sh", "package-lock.json"], { cwd: repoPath });
   execFileSync("git", ["commit", "-m", "add workspace helper"], {
     cwd: repoPath,
     env: {
@@ -178,6 +179,10 @@ test("diagnoseSetupReadiness keeps a tracked repo-owned workspace preparation he
   assert.equal(field?.state, "configured");
   assert.equal(field?.value, "./scripts/prepare-workspace.sh");
   assert.match(field?.message ?? "", /workspace preparation command is configured/i);
+  assert.doesNotMatch(
+    summary.nextActions.map((action) => action.source).join("\n"),
+    /workspace_preparation_candidate/u,
+  );
   assert.deepEqual(summary.nextActions, [
     {
       action: "continue",

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -20,6 +20,7 @@ import type { CodexModelStrategy, LocalCiContractSummary, LocalReviewPostureSumm
 import { diagnoseSupervisorHost, type DoctorCheck, type DoctorCheckStatus } from "./doctor";
 import { reviewProviderProfileFromConfig } from "./core/review-providers";
 import type { ExecutionSafetyMode, TrustMode } from "./core/types";
+import type { OperatorActionToken } from "./operator-actions";
 
 export type SetupFieldState = "configured" | "missing" | "invalid";
 export type SetupReadinessOverallStatus = "configured" | "missing" | "invalid";
@@ -111,6 +112,15 @@ export interface SetupReadinessBlocker {
   remediation: SetupReadinessRemediation;
 }
 
+export interface SetupReadinessNextAction {
+  action: OperatorActionToken;
+  source: string;
+  priority: number;
+  required: boolean;
+  summary: string;
+  fieldKeys: SetupReadinessConfigFieldKey[];
+}
+
 export type SetupReadinessModelRoutingStrategy = CodexModelStrategy | string;
 
 export interface SetupReadinessHostSummary {
@@ -161,6 +171,7 @@ export interface SetupReadinessReport {
   fields: SetupReadinessField[];
   configPostureGroups?: SetupReadinessConfigPostureGroup[];
   blockers: SetupReadinessBlocker[];
+  nextActions: SetupReadinessNextAction[];
   hostReadiness: SetupReadinessHostSummary;
   providerPosture: SetupReadinessProviderPosture;
   trustPosture: SetupReadinessTrustPosture;
@@ -853,6 +864,109 @@ function buildBlockers(args: {
   return blockers;
 }
 
+function sortNextActions(actions: SetupReadinessNextAction[]): SetupReadinessNextAction[] {
+  return [...actions].sort((left, right) => right.priority - left.priority);
+}
+
+function buildNextActions(args: {
+  blockers: SetupReadinessBlocker[];
+  configPostureGroups: SetupReadinessConfigPostureGroup[];
+  localCiContract: LocalCiContractSummary;
+  recommendedWorkspacePreparationCommand: string | null;
+}): SetupReadinessNextAction[] {
+  const actions: SetupReadinessNextAction[] = [];
+
+  for (const blocker of args.blockers) {
+    actions.push({
+      action: "fix_config",
+      source: blocker.code,
+      priority: 100,
+      required: true,
+      summary: blocker.remediation.summary,
+      fieldKeys: [...blocker.remediation.fieldKeys],
+    });
+  }
+
+  if (args.recommendedWorkspacePreparationCommand !== null) {
+    actions.push({
+      action: "adopt_local_ci",
+      source: "workspace_preparation_candidate",
+      priority: 55,
+      required: false,
+      summary:
+        `Optional: adopt the repo-owned workspace preparation command ${args.recommendedWorkspacePreparationCommand} in workspacePreparationCommand, or leave it unset until you want the setup contract.`,
+      fieldKeys: ["workspacePreparationCommand"],
+    });
+  }
+
+  if (args.localCiContract.source === "repo_script_candidate" && args.localCiContract.recommendedCommand !== null) {
+    actions.push({
+      action: "adopt_local_ci",
+      source: "local_ci_candidate",
+      priority: 50,
+      required: false,
+      summary:
+        `Optional: adopt the repo-owned local CI command ${args.localCiContract.recommendedCommand} in localCiCommand, or explicitly dismiss the candidate if you do not want codex-supervisor to treat it as the local verification contract.`,
+      fieldKeys: ["localCiCommand", "localCiCandidateDismissed"],
+    });
+    actions.push({
+      action: "dismiss_local_ci",
+      source: "local_ci_candidate",
+      priority: 49,
+      required: false,
+      summary:
+        `Optional: dismiss the repo-owned local CI candidate ${args.localCiContract.recommendedCommand} to keep localCiCommand unset without repeating the adoption prompt.`,
+      fieldKeys: ["localCiCandidateDismissed"],
+    });
+  }
+
+  if (args.localCiContract.source === "dismissed_repo_script_candidate") {
+    actions.push({
+      action: "safe_to_ignore",
+      source: "local_ci_candidate_dismissed",
+      priority: 10,
+      required: false,
+      summary: args.localCiContract.summary,
+      fieldKeys: ["localCiCandidateDismissed"],
+    });
+  }
+
+  for (const group of args.configPostureGroups) {
+    if (group.tier !== "dangerous_explicit_opt_in") {
+      continue;
+    }
+
+    for (const field of group.fields) {
+      if (field.state !== "configured") {
+        continue;
+      }
+
+      actions.push({
+        action: "manual_review",
+        source: `dangerous_explicit_opt_in:${field.key}`,
+        priority: 40,
+        required: false,
+        summary:
+          `Confirm ${field.label} remains an intentional dangerous explicit opt-in; do not treat it as a recommended setup default.`,
+        fieldKeys: [field.key],
+      });
+    }
+  }
+
+  if (actions.length === 0) {
+    actions.push({
+      action: "continue",
+      source: "setup_readiness",
+      priority: 0,
+      required: false,
+      summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+      fieldKeys: [],
+    });
+  }
+
+  return sortNextActions(actions);
+}
+
 function overallStatusFromFields(
   fields: SetupReadinessField[],
   modelRoutingPosture: SetupReadinessModelRoutingPosture,
@@ -915,6 +1029,13 @@ export async function diagnoseSetupReadiness(
     : null;
   const hostReadiness = buildHostReadiness(hostDiagnostics?.checks ?? null, hostDiagnostics?.overallStatus ?? null);
   const blockers = buildBlockers({ fields, hostReadiness, modelRoutingPosture });
+  const localCiContract = summarizeLocalCiContract(localCiContractConfig);
+  const nextActions = buildNextActions({
+    blockers,
+    configPostureGroups,
+    localCiContract,
+    recommendedWorkspacePreparationCommand,
+  });
 
   return {
     kind: "setup_readiness",
@@ -924,11 +1045,12 @@ export async function diagnoseSetupReadiness(
     fields,
     configPostureGroups,
     blockers,
+    nextActions,
     hostReadiness,
     providerPosture: buildProviderPosture(configSummary.config),
     trustPosture: buildTrustPostureFromRaw(rawConfig, configSummary.config),
     modelRoutingPosture,
-    localCiContract: summarizeLocalCiContract(localCiContractConfig),
+    localCiContract,
     localReviewPosture: configSummary.config ? summarizeLocalReviewPosture(configSummary.config) : undefined,
   };
 }

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -873,8 +873,13 @@ function buildNextActions(args: {
   configPostureGroups: SetupReadinessConfigPostureGroup[];
   localCiContract: LocalCiContractSummary;
   recommendedWorkspacePreparationCommand: string | null;
+  workspacePreparationCommand: ReturnType<typeof normalizeLocalCiCommand>;
 }): SetupReadinessNextAction[] {
   const actions: SetupReadinessNextAction[] = [];
+  const workspacePreparationField = args.configPostureGroups
+    .flatMap((group) => group.fields)
+    .find((field) => field.key === "workspacePreparationCommand");
+  const workspacePreparationCommandConfigured = args.workspacePreparationCommand !== undefined;
 
   for (const blocker of args.blockers) {
     actions.push({
@@ -887,7 +892,11 @@ function buildNextActions(args: {
     });
   }
 
-  if (args.recommendedWorkspacePreparationCommand !== null) {
+  if (
+    args.recommendedWorkspacePreparationCommand !== null &&
+    !workspacePreparationCommandConfigured &&
+    workspacePreparationField?.state !== "configured"
+  ) {
     actions.push({
       action: "adopt_local_ci",
       source: "workspace_preparation_candidate",
@@ -1035,6 +1044,7 @@ export async function diagnoseSetupReadiness(
     configPostureGroups,
     localCiContract,
     recommendedWorkspacePreparationCommand,
+    workspacePreparationCommand: localCiContractConfig.workspacePreparationCommand,
   });
 
   return {

--- a/src/supervisor/supervisor-service.test.ts
+++ b/src/supervisor/supervisor-service.test.ts
@@ -156,6 +156,16 @@ test("createSupervisorService exposes a dedicated typed setup readiness query", 
         },
       },
     ],
+    nextActions: [
+      {
+        action: "fix_config",
+        source: "missing_review_provider",
+        priority: 100,
+        required: true,
+        summary: "Add at least one review provider login before first-run setup is complete.",
+        fieldKeys: ["reviewProvider"],
+      },
+    ],
     hostReadiness: {
       overallStatus: "pass",
       checks: [


### PR DESCRIPTION
## Summary
- Add typed setup-readiness next actions for required fixes, local CI/workspace adoption decisions, dismissed candidates, dangerous opt-in confirmations, and configured continue state
- Render the setup WebUI next-action list directly from the readiness DTO
- Extend focused setup-readiness and WebUI fixture coverage

Closes #1695

## Verification
- npx tsx --test src/setup-readiness.test.ts src/config.test.ts src/backend/webui-dashboard.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Next setup actions" panel showing prioritized recommended steps, required vs optional flags, field-level pointers, and an empty-state message.
  * UI renders advisory actions (e.g., adopt/dismiss suggestions) and a "continue" action when no blockers remain.

* **Tests**
  * Expanded test coverage to assert presence and content of next-action entries across setup flows and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->