### PR TITLE
Classify handled stale configured-bot metadata

### DIFF
--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -100,6 +100,7 @@ function classifyRemediation(args: {
     configuredThreads.length === 0 ||
     manualReviewThreads(config, reviewThreads).length > 0 ||
     record.last_head_sha !== pr.headRefOid ||
+    !pr.configuredBotCurrentHeadObservedAt ||
     pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
     !allChecksPassing(checks) ||
     !hasCleanMergeState(pr) ||

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -1,4 +1,11 @@
-import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck } from "../core/types";
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
+import { hasProcessedReviewThread } from "../review-handling";
+import {
+  configuredBotReviewFollowUpState,
+  configuredBotReviewThreads,
+  manualReviewThreads,
+  pendingBotReviewThreads,
+} from "../review-thread-reporting";
 
 export interface StaleReviewBotRemediationDto {
   issueNumber: number;
@@ -7,6 +14,7 @@ export interface StaleReviewBotRemediationDto {
   currentHeadSha: string;
   processedOnCurrentHead: "yes" | "no" | "unknown";
   codeCiState: "green" | "not_green" | "unknown";
+  classification: "metadata_only" | "unresolved_work";
   reviewThreadUrl: string | null;
   manualNextStep: string;
   summary: string;
@@ -16,6 +24,8 @@ const STALE_REVIEW_BOT_MANUAL_NEXT_STEP =
   "inspect_exact_review_thread_then_resolve_or_leave_manual_note";
 const STALE_REVIEW_BOT_SUMMARY =
   "code_or_ci_green_but_review_thread_metadata_unresolved";
+const STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY =
+  "stale_configured_bot_thread_metadata_only";
 
 function formatTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
@@ -61,10 +71,57 @@ function codeCiState(
   return pr?.currentHeadCiGreenAt ? "green" : "unknown";
 }
 
-export function buildStaleReviewBotRemediation(args: {
+function allChecksPassing(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
+  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+}
+
+function hasCleanMergeState(pr: GitHubPullRequest): boolean {
+  return pr.state === "OPEN" && !pr.isDraft && pr.mergeStateStatus === "CLEAN" && pr.mergeable === "MERGEABLE";
+}
+
+function classifyRemediation(args: {
+  config: SupervisorConfig | null;
   record: IssueRunRecord;
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): Pick<StaleReviewBotRemediationDto, "classification" | "summary"> {
+  const unresolvedWork = {
+    classification: "unresolved_work" as const,
+    summary: STALE_REVIEW_BOT_SUMMARY,
+  };
+  if (!args.config || !args.pr) {
+    return unresolvedWork;
+  }
+
+  const { config, record, pr, checks, reviewThreads } = args;
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  if (
+    configuredThreads.length === 0 ||
+    manualReviewThreads(config, reviewThreads).length > 0 ||
+    record.last_head_sha !== pr.headRefOid ||
+    pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
+    !allChecksPassing(checks) ||
+    !hasCleanMergeState(pr) ||
+    pendingBotReviewThreads(config, record, pr, configuredThreads).length > 0 ||
+    configuredBotReviewFollowUpState(config, record, pr, configuredThreads) === "eligible" ||
+    !configuredThreads.every((thread) => hasProcessedReviewThread(record, pr, thread))
+  ) {
+    return unresolvedWork;
+  }
+
+  return {
+    classification: "metadata_only",
+    summary: STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY,
+  };
+}
+
+export function buildStaleReviewBotRemediation(args: {
+  config?: SupervisorConfig | null;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads?: ReviewThread[];
 }): StaleReviewBotRemediationDto | null {
   if (args.record.blocked_reason !== "stale_review_bot") {
     return null;
@@ -74,6 +131,13 @@ export function buildStaleReviewBotRemediation(args: {
   if (!currentHeadSha) {
     return null;
   }
+  const classification = classifyRemediation({
+    config: args.config ?? null,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads ?? [],
+  });
 
   return {
     issueNumber: args.record.issue_number,
@@ -82,9 +146,10 @@ export function buildStaleReviewBotRemediation(args: {
     currentHeadSha,
     processedOnCurrentHead: processedOnCurrentHead(args.record),
     codeCiState: codeCiState(args.pr, args.checks),
+    classification: classification.classification,
     reviewThreadUrl: args.record.last_failure_context?.url ?? null,
     manualNextStep: STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
-    summary: STALE_REVIEW_BOT_SUMMARY,
+    summary: classification.summary,
   };
 }
 
@@ -97,6 +162,7 @@ export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotR
     `code_ci=${remediation.codeCiState}`,
     `current_head_sha=${formatTokenValue(remediation.currentHeadSha)}`,
     `processed_on_current_head=${remediation.processedOnCurrentHead}`,
+    `classification=${remediation.classification}`,
     `review_thread_url=${remediation.reviewThreadUrl ? formatTokenValue(remediation.reviewThreadUrl) : "none"}`,
     `manual_next_step=${remediation.manualNextStep}`,
     `summary=${remediation.summary}`,

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -886,6 +886,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
     currentHeadSha: headSha,
     processedOnCurrentHead: "unknown",
     codeCiState: "green",
+    classification: "unresolved_work",
     reviewThreadUrl: "https://example.test/pr/295#discussion_r295",
     manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
     summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
@@ -894,7 +895,105 @@ test("explain surfaces stale configured-bot remediation with the exact review th
   const explanation = await supervisor.explain(issueNumber);
   assert.match(
     explanation,
-    /^stale_review_bot_remediation issue=#195 pr=#295 reason=stale_review_bot code_ci=green current_head_sha=head-195 processed_on_current_head=unknown review_thread_url=https:\/\/example\.test\/pr\/295#discussion_r295 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+    /^stale_review_bot_remediation issue=#195 pr=#295 reason=stale_review_bot code_ci=green current_head_sha=head-195 processed_on_current_head=unknown classification=unresolved_work review_thread_url=https:\/\/example\.test\/pr\/295#discussion_r295 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+  );
+});
+
+test("explain classifies handled stale configured-bot review threads as metadata-only", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["coderabbitai", "coderabbitai[bot]"];
+  const issueNumber = 196;
+  const prNumber = 296;
+  const headSha = "head-196";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-1@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-1@${headSha}#comment-1`],
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-1",
+          command: null,
+          details: ["reviewer=coderabbitai[bot] file=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/296#discussion_r296",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain handled stale configured bot metadata",
+    body: executionReadyBody("Explain should identify stale configured-bot provider metadata drift."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branchName(fixture.config, issueNumber),
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-03-13T00:19:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    currentHeadCiGreenAt: "2026-03-13T00:19:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const staleMetadataThread = {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this stale finding.",
+          createdAt: "2026-03-13T00:05:00Z",
+          url: "https://example.test/pr/296#discussion_r296",
+          author: {
+            login: "coderabbitai[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleMetadataThread],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^blocked_reason=stale_review_bot$/m);
+  assert.match(
+    explanation,
+    /^stale_review_bot_remediation issue=#196 pr=#296 reason=stale_review_bot code_ci=green current_head_sha=head-196 processed_on_current_head=yes classification=metadata_only review_thread_url=https:\/\/example\.test\/pr\/296#discussion_r296 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -997,6 +997,104 @@ test("explain classifies handled stale configured-bot review threads as metadata
   );
 });
 
+test("explain keeps configured-bot success without current-head observation as unresolved work", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["coderabbitai", "coderabbitai[bot]"];
+  const issueNumber = 197;
+  const prNumber = 297;
+  const headSha = "head-197";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-1@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-1@${headSha}#comment-1`],
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-1",
+          command: null,
+          details: ["reviewer=coderabbitai[bot] file=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/297#discussion_r297",
+          updated_at: "2026-03-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain unobserved configured bot success",
+    body: executionReadyBody("Explain should require observed current-head configured-bot evidence."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branchName(fixture.config, issueNumber),
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    currentHeadCiGreenAt: "2026-03-13T00:19:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const staleMetadataThread = {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this stale finding.",
+          createdAt: "2026-03-13T00:05:00Z",
+          url: "https://example.test/pr/297#discussion_r297",
+          author: {
+            login: "coderabbitai[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleMetadataThread],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^stale_review_bot_remediation issue=#197 pr=#297 reason=stale_review_bot code_ci=green current_head_sha=head-197 processed_on_current_head=yes classification=unresolved_work review_thread_url=https:\/\/example\.test\/pr\/297#discussion_r297 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+  );
+  assert.doesNotMatch(explanation, /classification=metadata_only/m);
+});
+
 test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.staleConfiguredBotReviewPolicy = "reply_and_resolve";

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -485,7 +485,7 @@ test("renderSupervisorStatusDto maps stale configured-bot remediation to the roo
     runnableIssues: [],
     blockedIssues: [],
     detailedStatusLines: [
-      "stale_review_bot_remediation issue=#366 pr=#44 reason=stale_review_bot code_ci=green current_head_sha=deadbeef processed_on_current_head=yes review_thread_url=https://example.test/pr/44#discussion_r44 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved",
+      "stale_review_bot_remediation issue=#366 pr=#44 reason=stale_review_bot code_ci=green current_head_sha=deadbeef processed_on_current_head=yes classification=unresolved_work review_thread_url=https://example.test/pr/44#discussion_r44 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved",
     ],
     reconciliationPhase: null,
     reconciliationWarning: null,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -416,9 +416,11 @@ export async function buildIssueExplainDto(
   const staleReviewBotRemediation =
     record && pr && !trackedPrHydrationFailed
       ? buildStaleReviewBotRemediation({
+        config,
         record,
         pr,
         checks: explainChecks,
+        reviewThreads: explainReviewThreads,
       })
       : null;
 

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -773,7 +773,7 @@ test("formatDetailedStatus surfaces stale configured-bot remediation as an expli
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#366 pr=#44 reason=stale_review_bot code_ci=green current_head_sha=deadbeef processed_on_current_head=yes review_thread_url=https:\/\/example\.test\/pr\/44#discussion_r44 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+    /^stale_review_bot_remediation issue=#366 pr=#44 reason=stale_review_bot code_ci=green current_head_sha=deadbeef processed_on_current_head=yes classification=unresolved_work review_thread_url=https:\/\/example\.test\/pr\/44#discussion_r44 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
   );
 });
 


### PR DESCRIPTION
## Summary
- add metadata-only vs unresolved-work classification to stale configured-bot remediation diagnostics
- require conservative current-head evidence before reporting metadata-only drift
- keep stale_review_bot blocking behavior unchanged

## Verification
- npx tsx --test src/review-thread-reporting.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build

Part of #1705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Remediation output now includes a classification (metadata_only | unresolved_work) for clearer remediation categorization.
  * Remediation logic uses additional contextual inputs to distinguish metadata-only cases from unresolved work, improving accuracy of displayed remediation status.

* **Tests**
  * Updated and added tests to validate both classification outcomes and updated status/detailed rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->