### PR TITLE
Classify no-active tracked records

### DIFF
--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -34,6 +34,7 @@ import type { IssueRunRecord } from "../core/types";
 import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
 import { truncate } from "../core/utils";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
+import { classifyStaleReviewBotRecoverability } from "./stale-diagnostic-recoverability";
 
 function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
@@ -67,15 +68,130 @@ export function formatLatestRecoveryStatusLine(
   return `latest_recovery issue=#${record.issue_number} at=${record.last_recovery_at} reason=${sanitizeStatusValue(reason)}${detail ? ` detail=${detail}` : ""}`;
 }
 
+export type NoActiveTrackedRecordClassification =
+  | "stale_but_recoverable"
+  | "active_tracked_work_blocker"
+  | "repair_already_queued"
+  | "safe_to_ignore"
+  | "manual_review_required"
+  | "stale_already_handled"
+  | "provider_outage_suspected";
+
+function noActiveTerminalReason(record: IssueRunRecord): string {
+  if (record.last_recovery_reason?.startsWith("merged_pr_convergence:")) {
+    return "merged_pr_convergence";
+  }
+  if (record.last_recovery_reason?.startsWith("stale_state_cleanup:")) {
+    return "cleared_stale_active_reservation";
+  }
+  return "terminal_done";
+}
+
+function activeTrackedWorkState(record: IssueRunRecord): boolean {
+  return (
+    record.state !== "done" &&
+    record.state !== "blocked" &&
+    record.state !== "failed" &&
+    record.state !== "repairing_ci"
+  );
+}
+
+export function classifyNoActiveTrackedRecord(
+  config: BuildDetailedStatusModelArgs["config"],
+  record: IssueRunRecord,
+): { classification: NoActiveTrackedRecordClassification; reason: string } {
+  if (record.state === "done") {
+    return {
+      classification: "safe_to_ignore",
+      reason: noActiveTerminalReason(record),
+    };
+  }
+
+  if (record.state === "repairing_ci") {
+    return {
+      classification: "repair_already_queued",
+      reason: record.last_failure_signature === "workstation-local-path-hygiene-failed"
+        ? "repairable_path_hygiene_retry_state"
+        : "repair_state_persisted",
+    };
+  }
+
+  if (activeTrackedWorkState(record)) {
+    return {
+      classification: "active_tracked_work_blocker",
+      reason: "tracked_record_not_terminal",
+    };
+  }
+
+  if (record.blocked_reason === "stale_review_bot") {
+    const recoverability = classifyStaleReviewBotRecoverability(record, config);
+    if (recoverability === "stale_already_handled") {
+      return {
+        classification: "stale_already_handled",
+        reason: "stale_review_bot_already_handled",
+      };
+    }
+    if (recoverability === "stale_but_recoverable") {
+      return {
+        classification: "stale_but_recoverable",
+        reason: "stale_review_bot_recoverable",
+      };
+    }
+    if (recoverability === "provider_outage_suspected") {
+      return {
+        classification: "provider_outage_suspected",
+        reason: "stale_review_bot_provider_signal_missing",
+      };
+    }
+  }
+
+  if (
+    record.blocked_reason === "verification" &&
+    record.last_failure_signature === "workstation-local-path-hygiene-failed"
+  ) {
+    return {
+      classification: "stale_but_recoverable",
+      reason: "stale_path_hygiene_blocker",
+    };
+  }
+
+  return {
+    classification: "manual_review_required",
+    reason: record.blocked_reason ?? record.last_failure_signature ?? "blocked_or_failed_record",
+  };
+}
+
+export function formatNoActiveTrackedRecordClassificationLine(
+  config: BuildDetailedStatusModelArgs["config"],
+  record: IssueRunRecord | null,
+): string | null {
+  if (!record) {
+    return null;
+  }
+
+  const classification = classifyNoActiveTrackedRecord(config, record);
+  return [
+    "no_active_tracked_record",
+    `issue=#${record.issue_number}`,
+    `classification=${classification.classification}`,
+    `state=${record.state}`,
+    `reason=${sanitizeStatusValue(classification.reason)}`,
+  ].join(" ");
+}
+
 export function buildInactiveDetailedStatusLines(
-  args: Pick<BuildDetailedStatusModelArgs, "latestRecord" | "latestRecoveryRecord" | "trackedIssueCount">,
+  args: Pick<BuildDetailedStatusModelArgs, "config" | "latestRecord" | "latestRecoveryRecord" | "trackedIssueCount">,
 ): string[] {
-  const { latestRecord, latestRecoveryRecord = null, trackedIssueCount } = args;
+  const { config, latestRecord, latestRecoveryRecord = null, trackedIssueCount } = args;
   const lines = [
     "No active issue.",
     `tracked_issues=${trackedIssueCount}`,
     `latest_record=${formatRecentRecord(latestRecord)}`,
   ];
+  const classificationLine = formatNoActiveTrackedRecordClassificationLine(config, latestRecord);
+  if (classificationLine) {
+    lines.push(classificationLine);
+  }
 
   if (latestRecoveryRecord?.last_recovery_reason && latestRecoveryRecord.last_recovery_at) {
     const latestRecoveryLine = formatLatestRecoveryStatusLine(latestRecoveryRecord);

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1613,6 +1613,10 @@ test("explain distinguishes repairable ready-promotion path hygiene blockers que
   const explanation = await supervisor.explain(issueNumber);
   assert.match(
     explanation,
+    /^no_active_tracked_record issue=#178 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state$/m,
+  );
+  assert.match(
+    explanation,
     /^tracked_pr_ready_promotion_blocked issue=#178 pr=#278 recoverability=repair_queued github_state=draft_pr local_state=repairing_ci local_blocked_reason=none stale_local_blocker=no$/m,
   );
   assert.match(

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3677,6 +3677,10 @@ test("status distinguishes repairable ready-promotion path hygiene blockers queu
   const status = await supervisor.status();
   assert.match(
     status,
+    /^no_active_tracked_record issue=#178 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state$/m,
+  );
+  assert.match(
+    status,
     /^tracked_pr_ready_promotion_blocked issue=#178 pr=#278 recoverability=repair_queued github_state=draft_pr local_state=repairing_ci local_blocked_reason=none stale_local_blocker=no$/m,
   );
   assert.match(

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -31,7 +31,10 @@ import {
   buildVerificationPolicyStatusLine,
   loadStatusChangedFiles,
 } from "./supervisor-status-rendering";
-import { formatLatestRecoveryStatusLine } from "./supervisor-detailed-status-assembly";
+import {
+  formatLatestRecoveryStatusLine,
+  formatNoActiveTrackedRecordClassificationLine,
+} from "./supervisor-detailed-status-assembly";
 import { externalSignalReadinessDiagnostics } from "./supervisor-status-review-bot";
 import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
 import { formatInventoryRefreshDiagnosticLines, formatInventoryRefreshStatusLine } from "../inventory-refresh-state";
@@ -92,6 +95,7 @@ export interface SupervisorExplainDto {
   activityContext: SupervisorIssueActivityContextDto | null;
   staleDiagnosticSummary?: string | null;
   staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
+  noActiveTrackedRecordSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
   trackedPrMismatchSummary: string | null;
   externalSignalReadinessSummary?: string | null;
@@ -330,6 +334,10 @@ export async function buildIssueExplainDto(
     record,
   });
   const latestRecoverySummary = record ? formatLatestRecoveryStatusLine(record) : null;
+  const noActiveTrackedRecordSummary =
+    record && state.activeIssueNumber === null
+      ? formatNoActiveTrackedRecordClassificationLine(config, record)
+      : null;
   const operatorEventSummary = record ? formatMergedPrConvergenceOperatorEventLine(record) : null;
   const staleRecoveryWarningSummary = record ? buildStaleStabilizingNoPrRecoveryWarningLine(record, config) : null;
   let pr: GitHubPullRequest | null = null;
@@ -508,6 +516,7 @@ export async function buildIssueExplainDto(
       })()
       : null,
     staleReviewBotRemediation,
+    noActiveTrackedRecordSummary,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary
         ? [
@@ -551,6 +560,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(localCiStatusLine ? [localCiStatusLine] : []),
     ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
+    ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),
     ...(dto.externalSignalReadinessSummary ? [dto.externalSignalReadinessSummary] : []),

--- a/src/supervisor/supervisor-status-model.test.ts
+++ b/src/supervisor/supervisor-status-model.test.ts
@@ -225,7 +225,77 @@ test("buildDetailedStatusModel formats the latest record for idle status", () =>
     "No active issue.",
     "tracked_issues=2",
     "latest_record=#92 state=done updated_at=2026-03-13T01:20:00Z",
+    "no_active_tracked_record issue=#92 classification=safe_to_ignore state=done reason=terminal_done",
   ]);
+});
+
+test("buildDetailedStatusModel classifies no-active tracked records", () => {
+  const cases = [
+    {
+      name: "merged",
+      record: createRecord({
+        issue_number: 93,
+        state: "done",
+        updated_at: "2026-03-13T01:20:00Z",
+        last_recovery_reason: "merged_pr_convergence: tracked PR #193 merged; marked issue #93 done",
+      }),
+      expected:
+        "no_active_tracked_record issue=#93 classification=safe_to_ignore state=done reason=merged_pr_convergence",
+    },
+    {
+      name: "cleared",
+      record: createRecord({
+        issue_number: 94,
+        state: "done",
+        updated_at: "2026-03-13T01:21:00Z",
+        last_recovery_reason: "stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing",
+      }),
+      expected:
+        "no_active_tracked_record issue=#94 classification=safe_to_ignore state=done reason=cleared_stale_active_reservation",
+    },
+    {
+      name: "repair-queued",
+      record: createRecord({
+        issue_number: 95,
+        state: "repairing_ci",
+        updated_at: "2026-03-13T01:22:00Z",
+        blocked_reason: null,
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+      }),
+      expected:
+        "no_active_tracked_record issue=#95 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state",
+    },
+    {
+      name: "manual-review-required",
+      record: createRecord({
+        issue_number: 96,
+        state: "blocked",
+        updated_at: "2026-03-13T01:23:00Z",
+        blocked_reason: "manual_review",
+      }),
+      expected:
+        "no_active_tracked_record issue=#96 classification=manual_review_required state=blocked reason=manual_review",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const lines = buildDetailedStatusModel({
+      config: createConfig(),
+      activeRecord: null,
+      latestRecord: testCase.record,
+      trackedIssueCount: 1,
+      pr: null,
+      checks: [],
+      reviewThreads: [],
+      manualReviewThreads: noReviewThreads,
+      configuredBotReviewThreads: noReviewThreads,
+      pendingBotReviewThreads: noPendingReviewThreads,
+      summarizeChecks,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.ok(lines.includes(testCase.expected), testCase.name);
+  }
 });
 
 test("buildDetailedStatusModel preserves active-line ordering across PR and failure sections", () => {

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -578,6 +578,7 @@ test("formatDetailedStatus keeps idle output compact when there is no active iss
       "No active issue.",
       "tracked_issues=2",
       "latest_record=#92 state=done updated_at=2026-03-13T01:20:00Z",
+      "no_active_tracked_record issue=#92 classification=safe_to_ignore state=done reason=terminal_done",
       "latest_recovery issue=#91 at=2026-03-13T00:20:00Z reason=merged_pr_convergence detail=tracked PR #191 merged; marked issue #91 done",
     ].join("\n"),
   );


### PR DESCRIPTION
## Summary
- add a shared no-active tracked record classification line for idle status and explain output
- classify terminal merged/cleared records as safe to ignore, repair states as already queued, stale path hygiene as recoverable, and unresolved blockers as manual review
- cover merged, cleared, repair-queued, and manual-review-required cases with focused tests

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-model.test.ts src/supervisor/supervisor-status-rendering.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npm run build
- npm run verify:paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed status classifications for inactive tracked records, helping users understand record states and recovery pathways with insights such as safe to ignore, repair queued, and work blocker detection.

* **Tests**
  * Expanded test coverage to validate classification and reason formatting across multiple inactive record scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->