### PR TITLE
Document supervised automation lane primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ GitHub-authored issue bodies, PR review comments, and related GitHub text are ex
 If you want the setup flow, first-run commands, and operator decisions, start with [Getting started](./docs/getting-started.md).
 If you need to understand what to put in `supervisor.config.json`, jump straight to the [Configuration guide](./docs/configuration.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
+If you need the product primitive framing for the supervised lane beside chat-driven Codex work, read the [Supervised automation lane](./docs/supervised-automation-lane.md) note.
 If you need the narrower freshness and durability contracts, use [Architecture](./docs/architecture.md) and [Configuration reference](./docs/configuration.md) instead of treating this README as the full runtime spec.
 If you use Codex app Automation around the loop, keep the [Codex app Automation boundary](./docs/automation.md) as the repo-owned contract: Automation orchestrates and records, while `codex-supervisor` remains the implementation executor.
 
@@ -265,6 +266,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Configuration reference](./docs/configuration.md): config setup, provider profiles, model/reasoning controls, durable memory, and execution policy
 - [Operator dashboard](./docs/operator-dashboard.md): WebUI launch, panel meanings, safe commands, and browser smoke verification
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
+- [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat and vibe coding
 - [Architecture](./docs/architecture.md): core loop, durable state, reconciliations, and safety boundaries
 - [Issue metadata](./docs/issue-metadata.md): canonical issue-body fields, sequencing rules, and execution-ready examples
 - [GSD to GitHub issues](./docs/examples/gsd-to-github-issues.md): how to hand planning output into execution-ready issues

--- a/docs/supervised-automation-lane.md
+++ b/docs/supervised-automation-lane.md
@@ -32,7 +32,7 @@ Operator action is explicit human control over the lane. Examples include choosi
 
 ### Bounded Recovery
 
-Bounded recovery keeps failures inside the lane. The supervisor can retry known repair states, resume Codex sessions, preserve issue journals, reconcile PR state, and keep failed attempts observable. Recovery must stay fail closed: corrupted state, missing auth, ambiguous scope, stale review facts, or half-written durable state should block or require explicit operator handling rather than becoming a new source of authority.
+Bounded recovery keeps failures inside the lane. The supervisor can retry known repair states, resume Codex sessions, preserve issue journals, reconcile PR state, and keep failed attempts observable. Recovery must stay fail-closed: corrupted state, missing auth, ambiguous scope, stale review facts, or half-written durable state should block or require explicit operator handling rather than becoming a new source of authority.
 
 ### Durable Memory Writeback
 

--- a/docs/supervised-automation-lane.md
+++ b/docs/supervised-automation-lane.md
@@ -1,0 +1,71 @@
+# Supervised Automation Lane
+
+This note defines `codex-supervisor` as an OpenAI-ready product primitive: a supervised automation lane for issue/spec-driven implementation work. It describes the product shape operators can reason about before they look at implementation modules.
+
+The lane sits beside Codex app chat and vibe coding. Chat-driven vibe coding is useful when a human is steering one session directly, revising the prompt as the work unfolds, and deciding when the result is good enough. The supervised automation lane is for work that has already been reduced to an explicit task contract, dependency order, trust posture, and verification surface. The operator gives the lane bounded authority to keep one issue moving through worktree, PR, CI, review, and merge-readiness states without treating chat memory as the source of truth.
+
+This is not a broader autonomy pitch. The lane does not create new automation authority, does not default-enable follow-up issue creation, and does not broaden trusted solo-lane automation into multi-user governance.
+
+## Product Primitive
+
+The supervised automation lane is a durable execution wrapper around Codex turns. Its primitive is not a module or a background worker; it is a product contract with explicit inputs, authority boundaries, observable evidence, and bounded recovery.
+
+### Task Contract
+
+The task contract is the execution-ready GitHub issue. It names the behavior delta, scope, acceptance criteria, verification, dependencies, parallelization posture, and execution order. The issue body is an input to the lane, not a policy override. GitHub-authored text is execution input, not supervisor policy, and malformed or incomplete metadata should block or stay unrunnable instead of being inferred into a permissive plan.
+
+### Trust Posture
+
+The lane starts from an operator trust decision. The managed repo, local config, GitHub authors, review-provider text, and Codex execution environment must be trusted before autonomous execution is appropriate. The current runtime invokes Codex with elevated local authority, so the safe boundary is to choose the trusted lane before the turn starts rather than trying to recover trust after untrusted text has become execution input.
+
+### Execution Attempt
+
+An execution attempt is one bounded Codex turn against one selected issue in a dedicated worktree. The supervisor supplies current issue context, durable memory pointers, path-literal hygiene guidance, and the issue journal. The turn can change files, run focused verification, and produce a handoff, but it should not invent runtime authority or ignore the repo-owned safety boundaries.
+
+### Evidence Timeline
+
+The evidence timeline is the chain of facts that lets an operator or later session understand what happened. It includes issue state, branch and head SHA, worktree state, PR facts, checks, review facts, local verification, failure signatures, and the per-issue journal. Derived status text is an operator surface; action-taking paths should resolve from authoritative lifecycle records and fresh GitHub facts.
+
+### Operator Action
+
+Operator action is explicit human control over the lane. Examples include choosing the config, starting or stopping the loop, acknowledging corrupted state recovery, pruning orphaned workspaces, approving follow-up issue creation, or deciding that a trust prerequisite is missing. Operator action is a boundary, not an implementation convenience; the lane should surface real prerequisites instead of silently guessing them.
+
+### Bounded Recovery
+
+Bounded recovery keeps failures inside the lane. The supervisor can retry known repair states, resume Codex sessions, preserve issue journals, reconcile PR state, and keep failed attempts observable. Recovery must stay fail closed: corrupted state, missing auth, ambiguous scope, stale review facts, or half-written durable state should block or require explicit operator handling rather than becoming a new source of authority.
+
+### Durable Memory Writeback
+
+Durable memory writeback is the repo-owned and issue-owned context that survives thread loss. The issue journal records the current hypothesis, changes, blockers, verification gap, files touched, and next exact step. Shared memory files and docs provide longer-lived operating context. Writeback should be concise, factual, and anchored to current evidence so later Codex turns can continue from the lane state instead of reconstructing from chat.
+
+## Difference From Vibe Coding
+
+| Chat-driven vibe coding | Issue/spec-driven supervised automation |
+| --- | --- |
+| Human steers a live chat session | GitHub issue and repo state steer the next runnable action |
+| Chat history often carries the working plan | Issue metadata, worktree state, PR facts, and journal entries carry the plan |
+| Safety depends on the human watching each step | Safety depends on explicit trust posture, branch protection, review facts, and local verification gates |
+| Recovery often means starting another chat | Recovery resumes from durable state, issue journal, and bounded failure signatures |
+| Follow-up work is usually discussed inline | Follow-up issue creation remains confirm-required and narrow |
+
+## Authority Boundaries
+
+- GitHub-authored issue bodies, review comments, and summaries are untrusted execution inputs until the operator has chosen a trusted repo and author lane.
+- Codex app Automation may orchestrate around the lane, but `codex-supervisor` remains the implementation executor.
+- The lane does not create new automation authority beyond the operator-selected config and repo workflow.
+- The lane does not default-enable follow-up issue creation; follow-ups remain confirm-required and scoped to one behavior delta.
+- The lane should preserve trusted solo-lane automation and should not recast the product as broad multi-user governance.
+- Fresh PR review facts, branch protection, head-SHA matching, local path hygiene, and issue metadata remain safety surfaces.
+
+## Current Behavior Anchors
+
+Current `codex-supervisor` behavior already implements most of this product shape:
+
+- execution-ready issues are linted from canonical metadata before they are treated as runnable
+- each issue runs in a dedicated worktree with a persistent issue journal
+- the loop refreshes GitHub facts before action-taking PR and merge transitions
+- local state and journals provide recovery points across process restarts and thread loss
+- review, CI, and verification failures are kept in bounded repair states instead of being hidden
+- operator actions own setup, loop hosting, explicit recovery, and risky cleanup decisions
+
+Use this note as the product primitive contract. Use [Architecture](./architecture.md), [Configuration reference](./configuration.md), [Issue metadata](./issue-metadata.md), and [Codex app Automation boundary](./automation.md) for the detailed runtime and operator references.

--- a/src/supervised-automation-lane-docs.test.ts
+++ b/src/supervised-automation-lane-docs.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+test("supervised automation lane product primitive note is repo-owned and discoverable", async () => {
+  const [readme, note] = await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/supervised-automation-lane.md"),
+  ]);
+
+  assert.match(readme, /\[Supervised automation lane\]\(\.\/docs\/supervised-automation-lane\.md\)/);
+
+  assert.match(note, /^# Supervised Automation Lane$/m);
+  assert.match(note, /OpenAI-ready product primitive/i);
+  assert.match(note, /chat-driven vibe coding/i);
+  assert.match(note, /issue\/spec-driven supervised automation/i);
+
+  for (const primitive of [
+    "Task Contract",
+    "Trust Posture",
+    "Execution Attempt",
+    "Evidence Timeline",
+    "Operator Action",
+    "Bounded Recovery",
+    "Durable Memory Writeback",
+  ]) {
+    assert.match(note, new RegExp(`### ${primitive}`));
+  }
+
+  for (const boundary of [
+    /GitHub-authored text is execution input, not supervisor policy/i,
+    /does not create new automation authority/i,
+    /does not default-enable follow-up issue creation/i,
+    /trusted solo-lane automation/i,
+  ]) {
+    assert.match(note, boundary);
+  }
+
+  assert.doesNotMatch(note, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(note, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+});

--- a/src/supervised-automation-lane-docs.test.ts
+++ b/src/supervised-automation-lane-docs.test.ts
@@ -13,7 +13,11 @@ test("supervised automation lane product primitive note is repo-owned and discov
     readRepoFile("docs/supervised-automation-lane.md"),
   ]);
 
-  assert.match(readme, /\[Supervised automation lane\]\(\.\/docs\/supervised-automation-lane\.md\)/);
+  const laneLink = /\[Supervised automation lane\]\(\.\/docs\/supervised-automation-lane\.md\)/;
+  const docsMapIndex = readme.indexOf("## Docs Map");
+  assert.notEqual(docsMapIndex, -1, "README must include a Docs Map section");
+  assert.match(readme.slice(0, docsMapIndex), laneLink);
+  assert.match(readme.slice(docsMapIndex), laneLink);
 
   assert.match(note, /^# Supervised Automation Lane$/m);
   assert.match(note, /OpenAI-ready product primitive/i);


### PR DESCRIPTION
## Summary
- add a repo-owned supervised automation lane product primitive note
- link the note from the README overview and docs map
- add a focused docs test for primitive coverage and discoverability

## Verification
- npx tsx --test src/supervised-automation-lane-docs.test.ts
- npx tsx --test src/readme-docs.test.ts
- npm run verify:paths
- npm run build

Part of #1793
Fixes #1794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new page describing the supervised automation lane, authority boundaries, operator control points, execution/evidence lifecycle, and recovery behavior.
  * Updated README to link to the new documentation in the Docs Map and read-order guidance.

* **Tests**
  * Added a verification test to ensure the README links to the docs and that the new doc contains required headings, phrases, and no local filesystem paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->