### PR TITLE
Fail closed after interrupted active turn

### DIFF
--- a/src/run-once-cycle-prelude.ts
+++ b/src/run-once-cycle-prelude.ts
@@ -89,6 +89,10 @@ function hasNonTrackedRecoverableBlockedStates(state: SupervisorStateFile): bool
   return Object.values(state.issues).some((record) => record.state === "blocked" && record.pr_number === null);
 }
 
+function isInterruptedTurnRecoveryEvent(event: RecoveryEvent): boolean {
+  return event.reason.startsWith("interrupted_turn_recovery:");
+}
+
 export async function runOnceCyclePrelude(
   args: RunOnceCyclePreludeArgs,
 ): Promise<RunOnceCyclePreludeResult | RunOnceCyclePreludeAuthFailure> {
@@ -171,9 +175,7 @@ export async function runOnceCyclePrelude(
     await setReconciliationPhase("stale_active_issue_reservation");
     const staleReservationEvents = await args.reconcileStaleActiveIssueReservation(state);
     collectRecoveryEvents(staleReservationEvents);
-    const blockedInterruptedTurnThisCycle = staleReservationEvents.some((event) =>
-      event.reason.startsWith("interrupted_turn_recovery:")
-    );
+    const blockedInterruptedTurnThisCycle = staleReservationEvents.some(isInterruptedTurnRecoveryEvent);
 
     const activeRecord =
       state.activeIssueNumber === null ? null : state.issues[String(state.activeIssueNumber)] ?? null;
@@ -245,6 +247,7 @@ export async function runOnceCyclePrelude(
 
       if (
         state.activeIssueNumber === null
+        && !blockedInterruptedTurnThisCycle
         && allowBoundedContinuation
         && await args.reserveRunnableIssueSelection?.(state) === true
       ) {
@@ -315,6 +318,7 @@ export async function runOnceCyclePrelude(
 
     if (
       state.activeIssueNumber === null &&
+      !blockedInterruptedTurnThisCycle &&
       await args.reserveRunnableIssueSelection?.(state) === true
     ) {
       return {

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1623,7 +1623,6 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
   const interruptedIssueNumber = 91;
   const nextIssueNumber = 92;
   const interruptedBranch = branchName(fixture.config, interruptedIssueNumber);
-  const nextBranch = branchName(fixture.config, nextIssueNumber);
   const { workspacePath: interruptedWorkspace, journalPath: interruptedJournalPath } = trackedIssuePaths(
     fixture.workspaceRoot,
     interruptedIssueNumber,
@@ -1694,12 +1693,12 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [nextIssue, interruptedIssue],
-    listCandidateIssues: async () => [nextIssue, interruptedIssue],
+    listCandidateIssues: async () => {
+      throw new Error("unexpected listCandidateIssues call");
+    },
     getIssue: async (issueNumber: number) => (issueNumber === nextIssueNumber ? nextIssue : interruptedIssue),
-    resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
-      assert.equal(branchName, nextBranch);
-      assert.equal(prNumber, null);
-      return null;
+    resolvePullRequestForBranch: async () => {
+      throw new Error("unexpected resolvePullRequestForBranch call");
     },
     getChecks: async () => [],
     getUnresolvedReviewThreads: async () => [],
@@ -1718,11 +1717,12 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
     message,
     /recovery issue=#91 reason=interrupted_turn_recovery: blocked issue #91 after an in-progress Codex turn ended without a durable handoff/,
   );
-  assert.match(message, /Dry run: would invoke Codex for issue #92\./);
+  assert.match(message, /Interrupted active turn for issue #91 requires manual recovery before selecting another runnable issue\./);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const interruptedRecord = persisted.issues[String(interruptedIssueNumber)]!;
-  assert.equal(persisted.activeIssueNumber, nextIssueNumber);
+  assert.equal(persisted.activeIssueNumber, null);
+  assert.equal(persisted.issues[String(nextIssueNumber)], undefined);
   assert.equal(interruptedRecord.state, "blocked");
   assert.equal(interruptedRecord.codex_session_id, null);
   assert.equal(interruptedRecord.blocked_reason, "handoff_missing");

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -219,6 +219,11 @@ interface CachedFullIssueInventory {
   fetchedAtMs: number;
 }
 
+function interruptedTurnRecoveryIssueNumber(events: RecoveryEvent[]): number | null {
+  const event = events.find((candidate) => candidate.reason.startsWith("interrupted_turn_recovery:"));
+  return event?.issueNumber ?? null;
+}
+
 function shouldBlockTrackedPrRepeatedFailure(args: {
   record: Pick<IssueRunRecord, "pr_number">;
   failureContext: FailureContext | null;
@@ -1138,6 +1143,14 @@ export class Supervisor {
     });
     if ("kind" in prelude) {
       return prependRecoveryLog(prelude.message, formatRecoveryLog(prelude.recoveryEvents));
+    }
+
+    const interruptedIssueNumber = interruptedTurnRecoveryIssueNumber(prelude.recoveryEvents);
+    if (interruptedIssueNumber !== null) {
+      return prependRecoveryLog(
+        `Interrupted active turn for issue #${interruptedIssueNumber} requires manual recovery before selecting another runnable issue.`,
+        formatRecoveryLog(prelude.recoveryEvents),
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary
- stop runOnce after interrupted-turn recovery blocks the active issue
- prevent same-cycle runnable reservation after `interrupted_turn_recovery`
- tighten orchestration regression so candidate selection fails if reached

## Verification
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`
- `npm test`

Part of #1770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interrupted-turn recovery handling to prevent unnecessary operations when recovery is needed. The supervisor now correctly pauses and requests manual recovery instead of attempting to proceed to candidate selection or continue with subsequent issues during recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->