### PR TITLE
Phase 11.3: Add post-merge evaluator workflow

### DIFF
--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -480,7 +480,7 @@ function createStubService(args?: {
         args.postMergeAuditSummaryCalls = (args.postMergeAuditSummaryCalls ?? 0) + 1;
       }
       return {
-        schemaVersion: 5,
+        schemaVersion: 6,
         advisoryOnly: true,
         autoApplyGuardrails: false,
         autoCreateFollowUpIssues: false,
@@ -494,6 +494,17 @@ function createStubService(args?: {
         followUpCandidates: [],
         promotionCandidates: [],
         releaseNotesSources: [],
+        evaluatorWorkflow: {
+          advisoryOnly: true,
+          autoCreateFollowUpIssues: false,
+          followUpIssueCreationRequiresConfirmation: true,
+          reviewerSummary: "Reviewed 0 post-merge audit artifacts.",
+          evaluatorSummary: "No evaluator evidence was available.",
+          productSafetyFindings: [],
+          verificationNotes: [],
+          followUpIssueDrafts: [],
+          obsidianHistoryDraft: "",
+        },
       };
     },
     queryDoctor: async () => doctorDiagnostics,
@@ -646,7 +657,7 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
   assert.equal(postMergeAuditSummaryResponse.statusCode, 200);
   assert.equal(serviceArgs.postMergeAuditSummaryCalls, 1);
   assert.deepEqual(postMergeAuditSummaryResponse.body, {
-    schemaVersion: 5,
+    schemaVersion: 6,
     advisoryOnly: true,
     autoApplyGuardrails: false,
     autoCreateFollowUpIssues: false,
@@ -660,6 +671,17 @@ test("createSupervisorHttpServer serves read-only supervisor DTOs as JSON", asyn
     followUpCandidates: [],
     promotionCandidates: [],
     releaseNotesSources: [],
+    evaluatorWorkflow: {
+      advisoryOnly: true,
+      autoCreateFollowUpIssues: false,
+      followUpIssueCreationRequiresConfirmation: true,
+      reviewerSummary: "Reviewed 0 post-merge audit artifacts.",
+      evaluatorSummary: "No evaluator evidence was available.",
+      productSafetyFindings: [],
+      verificationNotes: [],
+      followUpIssueDrafts: [],
+      obsidianHistoryDraft: "",
+    },
   });
 
   const setupReadinessResponse = await readJson({ server, path: "/api/setup-readiness" });

--- a/src/supervisor/post-merge-audit-summary-runtime.test.ts
+++ b/src/supervisor/post-merge-audit-summary-runtime.test.ts
@@ -37,7 +37,7 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
           throw new Error("unexpected resetCorruptJsonState");
         },
         queryPostMergeAuditSummary: async () => ({
-          schemaVersion: 5,
+          schemaVersion: 6,
           advisoryOnly: true,
           autoApplyGuardrails: false,
           autoCreateFollowUpIssues: false,
@@ -51,6 +51,17 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
           followUpCandidates: [],
           promotionCandidates: [],
           releaseNotesSources: [],
+          evaluatorWorkflow: {
+            advisoryOnly: true,
+            autoCreateFollowUpIssues: false,
+            followUpIssueCreationRequiresConfirmation: true,
+            reviewerSummary: "Reviewed 0 post-merge audit artifacts.",
+            evaluatorSummary: "No evaluator evidence was available.",
+            productSafetyFindings: [],
+            verificationNotes: [],
+            followUpIssueDrafts: [],
+            obsidianHistoryDraft: "",
+          },
         }),
       },
       writeStdout: (line) => {
@@ -61,7 +72,7 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
 
   assert.equal(stdout.length, 1);
   assert.deepEqual(JSON.parse(stdout[0] ?? ""), {
-    schemaVersion: 5,
+    schemaVersion: 6,
     advisoryOnly: true,
     autoApplyGuardrails: false,
     autoCreateFollowUpIssues: false,
@@ -75,5 +86,16 @@ test("runSupervisorCommand renders a structured post-merge audit summary result"
     followUpCandidates: [],
     promotionCandidates: [],
     releaseNotesSources: [],
+    evaluatorWorkflow: {
+      advisoryOnly: true,
+      autoCreateFollowUpIssues: false,
+      followUpIssueCreationRequiresConfirmation: true,
+      reviewerSummary: "Reviewed 0 post-merge audit artifacts.",
+      evaluatorSummary: "No evaluator evidence was available.",
+      productSafetyFindings: [],
+      verificationNotes: [],
+      followUpIssueDrafts: [],
+      obsidianHistoryDraft: "",
+    },
   });
 });

--- a/src/supervisor/post-merge-audit-summary.test.ts
+++ b/src/supervisor/post-merge-audit-summary.test.ts
@@ -480,7 +480,7 @@ test("summarizePostMergeAuditPatterns aggregates recurring review, failure, and 
 
   assert.deepEqual(validatePostMergeAuditPatternSummary(summary), summary);
   assert.deepEqual(Object.keys(summary).sort(), [...POST_MERGE_AUDIT_PATTERN_SUMMARY_TOP_LEVEL_KEYS].sort());
-  assert.equal(summary.schemaVersion, 5);
+  assert.equal(summary.schemaVersion, 6);
   assert.equal(summary.advisoryOnly, true);
   assert.equal(summary.autoApplyGuardrails, false);
   assert.equal(summary.autoCreateFollowUpIssues, false);
@@ -575,7 +575,7 @@ test("summarizePostMergeAuditPatterns skips persisted artifacts missing trusted 
 
 test("validatePostMergeAuditPatternSummary rejects unsupported schema versions and missing required fields", () => {
   const summary = {
-    schemaVersion: 5,
+    schemaVersion: 6,
     generatedAt: "2026-03-25T00:00:00Z",
     artifactDir: "/tmp/post-merge",
     advisoryOnly: true,
@@ -589,20 +589,31 @@ test("validatePostMergeAuditPatternSummary rejects unsupported schema versions a
     followUpCandidates: [],
     promotionCandidates: [],
     releaseNotesSources: [],
+    evaluatorWorkflow: {
+      advisoryOnly: true,
+      autoCreateFollowUpIssues: false,
+      followUpIssueCreationRequiresConfirmation: true,
+      reviewerSummary: "Reviewed 0 post-merge audit artifacts.",
+      evaluatorSummary: "No evaluator evidence was available.",
+      productSafetyFindings: [],
+      verificationNotes: [],
+      followUpIssueDrafts: [],
+      obsidianHistoryDraft: "",
+    },
   } as const;
 
   assert.deepEqual(validatePostMergeAuditPatternSummary(summary), summary);
 
   assert.throws(
     () => validatePostMergeAuditPatternSummary({ ...summary, schemaVersion: 1 }),
-    /schemaVersion must be 5\./u,
+    /schemaVersion must be 6\./u,
   );
 
   const { promotionCandidates, ...summaryWithoutPromotionCandidates } = summary;
   void promotionCandidates;
   assert.throws(
     () => validatePostMergeAuditPatternSummary(summaryWithoutPromotionCandidates),
-    /summary must contain schemaVersion, generatedAt, artifactDir, advisoryOnly, autoApplyGuardrails, autoCreateFollowUpIssues, artifactsAnalyzed, artifactsSkipped, reviewPatterns, failurePatterns, recoveryPatterns, followUpCandidates, promotionCandidates, and releaseNotesSources\./u,
+    /summary must contain schemaVersion, generatedAt, artifactDir, advisoryOnly, autoApplyGuardrails, autoCreateFollowUpIssues, artifactsAnalyzed, artifactsSkipped, reviewPatterns, failurePatterns, recoveryPatterns, followUpCandidates, promotionCandidates, releaseNotesSources, and evaluatorWorkflow\./u,
   );
 });
 
@@ -925,6 +936,202 @@ test("summarizePostMergeAuditPatterns promotes missed focused test regressions i
       },
     },
   ]);
+});
+
+test("summarizePostMergeAuditPatterns builds confirm-required evaluator workflow handoff material", async () => {
+  const { reviewDir } = await createArtifactTestPaths("post-merge-audit-evaluator-workflow");
+  const config = createConfig({
+    localReviewArtifactDir: reviewDir,
+    repoSlug: "owner/repo",
+  });
+  const artifactDir = postMergeAuditArtifactDir(config);
+  const missArtifactPath = path.join(reviewDir, "owner-repo", "issue-102", "external-review-misses-head-merged-head.json");
+
+  await fs.mkdir(path.dirname(missArtifactPath), { recursive: true });
+  await fs.mkdir(artifactDir, { recursive: true });
+  await writeJsonAtomic(missArtifactPath, createExternalReviewMissArtifact());
+  await writeJsonAtomic(
+    path.join(artifactDir, "issue-102-head-merged-head.json"),
+    createPostMergeArtifact({
+      artifacts: {
+        executionMetricsSummaryPath: null,
+        localReviewSummaryPath: null,
+        localReviewFindingsPath: null,
+        externalReviewMissesPath: missArtifactPath,
+      },
+      operatorAuditBundle: {
+        schemaVersion: 1,
+        advisoryOnly: true,
+        issue: {
+          number: 102,
+          title: "Persist a completed-work audit artifact",
+          url: "https://example.test/issues/102",
+          state: "CLOSED",
+          createdAt: "2026-03-24T09:55:00Z",
+          updatedAt: "2026-03-24T10:06:00Z",
+          bodySnapshot: "## Summary\nPersist a completed-work audit artifact",
+        },
+        pullRequest: {
+          status: "available",
+          summary: "Evidence is available.",
+          value: {
+            number: 116,
+            title: "Persist completed-work audit artifact",
+            url: "https://example.test/pull/116",
+            state: "MERGED",
+            isDraft: false,
+            headRefName: "codex/issue-102",
+            headRefOid: "merged-head-116",
+            createdAt: "2026-03-24T10:03:00Z",
+            mergedAt: "2026-03-24T10:05:00Z",
+          },
+        },
+        stateRecord: {
+          status: "available",
+          summary: "Evidence is available.",
+          value: {
+            state: "done",
+            branch: "codex/issue-102",
+            prNumber: 116,
+            headSha: "merged-head-116",
+            blockedReason: null,
+            attempts: { total: 1, implementation: 1, repair: 0 },
+            lastError: null,
+            lastFailureKind: null,
+            lastFailureSignature: null,
+            updatedAt: "2026-03-24T10:06:00Z",
+          },
+        },
+        journal: {
+          status: "available",
+          summary: "Evidence is available.",
+          value: {
+            hypothesis: "Evaluator output should stay grounded in the merged PR evidence.",
+            whatChanged: "Persisted post-merge audit summary evidence.",
+            currentBlocker: "none",
+            nextExactStep: "Draft evaluator handoff.",
+            verificationGap: "none",
+            filesTouched: "src/supervisor/post-merge-audit-summary.ts",
+            rollbackConcern: "none",
+            lastFocusedCommand: "npx tsx --test src/supervisor/post-merge-audit-summary.test.ts",
+          },
+        },
+        localCi: {
+          status: "available",
+          summary: "Evidence is available.",
+          value: {
+            outcome: "passed",
+            command: "npm run build",
+            ran_at: "2026-03-24T10:04:00Z",
+            head_sha: "merged-head-116",
+            execution_mode: "shell",
+            summary: "Build passed.",
+            stderr_summary: null,
+            failure_class: null,
+            remediation_target: null,
+          },
+        },
+        pathHygiene: {
+          status: "missing",
+          summary: "No workstation-local path hygiene result is recorded for this issue run.",
+          value: null,
+        },
+        staleConfiguredBotRemediation: {
+          status: "missing",
+          summary: "No stale configured-bot remediation result is recorded for this issue run.",
+          value: null,
+        },
+        recoveryEvents: {
+          status: "missing",
+          summary: "No recovery event is recorded for this issue run.",
+          value: null,
+        },
+        timeline: null,
+        verificationCommands: {
+          status: "available",
+          summary: "Evidence is available.",
+          value: [
+            "npx tsx --test src/supervisor/post-merge-audit-summary.test.ts",
+            "npm run build",
+          ],
+        },
+      },
+    } as unknown as Partial<PostMergeAuditArtifact>),
+  );
+
+  const summary = await summarizePostMergeAuditPatterns(config);
+
+  assert.equal(summary.evaluatorWorkflow.advisoryOnly, true);
+  assert.equal(summary.evaluatorWorkflow.autoCreateFollowUpIssues, false);
+  assert.equal(summary.evaluatorWorkflow.followUpIssueCreationRequiresConfirmation, true);
+  assert.match(summary.evaluatorWorkflow.reviewerSummary, /issue #102/i);
+  assert.match(summary.evaluatorWorkflow.reviewerSummary, /PR #116/u);
+  assert.match(summary.evaluatorWorkflow.evaluatorSummary, /Build passed/u);
+  assert.deepEqual(summary.evaluatorWorkflow.productSafetyFindings, [
+    {
+      key: "correctness:medium:retry-path-reused-stale-review-context-after-the-head-changed",
+      severity: "medium",
+      summary: "Retry path reused stale review context after the head changed.",
+      evidenceIssueNumbers: [102],
+      evidenceFindingKeys: ["src/supervisor.ts|210|214|retry path|stale context"],
+    },
+  ]);
+  assert.deepEqual(summary.evaluatorWorkflow.verificationNotes, [
+    {
+      source: "local_ci",
+      summary: "Build passed.",
+      evidenceIssueNumber: 102,
+    },
+    {
+      source: "path_hygiene",
+      summary: "No workstation-local path hygiene result is recorded for this issue run.",
+      evidenceIssueNumber: 102,
+    },
+    {
+      source: "verification_command",
+      summary: "npx tsx --test src/supervisor/post-merge-audit-summary.test.ts",
+      evidenceIssueNumber: 102,
+    },
+    {
+      source: "verification_command",
+      summary: "npm run build",
+      evidenceIssueNumber: 102,
+    },
+  ]);
+  assert.deepEqual(summary.evaluatorWorkflow.followUpIssueDrafts, [
+    {
+      title: "Add regression coverage for execution-ready metadata hardening fixture drift",
+      body: [
+        "## Summary",
+        "Execution-ready metadata hardening can drift the recovery reconciliation fixture.",
+        "",
+        "## Scope",
+        "- Add focused regression coverage for `src/recovery-reconciliation.ts:412`.",
+        "- Keep the fix grounded in merged issue #102 / PR #116 evidence.",
+        "",
+        "## Acceptance criteria",
+        "- The missed regression is covered by a focused test.",
+        "- The follow-up remains scoped to the cited evidence.",
+        "",
+        "## Verification",
+        "- Run the focused regression test added for this follow-up.",
+        "",
+        "Depends on: none",
+        "Parallelizable: No",
+        "",
+        "## Execution order",
+        "1 of 1",
+      ].join("\n"),
+      confirmRequired: true,
+      autoCreate: false,
+      sourceFollowUpCandidateKey:
+        "test_regression:102:116:regression:src/recovery-reconciliation.ts:412:fixture-drift",
+    },
+  ]);
+  assert.match(
+    summary.evaluatorWorkflow.obsidianHistoryDraft,
+    /- Issue #102, PR #116: Persisted post-merge audit summary evidence\./u,
+  );
 });
 
 test("summarizePostMergeAuditPatterns ignores external review miss artifacts with malformed nullable evidence fields", async () => {

--- a/src/supervisor/post-merge-audit-summary.ts
+++ b/src/supervisor/post-merge-audit-summary.ts
@@ -10,7 +10,7 @@ import { hasMatchingPromotionIdentity } from "../persisted-artifact-promotion";
 import type { PostMergeAuditArtifact } from "./post-merge-audit-artifact";
 import { postMergeAuditArtifactDir } from "./post-merge-audit-artifact";
 
-export const POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION = 5;
+export const POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION = 6;
 export const POST_MERGE_AUDIT_PATTERN_SUMMARY_TOP_LEVEL_KEYS = [
   "schemaVersion",
   "generatedAt",
@@ -26,6 +26,7 @@ export const POST_MERGE_AUDIT_PATTERN_SUMMARY_TOP_LEVEL_KEYS = [
   "followUpCandidates",
   "promotionCandidates",
   "releaseNotesSources",
+  "evaluatorWorkflow",
 ] as const;
 const POST_MERGE_AUDIT_REVIEW_PATTERN_KEYS = [
   "key",
@@ -116,6 +117,36 @@ const POST_MERGE_AUDIT_RELEASE_NOTES_AUDIT_BUNDLE_KEYS = [
   "localCiSummary",
   "pathHygieneSummary",
   "journalSummary",
+] as const;
+const POST_MERGE_AUDIT_EVALUATOR_WORKFLOW_KEYS = [
+  "advisoryOnly",
+  "autoCreateFollowUpIssues",
+  "followUpIssueCreationRequiresConfirmation",
+  "reviewerSummary",
+  "evaluatorSummary",
+  "productSafetyFindings",
+  "verificationNotes",
+  "followUpIssueDrafts",
+  "obsidianHistoryDraft",
+] as const;
+const POST_MERGE_AUDIT_EVALUATOR_PRODUCT_SAFETY_FINDING_KEYS = [
+  "key",
+  "severity",
+  "summary",
+  "evidenceIssueNumbers",
+  "evidenceFindingKeys",
+] as const;
+const POST_MERGE_AUDIT_EVALUATOR_VERIFICATION_NOTE_KEYS = [
+  "source",
+  "summary",
+  "evidenceIssueNumber",
+] as const;
+const POST_MERGE_AUDIT_EVALUATOR_FOLLOW_UP_DRAFT_KEYS = [
+  "title",
+  "body",
+  "confirmRequired",
+  "autoCreate",
+  "sourceFollowUpCandidateKey",
 ] as const;
 
 export interface PostMergeAuditReviewPatternDto {
@@ -218,6 +249,39 @@ export interface PostMergeAuditReleaseNotesSourceDto {
   followUpCandidateKeys: string[];
 }
 
+export type PostMergeAuditEvaluatorVerificationNoteSourceDto =
+  | "local_ci"
+  | "path_hygiene"
+  | "verification_command";
+
+export interface PostMergeAuditEvaluatorWorkflowDto {
+  advisoryOnly: true;
+  autoCreateFollowUpIssues: false;
+  followUpIssueCreationRequiresConfirmation: true;
+  reviewerSummary: string;
+  evaluatorSummary: string;
+  productSafetyFindings: {
+    key: string;
+    severity: ActionableSeverity;
+    summary: string;
+    evidenceIssueNumbers: number[];
+    evidenceFindingKeys: string[];
+  }[];
+  verificationNotes: {
+    source: PostMergeAuditEvaluatorVerificationNoteSourceDto;
+    summary: string;
+    evidenceIssueNumber: number;
+  }[];
+  followUpIssueDrafts: {
+    title: string;
+    body: string;
+    confirmRequired: true;
+    autoCreate: false;
+    sourceFollowUpCandidateKey: string;
+  }[];
+  obsidianHistoryDraft: string;
+}
+
 export interface PostMergeAuditPatternSummaryDto {
   schemaVersion: typeof POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION;
   generatedAt: string;
@@ -233,6 +297,7 @@ export interface PostMergeAuditPatternSummaryDto {
   followUpCandidates: PostMergeAuditFollowUpCandidateDto[];
   promotionCandidates: PostMergeAuditPromotionCandidateDto[];
   releaseNotesSources: PostMergeAuditReleaseNotesSourceDto[];
+  evaluatorWorkflow: PostMergeAuditEvaluatorWorkflowDto;
 }
 
 function failSummaryValidation(message: string): never {
@@ -589,6 +654,129 @@ function expectReleaseNotesSource(
   };
 }
 
+function expectEvaluatorVerificationNoteSource(
+  value: unknown,
+  field: string,
+): PostMergeAuditEvaluatorVerificationNoteSourceDto {
+  if (value !== "local_ci" && value !== "path_hygiene" && value !== "verification_command") {
+    failSummaryValidation(`${field} must be one of: local_ci, path_hygiene, verification_command.`);
+  }
+
+  return value;
+}
+
+function expectEvaluatorProductSafetyFinding(
+  value: unknown,
+  index: number,
+): PostMergeAuditEvaluatorWorkflowDto["productSafetyFindings"][number] {
+  const finding = expectSummaryObject(value, `evaluatorWorkflow.productSafetyFindings[${index}]`);
+  expectExactKeys(
+    finding,
+    POST_MERGE_AUDIT_EVALUATOR_PRODUCT_SAFETY_FINDING_KEYS,
+    `evaluatorWorkflow.productSafetyFindings[${index}]`,
+  );
+  const severity = expectSummaryString(
+    finding.severity,
+    `evaluatorWorkflow.productSafetyFindings[${index}].severity`,
+  );
+  if (!isActionableSeverity(severity)) {
+    failSummaryValidation(`evaluatorWorkflow.productSafetyFindings[${index}].severity must be one of: low, medium, high.`);
+  }
+
+  return {
+    key: expectSummaryString(finding.key, `evaluatorWorkflow.productSafetyFindings[${index}].key`),
+    severity,
+    summary: expectSummaryString(finding.summary, `evaluatorWorkflow.productSafetyFindings[${index}].summary`),
+    evidenceIssueNumbers: expectIntegerArray(
+      finding.evidenceIssueNumbers,
+      `evaluatorWorkflow.productSafetyFindings[${index}].evidenceIssueNumbers`,
+    ),
+    evidenceFindingKeys: expectStringArray(
+      finding.evidenceFindingKeys,
+      `evaluatorWorkflow.productSafetyFindings[${index}].evidenceFindingKeys`,
+    ),
+  };
+}
+
+function expectEvaluatorVerificationNote(
+  value: unknown,
+  index: number,
+): PostMergeAuditEvaluatorWorkflowDto["verificationNotes"][number] {
+  const note = expectSummaryObject(value, `evaluatorWorkflow.verificationNotes[${index}]`);
+  expectExactKeys(note, POST_MERGE_AUDIT_EVALUATOR_VERIFICATION_NOTE_KEYS, `evaluatorWorkflow.verificationNotes[${index}]`);
+
+  return {
+    source: expectEvaluatorVerificationNoteSource(note.source, `evaluatorWorkflow.verificationNotes[${index}].source`),
+    summary: expectSummaryString(note.summary, `evaluatorWorkflow.verificationNotes[${index}].summary`),
+    evidenceIssueNumber: expectSummaryInteger(
+      note.evidenceIssueNumber,
+      `evaluatorWorkflow.verificationNotes[${index}].evidenceIssueNumber`,
+    ),
+  };
+}
+
+function expectEvaluatorFollowUpIssueDraft(
+  value: unknown,
+  index: number,
+): PostMergeAuditEvaluatorWorkflowDto["followUpIssueDrafts"][number] {
+  const draft = expectSummaryObject(value, `evaluatorWorkflow.followUpIssueDrafts[${index}]`);
+  expectExactKeys(draft, POST_MERGE_AUDIT_EVALUATOR_FOLLOW_UP_DRAFT_KEYS, `evaluatorWorkflow.followUpIssueDrafts[${index}]`);
+  if (draft.confirmRequired !== true) {
+    failSummaryValidation(`evaluatorWorkflow.followUpIssueDrafts[${index}].confirmRequired must be true.`);
+  }
+  if (draft.autoCreate !== false) {
+    failSummaryValidation(`evaluatorWorkflow.followUpIssueDrafts[${index}].autoCreate must be false.`);
+  }
+
+  return {
+    title: expectSummaryString(draft.title, `evaluatorWorkflow.followUpIssueDrafts[${index}].title`),
+    body: expectSummaryString(draft.body, `evaluatorWorkflow.followUpIssueDrafts[${index}].body`),
+    confirmRequired: true,
+    autoCreate: false,
+    sourceFollowUpCandidateKey: expectSummaryString(
+      draft.sourceFollowUpCandidateKey,
+      `evaluatorWorkflow.followUpIssueDrafts[${index}].sourceFollowUpCandidateKey`,
+    ),
+  };
+}
+
+function expectEvaluatorWorkflow(value: unknown): PostMergeAuditEvaluatorWorkflowDto {
+  const workflow = expectSummaryObject(value, "evaluatorWorkflow");
+  expectExactKeys(workflow, POST_MERGE_AUDIT_EVALUATOR_WORKFLOW_KEYS, "evaluatorWorkflow");
+  if (workflow.advisoryOnly !== true) {
+    failSummaryValidation("evaluatorWorkflow.advisoryOnly must be true.");
+  }
+  if (workflow.autoCreateFollowUpIssues !== false) {
+    failSummaryValidation("evaluatorWorkflow.autoCreateFollowUpIssues must be false.");
+  }
+  if (workflow.followUpIssueCreationRequiresConfirmation !== true) {
+    failSummaryValidation("evaluatorWorkflow.followUpIssueCreationRequiresConfirmation must be true.");
+  }
+  if (!Array.isArray(workflow.productSafetyFindings)) {
+    failSummaryValidation("evaluatorWorkflow.productSafetyFindings must be an array.");
+  }
+  if (!Array.isArray(workflow.verificationNotes)) {
+    failSummaryValidation("evaluatorWorkflow.verificationNotes must be an array.");
+  }
+  if (!Array.isArray(workflow.followUpIssueDrafts)) {
+    failSummaryValidation("evaluatorWorkflow.followUpIssueDrafts must be an array.");
+  }
+
+  return {
+    advisoryOnly: true,
+    autoCreateFollowUpIssues: false,
+    followUpIssueCreationRequiresConfirmation: true,
+    reviewerSummary: expectSummaryString(workflow.reviewerSummary, "evaluatorWorkflow.reviewerSummary"),
+    evaluatorSummary: expectSummaryString(workflow.evaluatorSummary, "evaluatorWorkflow.evaluatorSummary"),
+    productSafetyFindings: workflow.productSafetyFindings.map((finding, index) =>
+      expectEvaluatorProductSafetyFinding(finding, index)),
+    verificationNotes: workflow.verificationNotes.map((note, index) => expectEvaluatorVerificationNote(note, index)),
+    followUpIssueDrafts: workflow.followUpIssueDrafts.map((draft, index) =>
+      expectEvaluatorFollowUpIssueDraft(draft, index)),
+    obsidianHistoryDraft: expectSummaryString(workflow.obsidianHistoryDraft, "evaluatorWorkflow.obsidianHistoryDraft"),
+  };
+}
+
 export function validatePostMergeAuditPatternSummary(raw: unknown): PostMergeAuditPatternSummaryDto {
   const summary = expectSummaryObject(raw, "summary");
   expectExactKeys(summary, POST_MERGE_AUDIT_PATTERN_SUMMARY_TOP_LEVEL_KEYS, "summary");
@@ -638,6 +826,7 @@ export function validatePostMergeAuditPatternSummary(raw: unknown): PostMergeAud
     followUpCandidates: summary.followUpCandidates.map((candidate, index) => expectFollowUpCandidate(candidate, index)),
     promotionCandidates: summary.promotionCandidates.map((candidate, index) => expectPromotionCandidate(candidate, index)),
     releaseNotesSources: summary.releaseNotesSources.map((source, index) => expectReleaseNotesSource(source, index)),
+    evaluatorWorkflow: expectEvaluatorWorkflow(summary.evaluatorWorkflow),
   };
 }
 
@@ -1088,6 +1277,167 @@ function buildReleaseNotesSource(
   };
 }
 
+function formatIssueList(issueNumbers: number[]): string {
+  if (issueNumbers.length === 0) {
+    return "no merged issues";
+  }
+  return issueNumbers.map((issueNumber) => `#${issueNumber}`).join(", ");
+}
+
+function buildEvaluatorReviewerSummary(args: {
+  artifactsAnalyzed: number;
+  reviewPatterns: PostMergeAuditReviewPatternDto[];
+  followUpCandidates: PostMergeAuditFollowUpCandidateDto[];
+  releaseNotesSources: PostMergeAuditReleaseNotesSourceDto[];
+}): string {
+  const issueNumbers = args.releaseNotesSources.map((source) => source.issue.number).sort(compareNumbersAscending);
+  const prNumbers = args.releaseNotesSources.map((source) => source.pullRequest.number).sort(compareNumbersAscending);
+  const findingCount = args.reviewPatterns.length;
+  const followUpCount = args.followUpCandidates.length;
+  if (issueNumbers.length === 0 && prNumbers.length === 0) {
+    return [
+      `Reviewed ${args.artifactsAnalyzed} post-merge audit artifact(s).`,
+      `Found ${findingCount} product/safety finding pattern(s) and ${followUpCount} confirm-required follow-up draft(s).`,
+    ].join(" ");
+  }
+  const issueSummary = issueNumbers.length === 1 ? `issue #${issueNumbers[0]}` : `issues ${formatIssueList(issueNumbers)}`;
+  const prSummary = prNumbers.length === 1
+    ? `PR #${prNumbers[0]}`
+    : `PRs ${prNumbers.map((prNumber) => `#${prNumber}`).join(", ")}`;
+
+  return [
+    `Reviewed ${args.artifactsAnalyzed} post-merge audit artifact(s) for ${issueSummary} and ${prSummary}.`,
+    `Found ${findingCount} product/safety finding pattern(s) and ${followUpCount} confirm-required follow-up draft(s).`,
+  ].join(" ");
+}
+
+function buildEvaluatorSummary(args: {
+  releaseNotesSources: PostMergeAuditReleaseNotesSourceDto[];
+  reviewPatterns: PostMergeAuditReviewPatternDto[];
+  followUpCandidates: PostMergeAuditFollowUpCandidateDto[];
+}): string {
+  const evidenceLines = args.releaseNotesSources.flatMap((source) => [
+    source.auditBundle.localCiSummary,
+    source.auditBundle.pathHygieneSummary,
+    source.auditBundle.journalSummary,
+  ]).filter((line): line is string => !!line && line.trim().length > 0);
+  const firstEvidence = evidenceLines[0] ?? "No local CI or journal summary evidence was available.";
+
+  return [
+    firstEvidence,
+    `Evaluator output is grounded in ${args.releaseNotesSources.length} merged PR evidence source(s), ${args.reviewPatterns.length} product/safety finding pattern(s), and ${args.followUpCandidates.length} follow-up candidate(s).`,
+    "Follow-up issue creation remains confirm-required and is not automatic.",
+  ].join(" ");
+}
+
+function buildEvaluatorVerificationNotes(
+  releaseNotesSources: PostMergeAuditReleaseNotesSourceDto[],
+): PostMergeAuditEvaluatorWorkflowDto["verificationNotes"] {
+  const notes: PostMergeAuditEvaluatorWorkflowDto["verificationNotes"] = [];
+  for (const source of releaseNotesSources) {
+    if (source.auditBundle.localCiSummary) {
+      notes.push({
+        source: "local_ci",
+        summary: source.auditBundle.localCiSummary,
+        evidenceIssueNumber: source.issue.number,
+      });
+    }
+    if (source.auditBundle.pathHygieneSummary) {
+      notes.push({
+        source: "path_hygiene",
+        summary: source.auditBundle.pathHygieneSummary,
+        evidenceIssueNumber: source.issue.number,
+      });
+    }
+    for (const command of source.verificationCommands) {
+      notes.push({
+        source: "verification_command",
+        summary: command,
+        evidenceIssueNumber: source.issue.number,
+      });
+    }
+  }
+
+  return notes;
+}
+
+function buildFollowUpIssueDraftBody(candidate: PostMergeAuditFollowUpCandidateDto): string {
+  return [
+    "## Summary",
+    candidate.summary,
+    "",
+    "## Scope",
+    `- Add focused regression coverage for \`${candidate.evidence.file}:${candidate.evidence.line}\`.`,
+    `- Keep the fix grounded in merged issue #${candidate.evidence.mergedIssueNumber} / PR #${candidate.evidence.mergedPrNumber} evidence.`,
+    "",
+    "## Acceptance criteria",
+    "- The missed regression is covered by a focused test.",
+    "- The follow-up remains scoped to the cited evidence.",
+    "",
+    "## Verification",
+    "- Run the focused regression test added for this follow-up.",
+    "",
+    "Depends on: none",
+    "Parallelizable: No",
+    "",
+    "## Execution order",
+    "1 of 1",
+  ].join("\n");
+}
+
+function buildObsidianHistoryDraft(
+  releaseNotesSources: PostMergeAuditReleaseNotesSourceDto[],
+  followUpCandidates: PostMergeAuditFollowUpCandidateDto[],
+): string {
+  const lines = releaseNotesSources.map((source) => {
+    const journalSummary = source.auditBundle.journalSummary ?? "Post-merge audit evidence evaluated.";
+    const followUpCount = source.followUpCandidateKeys.length;
+    const suffix = followUpCount > 0
+      ? ` Follow-up drafts: ${followUpCount} confirm-required.`
+      : " Follow-up drafts: none.";
+    return `- Issue #${source.issue.number}, PR #${source.pullRequest.number}: ${journalSummary.replace(/\.$/u, "")}.${suffix}`;
+  });
+
+  if (followUpCandidates.length > 0) {
+    lines.push(
+      `- Confirm-required follow-up candidates: ${followUpCandidates.map((candidate) => candidate.title).join("; ")}.`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function buildEvaluatorWorkflow(args: {
+  artifactsAnalyzed: number;
+  reviewPatterns: PostMergeAuditReviewPatternDto[];
+  followUpCandidates: PostMergeAuditFollowUpCandidateDto[];
+  releaseNotesSources: PostMergeAuditReleaseNotesSourceDto[];
+}): PostMergeAuditEvaluatorWorkflowDto {
+  return {
+    advisoryOnly: true,
+    autoCreateFollowUpIssues: false,
+    followUpIssueCreationRequiresConfirmation: true,
+    reviewerSummary: buildEvaluatorReviewerSummary(args),
+    evaluatorSummary: buildEvaluatorSummary(args),
+    productSafetyFindings: args.reviewPatterns.map((pattern) => ({
+      key: pattern.key,
+      severity: pattern.severity,
+      summary: pattern.summary,
+      evidenceIssueNumbers: [...pattern.supportingIssueNumbers],
+      evidenceFindingKeys: [...pattern.supportingFindingKeys],
+    })),
+    verificationNotes: buildEvaluatorVerificationNotes(args.releaseNotesSources),
+    followUpIssueDrafts: args.followUpCandidates.map((candidate) => ({
+      title: candidate.title,
+      body: buildFollowUpIssueDraftBody(candidate),
+      confirmRequired: true,
+      autoCreate: false,
+      sourceFollowUpCandidateKey: candidate.key,
+    })),
+    obsidianHistoryDraft: buildObsidianHistoryDraft(args.releaseNotesSources, args.followUpCandidates),
+  };
+}
+
 export async function summarizePostMergeAuditPatterns(
   config: Pick<SupervisorConfig, "localReviewArtifactDir" | "repoSlug">,
 ): Promise<PostMergeAuditPatternSummaryDto> {
@@ -1303,6 +1653,9 @@ export async function summarizePostMergeAuditPatterns(
     right.evidence.mergedIssueNumber - left.evidence.mergedIssueNumber ||
     right.evidence.mergedPrNumber - left.evidence.mergedPrNumber ||
     compareStringsAscending(left.key, right.key));
+  const summarizedReleaseNotesSources = releaseNotesSources.sort((left, right) =>
+    right.issue.number - left.issue.number ||
+    right.pullRequest.number - left.pullRequest.number);
 
   return validatePostMergeAuditPatternSummary({
     schemaVersion: POST_MERGE_AUDIT_PATTERN_SUMMARY_SCHEMA_VERSION,
@@ -1318,9 +1671,13 @@ export async function summarizePostMergeAuditPatterns(
     recoveryPatterns: summarizedRecoveryPatterns,
     followUpCandidates: summarizedFollowUpCandidates,
     promotionCandidates,
-    releaseNotesSources: releaseNotesSources.sort((left, right) =>
-      right.issue.number - left.issue.number ||
-      right.pullRequest.number - left.pullRequest.number),
+    releaseNotesSources: summarizedReleaseNotesSources,
+    evaluatorWorkflow: buildEvaluatorWorkflow({
+      artifactsAnalyzed,
+      reviewPatterns: summarizedReviewPatterns,
+      followUpCandidates: summarizedFollowUpCandidates,
+      releaseNotesSources: summarizedReleaseNotesSources,
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary
- add schema v6 evaluatorWorkflow to summarize-post-merge-audits
- include reviewer/evaluator summaries, product/safety findings, verification notes, confirm-required follow-up issue drafts, and Obsidian history draft material
- keep follow-up issue creation advisory-only and confirm-required

## Verification
- npx tsx --test src/supervisor/post-merge-audit-summary.test.ts src/supervisor/post-merge-audit-summary-runtime.test.ts src/supervisor/post-merge-audit-artifact.test.ts src/operator-audit-bundle.test.ts
- npm run build
- npm run verify:paths
- npm test

Closes #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-merge audit system to schema version 6 with enhanced evaluator workflow configuration and validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->