### PR TITLE
Phase 10.6: adopt CodeRabbit local CI posture

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1828,6 +1828,14 @@ test("shipped CodeRabbit starter profile enables strict current-head provider ga
   assert.equal(raw.configuredBotCurrentHeadSignalTimeoutAction, "block");
 });
 
+test("shipped CodeRabbit starter profile adopts the repo-owned local CI gate", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const profilePath = path.join(rootDir, "supervisor.config.coderabbit.json");
+  const raw = JSON.parse(await fs.readFile(profilePath, "utf8")) as { localCiCommand?: unknown };
+
+  assert.equal(raw.localCiCommand, "npm run verify:supervisor-pre-pr");
+});
+
 test("repo gitignore ignores workstation noise and live issue journals without hiding intentional files", async (t) => {
   const rootDir = path.resolve(__dirname, "..");
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-gitignore-"));

--- a/supervisor.config.coderabbit.json
+++ b/supervisor.config.coderabbit.json
@@ -76,7 +76,7 @@
   "issueJournalMaxChars": 6000,
   "issueLabel": "codex",
   "workspacePreparationCommand": "",
-  "localCiCommand": "",
+  "localCiCommand": "npm run verify:supervisor-pre-pr",
   "skipTitlePrefixes": [
     "Epic:"
   ],


### PR DESCRIPTION
## Summary
- configure the CodeRabbit supervisor profile to run npm run verify:supervisor-pre-pr as localCiCommand
- add a shipped-profile regression test for the adopted local CI gate

## Verification
- npx tsx --test src/config.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts --test-name-pattern "local CI|local_ci|localCiCommand|repo-owned local CI|CodeRabbit starter profile"
- npm run build
- npm run verify:supervisor-pre-pr
- runtime status/doctor posture checked with a disposable config replacing only the starter repoSlug placeholder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added configuration validation test for pre-PR verification settings.

* **Chores**
  * Configured local pre-PR verification command for automated code checks before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->