### PR TITLE
Show stale review root blockers in dependency status

### DIFF
--- a/src/issue-metadata/issue-metadata.ts
+++ b/src/issue-metadata/issue-metadata.ts
@@ -43,6 +43,11 @@ export interface BlockingIssue {
   reason: string;
 }
 
+interface DependencyRootBlocker {
+  issue: GitHubIssue;
+  blockedReason: string;
+}
+
 export interface ParentIssueClosureCandidate {
   parentIssue: GitHubIssue;
   childIssues: GitHubIssue[];
@@ -116,7 +121,10 @@ export function findBlockingIssue(
     if (dependencyIssue.state !== "CLOSED") {
       return {
         issue: dependencyIssue,
-        reason: `depends on #${dependencyNumber}`,
+        reason: formatBlockingReasonWithRoot(
+          `depends on #${dependencyNumber}`,
+          findStaleReviewBotDependencyRootBlocker(dependencyIssue, issueByNumber, state),
+        ),
       };
     }
 
@@ -124,7 +132,10 @@ export function findBlockingIssue(
     if (!isRecordDoneForSequencing(dependencyRecord)) {
       return {
         issue: dependencyIssue,
-        reason: `depends on #${dependencyNumber}`,
+        reason: formatBlockingReasonWithRoot(
+          `depends on #${dependencyNumber}`,
+          findStaleReviewBotDependencyRootBlocker(dependencyIssue, issueByNumber, state),
+        ),
       };
     }
   }
@@ -155,7 +166,10 @@ export function findBlockingIssue(
     if (predecessor.issue.state !== "CLOSED") {
       return {
         issue: predecessor.issue,
-        reason: `execution order requires #${predecessor.issue.number} first`,
+        reason: formatBlockingReasonWithRoot(
+          `execution order requires #${predecessor.issue.number} first`,
+          findStaleReviewBotDependencyRootBlocker(predecessor.issue, issueByNumber, state),
+        ),
       };
     }
 
@@ -163,8 +177,99 @@ export function findBlockingIssue(
     if (!isRecordDoneForSequencing(predecessorRecord)) {
       return {
         issue: predecessor.issue,
-        reason: `execution order requires #${predecessor.issue.number} first`,
+        reason: formatBlockingReasonWithRoot(
+          `execution order requires #${predecessor.issue.number} first`,
+          findStaleReviewBotDependencyRootBlocker(predecessor.issue, issueByNumber, state),
+        ),
       };
+    }
+  }
+
+  return null;
+}
+
+function formatBlockingReasonWithRoot(reason: string, rootBlocker: DependencyRootBlocker | null): string {
+  if (rootBlocker === null) {
+    return reason;
+  }
+
+  return `${reason} root_blocker=#${rootBlocker.issue.number} blocked_reason=${rootBlocker.blockedReason}`;
+}
+
+function findStaleReviewBotDependencyRootBlocker(
+  issue: GitHubIssue,
+  issueByNumber: Map<number, GitHubIssue>,
+  state: SupervisorStateFile,
+  visited = new Set<number>(),
+): DependencyRootBlocker | null {
+  if (visited.has(issue.number)) {
+    return null;
+  }
+  visited.add(issue.number);
+
+  const record = state.issues[String(issue.number)];
+  if (record?.state === "blocked" && record.blocked_reason === "stale_review_bot") {
+    return {
+      issue,
+      blockedReason: record.blocked_reason,
+    };
+  }
+
+  const metadata = parseIssueMetadata(issue);
+  for (const dependencyNumber of metadata.dependsOn) {
+    const dependencyIssue = issueByNumber.get(dependencyNumber);
+    if (!dependencyIssue) {
+      continue;
+    }
+
+    const dependencyRecord = state.issues[String(dependencyNumber)];
+    if (dependencyIssue.state !== "CLOSED" || !isRecordDoneForSequencing(dependencyRecord)) {
+      const dependencyRoot = findStaleReviewBotDependencyRootBlocker(
+        dependencyIssue,
+        issueByNumber,
+        state,
+        visited,
+      );
+      if (dependencyRoot) {
+        return dependencyRoot;
+      }
+    }
+  }
+
+  if (!metadata.parentIssueNumber || !metadata.executionOrderIndex || metadata.executionOrderIndex <= 1) {
+    return null;
+  }
+
+  const predecessors = [...issueByNumber.values()]
+    .filter((candidate) => candidate.number !== issue.number)
+    .map((candidate) => ({
+      issue: candidate,
+      metadata: parseIssueMetadata(candidate),
+    }))
+    .filter(
+      ({ metadata: candidateMetadata }) =>
+        candidateMetadata.parentIssueNumber === metadata.parentIssueNumber &&
+        candidateMetadata.executionOrderIndex !== null &&
+        candidateMetadata.executionOrderIndex < metadata.executionOrderIndex!,
+    )
+    .sort((left, right) => {
+      const leftIndex = left.metadata.executionOrderIndex ?? Number.MAX_SAFE_INTEGER;
+      const rightIndex = right.metadata.executionOrderIndex ?? Number.MAX_SAFE_INTEGER;
+      return leftIndex - rightIndex;
+    });
+
+  for (const predecessor of predecessors) {
+    const predecessorRecord = state.issues[String(predecessor.issue.number)];
+    if (predecessor.issue.state !== "CLOSED" || !isRecordDoneForSequencing(predecessorRecord)) {
+      const predecessorRoot = findStaleReviewBotDependencyRootBlocker(
+        predecessor.issue,
+        issueByNumber,
+        state,
+        visited,
+      );
+      if (predecessorRoot) {
+        return predecessorRoot;
+      }
     }
   }
 

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -1327,7 +1327,11 @@ Parallelizable: No
   };
   const issues = [rootIssue, firstDependent, secondDependent];
   const github = {
-    getIssue: async (issueNumber: number) => issues.find((issue) => issue.number === issueNumber) ?? rootIssue,
+    getIssue: async (issueNumber: number) => {
+      const found = issues.find((issue) => issue.number === issueNumber);
+      assert.ok(found, `Unexpected issue lookup in test fixture: ${issueNumber}`);
+      return found;
+    },
     listAllIssues: async () => issues,
     listCandidateIssues: async () => [firstDependent, secondDependent],
     resolvePullRequestForBranch: async () => createPullRequest({

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -1243,3 +1243,117 @@ test("buildIssueExplainDto reports local-review-blocked external readiness for d
     "external_signal_readiness status=blocked_by_local_review ci=passing review=local_review_blocked workflows=absent",
   );
 });
+
+test("buildIssueExplainDto reports dependency root blockers for stale configured-bot predecessors", async () => {
+  const fixture = await createSupervisorFixture();
+  const rootIssue = createIssue({
+    number: 1695,
+    title: "Refresh configured-bot metadata",
+    body: `## Summary
+Clear stale configured-bot metadata before later issues run.
+
+## Scope
+- keep the stale review-bot predecessor blocked
+
+## Acceptance criteria
+- explain shows actionable remediation on the predecessor
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const firstDependent = createIssue({
+    number: 1696,
+    title: "Use fresh configured-bot metadata",
+    body: `## Summary
+Run after the configured-bot metadata blocker clears.
+
+## Scope
+- depend on the stale review-bot predecessor
+
+## Acceptance criteria
+- explain shows the dependency root blocker
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: #1695
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const secondDependent = createIssue({
+    number: 1697,
+    title: "Run after the dependent issue",
+    body: `## Summary
+Run after the dependent configured-bot metadata issue.
+
+## Scope
+- depend on the chained predecessor
+
+## Acceptance criteria
+- explain shows the dependency root blocker through the chain
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: #1696
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "1695": createRecord({
+        issue_number: 1695,
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        branch: branchName(fixture.config, 1695),
+        workspace: path.join(fixture.workspaceRoot, "issue-1695"),
+        pr_number: 95,
+        last_head_sha: "head-1695",
+        last_stale_review_bot_reply_head_sha: "head-1695",
+        last_stale_review_bot_reply_signature: "stale-configured-bot-review",
+      }),
+    },
+  };
+  const issues = [rootIssue, firstDependent, secondDependent];
+  const github = {
+    getIssue: async (issueNumber: number) => issues.find((issue) => issue.number === issueNumber) ?? rootIssue,
+    listAllIssues: async () => issues,
+    listCandidateIssues: async () => [firstDependent, secondDependent],
+    resolvePullRequestForBranch: async () => createPullRequest({
+      number: 95,
+      headRefName: branchName(fixture.config, 1695),
+      headRefOid: "head-1695",
+      currentHeadCiGreenAt: "2026-04-25T00:10:00Z",
+    }),
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const rootRendered = renderIssueExplainDto(
+    await buildIssueExplainDto(github, fixture.config, state, 1695),
+  );
+  assert.match(
+    rootRendered,
+    /^stale_review_bot_remediation issue=#1695 pr=#95 reason=stale_review_bot code_ci=green current_head_sha=head-1695 .*manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note/m,
+  );
+
+  const dependentRendered = renderIssueExplainDto(
+    await buildIssueExplainDto(github, fixture.config, state, 1697),
+  );
+
+  assert.match(
+    dependentRendered,
+    /^reason_1=dependency depends on #1696 root_blocker=#1695 blocked_reason=stale_review_bot$/m,
+  );
+});

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -5,7 +5,8 @@ import path from "node:path";
 import test from "node:test";
 import { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
 import { buildDetailedStatusSummaryLines } from "./supervisor-status-model";
-import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig } from "../core/types";
+import { buildReadinessSummary } from "./supervisor-selection-readiness-summary";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -59,6 +60,123 @@ function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConf
     ...overrides,
   };
 }
+
+function createExecutionReadyIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  const number = overrides.number ?? 1695;
+  return {
+    number,
+    title: `Issue ${number}`,
+    body: `## Summary
+Keep the issue execution-ready.
+
+## Scope
+- preserve the focused test fixture
+
+## Acceptance criteria
+- status explains dependency readiness
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-status-rendering-supervisor.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+    createdAt: "2026-04-25T00:00:00Z",
+    updatedAt: "2026-04-25T00:00:00Z",
+    url: `https://example.test/issues/${number}`,
+    state: "OPEN",
+    labels: [],
+    ...overrides,
+  };
+}
+
+test("status readiness shows stale-review root blockers through dependency chains", async () => {
+  const config = createConfig();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      "1695": createRecord({
+        issue_number: 1695,
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+      }),
+    },
+  };
+  const staleRoot = createExecutionReadyIssue({
+    number: 1695,
+    title: "Refresh configured-bot metadata",
+  });
+  const firstDependent = createExecutionReadyIssue({
+    number: 1696,
+    title: "Use fresh configured-bot metadata",
+    body: `## Summary
+Run only after the configured-bot metadata blocker clears.
+
+## Scope
+- depend on the stale review-bot predecessor
+
+## Acceptance criteria
+- status shows the dependency root blocker
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-status-rendering-supervisor.test.ts
+
+Depends on: #1695
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const secondDependent = createExecutionReadyIssue({
+    number: 1697,
+    title: "Run after the dependent issue",
+    body: `## Summary
+Run only after the previous dependent issue clears.
+
+## Scope
+- depend on the chained predecessor
+
+## Acceptance criteria
+- status shows the dependency root blocker through the chain
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-status-rendering-supervisor.test.ts
+
+Depends on: #1696
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+
+  const summary = await buildReadinessSummary(
+    {
+      listCandidateIssues: async () => [firstDependent, secondDependent],
+      listAllIssues: async () => [staleRoot, firstDependent, secondDependent],
+    },
+    config,
+    state,
+  );
+
+  assert.deepEqual(summary.blockedIssues, [
+    {
+      issueNumber: 1696,
+      title: "Use fresh configured-bot metadata",
+      blockedBy: "depends on #1695 root_blocker=#1695 blocked_reason=stale_review_bot",
+    },
+    {
+      issueNumber: 1697,
+      title: "Run after the dependent issue",
+      blockedBy: "depends on #1696 root_blocker=#1695 blocked_reason=stale_review_bot",
+    },
+  ]);
+  assert.match(
+    summary.readinessLines.join("\n"),
+    /blocked_issues=#1696 blocked_by=depends on #1695 root_blocker=#1695 blocked_reason=stale_review_bot; #1697 blocked_by=depends on #1696 root_blocker=#1695 blocked_reason=stale_review_bot/,
+  );
+});
 
 function createRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
   return {


### PR DESCRIPTION
## Summary
- annotate dependency blockers with stale configured-bot root blockers in status/explain output
- keep immediate blocker and issue selection semantics unchanged
- add focused chain coverage for status readiness and issue explain

## Verification
- npx tsx --test src/supervisor/supervisor-status-rendering-supervisor.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts
- npm run build

Closes #1704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced blocking issue reasons to include root blocker identification and dependency chain provenance information.

* **Tests**
  * Added test coverage for dependency-root blocker detection in chained issue scenarios.
  * Added test coverage for status readiness reporting across blocked dependency chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->