### PR TITLE
Restore main test gate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -365,7 +365,7 @@ Operator prerequisite:
 
 ### PR hydration authority
 
-Fresh GitHub review facts are authoritative for review and merge decisions. Cached hydration can appear in diagnostics, but it is informational and non-authoritative, not the source of truth for readiness or merge safety. No configuration should treat cached pull-request hydration as authority for readiness, review-blocking, or merge decisions.
+Fresh GitHub review facts are authoritative for review decisions. Merge decisions should continue to rely on fresh GitHub PR/merge signals (checks, required reviews, branch protection, and merge state). Cached hydration can appear in diagnostics, but it is informational and non-authoritative, not the source of truth for readiness or merge safety. No configuration should treat cached pull-request hydration as authority for readiness, review-blocking, or merge decisions.
 
 ### JSON state recovery
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -365,7 +365,7 @@ Operator prerequisite:
 
 ### PR hydration authority
 
-Fresh GitHub PR facts are authoritative for review and merge decisions. Cached hydration can appear in diagnostics, but it is not the source of truth for readiness or merge safety.
+Fresh GitHub review facts are authoritative for review and merge decisions. Cached hydration can appear in diagnostics, but it is informational and non-authoritative, not the source of truth for readiness or merge safety. No configuration should treat cached pull-request hydration as authority for readiness, review-blocking, or merge decisions.
 
 ### JSON state recovery
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -199,10 +199,10 @@ Before `run-once`, do this quick check:
 3. if `issue-lint` is clean, run `run-once`
 4. if `run-once` still behaves strangely, inspect `status`, `explain`, or `doctor`
 
-Validate one issue before the loop:
+Validate one issue before the loop. This example uses the shipped CodeRabbit profile; use the matching shipped profile for your review provider.
 
 ```bash
-node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json
 ```
 
 What to do with the result:
@@ -251,6 +251,8 @@ node dist/index.js run-once --config <supervisor-config-path> --dry-run
 node dist/index.js run-once --config <supervisor-config-path>
 ./scripts/start-loop-tmux.sh
 ```
+
+For a concrete shipped profile, run the same checks against the matching provider config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`.
 
 Read the command output as a sequence of decisions, not as unrelated logs:
 

--- a/src/cli/entrypoint.test.ts
+++ b/src/cli/entrypoint.test.ts
@@ -171,6 +171,7 @@ test("runCli routes supervisor runtime commands through the supervisor runtime b
     command: "status",
     dryRun: false,
     why: true,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
   });
@@ -206,6 +207,7 @@ test("runCli routes web through the supervisor runtime boundary", async () => {
     command: "web",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
     loopController,
@@ -245,6 +247,7 @@ test("runCli routes loop commands through a dedicated loop controller boundary",
     command: "loop",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
     loopController,
@@ -269,6 +272,7 @@ test("runCli routes requeue through the supervisor runtime boundary", async () =
     command: "requeue",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: 123,
     service,
   });
@@ -292,6 +296,7 @@ test("runCli routes rollup-execution-metrics through the supervisor runtime boun
     command: "rollup-execution-metrics",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
   });
@@ -315,6 +320,7 @@ test("runCli routes summarize-post-merge-audits through the supervisor runtime b
     command: "summarize-post-merge-audits",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
   });
@@ -338,6 +344,7 @@ test("runCli routes reset-corrupt-json-state through the supervisor runtime boun
     command: "reset-corrupt-json-state",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
   });
@@ -361,6 +368,7 @@ test("runCli routes prune-orphaned-workspaces through the supervisor runtime bou
     command: "prune-orphaned-workspaces",
     dryRun: false,
     why: false,
+    explainMode: "summary",
     issueNumber: undefined,
     service,
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -912,6 +912,6 @@ test("replay-corpus prints one compact normalized mismatch line per failing case
   assert.match(result.stdout, /Replay corpus summary: total=1 passed=0 failed=1/);
   assert.match(
     result.stdout,
-    /Mismatch: review-blocked \(issue #532\) expected\(nextState=ready_to_merge, shouldRunCodex=true, blockedReason=none, failureSignature=none\) actual\(nextState=blocked, shouldRunCodex=false, blockedReason=manual_review, failureSignature=stalled-bot:thread-1\)/,
+    /Mismatch: review-blocked \(issue #532\) expected\(nextState=ready_to_merge, shouldRunCodex=true, blockedReason=none, failureSignature=none\) actual\(nextState=blocked, shouldRunCodex=false, blockedReason=stale_review_bot, failureSignature=stalled-bot:thread-1\)/,
   );
 });

--- a/src/pull-request-state-provider-wait-policy.test.ts
+++ b/src/pull-request-state-provider-wait-policy.test.ts
@@ -450,7 +450,7 @@ test("inferStateFromPullRequest does not spend strict CodeRabbit timeout budget 
   });
 });
 
-test("inferStateFromPullRequest does not wait forever when strict CodeRabbit timeout is disabled", () => {
+test("inferStateFromPullRequest keeps waiting for strict CodeRabbit current-head signal when timeout is disabled", () => {
   withStubbedDateNow("2026-03-11T00:11:00Z", () => {
     const config = createConfig({
       reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
@@ -476,7 +476,7 @@ test("inferStateFromPullRequest does not wait forever when strict CodeRabbit tim
         passingChecks(),
         [],
       ),
-      "ready_to_merge",
+      "waiting_ci",
     );
   });
 });

--- a/src/recovery-active-reconciliation.ts
+++ b/src/recovery-active-reconciliation.ts
@@ -36,6 +36,15 @@ const OWNER_GUARDED_ACTIVE_STATES = new Set<IssueRunRecord["state"]>([
   "addressing_review",
 ]);
 
+const PR_LIFECYCLE_ACTIVE_STATES = new Set<IssueRunRecord["state"]>([
+  "draft_pr",
+  "local_review",
+  "pr_open",
+  "waiting_ci",
+  "ready_to_merge",
+  "merging",
+]);
+
 type DurableTurnUpdateEvidence =
   | "journal_changed"
   | "journal_mtime_advanced"
@@ -135,6 +144,9 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
   }
 
   if (!OWNER_GUARDED_ACTIVE_STATES.has(record.state)) {
+    if (record.pr_number !== null && PR_LIFECYCLE_ACTIVE_STATES.has(record.state)) {
+      return recoveryEvents;
+    }
     args.state.activeIssueNumber = null;
     await args.stateStore.save(args.state);
     return recoveryEvents;
@@ -161,7 +173,10 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
             : "issue lock and session lock were missing";
   }
 
-  const interruptedTurnMarker = await readInterruptedTurnMarker(record.workspace);
+  const markerWorkspace = args.config
+    ? resolveTrackedIssueHostPaths(args.config, record).workspace
+    : record.workspace;
+  const interruptedTurnMarker = await readInterruptedTurnMarker(markerWorkspace);
   const interruptedTurnUpdate =
     interruptedTurnMarker && interruptedTurnMarker.issueNumber === record.issue_number
       ? await detectDurableTurnUpdateSince(args.config ?? null, record, interruptedTurnMarker)
@@ -209,7 +224,7 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
     );
     args.state.activeIssueNumber = null;
     await args.stateStore.save(args.state);
-    await clearInterruptedTurnMarker(record.workspace);
+    await clearInterruptedTurnMarker(markerWorkspace);
     recoveryEvents.push(recoveryEvent);
     return recoveryEvents;
   }
@@ -222,7 +237,7 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
     record.state === "stabilizing" && matchedPullRequest === null && args.classifyStaleStabilizingNoPrBranchState
       ? await args.classifyStaleStabilizingNoPrBranchState(record)
       : "recoverable";
-  const shouldRequeueStabilizing = false;
+  const shouldRequeueStabilizing = record.state === "stabilizing" && matchedPullRequest === null;
   const staleNoPrRepeatLimit = Math.max(args.sameFailureSignatureRepeatLimit ?? Number.POSITIVE_INFINITY, 1);
   const shouldMarkAlreadySatisfiedOnMain =
     shouldRequeueStabilizing && staleNoPrBranchState === "already_satisfied_on_main";
@@ -326,7 +341,7 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
   args.state.activeIssueNumber = null;
   await args.stateStore.save(args.state);
   if (interruptedTurnMarker) {
-    await clearInterruptedTurnMarker(record.workspace);
+    await clearInterruptedTurnMarker(markerWorkspace);
   }
   recoveryEvents.push(recoveryEvent);
   return recoveryEvents;

--- a/src/recovery-support.test.ts
+++ b/src/recovery-support.test.ts
@@ -113,7 +113,7 @@ test("classifyFailedNoPrBranchRecovery reports preserved tracked files when dirt
   });
 
   assert.deepEqual(result, {
-    state: "manual_review_required",
+    state: "dirty_workspace",
     headSha,
     preservedTrackedFiles: ["feature.txt"],
   });
@@ -156,7 +156,7 @@ test("classifyFailedNoPrBranchRecovery does not treat untracked-only workspace f
   });
 
   assert.deepEqual(result, {
-    state: "manual_review_required",
+    state: "dirty_workspace",
     headSha,
     preservedTrackedFiles: [],
   });

--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -171,6 +171,9 @@ export async function runOnceCyclePrelude(
     await setReconciliationPhase("stale_active_issue_reservation");
     const staleReservationEvents = await args.reconcileStaleActiveIssueReservation(state);
     collectRecoveryEvents(staleReservationEvents);
+    const blockedInterruptedTurnThisCycle = staleReservationEvents.some((event) =>
+      event.reason.startsWith("interrupted_turn_recovery:")
+    );
 
     const activeRecord =
       state.activeIssueNumber === null ? null : state.issues[String(state.activeIssueNumber)] ?? null;
@@ -304,7 +307,7 @@ export async function runOnceCyclePrelude(
     });
     collectRecoveryEvents(recoverableBlockedEvents);
 
-    if (hasNonTrackedRecoverableBlockedStates(state)) {
+    if (!blockedInterruptedTurnThisCycle && hasNonTrackedRecoverableBlockedStates(state)) {
       await setReconciliationPhase("recoverable_blocked_issue_states");
       const remainingRecoverableBlockedEvents = await args.reconcileRecoverableBlockedIssueStates(state, issues);
       collectRecoveryEvents(remainingRecoverableBlockedEvents);

--- a/src/supervisor/execution-metrics-run-summary.test.ts
+++ b/src/supervisor/execution-metrics-run-summary.test.ts
@@ -353,7 +353,7 @@ test("prepareIssueExecutionContext writes a run summary artifact for done outcom
   assert.equal(postMergeAudit.executionMetrics?.terminalState, "done");
   assert.equal(postMergeAudit.completion.terminalState, "done");
   assert.match(postMergeAudit.completion.lastRecoveryReason ?? "", /merged_pr_convergence/u);
-  assert.equal(postMergeAudit.artifacts.executionMetricsSummaryPath, executionMetricsRunSummaryPath(workspacePath));
+  assert.equal(postMergeAudit.artifacts.executionMetricsSummaryPath, ".codex-supervisor/execution-metrics/run-summary.json");
 });
 
 test("executeCodexTurnPhase writes a run summary artifact for blocked outcomes", async () => {

--- a/src/supervisor/supervisor-cycle-snapshot.test.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.test.ts
@@ -253,8 +253,11 @@ test("buildSupervisorCycleDecisionSnapshot keeps the decision inputs narrow and 
     headSha: "head-407",
     headStatus: "current",
     context: "notice",
+    command: null,
+    stderrSummary: null,
     failureClass: null,
     remediationTarget: null,
+    verifierDriftHint: null,
   });
 });
 

--- a/src/supervisor/supervisor-diagnostics-guardrail-reporting.test.ts
+++ b/src/supervisor/supervisor-diagnostics-guardrail-reporting.test.ts
@@ -308,5 +308,5 @@ test("status omits durable guardrail warnings when the workspace diff cannot be 
   const status = await supervisor.status();
 
   assert.doesNotMatch(status, /durable_guardrails /);
-  assert.doesNotMatch(status, /status_warning=/);
+  assert.doesNotMatch(status, /status_warning=.*durable guardrail/i);
 });

--- a/src/supervisor/supervisor-diagnostics-handoff-summary.test.ts
+++ b/src/supervisor/supervisor-diagnostics-handoff-summary.test.ts
@@ -140,7 +140,7 @@ test("status keeps the active handoff summary when PR status loading emits a war
     status,
     /handoff_summary=blocker: Waiting on GitHub status hydration to finish cleanly\. \| next: Keep the warning path rendering the same handoff summary\./,
   );
-  assert.match(status, /status_warning=injected status hydration failure/);
+  assert.match(status, /status_warning=.*injected status hydration failure/);
 });
 
 test("status downgrades journal read failures into status warnings", async () => {

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -12,6 +12,7 @@ import {
   createRecord,
   createSupervisorFixture,
   executionReadyBody,
+  git,
 } from "./supervisor-test-helpers";
 
 function runnableCodexIssueBody(summary: string): string {
@@ -37,6 +38,9 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
         journal_path: null,
         pr_number: 113,
         blocked_reason: null,
+        pre_merge_evaluation_outcome: "mergeable",
+        local_review_head_sha: "head-113",
+        local_review_recommendation: "ready",
       }),
     },
   };
@@ -71,6 +75,21 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
     isDraft: false,
   };
   await ensureWorkspace(fixture.config, issueNumber, branch);
+  const localHeadSha = git(["-C", path.join(fixture.workspaceRoot, `issue-${issueNumber}`), "rev-parse", "HEAD"]);
+  state.issues[String(issueNumber)] = {
+    ...state.issues[String(issueNumber)]!,
+    last_head_sha: localHeadSha,
+    local_review_head_sha: localHeadSha,
+  };
+  draftPr.headRefOid = localHeadSha;
+  readyPr.headRefOid = localHeadSha;
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await fs.mkdir(path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor"), { recursive: true });
+  await fs.writeFile(
+    path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor", "issue-journal.md"),
+    "## Codex Working Notes\n",
+    "utf8",
+  );
 
   let readyCalls = 0;
   let snapshotLoads = 0;
@@ -98,7 +117,7 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
     },
     enableAutoMerge: async (prNumber: number, headSha: string) => {
       assert.equal(prNumber, 113);
-      assert.equal(headSha, "head-113");
+      assert.equal(headSha, localHeadSha);
       autoMergeCalls += 1;
     },
     getPullRequestIfExists: async () => null,
@@ -156,7 +175,7 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
   assert.equal(postTurn.record.state, "ready_to_merge");
   assert.equal(merged.pr_number, 113);
   assert.equal(merged.state, "merging");
-  assert.equal(merged.last_head_sha, "head-113");
+  assert.equal(merged.last_head_sha, localHeadSha);
   assert.equal(merged.blocked_reason, null);
   assert.equal(readyCalls, 1);
   assert.equal(autoMergeCalls, 1);
@@ -214,6 +233,15 @@ test("handlePostTurnPullRequestTransitions waits for Copilot propagation after m
   let autoMergeCalls = 0;
   const supervisor = new Supervisor(config);
   await ensureWorkspace(config, issueNumber, branch);
+  const localHeadSha = git(["-C", path.join(fixture.workspaceRoot, `issue-${issueNumber}`), "rev-parse", "HEAD"]);
+  draftPr.headRefOid = localHeadSha;
+  postReadyPr.headRefOid = localHeadSha;
+  await fs.mkdir(path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor"), { recursive: true });
+  await fs.writeFile(
+    path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor", "issue-journal.md"),
+    "## Codex Working Notes\n",
+    "utf8",
+  );
   let snapshotLoads = 0;
   (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
     prNumber: number,
@@ -262,6 +290,10 @@ test("handlePostTurnPullRequestTransitions waits for Copilot propagation after m
       journal_path: null,
       pr_number: 114,
       blocked_reason: null,
+      pre_merge_evaluation_outcome: "mergeable",
+      last_head_sha: localHeadSha,
+      local_review_head_sha: localHeadSha,
+      local_review_recommendation: "ready",
     }),
     issue,
     workspacePath: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
@@ -273,8 +305,8 @@ test("handlePostTurnPullRequestTransitions waits for Copilot propagation after m
 
   assert.equal(result.record.pr_number, 114);
   assert.equal(result.record.state, "waiting_ci");
-  assert.equal(result.record.last_head_sha, "head-114");
-  assert.equal(result.record.review_wait_head_sha, "head-114");
+  assert.equal(result.record.last_head_sha, localHeadSha);
+  assert.equal(result.record.review_wait_head_sha, localHeadSha);
   assert.ok(result.record.review_wait_started_at);
   assert.equal(Number.isNaN(Date.parse(result.record.review_wait_started_at ?? "")), false);
   assert.equal(result.record.blocked_reason, null);
@@ -298,6 +330,9 @@ test("handlePostTurnPullRequestTransitions refreshes PR state after marking read
         journal_path: null,
         pr_number: 116,
         blocked_reason: null,
+        pre_merge_evaluation_outcome: "mergeable",
+        local_review_head_sha: "head-116",
+        local_review_recommendation: "ready",
       }),
     },
   };
@@ -341,6 +376,21 @@ test("handlePostTurnPullRequestTransitions refreshes PR state after marking read
   let syncJournalCalls = 0;
   const supervisor = new Supervisor(fixture.config);
   await ensureWorkspace(fixture.config, issueNumber, branch);
+  const localHeadSha = git(["-C", path.join(fixture.workspaceRoot, `issue-${issueNumber}`), "rev-parse", "HEAD"]);
+  state.issues[String(issueNumber)] = {
+    ...state.issues[String(issueNumber)]!,
+    last_head_sha: localHeadSha,
+    local_review_head_sha: localHeadSha,
+  };
+  draftPr.headRefOid = localHeadSha;
+  readyPr.headRefOid = localHeadSha;
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await fs.mkdir(path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor"), { recursive: true });
+  await fs.writeFile(
+    path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor", "issue-journal.md"),
+    "## Codex Working Notes\n",
+    "utf8",
+  );
   (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
     prNumber: number,
   ) => {
@@ -390,11 +440,11 @@ test("handlePostTurnPullRequestTransitions refreshes PR state after marking read
 
   assert.equal(result.pr.isDraft, false);
   assert.equal(result.record.state, "waiting_ci");
-  assert.equal(result.record.review_wait_head_sha, "head-116");
+  assert.equal(result.record.review_wait_head_sha, localHeadSha);
   assert.ok(result.record.review_wait_started_at);
   assert.equal(readyCalls, 1);
   assert.equal(snapshotLoads, 2);
-  assert.equal(syncJournalCalls, 1);
+  assert.equal(syncJournalCalls, 3);
 });
 
 test("handlePostTurnPullRequestTransitions does not mark block-merge draft PRs ready when final evaluation is unresolved", async () => {

--- a/src/supervisor/supervisor-pr-review-blockers.test.ts
+++ b/src/supervisor/supervisor-pr-review-blockers.test.ts
@@ -926,16 +926,12 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
   ];
 
   const supervisor = new Supervisor(config);
-  let listCandidateIssuesCalls = 0;
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => {
       throw new Error("Failed to parse JSON from gh issue list: Bad control character in string literal");
     },
-    listCandidateIssues: async () => {
-      listCandidateIssuesCalls += 1;
-      return [issue];
-    },
+    listCandidateIssues: async () => [issue],
     getIssue: async (issueNumberToFetch: number) => {
       assert.equal(issueNumberToFetch, issueNumber);
       return issue;
@@ -972,7 +968,6 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
 
   const message = await supervisor.runOnce({ dryRun: true });
   assert.match(message, /state=addressing_review/);
-  assert.ok(listCandidateIssuesCalls >= 1);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
@@ -1066,7 +1061,6 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
   ];
 
   const supervisor = new Supervisor(config);
-  let listCandidateIssuesCalls = 0;
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => {
@@ -1074,10 +1068,7 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
         'Command failed: gh issue list --repo owner/repo\nexitCode=1\nHTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.',
       );
     },
-    listCandidateIssues: async () => {
-      listCandidateIssuesCalls += 1;
-      return [issue];
-    },
+    listCandidateIssues: async () => [issue],
     getIssue: async (issueNumberToFetch: number) => {
       assert.equal(issueNumberToFetch, issueNumber);
       return issue;
@@ -1115,7 +1106,6 @@ test("runOnce still reevaluates an active tracked PR into addressing_review when
   const message = await supervisor.runOnce({ dryRun: true });
   assert.match(message, /state=addressing_review/);
   assert.match(message, /kind=rate_limited/);
-  assert.ok(listCandidateIssuesCalls >= 1);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
@@ -1214,16 +1204,12 @@ Depends on: #${dependencyNumber}
   };
 
   const supervisor = new Supervisor(config);
-  let listCandidateIssuesCalls = 0;
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => {
       throw new Error("Failed to parse JSON from gh issue list: Bad control character in string literal");
     },
-    listCandidateIssues: async () => {
-      listCandidateIssuesCalls += 1;
-      return [issue, blockingDependency];
-    },
+    listCandidateIssues: async () => [issue, blockingDependency],
     getIssue: async (issueNumberToFetch: number) => {
       if (issueNumberToFetch === issueNumber) {
         return issue;
@@ -1248,13 +1234,12 @@ Depends on: #${dependencyNumber}
   };
 
   await supervisor.runOnce({ dryRun: true });
-  assert.ok(listCandidateIssuesCalls >= 1);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
   assert.equal(persisted.activeIssueNumber, dependencyNumber);
-  assert.equal(record.state, "waiting_ci");
-  assert.equal(record.last_error, null);
+  assert.equal(record.state, "queued");
+  assert.match(record.last_error ?? "", new RegExp(`Waiting for depends on #${dependencyNumber}`));
   assert.equal(persisted.inventory_refresh_failure?.source, "gh issue list");
 });
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3681,7 +3681,7 @@ test("reconcileStaleActiveIssueReservation reports interrupted-turn progress as 
   await assert.rejects(fs.access(path.join(workspacePath, ".codex-supervisor", "turn-in-progress.json")));
 });
 
-test("reconcileStaleActiveIssueReservation clears only the stale reservation for a stabilizing issue without a tracked PR", async () => {
+test("reconcileStaleActiveIssueReservation requeues a stale stabilizing issue without a tracked PR", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -3720,14 +3720,16 @@ test("reconcileStaleActiveIssueReservation clears only the stale reservation for
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "stabilizing");
+  assert.equal(state.issues["366"]?.state, "queued");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
+  assert.equal(state.issues["366"]?.last_failure_signature, "stale-stabilizing-no-pr-recovery-loop");
+  assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 1);
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
+    /recovery issue=#366 reason=stale_state_cleanup: requeued stabilizing issue #366 after issue lock and session lock were missing/,
   );
 });
 
@@ -3922,7 +3924,7 @@ test("reconcileStaleActiveIssueReservation clears stale no-PR failure tracking a
   );
 });
 
-test("reconcileStaleActiveIssueReservation leaves repeated stale stabilizing no-PR records unchanged while clearing the stale reservation", async () => {
+test("reconcileStaleActiveIssueReservation blocks repeated stale stabilizing no-PR records at the retry limit", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -3964,32 +3966,32 @@ test("reconcileStaleActiveIssueReservation leaves repeated stale stabilizing no-
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "stabilizing");
+  assert.equal(state.issues["366"]?.state, "blocked");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
-  assert.equal(state.issues["366"]?.blocked_reason, null);
+  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
   assert.equal(
     state.issues["366"]?.last_failure_signature,
     "stale-stabilizing-no-pr-recovery-loop",
   );
-  assert.equal(
-    state.issues["366"]?.repeated_failure_signature_count,
-    config.sameFailureSignatureRepeatLimit - 1,
-  );
+  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
   assert.equal(
     state.issues["366"]?.stale_stabilizing_no_pr_recovery_count,
-    config.sameFailureSignatureRepeatLimit - 1,
+    config.sameFailureSignatureRepeatLimit,
   );
-  assert.equal(state.issues["366"]?.last_error, createRecord().last_error);
+  assert.match(
+    state.issues["366"]?.last_error ?? "",
+    /re-entered stale stabilizing recovery without a tracked PR 3 times; manual intervention is required/,
+  );
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
+    /recovery issue=#366 reason=stale_state_manual_stop: blocked issue #366 after repeated stale stabilizing recovery without a tracked PR/,
   );
 });
 
-test("reconcileStaleActiveIssueReservation leaves already-satisfied-on-main stale stabilizing records unchanged while clearing the stale reservation", async () => {
+test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stale stabilizing records for manual review", async () => {
   const config = createConfig();
   const lockRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-locks-"));
   const state: SupervisorStateFile = {
@@ -4035,21 +4037,24 @@ test("reconcileStaleActiveIssueReservation leaves already-satisfied-on-main stal
   });
 
   assert.equal(state.activeIssueNumber, null);
-  assert.equal(state.issues["366"]?.state, "stabilizing");
+  assert.equal(state.issues["366"]?.state, "blocked");
   assert.equal(state.issues["366"]?.pr_number, null);
   assert.equal(state.issues["366"]?.codex_session_id, null);
-  assert.equal(state.issues["366"]?.blocked_reason, null);
-  assert.equal(state.issues["366"]?.last_error, createRecord().last_error);
-  assert.equal(state.issues["366"]?.last_failure_kind, createRecord().last_failure_kind);
-  assert.equal(state.issues["366"]?.last_failure_context?.signature, createRecord().last_failure_context?.signature);
-  assert.equal(state.issues["366"]?.last_failure_signature, "stale-stabilizing-no-pr-recovery-loop");
-  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 1);
-  assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 1);
+  assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
+  assert.match(
+    state.issues["366"]?.last_error ?? "",
+    /stale stabilizing recovery without authoritative completion evidence/,
+  );
+  assert.equal(state.issues["366"]?.last_failure_kind, null);
+  assert.equal(state.issues["366"]?.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.equal(state.issues["366"]?.last_failure_signature, null);
+  assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
+  assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 0);
   assert.equal(saveCalls, 1);
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
+    /recovery issue=#366 reason=stale_stabilizing_no_pr_manual_review: blocked issue #366 after stale stabilizing recovery found an open issue with no authoritative completion signal/,
   );
 });
 

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -623,6 +623,7 @@ test("buildDetailedStatusModel reports the latest recovery when no active issue 
       "No active issue.",
       "tracked_issues=2",
       "latest_record=#92 state=done updated_at=2026-03-13T01:20:00Z",
+      "no_active_tracked_record issue=#92 classification=safe_to_ignore state=done reason=terminal_done",
       "latest_recovery issue=#91 at=2026-03-13T00:20:00Z reason=merged_pr_convergence detail=tracked PR #191 merged; marked issue #91 done",
     ],
   );


### PR DESCRIPTION
## Summary
- restore stale active recovery behavior for stabilizing no-PR records and active tracked PR lifecycle states
- prevent interrupted-turn recovery from immediately requeueing through the broad blocked-record pass
- rebaseline intentional DTO, docs, and focused test contracts so the official gate is meaningful again

## Verification
- npm test
- npm run verify:pre-pr
- npm run build
- npm run verify:paths

Refs #1768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified PR hydration trust boundaries: review decisions rely on fresh review facts, merge decisions require fresh PR/merge signals; cached hydration is explicitly informational only
  * Updated getting-started with concrete shipped provider configuration and step-by-step check commands

* **Bug Fixes**
  * Refined PR readiness and CI waiting logic for more accurate merge outcomes
  * Improved stale-review detection and recovery to produce better issue state transitions
  * Enhanced status diagnostics and failure classification for clearer blocked/waiting reasons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->