### PR TITLE
Split tracked PR status comment boundaries

### DIFF
--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildTrackedPrStatusCommentBody,
   buildTrackedPrStatusCommentMarker,
+  parseTrackedPrStatusCommentMarker,
+  selectOwnedTrackedPrStatusComment,
   workspacePreparationRemediationTarget,
 } from "./tracked-pr-status-comment";
 
@@ -14,6 +17,95 @@ test("buildTrackedPrStatusCommentMarker renders the stable sticky tracked PR mar
     }),
     "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
   );
+});
+
+test("parseTrackedPrStatusCommentMarker reads only the stable sticky tracked PR marker", () => {
+  assert.deepEqual(
+    parseTrackedPrStatusCommentMarker(
+      "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+    ),
+    {
+      issueNumber: 102,
+      prNumber: 116,
+      kind: "status",
+    },
+  );
+  assert.deepEqual(
+    parseTrackedPrStatusCommentMarker(
+      "prefix <!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=host-local-blocker --> suffix",
+    ),
+    {
+      issueNumber: 102,
+      prNumber: 116,
+      kind: "host-local-blocker",
+    },
+  );
+  assert.equal(
+    parseTrackedPrStatusCommentMarker(
+      "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=unknown -->",
+    ),
+    null,
+  );
+});
+
+test("buildTrackedPrStatusCommentBody appends the owned marker without GitHub transport", () => {
+  assert.equal(
+    buildTrackedPrStatusCommentBody({
+      body: "Tracked PR head `head-116` remains stopped near merge.",
+      marker: {
+        issueNumber: 102,
+        prNumber: 116,
+        kind: "status",
+      },
+    }),
+    [
+      "Tracked PR head `head-116` remains stopped near merge.",
+      "",
+      "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+    ].join("\n"),
+  );
+});
+
+test("selectOwnedTrackedPrStatusComment picks the newest editable marked comment", () => {
+  const marker = buildTrackedPrStatusCommentMarker({
+    issueNumber: 102,
+    prNumber: 116,
+    kind: "status",
+  });
+  const selected = selectOwnedTrackedPrStatusComment({
+    issueComments: [
+      {
+        id: "foreign",
+        databaseId: 10,
+        body: marker,
+        createdAt: "2026-03-16T02:00:00Z",
+        url: "https://example.test/comments/10",
+        viewerDidAuthor: false,
+        author: null,
+      },
+      {
+        id: "old-owned",
+        databaseId: 11,
+        body: marker,
+        createdAt: "2026-03-16T01:00:00Z",
+        url: "https://example.test/comments/11",
+        viewerDidAuthor: true,
+        author: null,
+      },
+      {
+        id: "new-owned",
+        databaseId: 12,
+        body: marker,
+        createdAt: "2026-03-16T03:00:00Z",
+        url: "https://example.test/comments/12",
+        viewerDidAuthor: true,
+        author: null,
+      },
+    ],
+    markers: [marker],
+  });
+
+  assert.equal(selected?.databaseId, 12);
 });
 
 test("workspacePreparationRemediationTarget keeps generic preparation failures on workspace environment", () => {

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -34,6 +34,11 @@ const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracke
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
 
 export type TrackedPrStatusCommentKind = "status" | "host-local-blocker";
+export interface TrackedPrStatusCommentMarker {
+  issueNumber: number;
+  prNumber: number;
+  kind: TrackedPrStatusCommentKind;
+}
 
 export function workspacePreparationFailureClass(
   signature: string | null | undefined,
@@ -387,21 +392,62 @@ function derivePersistentTrackedPrStatusComment(args: {
   return null;
 }
 
-export function buildTrackedPrStatusCommentMarker(args: {
-  issueNumber: number;
-  prNumber: number;
-  kind: TrackedPrStatusCommentKind;
-}): string {
+export function buildTrackedPrStatusCommentMarker(args: TrackedPrStatusCommentMarker): string {
   return `<!-- ${TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX} issue=${args.issueNumber} pr=${args.prNumber} kind=${args.kind} -->`;
 }
 
-function findOwnedTrackedPrStatusComment(
-  issueComments: IssueComment[],
-  markers: string[],
-): IssueComment | null {
-  const matchingComments = issueComments.filter(
+export function parseTrackedPrStatusCommentMarker(input: string): TrackedPrStatusCommentMarker | null {
+  const match = input.match(
+    /<!--\s*codex-supervisor:tracked-pr-status-comment\s+issue=(\d+)\s+pr=(\d+)\s+kind=([a-z-]+)\s*-->/,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const issueNumber = Number(match[1]);
+  const prNumber = Number(match[2]);
+  const kind = match[3];
+  if (
+    !Number.isSafeInteger(issueNumber) ||
+    issueNumber <= 0 ||
+    !Number.isSafeInteger(prNumber) ||
+    prNumber <= 0 ||
+    (kind !== "status" && kind !== "host-local-blocker")
+  ) {
+    return null;
+  }
+
+  return {
+    issueNumber,
+    prNumber,
+    kind,
+  };
+}
+
+export function buildTrackedPrStatusCommentBody(args: {
+  body: string;
+  marker: TrackedPrStatusCommentMarker;
+}): string {
+  return `${args.body}\n\n${buildTrackedPrStatusCommentMarker(args.marker)}`;
+}
+
+export function editableTrackedPrStatusCommentMarkers(args: TrackedPrStatusCommentMarker): string[] {
+  return [
+    buildTrackedPrStatusCommentMarker(args),
+    buildTrackedPrStatusCommentMarker({
+      ...args,
+      kind: args.kind === "status" ? "host-local-blocker" : "status",
+    }),
+  ];
+}
+
+export function selectOwnedTrackedPrStatusComment(args: {
+  issueComments: IssueComment[];
+  markers: string[];
+}): IssueComment | null {
+  const matchingComments = args.issueComments.filter(
     (comment) =>
-      markers.some((marker) => comment.body.includes(marker)) &&
+      args.markers.some((marker) => comment.body.includes(marker)) &&
       comment.viewerDidAuthor === true &&
       typeof comment.databaseId === "number",
   );
@@ -424,20 +470,16 @@ async function publishTrackedPrStatusComment(args: {
     return;
   }
 
-  const marker = buildTrackedPrStatusCommentMarker({
+  const marker: TrackedPrStatusCommentMarker = {
     issueNumber: args.issueNumber,
     prNumber: args.pr.number,
     kind: args.kind,
-  });
-  const bodyWithMarker = `${args.body}\n\n${marker}`;
-  const editableMarkers = [
+  };
+  const bodyWithMarker = buildTrackedPrStatusCommentBody({
+    body: args.body,
     marker,
-    buildTrackedPrStatusCommentMarker({
-      issueNumber: args.issueNumber,
-      prNumber: args.pr.number,
-      kind: args.kind === "status" ? "host-local-blocker" : "status",
-    }),
-  ];
+  });
+  const editableMarkers = editableTrackedPrStatusCommentMarkers(marker);
 
   if (args.github.getExternalReviewSurface && args.github.updateIssueComment) {
     const surface = await args.github.getExternalReviewSurface(args.pr.number, {
@@ -445,7 +487,10 @@ async function publishTrackedPrStatusComment(args: {
       headSha: args.pr.headRefOid,
       reviewSurfaceVersion: args.pr.updatedAt,
     });
-    const existingComment = findOwnedTrackedPrStatusComment(surface.issueComments, editableMarkers);
+    const existingComment = selectOwnedTrackedPrStatusComment({
+      issueComments: surface.issueComments,
+      markers: editableMarkers,
+    });
     const existingCommentDatabaseId = existingComment?.databaseId;
     if (typeof existingCommentDatabaseId === "number") {
       await args.github.updateIssueComment(existingCommentDatabaseId, bodyWithMarker);


### PR DESCRIPTION
## Summary
- split tracked PR status comment marker parsing/serialization into pure helpers
- add transport-free marker-appended body rendering coverage
- keep publish/update/dedupe behavior wired through the new owned-comment selector

## Verification
- npx tsx --test src/tracked-pr-status-comment.test.ts src/post-turn-pull-request.test.ts
- npm run build

Part of #1753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for PR status comment marker parsing, body construction, and comment selection logic.

* **Refactor**
  * Enhanced marker handling with typed interfaces and utility functions to improve comment tracking and selection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->