### PR TITLE
Add ready-promotion gate matrix test

### DIFF
--- a/src/ready-promotion-gate.test.ts
+++ b/src/ready-promotion-gate.test.ts
@@ -1,9 +1,146 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createFailureContext, createPullRequest, createRecord } from "./turn-execution-test-helpers";
-import { deriveReadyPromotionPathHygieneDecision } from "./ready-promotion-gate";
+import {
+  deriveReadyPromotionPathHygieneDecision,
+  type ReadyPromotionPathHygieneDecision,
+} from "./ready-promotion-gate";
+import { type WorkstationLocalPathGateResult } from "./workstation-local-path-gate";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
+
+function applyFailureSignature(
+  _record: Parameters<typeof deriveReadyPromotionPathHygieneDecision>[0]["record"],
+  context: Parameters<typeof deriveReadyPromotionPathHygieneDecision>[0]["gate"]["failureContext"],
+) {
+  return {
+    last_failure_signature: context?.signature ?? null,
+    repeated_failure_signature_count: context ? 1 : 0,
+  };
+}
+
+function deriveDecision(args: {
+  gate: WorkstationLocalPathGateResult;
+  fallbackSummary?: string;
+}): ReadyPromotionPathHygieneDecision {
+  return deriveReadyPromotionPathHygieneDecision({
+    record: createRecord({ state: "draft_pr" }),
+    pr: createPullRequest({ isDraft: true, headRefOid: "head-116" }),
+    gate: args.gate,
+    fallbackSummary: args.fallbackSummary ?? "fallback ready-promotion gate failure",
+    applyFailureSignature,
+  });
+}
+
+test("ready-promotion path hygiene gate matrix protects draft promotion safety transitions", async (t) => {
+  const failureContext = {
+    ...createFailureContext("Tracked durable artifacts failed workstation-local path hygiene before marking PR #116 ready."),
+    signature: "workstation-local-path-hygiene-failed",
+    command: "npm run verify:paths",
+    details: [`docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`],
+  };
+  const cases: {
+    name: string;
+    gate: WorkstationLocalPathGateResult;
+    expected: {
+      kind: ReadyPromotionPathHygieneDecision["kind"];
+      state?: string;
+      blockedReason?: string | null;
+      remediationTarget?: string;
+      rewrittenTrackedPaths?: string[];
+      lastFailureSignature?: string | null;
+      lastErrorPattern?: RegExp;
+    };
+  }[] = [
+    {
+      name: "clean gate keeps the draft ready-promotion path open",
+      gate: { ok: true, failureContext: null },
+      expected: {
+        kind: "passed",
+        rewrittenTrackedPaths: [],
+      },
+    },
+    {
+      name: "clean gate returns normalized durable artifacts before promotion",
+      gate: {
+        ok: true,
+        failureContext: null,
+        rewrittenJournalPaths: [".codex-supervisor/issue-journal.md"],
+        rewrittenTrustedGeneratedArtifactPaths: ["docs/generated-summary.md"],
+      },
+      expected: {
+        kind: "passed",
+        rewrittenTrackedPaths: [".codex-supervisor/issue-journal.md", "docs/generated-summary.md"],
+      },
+    },
+    {
+      name: "actionable path hygiene blocker queues repair instead of marking ready",
+      gate: {
+        ok: false,
+        failureContext,
+        actionablePublishableFilePaths: ["docs/guide.md"],
+      },
+      expected: {
+        kind: "repair",
+        state: "repairing_ci",
+        blockedReason: null,
+        remediationTarget: "repair_already_queued",
+        lastFailureSignature: "workstation-local-path-hygiene-failed",
+        lastErrorPattern: /will retry a repair turn/i,
+      },
+    },
+    {
+      name: "non-actionable path hygiene blocker requires manual verification",
+      gate: {
+        ok: false,
+        failureContext,
+        actionablePublishableFilePaths: [],
+      },
+      expected: {
+        kind: "manual_review",
+        state: "blocked",
+        blockedReason: "verification",
+        remediationTarget: "manual_review",
+        lastFailureSignature: "workstation-local-path-hygiene-failed",
+        lastErrorPattern: /Tracked durable artifacts failed workstation-local path hygiene/,
+      },
+    },
+    {
+      name: "malformed failed gate without failure context fails closed to manual verification",
+      gate: {
+        ok: false,
+        failureContext: null,
+        actionablePublishableFilePaths: ["docs/guide.md"],
+      },
+      expected: {
+        kind: "manual_review",
+        state: "blocked",
+        blockedReason: "verification",
+        remediationTarget: "manual_review",
+        lastFailureSignature: null,
+        lastErrorPattern: /fallback ready-promotion gate failure/,
+      },
+    },
+  ];
+
+  for (const matrixCase of cases) {
+    await t.test(matrixCase.name, () => {
+      const decision = deriveDecision({ gate: matrixCase.gate });
+
+      assert.equal(decision.kind, matrixCase.expected.kind);
+      if (decision.kind === "passed") {
+        assert.deepEqual(decision.rewrittenTrackedPaths, matrixCase.expected.rewrittenTrackedPaths);
+        return;
+      }
+
+      assert.equal(decision.recordPatch.state, matrixCase.expected.state);
+      assert.equal(decision.recordPatch.blocked_reason, matrixCase.expected.blockedReason);
+      assert.equal(decision.recordPatch.last_failure_signature, matrixCase.expected.lastFailureSignature);
+      assert.equal(decision.comment.remediationTarget, matrixCase.expected.remediationTarget);
+      assert.match(decision.recordPatch.last_error ?? "", matrixCase.expected.lastErrorPattern ?? /./);
+    });
+  }
+});
 
 test("deriveReadyPromotionPathHygieneDecision routes actionable path hygiene blockers to repair", () => {
   const record = createRecord({ state: "draft_pr" });


### PR DESCRIPTION
## Summary
- Add a compact ready-promotion path hygiene gate transition matrix at the unit boundary
- Cover clean pass-through, normalized artifact pass-through, repair queueing, manual-review blocking, and malformed failed-gate fail-closed behavior
- Leave production behavior unchanged

## Verification
- ./node_modules/.bin/tsx --test src/ready-promotion-gate.test.ts src/post-turn-pull-request.test.ts
- npm run build
- npm run verify:paths

Closes #1808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive matrix-based test coverage for promotion gate outcomes.
  * Introduced reusable test helpers for consistent gate failure scenario validation.
  * Enhanced coverage for decision types and error handling across clean, repair, and manual review paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->