### PR TITLE
Document repo-owned verification gate boundaries

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -397,6 +397,8 @@ Minimum rules for that contract:
 
 When a managed repo wants a canonical local verification step before PR publication or update, use a repo-owned local CI contract. The repo-owned local CI contract is a single repo-defined entrypoint such as `npm run ci:local` or `npm run verify:pre-pr`.
 
+Issue-level `## Verification` is issue-authored guidance for the operator and Codex turn. It is not a repo-owned fail-closed gate by itself. Status and doctor wording should name the active repo-owned gate, such as `localCiCommand`, workstation-local path hygiene, release-readiness posture, or ready-for-review promotion, instead of implying that issue-authored verification text has become a configured repository gate.
+
 The repo remains the source of truth for what that command does. codex-supervisor only runs the configured entrypoint. It does not decompose the command, append inferred subtasks, or try to decide which subset of checks matters for the current diff.
 
 Minimum expectations for that contract:

--- a/docs/validation-checklist.md
+++ b/docs/validation-checklist.md
@@ -60,7 +60,7 @@ Sufficient readiness means broader use is reasonable because the loop has surviv
 
 ## Advisory boundary
 
-This checklist is advisory unless `releaseReadinessGate: block_release_publication` is explicitly wired into release automation. That configured gate can block release publication only; it must not block PR publication, ready-for-review promotion, merge readiness, local CI, issue verification, or loop operation. Do not make release readiness depend on provider-specific external services being available at test time. Record unavailable provider signals as release notes or follow-up risks, and keep local product readiness focused on commands, state transitions, WebUI routes, local CI posture, and trust-boundary enforcement.
+This checklist is advisory unless `releaseReadinessGate: block_release_publication` is explicitly wired into release automation. That configured gate can block release publication only; it must not block PR publication, ready-for-review promotion, merge readiness, local CI, issue verification, or loop operation. Issue-authored verification guidance in `## Verification` helps define the expected work and review evidence, but it is not a repo-owned fail-closed gate by itself. Do not make release readiness depend on provider-specific external services being available at test time. Record unavailable provider signals as release notes or follow-up risks, and keep local product readiness focused on commands, state transitions, WebUI routes, local CI posture, and trust-boundary enforcement.
 
 ## Verification
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -2452,7 +2452,7 @@ test("diagnoseSupervisorHost preserves draft tracked PR verification blockers in
   );
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\./,
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\./,
   );
   assert.doesNotMatch(
     renderDoctorReport(diagnostics),
@@ -2772,7 +2772,7 @@ test("diagnoseSupervisorHost keeps same-head host-local ready-promotion blockers
   );
   assert.match(
     renderDoctorReport(diagnostics),
-    /doctor_detail name=worktrees detail=recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./,
+    /doctor_detail name=worktrees detail=recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\./,
   );
   assert.doesNotMatch(
     renderDoctorReport(diagnostics),

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -159,6 +159,8 @@ test("getting-started protects the first-run command flow and operator action vo
 test("getting-started defines the repo-owned local CI contract for pre-PR verification", async () => {
   const content = await readGettingStarted();
 
+  assert.match(content, /issue-level `## Verification` is issue-authored guidance/i);
+  assert.match(content, /not a repo-owned fail-closed gate by itself/i);
   assert.match(content, /repo-owned local CI contract/i);
   assert.match(content, /ci:local/);
   assert.match(content, /verify:pre-pr/);
@@ -174,6 +176,7 @@ test("getting-started defines the repo-owned local CI contract for pre-PR verifi
   assert.match(content, /does not infer or reconstruct workflow logic from GitHub Actions YAML/i);
   assert.match(content, /when configured local CI fails, PR publication stays blocked/i);
   assert.match(content, /ready-for-review promotion stays blocked/i);
+  assert.match(content, /status and doctor wording should name the active repo-owned gate/i);
 });
 
 test("operator-facing docs explain steady-state local CI posture and remediation flow", async () => {

--- a/src/recovery-reconciliation.test.ts
+++ b/src/recovery-reconciliation.test.ts
@@ -40,7 +40,7 @@ test("buildTrackedPrResumeRecoveryEvent reports draft ready-promotion verificati
   assert.deepEqual(event, {
     issueNumber: 366,
     reason:
-      "tracked_pr_ready_promotion_blocked: refreshed issue #366 while tracked PR #191 remains draft because ready-for-review promotion is blocked by local verification at head head-191",
+      "tracked_pr_ready_promotion_blocked: refreshed issue #366 while tracked PR #191 remains draft because ready-for-review promotion is blocked by a repo-owned gate at head head-191",
     at: "2026-03-13T00:30:00Z",
   });
 });

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -279,7 +279,7 @@ export function buildTrackedPrResumeRecoveryEvent(
   ) {
     return buildRecoveryEvent(
       record.issue_number,
-      `tracked_pr_ready_promotion_blocked: refreshed issue #${record.issue_number} while tracked PR #${pr.number} remains draft because ready-for-review promotion is blocked by local verification at head ${nextHead}`,
+      `tracked_pr_ready_promotion_blocked: refreshed issue #${record.issue_number} while tracked PR #${pr.number} remains draft because ready-for-review promotion is blocked by a repo-owned gate at head ${nextHead}`,
     );
   }
 

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1537,7 +1537,7 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
   );
   assert.match(
     explanation,
-    /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
+    /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
   );
   assert.match(
     explanation,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3266,7 +3266,7 @@ test("status skips tracked PR hydration for historical done records", async () =
   );
 });
 
-test("status preserves draft tracked PR lifecycle when ready-for-review promotion is blocked by local verification", async () => {
+test("status preserves draft tracked PR lifecycle when ready-for-review promotion is blocked by a repo-owned gate", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 174;
   const prNumber = 274;
@@ -3351,7 +3351,7 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
+    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
   );
   assert.doesNotMatch(report.detailedStatusLines.join("\n"), /^tracked_pr_mismatch /m);
 
@@ -3374,7 +3374,7 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
   );
   assert.match(
     status,
-    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
+    /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,
   );
   assert.doesNotMatch(status, /^tracked_pr_mismatch /m);
 });
@@ -3625,7 +3625,7 @@ test("status keeps same-head host-local ready-promotion blockers current when th
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by local verification\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
+    /^recovery_guidance=PR #277 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\./m,
   );
   assert.doesNotMatch(
     report.detailedStatusLines.join("\n"),

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -177,7 +177,7 @@ function readyPromotionGateSummary(
     record.latest_local_ci_result?.summary
     ?? record.last_failure_context?.summary
     ?? record.last_error
-    ?? "Local verification failed before ready-for-review promotion.";
+    ?? "A repo-owned gate failed before ready-for-review promotion.";
 
   if (record.latest_local_ci_result?.outcome === "failed") {
     return {
@@ -242,7 +242,7 @@ function readyPromotionGateSummary(
 
   return {
     gate: "verification",
-    failedGate: "local verification gate",
+    failedGate: "ready-promotion gate",
     summary,
     detailLines: [
       [
@@ -368,7 +368,7 @@ export function buildTrackedPrMismatch(
         `stale_local_blocker=${staleLocalBlocker ? "yes" : "no"}`,
       ].join(" "),
       guidanceLine: blockerHasFreshCurrentHeadEvidence
-        ? `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion is blocked by local verification. ` +
+        ? `recovery_guidance=PR #${pr.number} is still draft because ready-for-review promotion is blocked by a repo-owned gate. ` +
           `The same blocker is still present, so rerunning the supervisor alone will not help. ` +
           `Failed gate: ${readyPromotionGate.failedGate}. Fix the gate in the tracked workspace first, then rerun it to promote the PR.`
         : `recovery_guidance=PR #${pr.number} is still draft, but the stored ready-for-review verification blocker is stale relative to the current head. ` +

--- a/src/validation-checklist-docs.test.ts
+++ b/src/validation-checklist-docs.test.ts
@@ -41,6 +41,8 @@ test("validation checklist is maintained as the release-readiness artifact", asy
     "release gate",
     "trust boundaries",
     "advisory checklist",
+    "issue-authored verification guidance",
+    "not a repo-owned fail-closed gate by itself",
     "releaseReadinessGate: advisory",
     "releaseReadinessGate: block_release_publication",
     "doctor_release_readiness_gate",


### PR DESCRIPTION
## Summary
- Clarify that issue-level `## Verification` is issue-authored guidance, not a repo-owned fail-closed gate by itself.
- Update status/explain/doctor recovery wording to say ready-for-review promotion is blocked by a repo-owned gate and name the concrete failed gate.
- Add focused docs and status regression coverage for the boundary.

## Verification
- `npx tsx --test src/getting-started-docs.test.ts src/validation-checklist-docs.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/recovery-reconciliation.test.ts`
- `npm run build`
- `npm run verify:paths`

Part of #1732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified the distinction between issue-authored verification guidance and repository-owned gates in getting-started and validation checklist documentation.
  * Updated diagnostic messages to more accurately identify what blocks PR ready-for-review promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->