### PR TITLE
Add guided local CI adoption flow

### DIFF
--- a/src/backend/webui-browser-script-helpers.ts
+++ b/src/backend/webui-browser-script-helpers.ts
@@ -12,6 +12,25 @@ export type BrowserLocalCiContractLike = {
   source?: string | null;
   summary?: string | null;
   warning?: string | null;
+  adoptionFlow?: BrowserLocalCiAdoptionFlowLike | null;
+};
+
+export type BrowserLocalCiAdoptionDecisionLike = {
+  kind?: string | null;
+  enabled?: boolean | null;
+  summary?: string | null;
+  writes?: string[] | null;
+};
+
+export type BrowserLocalCiAdoptionFlowLike = {
+  state?: string | null;
+  candidateDetected?: boolean | null;
+  commandPreview?: string | null;
+  validationStatus?: string | null;
+  workspacePreparationCommand?: string | null;
+  workspacePreparationRecommendedCommand?: string | null;
+  workspacePreparationGuidance?: string | null;
+  decisions?: BrowserLocalCiAdoptionDecisionLike[] | null;
 };
 
 export type BrowserHostLike = {
@@ -61,6 +80,7 @@ export function normalizeBrowserLocalCiContract(
     source: localCiContract?.source ?? "config",
     summary: localCiContract?.summary ?? "No repo-owned local CI contract is configured.",
     warning: localCiContract?.warning ?? null,
+    adoptionFlow: localCiContract?.adoptionFlow ?? null,
   };
 }
 
@@ -89,6 +109,20 @@ export function buildBrowserLocalCiChecklistEntries(
 ): BrowserChecklistEntry[] {
   const normalized = normalizeBrowserLocalCiContract(localCiContract);
   const dismissed = normalized.source === "dismissed_repo_script_candidate";
+  const adoptionFlow = normalized.adoptionFlow;
+  const adoptionFlowNotes = adoptionFlow
+    ? [
+      "Wizard state: " + formatBrowserToken(adoptionFlow.state),
+      "Command preview: " + (adoptionFlow.commandPreview || "none"),
+      "Validation status: " + formatBrowserToken(adoptionFlow.validationStatus),
+      adoptionFlow.workspacePreparationGuidance || "workspacePreparationCommand guidance unavailable.",
+      ...(Array.isArray(adoptionFlow.decisions)
+        ? adoptionFlow.decisions
+          .filter((decision) => decision && decision.enabled === true && typeof decision.summary === "string")
+          .map((decision) => "Decision: " + decision.summary)
+        : []),
+    ]
+    : [];
   return [{
     title: "Configured: " + (normalized.configured ? "yes" : "no"),
     tone: "",
@@ -97,22 +131,23 @@ export function buildBrowserLocalCiChecklistEntries(
       "Source: " + formatBrowserToken(normalized.source),
       ...(normalized.recommendedCommand ? ["Recommended command: " + normalized.recommendedCommand] : []),
     ],
-    notes: normalized.warning
-      ? [
+    notes: [
+      ...(normalized.warning
+        ? [
         "Warning: " + normalized.warning,
         "This warning is advisory only; configure a repo-owned workspacePreparationCommand so preserved issue worktrees can prepare toolchains before host-local CI runs.",
       ]
-      : normalized.configured
-      ? [
+        : normalized.configured
+        ? [
         "This repo-owned command is the canonical local verification step before PR publication or update.",
         "When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again.",
       ]
-      : dismissed
+        : dismissed
         ? [
           "This repo-owned local CI candidate was intentionally dismissed, so localCiCommand remains unset and non-blocking.",
           "codex-supervisor will not run the dismissed candidate unless you opt in later by configuring localCiCommand.",
         ]
-      : normalized.recommendedCommand
+        : normalized.recommendedCommand
         ? [
           "This repo already defines a repo-owned local CI entrypoint, but codex-supervisor will not run it until localCiCommand is configured.",
           "This warning is advisory only; first-run setup readiness and blocker semantics stay unchanged until you opt in by configuring localCiCommand.",
@@ -120,7 +155,9 @@ export function buildBrowserLocalCiChecklistEntries(
         : [
           "If the repo does not declare this contract, codex-supervisor falls back to the issue's ## Verification guidance and operator workflow.",
           "When configured local CI fails, PR publication or ready-for-review promotion stays blocked until the repo-owned command passes again.",
-        ],
+        ]),
+      ...adoptionFlowNotes,
+    ],
   }];
 }
 

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -2045,6 +2045,30 @@ test("setup shell highlights a repo-owned local CI candidate when localCiCommand
           source: "repo_script_candidate",
           summary:
             "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
+          adoptionFlow: {
+            state: "candidate_detected",
+            candidateDetected: true,
+            commandPreview: "npm run verify:pre-pr",
+            validationStatus: "not_run",
+            workspacePreparationCommand: null,
+            workspacePreparationRecommendedCommand: "npm ci",
+            workspacePreparationGuidance:
+              "workspacePreparationCommand is unset. Recommended repo-native preparation command: npm ci.",
+            decisions: [
+              {
+                kind: "adopt",
+                enabled: true,
+                summary: "Save npm run verify:pre-pr as localCiCommand.",
+                writes: ["localCiCommand"],
+              },
+              {
+                kind: "dismiss",
+                enabled: true,
+                summary: "Record localCiCandidateDismissed=true without changing an already configured localCiCommand.",
+                writes: ["localCiCandidateDismissed"],
+              },
+            ],
+          },
         },
       }), unavailableManagedRestart)),
     },
@@ -2057,7 +2081,7 @@ test("setup shell highlights a repo-owned local CI candidate when localCiCommand
   );
   assert.match(
     harness.document.getElementById("setup-local-ci-details")?.textContent ?? "",
-    /Configured: no.*Command: none.*Source: repo script candidate.*Recommended command: npm run verify:pre-pr.*This repo already defines a repo-owned local CI entrypoint, but codex-supervisor will not run it until localCiCommand is configured.*This warning is advisory only; first-run setup readiness and blocker semantics stay unchanged until you opt in by configuring localCiCommand\./u,
+    /Configured: no.*Command: none.*Source: repo script candidate.*Recommended command: npm run verify:pre-pr.*This repo already defines a repo-owned local CI entrypoint, but codex-supervisor will not run it until localCiCommand is configured.*Command preview: npm run verify:pre-pr.*Validation status: not run.*workspacePreparationCommand is unset\. Recommended repo-native preparation command: npm ci\..*Decision: Save npm run verify:pre-pr as localCiCommand\./u,
   );
   assert.equal(harness.document.getElementById("setup-input-localCiCommand")?.value, "");
   const adoptButton = harness.document.getElementById("setup-local-ci-adopt-recommended");

--- a/src/backend/webui-local-ci-browser-helpers.test.ts
+++ b/src/backend/webui-local-ci-browser-helpers.test.ts
@@ -39,6 +39,50 @@ test("local CI browser helpers summarize a repo-owned candidate contract consist
   assert.equal(canDismissRecommendedLocalCiCommand(contract), true);
 });
 
+test("local CI browser helpers render guided adoption flow preview and decisions", () => {
+  const contract = {
+    configured: false,
+    command: null,
+    recommendedCommand: "npm run verify:pre-pr",
+    source: "repo_script_candidate",
+    summary:
+      "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
+    adoptionFlow: {
+      state: "candidate_detected",
+      candidateDetected: true,
+      commandPreview: "npm run verify:pre-pr",
+      validationStatus: "not_run",
+      workspacePreparationCommand: null,
+      workspacePreparationRecommendedCommand: "npm ci",
+      workspacePreparationGuidance: "workspacePreparationCommand is unset. Recommended repo-native preparation command: npm ci.",
+      decisions: [
+        {
+          kind: "adopt",
+          enabled: true,
+          summary: "Save npm run verify:pre-pr as localCiCommand.",
+          writes: ["localCiCommand"],
+        },
+        {
+          kind: "dismiss",
+          enabled: true,
+          summary: "Record localCiCandidateDismissed=true without changing an already configured localCiCommand.",
+          writes: ["localCiCandidateDismissed"],
+        },
+      ],
+    },
+  };
+
+  const notes = buildLocalCiContractChecklistItems(contract)[0]?.notes.join("\n") ?? "";
+  assert.match(
+    notes,
+    /Wizard state: candidate detected\nCommand preview: npm run verify:pre-pr\nValidation status: not run\nworkspacePreparationCommand is unset\. Recommended repo-native preparation command: npm ci\.\nDecision: Save npm run verify:pre-pr as localCiCommand\./u,
+  );
+  assert.match(
+    notes,
+    /Decision: Record localCiCandidateDismissed=true without changing an already configured localCiCommand\./u,
+  );
+});
+
 test("local CI browser helpers summarize an explicitly dismissed candidate", () => {
   const contract = {
     configured: false,

--- a/src/backend/webui-setup.test.ts
+++ b/src/backend/webui-setup.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createSetupField,
+  createSetupProviderPosture,
+  createSetupReadinessReport,
+  createSetupTrustPosture,
+  createUnavailableManagedRestart,
+  withManagedRestart,
+} from "./setup-test-fixtures";
+import { createSetupHarness, jsonResponse } from "./webui-dashboard-test-fixtures";
+
+const unavailableManagedRestart = createUnavailableManagedRestart();
+
+test("setup shell renders guided local CI adoption flow details", async () => {
+  const harness = createSetupHarness([
+    {
+      path: "/api/setup-readiness",
+      response: jsonResponse(withManagedRestart(createSetupReadinessReport({
+        ready: true,
+        overallStatus: "configured",
+        fields: [
+          createSetupField("localCiCommand"),
+        ],
+        blockers: [],
+        hostReadiness: { overallStatus: "pass", checks: [] },
+        providerPosture: createSetupProviderPosture({
+          profile: "codex",
+          provider: "codex",
+          reviewers: ["chatgpt-codex-connector"],
+          signalSource: "review_bot_logins",
+          configured: true,
+          summary: "Codex Connector is configured.",
+        }),
+        trustPosture: createSetupTrustPosture({ warning: null }),
+        localCiContract: {
+          configured: false,
+          command: null,
+          recommendedCommand: "npm run verify:pre-pr",
+          source: "repo_script_candidate",
+          summary:
+            "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
+          adoptionFlow: {
+            state: "candidate_detected",
+            candidateDetected: true,
+            commandPreview: "npm run verify:pre-pr",
+            validationStatus: "not_run",
+            workspacePreparationCommand: null,
+            workspacePreparationRecommendedCommand: "npm ci",
+            workspacePreparationGuidance:
+              "workspacePreparationCommand is unset. Recommended repo-native preparation command: npm ci.",
+            decisions: [
+              {
+                kind: "adopt",
+                enabled: true,
+                summary: "Save npm run verify:pre-pr as localCiCommand.",
+                writes: ["localCiCommand"],
+              },
+              {
+                kind: "dismiss",
+                enabled: true,
+                summary: "Record localCiCandidateDismissed=true without changing an already configured localCiCommand.",
+                writes: ["localCiCandidateDismissed"],
+              },
+            ],
+          },
+        },
+      }), unavailableManagedRestart)),
+    },
+  ]);
+  await harness.flush();
+
+  const details = harness.document.getElementById("setup-local-ci-details")?.textContent ?? "";
+  assert.match(details, /Command preview: npm run verify:pre-pr/u);
+  assert.match(details, /Validation status: not run/u);
+  assert.match(details, /workspacePreparationCommand is unset\. Recommended repo-native preparation command: npm ci\./u);
+  assert.match(details, /Decision: Save npm run verify:pre-pr as localCiCommand\./u);
+  assert.match(
+    details,
+    /Decision: Record localCiCandidateDismissed=true without changing an already configured localCiCommand\./u,
+  );
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2311,6 +2311,17 @@ test("updateSetupConfig accepts localCiCommand through the setup-owned write sur
     summary: "Repo-owned local CI contract is configured.",
     warning:
       "localCiCommand is configured but workspacePreparationCommand is unset. Configure a repo-owned workspacePreparationCommand so preserved issue worktrees can prepare toolchains before host-local CI runs. GitHub checks can stay green while host-local CI still blocks tracked PR progress.",
+    adoptionFlow: {
+      state: "configured",
+      candidateDetected: true,
+      commandPreview: "npm run verify:pre-pr",
+      validationStatus: "configured",
+      workspacePreparationCommand: null,
+      workspacePreparationRecommendedCommand: null,
+      workspacePreparationGuidance:
+        "workspacePreparationCommand is unset; confirm preserved issue worktrees can prepare required toolchains before adopting local CI.",
+      decisions: [],
+    },
   });
 });
 
@@ -2462,6 +2473,30 @@ test("updateSetupConfig clears localCiCommand back to the unset state", async (t
     source: "repo_script_candidate",
     summary: "Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: npm run verify:pre-pr.",
     warning: null,
+    adoptionFlow: {
+      state: "candidate_detected",
+      candidateDetected: true,
+      commandPreview: "npm run verify:pre-pr",
+      validationStatus: "not_run",
+      workspacePreparationCommand: null,
+      workspacePreparationRecommendedCommand: null,
+      workspacePreparationGuidance:
+        "workspacePreparationCommand is unset; confirm preserved issue worktrees can prepare required toolchains before adopting local CI.",
+      decisions: [
+        {
+          kind: "adopt",
+          enabled: true,
+          summary: "Save npm run verify:pre-pr as localCiCommand.",
+          writes: ["localCiCommand"],
+        },
+        {
+          kind: "dismiss",
+          enabled: true,
+          summary: "Record localCiCandidateDismissed=true without changing an already configured localCiCommand.",
+          writes: ["localCiCandidateDismissed"],
+        },
+      ],
+    },
   });
 });
 
@@ -2520,6 +2555,17 @@ test("updateSetupConfig records an explicit local CI candidate dismissal", async
     summary:
       "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
     warning: null,
+    adoptionFlow: {
+      state: "dismissed",
+      candidateDetected: true,
+      commandPreview: "npm run verify:pre-pr",
+      validationStatus: "dismissed",
+      workspacePreparationCommand: null,
+      workspacePreparationRecommendedCommand: null,
+      workspacePreparationGuidance:
+        "workspacePreparationCommand is unset; confirm preserved issue worktrees can prepare required toolchains before adopting local CI.",
+      decisions: [],
+    },
   });
 });
 
@@ -2619,6 +2665,17 @@ test("updateSetupConfig reports restart when dismissal resolves a malformed conf
     summary:
       "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: npm run verify:pre-pr.",
     warning: null,
+    adoptionFlow: {
+      state: "dismissed",
+      candidateDetected: true,
+      commandPreview: "npm run verify:pre-pr",
+      validationStatus: "dismissed",
+      workspacePreparationCommand: null,
+      workspacePreparationRecommendedCommand: null,
+      workspacePreparationGuidance:
+        "workspacePreparationCommand is unset; confirm preserved issue worktrees can prepare required toolchains before adopting local CI.",
+      decisions: [],
+    },
   });
 });
 

--- a/src/core/config-diagnostics.ts
+++ b/src/core/config-diagnostics.ts
@@ -144,6 +144,43 @@ export function summarizeLocalCiContract(
 ): LocalCiContractSummary {
   const command = displayLocalCiCommand(config.localCiCommand);
   const recommendedCommand = findRepoOwnedLocalCiCandidate(config.repoPath);
+  const workspacePreparationCommand = displayLocalCiCommand(config.workspacePreparationCommand);
+  const workspacePreparationRecommendedCommand = findRepoOwnedWorkspacePreparationCandidate(config.repoPath);
+  type LocalCiAdoptionFlowSummary = NonNullable<LocalCiContractSummary["adoptionFlow"]>;
+  const buildAdoptionFlow = (args: {
+    state: LocalCiAdoptionFlowSummary["state"];
+    validationStatus: LocalCiAdoptionFlowSummary["validationStatus"];
+    candidateDetected: boolean;
+    commandPreview: string | null;
+  }): LocalCiAdoptionFlowSummary => ({
+    state: args.state,
+    candidateDetected: args.candidateDetected,
+    commandPreview: args.commandPreview,
+    validationStatus: args.validationStatus,
+    workspacePreparationCommand,
+    workspacePreparationRecommendedCommand,
+    workspacePreparationGuidance: workspacePreparationCommand !== null
+      ? `workspacePreparationCommand is configured as ${workspacePreparationCommand}.`
+      : workspacePreparationRecommendedCommand !== null
+        ? `workspacePreparationCommand is unset. Recommended repo-native preparation command: ${workspacePreparationRecommendedCommand}.`
+        : "workspacePreparationCommand is unset; confirm preserved issue worktrees can prepare required toolchains before adopting local CI.",
+    decisions: args.state === "candidate_detected" && args.commandPreview !== null
+      ? [
+        {
+          kind: "adopt",
+          enabled: true,
+          summary: `Save ${args.commandPreview} as localCiCommand.`,
+          writes: ["localCiCommand"],
+        },
+        {
+          kind: "dismiss",
+          enabled: true,
+          summary: "Record localCiCandidateDismissed=true without changing an already configured localCiCommand.",
+          writes: ["localCiCandidateDismissed"],
+        },
+      ]
+      : [],
+  });
   const warning = buildMissingWorkspacePreparationContractWarning(config);
 
   if (command !== null) {
@@ -154,6 +191,12 @@ export function summarizeLocalCiContract(
       source: "config",
       summary: "Repo-owned local CI contract is configured.",
       warning,
+      adoptionFlow: buildAdoptionFlow({
+        state: "configured",
+        validationStatus: "configured",
+        candidateDetected: recommendedCommand !== null,
+        commandPreview: command,
+      }),
     };
   }
 
@@ -166,6 +209,12 @@ export function summarizeLocalCiContract(
       summary:
         `Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking. Dismissed candidate: ${recommendedCommand}.`,
       warning: null,
+      adoptionFlow: buildAdoptionFlow({
+        state: "dismissed",
+        validationStatus: "dismissed",
+        candidateDetected: true,
+        commandPreview: recommendedCommand,
+      }),
     };
   }
 
@@ -177,6 +226,12 @@ export function summarizeLocalCiContract(
       source: "repo_script_candidate",
       summary: `Repo-owned local CI candidate exists but localCiCommand is unset. Recommended command: ${recommendedCommand}.`,
       warning: null,
+      adoptionFlow: buildAdoptionFlow({
+        state: "candidate_detected",
+        validationStatus: "not_run",
+        candidateDetected: true,
+        commandPreview: recommendedCommand,
+      }),
     };
   }
 
@@ -187,6 +242,12 @@ export function summarizeLocalCiContract(
     source: "config",
     summary: "No repo-owned local CI contract is configured.",
     warning: null,
+    adoptionFlow: buildAdoptionFlow({
+      state: "not_available",
+      validationStatus: "not_available",
+      candidateDetected: false,
+      commandPreview: null,
+    }),
   };
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -103,6 +103,25 @@ export interface LocalCiContractSummary {
   source: "config" | "repo_script_candidate" | "dismissed_repo_script_candidate";
   summary: string;
   warning?: string | null;
+  adoptionFlow?: LocalCiAdoptionFlow;
+}
+
+export interface LocalCiAdoptionDecision {
+  kind: "adopt" | "dismiss";
+  enabled: boolean;
+  summary: string;
+  writes: string[];
+}
+
+export interface LocalCiAdoptionFlow {
+  state: "not_available" | "candidate_detected" | "configured" | "dismissed";
+  candidateDetected: boolean;
+  commandPreview: string | null;
+  validationStatus: "not_available" | "not_run" | "configured" | "dismissed";
+  workspacePreparationCommand: string | null;
+  workspacePreparationRecommendedCommand: string | null;
+  workspacePreparationGuidance: string;
+  decisions: LocalCiAdoptionDecision[];
 }
 
 export interface WorkspacePreparationContractSummary {

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -248,6 +248,94 @@ test("diagnoseSetupReadiness suggests a repo-native workspace preparation comman
   assert.match(summary.nextActions[0]?.summary ?? "", /adopt the repo-owned workspace preparation command npm ci/i);
 });
 
+test("diagnoseSetupReadiness exposes a guided local CI adoption flow for repo script candidates", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "package.json"),
+    JSON.stringify(
+      {
+        private: true,
+        scripts: {
+          "verify:pre-pr": "node --test",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await fs.writeFile(path.join(repoPath, "package-lock.json"), "{}\n", "utf8");
+  execFileSync("git", ["add", "package.json", "package-lock.json"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "add local ci candidate"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+      }),
+    ),
+    "utf8",
+  );
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.deepEqual(summary.localCiContract?.adoptionFlow, {
+    state: "candidate_detected",
+    candidateDetected: true,
+    commandPreview: "npm run verify:pre-pr",
+    validationStatus: "not_run",
+    workspacePreparationCommand: null,
+    workspacePreparationRecommendedCommand: "npm ci",
+    workspacePreparationGuidance: "workspacePreparationCommand is unset. Recommended repo-native preparation command: npm ci.",
+    decisions: [
+      {
+        kind: "adopt",
+        enabled: true,
+        summary: "Save npm run verify:pre-pr as localCiCommand.",
+        writes: ["localCiCommand"],
+      },
+      {
+        kind: "dismiss",
+        enabled: true,
+        summary: "Record localCiCandidateDismissed=true without changing an already configured localCiCommand.",
+        writes: ["localCiCandidateDismissed"],
+      },
+    ],
+  });
+  assert.deepEqual(
+    summary.nextActions
+      .filter((action) => action.source === "local_ci_candidate")
+      .map((action) => [action.action, action.fieldKeys]),
+    [
+      ["adopt_local_ci", ["localCiCommand", "localCiCandidateDismissed"]],
+      ["dismiss_local_ci", ["localCiCandidateDismissed"]],
+    ],
+  );
+});
+
 test("diagnoseSetupReadiness requires explicit trust posture decisions", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
   t.after(async () => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -982,6 +982,17 @@ test("statusReport exposes the typed local CI contract summary from config", asy
     summary: "Repo-owned local CI contract is configured.",
     warning:
       "localCiCommand is configured but workspacePreparationCommand is unset. Configure a repo-owned workspacePreparationCommand so preserved issue worktrees can prepare toolchains before host-local CI runs. GitHub checks can stay green while host-local CI still blocks tracked PR progress.",
+    adoptionFlow: {
+      state: "configured",
+      candidateDetected: false,
+      commandPreview: "npm run ci:local",
+      validationStatus: "configured",
+      workspacePreparationCommand: null,
+      workspacePreparationRecommendedCommand: null,
+      workspacePreparationGuidance:
+        "workspacePreparationCommand is unset; confirm preserved issue worktrees can prepare required toolchains before adopting local CI.",
+      decisions: [],
+    },
   });
 
   const status = await supervisor.status();


### PR DESCRIPTION
## Summary
- add a typed local CI adoptionFlow to setup-readiness local CI contract summaries
- render command preview, validation status, adopt/dismiss decisions, and workspacePreparationCommand guidance in the setup WebUI
- add focused setup-readiness, WebUI, and config coverage for preview/adopt/dismiss behavior

## Verification
- npx tsx --test src/setup-readiness.test.ts src/backend/webui-setup.test.ts src/backend/webui-dashboard.test.ts src/config.test.ts
- npm run build

Part of #1728
Closes #1729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided local CI adoption flow with candidate detection, command preview, and validation status display
  * Added workspace preparation guidance and recommendations
  * Added adoption and dismissal decision options for local CI candidates in the setup interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->