### PR TITLE
Strengthen WebUI server-side DTO boundary

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -93,6 +93,13 @@ export interface DashboardRuntimeRecoverySummaryLike {
   } | null;
 }
 
+export interface DashboardWorkflowStepLike {
+  id?: "observe" | "triage" | "select" | "execute" | "recover" | null;
+  title?: string | null;
+  detail?: string | null;
+  state?: "done" | "current" | "idle" | "current warn" | "warn" | null;
+}
+
 export interface DashboardInventoryStatusLike {
   mode?: "healthy" | "degraded" | null;
   posture?:
@@ -130,6 +137,7 @@ export interface DashboardStatusLike {
   trackedIssues?: DashboardTrackedIssueLike[] | null;
   runnableIssues?: DashboardRunnableIssueLike[] | null;
   blockedIssues?: DashboardBlockedIssueLike[] | null;
+  workflowSteps?: DashboardWorkflowStepLike[] | null;
   detailedStatusLines?: string[] | null;
   readinessLines?: string[] | null;
   whyLines?: string[] | null;

--- a/src/backend/webui-dashboard-browser-view-model.test.ts
+++ b/src/backend/webui-dashboard-browser-view-model.test.ts
@@ -37,7 +37,7 @@ test("buildWorkflowSteps marks execute as current when a selected issue is prese
     {
       id: "recover",
       title: "Recover",
-      detail: "Recovery remains quiet while runnable work is available.",
+      detail: "Recovery remains quiet while no active blockers are reported.",
       state: "idle",
     },
   ]);
@@ -59,6 +59,24 @@ test("buildWorkflowSteps renders server-provided workflow DTOs instead of parsin
           detail: "Server DTO says no issue is executing.",
           state: "idle",
         },
+        {
+          id: "triage",
+          title: "Triage",
+          detail: "Server DTO says triage is idle.",
+          state: "idle",
+        },
+        {
+          id: "select",
+          title: "Select",
+          detail: "Server DTO says selection is idle.",
+          state: "idle",
+        },
+        {
+          id: "recover",
+          title: "Recover",
+          detail: "Server DTO says recovery is idle.",
+          state: "idle",
+        },
       ],
       whyLines: ["selected_issue=#99"],
       detailedStatusLines: ["active_issue=#99"],
@@ -78,8 +96,110 @@ test("buildWorkflowSteps renders server-provided workflow DTOs instead of parsin
         detail: "Server DTO says no issue is executing.",
         state: "idle",
       },
+      {
+        id: "triage",
+        title: "Triage",
+        detail: "Server DTO says triage is idle.",
+        state: "idle",
+      },
+      {
+        id: "select",
+        title: "Select",
+        detail: "Server DTO says selection is idle.",
+        state: "idle",
+      },
+      {
+        id: "recover",
+        title: "Recover",
+        detail: "Server DTO says recovery is idle.",
+        state: "idle",
+      },
     ],
   );
+});
+
+test("buildWorkflowSteps falls back when server workflow DTOs are partial", () => {
+  const steps = buildWorkflowSteps({
+    workflowSteps: [
+      {
+        id: "observe",
+        title: "Observe",
+        detail: "Partial server DTO should not render.",
+        state: "current",
+      },
+      {
+        id: "execute",
+        title: "Execute",
+        detail: "Partial server DTO should not render.",
+        state: "idle",
+      },
+    ],
+    whyLines: ["selected_issue=#99"],
+  } as Parameters<typeof buildWorkflowSteps>[0] & {
+    workflowSteps: ReturnType<typeof buildWorkflowSteps>;
+  });
+
+  assert.deepEqual(
+    steps.map((step) => [step.id, step.state]),
+    [
+      ["observe", "done"],
+      ["triage", "done"],
+      ["select", "done"],
+      ["execute", "current"],
+      ["recover", "idle"],
+    ],
+  );
+  assert.equal(steps[3].detail, "Issue #99 is the current active focus.");
+  assert.ok(steps.every((step) => !step.detail.includes("Partial server DTO")));
+});
+
+test("buildWorkflowSteps falls back when server workflow DTOs include malformed entries", () => {
+  const steps = buildWorkflowSteps({
+    workflowSteps: [
+      {
+        id: "observe",
+        title: "Observe",
+        detail: "Complete server DTO should not render with malformed extras.",
+        state: "current",
+      },
+      {
+        id: "triage",
+        title: "Triage",
+        detail: "Complete server DTO should not render with malformed extras.",
+        state: "idle",
+      },
+      {
+        id: "select",
+        title: "Select",
+        detail: "Complete server DTO should not render with malformed extras.",
+        state: "idle",
+      },
+      {
+        id: "execute",
+        title: "Execute",
+        detail: "Complete server DTO should not render with malformed extras.",
+        state: "idle",
+      },
+      {
+        id: "recover",
+        title: "Recover",
+        detail: "Complete server DTO should not render with malformed extras.",
+        state: "idle",
+      },
+      {
+        id: "observe",
+        title: "Malformed",
+        detail: "",
+        state: "idle",
+      },
+    ],
+    selectionSummary: { selectedIssueNumber: 101 },
+  } as Parameters<typeof buildWorkflowSteps>[0] & {
+    workflowSteps: ReturnType<typeof buildWorkflowSteps>;
+  });
+
+  assert.equal(steps[3].detail, "Issue #101 is the current active focus.");
+  assert.ok(steps.every((step) => !step.detail.includes("Complete server DTO")));
 });
 
 test("buildWorkflowSteps surfaces recover as the current step when only blocked issues remain", () => {

--- a/src/backend/webui-dashboard-browser-view-model.test.ts
+++ b/src/backend/webui-dashboard-browser-view-model.test.ts
@@ -43,6 +43,45 @@ test("buildWorkflowSteps marks execute as current when a selected issue is prese
   ]);
 });
 
+test("buildWorkflowSteps renders server-provided workflow DTOs instead of parsing status lines", () => {
+  assert.deepEqual(
+    buildWorkflowSteps({
+      workflowSteps: [
+        {
+          id: "observe",
+          title: "Observe",
+          detail: "Server DTO says observation is current.",
+          state: "current",
+        },
+        {
+          id: "execute",
+          title: "Execute",
+          detail: "Server DTO says no issue is executing.",
+          state: "idle",
+        },
+      ],
+      whyLines: ["selected_issue=#99"],
+      detailedStatusLines: ["active_issue=#99"],
+    } as Parameters<typeof buildWorkflowSteps>[0] & {
+      workflowSteps: ReturnType<typeof buildWorkflowSteps>;
+    }),
+    [
+      {
+        id: "observe",
+        title: "Observe",
+        detail: "Server DTO says observation is current.",
+        state: "current",
+      },
+      {
+        id: "execute",
+        title: "Execute",
+        detail: "Server DTO says no issue is executing.",
+        state: "idle",
+      },
+    ],
+  );
+});
+
 test("buildWorkflowSteps surfaces recover as the current step when only blocked issues remain", () => {
   assert.deepEqual(
     buildWorkflowSteps({

--- a/src/backend/webui-dashboard-browser-view-model.ts
+++ b/src/backend/webui-dashboard-browser-view-model.ts
@@ -19,9 +19,6 @@ export interface DashboardLoopRuntimeSummary {
   chipTone: "ok" | "warn" | "info";
 }
 
-const DASHBOARD_WORKFLOW_STEP_IDS = new Set(["observe", "triage", "select", "execute", "recover"]);
-const DASHBOARD_WORKFLOW_STEP_STATES = new Set(["done", "current", "idle", "current warn", "warn"]);
-
 export function buildRuntimeRecoverySummaryLines(
   summary: DashboardRuntimeRecoverySummaryLike | null | undefined,
 ): string[] {
@@ -104,38 +101,46 @@ function parseSelectedIssueNumber(status: DashboardStatusLike | null | undefined
   return null;
 }
 
-function normalizeWorkflowStep(step: DashboardWorkflowStepLike): DashboardWorkflowStep | null {
-  if (
-    typeof step.id !== "string" ||
-    !DASHBOARD_WORKFLOW_STEP_IDS.has(step.id) ||
-    typeof step.title !== "string" ||
-    step.title.trim() === "" ||
-    typeof step.detail !== "string" ||
-    step.detail.trim() === "" ||
-    typeof step.state !== "string" ||
-    !DASHBOARD_WORKFLOW_STEP_STATES.has(step.state)
-  ) {
-    return null;
-  }
-
-  return {
-    id: step.id,
-    title: step.title,
-    detail: step.detail,
-    state: step.state,
-  };
-}
-
 export function countCandidateIssues(status: DashboardStatusLike | null | undefined): string {
   const observed = status?.candidateDiscovery?.observedMatchingOpenIssues ?? null;
   return typeof observed === "number" ? String(observed) : "n/a";
 }
 
 export function buildWorkflowSteps(status: DashboardStatusLike | null | undefined): DashboardWorkflowStep[] {
-  const workflowSteps = Array.isArray(status?.workflowSteps)
-    ? status.workflowSteps.map(normalizeWorkflowStep).filter((step): step is DashboardWorkflowStep => step !== null)
-    : [];
-  if (workflowSteps.length > 0) {
+  const workflowStepIds = new Set(["observe", "triage", "select", "execute", "recover"]);
+  const workflowStepStates = new Set(["done", "current", "idle", "current warn", "warn"]);
+
+  function normalizeWorkflowStep(step: DashboardWorkflowStepLike): DashboardWorkflowStep | null {
+    if (
+      typeof step.id !== "string" ||
+      !workflowStepIds.has(step.id) ||
+      typeof step.title !== "string" ||
+      step.title.trim() === "" ||
+      typeof step.detail !== "string" ||
+      step.detail.trim() === "" ||
+      typeof step.state !== "string" ||
+      !workflowStepStates.has(step.state)
+    ) {
+      return null;
+    }
+
+    return {
+      id: step.id,
+      title: step.title,
+      detail: step.detail,
+      state: step.state,
+    };
+  }
+
+  const serverWorkflowSteps = Array.isArray(status?.workflowSteps) ? status.workflowSteps : [];
+  const workflowSteps = serverWorkflowSteps
+    .map(normalizeWorkflowStep)
+    .filter((step): step is DashboardWorkflowStep => step !== null);
+  const hasCompleteServerWorkflow =
+    workflowSteps.length === serverWorkflowSteps.length &&
+    workflowSteps.length === workflowStepIds.size &&
+    new Set(workflowSteps.map((step) => step.id)).size === workflowStepIds.size;
+  if (hasCompleteServerWorkflow) {
     return workflowSteps;
   }
 
@@ -214,7 +219,7 @@ export function buildWorkflowSteps(status: DashboardStatusLike | null | undefine
           ? currentDetail
           : blockedCount > 0
             ? String(blockedCount) + " blocked issue(s) need unblock or recovery."
-            : "Recovery remains quiet while runnable work is available.",
+            : "Recovery remains quiet while no active blockers are reported.",
       state: currentIndex === 4 ? "current warn" : blockedCount > 0 && currentStepId !== "recover" ? "warn" : "idle",
     },
   ];

--- a/src/backend/webui-dashboard-browser-view-model.ts
+++ b/src/backend/webui-dashboard-browser-view-model.ts
@@ -2,6 +2,7 @@ import type {
   DashboardLoopRuntimeLike,
   DashboardRuntimeRecoverySummaryLike,
   DashboardStatusLike,
+  DashboardWorkflowStepLike,
 } from "./webui-dashboard-browser-logic";
 
 export interface DashboardWorkflowStep {
@@ -17,6 +18,9 @@ export interface DashboardLoopRuntimeSummary {
   chipLabel: string;
   chipTone: "ok" | "warn" | "info";
 }
+
+const DASHBOARD_WORKFLOW_STEP_IDS = new Set(["observe", "triage", "select", "execute", "recover"]);
+const DASHBOARD_WORKFLOW_STEP_STATES = new Set(["done", "current", "idle", "current warn", "warn"]);
 
 export function buildRuntimeRecoverySummaryLines(
   summary: DashboardRuntimeRecoverySummaryLike | null | undefined,
@@ -100,12 +104,41 @@ function parseSelectedIssueNumber(status: DashboardStatusLike | null | undefined
   return null;
 }
 
+function normalizeWorkflowStep(step: DashboardWorkflowStepLike): DashboardWorkflowStep | null {
+  if (
+    typeof step.id !== "string" ||
+    !DASHBOARD_WORKFLOW_STEP_IDS.has(step.id) ||
+    typeof step.title !== "string" ||
+    step.title.trim() === "" ||
+    typeof step.detail !== "string" ||
+    step.detail.trim() === "" ||
+    typeof step.state !== "string" ||
+    !DASHBOARD_WORKFLOW_STEP_STATES.has(step.state)
+  ) {
+    return null;
+  }
+
+  return {
+    id: step.id,
+    title: step.title,
+    detail: step.detail,
+    state: step.state,
+  };
+}
+
 export function countCandidateIssues(status: DashboardStatusLike | null | undefined): string {
   const observed = status?.candidateDiscovery?.observedMatchingOpenIssues ?? null;
   return typeof observed === "number" ? String(observed) : "n/a";
 }
 
 export function buildWorkflowSteps(status: DashboardStatusLike | null | undefined): DashboardWorkflowStep[] {
+  const workflowSteps = Array.isArray(status?.workflowSteps)
+    ? status.workflowSteps.map(normalizeWorkflowStep).filter((step): step is DashboardWorkflowStep => step !== null)
+    : [];
+  if (workflowSteps.length > 0) {
+    return workflowSteps;
+  }
+
   const selectedIssueNumber = parseSelectedIssueNumber(status);
   const runnableCount = Array.isArray(status?.runnableIssues) ? status.runnableIssues.length : 0;
   const blockedCount = Array.isArray(status?.blockedIssues) ? status.blockedIssues.length : 0;

--- a/src/supervisor/supervisor-dashboard-workflow.ts
+++ b/src/supervisor/supervisor-dashboard-workflow.ts
@@ -8,7 +8,11 @@ export interface SupervisorDashboardWorkflowStepDto {
 }
 
 function formatIssueRef(issueNumber: number | null | undefined): string {
-  return Number.isInteger(issueNumber) ? "#" + issueNumber : "none";
+  return isPositiveIssueNumber(issueNumber) ? "#" + issueNumber : "none";
+}
+
+function isPositiveIssueNumber(issueNumber: number | null | undefined): issueNumber is number {
+  return typeof issueNumber === "number" && Number.isInteger(issueNumber) && issueNumber > 0;
 }
 
 export function buildSupervisorDashboardWorkflowSteps(args: {
@@ -20,13 +24,14 @@ export function buildSupervisorDashboardWorkflowSteps(args: {
   reconciliationPhase: string | null;
 }): SupervisorDashboardWorkflowStepDto[] {
   const normalizedPhase = typeof args.reconciliationPhase === "string" ? args.reconciliationPhase.toLowerCase() : "steady";
+  const selectedIssueNumber = isPositiveIssueNumber(args.selectedIssueNumber) ? args.selectedIssueNumber : null;
 
   let currentStepId: SupervisorDashboardWorkflowStepId = "observe";
   let currentDetail = "Supervisor is watching the queue and waiting for the next actionable signal.";
 
-  if (args.selectedIssueNumber !== null) {
+  if (selectedIssueNumber !== null) {
     currentStepId = "execute";
-    currentDetail = "Issue " + formatIssueRef(args.selectedIssueNumber) + " is the current active focus.";
+    currentDetail = "Issue " + formatIssueRef(selectedIssueNumber) + " is the current active focus.";
   } else if (args.blockedIssueCount > 0 && args.runnableIssueCount === 0) {
     currentStepId = "recover";
     currentDetail = "No runnable issue is available, so the supervisor is waiting on recovery or unblock work.";
@@ -80,8 +85,8 @@ export function buildSupervisorDashboardWorkflowSteps(args: {
       detail:
         currentStepId === "execute"
           ? currentDetail
-          : args.selectedIssueNumber !== null
-            ? "Selected issue is " + formatIssueRef(args.selectedIssueNumber) + "."
+          : selectedIssueNumber !== null
+            ? "Selected issue is " + formatIssueRef(selectedIssueNumber) + "."
             : "No active issue is currently executing.",
       state: currentIndex > 3 ? "done" : currentIndex === 3 ? "current" : "idle",
     },

--- a/src/supervisor/supervisor-dashboard-workflow.ts
+++ b/src/supervisor/supervisor-dashboard-workflow.ts
@@ -1,0 +1,100 @@
+export type SupervisorDashboardWorkflowStepId = "observe" | "triage" | "select" | "execute" | "recover";
+
+export interface SupervisorDashboardWorkflowStepDto {
+  id: SupervisorDashboardWorkflowStepId;
+  title: string;
+  detail: string;
+  state: "done" | "current" | "idle" | "current warn" | "warn";
+}
+
+function formatIssueRef(issueNumber: number | null | undefined): string {
+  return Number.isInteger(issueNumber) ? "#" + issueNumber : "none";
+}
+
+export function buildSupervisorDashboardWorkflowSteps(args: {
+  selectedIssueNumber: number | null;
+  runnableIssueCount: number;
+  blockedIssueCount: number;
+  trackedIssueCount: number;
+  hasCandidateDiscovery: boolean;
+  reconciliationPhase: string | null;
+}): SupervisorDashboardWorkflowStepDto[] {
+  const normalizedPhase = typeof args.reconciliationPhase === "string" ? args.reconciliationPhase.toLowerCase() : "steady";
+
+  let currentStepId: SupervisorDashboardWorkflowStepId = "observe";
+  let currentDetail = "Supervisor is watching the queue and waiting for the next actionable signal.";
+
+  if (args.selectedIssueNumber !== null) {
+    currentStepId = "execute";
+    currentDetail = "Issue " + formatIssueRef(args.selectedIssueNumber) + " is the current active focus.";
+  } else if (args.blockedIssueCount > 0 && args.runnableIssueCount === 0) {
+    currentStepId = "recover";
+    currentDetail = "No runnable issue is available, so the supervisor is waiting on recovery or unblock work.";
+  } else if (args.runnableIssueCount > 0) {
+    currentStepId = "select";
+    currentDetail = "Runnable candidates are available and ready for selection.";
+  } else if (
+    args.trackedIssueCount > 0 ||
+    args.hasCandidateDiscovery ||
+    /discover|scan|triage|queue|reconcile|refresh/u.test(normalizedPhase)
+  ) {
+    currentStepId = "triage";
+    currentDetail = "Tracked work and queue signals are being reconciled before an issue is selected.";
+  }
+
+  const stepOrder: SupervisorDashboardWorkflowStepId[] = ["observe", "triage", "select", "execute", "recover"];
+  const currentIndex = stepOrder.indexOf(currentStepId);
+
+  return [
+    {
+      id: "observe",
+      title: "Observe",
+      detail: currentStepId === "observe" ? currentDetail : "Connection and freshness checks keep the workspace current.",
+      state: currentIndex > 0 ? "done" : currentIndex === 0 ? "current" : "idle",
+    },
+    {
+      id: "triage",
+      title: "Triage",
+      detail:
+        currentStepId === "triage"
+          ? currentDetail
+          : args.trackedIssueCount > 0
+            ? String(args.trackedIssueCount) + " tracked issues remain in the working set."
+            : "Queue discovery and reconciliation determine the next candidate.",
+      state: currentIndex > 1 ? "done" : currentIndex === 1 ? "current" : "idle",
+    },
+    {
+      id: "select",
+      title: "Select",
+      detail:
+        currentStepId === "select"
+          ? currentDetail
+          : args.runnableIssueCount > 0
+            ? String(args.runnableIssueCount) + " runnable issue(s) are available."
+            : "No runnable issue is currently waiting for handoff.",
+      state: currentIndex > 2 ? "done" : currentIndex === 2 ? "current" : "idle",
+    },
+    {
+      id: "execute",
+      title: "Execute",
+      detail:
+        currentStepId === "execute"
+          ? currentDetail
+          : args.selectedIssueNumber !== null
+            ? "Selected issue is " + formatIssueRef(args.selectedIssueNumber) + "."
+            : "No active issue is currently executing.",
+      state: currentIndex > 3 ? "done" : currentIndex === 3 ? "current" : "idle",
+    },
+    {
+      id: "recover",
+      title: "Recover",
+      detail:
+        currentStepId === "recover"
+          ? currentDetail
+          : args.blockedIssueCount > 0
+            ? String(args.blockedIssueCount) + " blocked issue(s) need unblock or recovery."
+            : "Recovery remains quiet while runnable work is available.",
+      state: currentIndex === 4 ? "current warn" : args.blockedIssueCount > 0 && currentStepId !== "recover" ? "warn" : "idle",
+    },
+  ];
+}

--- a/src/supervisor/supervisor-dashboard-workflow.ts
+++ b/src/supervisor/supervisor-dashboard-workflow.ts
@@ -93,7 +93,7 @@ export function buildSupervisorDashboardWorkflowSteps(args: {
           ? currentDetail
           : args.blockedIssueCount > 0
             ? String(args.blockedIssueCount) + " blocked issue(s) need unblock or recovery."
-            : "Recovery remains quiet while runnable work is available.",
+            : "Recovery remains quiet while no active blockers are reported.",
       state: currentIndex === 4 ? "current warn" : args.blockedIssueCount > 0 && currentStepId !== "recover" ? "warn" : "idle",
     },
   ];

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -25,6 +25,7 @@ import {
   type SupervisorExplainDto,
 } from "./supervisor-selection-issue-explain";
 import { buildDetailedStatusModel, buildDetailedStatusSummaryLines } from "./supervisor-status-model";
+import { buildSupervisorDashboardWorkflowSteps } from "./supervisor-dashboard-workflow";
 import {
   buildRuntimeRecoverySummary,
   buildInventoryRefreshWarningMessage,
@@ -155,6 +156,17 @@ async function loadGitHubRateLimitStatus(github: GitHubClient) {
   };
 }
 
+function buildStatusWorkflowSteps(args: {
+  selectedIssueNumber: number | null;
+  trackedIssueCount: number;
+  runnableIssueCount: number;
+  blockedIssueCount: number;
+  hasCandidateDiscovery: boolean;
+  reconciliationPhase: string | null;
+}) {
+  return buildSupervisorDashboardWorkflowSteps(args);
+}
+
 export async function buildSupervisorStatusReport(args: {
   config: SupervisorConfig;
   configPath?: string;
@@ -281,6 +293,14 @@ export async function buildSupervisorStatusReport(args: {
         trackedIssues,
         runnableIssues: readinessSummary?.runnableIssues ?? [],
         blockedIssues: readinessSummary?.blockedIssues ?? [],
+        workflowSteps: buildStatusWorkflowSteps({
+          selectedIssueNumber: null,
+          trackedIssueCount: trackedIssues.length,
+          runnableIssueCount: readinessSummary?.runnableIssues.length ?? 0,
+          blockedIssueCount: readinessSummary?.blockedIssues.length ?? 0,
+          hasCandidateDiscovery: true,
+          reconciliationPhase,
+        }),
         detailedStatusLines: [...inactiveDetailedStatusLines, ...trackedPrMismatchLines, ...stateDiagnosticLines],
         reconciliationPhase,
         reconciliationProgress,
@@ -349,6 +369,14 @@ export async function buildSupervisorStatusReport(args: {
         trackedIssues,
         runnableIssues: readinessSummary.runnableIssues,
         blockedIssues: readinessSummary.blockedIssues,
+        workflowSteps: buildStatusWorkflowSteps({
+          selectedIssueNumber: selectionSummary?.selectedIssueNumber ?? null,
+          trackedIssueCount: trackedIssues.length,
+          runnableIssueCount: readinessSummary.runnableIssues.length,
+          blockedIssueCount: readinessSummary.blockedIssues.length,
+          hasCandidateDiscovery: candidateDiscovery !== null,
+          reconciliationPhase,
+        }),
         detailedStatusLines: [...inactiveDetailedStatusLines, ...trackedPrMismatchLines, ...stateDiagnosticLines],
         reconciliationPhase,
         reconciliationProgress,
@@ -399,6 +427,14 @@ export async function buildSupervisorStatusReport(args: {
         trackedIssues,
         runnableIssues: [],
         blockedIssues: [],
+        workflowSteps: buildStatusWorkflowSteps({
+          selectedIssueNumber: null,
+          trackedIssueCount: trackedIssues.length,
+          runnableIssueCount: 0,
+          blockedIssueCount: 0,
+          hasCandidateDiscovery: true,
+          reconciliationPhase,
+        }),
         detailedStatusLines: [...inactiveDetailedStatusLines, ...trackedPrMismatchLines, ...stateDiagnosticLines],
         reconciliationPhase,
         reconciliationProgress,
@@ -501,6 +537,14 @@ export async function buildSupervisorStatusReport(args: {
     trackedIssues,
     runnableIssues: [],
     blockedIssues: [],
+    workflowSteps: buildStatusWorkflowSteps({
+      selectedIssueNumber: statusRecords.activeRecord.issue_number,
+      trackedIssueCount: trackedIssues.length,
+      runnableIssueCount: 0,
+      blockedIssueCount: 0,
+      hasCandidateDiscovery: true,
+      reconciliationPhase,
+    }),
     detailedStatusLines: [...detailedStatusLinesWithInventory, ...summaryLines, ...trackedPrMismatchLines, ...stateDiagnosticLines],
     reconciliationPhase,
     reconciliationProgress,

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildSupervisorDashboardWorkflowSteps } from "./supervisor-dashboard-workflow";
 import { buildRuntimeRecoverySummary } from "./supervisor-status-report";
 
 const baseLoopRuntime = {
@@ -13,6 +14,26 @@ const baseLoopRuntime = {
   ownershipConfidence: "none" as const,
   detail: null,
 };
+
+test("buildSupervisorDashboardWorkflowSteps owns queue workflow state as a server DTO", () => {
+  assert.deepEqual(
+    buildSupervisorDashboardWorkflowSteps({
+      selectedIssueNumber: null,
+      runnableIssueCount: 0,
+      blockedIssueCount: 2,
+      trackedIssueCount: 3,
+      hasCandidateDiscovery: true,
+      reconciliationPhase: "steady",
+    }).map((step) => [step.id, step.state, step.detail]),
+    [
+      ["observe", "done", "Connection and freshness checks keep the workspace current."],
+      ["triage", "done", "3 tracked issues remain in the working set."],
+      ["select", "done", "No runnable issue is currently waiting for handoff."],
+      ["execute", "done", "No active issue is currently executing."],
+      ["recover", "current warn", "No runnable issue is available, so the supervisor is waiting on recovery or unblock work."],
+    ],
+  );
+});
 
 test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recovery state exists", () => {
   assert.equal(

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -53,6 +53,27 @@ test("buildSupervisorDashboardWorkflowSteps uses neutral recover detail when no 
   });
 });
 
+test("buildSupervisorDashboardWorkflowSteps rejects invalid selected issue numbers before choosing execute", () => {
+  for (const selectedIssueNumber of [Number.NaN, 0, -7, 1.5]) {
+    const steps = buildSupervisorDashboardWorkflowSteps({
+      selectedIssueNumber,
+      runnableIssueCount: 1,
+      blockedIssueCount: 0,
+      trackedIssueCount: 3,
+      hasCandidateDiscovery: true,
+      reconciliationPhase: "steady",
+    });
+
+    assert.equal(steps.find((step) => step.id === "select")?.state, "current");
+    assert.deepEqual(steps.find((step) => step.id === "execute"), {
+      id: "execute",
+      title: "Execute",
+      detail: "No active issue is currently executing.",
+      state: "idle",
+    });
+  }
+});
+
 test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recovery state exists", () => {
   assert.equal(
     buildRuntimeRecoverySummary({

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -35,6 +35,24 @@ test("buildSupervisorDashboardWorkflowSteps owns queue workflow state as a serve
   );
 });
 
+test("buildSupervisorDashboardWorkflowSteps uses neutral recover detail when no blockers are present", () => {
+  const recoverStep = buildSupervisorDashboardWorkflowSteps({
+    selectedIssueNumber: null,
+    runnableIssueCount: 0,
+    blockedIssueCount: 0,
+    trackedIssueCount: 1,
+    hasCandidateDiscovery: false,
+    reconciliationPhase: "steady",
+  }).find((step) => step.id === "recover");
+
+  assert.deepEqual(recoverStep, {
+    id: "recover",
+    title: "Recover",
+    detail: "Recovery remains quiet while no active blockers are reported.",
+    state: "idle",
+  });
+});
+
 test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recovery state exists", () => {
   assert.equal(
     buildRuntimeRecoverySummary({

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -9,6 +9,7 @@ import { sanitizeStatusValue } from "./supervisor-status-rendering";
 import { truncate } from "../core/utils";
 import type { BlockedReason, RunState, SupervisorStateFile, TimelineArtifact } from "../core/types";
 import type { SupervisorIssueActivityContextDto } from "./supervisor-operator-activity-context";
+import type { SupervisorDashboardWorkflowStepDto } from "./supervisor-dashboard-workflow";
 import type { SupervisorLoopRuntimeDto } from "./supervisor-loop-runtime-state";
 import type {
   SupervisorBlockedIssueDto,
@@ -102,6 +103,7 @@ export interface SupervisorStatusDto {
   trackedIssues: SupervisorTrackedIssueDto[];
   runnableIssues: SupervisorRunnableIssueDto[];
   blockedIssues: SupervisorBlockedIssueDto[];
+  workflowSteps?: SupervisorDashboardWorkflowStepDto[];
   detailedStatusLines: string[];
   reconciliationPhase: string | null;
   reconciliationProgress?: SupervisorReconciliationProgressDto | null;


### PR DESCRIPTION
## Summary
- move the dashboard workflow-step decision into server-side status DTO assembly
- add typed workflowSteps to the WebUI status contract and render those DTO steps in the browser
- add focused server and browser regression coverage for the DTO boundary

## Verification
- npx tsx --test src/backend/webui-dashboard-browser-view-model.test.ts src/supervisor/supervisor-status-report.test.ts
- npx tsx --test src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-logic.test.ts src/backend/webui-dashboard-browser-issue-details.test.ts src/backend/webui-dashboard-browser-controls.test.ts
- npm run build

Part of #1758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard and status reports now include structured workflow steps (observe, triage, select, execute, recover) with multi-valued state indicators and contextual details.

* **Bug Fixes / Behavior**
  * Prefer validated server-provided workflow steps; fall back to heuristic construction when DTO data is missing or malformed.
  * Recover step messaging refined to reflect absence of active blockers and show warning state when appropriate.

* **Tests**
  * Expanded coverage for workflow-step handling, server-provided DTO preference, fallback behavior, and recover messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->