### PR TITLE
Add explain timeline mode

### DIFF
--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -8,6 +8,7 @@ test("parseArgs accepts --help as the help command", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -21,6 +22,7 @@ test("parseArgs accepts help as a command", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -34,6 +36,7 @@ test("parseArgs accepts doctor as a command", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -47,6 +50,7 @@ test("parseArgs accepts web as a command", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -60,6 +64,7 @@ test("parseArgs accepts issue-lint with an issue number", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: 123,
     snapshotPath: undefined,
     caseId: undefined,
@@ -73,6 +78,7 @@ test("parseArgs accepts readiness-checklist without an issue number", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -86,6 +92,7 @@ test("parseArgs accepts requeue with an issue number", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: 123,
     snapshotPath: undefined,
     caseId: undefined,
@@ -99,6 +106,7 @@ test("parseArgs accepts rollup-execution-metrics without an issue number", () =>
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -112,6 +120,7 @@ test("parseArgs accepts summarize-post-merge-audits without an issue number", ()
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -125,6 +134,7 @@ test("parseArgs accepts reset-corrupt-json-state without an issue number", () =>
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -138,6 +148,7 @@ test("parseArgs accepts prune-orphaned-workspaces without an issue number", () =
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -151,6 +162,7 @@ test("parseArgs accepts replay with a snapshot path", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: "/tmp/decision-cycle-snapshot.json",
     caseId: undefined,
@@ -164,6 +176,7 @@ test("parseArgs accepts replay-corpus with an explicit corpus root", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -177,6 +190,7 @@ test("parseArgs defaults replay-corpus to the checked-in corpus path", () => {
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: undefined,
     caseId: undefined,
@@ -195,6 +209,7 @@ test("parseArgs accepts replay-corpus-promote with explicit snapshot, case id, a
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: "/tmp/decision-cycle-snapshot.json",
     caseId: "issue-408-reproducing",
@@ -212,6 +227,7 @@ test("parseArgs defaults replay-corpus-promote to the checked-in corpus path", (
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: "/tmp/decision-cycle-snapshot.json",
     caseId: "issue-408-reproducing",
@@ -228,11 +244,47 @@ test("parseArgs accepts replay-corpus-promote without an explicit case id so sug
     configPath: undefined,
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     snapshotPath: "/tmp/decision-cycle-snapshot.json",
     caseId: undefined,
     corpusPath: "replay-corpus",
   });
+});
+
+test("parseArgs accepts explain timeline mode after the issue number", () => {
+  assert.deepEqual(parseArgs(["explain", "1743", "--timeline"]), {
+    command: "explain",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    explainMode: "timeline",
+    issueNumber: 1743,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
+test("parseArgs accepts explain timeline mode before the issue number", () => {
+  assert.deepEqual(parseArgs(["explain", "--timeline", "1743"]), {
+    command: "explain",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    explainMode: "timeline",
+    issueNumber: 1743,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
+test("parseArgs rejects timeline mode outside explain", () => {
+  assert.throws(
+    () => parseArgs(["status", "--timeline"]),
+    /The --timeline flag is only supported with the explain command\./,
+  );
 });
 
 test("parseArgs rejects a second command after replay", () => {

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -280,6 +280,20 @@ test("parseArgs accepts explain timeline mode before the issue number", () => {
   });
 });
 
+test("parseArgs accepts explain timeline mode before the command", () => {
+  assert.deepEqual(parseArgs(["--timeline", "explain", "1743"]), {
+    command: "explain",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    explainMode: "timeline",
+    issueNumber: 1743,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
 test("parseArgs rejects timeline mode outside explain", () => {
   assert.throws(
     () => parseArgs(["status", "--timeline"]),

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -16,6 +16,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let configPath: string | undefined;
   let dryRun = false;
   let why = false;
+  let explainMode: CliOptions["explainMode"] = "summary";
   let issueNumber: number | undefined;
   let snapshotPath: string | undefined;
   let caseId: string | undefined;
@@ -67,6 +68,14 @@ export function parseArgs(argv: string[]): CliOptions {
 
     if (token === "--why") {
       why = true;
+      continue;
+    }
+
+    if (token === "--timeline") {
+      if (command !== "explain") {
+        throw new Error("The --timeline flag is only supported with the explain command.");
+      }
+      explainMode = "timeline";
       continue;
     }
 
@@ -136,6 +145,7 @@ export function parseArgs(argv: string[]): CliOptions {
     configPath,
     dryRun,
     why,
+    explainMode,
     issueNumber,
     snapshotPath,
     caseId,

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -16,7 +16,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let configPath: string | undefined;
   let dryRun = false;
   let why = false;
-  let explainMode: CliOptions["explainMode"] = "summary";
+  let timelineRequested = false;
   let issueNumber: number | undefined;
   let snapshotPath: string | undefined;
   let caseId: string | undefined;
@@ -72,10 +72,7 @@ export function parseArgs(argv: string[]): CliOptions {
     }
 
     if (token === "--timeline") {
-      if (command !== "explain") {
-        throw new Error("The --timeline flag is only supported with the explain command.");
-      }
-      explainMode = "timeline";
+      timelineRequested = true;
       continue;
     }
 
@@ -120,6 +117,10 @@ export function parseArgs(argv: string[]): CliOptions {
     throw new Error("The --why flag is only supported with the status command.");
   }
 
+  if (timelineRequested && command !== "explain") {
+    throw new Error("The --timeline flag is only supported with the explain command.");
+  }
+
   if (command === "explain" && issueNumber === undefined) {
     throw new Error("The explain command requires one issue number.");
   }
@@ -139,6 +140,8 @@ export function parseArgs(argv: string[]): CliOptions {
   if (command === "replay-corpus-promote" && snapshotPath === undefined) {
     throw new Error("The replay-corpus-promote command requires one snapshot path.");
   }
+
+  const explainMode: CliOptions["explainMode"] = timelineRequested ? "timeline" : "summary";
 
   return {
     command,

--- a/src/cli/supervisor-runtime.ts
+++ b/src/cli/supervisor-runtime.ts
@@ -11,7 +11,7 @@ import { renderSupervisorExecutionMetricsRollupResultDto } from "../supervisor/s
 import { renderSupervisorMutationResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderSupervisorOrphanPruneResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderPostMergeAuditPatternSummaryDto } from "../supervisor/post-merge-audit-summary";
-import { renderIssueExplainDto } from "../supervisor/supervisor-selection-status";
+import { renderIssueExplainDto, renderIssueExplainTimelineDto } from "../supervisor/supervisor-selection-status";
 import { renderIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
 import { isCorruptJsonFailClosedMessage } from "../supervisor/supervisor";
 import type { SupervisorLoopController } from "../supervisor/supervisor-loop-controller";
@@ -119,7 +119,7 @@ export async function runSupervisorCycle(
 }
 
 export async function runSupervisorCommand(
-  options: Pick<CliOptions, "dryRun" | "why" | "issueNumber"> & { command: SupervisorRuntimeCommand },
+  options: Pick<CliOptions, "dryRun" | "why" | "explainMode" | "issueNumber"> & { command: SupervisorRuntimeCommand },
   dependencies: SupervisorRuntimeDependencies,
 ): Promise<void> {
   const {
@@ -204,7 +204,8 @@ export async function runSupervisorCommand(
   }
 
   if (options.command === "explain") {
-    writeStdout(renderIssueExplainDto(await service.queryExplain(options.issueNumber!)));
+    const explain = await service.queryExplain(options.issueNumber!);
+    writeStdout(options.explainMode === "timeline" ? renderIssueExplainTimelineDto(explain) : renderIssueExplainDto(explain));
     return;
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -553,6 +553,7 @@ export interface CliOptions {
   configPath?: string;
   dryRun: boolean;
   why: boolean;
+  explainMode?: "summary" | "timeline";
   issueNumber?: number;
   snapshotPath?: string;
   caseId?: string;

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -11,6 +11,7 @@ import {
   buildIssueExplainSummary,
   buildNonRunnableLocalStateReasons,
   renderIssueExplainDto,
+  renderIssueExplainTimelineDto,
 } from "./supervisor-selection-issue-explain";
 import {
   branchName,
@@ -102,7 +103,9 @@ test("buildIssueExplainSummary keeps non-runnable explain output stable", async 
     "state=blocked",
     "blocked_reason=verification",
     "runnable=no",
+    "no_active_tracked_record issue=#603 classification=manual_review_required state=blocked reason=verification",
     "retry_summary verification=3 same_blocker=2 same_failure_signature=3 last_failure_signature=verification-failure apparent_no_progress=yes",
+    "restart_recommendation category=manual_review_before_restart source=no_active_tracked_record summary=Manual review is required before a restart should be treated as a recovery action.",
     "reason_1=retry_budget implementation_attempt_count=5/5",
     "reason_2=retry_budget blocked_verification_retry_count=3/3",
     "reason_3=retry_budget repeated_blocker_count=2/2",
@@ -110,6 +113,215 @@ test("buildIssueExplainSummary keeps non-runnable explain output stable", async 
     "reason_5=local_state blocked",
     "last_error=verification still failing",
   ]);
+  assert.equal(lines.some((line) => line.startsWith("timeline_event ")), false);
+});
+
+test("renderIssueExplainTimelineDto shows ordered active issue timeline events", async () => {
+  const config = createConfig();
+  const issueNumber = 617;
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Active explain timeline",
+  });
+  const state = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [
+      createRecord({
+        issue_number: issueNumber,
+        state: "stabilizing",
+        branch: branchName(config, issueNumber),
+        pr_number: 716,
+        blocked_reason: null,
+        last_head_sha: "head-active",
+        last_codex_summary: "Implemented the active timeline slice.",
+        last_error: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "workspace_preparation",
+            command: "npm run verify:paths",
+            head_sha: "head-active",
+            outcome: "failed",
+            remediation_target: "tracked_publishable_content",
+            next_action: "repair_tracked_publishable_content",
+            summary: "Workspace preparation blocked publication.",
+            recorded_at: "2026-04-25T11:01:00Z",
+          },
+          {
+            type: "verification_result",
+            gate: "local_ci",
+            command: "npm run build",
+            head_sha: "head-active",
+            outcome: "passed",
+            remediation_target: null,
+            next_action: "continue",
+            summary: "Build passed.",
+            recorded_at: "2026-04-25T11:03:00Z",
+          },
+        ],
+        local_review_run_at: "2026-04-25T11:04:00Z",
+        local_review_recommendation: "ready",
+        local_review_head_sha: "head-active",
+        local_review_blocker_summary: null,
+        updated_at: "2026-04-25T11:05:00Z",
+      }),
+    ],
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+      resolvePullRequestForBranch: async () => createPullRequest({
+        number: 716,
+        createdAt: "2026-04-25T11:02:00Z",
+        headRefOid: "head-active",
+      }),
+    },
+    config,
+    state,
+    issueNumber,
+  );
+
+  const rendered = renderIssueExplainTimelineDto(dto);
+
+  assert.match(rendered, /^timeline issue=#617 pr=#716 events=11$/m);
+  assert.match(
+    rendered,
+    /^timeline_event index=1 issue=#617 pr=#716 type=reservation at=unknown outcome=recorded head_sha=head-active remediation_target=none next_action=none summary=Issue run reservation exists for branch codex\/reopen-issue-617\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=2 issue=#617 pr=#716 type=publication_gate at=2026-04-25T11:01:00Z outcome=failed head_sha=head-active remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content summary=Workspace preparation blocked publication\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=3 issue=#617 pr=#716 type=pr_created at=2026-04-25T11:02:00Z outcome=created head_sha=head-active remediation_target=none next_action=none summary=Pull request #716 is recorded for this issue run\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=4 issue=#617 pr=#716 type=local_ci at=2026-04-25T11:03:00Z outcome=passed head_sha=head-active remediation_target=none next_action=continue summary=Build passed\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=5 issue=#617 pr=#716 type=review at=2026-04-25T11:04:00Z outcome=ready head_sha=head-active remediation_target=none next_action=none summary=Local review recorded 0 finding\(s\)\.$/m,
+  );
+});
+
+test("renderIssueExplainTimelineDto shows done issue completion and merge events", async () => {
+  const config = createConfig();
+  const issueNumber = 618;
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Done explain timeline",
+  });
+  const state = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: issueNumber,
+        state: "done",
+        branch: branchName(config, issueNumber),
+        pr_number: 718,
+        blocked_reason: null,
+        last_head_sha: "head-done",
+        codex_session_id: null,
+        last_codex_summary: null,
+        last_error: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        updated_at: "2026-04-25T12:00:00Z",
+      }),
+    ],
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [],
+      resolvePullRequestForBranch: async () => createPullRequest({
+        number: 718,
+        createdAt: "2026-04-25T11:40:00Z",
+        mergedAt: "2026-04-25T11:58:00Z",
+        headRefOid: "head-done",
+      }),
+    },
+    config,
+    state,
+    issueNumber,
+  );
+
+  const rendered = renderIssueExplainTimelineDto(dto);
+
+  assert.match(
+    rendered,
+    /^timeline_event index=2 issue=#618 pr=#718 type=pr_created at=2026-04-25T11:40:00Z outcome=created head_sha=head-done remediation_target=none next_action=none summary=Pull request #718 is recorded for this issue run\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=3 issue=#618 pr=#718 type=merge at=2026-04-25T11:58:00Z outcome=merged head_sha=head-done remediation_target=none next_action=none summary=Pull request #718 is merged\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=4 issue=#618 pr=#718 type=done at=2026-04-25T12:00:00Z outcome=done head_sha=head-done remediation_target=none next_action=none summary=Issue run is recorded as done\.$/m,
+  );
+});
+
+test("renderIssueExplainTimelineDto keeps sparse historical records readable", async () => {
+  const config = createConfig();
+  const issueNumber = 619;
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Sparse explain timeline",
+  });
+  const state = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: issueNumber,
+        branch: branchName(config, issueNumber),
+        pr_number: null,
+        codex_session_id: null,
+        last_codex_summary: null,
+        latest_local_ci_result: undefined,
+        timeline_artifacts: undefined,
+        local_review_run_at: null,
+        local_review_recommendation: null,
+        last_recovery_reason: null,
+        last_recovery_at: null,
+      }),
+    ],
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+      resolvePullRequestForBranch: async () => null,
+    },
+    config,
+    state,
+    issueNumber,
+  );
+
+  const rendered = renderIssueExplainTimelineDto(dto);
+
+  assert.match(rendered, /^timeline issue=#619 pr=none events=11$/m);
+  assert.match(
+    rendered,
+    /^timeline_event index=2 issue=#619 pr=none type=codex_turn at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=No Codex turn summary is recorded for this issue run\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=5 issue=#619 pr=none type=local_ci at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=No local CI result is recorded for this issue run\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=11 issue=#619 pr=none type=done at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=Issue run is not recorded as done\.$/m,
+  );
 });
 
 test("buildNonRunnableLocalStateReasons keeps retry-budget ordering stable", () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -71,6 +71,11 @@ import {
 } from "./stale-review-bot-remediation";
 import { formatMergedPrConvergenceOperatorEventLine } from "./supervisor-operator-events";
 import { appendRestartRecommendationLine } from "../operator-actions";
+import {
+  buildIssueRunTimelineExport,
+  type IssueRunTimelineEvent,
+  type IssueRunTimelineExport,
+} from "../timeline-artifacts";
 
 export type ExplainIssueGitHub =
   Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
@@ -109,6 +114,7 @@ export interface SupervisorExplainDto {
   preservedPartialWorkSummary: string | null;
   runtimeFailureKind?: IssueRunRecord["last_runtime_failure_kind"] | null;
   runtimeFailureSummary?: string | null;
+  timeline?: IssueRunTimelineExport | null;
 }
 
 async function buildExplainChangeRiskSummary(args: {
@@ -536,7 +542,28 @@ export async function buildIssueExplainDto(
     preservedPartialWorkSummary: summarizePreservedPartialWork(record?.last_failure_context),
     runtimeFailureKind: record?.last_runtime_failure_kind ?? null,
     runtimeFailureSummary: record?.last_runtime_failure_context?.summary ?? null,
+    timeline: record ? buildIssueRunTimelineExport({ record, pr }) : null,
   };
+}
+
+function formatTimelineValue(value: string): string {
+  return value.replace(/\r\n|\r|\n/g, "\\n");
+}
+
+function renderIssueTimelineEvent(event: IssueRunTimelineEvent, index: number): string {
+  return [
+    "timeline_event",
+    `index=${index}`,
+    `issue=#${event.issue_number}`,
+    `pr=${event.pr_number === null ? "none" : `#${event.pr_number}`}`,
+    `type=${event.event_type}`,
+    `at=${event.timestamp ?? "unknown"}`,
+    `outcome=${event.outcome}`,
+    `head_sha=${event.head_sha ?? "unknown"}`,
+    `remediation_target=${event.remediation_target ?? "none"}`,
+    `next_action=${event.next_action ?? "none"}`,
+    `summary=${formatTimelineValue(event.summary)}`,
+  ].join(" ");
 }
 
 export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
@@ -599,6 +626,23 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
   }
 
   return lines.join("\n");
+}
+
+export function renderIssueExplainTimelineDto(dto: SupervisorExplainDto): string {
+  const summary = renderIssueExplainDto(dto);
+  const timeline = dto.timeline;
+  if (!timeline) {
+    return [
+      summary,
+      `timeline issue=#${dto.issueNumber} status=untracked events=0 summary=No issue-run timeline is recorded for this issue.`,
+    ].join("\n");
+  }
+
+  return [
+    summary,
+    `timeline issue=#${timeline.issue_number} pr=${timeline.pr_number === null ? "none" : `#${timeline.pr_number}`} events=${timeline.events.length}`,
+    ...timeline.events.map((event, index) => renderIssueTimelineEvent(event, index + 1)),
+  ].join("\n");
 }
 
 export async function buildIssueExplainSummary(

--- a/src/supervisor/supervisor-selection-status.ts
+++ b/src/supervisor/supervisor-selection-status.ts
@@ -7,6 +7,7 @@ export {
   buildNonRunnableLocalStateReasons,
   formatSelectionReason,
   renderIssueExplainDto,
+  renderIssueExplainTimelineDto,
 } from "./supervisor-selection-issue-explain";
 export type { IssueLintGitHub, SupervisorIssueLintDto } from "./supervisor-selection-issue-lint";
 export { buildIssueLintDto, renderIssueLintDto } from "./supervisor-selection-issue-lint";

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -104,6 +104,7 @@ import {
 import { buildIssueLintDto, type SupervisorIssueLintDto } from "./supervisor-selection-issue-lint";
 import {
   renderIssueExplainDto,
+  renderIssueExplainTimelineDto,
   SupervisorExplainDto,
 } from "./supervisor-selection-issue-explain";
 import { inferFailureContext } from "./supervisor-failure-context";
@@ -960,6 +961,10 @@ export class Supervisor {
 
   async explain(issueNumber: number): Promise<string> {
     return renderIssueExplainDto(await this.explainReport(issueNumber));
+  }
+
+  async explainTimeline(issueNumber: number): Promise<string> {
+    return renderIssueExplainTimelineDto(await this.explainReport(issueNumber));
   }
 
   async runRecoveryAction(


### PR DESCRIPTION
## Summary
- add opt-in `explain <issue> --timeline` rendering using the issue-run timeline export
- keep default explain summary rendering unchanged
- cover active, done, and sparse timeline records

## Verification
- `npx tsx --test src/cli/parse-args.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`
- `npm run build`
- `npm run verify:paths`

Part of #1741
Depends on #1742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `explain` command gains a `--timeline` flag to show issue details as a chronological timeline.
  * Explanations default to a concise summary when `--timeline` isn't used.

* **Bug Fixes**
  * Using `--timeline` with other commands now yields a clear, targeted error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->