### PR TITLE
Extract shared diagnostics DTO boundary

### DIFF
--- a/src/backend/supervisor-http-server.ts
+++ b/src/backend/supervisor-http-server.ts
@@ -12,6 +12,7 @@ import {
   type DangerousSetupConfigFieldKey,
   type SetupConfigUpdateResult,
 } from "../setup-config-write";
+import type { SharedDiagnosticHostSummaryDto } from "../diagnostics-dto";
 import type { SetupReadinessReport } from "../setup-readiness";
 import type { SupervisorLoopController } from "../supervisor/supervisor-loop-controller";
 import type { SupervisorEvent, SupervisorService } from "../supervisor";
@@ -52,7 +53,8 @@ interface RunOnceCommandResultDto {
   summary: string;
 }
 
-export interface SetupReadinessResponseDto extends SetupReadinessReport {
+export interface SetupReadinessResponseDto extends Omit<SetupReadinessReport, "hostReadiness"> {
+  hostReadiness: SharedDiagnosticHostSummaryDto;
   managedRestart: ManagedRestartCapability;
 }
 

--- a/src/backend/webui-setup.test.ts
+++ b/src/backend/webui-setup.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
 import {
   createSetupField,
@@ -11,6 +13,13 @@ import {
 import { createSetupHarness, jsonResponse } from "./webui-dashboard-test-fixtures";
 
 const unavailableManagedRestart = createUnavailableManagedRestart();
+
+test("WebUI setup API declares a server-side setup diagnostics DTO boundary", async () => {
+  const content = await fs.readFile(path.join(process.cwd(), "src", "backend", "supervisor-http-server.ts"), "utf8");
+
+  assert.match(content, /SetupReadinessResponseDto[\s\S]*SharedDiagnosticHostSummaryDto/u);
+  assert.doesNotMatch(content, /interface SetupReadinessResponseDto extends SetupReadinessReport/u);
+});
 
 test("setup shell renders guided local CI adoption flow details", async () => {
   const harness = createSetupHarness([

--- a/src/diagnostics-dto.ts
+++ b/src/diagnostics-dto.ts
@@ -1,0 +1,21 @@
+export type SharedDiagnosticStatus = "pass" | "warn" | "fail";
+
+export type SharedSupervisorDiagnosticCheckName =
+  | "github_auth"
+  | "codex_cli"
+  | "state_file"
+  | "worktrees";
+
+export interface SharedDiagnosticCheckDto<Name extends string = string> {
+  name: Name;
+  status: SharedDiagnosticStatus;
+  summary: string;
+  details: string[];
+}
+
+export interface SharedDiagnosticHostSummaryDto<
+  Name extends string = SharedSupervisorDiagnosticCheckName,
+> {
+  overallStatus: SharedDiagnosticStatus | "not_ready";
+  checks: Array<SharedDiagnosticCheckDto<Name>>;
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -44,17 +44,17 @@ import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./sup
 import { buildTrustAndConfigWarnings, buildWarning, renderDoctorWarningLine } from "./warning-formatting";
 import { buildTrackedMergedButOpenBacklogDiagnosticLine } from "./reconciliation-backlog-diagnostics";
 import { appendRestartRecommendationLine, renderOperatorActionLine, selectDoctorOperatorAction } from "./operator-actions";
+import type {
+  SharedDiagnosticCheckDto,
+  SharedDiagnosticStatus,
+  SharedSupervisorDiagnosticCheckName,
+} from "./diagnostics-dto";
 
-export type DoctorCheckStatus = "pass" | "warn" | "fail";
+export type DoctorCheckStatus = SharedDiagnosticStatus;
 export type DoctorDecisionAction = "stop" | "maintenance" | "continue";
 export type DoctorDiagnosticTier = "active_risk" | "maintenance" | "informational";
 
-export interface DoctorCheck {
-  name: "github_auth" | "codex_cli" | "state_file" | "worktrees";
-  status: DoctorCheckStatus;
-  summary: string;
-  details: string[];
-}
+export type DoctorCheck = SharedDiagnosticCheckDto<SharedSupervisorDiagnosticCheckName>;
 
 export interface DoctorDecisionSummary {
   action: DoctorDecisionAction;

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -18,6 +18,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
   files: [
     "committed-guardrails-cli.ts",
     "committed-guardrails.ts",
+    "diagnostics-dto.ts",
     "doctor.ts",
     "gsd.ts",
     "index.ts",

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -6,6 +6,14 @@ import path from "node:path";
 import test from "node:test";
 import { diagnoseSetupReadiness } from "./setup-readiness";
 
+test("setup-readiness imports shared diagnostic DTOs instead of doctor raw types", async () => {
+  const content = await fs.readFile(path.join(process.cwd(), "src", "setup-readiness.ts"), "utf8");
+
+  assert.match(content, /from "\.\/diagnostics-dto"/u);
+  assert.doesNotMatch(content, /type\s+DoctorCheck/u);
+  assert.doesNotMatch(content, /type\s+DoctorCheckStatus/u);
+});
+
 async function createTrackedRepo(root: string): Promise<string> {
   const repoPath = path.join(root, "repo");
   await fs.mkdir(repoPath, { recursive: true });

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -25,10 +25,15 @@ import type {
   ReleaseReadinessGateSummary,
   TrustDiagnosticsSummary,
 } from "./core/types";
-import { diagnoseSupervisorHost, type DoctorCheck, type DoctorCheckStatus } from "./doctor";
+import { diagnoseSupervisorHost } from "./doctor";
 import { reviewProviderProfileFromConfig } from "./core/review-providers";
 import type { ExecutionSafetyMode, TrustMode } from "./core/types";
 import type { OperatorActionToken } from "./operator-actions";
+import type {
+  SharedDiagnosticCheckDto,
+  SharedDiagnosticStatus,
+  SharedSupervisorDiagnosticCheckName,
+} from "./diagnostics-dto";
 
 export type SetupFieldState = "configured" | "missing" | "invalid";
 export type SetupReadinessOverallStatus = "configured" | "missing" | "invalid";
@@ -132,8 +137,8 @@ export interface SetupReadinessNextAction {
 export type SetupReadinessModelRoutingStrategy = CodexModelStrategy | string;
 
 export interface SetupReadinessHostSummary {
-  overallStatus: DoctorCheckStatus | "not_ready";
-  checks: DoctorCheck[];
+  overallStatus: SharedDiagnosticStatus | "not_ready";
+  checks: Array<SharedDiagnosticCheckDto<SharedSupervisorDiagnosticCheckName>>;
 }
 
 export interface SetupReadinessProviderPosture {
@@ -759,8 +764,8 @@ function buildModelRoutingPosture(args: {
 }
 
 function buildHostReadiness(
-  checks: DoctorCheck[] | null,
-  overallStatus: DoctorCheckStatus | null,
+  checks: Array<SharedDiagnosticCheckDto<SharedSupervisorDiagnosticCheckName>> | null,
+  overallStatus: SharedDiagnosticStatus | null,
 ): SetupReadinessHostSummary {
   if (!checks || !overallStatus) {
     return {
@@ -812,7 +817,7 @@ function buildBlockers(args: {
     });
   }
 
-  const hostBlockerChecks = new Set<DoctorCheck["name"]>(["github_auth", "codex_cli", "worktrees"]);
+  const hostBlockerChecks = new Set<SharedSupervisorDiagnosticCheckName>(["github_auth", "codex_cli", "worktrees"]);
   for (const check of args.hostReadiness.checks) {
     if (check.status !== "fail" || !hostBlockerChecks.has(check.name)) {
       continue;


### PR DESCRIPTION
## Summary
- Extract shared diagnostics DTOs for doctor/setup/WebUI host diagnostics
- Rewire setup-readiness host diagnostics away from doctor raw type imports
- Declare the WebUI setup-readiness response DTO with an explicit shared host diagnostics boundary

## Verification
- npx tsx --test src/doctor.test.ts src/setup-readiness.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-setup.test.ts
- npm run build

Closes #1756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated diagnostic type definitions to establish a unified, standardized structure for diagnostic checks and host readiness summaries throughout the application.

* **Tests**
  * Added tests to verify diagnostic type declarations and proper integration of the new shared diagnostic type structure across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->