### PR TITLE
Phase 11.2: Build evidence timeline artifacts

### DIFF
--- a/src/operator-audit-bundle.test.ts
+++ b/src/operator-audit-bundle.test.ts
@@ -124,6 +124,17 @@ test("buildOperatorAuditBundle includes structured issue-run evidence and explic
   assert.deepEqual(bundle.pathHygiene.value?.repairTargets, ["docs/guide.md"]);
   assert.equal(bundle.staleConfiguredBotRemediation.status, "missing");
   assert.equal(bundle.recoveryEvents.value?.[0]?.event_type, "recovery");
+  assert.deepEqual(
+    bundle.timeline?.events
+      .filter((event) => ["issue_body", "pr_created", "local_ci", "status_comment"].includes(event.event_type))
+      .map((event) => [event.event_type, event.outcome]),
+    [
+      ["issue_body", "available"],
+      ["pr_created", "created"],
+      ["local_ci", "failed"],
+      ["status_comment", "missing"],
+    ],
+  );
   assert.deepEqual(bundle.verificationCommands.value, [
     "npx tsx --test src/operator-audit-bundle.test.ts",
     "npm run verify:paths",

--- a/src/operator-audit-bundle.ts
+++ b/src/operator-audit-bundle.ts
@@ -3,6 +3,7 @@ import type {
   GitHubPullRequest,
   IssueRunRecord,
   LatestLocalCiResult,
+  PullRequestCheck,
   TimelineArtifact,
 } from "./core/types";
 import {
@@ -12,6 +13,7 @@ import {
 } from "./core/journal";
 import {
   buildIssueRunTimelineExport,
+  type IssueRunTimelineExternalEvidence,
   type IssueRunTimelineEvent,
   type IssueRunTimelineExport,
 } from "./timeline-artifacts";
@@ -162,13 +164,23 @@ export function buildOperatorAuditBundle(args: {
   issue: GitHubIssue;
   record?: IssueRunRecord | null;
   pr?: GitHubPullRequest | null;
+  checks?: PullRequestCheck[];
   journalContent?: string | null;
+  obsidianWriteback?: IssueRunTimelineExternalEvidence | null;
   staleConfiguredBotRemediation?: unknown | null;
 }): OperatorAuditBundleDto {
   const record = args.record ?? null;
   const pr = args.pr ?? null;
   const workspacePath = record?.workspace ?? ".";
-  const timeline = record ? buildIssueRunTimelineExport({ record, pr }) : null;
+  const timeline = record
+    ? buildIssueRunTimelineExport({
+      issue: args.issue,
+      record,
+      pr,
+      checks: args.checks ?? [],
+      obsidianWriteback: args.obsidianWriteback ?? null,
+    })
+    : null;
   const pathHygieneArtifact = latestPathHygieneArtifact(record);
   const verificationCommands = extractIssueVerificationCommands(args.issue.body ?? "");
   const recoveryEvents = timeline?.events.filter((event) => event.event_type === "recovery" && event.outcome !== "missing") ?? [];

--- a/src/supervisor/post-merge-audit-artifact.test.ts
+++ b/src/supervisor/post-merge-audit-artifact.test.ts
@@ -241,6 +241,18 @@ test("syncPostMergeAuditArtifact persists a typed completed-work artifact", asyn
     "npx tsx --test src/supervisor/post-merge-audit-artifact.test.ts",
   );
   assert.equal(artifact.operatorAuditBundle?.localCi.value?.summary, "Configured local CI passed.");
+  assert.deepEqual(
+    artifact.operatorAuditBundle?.timeline?.events
+      .filter((event) => ["issue_body", "pr_created", "local_ci", "merge", "terminal_state"].includes(event.event_type))
+      .map((event) => [event.event_type, event.outcome]),
+    [
+      ["pr_created", "created"],
+      ["local_ci", "passed"],
+      ["merge", "merged"],
+      ["issue_body", "available"],
+      ["terminal_state", "done"],
+    ],
+  );
   assert.deepEqual(artifact.operatorAuditBundle?.verificationCommands.value, [
     "npx tsx --test src/supervisor/post-merge-audit-artifact.test.ts",
     "npm run build",

--- a/src/supervisor/post-merge-audit-artifact.ts
+++ b/src/supervisor/post-merge-audit-artifact.ts
@@ -23,7 +23,7 @@ import {
   type OperatorAuditBundleDto,
   type OperatorAuditBundleEvidence,
 } from "../operator-audit-bundle";
-import { type IssueRunTimelineEvent } from "../timeline-artifacts";
+import { buildIssueRunTimelineExport, type IssueRunTimelineEvent } from "../timeline-artifacts";
 
 export const POST_MERGE_AUDIT_ARTIFACT_SCHEMA_VERSION = 1;
 
@@ -227,10 +227,29 @@ function buildPostMergeOperatorAuditBundle(args: {
     "number" | "title" | "url" | "createdAt" | "mergedAt" | "headRefName" | "headRefOid"
   >;
   previousRecord: PostMergeOperatorAuditBundleSourceRecord;
-  nextRecord: Pick<IssueRunRecord, "state" | "branch" | "updated_at">;
+  nextRecord: Pick<IssueRunRecord, "state" | "branch" | "updated_at"> &
+    Partial<Pick<IssueRunRecord, "last_recovery_reason" | "last_recovery_at">>;
   journalHandoff: IssueJournalHandoff | null;
 }): OperatorAuditBundleDto {
   const record = args.previousRecord;
+  const timelineRecord = {
+    ...args.previousRecord,
+    ...args.nextRecord,
+    issue_number: args.issue.number,
+    pr_number: args.previousRecord.pr_number ?? args.pullRequest.number,
+    last_head_sha: args.previousRecord.last_head_sha ?? args.pullRequest.headRefOid,
+    last_recovery_reason: args.nextRecord.last_recovery_reason ?? null,
+    last_recovery_at: args.nextRecord.last_recovery_at ?? null,
+  } as IssueRunRecord;
+  const timelinePr = {
+    ...args.pullRequest,
+    state: "MERGED",
+    updatedAt: args.pullRequest.mergedAt ?? args.pullRequest.createdAt,
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: null,
+    headRefOid: args.pullRequest.headRefOid,
+  } as GitHubPullRequest;
   const verificationCommands = extractIssueVerificationCommands(args.issue.body ?? "");
   const latestLocalCi = record.latest_local_ci_result ?? null;
   const pathHygieneArtifact = [...(record.timeline_artifacts ?? [])]
@@ -301,7 +320,15 @@ function buildPostMergeOperatorAuditBundle(args: {
       null,
       "No recovery event is embedded in the post-merge audit artifact.",
     ),
-    timeline: null,
+    timeline: buildIssueRunTimelineExport({
+      issue: {
+        number: args.issue.number,
+        updatedAt: args.issue.updatedAt,
+        body: args.issue.body ?? "",
+      },
+      record: timelineRecord,
+      pr: timelinePr,
+    }),
     verificationCommands: auditEvidence(
       verificationCommands.length > 0 ? verificationCommands : null,
       "No verification commands are listed in the issue body.",

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -188,26 +188,30 @@ test("renderIssueExplainTimelineDto shows ordered active issue timeline events",
 
   const rendered = renderIssueExplainTimelineDto(dto);
 
-  assert.match(rendered, /^timeline issue=#617 pr=#716 events=11$/m);
+  assert.match(rendered, /^timeline issue=#617 pr=#716 events=17$/m);
   assert.match(
     rendered,
     /^timeline_event index=1 issue=#617 pr=#716 type=reservation at=unknown outcome=recorded head_sha=head-active remediation_target=none next_action=none summary=Issue run reservation exists for branch codex\/reopen-issue-617\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=2 issue=#617 pr=#716 type=publication_gate at=2026-04-25T11:01:00Z outcome=failed head_sha=head-active remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content summary=Workspace preparation blocked publication\.$/m,
+    /^timeline_event index=2 issue=#617 pr=#716 type=issue_body at=2026-03-19T00:00:00Z outcome=available head_sha=unknown remediation_target=none next_action=none summary=Issue body snapshot is available from issue #617\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=3 issue=#617 pr=#716 type=pr_created at=2026-04-25T11:02:00Z outcome=created head_sha=head-active remediation_target=none next_action=none summary=Pull request #716 is recorded for this issue run\.$/m,
+    /^timeline_event index=3 issue=#617 pr=#716 type=publication_gate at=2026-04-25T11:01:00Z outcome=failed head_sha=head-active remediation_target=tracked_publishable_content next_action=repair_tracked_publishable_content summary=Workspace preparation blocked publication\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=4 issue=#617 pr=#716 type=local_ci at=2026-04-25T11:03:00Z outcome=passed head_sha=head-active remediation_target=none next_action=continue summary=Build passed\.$/m,
+    /^timeline_event index=4 issue=#617 pr=#716 type=pr_created at=2026-04-25T11:02:00Z outcome=created head_sha=head-active remediation_target=none next_action=none summary=Pull request #716 is recorded for this issue run\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=5 issue=#617 pr=#716 type=review at=2026-04-25T11:04:00Z outcome=ready head_sha=head-active remediation_target=none next_action=none summary=Local review recorded 0 finding\(s\)\.$/m,
+    /^timeline_event index=5 issue=#617 pr=#716 type=local_ci at=2026-04-25T11:03:00Z outcome=passed head_sha=head-active remediation_target=none next_action=continue summary=Build passed\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=6 issue=#617 pr=#716 type=review at=2026-04-25T11:04:00Z outcome=ready head_sha=head-active remediation_target=none next_action=none summary=Local review recorded 0 finding\(s\)\.$/m,
   );
 });
 
@@ -258,15 +262,19 @@ test("renderIssueExplainTimelineDto shows done issue completion and merge events
 
   assert.match(
     rendered,
-    /^timeline_event index=2 issue=#618 pr=#718 type=pr_created at=2026-04-25T11:40:00Z outcome=created head_sha=head-done remediation_target=none next_action=none summary=Pull request #718 is recorded for this issue run\.$/m,
+    /^timeline_event index=3 issue=#618 pr=#718 type=pr_created at=2026-04-25T11:40:00Z outcome=created head_sha=head-done remediation_target=none next_action=none summary=Pull request #718 is recorded for this issue run\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=3 issue=#618 pr=#718 type=merge at=2026-04-25T11:58:00Z outcome=merged head_sha=head-done remediation_target=none next_action=none summary=Pull request #718 is merged\.$/m,
+    /^timeline_event index=4 issue=#618 pr=#718 type=merge at=2026-04-25T11:58:00Z outcome=merged head_sha=head-done remediation_target=none next_action=none summary=Pull request #718 is merged\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=4 issue=#618 pr=#718 type=done at=2026-04-25T12:00:00Z outcome=done head_sha=head-done remediation_target=none next_action=none summary=Issue run is recorded as done\.$/m,
+    /^timeline_event index=5 issue=#618 pr=#718 type=terminal_state at=2026-04-25T12:00:00Z outcome=done head_sha=head-done remediation_target=none next_action=none summary=Issue run reached done\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=6 issue=#618 pr=#718 type=done at=2026-04-25T12:00:00Z outcome=done head_sha=head-done remediation_target=none next_action=none summary=Issue run is recorded as done\.$/m,
   );
 });
 
@@ -309,18 +317,22 @@ test("renderIssueExplainTimelineDto keeps sparse historical records readable", a
 
   const rendered = renderIssueExplainTimelineDto(dto);
 
-  assert.match(rendered, /^timeline issue=#619 pr=none events=11$/m);
+  assert.match(rendered, /^timeline issue=#619 pr=none events=17$/m);
   assert.match(
     rendered,
-    /^timeline_event index=2 issue=#619 pr=none type=codex_turn at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=No Codex turn summary is recorded for this issue run\.$/m,
+    /^timeline_event index=2 issue=#619 pr=none type=terminal_state at=2026-03-11T01:50:41\.997Z outcome=blocked head_sha=abcdef1 remediation_target=none next_action=operator_follow_up summary=Issue run reached blocked\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=5 issue=#619 pr=none type=local_ci at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=No local CI result is recorded for this issue run\.$/m,
+    /^timeline_event index=4 issue=#619 pr=none type=codex_turn at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=No Codex turn summary is recorded for this issue run\.$/m,
   );
   assert.match(
     rendered,
-    /^timeline_event index=11 issue=#619 pr=none type=done at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=Issue run is not recorded as done\.$/m,
+    /^timeline_event index=8 issue=#619 pr=none type=local_ci at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=No local CI result is recorded for this issue run\.$/m,
+  );
+  assert.match(
+    rendered,
+    /^timeline_event index=17 issue=#619 pr=none type=done at=unknown outcome=missing head_sha=unknown remediation_target=none next_action=none summary=Issue run is not recorded as done\.$/m,
   );
 });
 

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -550,11 +550,12 @@ export async function buildIssueExplainDto(
     preservedPartialWorkSummary: summarizePreservedPartialWork(record?.last_failure_context),
     runtimeFailureKind: record?.last_runtime_failure_kind ?? null,
     runtimeFailureSummary: record?.last_runtime_failure_context?.summary ?? null,
-    timeline: record ? buildIssueRunTimelineExport({ record, pr }) : null,
+    timeline: record ? buildIssueRunTimelineExport({ issue, record, pr, checks: explainChecks }) : null,
     auditBundle: buildOperatorAuditBundle({
       issue,
       record: record ?? null,
       pr,
+      checks: explainChecks,
       journalContent,
       staleConfiguredBotRemediation: staleReviewBotRemediation,
     }),

--- a/src/timeline-artifacts.test.ts
+++ b/src/timeline-artifacts.test.ts
@@ -4,7 +4,7 @@ import {
   buildIssueRunTimelineExport,
   formatTimelineArtifactStatusLine,
 } from "./timeline-artifacts";
-import { createPullRequest, createRecord } from "./turn-execution-test-helpers";
+import { createIssue, createPullRequest, createRecord } from "./turn-execution-test-helpers";
 
 test("formatTimelineArtifactStatusLine escapes multiline command and summary values", () => {
   const line = formatTimelineArtifactStatusLine({
@@ -106,6 +106,7 @@ test("buildIssueRunTimelineExport orders available major lifecycle events", () =
       ["review", "2026-04-25T10:08:00Z", "ready", null],
       ["merge", "2026-04-25T10:11:00Z", "merged", null],
       ["codex_turn", "2026-04-25T10:12:00Z", "completed", null],
+      ["terminal_state", "2026-04-25T10:12:00Z", "done", null],
       ["done", "2026-04-25T10:12:00Z", "done", null],
     ],
   );
@@ -120,6 +121,81 @@ test("buildIssueRunTimelineExport orders available major lifecycle events", () =
     remediation_target: null,
     next_action: null,
   });
+});
+
+test("buildIssueRunTimelineExport exposes the full post-merge evidence chain", () => {
+  const timeline = buildIssueRunTimelineExport({
+    issue: createIssue({
+      number: 1784,
+      updatedAt: "2026-04-26T01:00:00Z",
+      body: "## Summary\nBuild evidence timeline artifacts.\n\n## Verification\n- `npm test`\n",
+    }),
+    record: createRecord({
+      issue_number: 1784,
+      branch: "codex/issue-1784",
+      pr_number: 1800,
+      state: "done",
+      last_head_sha: "head-1784",
+      latest_local_ci_result: {
+        outcome: "passed",
+        summary: "npm test passed.",
+        ran_at: "2026-04-26T01:07:00Z",
+        head_sha: "head-1784",
+        execution_mode: "legacy_shell_string",
+        command: "npm test",
+        failure_class: null,
+        remediation_target: null,
+      },
+      local_review_run_at: "2026-04-26T01:10:00Z",
+      local_review_recommendation: "ready",
+      local_review_head_sha: "head-1784",
+      provider_success_observed_at: "2026-04-26T01:06:00Z",
+      provider_success_head_sha: "head-1784",
+      last_host_local_pr_blocker_comment_signature: "status-comment:cleared",
+      last_host_local_pr_blocker_comment_head_sha: "head-1784",
+      updated_at: "2026-04-26T01:20:00Z",
+    }),
+    pr: createPullRequest({
+      number: 1800,
+      createdAt: "2026-04-26T01:02:00Z",
+      updatedAt: "2026-04-26T01:05:00Z",
+      mergedAt: "2026-04-26T01:19:00Z",
+      headRefOid: "head-1784",
+      configuredBotCurrentHeadObservedAt: "2026-04-26T01:06:00Z",
+      configuredBotCurrentHeadStatusState: "COMMENTED",
+      currentHeadCiGreenAt: "2026-04-26T01:05:00Z",
+    }),
+    checks: [
+      { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+      { name: "test", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    ],
+    obsidianWriteback: {
+      outcome: "recorded",
+      summary: "Development history note was updated from the post-merge audit.",
+      recordedAt: "2026-04-26T01:21:00Z",
+      headSha: "head-1784",
+    },
+  });
+
+  assert.deepEqual(
+    timeline.events
+      .filter((event) => event.outcome !== "missing")
+      .map((event) => [event.event_type, event.timestamp, event.outcome, event.summary]),
+    [
+      ["reservation", null, "recorded", "Issue run reservation exists for branch codex/issue-1784."],
+      ["issue_body", "2026-04-26T01:00:00Z", "available", "Issue body snapshot is available from issue #1784."],
+      ["pr_created", "2026-04-26T01:02:00Z", "created", "Pull request #1800 is recorded for this issue run."],
+      ["github_ci", "2026-04-26T01:05:00Z", "passed", "GitHub CI evidence is green for 2 check(s): build, test."],
+      ["review_provider", "2026-04-26T01:06:00Z", "COMMENTED", "Configured review provider observed current head head-1784."],
+      ["local_ci", "2026-04-26T01:07:00Z", "passed", "npm test passed."],
+      ["review", "2026-04-26T01:10:00Z", "ready", "Local review recorded 0 finding(s)."],
+      ["merge", "2026-04-26T01:19:00Z", "merged", "Pull request #1800 is merged."],
+      ["status_comment", "2026-04-26T01:20:00Z", "published", "Tracked PR status comment evidence is recorded: status-comment:cleared."],
+      ["terminal_state", "2026-04-26T01:20:00Z", "done", "Issue run reached done."],
+      ["done", "2026-04-26T01:20:00Z", "done", "Issue run is recorded as done."],
+      ["obsidian_writeback", "2026-04-26T01:21:00Z", "recorded", "Development history note was updated from the post-merge audit."],
+    ],
+  );
 });
 
 test("buildIssueRunTimelineExport keeps sparse historical records explicit", () => {
@@ -145,15 +221,21 @@ test("buildIssueRunTimelineExport keeps sparse historical records explicit", () 
     timeline.events.map((event) => [event.event_type, event.timestamp, event.outcome, event.summary]),
     [
       ["reservation", null, "recorded", "Issue run reservation exists for branch codex/issue-102."],
+      ["issue_body", null, "missing", "No issue body snapshot is recorded for this issue run."],
       ["codex_turn", null, "missing", "No Codex turn summary is recorded for this issue run."],
       ["publication_gate", null, "missing", "No publication gate event is recorded for this issue run."],
       ["pr_created", null, "missing", "No pull request creation event is recorded for this issue run."],
+      ["github_ci", null, "missing", "No GitHub CI evidence is recorded for this issue run."],
       ["local_ci", null, "missing", "No local CI result is recorded for this issue run."],
       ["path_hygiene", null, "missing", "No workstation-local path hygiene result is recorded for this issue run."],
+      ["review_provider", null, "missing", "No review-provider signal is recorded for this issue run."],
       ["review", null, "missing", "No local review result is recorded for this issue run."],
       ["stale_review_metadata", null, "missing", "No stale review metadata handling event is recorded for this issue run."],
       ["recovery", null, "missing", "No recovery event is recorded for this issue run."],
       ["merge", null, "missing", "No merge event is recorded for this issue run."],
+      ["status_comment", null, "missing", "No tracked PR status comment evidence is recorded for this issue run."],
+      ["terminal_state", null, "missing", "Issue run has not reached done, blocked, waiting_ci, or manual_review."],
+      ["obsidian_writeback", null, "missing", "No Obsidian writeback evidence is recorded for this issue run."],
       ["done", null, "missing", "Issue run is not recorded as done."],
     ],
   );

--- a/src/timeline-artifacts.ts
+++ b/src/timeline-artifacts.ts
@@ -1,9 +1,11 @@
 import type {
   FailureContext,
+  GitHubIssue,
   GitHubPullRequest,
   IssueRunRecord,
   LatestLocalCiResult,
   LocalCiRemediationTarget,
+  PullRequestCheck,
   TimelineArtifact,
   TimelineArtifactGate,
   TimelineArtifactOutcome,
@@ -13,15 +15,21 @@ const MAX_TIMELINE_ARTIFACTS = 20;
 
 export type IssueRunTimelineEventType =
   | "reservation"
+  | "issue_body"
   | "codex_turn"
   | "publication_gate"
   | "pr_created"
+  | "github_ci"
   | "local_ci"
   | "path_hygiene"
+  | "review_provider"
   | "review"
   | "stale_review_metadata"
   | "recovery"
   | "merge"
+  | "status_comment"
+  | "terminal_state"
+  | "obsidian_writeback"
   | "done";
 
 export interface IssueRunTimelineEvent {
@@ -44,17 +52,31 @@ export interface IssueRunTimelineExport {
 
 const TIMELINE_EVENT_ORDER: IssueRunTimelineEventType[] = [
   "reservation",
+  "issue_body",
   "codex_turn",
   "publication_gate",
   "pr_created",
+  "github_ci",
   "local_ci",
   "path_hygiene",
+  "review_provider",
   "review",
   "stale_review_metadata",
   "recovery",
   "merge",
+  "status_comment",
+  "terminal_state",
+  "obsidian_writeback",
   "done",
 ];
+
+export interface IssueRunTimelineExternalEvidence {
+  outcome: string;
+  summary: string;
+  recordedAt: string | null;
+  headSha?: string | null;
+  nextAction?: string | null;
+}
 
 function escapeStatusLineValue(value: string): string {
   return value.replace(/\r\n|\r|\n/g, "\\n");
@@ -204,6 +226,162 @@ function timelineEventFromArtifact(record: IssueRunRecord, artifact: TimelineArt
   };
 }
 
+function checkEvidenceOutcome(checks: PullRequestCheck[]): "passed" | "failed" | "pending" | "skipped" | "unknown" {
+  if (checks.some((check) => check.bucket === "fail" || check.bucket === "cancel")) {
+    return "failed";
+  }
+  if (checks.some((check) => check.bucket === "pending")) {
+    return "pending";
+  }
+  if (checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping")) {
+    return checks.some((check) => check.bucket === "pass") ? "passed" : "skipped";
+  }
+  return "unknown";
+}
+
+function summarizeCheckNames(checks: PullRequestCheck[]): string {
+  return checks
+    .map((check) => check.name)
+    .filter((name) => name.trim() !== "")
+    .sort((left, right) => left.localeCompare(right))
+    .join(", ");
+}
+
+function buildGithubCiEvent(args: {
+  record: IssueRunRecord;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+}): IssueRunTimelineEvent | null {
+  if (args.checks.length > 0) {
+    const outcome = checkEvidenceOutcome(args.checks);
+    const names = summarizeCheckNames(args.checks);
+    return {
+      issue_number: args.record.issue_number,
+      pr_number: args.pr?.number ?? args.record.pr_number,
+      event_type: "github_ci",
+      timestamp: outcome === "passed"
+        ? args.pr?.currentHeadCiGreenAt ?? args.pr?.updatedAt ?? args.pr?.createdAt ?? null
+        : args.pr?.updatedAt ?? args.pr?.createdAt ?? null,
+      outcome,
+      summary: outcome === "passed"
+        ? `GitHub CI evidence is green for ${args.checks.length} check(s): ${names}.`
+        : `GitHub CI evidence is ${outcome} for ${args.checks.length} check(s): ${names}.`,
+      head_sha: args.pr?.headRefOid ?? args.record.last_head_sha,
+      remediation_target: null,
+      next_action: outcome === "passed" || outcome === "skipped" ? null : "inspect_github_checks",
+    };
+  }
+
+  if (args.pr?.currentHeadCiGreenAt) {
+    return {
+      issue_number: args.record.issue_number,
+      pr_number: args.pr.number,
+      event_type: "github_ci",
+      timestamp: args.pr.currentHeadCiGreenAt,
+      outcome: "passed",
+      summary: `GitHub CI evidence is green for head ${args.pr.headRefOid}.`,
+      head_sha: args.pr.headRefOid,
+      remediation_target: null,
+      next_action: null,
+    };
+  }
+
+  return null;
+}
+
+function buildReviewProviderEvent(record: IssueRunRecord, pr: GitHubPullRequest | null): IssueRunTimelineEvent | null {
+  if (pr?.configuredBotCurrentHeadObservedAt) {
+    return {
+      issue_number: record.issue_number,
+      pr_number: pr.number,
+      event_type: "review_provider",
+      timestamp: pr.configuredBotCurrentHeadObservedAt,
+      outcome: pr.configuredBotCurrentHeadStatusState ?? "observed",
+      summary: `Configured review provider observed current head ${pr.headRefOid}.`,
+      head_sha: pr.headRefOid,
+      remediation_target: null,
+      next_action: null,
+    };
+  }
+
+  if (record.provider_success_observed_at) {
+    return {
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "review_provider",
+      timestamp: record.provider_success_observed_at,
+      outcome: "observed",
+      summary: `Configured review provider success is recorded for head ${record.provider_success_head_sha ?? "unknown"}.`,
+      head_sha: record.provider_success_head_sha ?? null,
+      remediation_target: null,
+      next_action: null,
+    };
+  }
+
+  if (pr?.copilotReviewArrivedAt) {
+    return {
+      issue_number: record.issue_number,
+      pr_number: pr.number,
+      event_type: "review_provider",
+      timestamp: pr.copilotReviewArrivedAt,
+      outcome: "arrived",
+      summary: `Copilot review signal arrived for PR #${pr.number}.`,
+      head_sha: pr.headRefOid,
+      remediation_target: null,
+      next_action: null,
+    };
+  }
+
+  if (record.copilot_review_timed_out_at) {
+    return {
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "review_provider",
+      timestamp: record.copilot_review_timed_out_at,
+      outcome: "timed_out",
+      summary: record.copilot_review_timeout_reason ?? "Copilot review signal timed out.",
+      head_sha: record.copilot_review_requested_head_sha,
+      remediation_target: null,
+      next_action: record.copilot_review_timeout_action,
+    };
+  }
+
+  if (record.copilot_review_requested_observed_at) {
+    return {
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "review_provider",
+      timestamp: record.copilot_review_requested_observed_at,
+      outcome: "requested",
+      summary: "Copilot review request is recorded.",
+      head_sha: record.copilot_review_requested_head_sha,
+      remediation_target: null,
+      next_action: null,
+    };
+  }
+
+  return null;
+}
+
+function buildExternalEvidenceEvent(args: {
+  record: IssueRunRecord;
+  prNumber: number | null;
+  eventType: Extract<IssueRunTimelineEventType, "obsidian_writeback">;
+  evidence: IssueRunTimelineExternalEvidence;
+}): IssueRunTimelineEvent {
+  return {
+    issue_number: args.record.issue_number,
+    pr_number: args.prNumber,
+    event_type: args.eventType,
+    timestamp: args.evidence.recordedAt,
+    outcome: args.evidence.outcome,
+    summary: args.evidence.summary,
+    head_sha: args.evidence.headSha ?? args.record.last_head_sha,
+    remediation_target: null,
+    next_action: args.evidence.nextAction ?? null,
+  };
+}
+
 function sortTimelineEvents(left: IssueRunTimelineEvent, right: IssueRunTimelineEvent): number {
   if (left.event_type === "reservation" && right.event_type !== "reservation") {
     return -1;
@@ -224,11 +402,15 @@ function sortTimelineEvents(left: IssueRunTimelineEvent, right: IssueRunTimeline
 }
 
 export function buildIssueRunTimelineExport(args: {
+  issue?: Pick<GitHubIssue, "number" | "updatedAt" | "body"> | null;
   record: IssueRunRecord;
   pr?: GitHubPullRequest | null;
+  checks?: PullRequestCheck[];
+  obsidianWriteback?: IssueRunTimelineExternalEvidence | null;
 }): IssueRunTimelineExport {
   const { record } = args;
   const pr = args.pr ?? null;
+  const checks = args.checks ?? [];
   const events = new Map<IssueRunTimelineEventType, IssueRunTimelineEvent>();
 
   function setEvent(event: IssueRunTimelineEvent): void {
@@ -249,6 +431,22 @@ export function buildIssueRunTimelineExport(args: {
     remediation_target: null,
     next_action: null,
   });
+
+  if (args.issue) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "issue_body",
+      timestamp: args.issue.updatedAt,
+      outcome: args.issue.body && args.issue.body.trim() !== "" ? "available" : "missing",
+      summary: args.issue.body && args.issue.body.trim() !== ""
+        ? `Issue body snapshot is available from issue #${args.issue.number}.`
+        : `Issue #${args.issue.number} does not have a recorded body snapshot.`,
+      head_sha: null,
+      remediation_target: null,
+      next_action: args.issue.body && args.issue.body.trim() !== "" ? null : "inspect_issue_body",
+    });
+  }
 
   if (record.codex_session_id !== null || record.last_codex_summary !== null) {
     setEvent({
@@ -278,6 +476,11 @@ export function buildIssueRunTimelineExport(args: {
     });
   }
 
+  const githubCiEvent = buildGithubCiEvent({ record, pr, checks });
+  if (githubCiEvent) {
+    setEvent(githubCiEvent);
+  }
+
   for (const artifact of record.timeline_artifacts ?? []) {
     setEvent(timelineEventFromArtifact(record, artifact));
   }
@@ -304,6 +507,11 @@ export function buildIssueRunTimelineExport(args: {
       remediation_target: null,
       next_action: record.local_review_recommendation === "changes_requested" ? "address_review_findings" : null,
     });
+  }
+
+  const reviewProviderEvent = buildReviewProviderEvent(record, pr);
+  if (reviewProviderEvent) {
+    setEvent(reviewProviderEvent);
   }
 
   if (hasStaleReviewMetadataHandling(record)) {
@@ -349,6 +557,48 @@ export function buildIssueRunTimelineExport(args: {
     });
   }
 
+  if (record.last_host_local_pr_blocker_comment_signature != null) {
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "status_comment",
+      timestamp: record.updated_at,
+      outcome: "published",
+      summary: `Tracked PR status comment evidence is recorded: ${record.last_host_local_pr_blocker_comment_signature}.`,
+      head_sha: record.last_host_local_pr_blocker_comment_head_sha ?? null,
+      remediation_target: null,
+      next_action: null,
+    });
+  }
+
+  if (
+    record.state === "done" ||
+    record.state === "blocked" ||
+    record.state === "waiting_ci"
+  ) {
+    const outcome = record.state === "blocked" && record.blocked_reason === "manual_review" ? "manual_review" : record.state;
+    setEvent({
+      issue_number: record.issue_number,
+      pr_number: record.pr_number,
+      event_type: "terminal_state",
+      timestamp: record.updated_at,
+      outcome,
+      summary: `Issue run reached ${outcome}.`,
+      head_sha: record.last_head_sha,
+      remediation_target: null,
+      next_action: outcome === "done" ? null : "operator_follow_up",
+    });
+  }
+
+  if (args.obsidianWriteback) {
+    setEvent(buildExternalEvidenceEvent({
+      record,
+      prNumber: record.pr_number,
+      eventType: "obsidian_writeback",
+      evidence: args.obsidianWriteback,
+    }));
+  }
+
   if (record.state === "done") {
     setEvent({
       issue_number: record.issue_number,
@@ -365,15 +615,21 @@ export function buildIssueRunTimelineExport(args: {
 
   const missingSummaries: Record<IssueRunTimelineEventType, string> = {
     reservation: "No issue run reservation is recorded.",
+    issue_body: "No issue body snapshot is recorded for this issue run.",
     codex_turn: "No Codex turn summary is recorded for this issue run.",
     publication_gate: "No publication gate event is recorded for this issue run.",
     pr_created: "No pull request creation event is recorded for this issue run.",
+    github_ci: "No GitHub CI evidence is recorded for this issue run.",
     local_ci: "No local CI result is recorded for this issue run.",
     path_hygiene: "No workstation-local path hygiene result is recorded for this issue run.",
+    review_provider: "No review-provider signal is recorded for this issue run.",
     review: "No local review result is recorded for this issue run.",
     stale_review_metadata: "No stale review metadata handling event is recorded for this issue run.",
     recovery: "No recovery event is recorded for this issue run.",
     merge: "No merge event is recorded for this issue run.",
+    status_comment: "No tracked PR status comment evidence is recorded for this issue run.",
+    terminal_state: "Issue run has not reached done, blocked, waiting_ci, or manual_review.",
+    obsidian_writeback: "No Obsidian writeback evidence is recorded for this issue run.",
     done: "Issue run is not recorded as done.",
   };
 


### PR DESCRIPTION
## Summary
- Extend issue-run timeline artifacts with issue body, GitHub CI, review-provider, status-comment, terminal-state, and Obsidian writeback evidence events.
- Wire the typed timeline through explain, operator audit bundles, and post-merge audit artifacts.
- Keep missing evidence explicit and deterministic for downstream post-merge evaluation.

## Verification
- npx tsx --test src/timeline-artifacts.test.ts src/operator-audit-bundle.test.ts src/backend/webui-dashboard-browser-issue-details.test.ts src/supervisor/post-merge-audit-artifact.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/build.test.ts
- npm test

Part of #1784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced audit timeline with comprehensive event tracking including code reviews, CI checks, and external integrations.
  * Extended timeline now captures additional lifecycle events for improved visibility into issue and pull request progression.

* **Tests**
  * Updated test coverage to validate new timeline event types and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->