### PR TITLE
Add issue run timeline export

### DIFF
--- a/src/timeline-artifacts.test.ts
+++ b/src/timeline-artifacts.test.ts
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { formatTimelineArtifactStatusLine } from "./timeline-artifacts";
+import {
+  buildIssueRunTimelineExport,
+  formatTimelineArtifactStatusLine,
+} from "./timeline-artifacts";
+import { createPullRequest, createRecord } from "./turn-execution-test-helpers";
 
 test("formatTimelineArtifactStatusLine escapes multiline command and summary values", () => {
   const line = formatTimelineArtifactStatusLine({
@@ -24,5 +28,133 @@ test("formatTimelineArtifactStatusLine escapes multiline command and summary val
   assert.match(
     line,
     /^timeline_artifact issue=#1733 pr=#1738 type=verification_result gate=local_ci outcome=failed head_sha=abc123 remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content command=npm run verify:paths\\nnpm run build\\nnpm test\\nnode --version summary=first line\\nsecond line\\nthird line$/,
+  );
+});
+
+test("buildIssueRunTimelineExport orders available major lifecycle events", () => {
+  const record = createRecord({
+    issue_number: 1742,
+    branch: "codex/issue-1742",
+    last_head_sha: "head-1748",
+    pr_number: 1748,
+    state: "done",
+    codex_session_id: "session-1742",
+    last_codex_summary: "Implemented timeline export.",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "npm run build passed.",
+      ran_at: "2026-04-25T10:06:00Z",
+      head_sha: "head-1748",
+      execution_mode: "legacy_shell_string",
+      command: "npm run build",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "path_hygiene_result",
+        gate: "workstation_local_path_hygiene",
+        command: "npm run verify:paths",
+        head_sha: "head-1748",
+        outcome: "repair_queued",
+        remediation_target: "repair_already_queued",
+        next_action: "wait_for_repair_turn",
+        summary: "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+        recorded_at: "2026-04-25T10:04:00Z",
+        repair_targets: ["docs/guide.md"],
+      },
+      {
+        type: "verification_result",
+        gate: "local_ci",
+        command: "npm run build",
+        head_sha: "head-1748",
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "npm run build passed.",
+        recorded_at: "2026-04-25T10:06:00Z",
+      },
+    ],
+    local_review_head_sha: "head-1748",
+    local_review_run_at: "2026-04-25T10:08:00Z",
+    local_review_recommendation: "ready",
+    local_review_findings_count: 0,
+    local_review_blocker_summary: null,
+    last_recovery_reason: "stale_state_cleanup: moved from stabilizing to draft_pr",
+    last_recovery_at: "2026-04-25T10:05:00Z",
+    updated_at: "2026-04-25T10:12:00Z",
+  });
+  const pr = createPullRequest({
+    number: 1748,
+    createdAt: "2026-04-25T10:03:00Z",
+    mergedAt: "2026-04-25T10:11:00Z",
+    headRefOid: "head-1748",
+  });
+
+  const timeline = buildIssueRunTimelineExport({ record, pr });
+
+  assert.deepEqual(
+    timeline.events
+      .filter((event) => event.outcome !== "missing")
+      .map((event) => [event.event_type, event.timestamp, event.outcome, event.next_action]),
+    [
+      ["reservation", null, "recorded", null],
+      ["pr_created", "2026-04-25T10:03:00Z", "created", null],
+      ["path_hygiene", "2026-04-25T10:04:00Z", "repair_queued", "wait_for_repair_turn"],
+      ["recovery", "2026-04-25T10:05:00Z", "recorded", null],
+      ["local_ci", "2026-04-25T10:06:00Z", "passed", "continue"],
+      ["review", "2026-04-25T10:08:00Z", "ready", null],
+      ["merge", "2026-04-25T10:11:00Z", "merged", null],
+      ["codex_turn", "2026-04-25T10:12:00Z", "completed", null],
+      ["done", "2026-04-25T10:12:00Z", "done", null],
+    ],
+  );
+  assert.deepEqual(timeline.events[0], {
+    issue_number: 1742,
+    pr_number: 1748,
+    event_type: "reservation",
+    timestamp: null,
+    outcome: "recorded",
+    summary: "Issue run reservation exists for branch codex/issue-1742.",
+    head_sha: "head-1748",
+    remediation_target: null,
+    next_action: null,
+  });
+});
+
+test("buildIssueRunTimelineExport keeps sparse historical records explicit", () => {
+  const timeline = buildIssueRunTimelineExport({
+    record: createRecord({
+      pr_number: null,
+      latest_local_ci_result: undefined,
+      timeline_artifacts: undefined,
+      local_review_run_at: null,
+      local_review_recommendation: null,
+      last_recovery_reason: null,
+      last_recovery_at: null,
+      codex_session_id: null,
+      last_codex_summary: null,
+      updated_at: "2026-04-25T10:12:00Z",
+    }),
+    pr: null,
+  });
+
+  assert.equal(timeline.issue_number, 102);
+  assert.equal(timeline.pr_number, null);
+  assert.deepEqual(
+    timeline.events.map((event) => [event.event_type, event.timestamp, event.outcome, event.summary]),
+    [
+      ["reservation", null, "recorded", "Issue run reservation exists for branch codex/issue-102."],
+      ["codex_turn", null, "missing", "No Codex turn summary is recorded for this issue run."],
+      ["publication_gate", null, "missing", "No publication gate event is recorded for this issue run."],
+      ["pr_created", null, "missing", "No pull request creation event is recorded for this issue run."],
+      ["local_ci", null, "missing", "No local CI result is recorded for this issue run."],
+      ["path_hygiene", null, "missing", "No workstation-local path hygiene result is recorded for this issue run."],
+      ["review", null, "missing", "No local review result is recorded for this issue run."],
+      ["stale_review_metadata", null, "missing", "No stale review metadata handling event is recorded for this issue run."],
+      ["recovery", null, "missing", "No recovery event is recorded for this issue run."],
+      ["merge", null, "missing", "No merge event is recorded for this issue run."],
+      ["done", null, "missing", "Issue run is not recorded as done."],
+    ],
   );
 });

--- a/src/timeline-artifacts.ts
+++ b/src/timeline-artifacts.ts
@@ -1,5 +1,6 @@
 import type {
   FailureContext,
+  GitHubPullRequest,
   IssueRunRecord,
   LatestLocalCiResult,
   LocalCiRemediationTarget,
@@ -9,6 +10,51 @@ import type {
 } from "./core/types";
 
 const MAX_TIMELINE_ARTIFACTS = 20;
+
+export type IssueRunTimelineEventType =
+  | "reservation"
+  | "codex_turn"
+  | "publication_gate"
+  | "pr_created"
+  | "local_ci"
+  | "path_hygiene"
+  | "review"
+  | "stale_review_metadata"
+  | "recovery"
+  | "merge"
+  | "done";
+
+export interface IssueRunTimelineEvent {
+  issue_number: number;
+  pr_number: number | null;
+  event_type: IssueRunTimelineEventType;
+  timestamp: string | null;
+  outcome: string;
+  summary: string;
+  head_sha: string | null;
+  remediation_target: LocalCiRemediationTarget | null;
+  next_action: string | null;
+}
+
+export interface IssueRunTimelineExport {
+  issue_number: number;
+  pr_number: number | null;
+  events: IssueRunTimelineEvent[];
+}
+
+const TIMELINE_EVENT_ORDER: IssueRunTimelineEventType[] = [
+  "reservation",
+  "codex_turn",
+  "publication_gate",
+  "pr_created",
+  "local_ci",
+  "path_hygiene",
+  "review",
+  "stale_review_metadata",
+  "recovery",
+  "merge",
+  "done",
+];
 
 function escapeStatusLineValue(value: string): string {
   return value.replace(/\r\n|\r|\n/g, "\\n");
@@ -99,4 +145,247 @@ export function formatTimelineArtifactStatusLine(args: {
     ...(args.artifact.command ? [`command=${escapeStatusLineValue(args.artifact.command)}`] : []),
     `summary=${escapeStatusLineValue(args.artifact.summary)}`,
   ].join(" ");
+}
+
+function eventOrder(eventType: IssueRunTimelineEventType): number {
+  return TIMELINE_EVENT_ORDER.indexOf(eventType);
+}
+
+function hasStaleReviewMetadataHandling(record: Pick<
+  IssueRunRecord,
+  | "last_stale_review_bot_reply_signature"
+  | "last_stale_review_bot_reply_head_sha"
+  | "stale_review_bot_reply_progress_keys"
+  | "stale_review_bot_resolve_progress_keys"
+>): boolean {
+  return (
+    record.last_stale_review_bot_reply_signature !== null ||
+    record.last_stale_review_bot_reply_head_sha !== null ||
+    (record.stale_review_bot_reply_progress_keys?.length ?? 0) > 0 ||
+    (record.stale_review_bot_resolve_progress_keys?.length ?? 0) > 0
+  );
+}
+
+function missingTimelineEvent(args: {
+  record: IssueRunRecord;
+  eventType: IssueRunTimelineEventType;
+  summary: string;
+}): IssueRunTimelineEvent {
+  return {
+    issue_number: args.record.issue_number,
+    pr_number: args.record.pr_number,
+    event_type: args.eventType,
+    timestamp: null,
+    outcome: "missing",
+    summary: args.summary,
+    head_sha: null,
+    remediation_target: null,
+    next_action: null,
+  };
+}
+
+function timelineEventFromArtifact(record: IssueRunRecord, artifact: TimelineArtifact): IssueRunTimelineEvent {
+  const eventType: IssueRunTimelineEventType =
+    artifact.gate === "workstation_local_path_hygiene"
+      ? "path_hygiene"
+      : artifact.gate === "workspace_preparation"
+        ? "publication_gate"
+        : "local_ci";
+  return {
+    issue_number: record.issue_number,
+    pr_number: record.pr_number,
+    event_type: eventType,
+    timestamp: artifact.recorded_at,
+    outcome: artifact.outcome,
+    summary: artifact.summary,
+    head_sha: artifact.head_sha,
+    remediation_target: artifact.remediation_target,
+    next_action: artifact.next_action,
+  };
+}
+
+function sortTimelineEvents(left: IssueRunTimelineEvent, right: IssueRunTimelineEvent): number {
+  if (left.event_type === "reservation" && right.event_type !== "reservation") {
+    return -1;
+  }
+  if (right.event_type === "reservation" && left.event_type !== "reservation") {
+    return 1;
+  }
+  if (left.timestamp !== null && right.timestamp !== null && left.timestamp !== right.timestamp) {
+    return left.timestamp.localeCompare(right.timestamp);
+  }
+  if (left.timestamp !== null && right.timestamp === null) {
+    return -1;
+  }
+  if (left.timestamp === null && right.timestamp !== null) {
+    return 1;
+  }
+  return eventOrder(left.event_type) - eventOrder(right.event_type);
+}
+
+export function buildIssueRunTimelineExport(args: {
+  record: IssueRunRecord;
+  pr?: GitHubPullRequest | null;
+}): IssueRunTimelineExport {
+  const { record } = args;
+  const pr = args.pr ?? null;
+  const events = new Map<IssueRunTimelineEventType, IssueRunTimelineEvent>();
+
+  function setEvent(event: IssueRunTimelineEvent): void {
+    const existing = events.get(event.event_type);
+    if (!existing || sortTimelineEvents(event, existing) >= 0) {
+      events.set(event.event_type, event);
+    }
+  }
+
+  setEvent({
+    issue_number: record.issue_number,
+    pr_number: record.pr_number,
+    event_type: "reservation",
+    timestamp: null,
+    outcome: "recorded",
+    summary: `Issue run reservation exists for branch ${record.branch}.`,
+    head_sha: record.last_head_sha,
+    remediation_target: null,
+    next_action: null,
+  });
+
+  if (record.codex_session_id !== null || record.last_codex_summary !== null) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "codex_turn",
+      timestamp: record.updated_at,
+      outcome: record.last_failure_kind === null ? "completed" : "failed",
+      summary: record.last_codex_summary ?? "Codex turn state is recorded.",
+      head_sha: record.last_head_sha,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  if (pr?.createdAt) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: pr.number,
+      event_type: "pr_created",
+      timestamp: pr.createdAt,
+      outcome: "created",
+      summary: `Pull request #${pr.number} is recorded for this issue run.`,
+      head_sha: pr.headRefOid,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  for (const artifact of record.timeline_artifacts ?? []) {
+    setEvent(timelineEventFromArtifact(record, artifact));
+  }
+
+  const latestLocalCi = record.latest_local_ci_result ?? null;
+  if (latestLocalCi && !events.has("local_ci")) {
+    setEvent(timelineEventFromArtifact(record, buildLocalCiTimelineArtifact({
+      gate: "local_ci",
+      result: latestLocalCi,
+      headSha: latestLocalCi.head_sha,
+    })));
+  }
+
+  if (record.local_review_run_at !== null || record.local_review_recommendation !== null) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "review",
+      timestamp: record.local_review_run_at,
+      outcome: record.local_review_recommendation ?? "recorded",
+      summary: record.local_review_blocker_summary ??
+        `Local review recorded ${record.local_review_findings_count} finding(s).`,
+      head_sha: record.local_review_head_sha,
+      remediation_target: null,
+      next_action: record.local_review_recommendation === "changes_requested" ? "address_review_findings" : null,
+    });
+  }
+
+  if (hasStaleReviewMetadataHandling(record)) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "stale_review_metadata",
+      timestamp: record.updated_at,
+      outcome: "recorded",
+      summary: record.last_stale_review_bot_reply_signature ??
+        "Stale review metadata handling progress is recorded.",
+      head_sha: record.last_stale_review_bot_reply_head_sha ?? null,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  if (record.last_recovery_reason !== null || record.last_recovery_at !== null) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "recovery",
+      timestamp: record.last_recovery_at,
+      outcome: "recorded",
+      summary: record.last_recovery_reason ?? "Recovery event is recorded.",
+      head_sha: record.last_head_sha,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  if (pr?.mergedAt) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: pr.number,
+      event_type: "merge",
+      timestamp: pr.mergedAt,
+      outcome: "merged",
+      summary: `Pull request #${pr.number} is merged.`,
+      head_sha: pr.headRefOid,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  if (record.state === "done") {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "done",
+      timestamp: record.updated_at,
+      outcome: "done",
+      summary: "Issue run is recorded as done.",
+      head_sha: record.last_head_sha,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  const missingSummaries: Record<IssueRunTimelineEventType, string> = {
+    reservation: "No issue run reservation is recorded.",
+    codex_turn: "No Codex turn summary is recorded for this issue run.",
+    publication_gate: "No publication gate event is recorded for this issue run.",
+    pr_created: "No pull request creation event is recorded for this issue run.",
+    local_ci: "No local CI result is recorded for this issue run.",
+    path_hygiene: "No workstation-local path hygiene result is recorded for this issue run.",
+    review: "No local review result is recorded for this issue run.",
+    stale_review_metadata: "No stale review metadata handling event is recorded for this issue run.",
+    recovery: "No recovery event is recorded for this issue run.",
+    merge: "No merge event is recorded for this issue run.",
+    done: "Issue run is not recorded as done.",
+  };
+
+  for (const eventType of TIMELINE_EVENT_ORDER) {
+    if (!events.has(eventType)) {
+      setEvent(missingTimelineEvent({ record, eventType, summary: missingSummaries[eventType] }));
+    }
+  }
+
+  return {
+    issue_number: record.issue_number,
+    pr_number: record.pr_number,
+    events: [...events.values()].sort(sortTimelineEvents),
+  };
 }


### PR DESCRIPTION
## Summary
- add a structured issue-run timeline export builder for tracked issue records
- include available lifecycle events from PR facts, timeline artifacts, local CI, review, recovery, merge, and done state
- represent older sparse records with explicit missing events instead of throwing or fabricating timestamps

## Verification
- npx tsx --test src/supervisor/supervisor-status-report.test.ts src/timeline-artifacts.test.ts
- npm run build
- npm run verify:paths

Part of #1741
Closes #1742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue run timeline export functionality with chronologically ordered lifecycle events
  * Timeline automatically includes all major event types, gracefully marking unavailable events as missing with null timestamps and outcome indicators

* **Tests**
  * Added comprehensive test coverage for timeline export with fully populated and sparse historical data scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->