### PR TITLE
Add restart recommendation categories

### DIFF
--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -570,7 +570,7 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
   );
   assert.match(
     report,
-    /^doctor_restart_recommendation category=safe_restart source=loop_runtime_diagnostic summary=Restart can be safe after following the runtime ownership and duplicate-process guidance\.$/m,
+    /^doctor_restart_recommendation category=safe_restart source=doctor_loop_runtime_diagnostic summary=Restart can be safe after following the runtime ownership and duplicate-process guidance\.$/m,
   );
   assert.match(
     report,

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -570,6 +570,10 @@ test("renderDoctorReport includes loop host diagnostics and macOS tmux drift war
   );
   assert.match(
     report,
+    /^doctor_restart_recommendation category=safe_restart source=loop_runtime_diagnostic summary=Restart can be safe after following the runtime ownership and duplicate-process guidance\.$/m,
+  );
+  assert.match(
+    report,
     /doctor_warning kind=loop_host detail=macOS loop runtime is active outside tmux\. Restart it with \.\/scripts\/start-loop-tmux\.sh and stop unsupported direct hosts before relying on steady-state automation\./,
   );
 });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -41,7 +41,7 @@ import {
 import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./supervisor/tracked-pr-mismatch";
 import { buildTrustAndConfigWarnings, buildWarning, renderDoctorWarningLine } from "./warning-formatting";
 import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "./reconciliation-backlog-diagnostics";
-import { renderOperatorActionLine, selectDoctorOperatorAction } from "./operator-actions";
+import { appendRestartRecommendationLine, renderOperatorActionLine, selectDoctorOperatorAction } from "./operator-actions";
 
 export type DoctorCheckStatus = "pass" | "warn" | "fail";
 export type DoctorDecisionAction = "stop" | "maintenance" | "continue";
@@ -1007,7 +1007,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
     }),
   );
 
-  return [
+  const lines = [
     `doctor_decision action=${decisionSurface.decisionSummary.action} summary=${sanitizeDoctorValue(decisionSurface.decisionSummary.summary)}`,
     doctorOperatorActionLine,
     ...(["active_risk", "maintenance", "informational"] as const).flatMap((tier) => [
@@ -1042,5 +1042,7 @@ export function renderDoctorReport(diagnostics: DoctorDiagnostics): string {
         (detail) => `doctor_detail name=${check.name} detail=${sanitizeDoctorValue(detail)}`,
       ),
     ),
-  ].join("\n");
+  ];
+
+  return appendRestartRecommendationLine(lines, "doctor_restart_recommendation").join("\n");
 }

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type RestartRecommendation,
+  selectRestartRecommendation,
+} from "./operator-actions";
+
+function requireRestartRecommendation(recommendation: RestartRecommendation | null): RestartRecommendation {
+  if (recommendation === null) {
+    assert.fail("expected a restart recommendation");
+  }
+  return recommendation;
+}
+
+test("selectRestartRecommendation classifies every restart recommendation category from shared status lines", () => {
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=<supervisor-config-path> state_file=<state-file> recovery=inspect_then_restart",
+      ],
+    })).category,
+    "safe_restart",
+  );
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=addressing_review first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=inspect_runtime",
+      ],
+    })).category,
+    "restart_required_for_convergence",
+  );
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#188 classification=safe_to_ignore state=done reason=terminal_done",
+      ],
+    })).category,
+    "restart_not_enough",
+  );
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
+      ],
+    })).category,
+    "manual_review_before_restart",
+  );
+});

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -46,3 +46,52 @@ test("selectRestartRecommendation classifies every restart recommendation catego
     "manual_review_before_restart",
   );
 });
+
+test("selectRestartRecommendation preserves the matching source for safe restart recovery lines", () => {
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "loop_runtime_recovery action=inspect_then_restart owner=supervisor recommendation=restart_loop",
+      ],
+    })).source,
+    "loop_runtime_recovery",
+  );
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "doctor_loop_runtime_recovery action=inspect_then_restart owner=supervisor recommendation=restart_loop",
+      ],
+    })).source,
+    "doctor_loop_runtime_recovery",
+  );
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "doctor_loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=<supervisor-config-path> state_file=<state-file> recovery=inspect_then_restart",
+      ],
+    })).source,
+    "doctor_loop_runtime_diagnostic",
+  );
+});
+
+test("selectRestartRecommendation does not let safe restart outrank manual review before restart", () => {
+  const recommendation = requireRestartRecommendation(selectRestartRecommendation({
+    detailedStatusLines: [
+      "loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=<supervisor-config-path> state_file=<state-file> recovery=inspect_then_restart",
+      "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
+    ],
+  }));
+
+  assert.equal(recommendation.category, "manual_review_before_restart");
+  assert.equal(recommendation.source, "no_active_tracked_record");
+
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "loop_runtime_diagnostic kind=duplicate_loop_processes status=duplicate matching_processes=2 pids=4242,4243 config_path=<supervisor-config-path> state_file=<state-file> recovery=inspect_then_restart",
+        "no_active_tracked_record issue=#188 classification=provider_outage_suspected state=blocked reason=review_provider_wait",
+      ],
+    })).category,
+    "manual_review_before_restart",
+  );
+});

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -18,8 +18,25 @@ export interface OperatorAction {
   summary: string;
 }
 
+export type RestartRecommendationCategory =
+  | "safe_restart"
+  | "restart_required_for_convergence"
+  | "restart_not_enough"
+  | "manual_review_before_restart";
+
+export interface RestartRecommendation {
+  category: RestartRecommendationCategory;
+  source: string;
+  priority: number;
+  summary: string;
+}
+
 function chooseHighestPriority(actions: OperatorAction[], fallback: OperatorAction): OperatorAction {
   return [...actions].sort((left, right) => right.priority - left.priority)[0] ?? fallback;
+}
+
+function chooseHighestPriorityRecommendation(recommendations: RestartRecommendation[]): RestartRecommendation | null {
+  return [...recommendations].sort((left, right) => right.priority - left.priority)[0] ?? null;
 }
 
 const statusFallbackOperatorAction: OperatorAction = {
@@ -35,6 +52,112 @@ const doctorFallbackOperatorAction: OperatorAction = {
   priority: 0,
   summary: "No blocking doctor action was detected; continue normal supervisor operation.",
 };
+
+export function selectRestartRecommendation(args: {
+  detailedStatusLines: string[];
+}): RestartRecommendation | null {
+  const recommendations: RestartRecommendation[] = [];
+
+  for (const line of args.detailedStatusLines) {
+    if (/^loop_runtime_blocker\b/.test(line)) {
+      recommendations.push({
+        category: "restart_required_for_convergence",
+        source: "loop_runtime_blocker",
+        priority: 90,
+        summary: "Restarting the supported supervisor loop is required before active tracked work can converge.",
+      });
+      continue;
+    }
+
+    if (
+      /^loop_runtime_diagnostic\b/.test(line) && /\bstatus=duplicate\b/.test(line) ||
+      /^doctor_loop_runtime_diagnostic\b/.test(line) && /\bstatus=duplicate\b/.test(line) ||
+      /^loop_runtime_recovery\b/.test(line) ||
+      /^doctor_loop_runtime_recovery\b/.test(line)
+    ) {
+      recommendations.push({
+        category: "safe_restart",
+        source: "loop_runtime_diagnostic",
+        priority: 70,
+        summary: "Restart can be safe after following the runtime ownership and duplicate-process guidance.",
+      });
+      continue;
+    }
+
+    const noActiveClassification = /^no_active_tracked_record\b/.test(line)
+      ? /\bclassification=([^\s]+)/.exec(line)?.[1] ?? null
+      : null;
+    if (!noActiveClassification) {
+      continue;
+    }
+
+    if (
+      noActiveClassification === "active_tracked_work_blocker" ||
+      noActiveClassification === "stale_but_recoverable"
+    ) {
+      recommendations.push({
+        category: "restart_required_for_convergence",
+        source: "no_active_tracked_record",
+        priority: 60,
+        summary: "Restarting the supported supervisor loop is required before active tracked work can converge.",
+      });
+      continue;
+    }
+
+    if (
+      noActiveClassification === "manual_review_required" ||
+      noActiveClassification === "provider_outage_suspected"
+    ) {
+      recommendations.push({
+        category: "manual_review_before_restart",
+        source: "no_active_tracked_record",
+        priority: 55,
+        summary: "Manual review is required before a restart should be treated as a recovery action.",
+      });
+      continue;
+    }
+
+    recommendations.push({
+      category: "restart_not_enough",
+      source: "no_active_tracked_record",
+      priority: 40,
+      summary: "Restart alone is not expected to resolve the current supervisor state.",
+    });
+  }
+
+  return chooseHighestPriorityRecommendation(recommendations);
+}
+
+export function renderRestartRecommendationLine(
+  prefix: "restart_recommendation" | "doctor_restart_recommendation",
+  recommendation: RestartRecommendation | null,
+): string | null {
+  if (recommendation === null) {
+    return null;
+  }
+
+  return [
+    prefix,
+    `category=${recommendation.category}`,
+    `source=${recommendation.source}`,
+    `summary=${recommendation.summary}`,
+  ].join(" ");
+}
+
+export function appendRestartRecommendationLine(
+  detailedStatusLines: string[],
+  prefix: "restart_recommendation" | "doctor_restart_recommendation" = "restart_recommendation",
+): string[] {
+  if (detailedStatusLines.some((line) => line.startsWith(`${prefix} `))) {
+    return detailedStatusLines;
+  }
+
+  const recommendationLine = renderRestartRecommendationLine(
+    prefix,
+    selectRestartRecommendation({ detailedStatusLines }),
+  );
+  return recommendationLine === null ? detailedStatusLines : [...detailedStatusLines, recommendationLine];
+}
 
 export function selectStatusOperatorAction(args: {
   detailedStatusLines: string[];

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -31,12 +31,35 @@ export interface RestartRecommendation {
   summary: string;
 }
 
+const restartRecommendationPriority: Record<RestartRecommendationCategory, number> = {
+  restart_required_for_convergence: 90,
+  manual_review_before_restart: 80,
+  safe_restart: 70,
+  restart_not_enough: 40,
+};
+
 function chooseHighestPriority(actions: OperatorAction[], fallback: OperatorAction): OperatorAction {
   return [...actions].sort((left, right) => right.priority - left.priority)[0] ?? fallback;
 }
 
 function chooseHighestPriorityRecommendation(recommendations: RestartRecommendation[]): RestartRecommendation | null {
   return [...recommendations].sort((left, right) => right.priority - left.priority)[0] ?? null;
+}
+
+function getSafeRestartSource(line: string): string | null {
+  if (/^loop_runtime_diagnostic\b/.test(line) && /\bstatus=duplicate\b/.test(line)) {
+    return "loop_runtime_diagnostic";
+  }
+  if (/^doctor_loop_runtime_diagnostic\b/.test(line) && /\bstatus=duplicate\b/.test(line)) {
+    return "doctor_loop_runtime_diagnostic";
+  }
+  if (/^loop_runtime_recovery\b/.test(line)) {
+    return "loop_runtime_recovery";
+  }
+  if (/^doctor_loop_runtime_recovery\b/.test(line)) {
+    return "doctor_loop_runtime_recovery";
+  }
+  return null;
 }
 
 const statusFallbackOperatorAction: OperatorAction = {
@@ -63,22 +86,18 @@ export function selectRestartRecommendation(args: {
       recommendations.push({
         category: "restart_required_for_convergence",
         source: "loop_runtime_blocker",
-        priority: 90,
+        priority: restartRecommendationPriority.restart_required_for_convergence,
         summary: "Restarting the supported supervisor loop is required before active tracked work can converge.",
       });
       continue;
     }
 
-    if (
-      /^loop_runtime_diagnostic\b/.test(line) && /\bstatus=duplicate\b/.test(line) ||
-      /^doctor_loop_runtime_diagnostic\b/.test(line) && /\bstatus=duplicate\b/.test(line) ||
-      /^loop_runtime_recovery\b/.test(line) ||
-      /^doctor_loop_runtime_recovery\b/.test(line)
-    ) {
+    const safeRestartSource = getSafeRestartSource(line);
+    if (safeRestartSource !== null) {
       recommendations.push({
         category: "safe_restart",
-        source: "loop_runtime_diagnostic",
-        priority: 70,
+        source: safeRestartSource,
+        priority: restartRecommendationPriority.safe_restart,
         summary: "Restart can be safe after following the runtime ownership and duplicate-process guidance.",
       });
       continue;
@@ -111,7 +130,7 @@ export function selectRestartRecommendation(args: {
       recommendations.push({
         category: "manual_review_before_restart",
         source: "no_active_tracked_record",
-        priority: 55,
+        priority: restartRecommendationPriority.manual_review_before_restart,
         summary: "Manual review is required before a restart should be treated as a recovery action.",
       });
       continue;
@@ -120,7 +139,7 @@ export function selectRestartRecommendation(args: {
     recommendations.push({
       category: "restart_not_enough",
       source: "no_active_tracked_record",
-      priority: 40,
+      priority: restartRecommendationPriority.restart_not_enough,
       summary: "Restart alone is not expected to resolve the current supervisor state.",
     });
   }

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -333,6 +333,10 @@ test("explain surfaces loop-off as an operator blocker for active tracked work",
     explanation,
     /^loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#189 first_state=queued first_pr=#289 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config$/m,
   );
+  assert.match(
+    explanation,
+    /^restart_recommendation category=restart_required_for_convergence source=loop_runtime_blocker summary=Restarting the supported supervisor loop is required before active tracked work can converge\.$/m,
+  );
 });
 
 test("explain loop-off blocker summarizes all tracked work even when the explained issue is untracked", async () => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1306,6 +1306,10 @@ test("status surfaces loop-off as a blocker when tracked work is still active", 
     report.detailedStatusLines.join("\n"),
     /^loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=addressing_review first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config$/m,
   );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^restart_recommendation category=restart_required_for_convergence source=loop_runtime_blocker summary=Restarting the supported supervisor loop is required before active tracked work can converge\.$/m,
+  );
   assert.equal(
     report.warning?.message,
     "Tracked work is active for issue #188, but the supervisor loop is off. Restart the supported loop host; expect loop_runtime state=running before issue #188 advances.",
@@ -1319,6 +1323,10 @@ test("status surfaces loop-off as a blocker when tracked work is still active", 
   assert.match(
     status,
     /^operator_action action=restart_loop source=loop_runtime_blocker priority=90 summary=Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance\.$/m,
+  );
+  assert.match(
+    status,
+    /^restart_recommendation category=restart_required_for_convergence source=loop_runtime_blocker summary=Restarting the supported supervisor loop is required before active tracked work can converge\.$/m,
   );
   assert.match(
     status,

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -54,6 +54,7 @@ import {
   summarizeChecks,
 } from "./supervisor-status-rendering";
 import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "../reconciliation-backlog-diagnostics";
+import { appendRestartRecommendationLine } from "../operator-actions";
 
 const LONG_RECONCILIATION_WARNING_THRESHOLD_MS = 5 * 60 * 1000;
 const MAX_RENDERED_STATUS_STATE_LOAD_FINDINGS = 5;
@@ -248,7 +249,7 @@ export async function buildSupervisorStatusReport(args: {
       const readinessSummary = buildLastKnownGoodSnapshotReadinessSummary(config, state);
       const whyLines = options.why ? await buildSelectionWhySummary(github, config, state) : [];
       const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
-      const inactiveDetailedStatusLines = [
+      const inactiveDetailedStatusLines = appendRestartRecommendationLine([
         ...detailedStatusLines,
         ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
         inventoryPostureLine,
@@ -257,7 +258,7 @@ export async function buildSupervisorStatusReport(args: {
         ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
         ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
-      ];
+      ]);
 
       return {
         gsdSummary,
@@ -311,7 +312,7 @@ export async function buildSupervisorStatusReport(args: {
       const whyLines = options.why ? await buildSelectionWhySummary(github, config, state) : [];
       const selectionSummary = options.why ? await buildSelectionSummary(github, config, state) : null;
       const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
-      const inactiveDetailedStatusLines = [
+      const inactiveDetailedStatusLines = appendRestartRecommendationLine([
         ...detailedStatusLines,
         ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
         inventoryPostureLine,
@@ -320,7 +321,7 @@ export async function buildSupervisorStatusReport(args: {
         ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
         ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
-      ];
+      ]);
 
       return {
         gsdSummary,
@@ -357,7 +358,7 @@ export async function buildSupervisorStatusReport(args: {
     } catch (error) {
       const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
       const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
-      const inactiveDetailedStatusLines = [
+      const inactiveDetailedStatusLines = appendRestartRecommendationLine([
         ...detailedStatusLines,
         ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
         inventoryPostureLine,
@@ -365,7 +366,7 @@ export async function buildSupervisorStatusReport(args: {
         ...inventoryRefreshDiagnosticLines,
         ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
         ...githubRateLimitStatus.githubRateLimitLines,
-      ];
+      ]);
 
       return {
         gsdSummary,
@@ -443,7 +444,7 @@ export async function buildSupervisorStatusReport(args: {
     executionMetricsSummaryLines: activeStatus.executionMetricsSummaryLines,
   });
   const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
-  const detailedStatusLinesWithInventory = [
+  const detailedStatusLinesWithInventory = appendRestartRecommendationLine([
     ...detailedStatusLines,
     ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
     inventoryPostureLine,
@@ -452,7 +453,7 @@ export async function buildSupervisorStatusReport(args: {
     ...(inventorySnapshotStatusLine === null ? [] : [inventorySnapshotStatusLine]),
     ...(trackedMergedBacklogLine === null ? [] : [trackedMergedBacklogLine]),
     ...githubRateLimitStatus.githubRateLimitLines,
-  ];
+  ]);
 
   return {
     gsdSummary,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -70,6 +70,7 @@ import {
   type StaleReviewBotRemediationDto,
 } from "./stale-review-bot-remediation";
 import { formatMergedPrConvergenceOperatorEventLine } from "./supervisor-operator-events";
+import { appendRestartRecommendationLine } from "../operator-actions";
 
 export type ExplainIssueGitHub =
   Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
@@ -543,7 +544,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
   const preMergeEvaluationLine = formatPreMergeEvaluationStatusLine(dto.activityContext?.preMergeEvaluation ?? null);
   const retrySummaryLine = formatRetrySummaryLine(dto.activityContext);
   const recoveryLoopSummaryLine = formatRecoveryLoopSummaryLine(dto.activityContext);
-  const lines = [
+  const lines = appendRestartRecommendationLine([
     `issue=#${dto.issueNumber}`,
     `title=${dto.title}`,
     ...(dto.lookupTargetSummary ? [dto.lookupTargetSummary] : []),
@@ -571,7 +572,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.operatorEventSummary ? [dto.operatorEventSummary] : []),
     ...(dto.latestRecoverySummary ? [dto.latestRecoverySummary] : []),
     ...(dto.staleRecoveryWarningSummary ? [dto.staleRecoveryWarningSummary] : []),
-  ];
+  ]);
 
   if (dto.selectionReason) {
     lines.push(`selection_reason=${dto.selectionReason}`);


### PR DESCRIPTION
## Summary
- Add shared restart recommendation categories for runtime/status diagnostics
- Render restart recommendation lines in status, explain, and doctor surfaces
- Cover all categories with a focused shared-helper test and surface assertions

Part of #1715
Closes #1719

## Verification
- npx tsx --test src/operator-actions.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/doctor.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic and status reports now append prioritized restart recommendations (safe restart, restart required for convergence, manual review before restart, or insufficient for recovery) into rendered outputs when applicable.

* **Tests**
  * Added and updated tests validating classification, prioritization, propagation, and rendering of restart recommendations across report and diagnostic flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->