### PR TITLE
Fix queued ready-promotion path hygiene repairs

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -895,6 +895,48 @@ test("buildCodexPrompt suppresses stale handoff next actions during repairing_ci
   assert.match(prompt, /- Primary failure or risk: npm run build currently fails on the active branch\./);
 });
 
+test("buildCodexPrompt includes current structured path hygiene repair context during repairing_ci", () => {
+  const prompt = buildCodexPrompt({
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "repairing_ci" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+    journalExcerpt: `# Issue #46: Add a dedicated repair mode
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: A stale handoff says checks are green.
+- Next exact step: Leave the draft PR alone and wait.
+
+### Scratchpad
+- Keep this section short.`,
+    failureContext: {
+      category: "blocked",
+      summary:
+        "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: backend/app/features/auth/bridge.py.",
+      signature: "workstation-local-path-hygiene-failed",
+      command: "npm run verify:paths",
+      details: ["First fix: backend/app/features/auth/bridge.py (2 matches, Linux user home directory)."],
+      url: null,
+      updated_at: "2026-04-26T23:00:00Z",
+    },
+    previousSummary: "Checks are green.",
+    previousError: "wait_for_repair_turn",
+  });
+
+  assert.match(prompt, /Structured failure context:/);
+  assert.match(prompt, /Command\/source: npm run verify:paths/);
+  assert.match(prompt, /backend\/app\/features\/auth\/bridge\.py/);
+  assert.doesNotMatch(prompt, /Leave the draft PR alone and wait\./);
+});
+
 test("buildCodexPrompt suppresses structured next exact step guidance during local_review_fix without dropping later fields", () => {
   const prompt = buildCodexPrompt({
     repoSlug: "owner/repo",

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -37,6 +37,7 @@ import {
   reviewProviderWaitPolicyFromConfig,
 } from "./core/review-providers";
 import { nowIso } from "./core/utils";
+import { hasQueuedReadyPromotionPathHygieneRepair } from "./ready-promotion-path-hygiene-repair";
 
 const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
@@ -925,6 +926,10 @@ export function inferStateFromPullRequest(
 
   if (localReviewBlocksMerge(config, record, pr)) {
     return "blocked";
+  }
+
+  if (hasQueuedReadyPromotionPathHygieneRepair(record, pr)) {
+    return "repairing_ci";
   }
 
   if (pr.isDraft) {

--- a/src/ready-promotion-gate.ts
+++ b/src/ready-promotion-gate.ts
@@ -10,9 +10,7 @@ import {
   appendTimelineArtifact,
   buildPathHygieneTimelineArtifact,
 } from "./timeline-artifacts";
-
-export const READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY =
-  "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready.";
+import { READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY } from "./ready-promotion-path-hygiene-repair";
 
 export type ReadyPromotionPathHygieneDecision =
   | {

--- a/src/ready-promotion-path-hygiene-repair.ts
+++ b/src/ready-promotion-path-hygiene-repair.ts
@@ -43,9 +43,14 @@ function structuredRepairContext(record: IssueRunRecord): FailureContext | null 
 }
 
 function repairArtifactForHead(record: IssueRunRecord, pr: GitHubPullRequest): TimelineArtifact | null {
-  return (
-    record.timeline_artifacts ?? []
-  ).find((artifact) => repairQueuedArtifactForHead(artifact, pr)) ?? null;
+  const artifacts = record.timeline_artifacts ?? [];
+  for (let index = artifacts.length - 1; index >= 0; index -= 1) {
+    const artifact = artifacts[index];
+    if (artifact && repairQueuedArtifactForHead(artifact, pr)) {
+      return artifact;
+    }
+  }
+  return null;
 }
 
 export function queuedReadyPromotionPathHygieneRepairContext(
@@ -68,25 +73,20 @@ export function queuedReadyPromotionPathHygieneRepairContext(
     return null;
   }
 
-  const existingContext = structuredRepairContext(record);
-  if (existingContext !== null) {
-    return existingContext;
-  }
-
   const artifact = repairArtifactForHead(record, pr);
-  if (artifact === null) {
-    return null;
+  if (artifact !== null) {
+    return {
+      category: "blocked",
+      summary: artifact.summary,
+      signature: PATH_HYGIENE_SIGNATURE,
+      command: artifact.command,
+      details: (artifact.repair_targets ?? []).map((target) => `Actionable file: ${target}`),
+      url: null,
+      updated_at: artifact.recorded_at,
+    };
   }
 
-  return {
-    category: "blocked",
-    summary: artifact.summary,
-    signature: PATH_HYGIENE_SIGNATURE,
-    command: artifact.command,
-    details: (artifact.repair_targets ?? []).map((target) => `Actionable file: ${target}`),
-    url: null,
-    updated_at: artifact.recorded_at,
-  };
+  return structuredRepairContext(record);
 }
 
 export function hasQueuedReadyPromotionPathHygieneRepair(

--- a/src/ready-promotion-path-hygiene-repair.ts
+++ b/src/ready-promotion-path-hygiene-repair.ts
@@ -1,0 +1,97 @@
+import type { FailureContext, GitHubPullRequest, IssueRunRecord, TimelineArtifact } from "./core/types";
+
+const PATH_HYGIENE_SIGNATURE = "workstation-local-path-hygiene-failed";
+export const READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY =
+  "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready.";
+
+function matchesPathHygieneSignature(signature: string | null | undefined): boolean {
+  return typeof signature === "string" && signature.includes(PATH_HYGIENE_SIGNATURE);
+}
+
+function isCurrentHead(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  return (
+    record.last_head_sha === pr.headRefOid ||
+    record.last_observed_host_local_pr_blocker_head_sha === pr.headRefOid ||
+    record.last_host_local_pr_blocker_comment_head_sha === pr.headRefOid
+  );
+}
+
+function repairQueuedArtifactForHead(artifact: TimelineArtifact, pr: GitHubPullRequest): boolean {
+  return (
+    artifact.type === "path_hygiene_result" &&
+    artifact.gate === "workstation_local_path_hygiene" &&
+    artifact.outcome === "repair_queued" &&
+    artifact.remediation_target === "repair_already_queued" &&
+    artifact.head_sha === pr.headRefOid &&
+    (artifact.repair_targets?.length ?? 0) > 0
+  );
+}
+
+function hasStructuredRepairContext(record: IssueRunRecord): boolean {
+  const context = record.last_failure_context;
+  return (
+    context?.signature === PATH_HYGIENE_SIGNATURE &&
+    context.summary.includes(READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY) &&
+    context.summary.includes("Actionable files:") &&
+    context.command !== null &&
+    context.details.length > 0
+  );
+}
+
+function structuredRepairContext(record: IssueRunRecord): FailureContext | null {
+  return hasStructuredRepairContext(record) ? record.last_failure_context : null;
+}
+
+function repairArtifactForHead(record: IssueRunRecord, pr: GitHubPullRequest): TimelineArtifact | null {
+  return (
+    record.timeline_artifacts ?? []
+  ).find((artifact) => repairQueuedArtifactForHead(artifact, pr)) ?? null;
+}
+
+export function queuedReadyPromotionPathHygieneRepairContext(
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): FailureContext | null {
+  if (!pr.isDraft || pr.state !== "OPEN" || pr.mergedAt) {
+    return null;
+  }
+
+  if (!isCurrentHead(record, pr)) {
+    return null;
+  }
+
+  const hasPathHygieneSignature =
+    matchesPathHygieneSignature(record.last_failure_signature) ||
+    matchesPathHygieneSignature(record.last_observed_host_local_pr_blocker_signature) ||
+    matchesPathHygieneSignature(record.last_host_local_pr_blocker_comment_signature);
+  if (!hasPathHygieneSignature) {
+    return null;
+  }
+
+  const existingContext = structuredRepairContext(record);
+  if (existingContext !== null) {
+    return existingContext;
+  }
+
+  const artifact = repairArtifactForHead(record, pr);
+  if (artifact === null) {
+    return null;
+  }
+
+  return {
+    category: "blocked",
+    summary: artifact.summary,
+    signature: PATH_HYGIENE_SIGNATURE,
+    command: artifact.command,
+    details: (artifact.repair_targets ?? []).map((target) => `Actionable file: ${target}`),
+    url: null,
+    updated_at: artifact.recorded_at,
+  };
+}
+
+export function hasQueuedReadyPromotionPathHygieneRepair(
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): boolean {
+  return queuedReadyPromotionPathHygieneRepairContext(record, pr) !== null;
+}

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -828,13 +828,18 @@ export async function reconcileRecoverableBlockedIssueStates(
           buildRecoveryEvent,
         );
         const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);
+        const failureSignatureBaseRecord = {
+          ...record,
+          last_failure_signature: null,
+          repeated_failure_signature_count: 0,
+        };
         const updated = stateStore.touch(record, applyRecoveryEvent({
           state: "repairing_ci",
           blocked_reason: null,
           last_error: truncate(repairContext.summary, 1000),
           last_failure_kind: null,
           last_failure_context: repairContext,
-          last_failure_signature: repairContext.signature,
+          ...applyFailureSignature(failureSignatureBaseRecord, repairContext),
           last_blocker_signature: null,
           pr_number: trackedPullRequest.number,
           last_head_sha: trackedPullRequest.headRefOid,

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -60,6 +60,7 @@ import { buildTrackedPrStaleFailureConvergencePatch } from "./recovery-tracked-p
 import { mergeConflictDetected } from "./supervisor/supervisor-status-rendering";
 import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "./tracked-pr-ready-promotion-blocker";
+import { queuedReadyPromotionPathHygieneRepairContext } from "./ready-promotion-path-hygiene-repair";
 import { clearRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
 
 const OPERATOR_REQUEUEABLE_STATES = new Set<RunState>(["blocked", "failed"]);
@@ -816,6 +817,36 @@ export async function reconcileRecoverableBlockedIssueStates(
       record.pr_number !== null
     ) {
       const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);
+      const repairContext = trackedPullRequest
+        ? queuedReadyPromotionPathHygieneRepairContext(record, trackedPullRequest)
+        : null;
+      if (trackedPullRequest && repairContext) {
+        const recoveryEvent = buildTrackedPrResumeRecoveryEvent(
+          record,
+          trackedPullRequest,
+          "repairing_ci",
+          buildRecoveryEvent,
+        );
+        const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);
+        const updated = stateStore.touch(record, applyRecoveryEvent({
+          state: "repairing_ci",
+          blocked_reason: null,
+          last_error: truncate(repairContext.summary, 1000),
+          last_failure_kind: null,
+          last_failure_context: repairContext,
+          last_failure_signature: repairContext.signature,
+          last_blocker_signature: null,
+          pr_number: trackedPullRequest.number,
+          last_head_sha: trackedPullRequest.headRefOid,
+          codex_session_id: null,
+          ...headAdvanceResetPatch,
+        }, recoveryEvent));
+        state.issues[String(record.issue_number)] = updated;
+        changed = true;
+        recoveryEvents.push(recoveryEvent);
+        continue;
+      }
+
       if (!trackedPullRequest || trackedPullRequest.state !== "OPEN" || trackedPullRequest.mergedAt || !mergeConflictDetected(trackedPullRequest)) {
         continue;
       }

--- a/src/recovery-tracked-pr-reconciliation.test.ts
+++ b/src/recovery-tracked-pr-reconciliation.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { type IssueRunRecord, type SupervisorStateFile } from "./core/types";
 import { reconcileTrackedMergedButOpenIssues } from "./recovery-reconciliation";
-import { createConfig, createRecord } from "./supervisor/supervisor-test-helpers";
+import { createConfig, createPullRequest, createRecord } from "./supervisor/supervisor-test-helpers";
 
 test("reconcileTrackedMergedButOpenIssues default pass stops after recoverable tracked PR records in a mixed state", async () => {
   const recoverableRecords = [
@@ -155,6 +155,94 @@ test("reconcileTrackedMergedButOpenIssues preserves the historical done cursor w
   assert.deepEqual(prLookups, [901, 902]);
   assert.equal(saveCalls, 0);
   assert.equal(state.reconciliation_state?.tracked_merged_but_open_last_processed_issue_number, 324);
+});
+
+test("reconcileTrackedMergedButOpenIssues preserves queued ready-promotion path hygiene repairs", async () => {
+  const failureContext = {
+    category: "blocked" as const,
+    summary:
+      "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: backend/app/features/auth/bridge.py.",
+    signature: "workstation-local-path-hygiene-failed",
+    command: "npm run verify:paths",
+    details: ["First fix: backend/app/features/auth/bridge.py (2 matches, Linux user home directory)."],
+    url: null,
+    updated_at: "2026-04-26T23:00:00Z",
+  };
+  const record = createRecord({
+    issue_number: 315,
+    state: "repairing_ci",
+    branch: "codex/issue-315",
+    pr_number: 321,
+    blocked_reason: null,
+    last_head_sha: "head-ready",
+    last_failure_signature: failureContext.signature,
+    last_failure_context: failureContext,
+    last_observed_host_local_pr_blocker_signature: failureContext.signature,
+    last_observed_host_local_pr_blocker_head_sha: "head-ready",
+    timeline_artifacts: [
+      {
+        type: "path_hygiene_result",
+        gate: "workstation_local_path_hygiene",
+        command: "npm run verify:paths",
+        head_sha: "head-ready",
+        outcome: "repair_queued",
+        remediation_target: "repair_already_queued",
+        next_action: "wait_for_repair_turn",
+        summary: failureContext.summary,
+        recorded_at: "2026-04-26T23:00:00Z",
+        repair_targets: ["backend/app/features/auth/bridge.py"],
+      },
+    ],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: { "315": record },
+  };
+  let saveCalls = 0;
+
+  await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async () => createPullRequest({
+        number: 321,
+        state: "OPEN",
+        isDraft: true,
+        headRefName: "codex/issue-315",
+        headRefOid: "head-ready",
+        mergeStateStatus: "CLEAN",
+      }),
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-04-26T23:01:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    [],
+  );
+
+  assert.equal(saveCalls, 0);
+  assert.equal(state.issues["315"]?.state, "repairing_ci");
+  assert.equal(state.issues["315"]?.last_failure_context, failureContext);
 });
 
 test("reconcileTrackedMergedButOpenIssues emits a bounded backlog recovery event when historical tracked PR work is deferred", async () => {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   shouldRunCodex,
   summarizeTrackedPrProgress,
 } from "./supervisor-lifecycle";
+import { queuedReadyPromotionPathHygieneRepairContext } from "../ready-promotion-path-hygiene-repair";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -726,6 +727,64 @@ test("shouldRunCodex only returns true for actionable supervisor states", () => 
     ),
     true,
   );
+});
+
+test("queuedReadyPromotionPathHygieneRepairContext prefers the newest current-head artifact over cached context", () => {
+  const context = queuedReadyPromotionPathHygieneRepairContext(
+    createRecord({
+      state: "repairing_ci",
+      pr_number: 191,
+      last_head_sha: "head-ready",
+      last_failure_signature: "workstation-local-path-hygiene-failed",
+      last_failure_context: {
+        category: "blocked",
+        summary:
+          "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: stale/file.py.",
+        signature: "workstation-local-path-hygiene-failed",
+        command: "stale verify command",
+        details: ["Actionable file: stale/file.py"],
+        url: null,
+        updated_at: "2026-04-26T22:00:00Z",
+      },
+      timeline_artifacts: [
+        {
+          type: "path_hygiene_result",
+          gate: "workstation_local_path_hygiene",
+          command: "older verify command",
+          head_sha: "head-ready",
+          outcome: "repair_queued",
+          remediation_target: "repair_already_queued",
+          next_action: "wait_for_repair_turn",
+          summary:
+            "Ready-promotion path hygiene found actionable publishable tracked content. Actionable files: older/file.py.",
+          recorded_at: "2026-04-26T22:30:00Z",
+          repair_targets: ["older/file.py"],
+        },
+        {
+          type: "path_hygiene_result",
+          gate: "workstation_local_path_hygiene",
+          command: "npm run verify:paths",
+          head_sha: "head-ready",
+          outcome: "repair_queued",
+          remediation_target: "repair_already_queued",
+          next_action: "wait_for_repair_turn",
+          summary:
+            "Ready-promotion path hygiene found actionable publishable tracked content. Actionable files: current/file.py.",
+          recorded_at: "2026-04-26T23:00:00Z",
+          repair_targets: ["current/file.py"],
+        },
+      ],
+    }),
+    createPullRequest({ number: 191, isDraft: true, headRefOid: "head-ready" }),
+  );
+
+  assert.equal(
+    context?.summary,
+    "Ready-promotion path hygiene found actionable publishable tracked content. Actionable files: current/file.py.",
+  );
+  assert.equal(context?.command, "npm run verify:paths");
+  assert.deepEqual(context?.details, ["Actionable file: current/file.py"]);
+  assert.equal(context?.updated_at, "2026-04-26T23:00:00Z");
 });
 
 test("resetNoPrLifecycleFailureTracking preserves stale no-PR recovery tracking across queued-to-stabilizing cycles", () => {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -677,6 +677,47 @@ test("shouldRunCodex only returns true for actionable supervisor states", () => 
   );
   assert.equal(
     shouldRunCodex(
+      createRecord({
+        state: "repairing_ci",
+        pr_number: 191,
+        last_head_sha: "head-ready",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_failure_context: {
+          category: "blocked",
+          summary:
+            "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: backend/app/features/auth/bridge.py.",
+          signature: "workstation-local-path-hygiene-failed",
+          command: "npm run verify:paths",
+          details: ["First fix: backend/app/features/auth/bridge.py (2 matches, Linux user home directory)."],
+          url: null,
+          updated_at: "2026-04-26T23:00:00Z",
+        },
+        last_observed_host_local_pr_blocker_signature: "workstation-local-path-hygiene-failed",
+        last_observed_host_local_pr_blocker_head_sha: "head-ready",
+        timeline_artifacts: [
+          {
+            type: "path_hygiene_result",
+            gate: "workstation_local_path_hygiene",
+            command: "npm run verify:paths",
+            head_sha: "head-ready",
+            outcome: "repair_queued",
+            remediation_target: "repair_already_queued",
+            next_action: "wait_for_repair_turn",
+            summary: "Ready-promotion path hygiene found actionable publishable tracked content.",
+            recorded_at: "2026-04-26T23:00:00Z",
+            repair_targets: ["backend/app/features/auth/bridge.py"],
+          },
+        ],
+      }),
+      createPullRequest({ number: 191, isDraft: true, headRefOid: "head-ready" }),
+      checks,
+      reviewThreads,
+      config,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldRunCodex(
       createRecord({ state: "ready_to_merge", last_head_sha: "head-old" }),
       createPullRequest({ headRefOid: "head-new" }),
       checks,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -815,6 +815,119 @@ test("reconcileRecoverableBlockedIssueStates resumes conflicted tracked PR hando
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates resumes handoff-missing queued ready-promotion path hygiene repairs", async () => {
+  const failureContext = {
+    category: "blocked" as const,
+    summary:
+      "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: backend/app/features/auth/bridge.py.",
+    signature: "workstation-local-path-hygiene-failed",
+    command: "npm run verify:paths",
+    details: ["First fix: backend/app/features/auth/bridge.py (2 matches, Linux user home directory)."],
+    url: null,
+    updated_at: "2026-04-26T23:00:00Z",
+  };
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 315,
+        state: "blocked",
+        blocked_reason: "handoff_missing",
+        branch: "codex/issue-315",
+        pr_number: 321,
+        last_head_sha: "head-ready",
+        last_error: "Codex completed without updating the issue journal for issue #315.",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Codex completed without updating the issue journal for issue #315.",
+          signature: "handoff-missing",
+          command: null,
+          details: ["Update the Codex Working Notes section before ending the turn."],
+          url: null,
+          updated_at: "2026-04-26T23:01:00Z",
+        },
+        last_failure_signature: "handoff-missing",
+        last_observed_host_local_pr_blocker_signature: failureContext.signature,
+        last_observed_host_local_pr_blocker_head_sha: "head-ready",
+        timeline_artifacts: [
+          {
+            type: "path_hygiene_result",
+            gate: "workstation_local_path_hygiene",
+            command: "npm run verify:paths",
+            head_sha: "head-ready",
+            outcome: "repair_queued",
+            remediation_target: "repair_already_queued",
+            next_action: "wait_for_repair_turn",
+            summary: failureContext.summary,
+            recorded_at: "2026-04-26T23:00:00Z",
+            repair_targets: ["backend/app/features/auth/bridge.py"],
+          },
+        ],
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: 315,
+    title: "Ready promotion repair",
+    updatedAt: "2026-04-26T23:01:00Z",
+  });
+  const pr = createPullRequest({
+    number: 321,
+    state: "OPEN",
+    isDraft: true,
+    headRefName: "codex/issue-315",
+    headRefOid: "head-ready",
+    mergeStateStatus: "CLEAN",
+  });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-04-26T23:02:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createConfig(),
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["315"];
+  assert.equal(updated?.state, "repairing_ci");
+  assert.equal(updated?.blocked_reason, null);
+  assert.equal(updated?.last_failure_context?.summary, failureContext.summary);
+  assert.equal(updated?.last_failure_context?.command, "npm run verify:paths");
+  assert.deepEqual(updated?.last_failure_context?.details, [
+    "Actionable file: backend/app/features/auth/bridge.py",
+  ]);
+  assert.equal(updated?.last_failure_signature, failureContext.signature);
+  assert.equal(updated?.last_error, failureContext.summary);
+  assert.equal(saveCalls, 1);
+  assert.match(recoveryEvents[0]?.reason ?? "", /tracked_pr_lifecycle_recovered/);
+});
+
 test("reconcileRecoverableBlockedIssueStates clears stale tracked-PR review state when a conflicted handoff-missing PR advances heads", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = createSupervisorState({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -846,6 +846,7 @@ test("reconcileRecoverableBlockedIssueStates resumes handoff-missing queued read
           updated_at: "2026-04-26T23:01:00Z",
         },
         last_failure_signature: "handoff-missing",
+        repeated_failure_signature_count: 4,
         last_observed_host_local_pr_blocker_signature: failureContext.signature,
         last_observed_host_local_pr_blocker_head_sha: "head-ready",
         timeline_artifacts: [
@@ -923,6 +924,7 @@ test("reconcileRecoverableBlockedIssueStates resumes handoff-missing queued read
     "Actionable file: backend/app/features/auth/bridge.py",
   ]);
   assert.equal(updated?.last_failure_signature, failureContext.signature);
+  assert.equal(updated?.repeated_failure_signature_count, 1);
   assert.equal(updated?.last_error, failureContext.summary);
   assert.equal(saveCalls, 1);
   assert.match(recoveryEvents[0]?.reason ?? "", /tracked_pr_lifecycle_recovered/);

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -23,6 +23,7 @@ import {
 } from "../remediation-targets";
 import { projectTrackedPrLifecycle } from "../tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "../tracked-pr-ready-promotion-blocker";
+import { hasQueuedReadyPromotionPathHygieneRepair } from "../ready-promotion-path-hygiene-repair";
 import { formatTimelineArtifactStatusLine } from "../timeline-artifacts";
 import {
   classifyReadyPromotionRecoverability,
@@ -300,28 +301,18 @@ export function buildTrackedPrMismatch(
     return null;
   }
 
-  const projection = projectTrackedPrLifecycle({
-    config,
-    record,
-    pr,
-    checks,
-    reviewThreads,
-  });
-  const githubState = projection.nextState;
-  const githubBlockedReason = projection.nextBlockedReason;
-
   if (
     record.state === "repairing_ci" &&
     record.last_failure_signature === "workstation-local-path-hygiene-failed" &&
-    githubState === "draft_pr" &&
-    pr.isDraft
+    pr.isDraft &&
+    hasQueuedReadyPromotionPathHygieneRepair(record, pr)
   ) {
     const readyPromotionGate = readyPromotionGateSummary(config, record, pr, checks);
     return {
       issueNumber: record.issue_number,
       prNumber: pr.number,
-      githubState,
-      githubBlockedReason,
+      githubState: "draft_pr",
+      githubBlockedReason: null,
       localState: record.state,
       localBlockedReason: record.blocked_reason,
       staleLocalBlocker: false,
@@ -331,7 +322,7 @@ export function buildTrackedPrMismatch(
         `issue=#${record.issue_number}`,
         `pr=#${pr.number}`,
         recoverabilityStatusToken("repair_queued"),
-        `github_state=${githubState}`,
+        "github_state=draft_pr",
         `local_state=${record.state}`,
         `local_blocked_reason=${record.blocked_reason ?? "none"}`,
         "stale_local_blocker=no",
@@ -342,6 +333,16 @@ export function buildTrackedPrMismatch(
       detailLines: readyPromotionGate.detailLines,
     };
   }
+
+  const projection = projectTrackedPrLifecycle({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
+  const githubState = projection.nextState;
+  const githubBlockedReason = projection.nextBlockedReason;
 
   const mismatch =
     isBlockedLikeState(record.state) &&


### PR DESCRIPTION
## Summary
- keep queued ready-promotion path hygiene repairs actionable instead of converging them back to passive draft PR state
- restore structured path hygiene repair context when handoff-missing recovery resumes the queued repair
- cover lifecycle, tracked-PR reconciliation, blocked recovery, and prompt context regressions

Fixes #1804

## Verification
- npx tsx --test src/ready-promotion-gate.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/codex/codex-prompt.test.ts
- npx tsx --test src/supervisor/supervisor-lifecycle.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/codex/codex-prompt.test.ts src/ready-promotion-gate.test.ts
- npm run build
- npm run verify:paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure open draft PRs with queued path-hygiene repairs resume recovery and transition to a repairing CI state, clearing stale block markers and preserving actionable failure context.
  * Prevent stalled handoffs by detecting queued repairs and avoiding incorrect waiting behavior.

* **Tests**
  * Added tests for prompt generation with structured failure context, repair artifact selection, and recovery/reconciliation flows for draft PR repair scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->