### PR TITLE
Retry repairable ready-promotion path hygiene blockers

### DIFF
--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -87,7 +87,10 @@ test("runTrackedPrReadyLocalCiPublicationGate blocks ready promotion on local CI
   assert.equal(result.record.latest_local_ci_result?.failure_class, "non_zero_exit");
   assert.equal(result.record.last_observed_host_local_pr_blocker_signature, "local-ci-gate-non_zero_exit");
   assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, "head-116");
-  assert.equal(result.record.last_host_local_pr_blocker_comment_signature, "local-ci-gate-non_zero_exit");
+  assert.equal(
+    result.record.last_host_local_pr_blocker_comment_signature,
+    "local-ci-gate-non_zero_exit|gate=local_ci|failure=non_zero_exit|target=repo_owned_command",
+  );
   assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, "head-116");
   assert.match(
     comments[0] ?? "",

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1720,6 +1720,107 @@ test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion 
   assert.match(result.record.last_failure_context?.details[0] ?? "", /docs\/guide\.md:1/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase routes repairable ready-promotion path hygiene blockers into a repair turn", async () => {
+  const config = createConfig({ localCiCommand: "npm run ci:local" });
+  const issue = createIssue({ title: "Repair ready promotion path hygiene" });
+  const draftPr = createPullRequest({ title: "Repair ready promotion", isDraft: true });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+  };
+
+  let readyCalls = 0;
+  let syncJournalCalls = 0;
+  let localCiCalls = 0;
+  const commentBodies: string[] = [];
+  const failureDetails = [
+    `scripts/check-paths.sh:4 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`,
+    `docs/guide.md:7 matched /${"Users"}/ via "${SAMPLE_MACOS_WORKSTATION_PATH}"`,
+  ];
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch, updated_at: record.updated_at }),
+      save: async () => undefined,
+    },
+    github: {
+      getPullRequest: async () => {
+        throw new Error("unexpected getPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      markPullRequestReady: async () => {
+        readyCalls += 1;
+      },
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    },
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      syncJournal: async () => {
+        syncJournalCalls += 1;
+      },
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => createLifecycleSnapshot(record, "draft_pr"),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => {
+      localCiCalls += 1;
+    },
+    runWorkstationLocalPathGate: async () => ({
+      ok: false,
+      failureContext: {
+        ...createFailureContext(
+          "Tracked durable artifacts failed workstation-local path hygiene before marking PR #116 ready. Edit tracked publishable content to remove workstation-local paths. First fix: scripts/check-paths.sh (1 match, unix_home); docs/guide.md (1 match, macos_home).",
+        ),
+        signature: "workstation-local-path-hygiene-failed",
+        command: "npm run verify:paths",
+        details: failureDetails,
+      },
+      actionablePublishableFilePaths: ["docs/guide.md", "scripts/check-paths.sh"],
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [],
+      reviewThreads: [] satisfies ReviewThread[],
+    }),
+  });
+
+  assert.equal(readyCalls, 0);
+  assert.equal(localCiCalls, 0);
+  assert.equal(syncJournalCalls, 2);
+  assert.equal(result.record.state, "repairing_ci");
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(result.record.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.match(result.record.last_error ?? "", /will retry a repair turn/i);
+  assert.deepEqual(result.record.last_failure_context?.details, failureDetails);
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /automatic retry: yes/i);
+  assert.match(commentBodies[0] ?? "", /next action: supervisor will retry a repair turn/i);
+  assert.match(commentBodies[0] ?? "", /scripts\/check-paths\.sh/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase forwards publishable allowlist markers to the path hygiene gate", async () => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   const currentJournalPath = path.join(workspacePath, ".codex-supervisor", "issues", "102", "issue-journal.md");

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1024,7 +1024,8 @@ test("handlePostTurnPullRequestTransitionsPhase dedupes tracked PR host-local bl
         state: "draft_pr",
         pr_number: draftPr.number,
         last_host_local_pr_blocker_comment_head_sha: "head-116",
-        last_host_local_pr_blocker_comment_signature: "workspace-preparation-gate-workspace_toolchain_missing",
+        last_host_local_pr_blocker_comment_signature:
+          "workspace-preparation-gate-workspace_toolchain_missing|gate=workspace_preparation|failure=workspace_toolchain_missing|target=workspace_environment",
       }),
     },
   };
@@ -1514,7 +1515,7 @@ test("handlePostTurnPullRequestTransitionsPhase updates the owned tracked PR hos
   assert.equal(result.record.last_host_local_pr_blocker_comment_head_sha, draftPr.headRefOid);
   assert.equal(
     result.record.last_host_local_pr_blocker_comment_signature,
-    "workspace-preparation-gate-workspace_toolchain_missing",
+    "workspace-preparation-gate-workspace_toolchain_missing|gate=workspace_preparation|failure=workspace_toolchain_missing|target=workspace_environment",
   );
 });
 
@@ -1726,7 +1727,14 @@ test("handlePostTurnPullRequestTransitionsPhase routes repairable ready-promotio
   const draftPr = createPullRequest({ title: "Repair ready promotion", isDraft: true });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
-    issues: { "102": createRecord({ state: "draft_pr", pr_number: draftPr.number }) },
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: draftPr.number,
+        last_host_local_pr_blocker_comment_head_sha: draftPr.headRefOid,
+        last_host_local_pr_blocker_comment_signature: "workstation-local-path-hygiene-failed",
+      }),
+    },
   };
 
   let readyCalls = 0;
@@ -1813,6 +1821,10 @@ test("handlePostTurnPullRequestTransitionsPhase routes repairable ready-promotio
   assert.equal(result.record.state, "repairing_ci");
   assert.equal(result.record.blocked_reason, null);
   assert.equal(result.record.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(
+    result.record.last_host_local_pr_blocker_comment_signature,
+    "workstation-local-path-hygiene-failed|gate=workstation_local_path_hygiene|failure=workstation-local-path-hygiene-failed|target=workspace_contents_repairable",
+  );
   assert.match(result.record.last_error ?? "", /will retry a repair turn/i);
   assert.deepEqual(result.record.last_failure_context?.details, failureDetails);
   assert.equal(commentBodies.length, 1);
@@ -2054,7 +2066,10 @@ test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-l
   assert.equal(firstResult.record.state, "blocked");
   assert.equal(commentBodies.length, 1);
   assert.equal(firstResult.record.last_host_local_pr_blocker_comment_head_sha, draftPr.headRefOid);
-  assert.equal(firstResult.record.last_host_local_pr_blocker_comment_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(
+    firstResult.record.last_host_local_pr_blocker_comment_signature,
+    "workstation-local-path-hygiene-failed|gate=workstation_local_path_hygiene|failure=workstation-local-path-hygiene-failed|target=workspace_contents",
+  );
   assert.match(commentBodies[0] ?? "", /still draft because ready-for-review promotion is blocked locally/i);
   assert.match(commentBodies[0] ?? "", /gate name: `workstation_local_path_hygiene`/i);
   assert.match(commentBodies[0] ?? "", /First fix: docs\/guide\.md/i);

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -90,6 +90,8 @@ export interface PullRequestLifecycleSnapshot {
 }
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
+const READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY =
+  "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready.";
 
 function staleConfiguredBotThreadIdsFromSignature(signature: string | null | undefined): string[] {
   if (!signature) {
@@ -533,6 +535,48 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     });
     if (!pathHygieneGate.ok) {
       const failureContext = pathHygieneGate.failureContext;
+      const actionablePublishableFilePaths = pathHygieneGate.actionablePublishableFilePaths ?? [];
+      if (failureContext !== null && actionablePublishableFilePaths.length > 0) {
+        const repairFailureContext: FailureContext = {
+          ...failureContext,
+          summary: `${READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY} Actionable files: ${actionablePublishableFilePaths.join(", ")}. ${failureContext.summary}`,
+        };
+        record = stateStore.touch(record, {
+          state: "repairing_ci",
+          last_error: truncate(repairFailureContext.summary, 1000),
+          last_failure_kind: null,
+          last_failure_context: repairFailureContext,
+          ...args.applyFailureSignature(record, repairFailureContext),
+          blocked_reason: null,
+          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+            pr: refreshed.pr,
+            blockerSignature: repairFailureContext.signature,
+          }),
+        });
+        state.issues[String(record.issue_number)] = record;
+        await stateStore.save(state);
+        await syncJournal(record);
+        record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
+          github,
+          stateStore,
+          state,
+          record,
+          pr: refreshed.pr,
+          syncJournal,
+          gateType: "workstation_local_path_hygiene",
+          blockerSignature: repairFailureContext.signature,
+          failureClass: repairFailureContext.signature,
+          remediationTarget: "workspace_contents_repairable",
+          summary: repairFailureContext.summary,
+          details: repairFailureContext.details,
+        });
+        return {
+          record,
+          pr: refreshed.pr,
+          checks: refreshed.checks,
+          reviewThreads: refreshed.reviewThreads,
+        };
+      }
       record = stateStore.touch(record, {
         state: "blocked",
         last_error: truncate(

--- a/src/supervisor/stale-diagnostic-recoverability.ts
+++ b/src/supervisor/stale-diagnostic-recoverability.ts
@@ -5,6 +5,7 @@ import { shouldAutoRecoverStaleReviewBot } from "./supervisor-execution-policy";
 export type StaleDiagnosticRecoverability =
   | "stale_but_recoverable"
   | "stale_already_handled"
+  | "repair_queued"
   | "manual_attention_required"
   | "provider_outage_suspected";
 

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1482,6 +1482,82 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
   );
 });
 
+test("explain distinguishes repairable ready-promotion path hygiene blockers queued for repair", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 178;
+  const prNumber = 278;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "repairing_ci",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: null,
+        last_error:
+          "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: scripts/check-paths.sh.",
+        last_head_sha: "head-draft-278",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_failure_context: {
+          category: "blocked",
+          summary:
+            "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: scripts/check-paths.sh.",
+          signature: "workstation-local-path-hygiene-failed",
+          command: "npm run verify:paths",
+          details: [`scripts/check-paths.sh:4 matched /${"home"}/placeholder via "<workspace-root>"`],
+          url: null,
+          updated_at: "2026-03-13T00:10:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked repairable draft PR ready gate",
+    body: executionReadyBody("Explain should surface repairable draft PR ready-promotion blockers."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-draft-278",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+  assert.match(
+    explanation,
+    /^tracked_pr_ready_promotion_blocked issue=#178 pr=#278 recoverability=repair_queued github_state=draft_pr local_state=repairing_ci local_blocked_reason=none stale_local_blocker=no$/m,
+  );
+  assert.match(
+    explanation,
+    /^recovery_guidance=PR #278 is still draft because ready-for-review promotion found repairable workstation-local path hygiene findings\. The supervisor has queued a repair turn for the actionable publishable tracked files before retrying promotion\.$/m,
+  );
+});
+
 test("explain reports bootstrap repos as not ready for expected CI and review signals", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 181;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3560,6 +3560,81 @@ test("status keeps same-head host-local ready-promotion blockers current when th
   );
 });
 
+test("status distinguishes repairable ready-promotion path hygiene blockers queued for repair", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 178;
+  const prNumber = 278;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "repairing_ci",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: null,
+        last_error:
+          "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: scripts/check-paths.sh.",
+        last_head_sha: "head-draft-278",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_failure_context: {
+          category: "blocked",
+          summary:
+            "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: scripts/check-paths.sh.",
+          signature: "workstation-local-path-hygiene-failed",
+          command: "npm run verify:paths",
+          details: [`scripts/check-paths.sh:4 matched /${"home"}/placeholder via "<workspace-root>"`],
+          url: null,
+          updated_at: "2026-03-13T00:10:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked repairable draft PR ready gate",
+    body: executionReadyBody("Surface repairable draft PR ready-promotion blockers."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-draft-278",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status();
+  assert.match(
+    status,
+    /^tracked_pr_ready_promotion_blocked issue=#178 pr=#278 recoverability=repair_queued github_state=draft_pr local_state=repairing_ci local_blocked_reason=none stale_local_blocker=no$/m,
+  );
+  assert.match(
+    status,
+    /^recovery_guidance=PR #278 is still draft because ready-for-review promotion found repairable workstation-local path hygiene findings\. The supervisor has queued a repair turn for the actionable publishable tracked files before retrying promotion\.$/m,
+  );
+});
+
 test("status surfaces host-local CI blocker details for tracked PR mismatches", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -244,6 +244,40 @@ export function buildTrackedPrMismatch(
   });
   const githubState = projection.nextState;
   const githubBlockedReason = projection.nextBlockedReason;
+
+  if (
+    record.state === "repairing_ci" &&
+    record.last_failure_signature === "workstation-local-path-hygiene-failed" &&
+    githubState === "draft_pr" &&
+    pr.isDraft
+  ) {
+    const readyPromotionGate = readyPromotionGateSummary(config, record, pr, checks);
+    return {
+      issueNumber: record.issue_number,
+      prNumber: pr.number,
+      githubState,
+      githubBlockedReason,
+      localState: record.state,
+      localBlockedReason: record.blocked_reason,
+      staleLocalBlocker: false,
+      recoverability: "repair_queued",
+      summaryLine: [
+        "tracked_pr_ready_promotion_blocked",
+        `issue=#${record.issue_number}`,
+        `pr=#${pr.number}`,
+        recoverabilityStatusToken("repair_queued"),
+        `github_state=${githubState}`,
+        `local_state=${record.state}`,
+        `local_blocked_reason=${record.blocked_reason ?? "none"}`,
+        "stale_local_blocker=no",
+      ].join(" "),
+      guidanceLine:
+        `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion found repairable workstation-local path hygiene findings. ` +
+        "The supervisor has queued a repair turn for the actionable publishable tracked files before retrying promotion.",
+      detailLines: readyPromotionGate.detailLines,
+    };
+  }
+
   const mismatch =
     isBlockedLikeState(record.state) &&
     (githubState !== record.state || (githubState === "blocked" && githubBlockedReason !== record.blocked_reason));

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -146,11 +146,13 @@ function summarizeWorkstationLocalPathFirstFix(details: string[] | null | undefi
 function buildTrackedPrReadyPromotionPathHygieneComment(args: {
   pr: Pick<GitHubPullRequest, "headRefOid">;
   blockerSignature: string;
+  remediationTarget: string | null;
   summary: string;
   details?: string[] | null;
 }): string {
   const firstFix = summarizeWorkstationLocalPathFirstFix(args.details);
   const conciseSummary = args.summary.replace(/\s+First fix:.*$/i, "").trim();
+  const repairable = args.remediationTarget === "workspace_contents_repairable";
   return [
     `Tracked PR head \`${args.pr.headRefOid}\` is still draft because ready-for-review promotion is blocked locally.`,
     "",
@@ -159,8 +161,10 @@ function buildTrackedPrReadyPromotionPathHygieneComment(args: {
     `- blocker signature: \`${args.blockerSignature}\``,
     `- what failed: ${conciseSummary}`,
     ...(firstFix ? [`- ${firstFix}`] : []),
-    "- automatic retry: no",
-    "- rerunning the supervisor alone will not help yet; fix the tracked workspace artifacts first, then rerun promotion.",
+    `- automatic retry: ${repairable ? "yes" : "no"}`,
+    repairable
+      ? "- next action: supervisor will retry a repair turn with these actionable publishable files, then re-run ready-for-review promotion."
+      : "- rerunning the supervisor alone will not help yet; fix the tracked workspace artifacts first, then rerun promotion.",
     "",
     "GitHub checks may still be green because this blocker is host-local to the supervisor workspace.",
   ].join("\n");

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -174,6 +174,20 @@ function trackedPrReadyPromotionBlockedReasonCode(gateType: HostLocalTrackedPrBl
   return `ready_promotion_blocked_${gateType}`;
 }
 
+function trackedPrHostLocalBlockerCommentSignature(args: {
+  gateType: HostLocalTrackedPrBlockerGateType;
+  blockerSignature: string;
+  failureClass: string;
+  remediationTarget: string;
+}): string {
+  return [
+    args.blockerSignature,
+    `gate=${args.gateType}`,
+    `failure=${args.failureClass}`,
+    `target=${args.remediationTarget}`,
+  ].join("|");
+}
+
 function buildTrackedPrDraftReviewSuppressedComment(args: {
   pr: Pick<GitHubPullRequest, "headRefOid" | "number">;
 }): string {
@@ -655,10 +669,16 @@ export async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
   if (!args.blockerSignature || !args.failureClass || !args.remediationTarget || !args.summary) {
     return args.record;
   }
+  const blockerCommentSignature = trackedPrHostLocalBlockerCommentSignature({
+    gateType: args.gateType,
+    blockerSignature: args.blockerSignature,
+    failureClass: args.failureClass,
+    remediationTarget: args.remediationTarget,
+  });
 
   if (
     args.record.last_host_local_pr_blocker_comment_head_sha === args.pr.headRefOid
-    && args.record.last_host_local_pr_blocker_comment_signature === args.blockerSignature
+    && args.record.last_host_local_pr_blocker_comment_signature === blockerCommentSignature
   ) {
     return args.record;
   }
@@ -689,7 +709,7 @@ export async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
 
   const updatedRecord = args.stateStore.touch(args.record, {
     last_host_local_pr_blocker_comment_head_sha: args.pr.headRefOid,
-    last_host_local_pr_blocker_comment_signature: args.blockerSignature,
+    last_host_local_pr_blocker_comment_signature: blockerCommentSignature,
   });
   args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
   await args.stateStore.save(args.state);


### PR DESCRIPTION
## Summary
- route repairable ready-promotion workstation-local path hygiene findings into the tracked PR repair lane
- keep unsafe/non-publishable findings on the existing manual blocker path
- distinguish repair queued/manual/stale ready-promotion blockers in status and explain output

## Verification
- npm run build
- npm run verify:paths
- npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "path hygiene"
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts --test-name-pattern "ready-promotion path hygiene|ready promotion"
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts --test-name-pattern "ready-promotion path hygiene|ready promotion"
- npx tsx --test src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts

Closes #1707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervisor now queues automatic repairs for repairable path-hygiene findings on draft pull requests, leaving PRs as draft and scheduling a repair turn before retrying promotion.
  * Host-local blocker comments now indicate "automatic retry" and describe the supervisor's repair action and next steps.
  * Diagnostics/status messaging includes a repair-queued recoverability state.

* **Tests**
  * Added tests covering repair-queued flows, updated expectations for blocker comments and signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->