### PR TITLE
Continue domain-specific type exports from core types

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -13,8 +13,9 @@ import {
   loadConfigSummaryFromDocument,
   resolveConfigPath,
   summarizeCadenceDiagnostics,
+  summarizeLocalCiContract,
 } from "./core/config";
-import { SupervisorConfig } from "./core/types";
+import type { LocalCiContractSummary, SupervisorConfig } from "./core/config-types";
 import { buildSetupConfigPreview } from "./setup-config-preview";
 import { updateSetupConfig } from "./setup-config-write";
 
@@ -158,6 +159,22 @@ test("config field posture metadata classifies setup and automation-expanding fi
       ["approvedTrackedTopLevelEntries", "dangerous_explicit_opt_in"],
     ],
   );
+});
+
+test("config-owned local CI summary type covers diagnostics behavior", () => {
+  const summary = summarizeLocalCiContract({
+    localCiCommand: {
+      mode: "structured",
+      executable: "npm",
+      args: ["run", "build"],
+    },
+    localCiCandidateDismissed: false,
+  }) satisfies LocalCiContractSummary;
+
+  assert.equal(summary.configured, true);
+  assert.equal(summary.command, "npm run build");
+  assert.equal(summary.source, "config");
+  assert.equal(summary.adoptionFlow?.state, "configured");
 });
 
 test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", async (t) => {

--- a/src/core/config-diagnostics.ts
+++ b/src/core/config-diagnostics.ts
@@ -3,14 +3,14 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import {
   CadenceDiagnosticsSummary,
-  LocalReviewPostureSummary,
   LocalCiContractSummary,
+  LocalReviewPostureSummary,
   LocalReviewPosturePreset,
   ReleaseReadinessGateSummary,
   SupervisorConfig,
   TrustDiagnosticsSummary,
   WorkspacePreparationContractSummary,
-} from "./types";
+} from "./config-types";
 import { parseJson } from "./utils";
 import {
   DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW,

--- a/src/core/config-field-posture.ts
+++ b/src/core/config-field-posture.ts
@@ -1,4 +1,4 @@
-import type { SupervisorConfig } from "./types";
+import type { SupervisorConfig } from "./config-types";
 
 export const CONFIG_FIELD_POSTURE_TIERS = [
   "required",

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -6,17 +6,19 @@ import {
   LocalReviewHighSeverityAction,
   LocalReviewPolicy,
   LocalReviewPosturePreset,
-  LocalReviewReviewerThresholdConfig,
-  LocalReviewReviewerType,
   ReasoningEffort,
   ReleaseReadinessGatePosture,
-  RunState,
   ShellLocalCiCommandConfig,
   StaleConfiguredBotReviewPolicy,
   StructuredLocalCiCommandConfig,
   SupervisorConfig,
   TrustMode,
-} from "./types";
+} from "./config-types";
+import {
+  LocalReviewReviewerThresholdConfig,
+  LocalReviewReviewerType,
+} from "../local-review/types";
+import { RunState } from "./types";
 import { DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH } from "./journal";
 import { mapConfiguredReviewProviders } from "./review-providers";
 import { isValidGitRefName, resolveMaybeRelative } from "./utils";

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -1,0 +1,228 @@
+import type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "../local-review/types";
+import type { RunState } from "./types";
+
+export type CodexModelStrategy = "inherit" | "fixed" | "alias";
+export type CodexExecutionTarget = "supervisor" | "local_review_generic" | "local_review_specialist" | "local_review_verifier";
+
+export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
+export type TrustMode = "trusted_repo_and_authors" | "untrusted_or_mixed";
+export type ExecutionSafetyMode = "unsandboxed_autonomous" | "operator_gated";
+export type LocalReviewPolicy = "advisory" | "block_ready" | "block_merge";
+export type LocalReviewHighSeverityAction = "retry" | "blocked";
+export type LocalReviewPosturePreset =
+  | "off"
+  | "advisory"
+  | "block_merge"
+  | "repair_high_severity"
+  | "follow_up_issue_creation";
+export type ReleaseReadinessGatePosture = "advisory" | "block_release_publication";
+export type StaleConfiguredBotReviewPolicy = "diagnose_only" | "reply_only" | "reply_and_resolve";
+export type CopilotReviewTimeoutAction = "continue" | "block";
+export type ConfiguredReviewProviderKind = "copilot" | "codex" | "coderabbit" | "custom";
+export type ConfiguredReviewSignalSource = "copilot_lifecycle" | "review_threads";
+
+export interface ConfiguredReviewProvider {
+  kind: ConfiguredReviewProviderKind;
+  reviewerLogins: string[];
+  signalSource: ConfiguredReviewSignalSource;
+}
+
+export interface TrustDiagnosticsSummary {
+  trustMode: TrustMode;
+  executionSafetyMode: ExecutionSafetyMode;
+  warning: string | null;
+  configWarning?: string | null;
+}
+
+export interface CadenceDiagnosticsSummary {
+  pollIntervalSeconds: number;
+  mergeCriticalRecheckSeconds: number | null;
+  mergeCriticalEffectiveSeconds: number;
+  mergeCriticalRecheckEnabled: boolean;
+}
+
+export interface CandidateDiscoveryDiagnostics {
+  fetchWindow: number;
+  observedMatchingOpenIssues: number;
+  truncated: boolean;
+}
+
+export interface LocalCiContractSummary {
+  configured: boolean;
+  command: string | null;
+  recommendedCommand: string | null;
+  source: "config" | "repo_script_candidate" | "dismissed_repo_script_candidate";
+  summary: string;
+  warning?: string | null;
+  adoptionFlow?: LocalCiAdoptionFlow;
+}
+
+export interface LocalCiAdoptionDecision {
+  kind: "adopt" | "dismiss";
+  enabled: boolean;
+  summary: string;
+  writes: string[];
+}
+
+export interface LocalCiAdoptionFlow {
+  state: "not_available" | "candidate_detected" | "configured" | "dismissed";
+  candidateDetected: boolean;
+  commandPreview: string | null;
+  validationStatus: "not_available" | "not_run" | "configured" | "dismissed";
+  workspacePreparationCommand: string | null;
+  workspacePreparationRecommendedCommand: string | null;
+  workspacePreparationGuidance: string;
+  decisions: LocalCiAdoptionDecision[];
+}
+
+export interface WorkspacePreparationContractSummary {
+  configured: boolean;
+  command: string | null;
+  recommendedCommand: string | null;
+  source: "config";
+  summary: string;
+  warning?: string | null;
+}
+
+export interface LocalReviewPostureSummary {
+  preset: LocalReviewPosturePreset;
+  enabled: boolean;
+  policy: LocalReviewPolicy;
+  autoRepair: "off" | "high_severity_only";
+  followUpIssueCreation: boolean;
+  summary: string;
+  guarantees: string[];
+}
+
+export interface ReleaseReadinessGateSummary {
+  posture: ReleaseReadinessGatePosture;
+  configured: boolean;
+  canBlock: Array<"release_publication">;
+  cannotBlock: Array<"pr_publication" | "merge_readiness" | "loop_operation" | "release_publication">;
+  summary: string;
+}
+
+export interface StructuredLocalCiCommandConfig {
+  mode: "structured";
+  executable: string;
+  args?: string[];
+}
+
+export interface ShellLocalCiCommandConfig {
+  mode: "shell";
+  command: string;
+}
+
+export type LocalCiCommandConfig =
+  | string
+  | StructuredLocalCiCommandConfig
+  | ShellLocalCiCommandConfig;
+
+export type LocalCiExecutionMode = "structured" | "shell" | "legacy_shell_string";
+
+export type LocalCiResultOutcome = "passed" | "failed" | "not_configured";
+export type LocalCiFailureClass =
+  | "missing_command"
+  | "workspace_toolchain_missing"
+  | "worktree_helper_missing"
+  | "non_zero_exit"
+  | "unset_contract";
+export type LocalCiRemediationTarget =
+  | "workspace_environment"
+  | "config_contract"
+  | "tracked_publishable_content"
+  | "repair_already_queued"
+  | "manual_review";
+
+export interface LatestLocalCiResult {
+  outcome: LocalCiResultOutcome;
+  summary: string;
+  ran_at: string;
+  head_sha: string | null;
+  execution_mode: LocalCiExecutionMode | null;
+  command?: string | null;
+  stderr_summary?: string | null;
+  failure_class: LocalCiFailureClass | null;
+  remediation_target: LocalCiRemediationTarget | null;
+  verifier_drift_hint?: string | null;
+}
+
+export interface SupervisorConfig {
+  repoPath: string;
+  repoSlug: string;
+  defaultBranch: string;
+  workspaceRoot: string;
+  stateBackend: "json" | "sqlite";
+  stateFile: string;
+  stateBootstrapFile?: string;
+  codexBinary: string;
+  trustMode?: TrustMode;
+  executionSafetyMode?: ExecutionSafetyMode;
+  codexModelStrategy: CodexModelStrategy;
+  codexModel?: string;
+  boundedRepairModelStrategy?: CodexModelStrategy;
+  boundedRepairModel?: string;
+  localReviewModelStrategy?: CodexModelStrategy;
+  localReviewModel?: string;
+  codexReasoningEffortByState: Partial<Record<RunState, ReasoningEffort>>;
+  codexReasoningEscalateOnRepeatedFailure: boolean;
+  sharedMemoryFiles: string[];
+  gsdEnabled: boolean;
+  gsdAutoInstall: boolean;
+  gsdInstallScope: "global" | "local";
+  gsdCodexConfigDir?: string;
+  gsdPlanningFiles: string[];
+  localReviewEnabled: boolean;
+  localReviewPosture?: LocalReviewPosturePreset;
+  localReviewAutoDetect: boolean;
+  localReviewRoles: string[];
+  localReviewArtifactDir: string;
+  localReviewConfidenceThreshold: number;
+  localReviewReviewerThresholds: Record<LocalReviewReviewerType, LocalReviewReviewerThresholdConfig>;
+  localReviewPolicy: LocalReviewPolicy;
+  trackedPrCurrentHeadLocalReviewRequired?: boolean;
+  localReviewFollowUpRepairEnabled?: boolean;
+  localReviewManualReviewRepairEnabled?: boolean;
+  localReviewFollowUpIssueCreationEnabled?: boolean;
+  localReviewHighSeverityAction: LocalReviewHighSeverityAction;
+  releaseReadinessGate?: ReleaseReadinessGatePosture;
+  publishablePathAllowlistMarkers?: string[];
+  approvedTrackedTopLevelEntries?: string[];
+  staleConfiguredBotReviewPolicy?: StaleConfiguredBotReviewPolicy;
+  reviewBotLogins: string[];
+  configuredReviewProviders?: ConfiguredReviewProvider[];
+  humanReviewBlocksMerge: boolean;
+  issueJournalRelativePath: string;
+  issueJournalMaxChars: number;
+  issueLabel?: string;
+  issueSearch?: string;
+  workspacePreparationCommand?: LocalCiCommandConfig;
+  localCiCommand?: LocalCiCommandConfig;
+  localCiCandidateDismissed?: boolean;
+  candidateDiscoveryFetchWindow?: number;
+  skipTitlePrefixes: string[];
+  branchPrefix: string;
+  pollIntervalSeconds: number;
+  mergeCriticalRecheckSeconds?: number;
+  copilotReviewWaitMinutes: number;
+  copilotReviewTimeoutAction: CopilotReviewTimeoutAction;
+  configuredBotRateLimitWaitMinutes?: number;
+  configuredBotInitialGraceWaitSeconds?: number;
+  configuredBotSettledWaitSeconds?: number;
+  configuredBotRequireCurrentHeadSignal?: boolean;
+  configuredBotCurrentHeadSignalTimeoutMinutes?: number;
+  configuredBotCurrentHeadSignalTimeoutAction?: CopilotReviewTimeoutAction;
+  codexExecTimeoutMinutes: number;
+  maxCodexAttemptsPerIssue: number;
+  maxImplementationAttemptsPerIssue: number;
+  maxRepairAttemptsPerIssue: number;
+  timeoutRetryLimit: number;
+  blockedVerificationRetryLimit: number;
+  sameBlockerRepeatLimit: number;
+  sameFailureSignatureRepeatLimit: number;
+  maxDoneWorkspaces: number;
+  cleanupDoneWorkspacesAfterHours: number;
+  cleanupOrphanedWorkspacesAfterHours?: number;
+  mergeMethod: "merge" | "squash" | "rebase";
+  draftPrAfterAttempt: number;
+}

--- a/src/core/config-validation.ts
+++ b/src/core/config-validation.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { LocalCiCommandConfig, SupervisorConfig } from "./types";
+import { LocalCiCommandConfig, SupervisorConfig } from "./config-types";
 import { displayLocalCiCommand } from "./config-parsing";
 
 export const MISSING_WORKSPACE_PREPARATION_CONTRACT_WARNING =

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { SupervisorConfig, type TrustDiagnosticsSummary } from "./types";
+import { SupervisorConfig, type TrustDiagnosticsSummary } from "./config-types";
 import { parseJson } from "./utils";
 import { DEFAULT_CONFIG_FILE } from "./config-constants";
 import {

--- a/src/core/review-providers.ts
+++ b/src/core/review-providers.ts
@@ -2,7 +2,7 @@ import {
   ConfiguredReviewProvider,
   ConfiguredReviewProviderKind,
   SupervisorConfig,
-} from "./types";
+} from "./config-types";
 
 const COPILOT_REVIEWER_LOGIN = "copilot-pull-request-reviewer";
 const CODEX_REVIEWER_LOGIN = "chatgpt-codex-connector";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,10 @@
 import type { GitHubIssue } from "../github/types";
-import type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "../local-review/types";
+import type {
+  CopilotReviewTimeoutAction,
+  LatestLocalCiResult,
+  LocalCiRemediationTarget,
+  SupervisorConfig,
+} from "./config-types";
 
 export type {
   CopilotReviewState,
@@ -15,6 +20,40 @@ export type {
   ReviewThreadComment,
 } from "../github/types";
 export type { LocalReviewReviewerThresholdConfig, LocalReviewReviewerType } from "../local-review/types";
+export type {
+  CadenceDiagnosticsSummary,
+  CandidateDiscoveryDiagnostics,
+  CodexExecutionTarget,
+  CodexModelStrategy,
+  ConfiguredReviewProvider,
+  ConfiguredReviewProviderKind,
+  ConfiguredReviewSignalSource,
+  CopilotReviewTimeoutAction,
+  ExecutionSafetyMode,
+  LatestLocalCiResult,
+  LocalCiAdoptionDecision,
+  LocalCiAdoptionFlow,
+  LocalCiCommandConfig,
+  LocalCiContractSummary,
+  LocalCiExecutionMode,
+  LocalCiFailureClass,
+  LocalCiRemediationTarget,
+  LocalCiResultOutcome,
+  LocalReviewHighSeverityAction,
+  LocalReviewPolicy,
+  LocalReviewPosturePreset,
+  LocalReviewPostureSummary,
+  ReasoningEffort,
+  ReleaseReadinessGatePosture,
+  ReleaseReadinessGateSummary,
+  ShellLocalCiCommandConfig,
+  StaleConfiguredBotReviewPolicy,
+  StructuredLocalCiCommandConfig,
+  SupervisorConfig,
+  TrustDiagnosticsSummary,
+  TrustMode,
+  WorkspacePreparationContractSummary,
+} from "./config-types";
 
 export type RunState =
   | "queued"
@@ -36,46 +75,6 @@ export type RunState =
   | "blocked"
   | "failed";
 
-export type CodexModelStrategy = "inherit" | "fixed" | "alias";
-export type CodexExecutionTarget = "supervisor" | "local_review_generic" | "local_review_specialist" | "local_review_verifier";
-
-export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
-export type TrustMode = "trusted_repo_and_authors" | "untrusted_or_mixed";
-export type ExecutionSafetyMode = "unsandboxed_autonomous" | "operator_gated";
-export type LocalReviewPolicy = "advisory" | "block_ready" | "block_merge";
-export type LocalReviewHighSeverityAction = "retry" | "blocked";
-export type LocalReviewPosturePreset =
-  | "off"
-  | "advisory"
-  | "block_merge"
-  | "repair_high_severity"
-  | "follow_up_issue_creation";
-export type ReleaseReadinessGatePosture = "advisory" | "block_release_publication";
-export type StaleConfiguredBotReviewPolicy = "diagnose_only" | "reply_only" | "reply_and_resolve";
-export type CopilotReviewTimeoutAction = "continue" | "block";
-export type ConfiguredReviewProviderKind = "copilot" | "codex" | "coderabbit" | "custom";
-export type ConfiguredReviewSignalSource = "copilot_lifecycle" | "review_threads";
-
-export interface ConfiguredReviewProvider {
-  kind: ConfiguredReviewProviderKind;
-  reviewerLogins: string[];
-  signalSource: ConfiguredReviewSignalSource;
-}
-
-export interface TrustDiagnosticsSummary {
-  trustMode: TrustMode;
-  executionSafetyMode: ExecutionSafetyMode;
-  warning: string | null;
-  configWarning?: string | null;
-}
-
-export interface CadenceDiagnosticsSummary {
-  pollIntervalSeconds: number;
-  mergeCriticalRecheckSeconds: number | null;
-  mergeCriticalEffectiveSeconds: number;
-  mergeCriticalRecheckEnabled: boolean;
-}
-
 export type GitHubRateLimitBudgetState = "healthy" | "low" | "exhausted";
 
 export interface GitHubRateLimitBudget {
@@ -89,112 +88,6 @@ export interface GitHubRateLimitBudget {
 export interface GitHubRateLimitTelemetry {
   rest: GitHubRateLimitBudget;
   graphql: GitHubRateLimitBudget;
-}
-
-export interface CandidateDiscoveryDiagnostics {
-  fetchWindow: number;
-  observedMatchingOpenIssues: number;
-  truncated: boolean;
-}
-
-export interface LocalCiContractSummary {
-  configured: boolean;
-  command: string | null;
-  recommendedCommand: string | null;
-  source: "config" | "repo_script_candidate" | "dismissed_repo_script_candidate";
-  summary: string;
-  warning?: string | null;
-  adoptionFlow?: LocalCiAdoptionFlow;
-}
-
-export interface LocalCiAdoptionDecision {
-  kind: "adopt" | "dismiss";
-  enabled: boolean;
-  summary: string;
-  writes: string[];
-}
-
-export interface LocalCiAdoptionFlow {
-  state: "not_available" | "candidate_detected" | "configured" | "dismissed";
-  candidateDetected: boolean;
-  commandPreview: string | null;
-  validationStatus: "not_available" | "not_run" | "configured" | "dismissed";
-  workspacePreparationCommand: string | null;
-  workspacePreparationRecommendedCommand: string | null;
-  workspacePreparationGuidance: string;
-  decisions: LocalCiAdoptionDecision[];
-}
-
-export interface WorkspacePreparationContractSummary {
-  configured: boolean;
-  command: string | null;
-  recommendedCommand: string | null;
-  source: "config";
-  summary: string;
-  warning?: string | null;
-}
-
-export interface LocalReviewPostureSummary {
-  preset: LocalReviewPosturePreset;
-  enabled: boolean;
-  policy: LocalReviewPolicy;
-  autoRepair: "off" | "high_severity_only";
-  followUpIssueCreation: boolean;
-  summary: string;
-  guarantees: string[];
-}
-
-export interface ReleaseReadinessGateSummary {
-  posture: ReleaseReadinessGatePosture;
-  configured: boolean;
-  canBlock: Array<"release_publication">;
-  cannotBlock: Array<"pr_publication" | "merge_readiness" | "loop_operation" | "release_publication">;
-  summary: string;
-}
-
-export interface StructuredLocalCiCommandConfig {
-  mode: "structured";
-  executable: string;
-  args?: string[];
-}
-
-export interface ShellLocalCiCommandConfig {
-  mode: "shell";
-  command: string;
-}
-
-export type LocalCiCommandConfig =
-  | string
-  | StructuredLocalCiCommandConfig
-  | ShellLocalCiCommandConfig;
-
-export type LocalCiExecutionMode = "structured" | "shell" | "legacy_shell_string";
-
-export type LocalCiResultOutcome = "passed" | "failed" | "not_configured";
-export type LocalCiFailureClass =
-  | "missing_command"
-  | "workspace_toolchain_missing"
-  | "worktree_helper_missing"
-  | "non_zero_exit"
-  | "unset_contract";
-export type LocalCiRemediationTarget =
-  | "workspace_environment"
-  | "config_contract"
-  | "tracked_publishable_content"
-  | "repair_already_queued"
-  | "manual_review";
-
-export interface LatestLocalCiResult {
-  outcome: LocalCiResultOutcome;
-  summary: string;
-  ran_at: string;
-  head_sha: string | null;
-  execution_mode: LocalCiExecutionMode | null;
-  command?: string | null;
-  stderr_summary?: string | null;
-  failure_class: LocalCiFailureClass | null;
-  remediation_target: LocalCiRemediationTarget | null;
-  verifier_drift_hint?: string | null;
 }
 
 export type TimelineArtifactOutcome =
@@ -219,86 +112,6 @@ export interface TimelineArtifact {
   summary: string;
   recorded_at: string;
   repair_targets?: string[];
-}
-
-export interface SupervisorConfig {
-  repoPath: string;
-  repoSlug: string;
-  defaultBranch: string;
-  workspaceRoot: string;
-  stateBackend: "json" | "sqlite";
-  stateFile: string;
-  stateBootstrapFile?: string;
-  codexBinary: string;
-  trustMode?: TrustMode;
-  executionSafetyMode?: ExecutionSafetyMode;
-  codexModelStrategy: CodexModelStrategy;
-  codexModel?: string;
-  boundedRepairModelStrategy?: CodexModelStrategy;
-  boundedRepairModel?: string;
-  localReviewModelStrategy?: CodexModelStrategy;
-  localReviewModel?: string;
-  codexReasoningEffortByState: Partial<Record<RunState, ReasoningEffort>>;
-  codexReasoningEscalateOnRepeatedFailure: boolean;
-  sharedMemoryFiles: string[];
-  gsdEnabled: boolean;
-  gsdAutoInstall: boolean;
-  gsdInstallScope: "global" | "local";
-  gsdCodexConfigDir?: string;
-  gsdPlanningFiles: string[];
-  localReviewEnabled: boolean;
-  localReviewPosture?: LocalReviewPosturePreset;
-  localReviewAutoDetect: boolean;
-  localReviewRoles: string[];
-  localReviewArtifactDir: string;
-  localReviewConfidenceThreshold: number;
-  localReviewReviewerThresholds: Record<LocalReviewReviewerType, LocalReviewReviewerThresholdConfig>;
-  localReviewPolicy: LocalReviewPolicy;
-  trackedPrCurrentHeadLocalReviewRequired?: boolean;
-  localReviewFollowUpRepairEnabled?: boolean;
-  localReviewManualReviewRepairEnabled?: boolean;
-  localReviewFollowUpIssueCreationEnabled?: boolean;
-  localReviewHighSeverityAction: LocalReviewHighSeverityAction;
-  releaseReadinessGate?: ReleaseReadinessGatePosture;
-  publishablePathAllowlistMarkers?: string[];
-  approvedTrackedTopLevelEntries?: string[];
-  staleConfiguredBotReviewPolicy?: StaleConfiguredBotReviewPolicy;
-  reviewBotLogins: string[];
-  configuredReviewProviders?: ConfiguredReviewProvider[];
-  humanReviewBlocksMerge: boolean;
-  issueJournalRelativePath: string;
-  issueJournalMaxChars: number;
-  issueLabel?: string;
-  issueSearch?: string;
-  workspacePreparationCommand?: LocalCiCommandConfig;
-  localCiCommand?: LocalCiCommandConfig;
-  localCiCandidateDismissed?: boolean;
-  candidateDiscoveryFetchWindow?: number;
-  skipTitlePrefixes: string[];
-  branchPrefix: string;
-  pollIntervalSeconds: number;
-  mergeCriticalRecheckSeconds?: number;
-  copilotReviewWaitMinutes: number;
-  copilotReviewTimeoutAction: CopilotReviewTimeoutAction;
-  configuredBotRateLimitWaitMinutes?: number;
-  configuredBotInitialGraceWaitSeconds?: number;
-  configuredBotSettledWaitSeconds?: number;
-  configuredBotRequireCurrentHeadSignal?: boolean;
-  configuredBotCurrentHeadSignalTimeoutMinutes?: number;
-  configuredBotCurrentHeadSignalTimeoutAction?: CopilotReviewTimeoutAction;
-  codexExecTimeoutMinutes: number;
-  maxCodexAttemptsPerIssue: number;
-  maxImplementationAttemptsPerIssue: number;
-  maxRepairAttemptsPerIssue: number;
-  timeoutRetryLimit: number;
-  blockedVerificationRetryLimit: number;
-  sameBlockerRepeatLimit: number;
-  sameFailureSignatureRepeatLimit: number;
-  maxDoneWorkspaces: number;
-  cleanupDoneWorkspacesAfterHours: number;
-  cleanupOrphanedWorkspacesAfterHours?: number;
-  mergeMethod: "merge" | "squash" | "rebase";
-  draftPrAfterAttempt: number;
 }
 
 export type FailureKind = "timeout" | "command_error" | "codex_exit" | "codex_failed" | null;

--- a/src/local-review/types.ts
+++ b/src/local-review/types.ts
@@ -1,5 +1,5 @@
 import { type LocalReviewRoleSelection } from "../review-role-detector";
-import { type CodexExecutionTarget, type ReasoningEffort } from "../core/types";
+import { type CodexExecutionTarget, type ReasoningEffort } from "../core/config-types";
 import { type VerifierGuardrailRule } from "../verifier-guardrails";
 
 export type LocalReviewSeverity = "none" | "low" | "medium" | "high";


### PR DESCRIPTION
## Summary
- Extract the config/local-CI diagnostics type family into `src/core/config-types.ts`
- Keep `src/core/types.ts` as a compatibility re-export surface
- Point config-owned modules and the local-review type reference at the narrower boundary

## Verification
- `npx tsc --noEmit`
- `git diff --check`
- `npx tsx --test src/core/config.test.ts src/config.test.ts src/supervisor/supervisor-status-model.test.ts`
- `npm run build`

Part of #1752
Closes #1757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for configuration contract summarization with validation of configured state, command derivation, source tracking, and adoption flow status.

* **Refactor**
  * Reorganized type system to improve code modularity by consolidating configuration-related type definitions into a dedicated module for better maintainability and reduced duplication across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->