### PR TITLE
Show runtime recovery summary in WebUI

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -60,6 +60,26 @@ export interface DashboardLoopRuntimeLike {
   } | null;
 }
 
+export interface DashboardRuntimeRecoverySummaryLike {
+  loopState?: string | null;
+  lockConfidence?: string | null;
+  trackedRecords?: Array<{
+    issueNumber?: number | null;
+    state?: string | null;
+    prNumber?: number | null;
+    blockedReason?: string | null;
+  }> | null;
+  signals?: Array<{
+    kind?: string | null;
+    summary?: string | null;
+  }> | null;
+  recommendation?: {
+    category?: string | null;
+    source?: string | null;
+    summary?: string | null;
+  } | null;
+}
+
 export interface DashboardInventoryStatusLike {
   mode?: "healthy" | "degraded" | null;
   posture?:
@@ -107,6 +127,7 @@ export interface DashboardStatusLike {
   reconciliationWarning?: string | null;
   reconciliationPhase?: string | null;
   loopRuntime?: DashboardLoopRuntimeLike | null;
+  runtimeRecoverySummary?: DashboardRuntimeRecoverySummaryLike | null;
   warning?: { message?: string | null } | null;
 }
 

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -30,6 +30,7 @@ import {
 } from "./webui-dashboard-browser-logic";
 import {
   buildWorkflowSteps,
+  buildRuntimeRecoverySummaryLines,
   countCandidateIssues,
   describeLoopRuntime,
   formatKeyValueBlock,
@@ -105,6 +106,7 @@ const injectedBrowserLogic = [
   parseSelectedIssueNumber,
   countCandidateIssues,
   buildWorkflowSteps,
+  buildRuntimeRecoverySummaryLines,
   metricClass,
   formatKeyValueBlock,
   liveBadgeClass,
@@ -183,6 +185,8 @@ export function renderDashboardBrowserScript(): string {
         statusMetrics: document.getElementById("status-metrics"),
         statusWorkflow: document.getElementById("status-workflow"),
         statusLines: document.getElementById("status-lines"),
+        runtimeRecoverySummary: document.getElementById("runtime-recovery-summary"),
+        runtimeRecoveryLines: document.getElementById("runtime-recovery-lines"),
         statusPanelWarning: document.getElementById("status-panel-warning"),
         trackedHistorySummary: document.getElementById("tracked-history-summary"),
         trackedHistoryLines: document.getElementById("tracked-history-lines"),
@@ -329,6 +333,18 @@ export function renderDashboardBrowserScript(): string {
         card.className = className;
         card.textContent = text;
         container.appendChild(card);
+      }
+
+      function renderRuntimeRecoverySummary(status) {
+        if (!elements.runtimeRecoverySummary || !elements.runtimeRecoveryLines) {
+          return;
+        }
+        const lines = buildRuntimeRecoverySummaryLines(status && status.runtimeRecoverySummary);
+        elements.runtimeRecoverySummary.hidden = lines.length === 0;
+        elements.runtimeRecoveryLines.innerHTML = "";
+        for (const line of lines) {
+          appendTextCard(elements.runtimeRecoveryLines, "status-line", line);
+        }
       }
 
       function renderWorkflow(status) {
@@ -877,6 +893,7 @@ export function renderDashboardBrowserScript(): string {
             appendTextCard(elements.statusLines, "status-line", line);
           }
         }
+        renderRuntimeRecoverySummary(status);
         renderTrackedHistory();
         renderSelectedIssueSummary();
       }

--- a/src/backend/webui-dashboard-browser-view-model.test.ts
+++ b/src/backend/webui-dashboard-browser-view-model.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildRuntimeRecoverySummaryLines,
   buildWorkflowSteps,
   countCandidateIssues,
   describeLoopRuntime,
@@ -146,4 +147,36 @@ test("countCandidateIssues and formatRefreshTime handle missing values predictab
   assert.equal(typeof refreshTime, "string");
   assert.notEqual(refreshTime, "");
   assert.notEqual(refreshTime, "never");
+});
+
+test("buildRuntimeRecoverySummaryLines skips malformed tracked records and signals", () => {
+  const lines = buildRuntimeRecoverySummaryLines({
+    loopState: "off",
+    lockConfidence: "stale_lock",
+    trackedRecords: [
+      null,
+      "invalid",
+      {
+        issueNumber: 1720,
+        state: "blocked",
+        prNumber: 1725,
+        blockedReason: "review",
+      },
+    ] as unknown as NonNullable<Parameters<typeof buildRuntimeRecoverySummaryLines>[0]>["trackedRecords"],
+    signals: [
+      42,
+      null,
+      {
+        kind: "stale_review_bot_remediation",
+        summary: "metadata_only",
+      },
+    ] as unknown as NonNullable<Parameters<typeof buildRuntimeRecoverySummaryLines>[0]>["signals"],
+  });
+
+  assert.deepEqual(lines, [
+    "loop_state: off",
+    "lock_confidence: stale_lock",
+    "tracked_records: #1720 blocked pr=#1725 blocked_reason=review",
+    "signal: stale_review_bot_remediation metadata_only",
+  ]);
 });

--- a/src/backend/webui-dashboard-browser-view-model.ts
+++ b/src/backend/webui-dashboard-browser-view-model.ts
@@ -1,4 +1,8 @@
-import type { DashboardLoopRuntimeLike, DashboardStatusLike } from "./webui-dashboard-browser-logic";
+import type {
+  DashboardLoopRuntimeLike,
+  DashboardRuntimeRecoverySummaryLike,
+  DashboardStatusLike,
+} from "./webui-dashboard-browser-logic";
 
 export interface DashboardWorkflowStep {
   id: "observe" | "triage" | "select" | "execute" | "recover";
@@ -12,6 +16,54 @@ export interface DashboardLoopRuntimeSummary {
   summary: string;
   chipLabel: string;
   chipTone: "ok" | "warn" | "info";
+}
+
+export function buildRuntimeRecoverySummaryLines(
+  summary: DashboardRuntimeRecoverySummaryLike | null | undefined,
+): string[] {
+  if (!summary) {
+    return [];
+  }
+
+  function formatRuntimeTrackedRecord(
+    record: NonNullable<DashboardRuntimeRecoverySummaryLike["trackedRecords"]>[number],
+  ): string {
+    return [
+      formatIssueRef(record.issueNumber),
+      record.state || "unknown",
+      "pr=" + (Number.isInteger(record.prNumber) ? "#" + record.prNumber : "none"),
+      "blocked_reason=" + (record.blockedReason || "none"),
+    ].join(" ");
+  }
+
+  const lines = [
+    ["loop_state", summary.loopState || "unknown"],
+    ["lock_confidence", summary.lockConfidence || "none"],
+  ].map(([label, value]) => label + ": " + value);
+
+  const trackedRecords = Array.isArray(summary.trackedRecords) ? summary.trackedRecords : [];
+  lines.push(
+    "tracked_records: " +
+      (trackedRecords.length === 0 ? "none" : trackedRecords.map(formatRuntimeTrackedRecord).join("; ")),
+  );
+
+  const signals = Array.isArray(summary.signals) ? summary.signals : [];
+  for (const signal of signals) {
+    lines.push("signal: " + (signal.kind || "unknown") + " " + (signal.summary || ""));
+  }
+
+  if (summary.recommendation) {
+    lines.push(
+      "recommendation: " +
+        (summary.recommendation.category || "unknown") +
+        " source=" +
+        (summary.recommendation.source || "unknown") +
+        " summary=" +
+        (summary.recommendation.summary || ""),
+    );
+  }
+
+  return lines;
 }
 
 function formatIssueRef(issueNumber: number | null | undefined): string {

--- a/src/backend/webui-dashboard-browser-view-model.ts
+++ b/src/backend/webui-dashboard-browser-view-model.ts
@@ -36,19 +36,32 @@ export function buildRuntimeRecoverySummaryLines(
     ].join(" ");
   }
 
+  function isRuntimeRecoveryRecord(
+    record: unknown,
+  ): record is NonNullable<DashboardRuntimeRecoverySummaryLike["trackedRecords"]>[number] {
+    return typeof record === "object" && record !== null;
+  }
+
+  function isRuntimeRecoverySignal(
+    signal: unknown,
+  ): signal is NonNullable<DashboardRuntimeRecoverySummaryLike["signals"]>[number] {
+    return typeof signal === "object" && signal !== null;
+  }
+
   const lines = [
     ["loop_state", summary.loopState || "unknown"],
     ["lock_confidence", summary.lockConfidence || "none"],
   ].map(([label, value]) => label + ": " + value);
 
   const trackedRecords = Array.isArray(summary.trackedRecords) ? summary.trackedRecords : [];
+  const validTrackedRecords = trackedRecords.filter(isRuntimeRecoveryRecord);
   lines.push(
     "tracked_records: " +
-      (trackedRecords.length === 0 ? "none" : trackedRecords.map(formatRuntimeTrackedRecord).join("; ")),
+      (validTrackedRecords.length === 0 ? "none" : validTrackedRecords.map(formatRuntimeTrackedRecord).join("; ")),
   );
 
   const signals = Array.isArray(summary.signals) ? summary.signals : [];
-  for (const signal of signals) {
+  for (const signal of signals.filter(isRuntimeRecoverySignal)) {
     lines.push("signal: " + (signal.kind || "unknown") + " " + (signal.summary || ""));
   }
 

--- a/src/backend/webui-dashboard-panel-layout.ts
+++ b/src/backend/webui-dashboard-panel-layout.ts
@@ -120,6 +120,10 @@ export const DASHBOARD_PANEL_REGISTRY = [
                 <div id="status-lines" class="status-list">
                   <div class="status-line panel-empty-state">Loading /api/status?why=true…</div>
                 </div>
+              </div>
+              <div class="row" id="runtime-recovery-summary" hidden>
+                <div class="row-label">Runtime recovery</div>
+                <div id="runtime-recovery-lines" class="status-list"></div>
               </div>`,
   }),
   renderDashboardPanelShell({

--- a/src/backend/webui-dashboard-test-fixtures.ts
+++ b/src/backend/webui-dashboard-test-fixtures.ts
@@ -389,6 +389,25 @@ export function createDashboardStatusFixture(args: {
       recoveryGuidance?: string | null;
     };
   } | null;
+  runtimeRecoverySummary?: {
+    loopState: string;
+    lockConfidence: string;
+    trackedRecords: Array<{
+      issueNumber: number;
+      state: string;
+      prNumber: number | null;
+      blockedReason: string | null;
+    }>;
+    signals: Array<{
+      kind: string;
+      summary: string;
+    }>;
+    recommendation: {
+      category: string;
+      source: string;
+      summary: string;
+    } | null;
+  } | null;
   trackedIssues?: Array<{
     issueNumber: number;
     state: string;
@@ -440,6 +459,7 @@ export function createDashboardStatusFixture(args: {
         ownershipConfidence: "none",
         detail: null,
       },
+    runtimeRecoverySummary: args.runtimeRecoverySummary ?? null,
     reconciliationPhase: null,
     warning: args.warning ?? null,
     detailedStatusLines: args.detailedStatusLines ?? [],

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -804,6 +804,65 @@ test("dashboard status panel surfaces tracked PR host-local CI blockers", async 
   assert.equal(harness.remainingFetches.length, 0);
 });
 
+test("dashboard renders the typed runtime recovery summary without parsing domain lines in the browser", async () => {
+  const harness = createDashboardHarness([
+    {
+      path: "/api/status?why=true",
+      response: jsonResponse(
+        createStatus({
+          includeWhyLines: false,
+          runtimeRecoverySummary: {
+            loopState: "off",
+            lockConfidence: "stale_lock",
+            trackedRecords: [
+              {
+                issueNumber: 171,
+                state: "blocked",
+                prNumber: 271,
+                blockedReason: "stale_review_bot",
+              },
+            ],
+            signals: [
+              {
+                kind: "stale_review_bot_remediation",
+                summary:
+                  "stale_review_bot_remediation issue=#171 pr=#271 classification=metadata_only manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+              },
+              {
+                kind: "repairable_path_hygiene",
+                summary:
+                  "tracked_pr_mismatch issue=#178 pr=#278 recoverability=stale_but_recoverable gate=workstation_local_path_hygiene",
+              },
+            ],
+            recommendation: {
+              category: "restart_required_for_convergence",
+              source: "loop_runtime_blocker",
+              summary: "Restarting the supported supervisor loop is required before active tracked work can converge.",
+            },
+          },
+        }),
+      ),
+    },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const runtimeRecoverySummary = harness.document.getElementById("runtime-recovery-summary");
+  const runtimeRecoveryLines = harness.document.getElementById("runtime-recovery-lines");
+  assert.ok(runtimeRecoverySummary);
+  assert.ok(runtimeRecoveryLines);
+  assert.equal(runtimeRecoverySummary.hidden, false);
+  assert.match(runtimeRecoveryLines.textContent, /loop_state: off/u);
+  assert.match(runtimeRecoveryLines.textContent, /lock_confidence: stale_lock/u);
+  assert.match(runtimeRecoveryLines.textContent, /tracked_records: #171 blocked pr=#271 blocked_reason=stale_review_bot/u);
+  assert.match(runtimeRecoveryLines.textContent, /stale_review_bot_remediation/u);
+  assert.match(runtimeRecoveryLines.textContent, /classification=metadata_only/u);
+  assert.match(runtimeRecoveryLines.textContent, /workstation_local_path_hygiene/u);
+  assert.match(runtimeRecoveryLines.textContent, /recommendation: restart_required_for_convergence/u);
+  assert.match(runtimeRecoveryLines.textContent, /source=loop_runtime_blocker/u);
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
 test("dashboard moves tracked history into a dedicated panel with non-done default and reveal toggle", async () => {
   const harness = createDashboardHarness([
     {

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -26,6 +26,7 @@ import {
 } from "./supervisor-selection-issue-explain";
 import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
 import {
+  buildRuntimeRecoverySummary,
   buildInventoryRefreshWarningMessage,
   buildTrackedIssueDtos,
   renderGitHubRateLimitLine,
@@ -270,6 +271,11 @@ export async function buildSupervisorStatusReport(args: {
         candidateDiscovery: buildCandidateDiscoverySummary(config, null),
         localCiContract,
         loopRuntime,
+        runtimeRecoverySummary: buildRuntimeRecoverySummary({
+          loopRuntime,
+          trackedIssues,
+          detailedStatusLines: [...inactiveDetailedStatusLines, ...trackedPrMismatchLines],
+        }),
         activeIssue: null,
         selectionSummary: null,
         trackedIssues,
@@ -333,6 +339,11 @@ export async function buildSupervisorStatusReport(args: {
         candidateDiscovery,
         localCiContract,
         loopRuntime,
+        runtimeRecoverySummary: buildRuntimeRecoverySummary({
+          loopRuntime,
+          trackedIssues,
+          detailedStatusLines: [...inactiveDetailedStatusLines, ...trackedPrMismatchLines],
+        }),
         activeIssue: null,
         selectionSummary,
         trackedIssues,
@@ -378,6 +389,11 @@ export async function buildSupervisorStatusReport(args: {
         candidateDiscovery: buildCandidateDiscoverySummary(config, null),
         localCiContract,
         loopRuntime,
+        runtimeRecoverySummary: buildRuntimeRecoverySummary({
+          loopRuntime,
+          trackedIssues,
+          detailedStatusLines: [...inactiveDetailedStatusLines, ...trackedPrMismatchLines],
+        }),
         activeIssue: null,
         selectionSummary: null,
         trackedIssues,
@@ -465,6 +481,11 @@ export async function buildSupervisorStatusReport(args: {
     candidateDiscovery: buildCandidateDiscoverySummary(config, null),
     localCiContract,
     loopRuntime,
+    runtimeRecoverySummary: buildRuntimeRecoverySummary({
+      loopRuntime,
+      trackedIssues,
+      detailedStatusLines: [...detailedStatusLinesWithInventory, ...summaryLines, ...trackedPrMismatchLines],
+    }),
     activeIssue: {
       issueNumber: statusRecords.activeRecord.issue_number,
       state: statusRecords.activeRecord.state,

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildRuntimeRecoverySummary } from "./supervisor-status-report";
+
+const baseLoopRuntime = {
+  state: "off" as const,
+  hostMode: "unknown" as const,
+  markerPath: "none",
+  configPath: null,
+  stateFile: "none",
+  pid: null,
+  startedAt: null,
+  ownershipConfidence: "none" as const,
+  detail: null,
+};
+
+test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recovery state exists", () => {
+  assert.equal(
+    buildRuntimeRecoverySummary({
+      loopRuntime: baseLoopRuntime,
+      trackedIssues: [],
+      detailedStatusLines: ["tracked_issues=0"],
+    }),
+    null,
+  );
+});
+
+test("buildRuntimeRecoverySummary reuses restart recommendation vocabulary and classified recovery signals", () => {
+  assert.deepEqual(
+    buildRuntimeRecoverySummary({
+      loopRuntime: {
+        ...baseLoopRuntime,
+        ownershipConfidence: "stale_lock",
+      },
+      trackedIssues: [
+        {
+          issueNumber: 171,
+          state: "blocked",
+          branch: "codex/issue-171",
+          prNumber: 271,
+          blockedReason: "stale_review_bot",
+        },
+      ],
+      detailedStatusLines: [
+        "loop_runtime_blocker issue=#171 reason=recoverable_active_tracked_work_waiting_for_loop expected=loop_runtime_state_running_then_tracked_issue_advances",
+        "stale_review_bot_remediation issue=#171 pr=#271 reason=stale_review_bot classification=metadata_only manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+        "no_active_tracked_record issue=#178 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state",
+      ],
+    }),
+    {
+      loopState: "off",
+      lockConfidence: "stale_lock",
+      trackedRecords: [
+        {
+          issueNumber: 171,
+          state: "blocked",
+          prNumber: 271,
+          blockedReason: "stale_review_bot",
+        },
+      ],
+      signals: [
+        {
+          kind: "loop_runtime_stale_lock",
+          summary: "Loop runtime marker is stale.",
+        },
+        {
+          kind: "stale_review_bot_remediation",
+          summary:
+            "stale_review_bot_remediation issue=#171 pr=#271 reason=stale_review_bot classification=metadata_only manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+        },
+        {
+          kind: "repairable_path_hygiene",
+          summary:
+            "no_active_tracked_record issue=#178 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state",
+        },
+      ],
+      recommendation: {
+        category: "restart_required_for_convergence",
+        source: "loop_runtime_blocker",
+        summary: "Restarting the supported supervisor loop is required before active tracked work can converge.",
+      },
+    },
+  );
+});

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -22,7 +22,12 @@ import {
   formatLastSuccessfulInventorySnapshotStatusLine,
 } from "../inventory-refresh-state";
 import { buildTrustAndConfigWarnings, buildWarning, renderStatusWarningLine } from "../warning-formatting";
-import { renderOperatorActionLine, selectStatusOperatorAction } from "../operator-actions";
+import {
+  type RestartRecommendation,
+  renderOperatorActionLine,
+  selectRestartRecommendation,
+  selectStatusOperatorAction,
+} from "../operator-actions";
 
 export interface SupervisorStatusWarningDto {
   kind: "readiness" | "status";
@@ -46,6 +51,32 @@ export interface SupervisorTrackedIssueDto {
   blockedReason: BlockedReason | null;
 }
 
+export interface SupervisorRuntimeRecoverySignalDto {
+  kind:
+    | "loop_runtime_recovery"
+    | "loop_runtime_duplicate"
+    | "loop_runtime_stale_lock"
+    | "loop_runtime_ambiguous_owner"
+    | "stale_review_bot_remediation"
+    | "repairable_path_hygiene";
+  summary: string;
+}
+
+export interface SupervisorRuntimeRecoveryTrackedRecordDto {
+  issueNumber: number;
+  state: RunState;
+  prNumber: number | null;
+  blockedReason: BlockedReason | null;
+}
+
+export interface SupervisorRuntimeRecoverySummaryDto {
+  loopState: SupervisorLoopRuntimeDto["state"];
+  lockConfidence: SupervisorLoopRuntimeDto["ownershipConfidence"];
+  trackedRecords: SupervisorRuntimeRecoveryTrackedRecordDto[];
+  signals: SupervisorRuntimeRecoverySignalDto[];
+  recommendation: Pick<RestartRecommendation, "category" | "source" | "summary"> | null;
+}
+
 export interface SupervisorReconciliationProgressDto {
   phase: string;
   startedAt: string | null;
@@ -64,6 +95,7 @@ export interface SupervisorStatusDto {
   candidateDiscovery: SupervisorCandidateDiscoveryDto | null;
   localCiContract?: LocalCiContractSummary;
   loopRuntime: SupervisorLoopRuntimeDto;
+  runtimeRecoverySummary?: SupervisorRuntimeRecoverySummaryDto | null;
   activeIssue: SupervisorActiveIssueDto | null;
   selectionSummary: SupervisorSelectionSummaryDto | null;
   trackedIssues: SupervisorTrackedIssueDto[];
@@ -76,6 +108,89 @@ export interface SupervisorStatusDto {
   readinessLines: string[];
   whyLines: string[];
   warning: SupervisorStatusWarningDto | null;
+}
+
+function collectRuntimeRecoverySignals(args: {
+  loopRuntime: SupervisorLoopRuntimeDto;
+  detailedStatusLines: string[];
+}): SupervisorRuntimeRecoverySignalDto[] {
+  const signals: SupervisorRuntimeRecoverySignalDto[] = [];
+  const seen = new Set<string>();
+
+  function push(kind: SupervisorRuntimeRecoverySignalDto["kind"], summary: string): void {
+    const key = `${kind}\0${summary}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    signals.push({ kind, summary: truncate(sanitizeStatusValue(summary), 300) ?? summary });
+  }
+
+  if (args.loopRuntime.duplicateLoopDiagnostic) {
+    push(
+      "loop_runtime_duplicate",
+      args.loopRuntime.duplicateLoopDiagnostic.recoveryGuidance ??
+        args.loopRuntime.recoveryGuidance ??
+        "Loop runtime ownership is ambiguous because duplicate loop processes were detected.",
+    );
+  } else if (args.loopRuntime.recoveryGuidance) {
+    push("loop_runtime_recovery", args.loopRuntime.recoveryGuidance);
+  }
+
+  if (args.loopRuntime.ownershipConfidence === "stale_lock") {
+    push("loop_runtime_stale_lock", "Loop runtime marker is stale.");
+  } else if (args.loopRuntime.ownershipConfidence === "ambiguous_owner") {
+    push("loop_runtime_ambiguous_owner", args.loopRuntime.recoveryGuidance ?? "Loop runtime marker ownership is ambiguous.");
+  }
+
+  for (const line of args.detailedStatusLines) {
+    if (line.startsWith("stale_review_bot_remediation ")) {
+      push("stale_review_bot_remediation", line);
+      continue;
+    }
+    if (
+      /(?:repairable_path_hygiene|workstation_local_path_hygiene|workstation-local-path-hygiene-failed)/u.test(line)
+    ) {
+      push("repairable_path_hygiene", line);
+    }
+  }
+
+  return signals;
+}
+
+export function buildRuntimeRecoverySummary(args: {
+  loopRuntime: SupervisorLoopRuntimeDto;
+  trackedIssues: SupervisorTrackedIssueDto[];
+  detailedStatusLines: string[];
+}): SupervisorRuntimeRecoverySummaryDto | null {
+  const recommendation = selectRestartRecommendation({ detailedStatusLines: args.detailedStatusLines });
+  const signals = collectRuntimeRecoverySignals(args);
+
+  if (recommendation === null && signals.length === 0) {
+    return null;
+  }
+
+  return {
+    loopState: args.loopRuntime.state,
+    lockConfidence: args.loopRuntime.ownershipConfidence,
+    trackedRecords: args.trackedIssues
+      .filter((issue) => issue.state !== "done")
+      .map((issue) => ({
+        issueNumber: issue.issueNumber,
+        state: issue.state,
+        prNumber: issue.prNumber,
+        blockedReason: issue.blockedReason,
+      })),
+    signals,
+    recommendation:
+      recommendation === null
+        ? null
+        : {
+          category: recommendation.category,
+          source: recommendation.source,
+          summary: recommendation.summary,
+        },
+  };
 }
 
 export function renderGitHubRateLimitLine(resource: "rest" | "graphql", budget: GitHubRateLimitBudget): string {


### PR DESCRIPTION
## Summary
- add a typed runtimeRecoverySummary DTO to status reports from loop runtime, tracked records, restart recommendations, and recovery signals
- render the summary in the WebUI without browser-side domain classification
- cover stale-review metadata-only and repairable path-hygiene signals with focused tests

## Verification
- npx tsx --test src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-view-model.test.ts src/backend/webui-dashboard-browser-issue-details.test.ts src/backend/webui-dashboard-browser-smoke.test.ts src/supervisor/supervisor-status-report.test.ts
- npm run build

Closes #1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Runtime recovery" section to the dashboard that displays loop state, lock confidence, tracked recovery records, recovery signals, and an optional recommendation; the section is hidden when no summary is available and is rendered as ordered diagnostic lines.
* **Tests**
  * Added unit and integration tests validating summary construction and dashboard rendering; test fixtures updated to include the runtime recovery summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->