### PR TITLE
Phase 10.8: clarify no-PR stabilizing no-op stops

### DIFF
--- a/src/recovery-active-reconciliation.ts
+++ b/src/recovery-active-reconciliation.ts
@@ -118,7 +118,7 @@ function appendInterruptedTurnEvidence(
 }
 
 export async function reconcileStaleActiveIssueReservationInModule(args: {
-  config?: Pick<SupervisorConfig, "issueJournalRelativePath" | "workspaceRoot">;
+  config?: Pick<SupervisorConfig, "issueJournalRelativePath" | "workspaceRoot"> & Partial<Pick<SupervisorConfig, "defaultBranch">>;
   stateStore: StateStoreLike;
   state: SupervisorStateFile;
   issueLockPath: (issueNumber: number) => string;
@@ -279,7 +279,9 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
         issueNumber: record.issue_number,
         localState: "stabilizing",
         githubIssueState: "OPEN",
-        detail: "Stale stabilizing recovery found no meaningful branch changes, so the supervisor cannot treat the open issue as complete without authoritative completion evidence.",
+        detail: `Stale stabilizing recovery found the preserved branch no longer differs from origin/${args.config?.defaultBranch ?? "main"}, so the supervisor cannot treat the open issue as complete without authoritative completion evidence.`,
+        branchState: "already_satisfied_on_main",
+        defaultBranch: args.config?.defaultBranch ?? "main",
       })
     : null;
 
@@ -287,7 +289,7 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
     record.issue_number,
     appendInterruptedTurnEvidence(
       shouldMarkAlreadySatisfiedOnMain
-        ? `stale_stabilizing_no_pr_manual_review: blocked issue #${record.issue_number} after stale stabilizing recovery found an open issue with no authoritative completion signal`
+        ? `stale_stabilizing_no_pr_manual_review: blocked issue #${record.issue_number} after stale stabilizing recovery found the preserved branch already satisfied on origin/${args.config?.defaultBranch ?? "main"} with no authoritative completion signal`
         : shouldStopRepeatedStaleNoPrLoop
         ? `stale_state_manual_stop: blocked issue #${record.issue_number} after repeated stale stabilizing recovery without a tracked PR`
         : shouldRequeueStabilizing

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1098,7 +1098,7 @@ export async function reconcileParentEpicClosures(
 }
 
 export async function reconcileStaleActiveIssueReservation(args: {
-  config?: Pick<SupervisorConfig, "issueJournalRelativePath" | "workspaceRoot">;
+  config?: Pick<SupervisorConfig, "issueJournalRelativePath" | "workspaceRoot"> & Partial<Pick<SupervisorConfig, "defaultBranch">>;
   stateStore: StateStoreLike;
   state: SupervisorStateFile;
   issueLockPath: (issueNumber: number) => string;

--- a/src/recovery-support.ts
+++ b/src/recovery-support.ts
@@ -33,6 +33,8 @@ export function buildUnsafeNoPrFailureContext(args: {
   localState: "done" | "stabilizing";
   githubIssueState: "OPEN" | "UNKNOWN";
   detail: string;
+  branchState?: "already_satisfied_on_main";
+  defaultBranch?: string;
 }): NonNullable<IssueRunRecord["last_failure_context"]> {
   const localStateSummary = args.localState === "done"
     ? `Issue #${args.issueNumber} is locally marked done without authoritative completion evidence`
@@ -52,6 +54,8 @@ export function buildUnsafeNoPrFailureContext(args: {
       `state=${args.localState}`,
       "tracked_pr=none",
       `github_issue_state=${args.githubIssueState}`,
+      ...(args.branchState ? [`branch_state=${args.branchState}`] : []),
+      ...(args.defaultBranch ? [`default_branch=origin/${args.defaultBranch}`] : []),
       "completion_evidence=missing",
       "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
     ],

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -2340,7 +2340,7 @@ test("runOnce converges a stale no-PR issue to done when only supervisor-owned w
   const message = await supervisor.runOnce({ dryRun: false });
   assert.match(
     message,
-    /recovery issue=#92 reason=stale_stabilizing_no_pr_manual_review: blocked issue #92 after stale stabilizing recovery found an open issue with no authoritative completion signal; No matching open issue found\./,
+    /recovery issue=#92 reason=stale_stabilizing_no_pr_manual_review: blocked issue #92 after stale stabilizing recovery found the preserved branch already satisfied on origin\/main with no authoritative completion signal; No matching open issue found\./,
   );
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
@@ -2350,11 +2350,13 @@ test("runOnce converges a stale no-PR issue to done when only supervisor-owned w
   assert.equal(record.pr_number, null);
   assert.equal(record.codex_session_id, null);
   assert.equal(record.blocked_reason, "manual_review");
-  assert.match(record.last_error ?? "", /stale stabilizing recovery without authoritative completion evidence/);
+  assert.match(record.last_error ?? "", /preserved branch no longer differs from origin\/main/);
   assert.deepEqual(record.last_failure_context?.details ?? [], [
     "state=stabilizing",
     "tracked_pr=none",
     "github_issue_state=OPEN",
+    "branch_state=already_satisfied_on_main",
+    "default_branch=origin/main",
     "completion_evidence=missing",
     "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
   ]);

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -4043,10 +4043,19 @@ test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stal
   assert.equal(state.issues["366"]?.blocked_reason, "manual_review");
   assert.match(
     state.issues["366"]?.last_error ?? "",
-    /stale stabilizing recovery without authoritative completion evidence/,
+    /preserved branch no longer differs from origin\/main/,
   );
   assert.equal(state.issues["366"]?.last_failure_kind, null);
   assert.equal(state.issues["366"]?.last_failure_context?.signature, "failed-no-pr-already-satisfied-on-main");
+  assert.deepEqual(state.issues["366"]?.last_failure_context?.details ?? [], [
+    "state=stabilizing",
+    "tracked_pr=none",
+    "github_issue_state=OPEN",
+    "branch_state=already_satisfied_on_main",
+    "default_branch=origin/main",
+    "completion_evidence=missing",
+    "operator_action=confirm whether the issue should be requeued or whether completion landed outside the tracked PR flow",
+  ]);
   assert.equal(state.issues["366"]?.last_failure_signature, null);
   assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
   assert.equal(state.issues["366"]?.stale_stabilizing_no_pr_recovery_count, 0);
@@ -4054,7 +4063,7 @@ test("reconcileStaleActiveIssueReservation blocks already-satisfied-on-main stal
   assert.equal(recoveryEvents.length, 1);
   assert.match(
     formatRecoveryLog(recoveryEvents) ?? "",
-    /recovery issue=#366 reason=stale_stabilizing_no_pr_manual_review: blocked issue #366 after stale stabilizing recovery found an open issue with no authoritative completion signal/,
+    /recovery issue=#366 reason=stale_stabilizing_no_pr_manual_review: blocked issue #366 after stale stabilizing recovery found the preserved branch already satisfied on origin\/main with no authoritative completion signal/,
   );
 });
 


### PR DESCRIPTION
## Summary
- make stale stabilizing no-PR already-satisfied stops explicitly name the preserved branch as satisfied on origin/main
- carry branch_state and default_branch details in the manual-review failure context
- tighten recovery and runOnce tests for the deterministic no-op stop diagnostics

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build

Part of #1776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional default branch configuration in issue reconciliation.
  * Enhanced stale issue resolution to evaluate branch state against a default branch, providing clearer context on whether issues are already satisfied.

* **Refactor**
  * Updated internal logic to include branch comparison details in failure context tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->