### PR TITLE
Suppress quiet no-active restart recommendations

### DIFF
--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -863,6 +863,33 @@ test("dashboard renders the typed runtime recovery summary without parsing domai
   assert.equal(harness.remainingFetches.length, 0);
 });
 
+test("dashboard keeps runtime recovery summary hidden when typed summary is absent", async () => {
+  const harness = createDashboardHarness([
+    {
+      path: "/api/status?why=true",
+      response: jsonResponse(
+        createStatus({
+          includeWhyLines: false,
+          runtimeRecoverySummary: null,
+          detailedStatusLines: [
+            "no_active_tracked_record issue=#188 classification=safe_to_ignore state=done reason=terminal_done",
+          ],
+        }),
+      ),
+    },
+    { path: "/api/doctor", response: jsonResponse(createDoctor()) },
+  ]);
+  await harness.flush();
+
+  const runtimeRecoverySummary = harness.document.getElementById("runtime-recovery-summary");
+  const runtimeRecoveryLines = harness.document.getElementById("runtime-recovery-lines");
+  assert.ok(runtimeRecoverySummary);
+  assert.ok(runtimeRecoveryLines);
+  assert.equal(runtimeRecoverySummary.hidden, true);
+  assert.equal(runtimeRecoveryLines.textContent, "");
+  assert.equal(harness.remainingFetches.length, 0);
+});
+
 test("dashboard moves tracked history into a dedicated panel with non-done default and reveal toggle", async () => {
   const harness = createDashboardHarness([
     {

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -32,10 +32,18 @@ test("selectRestartRecommendation classifies every restart recommendation catego
   assert.equal(
     requireRestartRecommendation(selectRestartRecommendation({
       detailedStatusLines: [
-        "no_active_tracked_record issue=#188 classification=safe_to_ignore state=done reason=terminal_done",
+        "no_active_tracked_record issue=#188 classification=active_tracked_work_blocker state=addressing_review reason=loop_off",
       ],
     })).category,
-    "restart_not_enough",
+    "restart_required_for_convergence",
+  );
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#189 classification=stale_but_recoverable state=blocked reason=stale_review_bot",
+      ],
+    })).category,
+    "restart_required_for_convergence",
   );
   assert.equal(
     requireRestartRecommendation(selectRestartRecommendation({
@@ -44,6 +52,36 @@ test("selectRestartRecommendation classifies every restart recommendation catego
       ],
     })).category,
     "manual_review_before_restart",
+  );
+});
+
+test("selectRestartRecommendation stays quiet for completed no-active tracked records", () => {
+  assert.equal(
+    selectRestartRecommendation({
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#188 classification=safe_to_ignore state=done reason=terminal_done",
+      ],
+    }),
+    null,
+  );
+  assert.equal(
+    selectRestartRecommendation({
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#189 classification=stale_already_handled state=done reason=merged_pr_convergence",
+      ],
+    }),
+    null,
+  );
+});
+
+test("selectRestartRecommendation still flags non-quiet no-active classifications as restart-not-enough", () => {
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#188 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state",
+      ],
+    })).category,
+    "restart_not_enough",
   );
 });
 

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -111,6 +111,13 @@ export function selectRestartRecommendation(args: {
     }
 
     if (
+      noActiveClassification === "safe_to_ignore" ||
+      noActiveClassification === "stale_already_handled"
+    ) {
+      continue;
+    }
+
+    if (
       noActiveClassification === "active_tracked_work_blocker" ||
       noActiveClassification === "stale_but_recoverable"
     ) {

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -25,6 +25,37 @@ test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recover
   );
 });
 
+test("buildRuntimeRecoverySummary stays quiet for quiet no-active tracked records", () => {
+  assert.equal(
+    buildRuntimeRecoverySummary({
+      loopRuntime: baseLoopRuntime,
+      trackedIssues: [
+        {
+          issueNumber: 188,
+          state: "done",
+          branch: "codex/issue-188",
+          prNumber: 288,
+          blockedReason: null,
+        },
+      ],
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#188 classification=safe_to_ignore state=done reason=terminal_done",
+      ],
+    }),
+    null,
+  );
+  assert.equal(
+    buildRuntimeRecoverySummary({
+      loopRuntime: baseLoopRuntime,
+      trackedIssues: [],
+      detailedStatusLines: [
+        "no_active_tracked_record issue=#189 classification=stale_already_handled state=done reason=merged_pr_convergence",
+      ],
+    }),
+    null,
+  );
+});
+
 test("buildRuntimeRecoverySummary reuses restart recommendation vocabulary and classified recovery signals", () => {
   assert.deepEqual(
     buildRuntimeRecoverySummary({


### PR DESCRIPTION
## Summary
- Suppress restart recommendations for quiet no-active tracked records (`safe_to_ignore`, `stale_already_handled`)
- Preserve restart-required guidance for active/recoverable no-active states and manual-review-before-restart guidance for manual/provider cases
- Add focused status and WebUI regression coverage for hidden runtime recovery summaries

Fixes #1726

## Verification
- `npx tsx --test src/operator-actions.test.ts src/supervisor/supervisor-status-report.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-view-model.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime recovery handling for cases with no active tracked records.
  * Enhanced restart recommendation logic to accurately categorize recovery scenarios and filter non-actionable states.
  * Fixed runtime recovery summary display to properly hide when no actionable recovery state exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->