### PR TITLE
Classify stale reconciliation markers separately

### DIFF
--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -2651,9 +2651,19 @@ test("status emits a warning only after reconciliation exceeds the long-running 
   await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 
   const supervisor = new Supervisor(fixture.config);
+  const liveIssue = {
+    number: 1772,
+    title: "Classify stale reconciliation markers",
+    body: executionReadyBody("Classify stale reconciliation markers separately from live work."),
+    createdAt: "2026-03-20T00:00:00Z",
+    updatedAt: "2026-03-20T00:00:00Z",
+    url: "https://example.test/issues/1772",
+    labels: [],
+    state: "OPEN",
+  } satisfies GitHubIssue;
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
-    listCandidateIssues: async () => [],
-    listAllIssues: async () => [],
+    listCandidateIssues: async () => [liveIssue],
+    listAllIssues: async () => [liveIssue],
     getPullRequestIfExists: async () => null,
     getChecks: async () => [],
     getUnresolvedReviewThreads: async () => [],
@@ -2677,6 +2687,43 @@ test("status emits a warning only after reconciliation exceeds the long-running 
       status,
       /reconciliation_warning=long_running phase=tracked_merged_but_open_issues elapsed_seconds=301 threshold_seconds=\d+ started_at=2026-03-20T00:10:00\.000Z/,
     );
+  } finally {
+    Date.now = originalDateNow;
+    await clearCurrentReconciliationPhase(fixture.config);
+  }
+});
+
+test("status classifies an old reconciliation marker as stale artifact when no live work exists", async () => {
+  const fixture = await createSupervisorFixture();
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => null,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const originalDateNow = Date.now;
+  try {
+    Date.now = () => Date.parse("2026-03-20T00:10:00.000Z");
+    await writeCurrentReconciliationPhase(fixture.config, "tracked_merged_but_open_issues");
+
+    Date.now = () => Date.parse("2026-03-20T00:16:00.000Z");
+    const status = await supervisor.status({ why: true });
+    assert.doesNotMatch(status, /reconciliation_warning=long_running/);
+    assert.match(
+      status,
+      /reconciliation_marker=stale_artifact phase=tracked_merged_but_open_issues classification=safe_to_ignore maintenance=yes/,
+    );
+    assert.match(status, /^selected_issue=none$/m);
+    assert.match(status, /^selection_reason=no_runnable_issue$/m);
   } finally {
     Date.now = originalDateNow;
     await clearCurrentReconciliationPhase(fixture.config);

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -61,10 +61,45 @@ import { appendRestartRecommendationLine } from "../operator-actions";
 const LONG_RECONCILIATION_WARNING_THRESHOLD_MS = 5 * 60 * 1000;
 const MAX_RENDERED_STATUS_STATE_LOAD_FINDINGS = 5;
 
-function buildLongReconciliationWarning(snapshot: {
+function buildLongReconciliationWarningLine(snapshot: {
   phase: string;
   startedAt: string | null;
-} | null): string | null {
+}, elapsedMs: number): string {
+  return [
+    "reconciliation_warning=long_running",
+    `phase=${snapshot.phase}`,
+    `elapsed_seconds=${Math.floor(elapsedMs / 1000)}`,
+    `threshold_seconds=${Math.floor(LONG_RECONCILIATION_WARNING_THRESHOLD_MS / 1000)}`,
+    `started_at=${snapshot.startedAt}`,
+  ].join(" ");
+}
+
+function buildStaleReconciliationMarkerLine(snapshot: {
+  phase: string;
+  startedAt: string | null;
+}, elapsedMs: number): string {
+  return [
+    "reconciliation_marker=stale_artifact",
+    `phase=${snapshot.phase}`,
+    "classification=safe_to_ignore",
+    "maintenance=yes",
+    `elapsed_seconds=${Math.floor(elapsedMs / 1000)}`,
+    `threshold_seconds=${Math.floor(LONG_RECONCILIATION_WARNING_THRESHOLD_MS / 1000)}`,
+    `started_at=${snapshot.startedAt}`,
+  ].join(" ");
+}
+
+function buildReconciliationMarkerStatus(snapshot: {
+  phase: string;
+  startedAt: string | null;
+} | null, context: {
+  hasActiveIssue: boolean;
+  runnableIssueCount: number;
+  openIssueCount: number;
+  openPrCount: number;
+  loopRuntimeState: "running" | "off" | "unknown";
+  factsAvailable: boolean;
+}): string | null {
   if (snapshot === null || snapshot.startedAt === null) {
     return null;
   }
@@ -79,13 +114,17 @@ function buildLongReconciliationWarning(snapshot: {
     return null;
   }
 
-  return [
-    "reconciliation_warning=long_running",
-    `phase=${snapshot.phase}`,
-    `elapsed_seconds=${Math.floor(elapsedMs / 1000)}`,
-    `threshold_seconds=${Math.floor(LONG_RECONCILIATION_WARNING_THRESHOLD_MS / 1000)}`,
-    `started_at=${snapshot.startedAt}`,
-  ].join(" ");
+  const hasLiveWork =
+    !context.factsAvailable ||
+    context.hasActiveIssue ||
+    context.runnableIssueCount > 0 ||
+    context.openIssueCount > 0 ||
+    context.openPrCount > 0 ||
+    context.loopRuntimeState !== "off";
+
+  return hasLiveWork
+    ? buildLongReconciliationWarningLine(snapshot, elapsedMs)
+    : buildStaleReconciliationMarkerLine(snapshot, elapsedMs);
 }
 
 function formatStatusStateLoadFinding(finding: StateLoadFinding): string {
@@ -204,7 +243,6 @@ export async function buildSupervisorStatusReport(args: {
   const inventoryRefreshWarning = buildInventoryRefreshWarningMessage(state);
   const reconciliationSnapshot = await readCurrentReconciliationPhaseSnapshot(config);
   const reconciliationPhase = reconciliationSnapshot?.phase ?? null;
-  const reconciliationWarning = buildLongReconciliationWarning(reconciliationSnapshot);
   const reconciliationProgress = reconciliationSnapshot === null
     ? null
     : {
@@ -262,6 +300,14 @@ export async function buildSupervisorStatusReport(args: {
       const readinessSummary = buildLastKnownGoodSnapshotReadinessSummary(config, state);
       const whyLines = options.why ? await buildSelectionWhySummary(github, config, state) : [];
       const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
+      const reconciliationWarning = buildReconciliationMarkerStatus(reconciliationSnapshot, {
+        hasActiveIssue: false,
+        runnableIssueCount: readinessSummary?.runnableIssues.length ?? 0,
+        openIssueCount: (readinessSummary?.runnableIssues.length ?? 0) + (readinessSummary?.blockedIssues.length ?? 0),
+        openPrCount: trackedIssues.filter((issue) => issue.state !== "done" && issue.prNumber !== null).length,
+        loopRuntimeState: loopRuntime.state,
+        factsAvailable: true,
+      });
       const inactiveDetailedStatusLines = appendRestartRecommendationLine([
         ...detailedStatusLines,
         ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
@@ -338,6 +384,14 @@ export async function buildSupervisorStatusReport(args: {
       const whyLines = options.why ? await buildSelectionWhySummary(github, config, state) : [];
       const selectionSummary = options.why ? await buildSelectionSummary(github, config, state) : null;
       const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
+      const reconciliationWarning = buildReconciliationMarkerStatus(reconciliationSnapshot, {
+        hasActiveIssue: false,
+        runnableIssueCount: readinessSummary.runnableIssues.length,
+        openIssueCount: readinessSummary.runnableIssues.length + readinessSummary.blockedIssues.length,
+        openPrCount: trackedIssues.filter((issue) => issue.state !== "done" && issue.prNumber !== null).length,
+        loopRuntimeState: loopRuntime.state,
+        factsAvailable: true,
+      });
       const inactiveDetailedStatusLines = appendRestartRecommendationLine([
         ...detailedStatusLines,
         ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
@@ -397,6 +451,14 @@ export async function buildSupervisorStatusReport(args: {
     } catch (error) {
       const message = sanitizeStatusValue(error instanceof Error ? error.message : String(error));
       const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
+      const reconciliationWarning = buildReconciliationMarkerStatus(reconciliationSnapshot, {
+        hasActiveIssue: false,
+        runnableIssueCount: 0,
+        openIssueCount: 0,
+        openPrCount: trackedIssues.filter((issue) => issue.state !== "done" && issue.prNumber !== null).length,
+        loopRuntimeState: loopRuntime.state,
+        factsAvailable: false,
+      });
       const inactiveDetailedStatusLines = appendRestartRecommendationLine([
         ...detailedStatusLines,
         ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),
@@ -496,6 +558,14 @@ export async function buildSupervisorStatusReport(args: {
     executionMetricsSummaryLines: activeStatus.executionMetricsSummaryLines,
   });
   const githubRateLimitStatus = await loadGitHubRateLimitStatus(github);
+  const reconciliationWarning = buildReconciliationMarkerStatus(reconciliationSnapshot, {
+    hasActiveIssue: true,
+    runnableIssueCount: 0,
+    openIssueCount: 0,
+    openPrCount: activeStatus.pr?.state === "OPEN" ? 1 : 0,
+    loopRuntimeState: loopRuntime.state,
+    factsAvailable: true,
+  });
   const detailedStatusLinesWithInventory = appendRestartRecommendationLine([
     ...detailedStatusLines,
     ...(loopOffTrackedWorkBlocker ? [loopOffTrackedWorkBlocker.summaryLine] : []),


### PR DESCRIPTION
## Summary
- classify old reconciliation phase markers as stale artifacts when status can see no active, runnable, tracked PR, or loop-runtime work
- keep long-running reconciliation warnings for live or unknown status contexts
- add a focused status --why regression for stale marker wording

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-status-model-supervisor.test.ts
- npm test

Part of #1772