### PR TITLE
Add operator audit bundle explain mode

### DIFF
--- a/src/cli/entrypoint.ts
+++ b/src/cli/entrypoint.ts
@@ -19,7 +19,7 @@ import { renderCliHelp } from "./help";
 import { isSupervisorRuntimeCommand, runSupervisorCommand } from "./supervisor-runtime";
 import { assertRuntimeFreshness } from "../build-freshness";
 
-type SupervisorRuntimeOptions = Pick<CliOptions, "command" | "dryRun" | "why" | "issueNumber">;
+type SupervisorRuntimeOptions = Pick<CliOptions, "command" | "dryRun" | "why" | "explainMode" | "issueNumber">;
 
 async function readReadinessChecklist(): Promise<string> {
   const checklistPath = path.resolve(__dirname, "..", "..", "docs", "validation-checklist.md");
@@ -130,6 +130,7 @@ export async function runCli(
       command: options.command,
       dryRun: options.dryRun,
       why: options.why,
+      explainMode: options.explainMode,
       issueNumber: options.issueNumber,
     },
     {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -27,6 +27,9 @@ Inspect commands:
   status [--why]                    Show queue, PR, CI, review, and loop state.
   doctor                            Check local configuration and repository prerequisites.
   explain <issue-number>            Explain supervisor readiness for one issue.
+  explain <issue-number> --timeline Show the issue-run evidence timeline.
+  explain <issue-number> --audit-bundle
+                                    Print a sanitized operator audit bundle.
   issue-lint <issue-number>         Validate an execution-ready issue body.
   readiness-checklist               Print the release-readiness checklist.
 

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -294,10 +294,38 @@ test("parseArgs accepts explain timeline mode before the command", () => {
   });
 });
 
+test("parseArgs accepts explain audit bundle mode", () => {
+  assert.deepEqual(parseArgs(["explain", "1745", "--audit-bundle"]), {
+    command: "explain",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    explainMode: "audit_bundle",
+    issueNumber: 1745,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
 test("parseArgs rejects timeline mode outside explain", () => {
   assert.throws(
     () => parseArgs(["status", "--timeline"]),
     /The --timeline flag is only supported with the explain command\./,
+  );
+});
+
+test("parseArgs rejects audit bundle mode outside explain", () => {
+  assert.throws(
+    () => parseArgs(["status", "--audit-bundle"]),
+    /The --audit-bundle flag is only supported with the explain command\./,
+  );
+});
+
+test("parseArgs rejects combining explain timeline and audit bundle modes", () => {
+  assert.throws(
+    () => parseArgs(["explain", "1745", "--timeline", "--audit-bundle"]),
+    /The --timeline and --audit-bundle flags cannot be combined\./,
   );
 });
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -17,6 +17,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let dryRun = false;
   let why = false;
   let timelineRequested = false;
+  let auditBundleRequested = false;
   let issueNumber: number | undefined;
   let snapshotPath: string | undefined;
   let caseId: string | undefined;
@@ -76,6 +77,11 @@ export function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (token === "--audit-bundle") {
+      auditBundleRequested = true;
+      continue;
+    }
+
     if ((command === "explain" || command === "issue-lint" || command === "requeue") && issueNumber === undefined) {
       if (/^[1-9]\d*$/.test(token)) {
         issueNumber = Number(token);
@@ -121,6 +127,14 @@ export function parseArgs(argv: string[]): CliOptions {
     throw new Error("The --timeline flag is only supported with the explain command.");
   }
 
+  if (auditBundleRequested && command !== "explain") {
+    throw new Error("The --audit-bundle flag is only supported with the explain command.");
+  }
+
+  if (timelineRequested && auditBundleRequested) {
+    throw new Error("The --timeline and --audit-bundle flags cannot be combined.");
+  }
+
   if (command === "explain" && issueNumber === undefined) {
     throw new Error("The explain command requires one issue number.");
   }
@@ -141,7 +155,11 @@ export function parseArgs(argv: string[]): CliOptions {
     throw new Error("The replay-corpus-promote command requires one snapshot path.");
   }
 
-  const explainMode: CliOptions["explainMode"] = timelineRequested ? "timeline" : "summary";
+  const explainMode: CliOptions["explainMode"] = auditBundleRequested
+    ? "audit_bundle"
+    : timelineRequested
+      ? "timeline"
+      : "summary";
 
   return {
     command,

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -580,6 +580,93 @@ test("runSupervisorCommand routes query commands through the supervisor service 
   assert.match(stdout[0] ?? "", /status output/);
 });
 
+test("runSupervisorCommand renders explain audit bundles as JSON", async () => {
+  const stdout: string[] = [];
+
+  await runSupervisorCommand(
+    { command: "explain", dryRun: false, why: false, explainMode: "audit_bundle", issueNumber: 1745 },
+    {
+      service: {
+        config: {} as SupervisorConfig,
+        pollIntervalMs: async () => 50,
+        runOnce: async () => "runOnce",
+        queryStatus: async () => createStatusDto(),
+        queryExplain: async (issueNumber) => ({
+          issueNumber,
+          title: "Audit bundle",
+          state: "stabilizing",
+          blockedReason: "none",
+          runnable: false,
+          changeRiskLines: [],
+          externalReviewFollowUpSummary: null,
+          latestRecoverySummary: null,
+          operatorEventSummary: null,
+          staleRecoveryWarningSummary: null,
+          activityContext: null,
+          trackedPrMismatchSummary: null,
+          recoveryGuidance: null,
+          selectionReason: null,
+          reasons: [],
+          lastError: null,
+          failureSummary: null,
+          preservedPartialWorkSummary: null,
+          timeline: null,
+          auditBundle: {
+            schemaVersion: 1,
+            advisoryOnly: true,
+            issue: {
+              number: issueNumber,
+              title: "Audit bundle",
+              url: "https://example.test/issues/1745",
+              state: "OPEN",
+              createdAt: "2026-04-25T00:00:00Z",
+              updatedAt: "2026-04-25T00:00:00Z",
+              bodySnapshot: "## Summary\nAudit bundle",
+            },
+            pullRequest: { status: "missing", value: null, summary: "No pull request is recorded." },
+            stateRecord: { status: "missing", value: null, summary: "No state record is tracked." },
+            journal: { status: "missing", value: null, summary: "No journal is available." },
+            localCi: { status: "missing", value: null, summary: "No local CI result is recorded." },
+            pathHygiene: { status: "missing", value: null, summary: "No path hygiene result is recorded." },
+            staleConfiguredBotRemediation: {
+              status: "missing",
+              value: null,
+              summary: "No stale configured-bot remediation result is recorded.",
+            },
+            recoveryEvents: { status: "missing", value: null, summary: "No recovery event is recorded." },
+            timeline: null,
+            verificationCommands: { status: "missing", value: null, summary: "No verification commands are listed." },
+          },
+        }),
+        runRecoveryAction: async () => {
+          throw new Error("unexpected runRecoveryAction");
+        },
+        pruneOrphanedWorkspaces: async () => {
+          throw new Error("unexpected pruneOrphanedWorkspaces");
+        },
+        resetCorruptJsonState: async () => {
+          throw new Error("unexpected resetCorruptJsonState");
+        },
+        queryIssueLint: async () => {
+          throw new Error("unexpected queryIssueLint");
+        },
+        queryDoctor: async () => {
+          throw new Error("unexpected queryDoctor");
+        },
+      },
+      writeStdout: (line) => {
+        stdout.push(line);
+      },
+      registerStopSignals: () => {},
+    },
+  );
+
+  assert.equal(stdout.length, 1);
+  const rendered = JSON.parse(stdout[0] ?? "{}") as { advisoryOnly?: boolean; issue?: { number?: number } };
+  assert.equal(rendered.advisoryOnly, true);
+  assert.equal(rendered.issue?.number, 1745);
+});
+
 test("runSupervisorCommand renders issue-lint output from the structured DTO", async () => {
   const stdout: string[] = [];
   const dto = createIssueLintDto({

--- a/src/cli/supervisor-runtime.ts
+++ b/src/cli/supervisor-runtime.ts
@@ -11,7 +11,11 @@ import { renderSupervisorExecutionMetricsRollupResultDto } from "../supervisor/s
 import { renderSupervisorMutationResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderSupervisorOrphanPruneResultDto } from "../supervisor/supervisor-mutation-report";
 import { renderPostMergeAuditPatternSummaryDto } from "../supervisor/post-merge-audit-summary";
-import { renderIssueExplainDto, renderIssueExplainTimelineDto } from "../supervisor/supervisor-selection-status";
+import {
+  renderIssueExplainAuditBundleDto,
+  renderIssueExplainDto,
+  renderIssueExplainTimelineDto,
+} from "../supervisor/supervisor-selection-status";
 import { renderIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
 import { isCorruptJsonFailClosedMessage } from "../supervisor/supervisor";
 import type { SupervisorLoopController } from "../supervisor/supervisor-loop-controller";
@@ -205,7 +209,13 @@ export async function runSupervisorCommand(
 
   if (options.command === "explain") {
     const explain = await service.queryExplain(options.issueNumber!);
-    writeStdout(options.explainMode === "timeline" ? renderIssueExplainTimelineDto(explain) : renderIssueExplainDto(explain));
+    writeStdout(
+      options.explainMode === "audit_bundle"
+        ? renderIssueExplainAuditBundleDto(explain)
+        : options.explainMode === "timeline"
+          ? renderIssueExplainTimelineDto(explain)
+          : renderIssueExplainDto(explain),
+    );
     return;
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -553,7 +553,7 @@ export interface CliOptions {
   configPath?: string;
   dryRun: boolean;
   why: boolean;
-  explainMode?: "summary" | "timeline";
+  explainMode?: "summary" | "timeline" | "audit_bundle";
   issueNumber?: number;
   snapshotPath?: string;
   caseId?: string;

--- a/src/operator-audit-bundle.test.ts
+++ b/src/operator-audit-bundle.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildOperatorAuditBundle,
+  extractIssueVerificationCommands,
+  renderOperatorAuditBundleDto,
+} from "./operator-audit-bundle";
+import { createIssue, createPullRequest, createRecord } from "./turn-execution-test-helpers";
+
+function buildMacHomePath(owner: string, ...segments: string[]): string {
+  return ["/", "Users", "/", owner, ...segments.flatMap((segment) => ["/", segment])].join("");
+}
+
+function buildWindowsHomePath(owner: string, ...segments: string[]): string {
+  return ["C:", "\\", "Users", "\\", owner, ...segments.flatMap((segment) => ["\\", segment])].join("");
+}
+
+test("extractIssueVerificationCommands reads the issue Verification section", () => {
+  assert.deepEqual(
+    extractIssueVerificationCommands([
+      "## Summary",
+      "Ship a bundle.",
+      "",
+      "## Verification",
+      "- `npm run verify:paths`",
+      "- `npm run build`",
+      "",
+      "## Notes",
+      "- not a command",
+      "",
+    ].join("\n")),
+    ["npm run verify:paths", "npm run build"],
+  );
+});
+
+test("buildOperatorAuditBundle includes structured issue-run evidence and explicit missing entries", () => {
+  const forbiddenPath = buildMacHomePath("alice", "Dev", "private-repo");
+  const forbiddenWindowsPath = buildWindowsHomePath("Alice", "Dev", "private-repo");
+  const bundle = buildOperatorAuditBundle({
+    issue: createIssue({
+      number: 1745,
+      title: "Generate operator audit bundle",
+      body: [
+        "## Summary",
+        `Bundle should redact ${forbiddenPath} and ${forbiddenWindowsPath}.`,
+        "",
+        "## Verification",
+        "- `npx tsx --test src/operator-audit-bundle.test.ts`",
+        "- `npm run verify:paths`",
+        "",
+      ].join("\n"),
+    }),
+    record: createRecord({
+      issue_number: 1745,
+      branch: "codex/issue-1745",
+      workspace: buildMacHomePath("alice", "Dev", "codex-supervisor", ".local", "worktrees", "issue-1745"),
+      pr_number: 1750,
+      last_head_sha: "head-1745",
+      latest_local_ci_result: {
+        outcome: "failed",
+        summary: `Local CI failed while reading ${forbiddenPath}.`,
+        ran_at: "2026-04-25T10:06:00Z",
+        head_sha: "head-1745",
+        execution_mode: "legacy_shell_string",
+        command: "npm run build",
+        failure_class: "non_zero_exit",
+        remediation_target: "tracked_publishable_content",
+      },
+      timeline_artifacts: [
+        {
+          type: "path_hygiene_result",
+          gate: "workstation_local_path_hygiene",
+          command: "npm run verify:paths",
+          head_sha: "head-1745",
+          outcome: "repair_queued",
+          remediation_target: "repair_already_queued",
+          next_action: "wait_for_repair_turn",
+          summary: `Path hygiene repaired ${forbiddenPath}.`,
+          recorded_at: "2026-04-25T10:04:00Z",
+          repair_targets: ["docs/guide.md"],
+        },
+      ],
+      last_recovery_reason: "stale_state_cleanup: moved from stabilizing to draft_pr",
+      last_recovery_at: "2026-04-25T10:05:00Z",
+      updated_at: "2026-04-25T10:12:00Z",
+    }),
+    pr: createPullRequest({
+      number: 1750,
+      title: "Generate audit bundle",
+      url: "https://example.test/pull/1750",
+      headRefName: "codex/issue-1745",
+      headRefOid: "head-1745",
+    }),
+    journalContent: [
+      "# Issue #1745: Generate operator audit bundle",
+      "",
+      "## Codex Working Notes",
+      "### Current Handoff",
+      "- Hypothesis: bundle evidence is scattered.",
+      "- Current blocker: none",
+      "- Next exact step: run focused verification.",
+      `- Verification gap: inspect ${forbiddenPath}.`,
+      "",
+    ].join("\n"),
+  });
+
+  assert.equal(bundle.advisoryOnly, true);
+  assert.equal(bundle.issue.number, 1745);
+  assert.equal(bundle.pullRequest.value?.number, 1750);
+  assert.equal(bundle.stateRecord.value?.branch, "codex/issue-1745");
+  assert.equal(bundle.localCi.value?.outcome, "failed");
+  assert.equal(bundle.pathHygiene.value?.outcome, "repair_queued");
+  assert.deepEqual(bundle.pathHygiene.value?.repairTargets, ["docs/guide.md"]);
+  assert.equal(bundle.staleConfiguredBotRemediation.status, "missing");
+  assert.equal(bundle.recoveryEvents.value?.[0]?.event_type, "recovery");
+  assert.deepEqual(bundle.verificationCommands.value, [
+    "npx tsx --test src/operator-audit-bundle.test.ts",
+    "npm run verify:paths",
+  ]);
+
+  const rendered = renderOperatorAuditBundleDto(bundle);
+  assert.doesNotMatch(rendered, new RegExp(forbiddenPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(rendered, new RegExp(forbiddenWindowsPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(rendered, /<redacted-local-path>/);
+});

--- a/src/operator-audit-bundle.test.ts
+++ b/src/operator-audit-bundle.test.ts
@@ -22,14 +22,25 @@ test("extractIssueVerificationCommands reads the issue Verification section", ()
       "Ship a bundle.",
       "",
       "## Verification",
+      "Run locally first.",
+      "- Confirm the local environment is clean.",
       "- `npm run verify:paths`",
+      "- npx tsx --test src/operator-audit-bundle.test.ts",
+      "- CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint 1745",
+      "`make verify`",
       "- `npm run build`",
       "",
       "## Notes",
       "- not a command",
       "",
     ].join("\n")),
-    ["npm run verify:paths", "npm run build"],
+    [
+      "npm run verify:paths",
+      "npx tsx --test src/operator-audit-bundle.test.ts",
+      "CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint 1745",
+      "make verify",
+      "npm run build",
+    ],
   );
 });
 

--- a/src/operator-audit-bundle.ts
+++ b/src/operator-audit-bundle.ts
@@ -19,6 +19,8 @@ import {
 export const OPERATOR_AUDIT_BUNDLE_SCHEMA_VERSION = 1;
 
 type EvidenceAvailability = "available" | "missing";
+const VERIFICATION_COMMAND_PATTERN =
+  /^(?:(?:[A-Z_][A-Z0-9_]*=\S+)\s+)*(?:npm|pnpm|yarn|npx|node|bun|make|\.\/|bash|sh)\b/u;
 
 export interface OperatorAuditBundleEvidence<T> {
   status: EvidenceAvailability;
@@ -101,9 +103,16 @@ export function extractIssueVerificationCommands(issueBody: string): string[] {
       continue;
     }
 
-    const bullet = trimmed.match(/^[-*]\s+(.+)$/u)?.[1] ?? trimmed;
-    const fenced = bullet.match(/^`([^`]+)`$/u)?.[1] ?? bullet;
-    commands.push(fenced);
+    const bullet = trimmed.match(/^[-*]\s+(.+)$/u)?.[1];
+    const entry = bullet ?? trimmed.match(/^`([^`]+)`$/u)?.[1];
+    if (!entry) {
+      continue;
+    }
+
+    const command = entry.match(/^`([^`]+)`$/u)?.[1] ?? entry;
+    if (VERIFICATION_COMMAND_PATTERN.test(command)) {
+      commands.push(command);
+    }
   }
 
   return commands;

--- a/src/operator-audit-bundle.ts
+++ b/src/operator-audit-bundle.ts
@@ -1,0 +1,246 @@
+import type {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  LatestLocalCiResult,
+  TimelineArtifact,
+} from "./core/types";
+import {
+  extractIssueJournalHandoff,
+  normalizeDurableTrackedArtifactContent,
+  type IssueJournalHandoff,
+} from "./core/journal";
+import {
+  buildIssueRunTimelineExport,
+  type IssueRunTimelineEvent,
+  type IssueRunTimelineExport,
+} from "./timeline-artifacts";
+
+export const OPERATOR_AUDIT_BUNDLE_SCHEMA_VERSION = 1;
+
+type EvidenceAvailability = "available" | "missing";
+
+export interface OperatorAuditBundleEvidence<T> {
+  status: EvidenceAvailability;
+  value: T | null;
+  summary: string;
+}
+
+export interface OperatorAuditBundleDto {
+  schemaVersion: typeof OPERATOR_AUDIT_BUNDLE_SCHEMA_VERSION;
+  advisoryOnly: true;
+  issue: {
+    number: number;
+    title: string;
+    url: string;
+    state: string;
+    createdAt: string;
+    updatedAt: string;
+    bodySnapshot: string;
+  };
+  pullRequest: OperatorAuditBundleEvidence<{
+    number: number;
+    title: string;
+    url: string;
+    state: string;
+    isDraft: boolean;
+    headRefName: string;
+    headRefOid: string;
+    createdAt: string;
+    mergedAt: string | null;
+  }>;
+  stateRecord: OperatorAuditBundleEvidence<{
+    state: IssueRunRecord["state"];
+    branch: string;
+    prNumber: number | null;
+    headSha: string | null;
+    blockedReason: IssueRunRecord["blocked_reason"];
+    attempts: {
+      total: number;
+      implementation: number;
+      repair: number;
+    };
+    lastError: string | null;
+    lastFailureKind: IssueRunRecord["last_failure_kind"];
+    lastFailureSignature: string | null;
+    updatedAt: string;
+  }>;
+  journal: OperatorAuditBundleEvidence<IssueJournalHandoff>;
+  localCi: OperatorAuditBundleEvidence<LatestLocalCiResult>;
+  pathHygiene: OperatorAuditBundleEvidence<{
+    outcome: TimelineArtifact["outcome"];
+    summary: string;
+    command: string | null;
+    headSha: string | null;
+    remediationTarget: TimelineArtifact["remediation_target"];
+    nextAction: string;
+    recordedAt: string;
+    repairTargets: string[];
+  }>;
+  staleConfiguredBotRemediation: OperatorAuditBundleEvidence<unknown>;
+  recoveryEvents: OperatorAuditBundleEvidence<IssueRunTimelineEvent[]>;
+  timeline: IssueRunTimelineExport | null;
+  verificationCommands: OperatorAuditBundleEvidence<string[]>;
+}
+
+export function extractIssueVerificationCommands(issueBody: string): string[] {
+  const lines = issueBody.split(/\r?\n/u);
+  const headingIndex = lines.findIndex((line) => /^##\s+Verification\s*$/iu.test(line.trim()));
+  if (headingIndex < 0) {
+    return [];
+  }
+
+  const commands: string[] = [];
+  for (const line of lines.slice(headingIndex + 1)) {
+    if (/^##\s+/u.test(line.trim())) {
+      break;
+    }
+
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const bullet = trimmed.match(/^[-*]\s+(.+)$/u)?.[1] ?? trimmed;
+    const fenced = bullet.match(/^`([^`]+)`$/u)?.[1] ?? bullet;
+    commands.push(fenced);
+  }
+
+  return commands;
+}
+
+function sanitizeBundleValue<T>(value: T, workspacePath: string): T {
+  if (typeof value === "string") {
+    return normalizeDurableTrackedArtifactContent(value, workspacePath) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeBundleValue(entry, workspacePath)) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, sanitizeBundleValue(entry, workspacePath)]),
+    ) as T;
+  }
+  return value;
+}
+
+function evidence<T>(value: T | null, missingSummary: string): OperatorAuditBundleEvidence<T> {
+  return value === null
+    ? {
+      status: "missing",
+      value: null,
+      summary: missingSummary,
+    }
+    : {
+      status: "available",
+      value,
+      summary: "Evidence is available.",
+    };
+}
+
+function latestPathHygieneArtifact(record: IssueRunRecord | null): TimelineArtifact | null {
+  const artifacts = record?.timeline_artifacts ?? [];
+  for (let index = artifacts.length - 1; index >= 0; index -= 1) {
+    const artifact = artifacts[index];
+    if (artifact.gate === "workstation_local_path_hygiene") {
+      return artifact;
+    }
+  }
+  return null;
+}
+
+export function buildOperatorAuditBundle(args: {
+  issue: GitHubIssue;
+  record?: IssueRunRecord | null;
+  pr?: GitHubPullRequest | null;
+  journalContent?: string | null;
+  staleConfiguredBotRemediation?: unknown | null;
+}): OperatorAuditBundleDto {
+  const record = args.record ?? null;
+  const pr = args.pr ?? null;
+  const workspacePath = record?.workspace ?? ".";
+  const timeline = record ? buildIssueRunTimelineExport({ record, pr }) : null;
+  const pathHygieneArtifact = latestPathHygieneArtifact(record);
+  const verificationCommands = extractIssueVerificationCommands(args.issue.body ?? "");
+  const recoveryEvents = timeline?.events.filter((event) => event.event_type === "recovery" && event.outcome !== "missing") ?? [];
+
+  const bundle: OperatorAuditBundleDto = {
+    schemaVersion: OPERATOR_AUDIT_BUNDLE_SCHEMA_VERSION,
+    advisoryOnly: true,
+    issue: {
+      number: args.issue.number,
+      title: args.issue.title,
+      url: args.issue.url,
+      state: args.issue.state ?? "UNKNOWN",
+      createdAt: args.issue.createdAt,
+      updatedAt: args.issue.updatedAt,
+      bodySnapshot: args.issue.body ?? "",
+    },
+    pullRequest: evidence(pr
+      ? {
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        state: pr.state,
+        isDraft: pr.isDraft,
+        headRefName: pr.headRefName,
+        headRefOid: pr.headRefOid,
+        createdAt: pr.createdAt,
+        mergedAt: pr.mergedAt ?? null,
+      }
+      : null, "No pull request is recorded for this tracked issue."),
+    stateRecord: evidence(record
+      ? {
+        state: record.state,
+        branch: record.branch,
+        prNumber: record.pr_number,
+        headSha: record.last_head_sha,
+        blockedReason: record.blocked_reason,
+        attempts: {
+          total: record.attempt_count,
+          implementation: record.implementation_attempt_count,
+          repair: record.repair_attempt_count,
+        },
+        lastError: record.last_error,
+        lastFailureKind: record.last_failure_kind,
+        lastFailureSignature: record.last_failure_signature,
+        updatedAt: record.updated_at,
+      }
+      : null, "No supervisor state record is tracked for this issue."),
+    journal: evidence(args.journalContent !== undefined && args.journalContent !== null
+      ? extractIssueJournalHandoff(args.journalContent)
+      : null, "No issue journal content is available for this issue."),
+    localCi: evidence(record?.latest_local_ci_result ?? null, "No local CI result is recorded for this issue run."),
+    pathHygiene: evidence(pathHygieneArtifact
+      ? {
+        outcome: pathHygieneArtifact.outcome,
+        summary: pathHygieneArtifact.summary,
+        command: pathHygieneArtifact.command,
+        headSha: pathHygieneArtifact.head_sha,
+        remediationTarget: pathHygieneArtifact.remediation_target,
+        nextAction: pathHygieneArtifact.next_action,
+        recordedAt: pathHygieneArtifact.recorded_at,
+        repairTargets: pathHygieneArtifact.repair_targets ?? [],
+      }
+      : null, "No workstation-local path hygiene result is recorded for this issue run."),
+    staleConfiguredBotRemediation: evidence(
+      args.staleConfiguredBotRemediation ?? null,
+      "No stale configured-bot remediation result is recorded for this issue run.",
+    ),
+    recoveryEvents: evidence(
+      recoveryEvents.length > 0 ? recoveryEvents : null,
+      "No recovery event is recorded for this issue run.",
+    ),
+    timeline,
+    verificationCommands: evidence(
+      verificationCommands.length > 0 ? verificationCommands : null,
+      "No verification commands are listed in the issue body.",
+    ),
+  };
+
+  return sanitizeBundleValue(bundle, workspacePath);
+}
+
+export function renderOperatorAuditBundleDto(dto: OperatorAuditBundleDto): string {
+  return `${JSON.stringify(dto, null, 2)}\n`;
+}

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -76,6 +76,11 @@ import {
   type IssueRunTimelineEvent,
   type IssueRunTimelineExport,
 } from "../timeline-artifacts";
+import {
+  buildOperatorAuditBundle,
+  renderOperatorAuditBundleDto,
+  type OperatorAuditBundleDto,
+} from "../operator-audit-bundle";
 
 export type ExplainIssueGitHub =
   Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
@@ -115,6 +120,7 @@ export interface SupervisorExplainDto {
   runtimeFailureKind?: IssueRunRecord["last_runtime_failure_kind"] | null;
   runtimeFailureSummary?: string | null;
   timeline?: IssueRunTimelineExport | null;
+  auditBundle?: OperatorAuditBundleDto | null;
 }
 
 async function buildExplainChangeRiskSummary(args: {
@@ -358,9 +364,11 @@ export async function buildIssueExplainDto(
   let handoffSummary: string | null = null;
   let hostPathSummary: string | null = null;
   let journalStateSummary: string | null = null;
+  let journalContent: string | null = null;
   if (record) {
     try {
       const hostDiagnostics = await inspectTrackedIssueHostDiagnostics(config, record);
+      journalContent = hostDiagnostics.journalContent;
       if (hostDiagnostics.journalContent !== null) {
         handoffSummary = summarizeIssueJournalHandoff(hostDiagnostics.journalContent);
       }
@@ -543,6 +551,13 @@ export async function buildIssueExplainDto(
     runtimeFailureKind: record?.last_runtime_failure_kind ?? null,
     runtimeFailureSummary: record?.last_runtime_failure_context?.summary ?? null,
     timeline: record ? buildIssueRunTimelineExport({ record, pr }) : null,
+    auditBundle: buildOperatorAuditBundle({
+      issue,
+      record: record ?? null,
+      pr,
+      journalContent,
+      staleConfiguredBotRemediation: staleReviewBotRemediation,
+    }),
   };
 }
 
@@ -643,6 +658,20 @@ export function renderIssueExplainTimelineDto(dto: SupervisorExplainDto): string
     `timeline issue=#${timeline.issue_number} pr=${timeline.pr_number === null ? "none" : `#${timeline.pr_number}`} events=${timeline.events.length}`,
     ...timeline.events.map((event, index) => renderIssueTimelineEvent(event, index + 1)),
   ].join("\n");
+}
+
+export function renderIssueExplainAuditBundleDto(dto: SupervisorExplainDto): string {
+  return renderOperatorAuditBundleDto(dto.auditBundle ?? buildOperatorAuditBundle({
+    issue: {
+      number: dto.issueNumber,
+      title: dto.title,
+      body: "",
+      createdAt: "",
+      updatedAt: "",
+      url: "",
+      state: "UNKNOWN",
+    },
+  }));
 }
 
 export async function buildIssueExplainSummary(

--- a/src/supervisor/supervisor-selection-status.ts
+++ b/src/supervisor/supervisor-selection-status.ts
@@ -7,6 +7,7 @@ export {
   buildNonRunnableLocalStateReasons,
   formatSelectionReason,
   renderIssueExplainDto,
+  renderIssueExplainAuditBundleDto,
   renderIssueExplainTimelineDto,
 } from "./supervisor-selection-issue-explain";
 export type { IssueLintGitHub, SupervisorIssueLintDto } from "./supervisor-selection-issue-lint";


### PR DESCRIPTION
## Summary
- add a sanitized operator audit bundle DTO for tracked issues
- expose it through `explain <issue-number> --audit-bundle`
- include explicit missing-evidence entries plus parser/runtime/path-hygiene coverage

## Verification
- `npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/workstation-local-paths.test.ts src/timeline-artifacts.test.ts`
- `npx tsx --test src/operator-audit-bundle.test.ts src/cli/parse-args.test.ts src/cli/supervisor-runtime.test.ts`
- `npm run verify:paths`
- `npm run build`

Closes #1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--audit-bundle` flag for the `explain` command to enable audit bundle output mode
  * Input validation prevents combined use of `--audit-bundle` and `--timeline` flags

* **Documentation**
  * Updated help text to document `--timeline` and `--audit-bundle` options for the `explain` command

* **Tests**
  * New test coverage for audit bundle mode and flag constraint validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->