### PR TITLE
Extract ready-promotion gate handling

### DIFF
--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -36,6 +36,7 @@ import {
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
 } from "./workstation-local-path-gate";
+import { deriveReadyPromotionPathHygieneDecision } from "./ready-promotion-gate";
 import {
   emitSupervisorEvent,
   maybeBuildReviewWaitChangedEvent,
@@ -50,10 +51,6 @@ import {
 } from "./post-turn-pull-request-policy";
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
-import {
-  appendTimelineArtifact,
-  buildPathHygieneTimelineArtifact,
-} from "./timeline-artifacts";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -94,8 +91,6 @@ export interface PullRequestLifecycleSnapshot {
 }
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
-const READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY =
-  "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready.";
 
 function staleConfiguredBotThreadIdsFromSignature(signature: string | null | undefined): string[] {
   if (!signature) {
@@ -537,81 +532,15 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       gateLabel: `before marking PR #${refreshed.pr.number} ready`,
       publishablePathAllowlistMarkers: config.publishablePathAllowlistMarkers,
     });
-    if (!pathHygieneGate.ok) {
-      const failureContext = pathHygieneGate.failureContext;
-      const actionablePublishableFilePaths = pathHygieneGate.actionablePublishableFilePaths ?? [];
-      if (failureContext !== null && actionablePublishableFilePaths.length > 0) {
-        const repairFailureContext: FailureContext = {
-          ...failureContext,
-          summary: `${READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY} Actionable files: ${actionablePublishableFilePaths.join(", ")}. ${failureContext.summary}`,
-        };
-        record = stateStore.touch(record, {
-          state: "repairing_ci",
-          timeline_artifacts: appendTimelineArtifact(record, buildPathHygieneTimelineArtifact({
-            failureContext: repairFailureContext,
-            headSha: refreshed.pr.headRefOid ?? null,
-            outcome: "repair_queued",
-            remediationTarget: "repair_already_queued",
-            repairTargets: actionablePublishableFilePaths,
-          })),
-          last_error: truncate(repairFailureContext.summary, 1000),
-          last_failure_kind: null,
-          last_failure_context: repairFailureContext,
-          ...args.applyFailureSignature(record, repairFailureContext),
-          blocked_reason: null,
-          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-            pr: refreshed.pr,
-            blockerSignature: repairFailureContext.signature,
-          }),
-        });
-        state.issues[String(record.issue_number)] = record;
-        await stateStore.save(state);
-        await syncJournal(record);
-        record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
-          github,
-          stateStore,
-          state,
-          record,
-          pr: refreshed.pr,
-          syncJournal,
-          gateType: "workstation_local_path_hygiene",
-          blockerSignature: repairFailureContext.signature,
-          failureClass: repairFailureContext.signature,
-          remediationTarget: "repair_already_queued",
-          summary: repairFailureContext.summary,
-          details: repairFailureContext.details,
-        });
-        return {
-          record,
-          pr: refreshed.pr,
-          checks: refreshed.checks,
-          reviewThreads: refreshed.reviewThreads,
-        };
-      }
-      record = stateStore.touch(record, {
-        state: "blocked",
-        timeline_artifacts: failureContext
-          ? appendTimelineArtifact(record, buildPathHygieneTimelineArtifact({
-            failureContext,
-            headSha: refreshed.pr.headRefOid ?? null,
-            outcome: "failed",
-            remediationTarget: "manual_review",
-          }))
-          : record.timeline_artifacts,
-        last_error: truncate(
-          failureContext?.summary
-            ?? `Tracked durable artifacts failed workstation-local path hygiene before marking PR #${refreshed.pr.number} ready.`,
-          1000,
-        ),
-        last_failure_kind: null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: "verification",
-        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-          pr: refreshed.pr,
-          blockerSignature: failureContext?.signature ?? null,
-        }),
-      });
+    const pathHygieneDecision = deriveReadyPromotionPathHygieneDecision({
+      record,
+      pr: refreshed.pr,
+      gate: pathHygieneGate,
+      fallbackSummary: `Tracked durable artifacts failed workstation-local path hygiene before marking PR #${refreshed.pr.number} ready.`,
+      applyFailureSignature: args.applyFailureSignature,
+    });
+    if (pathHygieneDecision.kind === "repair" || pathHygieneDecision.kind === "manual_review") {
+      record = stateStore.touch(record, pathHygieneDecision.recordPatch);
       state.issues[String(record.issue_number)] = record;
       await stateStore.save(state);
       await syncJournal(record);
@@ -622,12 +551,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         record,
         pr: refreshed.pr,
         syncJournal,
-        gateType: "workstation_local_path_hygiene",
-        blockerSignature: failureContext?.signature ?? null,
-        failureClass: failureContext?.signature ?? null,
-        remediationTarget: "manual_review",
-        summary: failureContext?.summary ?? null,
-        details: failureContext?.details,
+        ...pathHygieneDecision.comment,
       });
       return {
         record,
@@ -636,11 +560,11 @@ export async function handlePostTurnPullRequestTransitionsPhase(
         reviewThreads: refreshed.reviewThreads,
       };
     }
-    const rewrittenTrackedPaths = [
-      ...(pathHygieneGate.rewrittenJournalPaths ?? []),
-      ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
-    ];
-    const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(workspacePath, rewrittenTrackedPaths);
+
+    const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(
+      workspacePath,
+      pathHygieneDecision.rewrittenTrackedPaths,
+    );
     if (presentRewrittenTrackedPaths.length > 0) {
       let persistedNormalizationCommit = false;
       try {

--- a/src/ready-promotion-gate.test.ts
+++ b/src/ready-promotion-gate.test.ts
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createFailureContext, createPullRequest, createRecord } from "./turn-execution-test-helpers";
+import { deriveReadyPromotionPathHygieneDecision } from "./ready-promotion-gate";
+
+const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
+
+test("deriveReadyPromotionPathHygieneDecision routes actionable path hygiene blockers to repair", () => {
+  const record = createRecord({ state: "draft_pr" });
+  const pr = createPullRequest({ isDraft: true, headRefOid: "head-116" });
+  const failureContext = {
+    ...createFailureContext("Tracked durable artifacts failed workstation-local path hygiene before marking PR #116 ready."),
+    signature: "workstation-local-path-hygiene-failed",
+    command: "npm run verify:paths",
+    details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
+  };
+
+  const decision = deriveReadyPromotionPathHygieneDecision({
+    record,
+    pr,
+    gate: {
+      ok: false,
+      failureContext,
+      actionablePublishableFilePaths: ["docs/guide.md"],
+    },
+    fallbackSummary: "fallback",
+    applyFailureSignature: (_record, context) => ({
+      last_failure_signature: context?.signature ?? null,
+      repeated_failure_signature_count: context ? 1 : 0,
+    }),
+  });
+
+  assert.equal(decision.kind, "repair");
+  assert.equal(decision.recordPatch.state, "repairing_ci");
+  assert.equal(decision.recordPatch.blocked_reason, null);
+  assert.equal(decision.recordPatch.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(decision.comment.remediationTarget, "repair_already_queued");
+  assert.match(decision.failureContext.summary, /will retry a repair turn/i);
+  assert.deepEqual(decision.recordPatch.timeline_artifacts, [
+    {
+      type: "path_hygiene_result",
+      gate: "workstation_local_path_hygiene",
+      command: "npm run verify:paths",
+      head_sha: "head-116",
+      outcome: "repair_queued",
+      remediation_target: "repair_already_queued",
+      next_action: "wait_for_repair_turn",
+      summary: decision.failureContext.summary,
+      recorded_at: decision.failureContext.updated_at,
+      repair_targets: ["docs/guide.md"],
+    },
+  ]);
+});
+
+test("deriveReadyPromotionPathHygieneDecision falls back to manual review for non-actionable blockers", () => {
+  const record = createRecord({ state: "draft_pr" });
+  const pr = createPullRequest({ isDraft: true, headRefOid: "head-116" });
+  const failureContext = {
+    ...createFailureContext("Tracked durable artifacts failed workstation-local path hygiene before marking PR #116 ready."),
+    signature: "workstation-local-path-hygiene-failed",
+    command: "npm run verify:paths",
+    details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
+  };
+
+  const decision = deriveReadyPromotionPathHygieneDecision({
+    record,
+    pr,
+    gate: {
+      ok: false,
+      failureContext,
+      actionablePublishableFilePaths: [],
+    },
+    fallbackSummary: "fallback",
+    applyFailureSignature: (_record, context) => ({
+      last_failure_signature: context?.signature ?? null,
+      repeated_failure_signature_count: context ? 1 : 0,
+    }),
+  });
+
+  assert.equal(decision.kind, "manual_review");
+  assert.equal(decision.recordPatch.state, "blocked");
+  assert.equal(decision.recordPatch.blocked_reason, "verification");
+  assert.equal(decision.recordPatch.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(decision.comment.remediationTarget, "manual_review");
+  assert.match(decision.recordPatch.last_error ?? "", /Tracked durable artifacts failed/);
+  assert.deepEqual(decision.recordPatch.timeline_artifacts, [
+    {
+      type: "path_hygiene_result",
+      gate: "workstation_local_path_hygiene",
+      command: "npm run verify:paths",
+      head_sha: "head-116",
+      outcome: "failed",
+      remediation_target: "manual_review",
+      next_action: "operator_manual_review",
+      summary: failureContext.summary,
+      recorded_at: failureContext.updated_at,
+    },
+  ]);
+});

--- a/src/ready-promotion-gate.ts
+++ b/src/ready-promotion-gate.ts
@@ -1,0 +1,141 @@
+import {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+} from "./core/types";
+import { truncate } from "./core/utils";
+import { type WorkstationLocalPathGateResult } from "./workstation-local-path-gate";
+import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+import {
+  appendTimelineArtifact,
+  buildPathHygieneTimelineArtifact,
+} from "./timeline-artifacts";
+
+export const READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY =
+  "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready.";
+
+export type ReadyPromotionPathHygieneDecision =
+  | {
+      kind: "passed";
+      rewrittenTrackedPaths: string[];
+    }
+  | {
+      kind: "repair";
+      failureContext: FailureContext;
+      recordPatch: Partial<IssueRunRecord>;
+      comment: {
+        gateType: "workstation_local_path_hygiene";
+        blockerSignature: string | null;
+        failureClass: string | null;
+        remediationTarget: "repair_already_queued";
+        summary: string;
+        details: string[] | null | undefined;
+      };
+    }
+  | {
+      kind: "manual_review";
+      failureContext: FailureContext | null;
+      recordPatch: Partial<IssueRunRecord>;
+      comment: {
+        gateType: "workstation_local_path_hygiene";
+        blockerSignature: string | null;
+        failureClass: string | null;
+        remediationTarget: "manual_review";
+        summary: string | null;
+        details: string[] | null | undefined;
+      };
+    };
+
+export function deriveReadyPromotionPathHygieneDecision(args: {
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  gate: WorkstationLocalPathGateResult;
+  fallbackSummary: string;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+}): ReadyPromotionPathHygieneDecision {
+  if (args.gate.ok) {
+    return {
+      kind: "passed",
+      rewrittenTrackedPaths: [
+        ...(args.gate.rewrittenJournalPaths ?? []),
+        ...(args.gate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+      ],
+    };
+  }
+
+  const failureContext = args.gate.failureContext;
+  const actionablePublishableFilePaths = args.gate.actionablePublishableFilePaths ?? [];
+  if (failureContext !== null && actionablePublishableFilePaths.length > 0) {
+    const repairFailureContext: FailureContext = {
+      ...failureContext,
+      summary: `${READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY} Actionable files: ${actionablePublishableFilePaths.join(", ")}. ${failureContext.summary}`,
+    };
+    return {
+      kind: "repair",
+      failureContext: repairFailureContext,
+      recordPatch: {
+        state: "repairing_ci",
+        timeline_artifacts: appendTimelineArtifact(args.record, buildPathHygieneTimelineArtifact({
+          failureContext: repairFailureContext,
+          headSha: args.pr.headRefOid ?? null,
+          outcome: "repair_queued",
+          remediationTarget: "repair_already_queued",
+          repairTargets: actionablePublishableFilePaths,
+        })),
+        last_error: truncate(repairFailureContext.summary, 1000),
+        last_failure_kind: null,
+        last_failure_context: repairFailureContext,
+        ...args.applyFailureSignature(args.record, repairFailureContext),
+        blocked_reason: null,
+        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+          pr: args.pr,
+          blockerSignature: repairFailureContext.signature,
+        }),
+      },
+      comment: {
+        gateType: "workstation_local_path_hygiene",
+        blockerSignature: repairFailureContext.signature,
+        failureClass: repairFailureContext.signature,
+        remediationTarget: "repair_already_queued",
+        summary: repairFailureContext.summary,
+        details: repairFailureContext.details,
+      },
+    };
+  }
+
+  return {
+    kind: "manual_review",
+    failureContext,
+    recordPatch: {
+      state: "blocked",
+      timeline_artifacts: failureContext
+        ? appendTimelineArtifact(args.record, buildPathHygieneTimelineArtifact({
+          failureContext,
+          headSha: args.pr.headRefOid ?? null,
+          outcome: "failed",
+          remediationTarget: "manual_review",
+        }))
+        : args.record.timeline_artifacts,
+      last_error: truncate(failureContext?.summary ?? args.fallbackSummary, 1000),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason: "verification",
+      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+        pr: args.pr,
+        blockerSignature: failureContext?.signature ?? null,
+      }),
+    },
+    comment: {
+      gateType: "workstation_local_path_hygiene",
+      blockerSignature: failureContext?.signature ?? null,
+      failureClass: failureContext?.signature ?? null,
+      remediationTarget: "manual_review",
+      summary: failureContext?.summary ?? null,
+      details: failureContext?.details,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extract ready-promotion path hygiene decisions into a focused helper module.
- Keep post-turn PR transition responsible for persistence, journal sync, and status-comment side effects.
- Add focused coverage for repairable and non-repairable ready-promotion path hygiene blockers.

## Verification
- npx tsx --test src/ready-promotion-gate.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/ready-promotion-gate.test.ts src/post-turn-pull-request.test.ts src/tracked-pr-local-ci-publication-gate.test.ts src/workstation-local-paths.test.ts
- npm run verify:paths
- npm run build

Part of #1754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced path hygiene failure handling during PR readiness assessment, improving the system's ability to determine when to attempt automatic repair versus requiring manual review of file path issues.

* **Tests**
  * Added comprehensive test coverage for path hygiene decision logic, validating both repair-eligible and manual-review scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->