### PR TITLE
Add WebUI mutation auth invariant test

### DIFF
--- a/src/backend/supervisor-http-server.test.ts
+++ b/src/backend/supervisor-http-server.test.ts
@@ -1185,6 +1185,132 @@ test("createSupervisorHttpServer rejects cross-origin mutation requests before s
   assert.deepEqual(setupConfigUpdateCalls, []);
 });
 
+test("createSupervisorHttpServer requires token, loopback http Origin, and matching Host port for mutations", async (t) => {
+  const setupConfigUpdateCalls: Array<unknown> = [];
+  const server = createSupervisorHttpServer({
+    service: createStubService({ setupConfigUpdateCalls }),
+    mutationAuth: testMutationAuth,
+  });
+  t.after(async () => {
+    await closeServer(server);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.on("error", reject);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected server to listen on an ephemeral port.");
+  }
+
+  const localHost = `127.0.0.1:${address.port}`;
+  const localOrigin = `http://${localHost}`;
+  const setupConfigWriteBody = JSON.stringify({
+    changes: {
+      reviewProvider: "codex",
+    },
+  });
+  const validHeaders = {
+    Host: localHost,
+    Origin: localOrigin,
+    "Content-Type": "application/json",
+    [WEBUI_MUTATION_AUTH_HEADER]: testMutationAuth.token,
+  };
+
+  const acceptedResponse = await readJson({
+    server,
+    path: "/api/setup-config",
+    method: "POST",
+    headers: validHeaders,
+    body: setupConfigWriteBody,
+  });
+
+  assert.equal(acceptedResponse.statusCode, 200);
+  assert.equal(setupConfigUpdateCalls.length, 1);
+
+  const rejectionCases: Array<{
+    name: string;
+    headers: http.OutgoingHttpHeaders;
+    statusCode: number;
+  }> = [
+    {
+      name: "token-only",
+      headers: {
+        Host: localHost,
+        "Content-Type": "application/json",
+        [WEBUI_MUTATION_AUTH_HEADER]: testMutationAuth.token,
+      },
+      statusCode: 403,
+    },
+    {
+      name: "origin-only",
+      headers: {
+        Host: localHost,
+        Origin: localOrigin,
+        "Content-Type": "application/json",
+      },
+      statusCode: 401,
+    },
+    {
+      name: "host-only",
+      headers: {
+        Host: localHost,
+        "Content-Type": "application/json",
+      },
+      statusCode: 401,
+    },
+    {
+      name: "non-loopback host",
+      headers: {
+        ...validHeaders,
+        Host: `example.test:${address.port}`,
+      },
+      statusCode: 403,
+    },
+    {
+      name: "non-http origin",
+      headers: {
+        ...validHeaders,
+        Origin: `https://${localHost}`,
+      },
+      statusCode: 403,
+    },
+    {
+      name: "port mismatch",
+      headers: {
+        ...validHeaders,
+        Origin: "http://127.0.0.1:1",
+      },
+      statusCode: 403,
+    },
+    {
+      name: "missing Origin",
+      headers: {
+        Host: localHost,
+        "Content-Type": "application/json",
+        [WEBUI_MUTATION_AUTH_HEADER]: testMutationAuth.token,
+      },
+      statusCode: 403,
+    },
+  ];
+
+  for (const rejectionCase of rejectionCases) {
+    const beforeCalls: number = setupConfigUpdateCalls.length;
+    const response = await readJson({
+      server,
+      path: "/api/setup-config",
+      method: "POST",
+      headers: rejectionCase.headers,
+      body: setupConfigWriteBody,
+    });
+
+    assert.equal(response.statusCode, rejectionCase.statusCode, rejectionCase.name);
+    assert.equal(setupConfigUpdateCalls.length, beforeCalls, rejectionCase.name);
+  }
+});
+
 test("createSupervisorHttpServer serializes concurrent run-once requests", async (t) => {
   let activeRuns = 0;
   let maxConcurrentRuns = 0;

--- a/src/backend/supervisor-http-server.ts
+++ b/src/backend/supervisor-http-server.ts
@@ -287,9 +287,6 @@ function authorizeMutationRequest(
   if (!isLocalHostHeader(request.headers.host)) {
     throw new HttpRequestError(403, "Mutation requests must target a localhost host.");
   }
-  if (!isAllowedLocalOrigin(request.headers.origin, request.headers.host)) {
-    throw new HttpRequestError(403, "Mutation requests must originate from the local WebUI origin.");
-  }
   if (!mutationAuth?.token) {
     throw new HttpRequestError(503, "Mutation auth is not configured.");
   }
@@ -297,6 +294,9 @@ function authorizeMutationRequest(
   const providedToken = readSingleHeaderValue(request.headers[WEBUI_MUTATION_AUTH_HEADER]);
   if (!providedToken || providedToken !== mutationAuth.token) {
     throw new HttpRequestError(401, "Mutation auth required.");
+  }
+  if (!isAllowedLocalOrigin(request.headers.origin, request.headers.host)) {
+    throw new HttpRequestError(403, "Mutation requests must originate from the local WebUI origin.");
   }
 }
 
@@ -325,7 +325,7 @@ function isLocalHostHeader(hostHeader: string | string[] | undefined): boolean {
 function isAllowedLocalOrigin(originHeader: string | string[] | undefined, hostHeader: string | string[] | undefined): boolean {
   const origin = readSingleHeaderValue(originHeader);
   if (origin === null) {
-    return true;
+    return false;
   }
 
   const host = readSingleHeaderValue(hostHeader);


### PR DESCRIPTION
## Summary
- add focused WebUI mutation auth invariant coverage for token, loopback http Origin, and Host port matching
- reject mutation requests that omit Origin after valid token validation

## Verification
- ./node_modules/.bin/tsx --test src/backend/supervisor-http-server.test.ts
- npm run build
- npm run verify:paths

Closes #1809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization validation for API mutation requests to require valid `Origin` headers and improved header validation sequencing for the setup configuration endpoint.

* **Tests**
  * Added comprehensive test coverage for authorization requirements including valid and invalid header combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->