### PR TITLE
Normalize recovery family entrypoint contracts

### DIFF
--- a/src/recovery-entrypoint-result.ts
+++ b/src/recovery-entrypoint-result.ts
@@ -26,13 +26,20 @@ function commonIssueNumber(events: RecoveryEvent[]): number | null {
   return events.every((event) => event.issueNumber === firstIssueNumber) ? firstIssueNumber : null;
 }
 
+function commonReason(events: RecoveryEvent[]): string | null {
+  const firstReason = events[0]?.reason ?? null;
+  if (firstReason === null) {
+    return null;
+  }
+  return events.every((event) => event.reason === firstReason) ? firstReason : null;
+}
+
 export function normalizeRecoveryEntrypointResult(
   events: readonly RecoveryEvent[] | null | undefined,
   options: RecoveryEntrypointResultOptions = {},
 ): RecoveryEntrypointResult {
   const recoveryEvents = [...(events ?? [])];
-  const firstReason = recoveryEvents[0]?.reason ?? null;
-  const reason = options.reason ?? firstReason;
+  const reason = options.reason ?? commonReason(recoveryEvents);
   const operatorMessage = options.operatorMessage ?? reason;
 
   return {

--- a/src/recovery-entrypoint-result.ts
+++ b/src/recovery-entrypoint-result.ts
@@ -1,0 +1,46 @@
+import { type RecoveryEvent } from "./run-once-cycle-prelude";
+
+export type RecoveryEntrypointOutcome = "recovered" | "unchanged";
+
+export interface RecoveryEntrypointResult {
+  outcome: RecoveryEntrypointOutcome;
+  reason: string | null;
+  issueNumber: number | null;
+  prNumber: number | null;
+  operatorMessage: string | null;
+  events: RecoveryEvent[];
+}
+
+export interface RecoveryEntrypointResultOptions {
+  issueNumber?: number | null;
+  prNumber?: number | null;
+  reason?: string | null;
+  operatorMessage?: string | null;
+}
+
+function commonIssueNumber(events: RecoveryEvent[]): number | null {
+  const firstIssueNumber = events[0]?.issueNumber ?? null;
+  if (firstIssueNumber === null) {
+    return null;
+  }
+  return events.every((event) => event.issueNumber === firstIssueNumber) ? firstIssueNumber : null;
+}
+
+export function normalizeRecoveryEntrypointResult(
+  events: readonly RecoveryEvent[] | null | undefined,
+  options: RecoveryEntrypointResultOptions = {},
+): RecoveryEntrypointResult {
+  const recoveryEvents = [...(events ?? [])];
+  const firstReason = recoveryEvents[0]?.reason ?? null;
+  const reason = options.reason ?? firstReason;
+  const operatorMessage = options.operatorMessage ?? reason;
+
+  return {
+    outcome: recoveryEvents.length > 0 ? "recovered" : "unchanged",
+    reason,
+    issueNumber: options.issueNumber ?? commonIssueNumber(recoveryEvents),
+    prNumber: options.prNumber ?? null,
+    operatorMessage,
+    events: recoveryEvents,
+  };
+}

--- a/src/recovery-family-boundaries.test.ts
+++ b/src/recovery-family-boundaries.test.ts
@@ -217,3 +217,38 @@ test("recovery entrypoint results normalize event arrays into a shared operator-
     events: [],
   });
 });
+
+test("recovery entrypoint results avoid summarizing mixed event reasons without an explicit batch reason", () => {
+  const noPrEvent = buildRecoveryEvent(
+    451,
+    "failed_no_pr_recovered: requeued issue #451 after branch recovered",
+  );
+  const trackedPrEvent = buildRecoveryEvent(
+    452,
+    "tracked_pr_lifecycle_recovered: resumed issue #452 using fresh tracked PR #952 facts",
+  );
+
+  assert.deepEqual(normalizeRecoveryEntrypointResult([noPrEvent, trackedPrEvent]), {
+    outcome: "recovered",
+    reason: null,
+    issueNumber: null,
+    prNumber: null,
+    operatorMessage: null,
+    events: [noPrEvent, trackedPrEvent],
+  });
+
+  assert.deepEqual(
+    normalizeRecoveryEntrypointResult([noPrEvent, trackedPrEvent], {
+      reason: "stale failed recovery batch",
+      operatorMessage: "stale failed recovery batch completed",
+    }),
+    {
+      outcome: "recovered",
+      reason: "stale failed recovery batch",
+      issueNumber: null,
+      prNumber: null,
+      operatorMessage: "stale failed recovery batch completed",
+      events: [noPrEvent, trackedPrEvent],
+    },
+  );
+});

--- a/src/recovery-family-boundaries.test.ts
+++ b/src/recovery-family-boundaries.test.ts
@@ -7,6 +7,7 @@ import { type IssueRunRecord, type SupervisorStateFile } from "./core/types";
 import { reconcileStaleActiveIssueReservationInModule } from "./recovery-active-reconciliation";
 import { reconcileStaleDoneIssueStatesInModule } from "./recovery-historical-reconciliation";
 import { reconcileParentEpicClosuresInModule } from "./recovery-parent-epic-reconciliation";
+import { normalizeRecoveryEntrypointResult } from "./recovery-entrypoint-result";
 import { type RecoveryEvent } from "./run-once-cycle-prelude";
 import {
   createIssue,
@@ -184,4 +185,35 @@ test("parent epic recovery boundary closes ready parents without aggregate recon
   assert.equal(saveCalls, 1);
   assert.equal(state.issues["123"]?.state, "done");
   assert.equal(recoveryEvents[0]?.reason, "parent_epic_auto_closed: auto-closed parent epic #123 because child issues #201, #202 are closed");
+});
+
+test("recovery entrypoint results normalize event arrays into a shared operator-facing contract", () => {
+  const event = buildRecoveryEvent(
+    451,
+    "tracked_pr_lifecycle_recovered: resumed issue #451 from failed to pr_open using fresh tracked PR #951 facts at head head-951",
+  );
+
+  assert.deepEqual(
+    normalizeRecoveryEntrypointResult([event], {
+      prNumber: 951,
+      operatorMessage: "tracked PR recovery resumed issue #451",
+    }),
+    {
+      outcome: "recovered",
+      reason: event.reason,
+      issueNumber: 451,
+      prNumber: 951,
+      operatorMessage: "tracked PR recovery resumed issue #451",
+      events: [event],
+    },
+  );
+
+  assert.deepEqual(normalizeRecoveryEntrypointResult([]), {
+    outcome: "unchanged",
+    reason: null,
+    issueNumber: null,
+    prNumber: null,
+    operatorMessage: null,
+    events: [],
+  });
 });

--- a/src/recovery-no-pr-reconciliation.ts
+++ b/src/recovery-no-pr-reconciliation.ts
@@ -77,7 +77,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     patch: Partial<IssueRunRecord>,
     recoveryEvent: RecoveryEvent,
   ) => Partial<IssueRunRecord>;
-}): Promise<boolean> {
+}): Promise<RecoveryEvent | null> {
   const {
     github,
     stateStore,
@@ -100,7 +100,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
   }
 
   if (issueState !== "OPEN" || !shouldAutoRecoverFailedNoPr(record, config)) {
-    return false;
+    return null;
   }
 
   const branchRecovery = await classifyFailedNoPrBranchRecovery({
@@ -110,7 +110,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     isSafeCleanupTarget,
   });
   if (branchRecovery.state === "dirty_workspace" && shouldAutoRetryTimeout(record, config)) {
-    return false;
+    return null;
   }
   const previousNoPrRecoveryCount = record.stale_stabilizing_no_pr_recovery_count ?? 0;
   const transientRuntimeEvidence = transientNoPrRuntimeEvidenceLabel(record, config);
@@ -141,7 +141,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     };
     const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
     state.issues[String(record.issue_number)] = updated;
-    return true;
+    return recoveryEvent;
   }
   if (branchRecovery.state !== "recoverable") {
     const branchRecoveryReason = branchRecovery.state === "already_satisfied_on_main"
@@ -178,7 +178,7 @@ export async function reconcileStaleFailedNoPrRecord(args: {
     };
     const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
     state.issues[String(record.issue_number)] = updated;
-    return true;
+    return recoveryEvent;
   }
 
   const repeatLimit = Math.max(config.sameFailureSignatureRepeatLimit, 1);
@@ -222,5 +222,5 @@ export async function reconcileStaleFailedNoPrRecord(args: {
   };
   const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
   state.issues[String(record.issue_number)] = updated;
-  return true;
+  return recoveryEvent;
 }

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -550,8 +550,9 @@ export async function reconcileStaleFailedIssueStates(
     targetPrNumber?: number | null;
     waitStep?: string | null;
   }) => Promise<void>) | null = null,
-): Promise<void> {
+): Promise<RecoveryEvent[]> {
   let changed = false;
+  const recoveryEvents: RecoveryEvent[] = [];
   const issuesByNumber = new Map(issues.map((issue) => [issue.number, issue]));
   const issueStateByNumber = new Map(issues.map((issue) => [issue.number, issue.state ?? null]));
   let failedNoPrFetchPromise: Promise<void> | null = null;
@@ -611,10 +612,11 @@ export async function reconcileStaleFailedIssueStates(
         });
         state.issues[String(record.issue_number)] = updated;
         changed = true;
+        recoveryEvents.push(recoveryEvent);
         continue;
       }
 
-      if (await reconcileStaleFailedNoPrRecord({
+      const noPrRecoveryEvent = await reconcileStaleFailedNoPrRecord({
         github,
         stateStore,
         state,
@@ -624,13 +626,15 @@ export async function reconcileStaleFailedIssueStates(
         ensureOriginDefaultBranchFetched,
         buildRecoveryEvent,
         applyRecoveryEvent,
-      })) {
+      });
+      if (noPrRecoveryEvent !== null) {
         changed = true;
+        recoveryEvents.push(noPrRecoveryEvent);
       }
       continue;
     }
 
-    if (await reconcileStaleFailedTrackedPrRecord(
+    const trackedPrRecoveryEvent = await reconcileStaleFailedTrackedPrRecord(
       github,
       stateStore,
       state,
@@ -642,14 +646,18 @@ export async function reconcileStaleFailedIssueStates(
         applyRecoveryEvent,
       },
       updateReconciliationProgress,
-    )) {
+    );
+    if (trackedPrRecoveryEvent !== null) {
       changed = true;
+      recoveryEvents.push(trackedPrRecoveryEvent);
     }
   }
 
   if (changed) {
     await stateStore.save(state);
   }
+
+  return recoveryEvents;
 }
 
 export async function reconcileStaleDoneIssueStates(

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -641,15 +641,15 @@ export async function reconcileStaleFailedTrackedPrRecord(
     targetPrNumber?: number | null;
     waitStep?: string | null;
   }) => Promise<void>) | null = null,
-): Promise<boolean> {
+): Promise<RecoveryEvent | null> {
   const trackedPrNumber = record.pr_number;
   if (trackedPrNumber === null) {
-    return false;
+    return null;
   }
 
   const pr = await github.getPullRequestIfExists(trackedPrNumber);
   if (!pr || !deps.isOpenPullRequest(pr)) {
-    return false;
+    return null;
   }
 
   const checks = await github.getChecks(pr.number);
@@ -673,7 +673,7 @@ export async function reconcileStaleFailedTrackedPrRecord(
   });
 
   if (projection.shouldSuppressRecovery) {
-    return false;
+    return null;
   }
 
   const failureContext =
@@ -691,11 +691,11 @@ export async function reconcileStaleFailedTrackedPrRecord(
     copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
   });
   if (!needsRecordUpdate(record, patch)) {
-    return false;
+    return null;
   }
   const recoveryEvent = buildTrackedPrResumeRecoveryEvent(record, pr, nextState, helpers.buildRecoveryEvent);
 
   const updated = stateStore.touch(record, helpers.applyRecoveryEvent(patch, recoveryEvent));
   state.issues[String(record.issue_number)] = updated;
-  return true;
+  return recoveryEvent;
 }

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -48,6 +48,11 @@ test("runOnceCyclePrelude loads state and aggregates recovery setup events in or
     reason: "blocked recovery",
     at: "2026-03-14T00:03:00Z",
   };
+  const staleFailedRecoveryEvent: RecoveryEvent = {
+    issueNumber: 47,
+    reason: "failed no-PR recovery",
+    at: "2026-03-14T00:03:15Z",
+  };
   const parentEpicClosureEvent: RecoveryEvent = {
     issueNumber: 45,
     reason: "parent_epic_auto_closed: auto-closed parent epic #45 because child issues #46, #47 are closed",
@@ -101,6 +106,7 @@ test("runOnceCyclePrelude loads state and aggregates recovery setup events in or
       calls.push("reconcileStaleFailedIssueStates");
       assert.equal(loadedState, state);
       assert.equal(loadedIssues, issues);
+      return [staleFailedRecoveryEvent];
     },
     reconcileRecoverableBlockedIssueStates: async (loadedState, loadedIssues) => {
       calls.push("reconcileRecoverableBlockedIssueStates");
@@ -140,10 +146,78 @@ test("runOnceCyclePrelude loads state and aggregates recovery setup events in or
     ...carryover,
     staleReservationEvent,
     mergedConvergenceEvent,
+    staleFailedRecoveryEvent,
     blockedRecoveryEvent,
     parentEpicClosureEvent,
     orphanCleanupEvent,
   ]);
+  assert.deepEqual(
+    result.recoveryResults.map((recoveryResult) => ({
+      outcome: recoveryResult.outcome,
+      reason: recoveryResult.reason,
+      issueNumber: recoveryResult.issueNumber,
+      prNumber: recoveryResult.prNumber,
+      operatorMessage: recoveryResult.operatorMessage,
+    })),
+    [
+      {
+        outcome: "recovered",
+        reason: "carryover recovery",
+        issueNumber: 90,
+        prNumber: null,
+        operatorMessage: "carryover recovery",
+      },
+      {
+        outcome: "recovered",
+        reason: "cleared stale reservation",
+        issueNumber: 41,
+        prNumber: null,
+        operatorMessage: "cleared stale reservation",
+      },
+      {
+        outcome: "recovered",
+        reason: "merged convergence",
+        issueNumber: 42,
+        prNumber: null,
+        operatorMessage: "merged convergence",
+      },
+      {
+        outcome: "unchanged",
+        reason: null,
+        issueNumber: null,
+        prNumber: null,
+        operatorMessage: null,
+      },
+      {
+        outcome: "recovered",
+        reason: "failed no-PR recovery",
+        issueNumber: 47,
+        prNumber: null,
+        operatorMessage: "failed no-PR recovery",
+      },
+      {
+        outcome: "recovered",
+        reason: "blocked recovery",
+        issueNumber: 43,
+        prNumber: null,
+        operatorMessage: "blocked recovery",
+      },
+      {
+        outcome: "recovered",
+        reason: "parent_epic_auto_closed: auto-closed parent epic #45 because child issues #46, #47 are closed",
+        issueNumber: 45,
+        prNumber: null,
+        operatorMessage: "parent_epic_auto_closed: auto-closed parent epic #45 because child issues #46, #47 are closed",
+      },
+      {
+        outcome: "recovered",
+        reason: "pruned orphaned worktree",
+        issueNumber: 44,
+        prNumber: null,
+        operatorMessage: "pruned orphaned worktree",
+      },
+    ],
+  );
 });
 
 test("runOnceCyclePrelude persists the last-known-good inventory snapshot after a successful full inventory refresh", async () => {

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -266,7 +266,7 @@ test("runOnceCyclePrelude persists the last-known-good inventory snapshot after 
     reserveRunnableIssueSelection: async () => false,
     reconcileTrackedMergedButOpenIssues: async () => [],
     reconcileMergedIssueClosures: async () => [],
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
@@ -367,7 +367,7 @@ test("runOnceCyclePrelude prioritizes recoverable tracked PR reconciliation ahea
         options,
       ),
     reconcileMergedIssueClosures: async () => [],
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
@@ -525,7 +525,7 @@ test("runOnceCyclePrelude bounds merged issue closure revalidation for historica
         loadedIssues,
       );
     },
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
@@ -587,6 +587,7 @@ test("runOnceCyclePrelude rehydrates tracked blocked PRs before reserving select
     },
     reconcileStaleFailedIssueStates: async () => {
       calls.push("stale_failed");
+      return [];
     },
     reconcileRecoverableBlockedIssueStates: async (loadedState, _loadedIssues, options) => {
       calls.push(`recoverable_blocked:${options?.onlyTrackedPrStates === true ? "tracked" : "all"}`);
@@ -692,6 +693,7 @@ test("runOnceCyclePrelude requeues rehydrated requirements-blocked no-PR records
     },
     reconcileStaleFailedIssueStates: async () => {
       calls.push("stale_failed");
+      return [];
     },
     reconcileRecoverableBlockedIssueStates: async (loadedState, _loadedIssues, options) => {
       calls.push(`recoverable_blocked:${options?.onlyTrackedPrStates === true ? "tracked" : "all"}`);
@@ -785,6 +787,7 @@ test("runOnceCyclePrelude reconciles stale done no-PR records before reserving a
     },
     reconcileStaleFailedIssueStates: async () => {
       calls.push("stale_failed");
+      return [];
     },
     reconcileStaleDoneIssueStates: async (loadedState, loadedIssues) => {
       calls.push("stale_done");
@@ -885,6 +888,7 @@ test("runOnceCyclePrelude reconciles tracked PR-open issues before reserving a n
     },
     reconcileStaleFailedIssueStates: async () => {
       calls.push("stale_failed");
+      return [];
     },
     reconcileRecoverableBlockedIssueStates: async () => {
       calls.push("recoverable_blocked");
@@ -986,7 +990,7 @@ test("runOnceCyclePrelude publishes the active reconciliation phase and clears i
     listAllIssues: async () => [],
     reconcileTrackedMergedButOpenIssues: async () => [],
     reconcileMergedIssueClosures: async () => [],
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
@@ -1037,7 +1041,7 @@ test("runOnceCyclePrelude publishes reconciliation target updates within a phase
       });
       return [];
     },
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
@@ -1131,7 +1135,7 @@ test("runOnceCyclePrelude emits typed recovery events for transport adapters", a
     listAllIssues: async () => issues,
     reconcileTrackedMergedButOpenIssues: async () => recoveryEvents,
     reconcileMergedIssueClosures: async () => [],
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => [],
     cleanupExpiredDoneWorkspaces: async () => [],
@@ -1795,15 +1799,17 @@ test("runOnceCyclePrelude rehydrates stale failed tracked PRs during degraded in
     },
     reconcileStaleFailedIssueStates: async (loadedState, loadedIssues) => {
       staleFailedCalls.push({ loadedState, loadedIssues });
+      const reason =
+        "tracked_pr_head_advanced: resumed issue #77 from failed to addressing_review after tracked PR #170 advanced from head-old-170 to head-new-170";
       loadedState.issues["77"] = {
         ...loadedState.issues["77"]!,
         state: "addressing_review",
         last_head_sha: "head-new-170",
         last_failure_signature: null,
         repeated_failure_signature_count: 0,
-        last_recovery_reason:
-          "tracked_pr_head_advanced: resumed issue #77 from failed to addressing_review after tracked PR #170 advanced from head-old-170 to head-new-170",
+        last_recovery_reason: reason,
       };
+      return [{ issueNumber: 77, reason, at: "2026-03-26T00:06:00Z" }];
     },
     reconcileRecoverableBlockedIssueStates: async () => {
       throw new Error("unexpected reconcileRecoverableBlockedIssueStates call");
@@ -1824,6 +1830,9 @@ test("runOnceCyclePrelude rehydrates stale failed tracked PRs during degraded in
       loadedState: state,
       loadedIssues: [],
     },
+  ]);
+  assert.deepEqual(result.recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_head_advanced: resumed issue #77 from failed to addressing_review after tracked PR #170 advanced from head-old-170 to head-new-170",
   ]);
   assert.equal(result.state.issues["77"]?.state, "addressing_review");
   assert.equal(result.state.issues["77"]?.last_head_sha, "head-new-170");
@@ -1872,6 +1881,8 @@ test("runOnceCyclePrelude rehydrates an active stale failed tracked PR during de
     },
     reconcileStaleFailedIssueStates: async (loadedState, loadedIssues) => {
       staleFailedCalls.push({ loadedState, loadedIssues });
+      const reason =
+        "tracked_pr_lifecycle_recovered: resumed issue #77 from failed to draft_pr using fresh tracked PR #170 facts at head head-old-170";
       loadedState.issues["77"] = {
         ...loadedState.issues["77"]!,
         state: "draft_pr",
@@ -1880,9 +1891,9 @@ test("runOnceCyclePrelude rehydrates an active stale failed tracked PR during de
         last_failure_context: null,
         last_failure_signature: null,
         repeated_failure_signature_count: 0,
-        last_recovery_reason:
-          "tracked_pr_lifecycle_recovered: resumed issue #77 from failed to draft_pr using fresh tracked PR #170 facts at head head-old-170",
+        last_recovery_reason: reason,
       };
+      return [{ issueNumber: 77, reason, at: "2026-03-26T00:06:00Z" }];
     },
     reconcileRecoverableBlockedIssueStates: async () => {
       throw new Error("unexpected reconcileRecoverableBlockedIssueStates call");
@@ -1901,6 +1912,9 @@ test("runOnceCyclePrelude rehydrates an active stale failed tracked PR during de
       loadedState: state,
       loadedIssues: [],
     },
+  ]);
+  assert.deepEqual(result.recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #77 from failed to draft_pr using fresh tracked PR #170 facts at head head-old-170",
   ]);
   assert.equal(result.state.issues["77"]?.state, "draft_pr");
   assert.equal(result.state.issues["77"]?.last_error, null);
@@ -2206,7 +2220,7 @@ test("runOnceCyclePrelude does not attempt degraded parent epic closure from a p
     },
     reconcileTrackedMergedButOpenIssues: async () => [],
     reconcileMergedIssueClosures: async () => [],
-    reconcileStaleFailedIssueStates: async () => {},
+    reconcileStaleFailedIssueStates: async () => [],
     reconcileRecoverableBlockedIssueStates: async () => [],
     reconcileParentEpicClosures: async () => {
       parentEpicClosureCalls += 1;

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -13,6 +13,10 @@ import {
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
 import type { ReconciliationProgressUpdate } from "./supervisor/supervisor-reconciliation-phase";
+import {
+  normalizeRecoveryEntrypointResult,
+  type RecoveryEntrypointResult,
+} from "./recovery-entrypoint-result";
 
 export interface RecoveryEvent {
   issueNumber: number;
@@ -23,12 +27,14 @@ export interface RecoveryEvent {
 export interface RunOnceCyclePreludeResult {
   state: SupervisorStateFile;
   recoveryEvents: RecoveryEvent[];
+  recoveryResults: RecoveryEntrypointResult[];
 }
 
 export interface RunOnceCyclePreludeAuthFailure {
   kind: "auth_failure";
   message: string;
   recoveryEvents: RecoveryEvent[];
+  recoveryResults: RecoveryEntrypointResult[];
 }
 
 type ReconciliationProgressPatch = Partial<Omit<ReconciliationProgressUpdate, "phase">>;
@@ -62,7 +68,7 @@ interface RunOnceCyclePreludeArgs {
     state: SupervisorStateFile,
     issues: GitHubIssue[],
     updateReconciliationProgress: (patch: ReconciliationProgressPatch) => Promise<void>,
-  ) => Promise<void>;
+  ) => Promise<RecoveryEvent[] | void>;
   reconcileStaleDoneIssueStates?: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
@@ -88,6 +94,9 @@ export async function runOnceCyclePrelude(
 ): Promise<RunOnceCyclePreludeResult | RunOnceCyclePreludeAuthFailure> {
   const state = await args.stateStore.load();
   const recoveryEvents: RecoveryEvent[] = [...args.carryoverRecoveryEvents];
+  const recoveryResults: RecoveryEntrypointResult[] = args.carryoverRecoveryEvents.map((event) =>
+    normalizeRecoveryEntrypointResult([event])
+  );
   let currentReconciliationProgress: ReconciliationProgressUpdate | null = null;
   const setReconciliationProgress = async (progress: ReconciliationProgressUpdate | null) => {
     currentReconciliationProgress = progress;
@@ -114,7 +123,9 @@ export async function runOnceCyclePrelude(
       ...patch,
     });
   };
-  const emitRecoveryEvents = (events: RecoveryEvent[]) => {
+  const collectRecoveryEvents = (events: RecoveryEvent[]) => {
+    recoveryEvents.push(...events);
+    recoveryResults.push(normalizeRecoveryEntrypointResult(events));
     for (const event of events) {
       emitSupervisorEvent(args.emitEvent, buildRecoverySupervisorEvent(event));
     }
@@ -152,14 +163,14 @@ export async function runOnceCyclePrelude(
       kind: "auth_failure",
       message: authFailure,
       recoveryEvents,
+      recoveryResults,
     };
   }
 
   try {
     await setReconciliationPhase("stale_active_issue_reservation");
     const staleReservationEvents = await args.reconcileStaleActiveIssueReservation(state);
-    recoveryEvents.push(...staleReservationEvents);
-    emitRecoveryEvents(staleReservationEvents);
+    collectRecoveryEvents(staleReservationEvents);
 
     const activeRecord =
       state.activeIssueNumber === null ? null : state.issues[String(state.activeIssueNumber)] ?? null;
@@ -201,14 +212,14 @@ export async function runOnceCyclePrelude(
           updateReconciliationProgress,
           { onlyIssueNumber: activeRecord.issue_number },
         );
-        recoveryEvents.push(...activeMergedEvents);
-        emitRecoveryEvents(activeMergedEvents);
+        collectRecoveryEvents(activeMergedEvents);
       }
 
       const hasFailedRecords = Object.values(state.issues).some((record) => record.state === "failed");
       if (allowDegradedContinuation && hasFailedRecords) {
         await setReconciliationPhase("stale_failed_issue_states");
-        await args.reconcileStaleFailedIssueStates(state, [], updateReconciliationProgress);
+        const staleFailedEvents = await args.reconcileStaleFailedIssueStates(state, [], updateReconciliationProgress);
+        collectRecoveryEvents(staleFailedEvents ?? []);
       }
 
       const hasBlockedTrackedPrRecords = Object.values(state.issues).some((record) =>
@@ -226,8 +237,7 @@ export async function runOnceCyclePrelude(
         const recoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, [], {
           onlyTrackedPrStates: true,
         });
-        recoveryEvents.push(...recoverableBlockedEvents);
-        emitRecoveryEvents(recoverableBlockedEvents);
+        collectRecoveryEvents(recoverableBlockedEvents);
       }
 
       if (
@@ -238,12 +248,14 @@ export async function runOnceCyclePrelude(
         return {
           state,
           recoveryEvents,
+          recoveryResults,
         };
       }
 
       return {
         state,
         recoveryEvents,
+        recoveryResults,
       };
     }
 
@@ -255,14 +267,14 @@ export async function runOnceCyclePrelude(
         updateReconciliationProgress,
         { onlyIssueNumber: activeRecord.issue_number },
       );
-      recoveryEvents.push(...activeMergedEvents);
-      emitRecoveryEvents(activeMergedEvents);
+      collectRecoveryEvents(activeMergedEvents);
 
       const activeRecordAfterFastPath = state.issues[String(activeRecord.issue_number)] ?? null;
       if (activeRecordAfterFastPath?.state === "done") {
         return {
           state,
           recoveryEvents,
+          recoveryResults,
         };
       }
 
@@ -270,36 +282,32 @@ export async function runOnceCyclePrelude(
     }
 
     const trackedMergedEvents = await args.reconcileTrackedMergedButOpenIssues(state, issues, updateReconciliationProgress);
-    recoveryEvents.push(...trackedMergedEvents);
-    emitRecoveryEvents(trackedMergedEvents);
+    collectRecoveryEvents(trackedMergedEvents);
 
     await setReconciliationPhase("merged_issue_closures");
     const mergedIssueClosureEvents = await args.reconcileMergedIssueClosures(state, issues, updateReconciliationProgress);
-    recoveryEvents.push(...mergedIssueClosureEvents);
-    emitRecoveryEvents(mergedIssueClosureEvents);
+    collectRecoveryEvents(mergedIssueClosureEvents);
 
     await setReconciliationPhase("stale_failed_issue_states");
-    await args.reconcileStaleFailedIssueStates(state, issues, updateReconciliationProgress);
+    const staleFailedEvents = await args.reconcileStaleFailedIssueStates(state, issues, updateReconciliationProgress);
+    collectRecoveryEvents(staleFailedEvents ?? []);
 
     if (args.reconcileStaleDoneIssueStates) {
       await setReconciliationPhase("stale_done_issue_states");
       const staleDoneEvents = await args.reconcileStaleDoneIssueStates(state, issues);
-      recoveryEvents.push(...staleDoneEvents);
-      emitRecoveryEvents(staleDoneEvents);
+      collectRecoveryEvents(staleDoneEvents);
     }
 
     await setReconciliationPhase("recoverable_blocked_issue_states");
     const recoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues, {
       onlyTrackedPrStates: true,
     });
-    recoveryEvents.push(...recoverableBlockedEvents);
-    emitRecoveryEvents(recoverableBlockedEvents);
+    collectRecoveryEvents(recoverableBlockedEvents);
 
     if (hasNonTrackedRecoverableBlockedStates(state)) {
       await setReconciliationPhase("recoverable_blocked_issue_states");
       const remainingRecoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues);
-      recoveryEvents.push(...remainingRecoverableBlockedEvents);
-      emitRecoveryEvents(remainingRecoverableBlockedEvents);
+      collectRecoveryEvents(remainingRecoverableBlockedEvents);
     }
 
     if (
@@ -309,22 +317,22 @@ export async function runOnceCyclePrelude(
       return {
         state,
         recoveryEvents,
+        recoveryResults,
       };
     }
 
     await setReconciliationPhase("parent_epic_closures");
     const parentEpicClosureEvents = await args.reconcileParentEpicClosures(state, issues) ?? [];
-    recoveryEvents.push(...parentEpicClosureEvents);
-    emitRecoveryEvents(parentEpicClosureEvents);
+    collectRecoveryEvents(parentEpicClosureEvents);
 
     await setReconciliationPhase("cleanup_expired_done_workspaces");
     const cleanupEvents = await args.cleanupExpiredDoneWorkspaces(state);
-    recoveryEvents.push(...cleanupEvents);
-    emitRecoveryEvents(cleanupEvents);
+    collectRecoveryEvents(cleanupEvents);
 
     return {
       state,
       recoveryEvents,
+      recoveryResults,
     };
   } finally {
     await setReconciliationProgress(null);

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -68,7 +68,7 @@ interface RunOnceCyclePreludeArgs {
     state: SupervisorStateFile,
     issues: GitHubIssue[],
     updateReconciliationProgress: (patch: ReconciliationProgressPatch) => Promise<void>,
-  ) => Promise<RecoveryEvent[] | void>;
+  ) => Promise<RecoveryEvent[]>;
   reconcileStaleDoneIssueStates?: (
     state: SupervisorStateFile,
     issues: GitHubIssue[],
@@ -219,7 +219,7 @@ export async function runOnceCyclePrelude(
       if (allowDegradedContinuation && hasFailedRecords) {
         await setReconciliationPhase("stale_failed_issue_states");
         const staleFailedEvents = await args.reconcileStaleFailedIssueStates(state, [], updateReconciliationProgress);
-        collectRecoveryEvents(staleFailedEvents ?? []);
+        collectRecoveryEvents(staleFailedEvents);
       }
 
       const hasBlockedTrackedPrRecords = Object.values(state.issues).some((record) =>
@@ -290,7 +290,7 @@ export async function runOnceCyclePrelude(
 
     await setReconciliationPhase("stale_failed_issue_states");
     const staleFailedEvents = await args.reconcileStaleFailedIssueStates(state, issues, updateReconciliationProgress);
-    collectRecoveryEvents(staleFailedEvents ?? []);
+    collectRecoveryEvents(staleFailedEvents);
 
     if (args.reconcileStaleDoneIssueStates) {
       await setReconciliationPhase("stale_done_issue_states");

--- a/src/supervisor/supervisor-execution-cleanup.test.ts
+++ b/src/supervisor/supervisor-execution-cleanup.test.ts
@@ -675,7 +675,9 @@ test("runOnce preserves orphaned done worktrees that are no longer referenced by
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
-    listAllIssues: async () => [],
+    listAllIssues: async () => [
+      createIssue({ number: trackedIssueNumber, state: "CLOSED" }),
+    ],
     listCandidateIssues: async () => [],
     getIssue: async () => {
       throw new Error("unexpected getIssue call");
@@ -746,7 +748,10 @@ test("runOnce still cleans tracked done workspaces under the done-workspace poli
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
-    listAllIssues: async () => [],
+    listAllIssues: async () => [
+      createIssue({ number: olderIssueNumber, state: "CLOSED" }),
+      createIssue({ number: newerIssueNumber, state: "CLOSED" }),
+    ],
     listCandidateIssues: async () => [],
     getIssue: async () => {
       throw new Error("unexpected getIssue call");


### PR DESCRIPTION
## Summary
- Add a shared normalized recovery entrypoint result shape with outcome, reason, issue, PR, operator message, and events.
- Preserve legacy recovery event arrays while exposing normalized prelude recovery results.
- Return concrete recovery events from stale failed no-PR/tracked-PR recovery so those paths fit the shared contract.

## Verification
- npx tsx --test src/recovery-family-boundaries.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/recovery-reconciliation.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-cleanup.test.ts
- npm run build

Part of #1755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery results are now normalized and surfaced alongside recovered events in cycle summaries (outcome, reason, issue/PR references, and operator message).

* **Tests**
  * Expanded tests cover normalization, mixed-event aggregation, and end-to-end propagation of recovery events/results through the run-once prelude and supervisor flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->