### PR TITLE
Surface stale configured-bot remediation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -268,6 +268,7 @@ Phase 5 operator-action vocabulary is intentionally small:
 - `operator_action action=fix_config` or `doctor_operator_action action=fix_config`: repair host prerequisites, setup fields, or workspace-preparation configuration before continuing.
 - `operator_action action=restart_loop`: tracked work exists but the background loop is off; restart the supported loop host after confirming the config.
 - `operator_action action=provider_outage_suspected`: required checks are green but the configured review provider has not produced a current-head signal; wait, verify provider delivery, or escalate to manual review.
+- `operator_action action=resolve_stale_review_bot`: code or CI is green, but stale configured-bot review thread metadata still blocks the tracked PR; inspect the exact thread URL reported by `stale_review_bot_remediation`, then resolve it or leave a manual note without changing merge policy.
 - `operator_action action=manual_review`: a tracked path has a manual-review blocker; do not let the loop infer success.
 - `operator_action action=continue`: no blocking operator action was detected on that surface.
 - `doctor_operator_action action=adopt_local_ci`: a repo-owned local CI candidate exists; configure it or explicitly dismiss it before treating the local CI posture as settled.

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -137,6 +137,7 @@ test("getting-started protects the first-run command flow and operator action vo
     "operator_action action=fix_config",
     "operator_action action=restart_loop",
     "operator_action action=provider_outage_suspected",
+    "operator_action action=resolve_stale_review_bot",
     "operator_action action=manual_review",
     "operator_action action=continue",
     "doctor_operator_action action=fix_config",

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -7,6 +7,7 @@ export type OperatorActionToken =
   | "adopt_local_ci"
   | "dismiss_local_ci"
   | "manual_review"
+  | "resolve_stale_review_bot"
   | "provider_outage_suspected"
   | "safe_to_ignore";
 
@@ -80,6 +81,17 @@ export function selectStatusOperatorAction(args: {
         priority: 70,
         summary:
           "The configured review provider has not reported on the current head after checks turned green; wait, verify provider delivery, or escalate to manual review.",
+      });
+      continue;
+    }
+
+    if (/^stale_review_bot_remediation\b/.test(line)) {
+      actions.push({
+        action: "resolve_stale_review_bot",
+        source: "stale_review_bot_remediation",
+        priority: 72,
+        summary:
+          "Code or CI is green but configured-bot review thread metadata is still unresolved; inspect the exact thread and resolve it or leave a manual note without changing merge policy.",
       });
       continue;
     }

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -22,13 +22,27 @@ function formatTokenValue(value: string): string {
 }
 
 function processedOnCurrentHead(record: Pick<IssueRunRecord, "last_failure_context">): "yes" | "no" | "unknown" {
+  let sawYes = false;
+  let sawNo = false;
+
   for (const detail of record.last_failure_context?.details ?? []) {
     const match = detail.match(/\bprocessed_on_current_head=(yes|no)\b/u);
-    if (match?.[1] === "yes" || match?.[1] === "no") {
-      return match[1];
+    if (match?.[1] === "yes") {
+      sawYes = true;
+    } else if (match?.[1] === "no") {
+      sawNo = true;
     }
   }
 
+  if (sawYes && sawNo) {
+    return "unknown";
+  }
+  if (sawYes) {
+    return "yes";
+  }
+  if (sawNo) {
+    return "no";
+  }
   return "unknown";
 }
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -1,0 +1,90 @@
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck } from "../core/types";
+
+export interface StaleReviewBotRemediationDto {
+  issueNumber: number;
+  prNumber: number | null;
+  reasonCode: "stale_review_bot";
+  currentHeadSha: string;
+  processedOnCurrentHead: "yes" | "no" | "unknown";
+  codeCiState: "green" | "not_green" | "unknown";
+  reviewThreadUrl: string | null;
+  manualNextStep: string;
+  summary: string;
+}
+
+const STALE_REVIEW_BOT_MANUAL_NEXT_STEP =
+  "inspect_exact_review_thread_then_resolve_or_leave_manual_note";
+const STALE_REVIEW_BOT_SUMMARY =
+  "code_or_ci_green_but_review_thread_metadata_unresolved";
+
+function formatTokenValue(value: string): string {
+  return value.replace(/\r?\n/gu, "\\n");
+}
+
+function processedOnCurrentHead(record: Pick<IssueRunRecord, "last_failure_context">): "yes" | "no" | "unknown" {
+  for (const detail of record.last_failure_context?.details ?? []) {
+    const match = detail.match(/\bprocessed_on_current_head=(yes|no)\b/u);
+    if (match?.[1] === "yes" || match?.[1] === "no") {
+      return match[1];
+    }
+  }
+
+  return "unknown";
+}
+
+function codeCiState(
+  pr: Pick<GitHubPullRequest, "currentHeadCiGreenAt"> | null,
+  checks: Pick<PullRequestCheck, "bucket">[],
+): StaleReviewBotRemediationDto["codeCiState"] {
+  if (checks.some((check) => check.bucket === "fail" || check.bucket === "pending" || check.bucket === "cancel")) {
+    return "not_green";
+  }
+
+  if (checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping")) {
+    return "green";
+  }
+
+  return pr?.currentHeadCiGreenAt ? "green" : "unknown";
+}
+
+export function buildStaleReviewBotRemediation(args: {
+  record: IssueRunRecord;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+}): StaleReviewBotRemediationDto | null {
+  if (args.record.blocked_reason !== "stale_review_bot") {
+    return null;
+  }
+
+  const currentHeadSha = args.pr?.headRefOid ?? args.record.last_head_sha;
+  if (!currentHeadSha) {
+    return null;
+  }
+
+  return {
+    issueNumber: args.record.issue_number,
+    prNumber: args.record.pr_number,
+    reasonCode: "stale_review_bot",
+    currentHeadSha,
+    processedOnCurrentHead: processedOnCurrentHead(args.record),
+    codeCiState: codeCiState(args.pr, args.checks),
+    reviewThreadUrl: args.record.last_failure_context?.url ?? null,
+    manualNextStep: STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
+    summary: STALE_REVIEW_BOT_SUMMARY,
+  };
+}
+
+export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotRemediationDto): string {
+  return [
+    "stale_review_bot_remediation",
+    `issue=#${remediation.issueNumber}`,
+    `pr=${remediation.prNumber === null ? "none" : `#${remediation.prNumber}`}`,
+    `reason=${remediation.reasonCode}`,
+    `code_ci=${remediation.codeCiState}`,
+    `current_head_sha=${formatTokenValue(remediation.currentHeadSha)}`,
+    `processed_on_current_head=${remediation.processedOnCurrentHead}`,
+    `review_thread_url=${remediation.reviewThreadUrl ? formatTokenValue(remediation.reviewThreadUrl) : "none"}`,
+    `manual_next_step=${remediation.manualNextStep}`,
+    `summary=${remediation.summary}`,
+  ].join(" ");
+}

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -25,6 +25,10 @@ import {
   inferReviewBotProfile,
   reviewBotDiagnostics,
 } from "./supervisor-status-review-bot";
+import {
+  buildStaleReviewBotRemediation,
+  formatStaleReviewBotRemediationLine,
+} from "./stale-review-bot-remediation";
 import { buildIssueActivityContext, formatLocalCiStatusLine } from "./supervisor-operator-activity-context";
 import type { IssueRunRecord } from "../core/types";
 import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
@@ -165,6 +169,14 @@ export function buildActiveDetailedStatusLines(
   }
 
   if (pr) {
+    const staleReviewBotRemediation = buildStaleReviewBotRemediation({
+      record: activeRecord,
+      pr,
+      checks,
+    });
+    if (staleReviewBotRemediation) {
+      lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));
+    }
     const reviewBotProfile = inferReviewBotProfile(config);
     const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
     const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -813,6 +813,90 @@ Explain should surface same-head no-actionable configured-bot blockers as stale 
   assert.doesNotMatch(explanation, /^blocked_reason=manual_review$/m);
 });
 
+test("explain surfaces stale configured-bot remediation with the exact review thread", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["coderabbitai", "coderabbitai[bot]"];
+  const issueNumber = 195;
+  const prNumber = 295;
+  const headSha = "head-195";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-1",
+          command: null,
+          details: [
+            "reviewer=coderabbitai[bot] file=src/file.ts line=12 processed_on_current_head=yes",
+          ],
+          url: "https://example.test/pr/295#discussion_r295",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain stale configured bot remediation",
+    body: executionReadyBody("Explain should point operators at the stale configured-bot review thread."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branchName(fixture.config, issueNumber),
+    headRefOid: headSha,
+    currentHeadCiGreenAt: "2026-03-13T00:19:00Z",
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.explainReport(issueNumber);
+  assert.deepEqual(report.staleReviewBotRemediation, {
+    issueNumber,
+    prNumber,
+    reasonCode: "stale_review_bot",
+    currentHeadSha: headSha,
+    processedOnCurrentHead: "yes",
+    codeCiState: "green",
+    reviewThreadUrl: "https://example.test/pr/295#discussion_r295",
+    manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+    summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+  });
+
+  const explanation = await supervisor.explain(issueNumber);
+  assert.match(
+    explanation,
+    /^stale_review_bot_remediation issue=#195 pr=#295 reason=stale_review_bot code_ci=green current_head_sha=head-195 processed_on_current_head=yes review_thread_url=https:\/\/example\.test\/pr\/295#discussion_r295 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+  );
+});
+
 test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.staleConfiguredBotReviewPolicy = "reply_and_resolve";

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -841,6 +841,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
           command: null,
           details: [
             "reviewer=coderabbitai[bot] file=src/file.ts line=12 processed_on_current_head=yes",
+            "reviewer=coderabbitai[bot] file=src/other.ts line=24 processed_on_current_head=no",
           ],
           url: "https://example.test/pr/295#discussion_r295",
           updated_at: "2026-03-13T00:20:00Z",
@@ -883,7 +884,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
     prNumber,
     reasonCode: "stale_review_bot",
     currentHeadSha: headSha,
-    processedOnCurrentHead: "yes",
+    processedOnCurrentHead: "unknown",
     codeCiState: "green",
     reviewThreadUrl: "https://example.test/pr/295#discussion_r295",
     manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
@@ -893,7 +894,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
   const explanation = await supervisor.explain(issueNumber);
   assert.match(
     explanation,
-    /^stale_review_bot_remediation issue=#195 pr=#295 reason=stale_review_bot code_ci=green current_head_sha=head-195 processed_on_current_head=yes review_thread_url=https:\/\/example\.test\/pr\/295#discussion_r295 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+    /^stale_review_bot_remediation issue=#195 pr=#295 reason=stale_review_bot code_ci=green current_head_sha=head-195 processed_on_current_head=unknown review_thread_url=https:\/\/example\.test\/pr\/295#discussion_r295 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -463,6 +463,43 @@ test("renderSupervisorStatusDto maps provider outage diagnostics to an operator 
   );
 });
 
+test("renderSupervisorStatusDto maps stale configured-bot remediation to the root operator action", () => {
+  const status = renderSupervisorStatusDto({
+    gsdSummary: null,
+    candidateDiscovery: null,
+    loopRuntime: {
+      state: "running",
+      hostMode: "tmux",
+      runMode: "macos_tmux_loop",
+      markerPath: "/tmp/locks/supervisor/loop-runtime.lock",
+      configPath: "/tmp/supervisor.config.json",
+      stateFile: "/tmp/state.json",
+      pid: 4242,
+      startedAt: "2026-03-27T00:15:00.000Z",
+      ownershipConfidence: "live_lock",
+      detail: "supervisor-loop-runtime",
+    },
+    activeIssue: null,
+    selectionSummary: null,
+    trackedIssues: [],
+    runnableIssues: [],
+    blockedIssues: [],
+    detailedStatusLines: [
+      "stale_review_bot_remediation issue=#366 pr=#44 reason=stale_review_bot code_ci=green current_head_sha=deadbeef processed_on_current_head=yes review_thread_url=https://example.test/pr/44#discussion_r44 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved",
+    ],
+    reconciliationPhase: null,
+    reconciliationWarning: null,
+    readinessLines: [],
+    whyLines: [],
+    warning: null,
+  });
+
+  assert.match(
+    status,
+    /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation priority=72 summary=Code or CI is green but configured-bot review thread metadata is still unresolved; inspect the exact thread and resolve it or leave a manual note without changing merge policy\.$/m,
+  );
+});
+
 test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
   const status = renderSupervisorStatusDto({
     gsdSummary: null,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -61,6 +61,11 @@ import {
   classifyStaleReviewBotRecoverability,
   recoverabilityStatusToken,
 } from "./stale-diagnostic-recoverability";
+import {
+  buildStaleReviewBotRemediation,
+  formatStaleReviewBotRemediationLine,
+  type StaleReviewBotRemediationDto,
+} from "./stale-review-bot-remediation";
 
 export type ExplainIssueGitHub =
   Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
@@ -84,6 +89,7 @@ export interface SupervisorExplainDto {
   staleRecoveryWarningSummary: string | null;
   activityContext: SupervisorIssueActivityContextDto | null;
   staleDiagnosticSummary?: string | null;
+  staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
   trackedPrRetryabilitySummary?: string | null;
   trackedPrMismatchSummary: string | null;
   externalSignalReadinessSummary?: string | null;
@@ -407,6 +413,14 @@ export async function buildIssueExplainDto(
         return `external_signal_readiness status=${readiness.status} ci=${readiness.ci} review=${readiness.review} workflows=${readiness.workflows}`;
       })()
       : null;
+  const staleReviewBotRemediation =
+    record && pr && !trackedPrHydrationFailed
+      ? buildStaleReviewBotRemediation({
+        record,
+        pr,
+        checks: explainChecks,
+      })
+      : null;
 
   if (matchingSkipPrefix) {
     reasons.push(`skip_title_prefix ${matchingSkipPrefix}`);
@@ -487,6 +501,7 @@ export async function buildIssueExplainDto(
           : ["stale_diagnostic", "kind=stale_review_bot", recoverabilityStatusToken(recoverability)].join(" ");
       })()
       : null,
+    staleReviewBotRemediation,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary
         ? [
@@ -529,6 +544,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(preMergeEvaluationLine ? [preMergeEvaluationLine] : []),
     ...(localCiStatusLine ? [localCiStatusLine] : []),
     ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
+    ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),
     ...(dto.externalSignalReadinessSummary ? [dto.externalSignalReadinessSummary] : []),

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -617,6 +617,48 @@ test("formatDetailedStatus surfaces active review-bot profile and missing extern
   );
 });
 
+test("formatDetailedStatus surfaces stale configured-bot remediation as an explicit operator action", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+  });
+  const status = formatDetailedStatus({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "blocked",
+      blocked_reason: "stale_review_bot",
+      last_head_sha: "deadbeef",
+      last_failure_context: {
+        category: "manual",
+        summary:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        signature: "stalled-bot:thread-1",
+        command: null,
+        details: [
+          "reviewer=coderabbitai[bot] file=src/file.ts line=12 processed_on_current_head=yes",
+        ],
+        url: "https://example.test/pr/44#discussion_r44",
+        updated_at: "2026-03-13T02:10:00Z",
+      },
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr: createPullRequest({
+      number: 44,
+      headRefOid: "deadbeef",
+      currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
+      configuredBotCurrentHeadObservedAt: null,
+    }),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+  });
+
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#366 pr=#44 reason=stale_review_bot code_ci=green current_head_sha=deadbeef processed_on_current_head=yes review_thread_url=https:\/\/example\.test\/pr\/44#discussion_r44 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+  );
+});
+
 test("formatDetailedStatus marks bootstrap repos without workflows as not ready for expected external signals", async (t) => {
   const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-status-bootstrap-"));
   t.after(async () => {


### PR DESCRIPTION
## Summary
- add a typed stale configured-bot remediation model shared by status and explain
- render the exact review thread URL, reason code, current-head processing state, code/CI state, and safest manual next step
- map the remediation line to a root status operator action without changing merge or auto-resolve policy

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/getting-started-docs.test.ts
- npm run build
- git diff --check

Closes #1703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit operator action to resolve stale configured-bot review blocks when CI is green. Status and diagnostics now surface a remediation entry with the review-thread URL, priority, and a suggested manual next step while leaving merge policy unchanged.

* **Documentation**
  * Updated the getting-started guide to document the new operator action and remediation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->