### PR TITLE
Add WebUI first-run setup panel

### DIFF
--- a/src/backend/webui-dashboard-page-layout.ts
+++ b/src/backend/webui-dashboard-page-layout.ts
@@ -1,6 +1,7 @@
 export interface DashboardPageLayoutInput {
   repoSlugMarkup: string;
   detailsMenuMarkup: string;
+  firstRunSetupMarkup?: string;
   overviewPanelsMarkup: string;
   detailPanelsMarkup: string;
   footerMarkup: string;
@@ -10,6 +11,7 @@ export interface DashboardPageLayoutInput {
 export function renderDashboardPageLayout({
   repoSlugMarkup,
   detailsMenuMarkup,
+  firstRunSetupMarkup = "",
   overviewPanelsMarkup,
   detailPanelsMarkup,
   footerMarkup,
@@ -144,6 +146,16 @@ export function renderDashboardPageLayout({
       .issue-summary-copy,
       .summary-list,
       .summary-banner {
+        display: grid;
+        gap: 12px;
+      }
+
+      .setup-readiness-panel,
+      .setup-readiness-header,
+      .setup-readiness-body,
+      .setup-readiness-section,
+      .setup-readiness-list,
+      .setup-context-grid {
         display: grid;
         gap: 12px;
       }
@@ -509,6 +521,55 @@ export function renderDashboardPageLayout({
         border-radius: var(--radius-md);
         background: var(--surface);
         box-shadow: var(--shadow-sm);
+      }
+
+      .setup-readiness-panel {
+        padding: 18px 20px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+        box-shadow: var(--shadow-sm);
+      }
+
+      .setup-readiness-header {
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: start;
+      }
+
+      .setup-readiness-header h2,
+      .setup-readiness-section h3 {
+        margin: 0;
+      }
+
+      .setup-readiness-header h2 {
+        letter-spacing: -0.03em;
+      }
+
+      .setup-readiness-body {
+        grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+        align-items: start;
+      }
+
+      .setup-context-grid {
+        grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      }
+
+      .setup-readiness-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .setup-readiness-list li {
+        padding: 10px 12px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-soft);
+      }
+
+      .setup-danger-zone {
+        border-color: rgba(217, 83, 79, 0.4);
+        background: #fffafa;
       }
 
       .issue-summary-grid {
@@ -1046,6 +1107,7 @@ export function renderDashboardPageLayout({
         }
 
         .details-grid,
+        .setup-readiness-body,
         .workflow-rail {
           grid-template-columns: 1fr;
         }
@@ -1150,6 +1212,8 @@ ${detailsMenuMarkup}
             <strong id="last-refresh-badge">never</strong>
           </div>
         </section>
+
+${firstRunSetupMarkup}
 
         <details id="details-disclosure" class="details-disclosure">
           <summary>

--- a/src/backend/webui-dashboard-page-sections.ts
+++ b/src/backend/webui-dashboard-page-sections.ts
@@ -4,6 +4,7 @@ import type { SetupReadinessFieldKey, SetupReadinessReport } from "../setup-read
 export interface DashboardPageSections {
   repoSlugMarkup: string;
   detailsMenuMarkup: string;
+  firstRunSetupMarkup: string;
   overviewPanelsMarkup: string;
   detailPanelsMarkup: string;
   footerMarkup: string;
@@ -56,6 +57,7 @@ function renderDetailsMenu(): string {
             <p class="eyebrow">Overview</p>
             <a id="nav-summary-top" class="side-nav-link" href="#summary-top"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M3 3.5h10v2H3zm0 3.5h10v2H3zm0 3.5h6v2H3z"/></svg></span><span>Current Status</span></a>
             <a id="nav-issue-summary" class="side-nav-link" href="#selected-issue-heading"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M3 2.5h10v11H3zm2 2v1h6v-1zm0 3v1h6v-1zm0 3v1h4v-1z"/></svg></span><span>Issue Summary</span></a>
+            <a id="nav-first-run-setup" class="side-nav-link" href="#dashboard-first-run-setup"><span class="side-nav-icon" aria-hidden="true"><svg viewBox="0 0 16 16" focusable="false"><path d="M8 2.5l5 2v4c0 2.9-2.1 4.7-5 5.5-2.9-.8-5-2.6-5-5.5v-4zm0 2.1L5 5.7v2.8c0 1.8 1.2 3.1 3 3.8 1.8-.7 3-2 3-3.8V5.7zM7.2 7h1.6v2.2H7.2zm0 2.8h1.6v1.2H7.2z"/></svg></span><span>First-run Setup</span></a>
           </div>
           <div class="side-nav-section">
             <p class="eyebrow">Details</p>
@@ -112,12 +114,116 @@ function renderHeaderRepoSlug(report: SetupReadinessReport | null | undefined): 
   return escapeHtml(repoSlug ?? "Repository unavailable");
 }
 
+function renderSetupContextTile(label: string, value: string): string {
+  return `<div class="metric-tile">
+                <span class="metric-tile-label">${escapeHtml(label)}</span>
+                <code class="context-path">${escapeHtml(value)}</code>
+              </div>`;
+}
+
+function setupToneClass(report: SetupReadinessReport): "ok" | "warn" | "fail" {
+  if (report.ready) {
+    return "ok";
+  }
+  return report.blockers.length > 0 || report.hostReadiness.overallStatus === "fail" ? "fail" : "warn";
+}
+
+function setupStatusLabel(report: SetupReadinessReport): string {
+  if (report.ready) {
+    return "Setup ready";
+  }
+  return report.blockers.length > 0 ? "Setup blocked" : "Setup advisory";
+}
+
+function renderSetupActionList(report: SetupReadinessReport): string {
+  const requiredActions = report.nextActions.filter((action) => action.required);
+  if (requiredActions.length === 0) {
+    return `<li>No required setup actions remain.</li>`;
+  }
+  return requiredActions
+    .map((action) => `<li><strong>${escapeHtml(action.action)}</strong><br>${escapeHtml(action.summary)}</li>`)
+    .join("\n");
+}
+
+function renderDangerousOptInList(report: SetupReadinessReport): string {
+  const dangerousFields =
+    report.configPostureGroups?.find((group) => group.tier === "dangerous_explicit_opt_in")?.fields ?? [];
+  const dangerousActions = report.nextActions.filter((action) => action.source.startsWith("dangerous_explicit_opt_in:"));
+
+  if (dangerousFields.length === 0 && dangerousActions.length === 0) {
+    return `<li>No dangerous explicit opt-ins are configured.</li>`;
+  }
+
+  const fieldLines = dangerousFields.map((field) => {
+    const value = field.value === null ? "unset" : field.value;
+    return `<li><strong>${escapeHtml(field.label)}</strong><br>${escapeHtml(field.message)}<br><span class="hint">Current value: ${escapeHtml(value)}</span></li>`;
+  });
+  const actionLines = dangerousActions.map(
+    (action) => `<li><strong>${escapeHtml(action.action)}</strong><br>${escapeHtml(action.summary)}</li>`,
+  );
+  return [...fieldLines, ...actionLines].join("\n");
+}
+
+function renderFirstRunSetupPanel(report: SetupReadinessReport | null | undefined): string {
+  if (!report) {
+    return "";
+  }
+
+  const { repoPath, workspaceRoot } = readRepoContext(report);
+  const tone = setupToneClass(report);
+  const githubAuthSummary =
+    report.hostReadiness.checks.find((check) => check.name === "github_auth")?.summary ??
+    `Host readiness: ${report.hostReadiness.overallStatus}.`;
+  const localCiSummary =
+    report.localCiContract?.summary ?? readSetupFieldValue(report, "localCiCommand") ?? "Local CI command is not configured.";
+  const localReviewSummary = report.localReviewPosture?.summary ?? "Local review posture is not configured.";
+
+  return `<section id="dashboard-first-run-setup" class="setup-readiness-panel" aria-labelledby="dashboard-first-run-setup-heading">
+          <div class="setup-readiness-header">
+            <div>
+              <p class="section-kicker">First-run setup</p>
+              <h2 id="dashboard-first-run-setup-heading">First-run setup</h2>
+              <p class="section-lead">Typed setup-readiness and operator-action posture for this WebUI session.</p>
+            </div>
+            <span class="summary-pill ${tone}">${setupStatusLabel(report)}</span>
+          </div>
+          <div class="setup-readiness-body">
+            <div class="setup-readiness-section">
+              <div class="setup-context-grid">
+                ${renderSetupContextTile("Config path", report.configPath)}
+                ${renderSetupContextTile("Repository path", repoPath ?? "Not configured")}
+                ${renderSetupContextTile("Workspace root", workspaceRoot ?? "Not configured")}
+                ${renderSetupContextTile("Loop mode", "WebUI is an operator surface only; no loop ownership or runtime marker is introduced here.")}
+              </div>
+              <div class="setup-context-grid">
+                ${renderSetupContextTile("GitHub auth readiness", githubAuthSummary)}
+                ${renderSetupContextTile("Trust posture", report.trustPosture.summary)}
+                ${renderSetupContextTile("Local CI posture", localCiSummary)}
+                ${renderSetupContextTile("Review provider posture", report.providerPosture.summary)}
+                ${renderSetupContextTile("Local review posture", localReviewSummary)}
+              </div>
+            </div>
+            <div class="setup-readiness-section">
+              <h3>Required next actions</h3>
+              <ul class="setup-readiness-list">
+                ${renderSetupActionList(report)}
+              </ul>
+              <h3>Dangerous explicit opt-ins</h3>
+              <ul class="setup-readiness-list setup-danger-zone">
+                ${renderDangerousOptInList(report)}
+              </ul>
+            </div>
+          </div>
+        </section>`;
+}
+
 export function renderDashboardPageSections(
   setupReadiness?: SetupReadinessReport | null,
 ): DashboardPageSections {
   return {
     repoSlugMarkup: renderHeaderRepoSlug(setupReadiness),
     detailsMenuMarkup: renderDetailsMenu(),
+    firstRunSetupMarkup: renderFirstRunSetupPanel(setupReadiness),
     overviewPanelsMarkup: renderDashboardPanelSection("overview"),
     detailPanelsMarkup: renderDashboardPanelSection("details"),
     footerMarkup: renderDashboardFooter(setupReadiness),

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createSetupConfigUpdateResult,
+  createSetupConfigPostureField,
+  createSetupConfigPostureGroups,
   createSetupField,
+  createMissingReviewProviderBlocker,
+  createSetupNextAction,
+  createSetupHostReadiness,
   createSetupProviderPosture,
   createSetupReadinessReport,
   createSetupTrustPosture,
@@ -204,6 +209,138 @@ test("dashboard page renders repository identity from setup readiness data", () 
   assert.match(html, /id="repo-slug-value" class="masthead-repo">owner\/&lt;repo&gt;&quot;</u);
   assert.match(html, /id="repo-path-value" class="context-path">\/Users\/&lt;example&gt;\/dev\/&quot;repo</u);
   assert.match(html, /id="workspace-root-value" class="context-path">\/Users\/example\/dev\/work&quot;trees</u);
+});
+
+test("dashboard page renders first-run setup readiness from the typed setup DTO", () => {
+  const html = renderSupervisorDashboardHtml(createSetupReadinessReport({
+    ready: false,
+    overallStatus: "missing",
+    configPath: "<supervisor-config-path>",
+    fields: [
+      createSetupField("repoSlug", { value: "owner/repo" }),
+      createSetupField("repoPath", { value: "<codex-supervisor-root>" }),
+      createSetupField("workspaceRoot", { value: "<codex-supervisor-root>/.local/worktrees" }),
+      createSetupField("trustMode", {
+        state: "missing",
+        value: null,
+        message: "Trust mode needs an explicit first-run setup decision.",
+      }),
+      createSetupField("executionSafetyMode", {
+        state: "configured",
+        value: "operator_gated",
+        message: "Execution safety mode is explicitly configured.",
+      }),
+      createSetupField("reviewProvider", {
+        state: "missing",
+        value: null,
+        message: "Configure at least one review provider before first-run setup is complete.",
+      }),
+      createSetupField("localCiCommand", {
+        state: "missing",
+        value: null,
+        message: "Local CI command is optional until you opt in to the repo-owned contract.",
+      }),
+    ],
+    blockers: [
+      createMissingReviewProviderBlocker(),
+    ],
+    nextActions: [
+      createSetupNextAction({
+        action: "fix_config",
+        source: "missing_review_provider",
+        priority: 100,
+        required: true,
+        summary: "Configure at least one review provider before first-run setup is complete.",
+        fieldKeys: ["reviewProvider"],
+      }),
+      createSetupNextAction({
+        action: "manual_review",
+        source: "dangerous_explicit_opt_in:approvedTrackedTopLevelEntries",
+        priority: 300,
+        required: false,
+        summary:
+          "Confirm approved tracked top level entries remains an intentional dangerous explicit opt-in; do not treat it as a recommended setup default.",
+        fieldKeys: ["approvedTrackedTopLevelEntries"],
+      }),
+    ],
+    configPostureGroups: createSetupConfigPostureGroups({
+      dangerous_explicit_opt_in: [
+        createSetupConfigPostureField({
+          key: "approvedTrackedTopLevelEntries",
+          label: "Approved tracked top level entries",
+          state: "configured",
+          value: "dist",
+          message:
+            "Approved tracked top level entries is configured as a dangerous explicit opt-in.",
+          required: false,
+          metadata: { source: "config", editable: true, valueType: "text" },
+          posture: {
+            field: "approvedTrackedTopLevelEntries",
+            tier: "dangerous_explicit_opt_in",
+            summary: "Allows specific tracked top-level entries in worktrees.",
+          },
+        }),
+      ],
+    }),
+    hostReadiness: createSetupHostReadiness({
+      overallStatus: "fail",
+      checks: [
+        {
+          name: "github_auth",
+          status: "fail",
+          summary: "GitHub auth is not ready.",
+          details: ["Run gh auth status before starting autonomous operation."],
+        },
+      ],
+    }),
+    providerPosture: createSetupProviderPosture({
+      profile: "none",
+      provider: "none",
+      reviewers: [],
+      signalSource: "none",
+      configured: false,
+      summary: "No review provider is configured.",
+    }),
+    trustPosture: createSetupTrustPosture({
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "operator_gated",
+      configured: false,
+      warning: null,
+      summary: "Trust posture needs an explicit first-run setup decision.",
+    }),
+    localCiContract: {
+      configured: false,
+      command: null,
+      recommendedCommand: "npm run verify:pre-pr",
+      source: "repo_script_candidate",
+      summary:
+        "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
+    },
+    localReviewPosture: {
+      preset: "off",
+      enabled: false,
+      policy: "advisory",
+      autoRepair: "off",
+      followUpIssueCreation: false,
+      summary: "Local review provider is disabled.",
+      guarantees: ["No local review repair authority is enabled."],
+    },
+  }));
+
+  assert.match(html, /id="dashboard-first-run-setup"/u);
+  assert.match(html, /First-run setup/u);
+  assert.match(html, /Setup blocked/u);
+  assert.match(html, /Config path[\s\S]*&lt;supervisor-config-path&gt;/u);
+  assert.match(html, /Repository path[\s\S]*&lt;codex-supervisor-root&gt;/u);
+  assert.match(html, /Workspace root[\s\S]*&lt;codex-supervisor-root&gt;\/\.local\/worktrees/u);
+  assert.match(html, /GitHub auth readiness[\s\S]*GitHub auth is not ready\./u);
+  assert.match(html, /Trust posture[\s\S]*Trust posture needs an explicit first-run setup decision\./u);
+  assert.match(html, /Loop mode[\s\S]*WebUI is an operator surface only/u);
+  assert.match(html, /Local CI posture[\s\S]*Recommended command: npm run verify:pre-pr\./u);
+  assert.match(html, /Review provider posture[\s\S]*No review provider is configured\./u);
+  assert.match(html, /Required next actions[\s\S]*Configure at least one review provider before first-run setup is complete\./u);
+  assert.match(html, /Dangerous explicit opt-ins[\s\S]*Approved tracked top level entries[\s\S]*intentional dangerous explicit opt-in/u);
+  assert.doesNotMatch(html, /\/api\/commands\/loop/u);
 });
 
 test("dashboard page renders sidebar links from the panel registry", () => {


### PR DESCRIPTION
## Summary
- add a server-rendered first-run setup panel to the operator dashboard from the typed setup-readiness DTO
- show config/repo/worktree context, GitHub auth readiness, trust posture, local CI posture, review posture, required next actions, and separated dangerous explicit opt-ins
- keep the WebUI wording operator-surface-only with no loop ownership endpoint or runtime marker semantics

## Verification
- npx tsx --test src/backend/webui-dashboard.test.ts src/backend/supervisor-http-server.test.ts src/backend/webui-setup-browser-script.test.ts src/setup-readiness.test.ts
- npm run build

Part of #1697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-run setup dashboard section displaying readiness status, configuration context, authentication and safety summaries, and required next actions to guide users through initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->