### PR TITLE
Document Codex app Automation boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you want the setup flow, first-run commands, and operator decisions, start wi
 If you need to understand what to put in `supervisor.config.json`, jump straight to the [Configuration guide](./docs/configuration.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
 If you need the narrower freshness and durability contracts, use [Architecture](./docs/architecture.md) and [Configuration reference](./docs/configuration.md) instead of treating this README as the full runtime spec.
+If you use Codex app Automation around the loop, keep the [Codex app Automation boundary](./docs/automation.md) as the repo-owned contract: Automation orchestrates and records, while `codex-supervisor` remains the implementation executor.
 
 ## Who It Is For
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,8 @@ Today the supervisor invokes Codex with `--dangerously-bypass-approvals-and-sand
 
 The same fail-open vs fail-closed distinction applies to state recovery guidance: missing JSON state can bootstrap, but corrupted JSON state should be surfaced to the operator through diagnostics and recovery flow, not silently reused as if it were trustworthy state.
 
+Codex app Automation is an orchestration boundary around this loop. It can watch loop state, evaluate merges, draft confirm-required follow-up issues, and record Obsidian history, but codex-supervisor remains the implementation executor. Automation is not an executor replacement, and it must preserve quiet-when-no-change behavior, no destructive git operations, and the same issue metadata, path hygiene, review, branch, and merge safety gates described here.
+
 ## Main reconciliations
 
 - merged PR -> close issue

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,57 @@
+# Codex App Automation Boundary
+
+Codex app Automation may coordinate a `codex-supervisor` operating lane, but codex-supervisor remains the implementation executor. Automation is not an executor replacement and must not move loop ownership out of the supervisor.
+
+Use Automation for orchestration, review, follow-up issue drafting, and Obsidian
+record support around the loop. Keep the implementation turn, issue worktree,
+journal, PR lifecycle, CI repair loop, review handling, and merge safety inside
+the supervisor-owned flow.
+
+## Roles
+
+- Loop Watcher: reads roadmap, GitHub issue and PR state, local status, loop
+  runtime state, and supervisor diagnostics; reports only actionable changes.
+- Merge Evaluator: inspects recently merged work against the roadmap and local
+  repository state before declaring a phase complete or identifying a narrow
+  follow-up.
+- Follow-up Issue Creator: drafts a single behavior delta only after a concrete
+  unmet requirement is confirmed; issue creation is confirm-required and must
+  preserve canonical issue metadata.
+- Obsidian Recorder: updates external development history or operating notes
+  after real issue, PR, verification, or phase state changes.
+
+## Safety Contract
+
+Automation must stay quiet when there is no actionable change. It should not
+create status noise, issue churn, or durable notes merely because it ran.
+
+Follow-up issue creation is confirm-required. Automation can identify and draft
+follow-ups, but it must not make default-enabled follow-up issue creation the
+normal path.
+
+Automation must perform no destructive git operations. It must not discard local
+changes, reset branches, force-push, or repair broad path drift without explicit
+operator direction and a verified reason.
+
+Automation must respect core safety gates. Issue metadata, path-literal hygiene,
+fresh GitHub PR facts, review-provider boundaries, branch protection, head-SHA
+matching, local config drift, and fail-closed trust-boundary behavior remain
+supervisor requirements.
+
+## Explicit Non-Goals
+
+- Do not move implementation execution from `codex-supervisor` into Codex app
+  Automation.
+- Do not enable default-enabled follow-up issue creation.
+- Do not add metadata-only review auto-resolve.
+- Do not run broad path repair as an Automation default.
+- Do not broaden the solo automation lane into multi-user governance.
+
+## Portable References
+
+Repo-owned guidance should use repo-relative paths, documented environment
+variables, and placeholders such as `<codex-supervisor-root>` and
+`<supervisor-config-path>`. Durable examples should prefer commands like
+`node dist/index.js status --config <supervisor-config-path>` or
+`CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>` instead of host-local
+absolute paths.

--- a/src/automation-boundary-docs.test.ts
+++ b/src/automation-boundary-docs.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+test("repo guidance documents Codex app Automation as orchestration rather than executor replacement", async () => {
+  const [readme, architecture, automation] = await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/architecture.md"),
+    readRepoFile("docs/automation.md"),
+  ]);
+
+  assert.match(readme, /\[Codex app Automation boundary\]\(\.\/docs\/automation\.md\)/);
+  assert.match(architecture, /Codex app Automation is an orchestration boundary/i);
+
+  for (const content of [architecture, automation]) {
+    assert.match(content, /codex-supervisor remains the implementation executor/i);
+    assert.match(content, /Automation is not an executor replacement/i);
+  }
+
+  for (const role of ["Loop Watcher", "Merge Evaluator", "Follow-up Issue Creator", "Obsidian Recorder"]) {
+    assert.match(automation, new RegExp(role));
+  }
+
+  for (const requiredBoundary of [
+    /quiet when there is no actionable change/i,
+    /confirm-required/i,
+    /no destructive git operations/i,
+    /respect core safety gates/i,
+  ]) {
+    assert.match(automation, requiredBoundary);
+  }
+
+  for (const forbiddenExpansion of [
+    /default-enabled follow-up issue creation/i,
+    /metadata-only review auto-resolve/i,
+    /broad path repair/i,
+    /multi-user governance/i,
+  ]) {
+    assert.match(automation, forbiddenExpansion);
+  }
+
+  assert.doesNotMatch(automation, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(automation, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+});


### PR DESCRIPTION
## Summary
- add repo-owned Codex app Automation boundary guidance
- define Loop Watcher, Merge Evaluator, Follow-up Issue Creator, and Obsidian Recorder as orchestration roles, not executor replacement authority
- add a docs regression test for the boundary and safety non-goals

Closes #1787

## Verification
- npx tsx --test src/automation-boundary-docs.test.ts
- npm run verify:paths
- npm run build
- npm test

Note: attempted `node dist/index.js issue-lint 1787 --config supervisor.config.coderabbit.json`, but the checked-in profile in this worktree still has the placeholder `repoSlug`, so config parsing stopped before issue validation.