### PR TITLE
Phase 12.4: Design explicit trust posture setup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,31 @@ The setup/readiness report stays `ready: false` until these required first-run b
 
 The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so operators must replace it before the first run.
 
+### Explicit trust posture setup
+
+Trust posture setup is a product primitive for trusted solo-lane automation. It packages the authority choices that decide whether the supervisor may turn GitHub-authored text, local repo state, review signals, and configured commands into autonomous Codex work.
+
+Treat these as operator-owned decisions:
+
+- repo trust: the managed repository is the repo you intend to let the supervisor mutate
+- author trust: the GitHub authors who can edit issues, review comments, and related execution text are trusted for that repo
+- sandbox posture: `executionSafetyMode` is chosen deliberately, especially when the runtime is unsandboxed autonomous execution
+- local CI posture: `localCiCommand` is absent, dismissed, or configured as the repo-owned fail-closed gate
+- review provider posture: `reviewBotLogins` and provider wait settings match the review source you intend to trust
+- auto-merge posture: merge progression remains bounded by branch protection, fresh PR facts, and the configured merge policy
+- follow-up issue posture: automatic follow-up issue creation stays disabled unless the operator explicitly wants that route
+
+Automation-owned decisions start only after those operator-owned decisions are explicit. The supervisor can lint issue metadata, report setup/readiness, run the configured local CI command, wait for configured review providers, block on stale or missing signals, and advance the loop inside the chosen posture. It should not expand authority by inferring trust from repo names, author comments, nearby config, provider presence, or detected scripts.
+
+Dangerous or authority-expanding choices remain explicit opt-ins. Unsandboxed autonomous execution, local CI as a publication gate, local review as a merge gate, high-severity auto-repair, automatic follow-up issue creation, and any auto-merge path must be visible config or operator action rather than hidden authority. Local CI and review-provider posture contribute to trust by adding observable gates and signals without becoming hidden authority: a detected script is advisory until configured, and provider activity matters only for the configured provider identities.
+
+Use the same vocabulary across setup/readiness, `doctor`, `status`, and WebUI:
+
+- setup/readiness answers whether the required trust posture fields are configured, missing, or invalid before first run
+- `doctor` reports host, state, local CI candidate, release-readiness, and config health without rewriting the trust decision
+- `status` reports the active issue, external signal readiness, loop runtime, and operator actions inside the chosen posture
+- WebUI setup edits the same config-backed fields and should not imply a separate run mode or broader authority
+
 Recommended model posture for a first operator profile:
 
 - keep `codexModelStrategy: "inherit"` so the supervisor follows the host Codex CLI/App default model

--- a/src/getting-started-docs.test.ts
+++ b/src/getting-started-docs.test.ts
@@ -104,6 +104,36 @@ test("getting-started defines setup readiness as a typed first-run contract dist
   assert.match(content, /explicit trust posture decisions/i);
 });
 
+test("getting-started defines explicit trust posture setup as a product primitive", async () => {
+  const content = await readGettingStarted();
+
+  assert.match(content, /^### Explicit trust posture setup$/m);
+  assert.match(content, /trust posture setup is a product primitive/i);
+
+  const requiredPostureSignals = [
+    "repo trust",
+    "author trust",
+    "sandbox posture",
+    "local CI posture",
+    "review provider posture",
+    "auto-merge posture",
+    "follow-up issue posture",
+  ];
+
+  for (const signal of requiredPostureSignals) {
+    assert.match(content, new RegExp(signal, "i"));
+  }
+
+  assert.match(content, /operator-owned decision/i);
+  assert.match(content, /automation-owned decision/i);
+  assert.match(content, /dangerous or authority-expanding choices/i);
+  assert.match(content, /explicit opt-ins/i);
+  assert.match(content, /local CI and review-provider posture contribute to trust/i);
+  assert.match(content, /without becoming hidden authority/i);
+  assert.match(content, /trusted solo-lane automation/i);
+  assert.match(content, /setup\/readiness, `doctor`, `status`, and WebUI/i);
+});
+
 test("getting-started protects the first-run command flow and operator action vocabulary", async () => {
   const content = await readGettingStarted();
 


### PR DESCRIPTION
## Summary
- add an explicit trust posture setup section to the getting-started guide
- distinguish operator-owned trust decisions from automation-owned behavior
- cover local CI, review provider, auto-merge, and follow-up issue authority as explicit posture choices

## Verification
- npx tsx --test src/getting-started-docs.test.ts
- npm run verify:paths
- rg -n 'Explicit trust posture setup|trust posture setup|repo trust|author trust|sandbox posture|local CI posture|review provider posture|auto-merge posture|follow-up issue posture|setup/readiness, `doctor`, `status`, and WebUI' docs/getting-started.md src/getting-started-docs.test.ts
- npm run build

Part of #1797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added getting started guide on explicit trust posture setup, detailing configuration options for CI integration, code review signals, auto-merge settings, sandboxing, and trust scope. Guide clarifies operator-controlled versus system-automated decision boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->