### PR TITLE
Persist verification timeline artifacts

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -16,6 +16,19 @@ export interface DashboardTrackedIssueLike {
   branch?: string | null;
   prNumber?: number | null;
   blockedReason?: string | null;
+  timelineArtifacts?: DashboardTimelineArtifactLike[] | null;
+}
+
+export interface DashboardTimelineArtifactLike {
+  type?: string | null;
+  gate?: string | null;
+  command?: string | null;
+  head_sha?: string | null;
+  outcome?: string | null;
+  remediation_target?: string | null;
+  next_action?: string | null;
+  summary?: string | null;
+  recorded_at?: string | null;
 }
 
 export interface DashboardRunnableIssueLike {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -197,6 +197,30 @@ export interface LatestLocalCiResult {
   verifier_drift_hint?: string | null;
 }
 
+export type TimelineArtifactOutcome =
+  | "passed"
+  | "failed"
+  | "not_configured"
+  | "repair_queued";
+
+export type TimelineArtifactGate =
+  | "local_ci"
+  | "workspace_preparation"
+  | "workstation_local_path_hygiene";
+
+export interface TimelineArtifact {
+  type: "verification_result" | "path_hygiene_result";
+  gate: TimelineArtifactGate;
+  command: string | null;
+  head_sha: string | null;
+  outcome: TimelineArtifactOutcome;
+  remediation_target: LocalCiRemediationTarget | null;
+  next_action: string;
+  summary: string;
+  recorded_at: string;
+  repair_targets?: string[];
+}
+
 export interface SupervisorConfig {
   repoPath: string;
   repoSlug: string;
@@ -408,6 +432,7 @@ export interface IssueRunRecord {
   last_local_review_signature: string | null;
   repeated_local_review_signature_count: number;
   latest_local_ci_result?: LatestLocalCiResult | null;
+  timeline_artifacts?: TimelineArtifact[];
   external_review_head_sha: string | null;
   external_review_misses_path: string | null;
   external_review_matched_findings_count: number;

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1827,6 +1827,24 @@ test("handlePostTurnPullRequestTransitionsPhase routes repairable ready-promotio
   );
   assert.match(result.record.last_error ?? "", /will retry a repair turn/i);
   assert.deepEqual(result.record.last_failure_context?.details, failureDetails);
+  assert.deepEqual(result.record.timeline_artifacts, [
+    {
+      type: "path_hygiene_result",
+      gate: "workstation_local_path_hygiene",
+      command: "npm run verify:paths",
+      head_sha: draftPr.headRefOid,
+      outcome: "repair_queued",
+      remediation_target: "repair_already_queued",
+      next_action: "wait_for_repair_turn",
+      summary: result.record.last_failure_context?.summary ?? "",
+      recorded_at: result.record.timeline_artifacts?.[0]?.recorded_at ?? "",
+      repair_targets: ["docs/guide.md", "scripts/check-paths.sh"],
+    },
+  ]);
+  assert.doesNotMatch(
+    JSON.stringify(result.record.timeline_artifacts),
+    /\/(?:Users|home)\//,
+  );
   assert.equal(commentBodies.length, 1);
   assert.match(commentBodies[0] ?? "", /automatic retry: yes/i);
   assert.match(commentBodies[0] ?? "", /next action: supervisor will retry a repair turn/i);

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -50,6 +50,10 @@ import {
 } from "./post-turn-pull-request-policy";
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+import {
+  appendTimelineArtifact,
+  buildPathHygieneTimelineArtifact,
+} from "./timeline-artifacts";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -543,6 +547,13 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         };
         record = stateStore.touch(record, {
           state: "repairing_ci",
+          timeline_artifacts: appendTimelineArtifact(record, buildPathHygieneTimelineArtifact({
+            failureContext: repairFailureContext,
+            headSha: refreshed.pr.headRefOid ?? null,
+            outcome: "repair_queued",
+            remediationTarget: "repair_already_queued",
+            repairTargets: actionablePublishableFilePaths,
+          })),
           last_error: truncate(repairFailureContext.summary, 1000),
           last_failure_kind: null,
           last_failure_context: repairFailureContext,
@@ -579,6 +590,14 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       }
       record = stateStore.touch(record, {
         state: "blocked",
+        timeline_artifacts: failureContext
+          ? appendTimelineArtifact(record, buildPathHygieneTimelineArtifact({
+            failureContext,
+            headSha: refreshed.pr.headRefOid ?? null,
+            outcome: "failed",
+            remediationTarget: "manual_review",
+          }))
+          : record.timeline_artifacts,
         last_error: truncate(
           failureContext?.summary
             ?? `Tracked durable artifacts failed workstation-local path hygiene before marking PR #${refreshed.pr.number} ready.`,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3298,6 +3298,19 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
           verifier_drift_hint:
             "repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI.",
         },
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "local_ci",
+            command: "npm run verify:paths",
+            head_sha: "head-draft-274",
+            outcome: "failed",
+            remediation_target: "tracked_publishable_content",
+            next_action: "repair_tracked_publishable_content",
+            summary: "Configured local CI command failed before marking PR #274 ready.",
+            recorded_at: "2026-03-13T00:10:00Z",
+          },
+        ],
       }),
     },
   };
@@ -3349,6 +3362,11 @@ test("status preserves draft tracked PR lifecycle when ready-for-review promotio
     report.detailedStatusLines.join("\n"),
     /^tracked_pr_host_local_ci_hint issue=#174 pr=#274 kind=repo_owned_verifier_drift summary=repo_owned_verifier_drift: the repo-owned verifier appears to disagree with a changed docs or contract expectation; repair the verifier expectation or the repo content before rerunning local CI\.$/m,
   );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^timeline_artifact issue=#174 pr=#274 type=verification_result gate=local_ci outcome=failed head_sha=head-draft-274 remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content command=npm run verify:paths summary=Configured local CI command failed before marking PR #274 ready\.$/m,
+  );
+  assert.deepEqual(report.trackedIssues[0]?.timelineArtifacts, state.issues[String(issueNumber)]?.timeline_artifacts);
   assert.match(
     report.detailedStatusLines.join("\n"),
     /^recovery_guidance=PR #274 is still draft because ready-for-review promotion is blocked by a repo-owned gate\. The same blocker is still present, so rerunning the supervisor alone will not help\. Failed gate: npm run verify:paths\. Fix the gate in the tracked workspace first, then rerun it to promote the PR\.$/m,

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -7,7 +7,7 @@ import type {
 } from "../core/types";
 import { sanitizeStatusValue } from "./supervisor-status-rendering";
 import { truncate } from "../core/utils";
-import type { BlockedReason, RunState, SupervisorStateFile } from "../core/types";
+import type { BlockedReason, RunState, SupervisorStateFile, TimelineArtifact } from "../core/types";
 import type { SupervisorIssueActivityContextDto } from "./supervisor-operator-activity-context";
 import type { SupervisorLoopRuntimeDto } from "./supervisor-loop-runtime-state";
 import type {
@@ -49,6 +49,7 @@ export interface SupervisorTrackedIssueDto {
   branch: string;
   prNumber: number | null;
   blockedReason: BlockedReason | null;
+  timelineArtifacts?: TimelineArtifact[];
 }
 
 export interface SupervisorRuntimeRecoverySignalDto {
@@ -338,11 +339,15 @@ export function buildInventoryRefreshWarningMessage(state: SupervisorStateFile):
 export function buildTrackedIssueDtos(state: SupervisorStateFile): SupervisorTrackedIssueDto[] {
   return Object.values(state.issues)
     .sort((left, right) => left.issue_number - right.issue_number)
-    .map((record) => ({
-      issueNumber: record.issue_number,
-      state: record.state,
-      branch: record.branch,
-      prNumber: record.pr_number,
-      blockedReason: record.blocked_reason,
-    }));
+    .map((record) => {
+      const timelineArtifacts = record.timeline_artifacts ?? [];
+      return {
+        issueNumber: record.issue_number,
+        state: record.state,
+        branch: record.branch,
+        prNumber: record.pr_number,
+        blockedReason: record.blocked_reason,
+        ...(timelineArtifacts.length > 0 ? { timelineArtifacts } : {}),
+      };
+    });
 }

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -23,6 +23,7 @@ import {
 } from "../remediation-targets";
 import { projectTrackedPrLifecycle } from "../tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "../tracked-pr-ready-promotion-blocker";
+import { formatTimelineArtifactStatusLine } from "../timeline-artifacts";
 import {
   classifyReadyPromotionRecoverability,
   classifyTrackedPrMismatchRecoverability,
@@ -134,6 +135,16 @@ function buildTrackedPrHostLocalCiDetailLines(
   return detailLines;
 }
 
+function buildTimelineArtifactDetailLines(record: IssueRunRecord): string[] {
+  return (record.timeline_artifacts ?? []).slice(-3).map((artifact) =>
+    formatTimelineArtifactStatusLine({
+      issueNumber: record.issue_number,
+      prNumber: record.pr_number,
+      artifact,
+    }),
+  );
+}
+
 function parseRemediationTargetFromSignature(
   signature: string | null | undefined,
 ): LocalCiRemediationTarget | null {
@@ -193,6 +204,7 @@ function readyPromotionGateSummary(
           `summary=${summary.replace(/\r?\n/g, "\\n")}`,
         ].join(" "),
         ...buildTrackedPrHostLocalCiDetailLines(config, record, pr, checks),
+        ...buildTimelineArtifactDetailLines(record),
       ],
     };
   }
@@ -216,6 +228,7 @@ function readyPromotionGateSummary(
           `remediation_target=${remediationTarget}`,
           `summary=${pathHygieneSummary.replace(/\r?\n/g, "\\n")}`,
         ].join(" "),
+        ...buildTimelineArtifactDetailLines(record),
       ],
     };
   }
@@ -236,6 +249,7 @@ function readyPromotionGateSummary(
           `remediation_target=${workspacePreparationRemediationTargetForFailureClass(preparationFailureClass)}`,
           `summary=${summary.replace(/\r?\n/g, "\\n")}`,
         ].join(" "),
+        ...buildTimelineArtifactDetailLines(record),
       ],
     };
   }

--- a/src/timeline-artifacts.test.ts
+++ b/src/timeline-artifacts.test.ts
@@ -9,19 +9,20 @@ test("formatTimelineArtifactStatusLine escapes multiline command and summary val
     artifact: {
       type: "verification_result",
       gate: "local_ci",
-      command: "npm run verify:paths\nnpm run build\r\nnpm test",
+      command: "npm run verify:paths\nnpm run build\r\nnpm test\rnode --version",
       head_sha: "abc123",
       outcome: "failed",
       remediation_target: "tracked_publishable_content",
       next_action: "repair_tracked_publishable_content",
-      summary: "first line\nsecond line",
+      summary: "first line\nsecond line\rthird line",
       recorded_at: "2026-04-25T10:50:35Z",
     },
   });
 
   assert.equal(line.split("\n").length, 1);
+  assert.equal(line.includes("\r"), false);
   assert.match(
     line,
-    /^timeline_artifact issue=#1733 pr=#1738 type=verification_result gate=local_ci outcome=failed head_sha=abc123 remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content command=npm run verify:paths\\nnpm run build\\nnpm test summary=first line\\nsecond line$/,
+    /^timeline_artifact issue=#1733 pr=#1738 type=verification_result gate=local_ci outcome=failed head_sha=abc123 remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content command=npm run verify:paths\\nnpm run build\\nnpm test\\nnode --version summary=first line\\nsecond line\\nthird line$/,
   );
 });

--- a/src/timeline-artifacts.test.ts
+++ b/src/timeline-artifacts.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatTimelineArtifactStatusLine } from "./timeline-artifacts";
+
+test("formatTimelineArtifactStatusLine escapes multiline command and summary values", () => {
+  const line = formatTimelineArtifactStatusLine({
+    issueNumber: 1733,
+    prNumber: 1738,
+    artifact: {
+      type: "verification_result",
+      gate: "local_ci",
+      command: "npm run verify:paths\nnpm run build\r\nnpm test",
+      head_sha: "abc123",
+      outcome: "failed",
+      remediation_target: "tracked_publishable_content",
+      next_action: "repair_tracked_publishable_content",
+      summary: "first line\nsecond line",
+      recorded_at: "2026-04-25T10:50:35Z",
+    },
+  });
+
+  assert.equal(line.split("\n").length, 1);
+  assert.match(
+    line,
+    /^timeline_artifact issue=#1733 pr=#1738 type=verification_result gate=local_ci outcome=failed head_sha=abc123 remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content command=npm run verify:paths\\nnpm run build\\nnpm test summary=first line\\nsecond line$/,
+  );
+});

--- a/src/timeline-artifacts.ts
+++ b/src/timeline-artifacts.ts
@@ -10,6 +10,10 @@ import type {
 
 const MAX_TIMELINE_ARTIFACTS = 20;
 
+function escapeStatusLineValue(value: string): string {
+  return value.replace(/\r?\n/g, "\\n");
+}
+
 export function appendTimelineArtifact(
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   artifact: TimelineArtifact,
@@ -92,7 +96,7 @@ export function formatTimelineArtifactStatusLine(args: {
     `head_sha=${args.artifact.head_sha ?? "unknown"}`,
     `remediation_target=${args.artifact.remediation_target ?? "none"}`,
     `next_action=${args.artifact.next_action}`,
-    ...(args.artifact.command ? [`command=${args.artifact.command}`] : []),
-    `summary=${args.artifact.summary.replace(/\r?\n/g, "\\n")}`,
+    ...(args.artifact.command ? [`command=${escapeStatusLineValue(args.artifact.command)}`] : []),
+    `summary=${escapeStatusLineValue(args.artifact.summary)}`,
   ].join(" ");
 }

--- a/src/timeline-artifacts.ts
+++ b/src/timeline-artifacts.ts
@@ -1,0 +1,98 @@
+import type {
+  FailureContext,
+  IssueRunRecord,
+  LatestLocalCiResult,
+  LocalCiRemediationTarget,
+  TimelineArtifact,
+  TimelineArtifactGate,
+  TimelineArtifactOutcome,
+} from "./core/types";
+
+const MAX_TIMELINE_ARTIFACTS = 20;
+
+export function appendTimelineArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  artifact: TimelineArtifact,
+): TimelineArtifact[] {
+  return [...(record.timeline_artifacts ?? []), artifact].slice(-MAX_TIMELINE_ARTIFACTS);
+}
+
+export function nextActionForRemediationTarget(
+  remediationTarget: LocalCiRemediationTarget | null,
+): string {
+  switch (remediationTarget) {
+    case "workspace_environment":
+      return "fix_workspace_environment";
+    case "config_contract":
+      return "fix_config_contract";
+    case "tracked_publishable_content":
+      return "repair_tracked_publishable_content";
+    case "repair_already_queued":
+      return "wait_for_repair_turn";
+    case "manual_review":
+      return "operator_manual_review";
+    case null:
+      return "continue";
+  }
+}
+
+export function buildLocalCiTimelineArtifact(args: {
+  gate: Exclude<TimelineArtifactGate, "workstation_local_path_hygiene">;
+  result: LatestLocalCiResult;
+  headSha: string | null;
+}): TimelineArtifact {
+  return {
+    type: "verification_result",
+    gate: args.gate,
+    command: args.result.command ?? null,
+    head_sha: args.headSha,
+    outcome: args.result.outcome,
+    remediation_target: args.result.remediation_target,
+    next_action: nextActionForRemediationTarget(args.result.remediation_target),
+    summary: args.result.summary,
+    recorded_at: args.result.ran_at,
+  };
+}
+
+export function buildPathHygieneTimelineArtifact(args: {
+  failureContext: FailureContext;
+  headSha: string | null;
+  outcome: Extract<TimelineArtifactOutcome, "failed" | "repair_queued">;
+  remediationTarget: LocalCiRemediationTarget;
+  repairTargets?: readonly string[];
+}): TimelineArtifact {
+  return {
+    type: "path_hygiene_result",
+    gate: "workstation_local_path_hygiene",
+    command: args.failureContext.command,
+    head_sha: args.headSha,
+    outcome: args.outcome,
+    remediation_target: args.remediationTarget,
+    next_action: nextActionForRemediationTarget(args.remediationTarget),
+    summary: args.failureContext.summary,
+    recorded_at: args.failureContext.updated_at,
+    ...(args.repairTargets && args.repairTargets.length > 0
+      ? { repair_targets: [...args.repairTargets].sort((left, right) => left.localeCompare(right)) }
+      : {}),
+  };
+}
+
+export function formatTimelineArtifactStatusLine(args: {
+  issueNumber: number;
+  prNumber: number | null;
+  artifact: TimelineArtifact;
+}): string {
+  return [
+    "timeline_artifact",
+    `issue=#${args.issueNumber}`,
+    `pr=${args.prNumber === null ? "none" : `#${args.prNumber}`}`,
+    `type=${args.artifact.type}`,
+    `gate=${args.artifact.gate}`,
+    `outcome=${args.artifact.outcome}`,
+    `head_sha=${args.artifact.head_sha ?? "unknown"}`,
+    `remediation_target=${args.artifact.remediation_target ?? "none"}`,
+    `next_action=${args.artifact.next_action}`,
+    ...(args.artifact.command ? [`command=${args.artifact.command}`] : []),
+    `summary=${args.artifact.summary.replace(/\r?\n/g, "\\n")}`,
+  ].join(" ");
+}

--- a/src/timeline-artifacts.ts
+++ b/src/timeline-artifacts.ts
@@ -11,7 +11,7 @@ import type {
 const MAX_TIMELINE_ARTIFACTS = 20;
 
 function escapeStatusLineValue(value: string): string {
-  return value.replace(/\r?\n/g, "\\n");
+  return value.replace(/\r\n|\r|\n/g, "\\n");
 }
 
 export function appendTimelineArtifact(

--- a/src/tracked-pr-local-ci-publication-gate.test.ts
+++ b/src/tracked-pr-local-ci-publication-gate.test.ts
@@ -57,6 +57,20 @@ test("runTrackedPrReadyLocalCiPublicationGate reports workspace failures with th
   assert.equal(result.ok, false);
   assert.equal(result.record.latest_local_ci_result?.failure_class, "workspace_toolchain_missing");
   assert.equal(result.record.latest_local_ci_result?.remediation_target, "workspace_environment");
+  assert.deepEqual(result.record.timeline_artifacts, [
+    {
+      type: "verification_result",
+      gate: "local_ci",
+      command: "npm run ci:local",
+      head_sha: "head-116",
+      outcome: "failed",
+      remediation_target: "workspace_environment",
+      next_action: "fix_workspace_environment",
+      summary:
+        "Configured local CI command could not run before marking PR #116 ready because the workspace toolchain is unavailable. Remediation target: workspace environment.",
+      recorded_at: result.record.timeline_artifacts?.[0]?.recorded_at ?? "",
+    },
+  ]);
   assert.equal(
     result.record.last_host_local_pr_blocker_comment_signature,
     "local-ci-gate-workspace_toolchain_missing|gate=local_ci|failure=workspace_toolchain_missing|target=workspace_environment",

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -15,6 +15,10 @@ import {
 } from "./core/types";
 import { truncate } from "./core/utils";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+import {
+  appendTimelineArtifact,
+  buildLocalCiTimelineArtifact,
+} from "./timeline-artifacts";
 
 export interface TrackedPrReadyLocalCiPublicationGateResult {
   ok: boolean;
@@ -90,6 +94,13 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
     let record = args.stateStore.touch(args.record, {
       state: "blocked",
       latest_local_ci_result: localCiGate.latestResult ?? null,
+      timeline_artifacts: localCiGate.latestResult
+        ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
+          gate: "local_ci",
+          result: localCiGate.latestResult,
+          headSha: args.pr.headRefOid ?? null,
+        }))
+        : args.record.timeline_artifacts,
       last_error: truncate(failureContext?.summary, 1000),
       last_failure_kind: null,
       last_failure_context: failureContext,
@@ -122,6 +133,13 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
 
   const record = args.stateStore.touch(args.record, {
     latest_local_ci_result: localCiGate.latestResult ?? null,
+    timeline_artifacts: localCiGate.latestResult
+      ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
+        gate: "local_ci",
+        result: localCiGate.latestResult,
+        headSha: args.pr.headRefOid ?? null,
+      }))
+      : args.record.timeline_artifacts,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
   });


### PR DESCRIPTION
## Summary
- add typed timeline artifacts for local CI verification and ready-promotion path hygiene outcomes
- persist artifacts on issue records and surface them through status details plus tracked issue DTOs for WebUI consumption
- keep path hygiene repair artifacts repo-relative and free of raw workstation-local paths

## Verification
- npx tsx --test src/local-ci.test.ts src/tracked-pr-local-ci-publication-gate.test.ts src/turn-execution-publication-gate.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/backend/webui-dashboard.test.ts
- npm run verify:paths
- npm run build

Part of #1728
Addresses #1733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline artifacts added to track verification results and repair actions (gate, outcome, remediation target, head SHA, next action, timestamp). Persisted on issue records and surfaced in status/summary views; capped to the most recent 20 entries.
  * Path-hygiene repair queuing and failures are recorded as timeline artifacts.

* **Tests**
  * New/updated tests validate artifact creation, serialization (no absolute home paths), and single-line formatted status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->