### PR TITLE
Phase 11.1: align operator action vocabulary

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -644,6 +644,27 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
   );
 
   assert.deepEqual(
+    buildPrimaryActionSummary({
+      status: {
+        selectionSummary: { selectedIssueNumber: 77 },
+        runnableIssues: [{ issueNumber: 77, title: "Ready issue", readiness: "execution_ready" }],
+        detailedStatusLines: [
+          "operator_action action=fix_config source=tracked_pr_host_local_ci priority=80 summary=Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+        ],
+      },
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    {
+      title: "Fix supervisor configuration",
+      detail:
+        "Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+    },
+  );
+
+  assert.deepEqual(
     buildAttentionItems({
       status: {
         inventoryStatus: {

--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -665,6 +665,27 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
   );
 
   assert.deepEqual(
+    buildPrimaryActionSummary({
+      status: {
+        selectionSummary: { selectedIssueNumber: 77 },
+        runnableIssues: [{ issueNumber: 77, title: "Ready issue", readiness: "execution_ready" }],
+        detailedStatusLines: [
+          "operator_action action=continue source=status priority=0 summary=No blocking operator action was detected; continue normal supervisor operation.",
+          "operator_action action=manual_review source=tracked_pr_review priority=70 summary=Review threads require operator attention before the supervisor can continue.",
+        ],
+      },
+      doctor: { overallStatus: "pass", checks: [] },
+      connectionPhase: "open",
+      refreshPhase: "idle",
+      hasSuccessfulRefresh: true,
+    }),
+    {
+      title: "Complete manual review",
+      detail: "Review threads require operator attention before the supervisor can continue.",
+    },
+  );
+
+  assert.deepEqual(
     buildAttentionItems({
       status: {
         inventoryStatus: {

--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -18,6 +18,7 @@ import {
   formatRecoveryLoopSummary,
   formatRetryContextSummary,
   formatTrackedIssues,
+  parseRenderedOperatorAction,
   parseSelectedIssueNumber,
   type DashboardStatusLike,
 } from "./webui-dashboard-browser-logic";
@@ -683,6 +684,13 @@ test("buildOverviewSummary and related beginner-first helpers produce concise En
       title: "Complete manual review",
       detail: "Review threads require operator attention before the supervisor can continue.",
     },
+  );
+
+  assert.equal(
+    parseRenderedOperatorAction(
+      "operator_action action=fix_config source=tracked_pr_host_local_ci priority=80foo summary=Host-local CI needs attention.",
+    ),
+    null,
   );
 
   assert.deepEqual(

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -1,5 +1,21 @@
 import { buildBrowserLocalCiStatusLines } from "./webui-browser-script-helpers";
 
+type DashboardOperatorActionToken =
+  | "continue"
+  | "restart_loop"
+  | "fix_config"
+  | "adopt_local_ci"
+  | "dismiss_local_ci"
+  | "manual_review"
+  | "resolve_stale_review_bot"
+  | "provider_outage_suspected"
+  | "safe_to_ignore";
+
+interface DashboardOperatorActionSummary {
+  action: DashboardOperatorActionToken;
+  summary: string;
+}
+
 export interface DashboardSelectionSummaryLike {
   selectedIssueNumber?: number | null;
 }
@@ -411,6 +427,48 @@ export function parseSelectedIssueNumber(status: DashboardStatusLike | null | un
   return null;
 }
 
+export function readOperatorActionToken(line: string, key: string): string | null {
+  const match = new RegExp("(?:^|\\s)" + key + "=([^\\s]+)", "u").exec(line);
+  return match?.[1] ?? null;
+}
+
+export function parseRenderedOperatorAction(line: string): DashboardOperatorActionSummary | null {
+  if (!/^operator_action\b/u.test(line)) {
+    return null;
+  }
+
+  const action = readOperatorActionToken(line, "action") as DashboardOperatorActionToken | null;
+  const summary = /(?:^|\s)summary=(.*)$/u.exec(line)?.[1]?.trim() || null;
+  const validActions: Record<DashboardOperatorActionToken, true> = {
+    continue: true,
+    restart_loop: true,
+    fix_config: true,
+    adopt_local_ci: true,
+    dismiss_local_ci: true,
+    manual_review: true,
+    resolve_stale_review_bot: true,
+    provider_outage_suspected: true,
+    safe_to_ignore: true,
+  };
+
+  if (action === null || validActions[action] !== true || summary === null) {
+    return null;
+  }
+
+  return { action, summary };
+}
+
+export function selectRenderedOperatorAction(status: DashboardStatusLike | null | undefined): DashboardOperatorActionSummary | null {
+  const lines = Array.isArray(status?.detailedStatusLines) ? status.detailedStatusLines : [];
+  for (const line of lines) {
+    const action = parseRenderedOperatorAction(line);
+    if (action !== null) {
+      return action;
+    }
+  }
+  return null;
+}
+
 export function collectTrackedIssues(
   status: DashboardStatusLike | null | undefined,
   options: DashboardTrackedIssueFormatOptions = {},
@@ -732,6 +790,19 @@ export function buildPrimaryActionSummary(args: {
   const runnableCount = Array.isArray(args.status?.runnableIssues) ? args.status.runnableIssues.length : 0;
   const doctorStatus = typeof args.doctor?.overallStatus === "string" ? args.doctor.overallStatus.toLowerCase() : "";
   const loopOffTrackedWorkBlocker = describeLoopOffTrackedWorkBlocker(args.status);
+  const operatorAction = selectRenderedOperatorAction(args.status);
+
+  function titleForOperatorAction(action: DashboardOperatorActionToken): string {
+    if (action === "fix_config") return "Fix supervisor configuration";
+    if (action === "restart_loop") return describeLoopOffTrackedWorkRestartActionTitle();
+    if (action === "adopt_local_ci") return "Adopt local CI contract";
+    if (action === "dismiss_local_ci") return "Dismiss local CI recommendation";
+    if (action === "manual_review") return "Complete manual review";
+    if (action === "resolve_stale_review_bot") return "Resolve stale review metadata";
+    if (action === "provider_outage_suspected") return "Check review provider delivery";
+    if (action === "safe_to_ignore") return "No operator action required";
+    return "Observe and refresh";
+  }
 
   if (!args.hasSuccessfulRefresh) {
     return {
@@ -751,6 +822,13 @@ export function buildPrimaryActionSummary(args: {
     return {
       title: "Resolve environment checks",
       detail: "A required dependency is failing, so the supervisor should not advance until checks recover.",
+    };
+  }
+
+  if (operatorAction !== null && operatorAction.action !== "continue") {
+    return {
+      title: titleForOperatorAction(operatorAction.action),
+      detail: operatorAction.summary,
     };
   }
 

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -1,15 +1,11 @@
 import { buildBrowserLocalCiStatusLines } from "./webui-browser-script-helpers";
+import {
+  parseOperatorActionPriority,
+  validOperatorActions,
+  type OperatorActionToken,
+} from "../operator-actions";
 
-type DashboardOperatorActionToken =
-  | "continue"
-  | "restart_loop"
-  | "fix_config"
-  | "adopt_local_ci"
-  | "dismiss_local_ci"
-  | "manual_review"
-  | "resolve_stale_review_bot"
-  | "provider_outage_suspected"
-  | "safe_to_ignore";
+type DashboardOperatorActionToken = OperatorActionToken;
 
 interface DashboardOperatorActionSummary {
   action: DashboardOperatorActionToken;
@@ -440,21 +436,10 @@ export function parseRenderedOperatorAction(line: string): DashboardOperatorActi
 
   const action = readOperatorActionToken(line, "action") as DashboardOperatorActionToken | null;
   const priorityValue = readOperatorActionToken(line, "priority");
-  const priority = priorityValue === null ? Number.NaN : Number.parseInt(priorityValue, 10);
+  const priority = parseOperatorActionPriority(priorityValue);
   const summary = /(?:^|\s)summary=(.*)$/u.exec(line)?.[1]?.trim() || null;
-  const validActions: Record<DashboardOperatorActionToken, true> = {
-    continue: true,
-    restart_loop: true,
-    fix_config: true,
-    adopt_local_ci: true,
-    dismiss_local_ci: true,
-    manual_review: true,
-    resolve_stale_review_bot: true,
-    provider_outage_suspected: true,
-    safe_to_ignore: true,
-  };
 
-  if (action === null || validActions[action] !== true || !Number.isFinite(priority) || summary === null) {
+  if (action === null || validOperatorActions[action] !== true || !Number.isFinite(priority) || summary === null) {
     return null;
   }
 

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -13,6 +13,7 @@ type DashboardOperatorActionToken =
 
 interface DashboardOperatorActionSummary {
   action: DashboardOperatorActionToken;
+  priority: number;
   summary: string;
 }
 
@@ -438,6 +439,8 @@ export function parseRenderedOperatorAction(line: string): DashboardOperatorActi
   }
 
   const action = readOperatorActionToken(line, "action") as DashboardOperatorActionToken | null;
+  const priorityValue = readOperatorActionToken(line, "priority");
+  const priority = priorityValue === null ? Number.NaN : Number.parseInt(priorityValue, 10);
   const summary = /(?:^|\s)summary=(.*)$/u.exec(line)?.[1]?.trim() || null;
   const validActions: Record<DashboardOperatorActionToken, true> = {
     continue: true,
@@ -451,22 +454,23 @@ export function parseRenderedOperatorAction(line: string): DashboardOperatorActi
     safe_to_ignore: true,
   };
 
-  if (action === null || validActions[action] !== true || summary === null) {
+  if (action === null || validActions[action] !== true || !Number.isFinite(priority) || summary === null) {
     return null;
   }
 
-  return { action, summary };
+  return { action, priority, summary };
 }
 
 export function selectRenderedOperatorAction(status: DashboardStatusLike | null | undefined): DashboardOperatorActionSummary | null {
   const lines = Array.isArray(status?.detailedStatusLines) ? status.detailedStatusLines : [];
+  let selected: DashboardOperatorActionSummary | null = null;
   for (const line of lines) {
     const action = parseRenderedOperatorAction(line);
-    if (action !== null) {
-      return action;
+    if (action !== null && (selected === null || action.priority > selected.priority)) {
+      selected = action;
     }
   }
-  return null;
+  return selected;
 }
 
 export function collectTrackedIssues(

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -69,11 +69,20 @@ import {
   readStoredMutationAuthToken,
   writeStoredMutationAuthToken,
 } from "./webui-browser-script-helpers";
+import {
+  parseOperatorActionPriority,
+  validOperatorActions,
+} from "../operator-actions";
+
+const injectedBrowserConstants = [
+  `const validOperatorActions = ${JSON.stringify(validOperatorActions)};`,
+].join("\n\n");
 
 const injectedBrowserLogic = [
   formatBrowserToken,
   normalizeBrowserLocalCiContract,
   buildBrowserLocalCiStatusLines,
+  parseOperatorActionPriority,
   readStoredMutationAuthToken,
   writeStoredMutationAuthToken,
   promptForMutationAuthToken,
@@ -135,6 +144,8 @@ const injectedBrowserLogic = [
 
 export function renderDashboardBrowserScript(): string {
   return `
+      ${injectedBrowserConstants}
+
       ${injectedBrowserLogic}
 
       const state = {

--- a/src/backend/webui-dashboard-browser-script.ts
+++ b/src/backend/webui-dashboard-browser-script.ts
@@ -27,6 +27,9 @@ import {
   collectTimelineEventIssueNumbers,
   humanizeTimelineValue,
   parseSelectedIssueNumber,
+  parseRenderedOperatorAction,
+  readOperatorActionToken,
+  selectRenderedOperatorAction,
 } from "./webui-dashboard-browser-logic";
 import {
   buildWorkflowSteps,
@@ -108,6 +111,9 @@ const injectedBrowserLogic = [
   describeTimelineEvent,
   collectTimelineEventIssueNumbers,
   parseSelectedIssueNumber,
+  readOperatorActionToken,
+  parseRenderedOperatorAction,
+  selectRenderedOperatorAction,
   countCandidateIssues,
   buildWorkflowSteps,
   buildRuntimeRecoverySummaryLines,

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -58,20 +58,30 @@ test("selectRestartRecommendation classifies every restart recommendation catego
 });
 
 test("parseOperatorActionLine reads rendered status and doctor action lines", () => {
+  const expected = {
+    action: "fix_config",
+    source: "tracked_pr_host_local_ci",
+    priority: 80,
+    summary:
+      "Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+  };
+
   assert.deepEqual(
     parseOperatorActionLine(
       "operator_action action=fix_config source=tracked_pr_host_local_ci priority=80 summary=Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
     ),
-    {
-      action: "fix_config",
-      source: "tracked_pr_host_local_ci",
-      priority: 80,
-      summary:
-        "Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
-    },
+    expected,
+  );
+
+  assert.deepEqual(
+    parseOperatorActionLine(
+      "doctor_operator_action action=fix_config source=tracked_pr_host_local_ci priority=80 summary=Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+    ),
+    expected,
   );
 
   assert.equal(parseOperatorActionLine("operator_action action=unknown source=status priority=0 summary=nope"), null);
+  assert.equal(parseOperatorActionLine("doctor_operator_action action=unknown source=doctor priority=0 summary=nope"), null);
 });
 
 test("buildStatusOperatorCockpitViewModel carries the shared action contract and evidence", () => {
@@ -100,6 +110,16 @@ test("buildStatusOperatorCockpitViewModel carries the shared action contract and
       ],
       fallbackCommand: "node dist/index.js doctor --config <supervisor-config-path>",
     },
+  );
+});
+
+test("buildStatusOperatorCockpitViewModel prefers whyLines for the current task contract", () => {
+  assert.equal(
+    buildStatusOperatorCockpitViewModel({
+      detailedStatusLines: ["selected_issue=#1777"],
+      whyLines: ["selected_issue=#1783"],
+    }).currentTaskContract,
+    "selected_issue=#1783",
   );
 });
 

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildStatusOperatorCockpitViewModel,
+  parseOperatorActionLine,
   type RestartRecommendation,
   selectRestartRecommendation,
 } from "./operator-actions";
@@ -52,6 +54,52 @@ test("selectRestartRecommendation classifies every restart recommendation catego
       ],
     })).category,
     "manual_review_before_restart",
+  );
+});
+
+test("parseOperatorActionLine reads rendered status and doctor action lines", () => {
+  assert.deepEqual(
+    parseOperatorActionLine(
+      "operator_action action=fix_config source=tracked_pr_host_local_ci priority=80 summary=Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+    ),
+    {
+      action: "fix_config",
+      source: "tracked_pr_host_local_ci",
+      priority: 80,
+      summary:
+        "Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+    },
+  );
+
+  assert.equal(parseOperatorActionLine("operator_action action=unknown source=status priority=0 summary=nope"), null);
+});
+
+test("buildStatusOperatorCockpitViewModel carries the shared action contract and evidence", () => {
+  assert.deepEqual(
+    buildStatusOperatorCockpitViewModel({
+      detailedStatusLines: [
+        "tracked_pr_host_local_ci issue=#1783 gate=local_ci blocked_reason=workspace_environment remediation_target=workspace_environment",
+        "trust_mode=trusted_repo_and_authors execution_safety_mode=operator_gated",
+      ],
+      whyLines: ["selected_issue=#1783"],
+    }),
+    {
+      action: {
+        action: "fix_config",
+        source: "tracked_pr_host_local_ci",
+        priority: 80,
+        summary:
+          "Host-local CI could not run because the workspace environment is missing prerequisites; fix configuration or workspace preparation before continuing.",
+      },
+      currentTaskContract: "selected_issue=#1783",
+      trustPosture: "trust_mode=trusted_repo_and_authors execution_safety_mode=operator_gated",
+      gateState: "gate=local_ci remediation_target=workspace_environment",
+      blockingReason: "workspace_environment",
+      evidence: [
+        "tracked_pr_host_local_ci issue=#1783 gate=local_ci blocked_reason=workspace_environment remediation_target=workspace_environment",
+      ],
+      fallbackCommand: "node dist/index.js doctor --config <supervisor-config-path>",
+    },
   );
 });
 

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -5,6 +5,7 @@ import {
   parseOperatorActionLine,
   type RestartRecommendation,
   selectRestartRecommendation,
+  selectStatusOperatorAction,
 } from "./operator-actions";
 
 function requireRestartRecommendation(recommendation: RestartRecommendation | null): RestartRecommendation {
@@ -82,6 +83,24 @@ test("parseOperatorActionLine reads rendered status and doctor action lines", ()
 
   assert.equal(parseOperatorActionLine("operator_action action=unknown source=status priority=0 summary=nope"), null);
   assert.equal(parseOperatorActionLine("doctor_operator_action action=unknown source=doctor priority=0 summary=nope"), null);
+  assert.equal(parseOperatorActionLine("operator_action action=fix_config source=status priority=80foo summary=nope"), null);
+});
+
+test("selectStatusOperatorAction ignores rendered doctor action lines", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "doctor_operator_action action=fix_config source=doctor_check priority=80 summary=Doctor found a failing host prerequisite; fix the reported check before continuing supervisor operation.",
+        "operator_action action=continue source=status priority=0 summary=No blocking operator action was detected; continue normal supervisor operation.",
+      ],
+    }),
+    {
+      action: "continue",
+      source: "status",
+      priority: 0,
+      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+    },
+  );
 });
 
 test("buildStatusOperatorCockpitViewModel carries the shared action contract and evidence", () => {

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -417,13 +417,18 @@ export function buildStatusOperatorCockpitViewModel(args: {
     ...(args.readinessLines ?? []),
     ...(args.whyLines ?? []),
   ];
+  const taskContractLines = [
+    ...(args.whyLines ?? []),
+    ...args.detailedStatusLines,
+    ...(args.readinessLines ?? []),
+  ];
   const action = selectStatusOperatorAction({ detailedStatusLines: args.detailedStatusLines });
   const evidenceLine = firstMatchingLine(lines, action.source);
   const evidence = evidenceLine === null ? [] : [evidenceLine];
 
   return {
     action,
-    currentTaskContract: summarizeCurrentTaskContract(lines),
+    currentTaskContract: summarizeCurrentTaskContract(taskContractLines),
     trustPosture: summarizeTrustPosture(lines),
     gateState: summarizeGateState(evidenceLine),
     blockingReason: summarizeBlockingReason(evidenceLine),

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -18,6 +18,16 @@ export interface OperatorAction {
   summary: string;
 }
 
+export interface OperatorCockpitViewModel {
+  action: OperatorAction;
+  currentTaskContract: string | null;
+  trustPosture: string | null;
+  gateState: string | null;
+  blockingReason: string | null;
+  evidence: string[];
+  fallbackCommand: string | null;
+}
+
 export type RestartRecommendationCategory =
   | "safe_restart"
   | "restart_required_for_convergence"
@@ -75,6 +85,58 @@ const doctorFallbackOperatorAction: OperatorAction = {
   priority: 0,
   summary: "No blocking doctor action was detected; continue normal supervisor operation.",
 };
+
+function readTokenValue(line: string, key: string): string | null {
+  const match = new RegExp(`(?:^|\\s)${key}=([^\\s]+)`, "u").exec(line);
+  return match?.[1] ?? null;
+}
+
+function readSummaryValue(line: string): string | null {
+  const match = /(?:^|\s)summary=(.*)$/u.exec(line);
+  return match?.[1]?.trim() || null;
+}
+
+export function parseOperatorActionLine(line: string): OperatorAction | null {
+  if (!/^(operator_action|doctor_operator_action)\b/u.test(line)) {
+    return null;
+  }
+
+  const action = readTokenValue(line, "action") as OperatorActionToken | null;
+  const source = readTokenValue(line, "source");
+  const priorityValue = readTokenValue(line, "priority");
+  const summary = readSummaryValue(line);
+  const validActions: Record<OperatorActionToken, true> = {
+    continue: true,
+    restart_loop: true,
+    fix_config: true,
+    adopt_local_ci: true,
+    dismiss_local_ci: true,
+    manual_review: true,
+    resolve_stale_review_bot: true,
+    provider_outage_suspected: true,
+    safe_to_ignore: true,
+  };
+  const priority = priorityValue === null ? Number.NaN : Number.parseInt(priorityValue, 10);
+
+  if (
+    action === null ||
+    validActions[action] !== true ||
+    source === null ||
+    !Number.isFinite(priority) ||
+    summary === null
+  ) {
+    return null;
+  }
+
+  return { action, source, priority, summary };
+}
+
+function selectRenderedOperatorAction(lines: string[]): OperatorAction | null {
+  const actions = lines
+    .map(parseOperatorActionLine)
+    .filter((action): action is OperatorAction => action !== null);
+  return actions.length === 0 ? null : chooseHighestPriority(actions, statusFallbackOperatorAction);
+}
 
 export function selectRestartRecommendation(args: {
   detailedStatusLines: string[];
@@ -188,6 +250,11 @@ export function appendRestartRecommendationLine(
 export function selectStatusOperatorAction(args: {
   detailedStatusLines: string[];
 }): OperatorAction {
+  const renderedAction = selectRenderedOperatorAction(args.detailedStatusLines);
+  if (renderedAction !== null) {
+    return renderedAction;
+  }
+
   const actions: OperatorAction[] = [];
 
   for (const line of args.detailedStatusLines) {
@@ -261,6 +328,108 @@ export function selectStatusOperatorAction(args: {
   }
 
   return chooseHighestPriority(actions, statusFallbackOperatorAction);
+}
+
+function fallbackCommandForOperatorAction(action: OperatorActionToken): string | null {
+  if (action === "fix_config" || action === "adopt_local_ci" || action === "dismiss_local_ci") {
+    return "node dist/index.js doctor --config <supervisor-config-path>";
+  }
+  if (action === "restart_loop") {
+    return "node dist/index.js status --why --config <supervisor-config-path>";
+  }
+  if (
+    action === "manual_review" ||
+    action === "resolve_stale_review_bot" ||
+    action === "provider_outage_suspected"
+  ) {
+    return "node dist/index.js status --why --config <supervisor-config-path>";
+  }
+  return null;
+}
+
+function firstMatchingLine(lines: string[], source: string): string | null {
+  return lines.find((line) => line.startsWith(`${source} `) || line === source) ?? null;
+}
+
+function summarizeCurrentTaskContract(lines: string[]): string | null {
+  for (const line of lines) {
+    const selectedIssue = readTokenValue(line, "selected_issue");
+    if (selectedIssue !== null && selectedIssue !== "none") {
+      return `selected_issue=${selectedIssue}`;
+    }
+    const activeIssue = readTokenValue(line, "active_issue");
+    if (activeIssue !== null && activeIssue !== "none") {
+      return `active_issue=${activeIssue}`;
+    }
+    if (/^current_issue=/u.test(line) || /^current_issue\b/u.test(line)) {
+      return line;
+    }
+  }
+  return null;
+}
+
+function summarizeTrustPosture(lines: string[]): string | null {
+  const trustMode = lines.map((line) => readTokenValue(line, "trust_mode")).find((value) => value !== null) ?? null;
+  const executionSafetyMode =
+    lines.map((line) => readTokenValue(line, "execution_safety_mode")).find((value) => value !== null) ?? null;
+  if (trustMode === null && executionSafetyMode === null) {
+    return null;
+  }
+  return [
+    trustMode === null ? null : `trust_mode=${trustMode}`,
+    executionSafetyMode === null ? null : `execution_safety_mode=${executionSafetyMode}`,
+  ].filter(Boolean).join(" ");
+}
+
+function summarizeGateState(evidenceLine: string | null): string | null {
+  if (evidenceLine === null) {
+    return null;
+  }
+  const gate = readTokenValue(evidenceLine, "gate");
+  const remediationTarget = readTokenValue(evidenceLine, "remediation_target");
+  if (gate === null && remediationTarget === null) {
+    return null;
+  }
+  return [
+    gate === null ? null : `gate=${gate}`,
+    remediationTarget === null ? null : `remediation_target=${remediationTarget}`,
+  ].filter(Boolean).join(" ");
+}
+
+function summarizeBlockingReason(evidenceLine: string | null): string | null {
+  if (evidenceLine === null) {
+    return null;
+  }
+  return (
+    readTokenValue(evidenceLine, "blocked_reason") ??
+    readTokenValue(evidenceLine, "local_blocked_reason") ??
+    readTokenValue(evidenceLine, "reason")
+  );
+}
+
+export function buildStatusOperatorCockpitViewModel(args: {
+  detailedStatusLines: string[];
+  readinessLines?: string[];
+  whyLines?: string[];
+}): OperatorCockpitViewModel {
+  const lines = [
+    ...args.detailedStatusLines,
+    ...(args.readinessLines ?? []),
+    ...(args.whyLines ?? []),
+  ];
+  const action = selectStatusOperatorAction({ detailedStatusLines: args.detailedStatusLines });
+  const evidenceLine = firstMatchingLine(lines, action.source);
+  const evidence = evidenceLine === null ? [] : [evidenceLine];
+
+  return {
+    action,
+    currentTaskContract: summarizeCurrentTaskContract(lines),
+    trustPosture: summarizeTrustPosture(lines),
+    gateState: summarizeGateState(evidenceLine),
+    blockingReason: summarizeBlockingReason(evidenceLine),
+    evidence,
+    fallbackCommand: fallbackCommandForOperatorAction(action.action),
+  };
 }
 
 export function selectDoctorOperatorAction(args: {

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -86,6 +86,18 @@ const doctorFallbackOperatorAction: OperatorAction = {
   summary: "No blocking doctor action was detected; continue normal supervisor operation.",
 };
 
+const validOperatorActions: Record<OperatorActionToken, true> = {
+  continue: true,
+  restart_loop: true,
+  fix_config: true,
+  adopt_local_ci: true,
+  dismiss_local_ci: true,
+  manual_review: true,
+  resolve_stale_review_bot: true,
+  provider_outage_suspected: true,
+  safe_to_ignore: true,
+};
+
 function readTokenValue(line: string, key: string): string | null {
   const match = new RegExp(`(?:^|\\s)${key}=([^\\s]+)`, "u").exec(line);
   return match?.[1] ?? null;
@@ -105,22 +117,11 @@ export function parseOperatorActionLine(line: string): OperatorAction | null {
   const source = readTokenValue(line, "source");
   const priorityValue = readTokenValue(line, "priority");
   const summary = readSummaryValue(line);
-  const validActions: Record<OperatorActionToken, true> = {
-    continue: true,
-    restart_loop: true,
-    fix_config: true,
-    adopt_local_ci: true,
-    dismiss_local_ci: true,
-    manual_review: true,
-    resolve_stale_review_bot: true,
-    provider_outage_suspected: true,
-    safe_to_ignore: true,
-  };
   const priority = priorityValue === null ? Number.NaN : Number.parseInt(priorityValue, 10);
 
   if (
     action === null ||
-    validActions[action] !== true ||
+    validOperatorActions[action] !== true ||
     source === null ||
     !Number.isFinite(priority) ||
     summary === null

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -86,7 +86,7 @@ const doctorFallbackOperatorAction: OperatorAction = {
   summary: "No blocking doctor action was detected; continue normal supervisor operation.",
 };
 
-const validOperatorActions: Record<OperatorActionToken, true> = {
+export const validOperatorActions: Record<OperatorActionToken, true> = {
   continue: true,
   restart_loop: true,
   fix_config: true,
@@ -97,6 +97,12 @@ const validOperatorActions: Record<OperatorActionToken, true> = {
   provider_outage_suspected: true,
   safe_to_ignore: true,
 };
+
+export function parseOperatorActionPriority(priorityValue: string | null): number {
+  return priorityValue !== null && /^-?\d+$/u.test(priorityValue)
+    ? Number.parseInt(priorityValue, 10)
+    : Number.NaN;
+}
 
 function readTokenValue(line: string, key: string): string | null {
   const match = new RegExp(`(?:^|\\s)${key}=([^\\s]+)`, "u").exec(line);
@@ -117,7 +123,7 @@ export function parseOperatorActionLine(line: string): OperatorAction | null {
   const source = readTokenValue(line, "source");
   const priorityValue = readTokenValue(line, "priority");
   const summary = readSummaryValue(line);
-  const priority = priorityValue === null ? Number.NaN : Number.parseInt(priorityValue, 10);
+  const priority = parseOperatorActionPriority(priorityValue);
 
   if (
     action === null ||
@@ -134,6 +140,7 @@ export function parseOperatorActionLine(line: string): OperatorAction | null {
 
 function selectRenderedOperatorAction(lines: string[]): OperatorAction | null {
   const actions = lines
+    .filter((line) => /^operator_action\b/u.test(line))
     .map(parseOperatorActionLine)
     .filter((action): action is OperatorAction => action !== null);
   return actions.length === 0 ? null : chooseHighestPriority(actions, statusFallbackOperatorAction);


### PR DESCRIPTION
## Summary
- Add shared operator action parsing and a status cockpit view model carrying action, task, trust, gate, blocker, evidence, and fallback command fields.
- Teach the WebUI primary action to honor rendered `operator_action` tokens so it does not contradict `status --why`.
- Add focused regressions for the shared cockpit contract and WebUI `fix_config` rendering.

## Verification
- `npx tsc --noEmit`
- `npx tsx --test src/operator-actions.test.ts src/backend/webui-dashboard-browser-logic.test.ts`
- `npx tsx --test src/operator-actions.test.ts src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/backend/webui-dashboard.test.ts src/backend/webui-dashboard-browser-view-model.test.ts`
- `npm test`

Part of #1783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard surfaces and prioritizes operator actions in the cockpit and primary-action area, showing action titles, details, evidence, and fallback commands; manual-review actions take precedence when present.

* **Tests**
  * Added unit tests covering parsing of rendered operator-action lines, priority-based selection, integration into primary-action selection, and cockpit view-model population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->