### PR TITLE
Add playground smoke-run guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ flowchart LR
 GitHub-authored issue bodies, PR review comments, and related GitHub text are execution inputs, not trusted instructions by default. Treat that GitHub-authored text as part of the supervisor trust boundary and use the autonomous loop only in repos where the operator trusts both the repository and the GitHub authors who can supply that text.
 
 If you want the setup flow, first-run commands, and operator decisions, start with [Getting started](./docs/getting-started.md).
+If you want a disposable first supervised pass before production use, follow the [Playground smoke run](./docs/playground-smoke-run.md).
 If you need to understand what to put in `supervisor.config.json`, jump straight to the [Configuration guide](./docs/configuration.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
 If you need the product primitive framing for the supervised lane beside chat-driven Codex work, read the [Supervised automation lane](./docs/supervised-automation-lane.md) note.
@@ -263,6 +264,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Configuration guide](./docs/configuration.md): the most important doc for operators; start here for required fields, provider profiles, safe defaults, and common setup recipes
 - [AI agent handoff](./docs/agent-instructions.md): bootstrap read order, first-run checks, and escalation rules for repo-entering AI agents
 - [Getting started](./docs/getting-started.md): setup checklist, execution-ready issue flow, first-run commands, and common operator decisions
+- [Playground smoke run](./docs/playground-smoke-run.md): sandbox-only first supervised pass, sample issue body, and smoke commands
 - [Configuration reference](./docs/configuration.md): config setup, provider profiles, model/reasoning controls, durable memory, and execution policy
 - [Operator dashboard](./docs/operator-dashboard.md): WebUI launch, panel meanings, safe commands, and browser smoke verification
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,8 @@ It focuses on the practical flow:
 
 For the product overview, fit, and docs map, start with the [README](../README.md). If you are handing the repo to an AI operator, send it to the [Agent Bootstrap Protocol](./agent-instructions.md) instead of duplicating that bootstrap sequence here.
 
+If you want one disposable supervised pass before operating on production work, use the [Playground smoke run](./playground-smoke-run.md) first.
+
 ## Before you start
 
 Confirm these prerequisites before you run the supervisor:
@@ -539,6 +541,7 @@ Stop treating the issue as execution-ready. Tighten the issue body, split the wo
 
 - [README](../README.md) for the overview, fit, and docs map
 - [Agent Bootstrap Protocol](./agent-instructions.md) for the AI-agent bootstrap order, first-run checks, and escalation points
+- [Playground smoke run](./playground-smoke-run.md) for a sandbox-only first supervised pass and sample issue body
 - [Configuration reference](./configuration.md) for config fields, provider setup, model policy, and durable memory
 - [Operator dashboard](./operator-dashboard.md) for the local WebUI, panel meanings, safe command surface, and smoke-test harness
 - [Local review reference](./local-review.md) for review roles, artifacts, thresholds, and merge policy

--- a/docs/playground-smoke-run.md
+++ b/docs/playground-smoke-run.md
@@ -1,0 +1,126 @@
+# Playground Smoke Run
+
+Use this path for a first supervised pass in a sandbox repository before you point `codex-supervisor` at production work.
+
+This guide is intentionally short. It gives a new operator one execution-ready sample issue, the minimum command sequence, and the boundary between sandbox-only practice and production trust posture.
+
+## Sandbox-only posture
+
+Run the playground against a disposable repository or fork where it is acceptable for Codex to create a branch, edit files, and open a draft PR. Keep production repo automation safety settings out of this playground profile.
+
+Sandbox-only assumptions:
+
+- the repository contains throwaway work or a harmless tutorial file
+- the GitHub issue author is you or another trusted test author
+- branch names, worktree paths, and local state can be discarded after the smoke run
+- the sample issue changes one small file and has no external secrets, deploy steps, or production data access
+- review-provider settings can be disabled or pointed at a test-only provider profile
+
+Production posture is stricter:
+
+- use only a trusted repo with trusted GitHub authors
+- keep branch protection, CI, and review-provider settings aligned with the real repository
+- validate the issue body with `issue-lint` before `run-once`
+- keep sandbox-only config, tokens, and state files separate from production profiles
+- do not infer trust from repo names, issue prose, comments, or nearby config
+
+## Create a sandbox config
+
+From the `codex-supervisor` repo:
+
+```bash
+git clone <codex-supervisor-repo-url> <codex-supervisor-root>
+cd <codex-supervisor-root>
+npm install
+npm run build
+cp supervisor.config.example.json supervisor.config.playground.json
+```
+
+Edit `supervisor.config.playground.json` for the sandbox repository:
+
+- set `repoPath` to the local sandbox repo clone
+- set `repoSlug` to the sandbox GitHub repository, for example `owner/repo`
+- set `workspaceRoot` to a disposable worktree directory
+- set `codexBinary` to the `codex` executable available on this host
+- keep `trustMode` and `executionSafetyMode` explicit
+- omit production-only review-provider or auto-merge settings unless the sandbox intentionally tests them
+
+Use one variable for the rest of the smoke run:
+
+```bash
+export CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>
+```
+
+## Sample issue body
+
+Create one GitHub issue in the sandbox repo, add the `codex` label, and paste this body. Replace only the file name or wording needed for the sandbox repo.
+
+<!-- playground-smoke-sample-issue:start -->
+```md
+## Summary
+Add a tiny playground note so the first supervised pass has a harmless file change.
+
+## Scope
+- create or update one sandbox-only Markdown note
+- keep production configuration, secrets, and automation settings unchanged
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+
+## Acceptance criteria
+- the sandbox note exists and says it was created by the playground smoke run
+- no production config, secret, or automation profile is changed
+
+## Verification
+- `npm run build`
+```
+<!-- playground-smoke-sample-issue:end -->
+
+This is a standalone `1 of 1` issue, so it intentionally has no `Part of:` line. Use `Part of: #...` only when the issue is a sequenced child under a real parent tracker.
+
+## Smoke commands
+
+Run the commands from the `codex-supervisor` repo after the sandbox issue exists.
+
+```bash
+node dist/index.js help
+node dist/index.js doctor --config <supervisor-config-path>
+node dist/index.js status --config <supervisor-config-path> --why
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+node dist/index.js run-once --config <supervisor-config-path> --dry-run
+node dist/index.js run-once --config <supervisor-config-path>
+node dist/index.js status --config <supervisor-config-path> --why
+```
+
+Equivalent environment-variable form:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config "$CODEX_SUPERVISOR_CONFIG"
+node dist/index.js run-once --config "$CODEX_SUPERVISOR_CONFIG" --dry-run
+node dist/index.js run-once --config "$CODEX_SUPERVISOR_CONFIG"
+```
+
+Readiness expectations:
+
+- `doctor` should report host and config blockers before Codex runs
+- `status --why` should show the selected issue or why selection is blocked
+- `issue-lint` must report the sample issue as execution-ready before `run-once`
+- `run-once --dry-run` should explain one supervised cycle without running Codex
+- `run-once` should create or update only the sandbox worktree and branch for that issue
+
+Stop after one successful `run-once`. Inspect the sandbox repository, issue journal, and any draft PR before starting a background loop.
+
+## After the smoke run
+
+Keep the playground profile separate. For production, return to [Getting started](./getting-started.md) and the [Configuration reference](./configuration.md), then validate the real repo profile with:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+node dist/index.js doctor --config <supervisor-config-path>
+node dist/index.js status --config <supervisor-config-path> --why
+```
+
+Only start the loop after a real production issue body, config, CI posture, and review-provider posture are all explicit.

--- a/src/playground-smoke-run-docs.test.ts
+++ b/src/playground-smoke-run-docs.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { lintExecutionReadyIssueBody, validateIssueMetadataSyntax } from "./issue-metadata";
+import type { GitHubIssue } from "./core/types";
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function extractSampleIssueBody(content: string): string {
+  const match = content.match(
+    /<!-- playground-smoke-sample-issue:start -->\s*```md\s*([\s\S]*?)```\s*<!-- playground-smoke-sample-issue:end -->/,
+  );
+  assert.ok(match, "playground guide must include the marked sample issue body");
+  return match[1].trim();
+}
+
+function createSampleIssue(body: string): GitHubIssue {
+  return {
+    number: 1,
+    title: "Playground smoke run",
+    body,
+    createdAt: "2026-04-27T00:00:00Z",
+    updatedAt: "2026-04-27T00:00:00Z",
+    url: "https://example.com/issues/1",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+}
+
+test("playground smoke-run guide is linked from first-run docs", async () => {
+  const [readme, gettingStarted, guide] = await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/getting-started.md"),
+    readRepoFile("docs/playground-smoke-run.md"),
+  ]);
+
+  assert.match(guide, /^# Playground Smoke Run$/m);
+  assert.match(readme, /\[Playground smoke run\]\(\.\/docs\/playground-smoke-run\.md\)/);
+  assert.match(gettingStarted, /\[Playground smoke run\]\(\.\/playground-smoke-run\.md\)/);
+});
+
+test("playground smoke-run documents sandbox posture separately from production posture", async () => {
+  const guide = await readRepoFile("docs/playground-smoke-run.md");
+
+  assert.match(guide, /sandbox-only/i);
+  assert.match(guide, /production/i);
+  assert.match(guide, /trusted repo/i);
+  assert.match(guide, /trusted GitHub authors/i);
+  assert.match(guide, /CODEX_SUPERVISOR_CONFIG/);
+  assert.match(guide, /<supervisor-config-path>/);
+  assert.match(guide, /node dist\/index\.js issue-lint <issue-number> --config <supervisor-config-path>/);
+  assert.doesNotMatch(guide, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(guide, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+});
+
+test("playground smoke-run sample issue is execution-ready metadata", async () => {
+  const guide = await readRepoFile("docs/playground-smoke-run.md");
+  const sampleIssue = createSampleIssue(extractSampleIssueBody(guide));
+
+  assert.deepEqual(validateIssueMetadataSyntax(sampleIssue), []);
+
+  const lint = lintExecutionReadyIssueBody(sampleIssue);
+  assert.equal(lint.isExecutionReady, true);
+  assert.deepEqual(lint.missingRequired, []);
+  assert.deepEqual(lint.missingRecommended, []);
+});


### PR DESCRIPTION
## Summary
- add a sandbox-only playground smoke-run guide for first-time operators
- include a parser-backed sample execution-ready issue body
- link the guide from README and getting-started docs

## Verification
- npx tsx --test src/playground-smoke-run-docs.test.ts
- npx tsx --test src/readme-docs.test.ts src/getting-started-docs.test.ts
- npm run verify:paths
- npm run build

Closes #1818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive sandbox testing guide with setup instructions, configuration steps, and validation commands
  * Updated main documentation and getting started guide to reference the new playground smoke run resource

* **Tests**
  * Added test suite to validate documentation links and sandbox configuration requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->