### PR TITLE
Phase 14.4: Make starter profile placeholders first-run friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,17 @@ When the sandbox pass is clean, validate the production config and a real issue 
    node dist/index.js loop --config <supervisor-config-path>
    ```
 
-For a shipped provider profile, pass the concrete profile file explicitly:
+For a shipped provider profile, choose the command block that matches the copied profile you are validating:
 
    ```bash
+   node dist/index.js issue-lint <issue-number> --config supervisor.config.copilot.json
+   node dist/index.js doctor --config supervisor.config.copilot.json
+   node dist/index.js status --config supervisor.config.copilot.json --why
+
+   node dist/index.js issue-lint <issue-number> --config supervisor.config.codex.json
+   node dist/index.js doctor --config supervisor.config.codex.json
+   node dist/index.js status --config supervisor.config.codex.json --why
+
    node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json
    node dist/index.js doctor --config supervisor.config.coderabbit.json
    node dist/index.js status --config supervisor.config.coderabbit.json --why

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ When the sandbox pass is clean, validate the production config and a real issue 
    node dist/index.js loop --config <supervisor-config-path>
    ```
 
+For a shipped provider profile, pass the concrete profile file explicitly:
+
+   ```bash
+   node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json
+   node dist/index.js doctor --config supervisor.config.coderabbit.json
+   node dist/index.js status --config supervisor.config.coderabbit.json --why
+   ```
+
 On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path. The tmux scripts use `CODEX_SUPERVISOR_CONFIG`; keep it pointed at the config you validated.
 
 If you want the local operator dashboard, start the WebUI against the same config:

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1769,6 +1769,31 @@ test("shipped CodeRabbit starter profile uses a fail-fast repoSlug placeholder",
   assertCodeRabbitStarterRepoSlugPlaceholder(raw);
 });
 
+test("shipped starter profiles fail closed with first-run placeholder guidance", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const expectedInvalidFields = new Map<string, string[]>([
+    ["supervisor.config.example.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
+    ["supervisor.config.copilot.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
+    ["supervisor.config.codex.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
+    ["supervisor.config.coderabbit.json", ["repoSlug"]],
+  ]);
+
+  for (const [relativePath, invalidFields] of expectedInvalidFields) {
+    const raw = await readShippedProfileJson(rootDir, relativePath);
+    const summary = loadConfigSummaryFromDocument(raw, path.join(rootDir, relativePath));
+
+    assert.equal(summary.status, "invalid_config", `${relativePath} should require placeholder replacement`);
+    assert.deepEqual(summary.invalidFields, invalidFields, `${relativePath} should identify starter placeholders`);
+    assert.match(summary.error ?? "", /Starter profile placeholders must be replaced before this config can run/);
+    assert.match(summary.error ?? "", /node dist\/index\.js doctor --config <supervisor-config-path>/);
+    assert.throws(
+      () => loadConfig(path.join(rootDir, relativePath)),
+      /Starter profile placeholders must be replaced before this config can run/,
+      `${relativePath} should fail closed before runtime use`,
+    );
+  }
+});
+
 test("shipped CodeRabbit starter profile validation ignores unstaged host-local active profile drift", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-coderabbit-profile-"));
   t.after(async () => {
@@ -2078,7 +2103,9 @@ test("buildSetupConfigPreview preserves unknown fields and leaves the config fil
       ["approvedTrackedTopLevelEntries", true, true],
     ],
   );
-  assert.equal(preview.validation.status, "ready");
+  assert.equal(preview.validation.status, "invalid_config");
+  assert.deepEqual(preview.validation.invalidFields, ["workspaceRoot", "codexBinary"]);
+  assert.match(preview.validation.error ?? "", /Starter profile placeholders must be replaced/i);
   assert.equal(before, after);
 });
 

--- a/src/core/config-validation.ts
+++ b/src/core/config-validation.ts
@@ -17,6 +17,13 @@ const REQUIRED_STRING_CONFIG_FIELDS = [
   "branchPrefix",
 ] as const;
 
+const STARTER_PROFILE_PLACEHOLDERS: Record<string, Set<string>> = {
+  repoPath: new Set(["/absolute/path/to/managed-repo"]),
+  repoSlug: new Set(["OWNER/REPO", "REPLACE_ME"]),
+  workspaceRoot: new Set(["/absolute/path/to/worktrees"]),
+  codexBinary: new Set(["/absolute/path/to/codex"]),
+};
+
 const WORKSPACE_PREPARATION_SCRIPT_RUNNERS = new Set(["bash", "sh", "node", "bun", "deno", "python", "python3", "ruby", "tsx", "ts-node"]);
 
 function hasNonEmptyString(value: unknown): boolean {
@@ -42,6 +49,44 @@ export function collectMissingRequiredFields(raw: Record<string, unknown>): stri
   }
 
   return missing;
+}
+
+export function isStarterProfilePlaceholder(field: string, value: unknown): boolean {
+  return typeof value === "string" && (STARTER_PROFILE_PLACEHOLDERS[field]?.has(value.trim()) ?? false);
+}
+
+export function collectStarterProfilePlaceholderFields(raw: Record<string, unknown>): string[] {
+  return REQUIRED_STRING_CONFIG_FIELDS.filter((field) => isStarterProfilePlaceholder(field, raw[field])) as string[];
+}
+
+export function buildStarterProfilePlaceholderFieldMessage(field: string, value: unknown): string | null {
+  if (!isStarterProfilePlaceholder(field, value)) {
+    return null;
+  }
+
+  switch (field) {
+    case "repoPath":
+      return "Repository path still contains a starter placeholder. Replace it with the absolute path to the managed repository.";
+    case "repoSlug":
+      return "Repository slug still contains a starter placeholder. Replace it with the GitHub owner/repo slug for the managed repository.";
+    case "workspaceRoot":
+      return "Workspace root still contains a starter placeholder. Replace it with the directory where issue worktrees should be created.";
+    case "codexBinary":
+      return "Codex binary still contains a starter placeholder. Replace it with a PATH command such as codex or the path to the Codex executable.";
+    default:
+      return `${field} still contains a starter placeholder. Replace it before running the supervisor.`;
+  }
+}
+
+export function buildStarterProfilePlaceholderError(raw: Record<string, unknown>, fields: string[]): string {
+  const details = fields
+    .map((field) => buildStarterProfilePlaceholderFieldMessage(field, raw[field]) ?? `${field} still contains a starter placeholder.`)
+    .join(" ");
+  return [
+    "Starter profile placeholders must be replaced before this config can run.",
+    details,
+    "Copy the starter profile to supervisor.config.json, replace the placeholders, then rerun node dist/index.js doctor --config <supervisor-config-path> or inspect /api/setup-readiness.",
+  ].join(" ");
 }
 
 export function extractInvalidFieldName(error: unknown): string | null {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,7 +10,10 @@ import {
 } from "./config-field-posture";
 import { parseSupervisorConfigDocument, normalizeLocalCiCommand, displayLocalCiCommand } from "./config-parsing";
 import {
+  buildStarterProfilePlaceholderError,
+  buildStarterProfilePlaceholderFieldMessage,
   buildMissingWorkspacePreparationContractWarning,
+  collectStarterProfilePlaceholderFields,
   collectMissingRequiredFields,
   extractInvalidFieldName,
   extractRepoRelativeWorkspacePreparationHelper,
@@ -33,8 +36,11 @@ import {
 
 export {
   buildMissingWorkspacePreparationContractWarning,
+  buildStarterProfilePlaceholderError,
+  buildStarterProfilePlaceholderFieldMessage,
   CONFIG_FIELD_POSTURE_METADATA,
   CONFIG_FIELD_POSTURE_TIERS,
+  collectStarterProfilePlaceholderFields,
   DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW,
   displayLocalCiCommand,
   extractRepoRelativeWorkspacePreparationHelper,
@@ -74,6 +80,18 @@ export interface ConfigLoadSummary {
 
 function buildConfigLoadSummaryFromDocument(raw: Record<string, unknown>, resolvedPath: string): ConfigLoadSummary {
   const missingRequiredFields = collectMissingRequiredFields(raw);
+  const starterPlaceholderFields = collectStarterProfilePlaceholderFields(raw);
+  if (starterPlaceholderFields.length > 0) {
+    return {
+      configPath: resolvedPath,
+      status: "invalid_config",
+      missingRequiredFields,
+      invalidFields: starterPlaceholderFields,
+      error: buildStarterProfilePlaceholderError(raw, starterPlaceholderFields),
+      config: null,
+      trustDiagnostics: null,
+    };
+  }
 
   try {
     const config = parseSupervisorConfigDocument(raw, resolvedPath);
@@ -157,6 +175,10 @@ export function loadConfig(configPath?: string): SupervisorConfig {
   }
 
   const raw = parseJson<Record<string, unknown>>(fs.readFileSync(resolvedPath, "utf8"), resolvedPath);
+  const starterPlaceholderFields = collectStarterProfilePlaceholderFields(raw);
+  if (starterPlaceholderFields.length > 0) {
+    throw new Error(buildStarterProfilePlaceholderError(raw, starterPlaceholderFields));
+  }
   const config = parseSupervisorConfigDocument(raw, resolvedPath);
   validateParsedConfig(config);
   return config;

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -31,6 +31,9 @@ test("diagnoseSetupReadiness explains copied starter profile placeholders as fir
 
   assert.equal(summary.ready, false);
   assert.equal(summary.overallStatus, "invalid");
+  assert.equal(summary.providerPosture.profile, "copilot");
+  assert.deepEqual(summary.providerPosture.reviewers, ["copilot-pull-request-reviewer"]);
+  assert.equal(summary.localReviewPosture?.preset, "off");
   assert.deepEqual(
     summary.fields
       .filter((field) => field.state === "invalid")
@@ -56,6 +59,34 @@ test("diagnoseSetupReadiness explains copied starter profile placeholders as fir
   assert.match(
     summary.nextActions.find((action) => action.source === "invalid_repo_slug")?.summary ?? "",
     /replace it with the GitHub owner\/repo slug/i,
+  );
+});
+
+test("diagnoseSetupReadiness preserves provider-specific posture for copied CodeRabbit starter profile", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-coderabbit-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const sourcePath = path.join(process.cwd(), "supervisor.config.coderabbit.json");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.copyFile(sourcePath, configPath);
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "invalid");
+  assert.equal(summary.providerPosture.profile, "coderabbit");
+  assert.deepEqual(summary.providerPosture.reviewers, ["coderabbitai", "coderabbitai[bot]"]);
+  assert.equal(summary.localReviewPosture?.preset, "off");
+  assert.deepEqual(
+    summary.fields
+      .filter((field) => field.state === "invalid")
+      .map((field) => field.key),
+    ["repoSlug"],
   );
 });
 

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -14,6 +14,51 @@ test("setup-readiness imports shared diagnostic DTOs instead of doctor raw types
   assert.doesNotMatch(content, /type\s+DoctorCheckStatus/u);
 });
 
+test("diagnoseSetupReadiness explains copied starter profile placeholders as first-run setup blockers", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const sourcePath = path.join(process.cwd(), "supervisor.config.example.json");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.copyFile(sourcePath, configPath);
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "invalid");
+  assert.deepEqual(
+    summary.fields
+      .filter((field) => field.state === "invalid")
+      .map((field) => [field.key, field.message]),
+    [
+      ["repoPath", "Repository path still contains a starter placeholder. Replace it with the absolute path to the managed repository."],
+      ["repoSlug", "Repository slug still contains a starter placeholder. Replace it with the GitHub owner/repo slug for the managed repository."],
+      ["workspaceRoot", "Workspace root still contains a starter placeholder. Replace it with the directory where issue worktrees should be created."],
+      ["codexBinary", "Codex binary still contains a starter placeholder. Replace it with a PATH command such as codex or the path to the Codex executable."],
+    ],
+  );
+  assert.deepEqual(
+    summary.blockers
+      .filter((blocker) => blocker.code.startsWith("invalid_"))
+      .map((blocker) => [blocker.code, blocker.fieldKeys]),
+    [
+      ["invalid_repo_path", ["repoPath"]],
+      ["invalid_repo_slug", ["repoSlug"]],
+      ["invalid_workspace_root", ["workspaceRoot"]],
+      ["invalid_codex_binary", ["codexBinary"]],
+    ],
+  );
+  assert.match(
+    summary.nextActions.find((action) => action.source === "invalid_repo_slug")?.summary ?? "",
+    /replace it with the GitHub owner\/repo slug/i,
+  );
+});
+
 async function createTrackedRepo(root: string): Promise<string> {
   const repoPath = path.join(root, "repo");
   await fs.mkdir(repoPath, { recursive: true });

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   CONFIG_FIELD_POSTURE_METADATA,
   CONFIG_FIELD_POSTURE_TIERS,
+  buildStarterProfilePlaceholderFieldMessage,
   type ConfigFieldName,
   type ConfigFieldPostureMetadata,
   type ConfigFieldPostureTier,
@@ -350,8 +351,13 @@ function buildFieldMessage(args: {
   field: SetupReadinessField;
   workspacePreparationWarning: string | null;
   recommendedWorkspacePreparationCommand: string | null;
+  starterPlaceholderMessage: string | null;
 }): string {
-  const { field, workspacePreparationWarning, recommendedWorkspacePreparationCommand } = args;
+  const { field, workspacePreparationWarning, recommendedWorkspacePreparationCommand, starterPlaceholderMessage } = args;
+  if (starterPlaceholderMessage !== null) {
+    return starterPlaceholderMessage;
+  }
+
   if (field.key === "workspacePreparationCommand") {
     if (workspacePreparationWarning !== null && field.state === "invalid") {
       return recommendedWorkspacePreparationCommand === null
@@ -450,7 +456,12 @@ function buildConfigFields(args: {
     };
     return {
       ...field,
-      message: buildFieldMessage({ field, workspacePreparationWarning, recommendedWorkspacePreparationCommand }),
+      message: buildFieldMessage({
+        field,
+        workspacePreparationWarning,
+        recommendedWorkspacePreparationCommand,
+        starterPlaceholderMessage: buildStarterProfilePlaceholderFieldMessage(key, rawValue),
+      }),
     };
   });
 

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -21,7 +21,10 @@ import {
 import type {
   CodexModelStrategy,
   LocalCiContractSummary,
+  LocalReviewHighSeverityAction,
+  LocalReviewPolicy,
   LocalReviewPostureSummary,
+  LocalReviewPosturePreset,
   ReleaseReadinessGatePosture,
   ReleaseReadinessGateSummary,
   TrustDiagnosticsSummary,
@@ -237,6 +240,15 @@ const SETUP_FIELD_METADATA: Record<SetupReadinessFieldKey, SetupReadinessFieldMe
 
 const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untrusted_or_mixed"]);
 const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
+const VALID_LOCAL_REVIEW_POSTURE_PRESETS = new Set<LocalReviewPosturePreset>([
+  "off",
+  "advisory",
+  "block_merge",
+  "repair_high_severity",
+  "follow_up_issue_creation",
+]);
+const VALID_LOCAL_REVIEW_POLICIES = new Set<LocalReviewPolicy>(["advisory", "block_ready", "block_merge"]);
+const VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS = new Set<LocalReviewHighSeverityAction>(["retry", "blocked"]);
 const SETUP_POSTURE_GROUP_LABELS: Record<ConfigFieldPostureTier, string> = {
   required: "Required setup decisions",
   recommended: "Recommended setup contracts",
@@ -345,6 +357,31 @@ function tryNormalizeLocalCiCommand(value: unknown): ReturnType<typeof normalize
 
 function tryReadReleaseReadinessGatePosture(value: unknown): ReleaseReadinessGatePosture {
   return value === "block_release_publication" ? "block_release_publication" : "advisory";
+}
+
+function readRawStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "")
+    : [];
+}
+
+function readRawLocalReviewPosturePreset(value: unknown): LocalReviewPosturePreset | undefined {
+  return typeof value === "string" && VALID_LOCAL_REVIEW_POSTURE_PRESETS.has(value as LocalReviewPosturePreset)
+    ? (value as LocalReviewPosturePreset)
+    : undefined;
+}
+
+function readRawLocalReviewPolicy(value: unknown): LocalReviewPolicy | undefined {
+  return typeof value === "string" && VALID_LOCAL_REVIEW_POLICIES.has(value as LocalReviewPolicy)
+    ? (value as LocalReviewPolicy)
+    : undefined;
+}
+
+function readRawLocalReviewHighSeverityAction(value: unknown): LocalReviewHighSeverityAction | undefined {
+  return typeof value === "string" &&
+    VALID_LOCAL_REVIEW_HIGH_SEVERITY_ACTIONS.has(value as LocalReviewHighSeverityAction)
+    ? (value as LocalReviewHighSeverityAction)
+    : undefined;
 }
 
 function buildFieldMessage(args: {
@@ -579,19 +616,27 @@ function buildConfigPostureGroups(args: {
 
 function buildProviderPosture(
   config: ReturnType<typeof loadConfigSummary>["config"],
+  rawConfig: RawConfigDocument,
 ): SetupReadinessProviderPosture {
+  const providerConfig = config ?? {
+    reviewBotLogins: readRawStringArray(rawConfig?.reviewBotLogins),
+  };
   if (!config) {
-    return {
-      profile: "none",
-      provider: "none",
-      reviewers: [],
-      signalSource: "none",
-      configured: false,
-      summary: "No review provider is configured.",
-    };
+    const rawProfile = reviewProviderProfileFromConfig(providerConfig);
+    return rawProfile.profile === "none"
+      ? {
+        ...rawProfile,
+        configured: false,
+        summary: "No review provider is configured.",
+      }
+      : {
+        ...rawProfile,
+        configured: true,
+        summary: `Review provider posture uses ${rawProfile.provider} via ${rawProfile.signalSource}.`,
+      };
   }
 
-  const profile = reviewProviderProfileFromConfig(config);
+  const profile = reviewProviderProfileFromConfig(providerConfig);
   if (profile.profile === "none") {
     return {
       ...profile,
@@ -605,6 +650,55 @@ function buildProviderPosture(
     configured: true,
     summary: `Review provider posture uses ${profile.provider} via ${profile.signalSource}.`,
   };
+}
+
+function buildLocalReviewPosture(
+  config: ReturnType<typeof loadConfigSummary>["config"],
+  rawConfig: RawConfigDocument,
+): LocalReviewPostureSummary | undefined {
+  if (config) {
+    return summarizeLocalReviewPosture(config);
+  }
+
+  const rawDocument = rawConfig ?? {};
+  const hasRawLocalReviewSetting = [
+    "localReviewPosture",
+    "localReviewEnabled",
+    "localReviewPolicy",
+    "localReviewFollowUpIssueCreationEnabled",
+    "localReviewHighSeverityAction",
+  ].some((field) => Object.prototype.hasOwnProperty.call(rawDocument, field));
+  if (!hasRawLocalReviewSetting) {
+    return undefined;
+  }
+
+  const localReviewPosture = readRawLocalReviewPosturePreset(rawDocument.localReviewPosture);
+  const localReviewEnabled =
+    localReviewPosture !== undefined
+      ? localReviewPosture !== "off"
+      : rawDocument.localReviewEnabled === true;
+  const localReviewPolicy =
+    localReviewPosture === "advisory"
+      ? "advisory"
+      : localReviewPosture !== undefined
+        ? "block_merge"
+        : readRawLocalReviewPolicy(rawDocument.localReviewPolicy) ?? "block_merge";
+  const localReviewFollowUpIssueCreationEnabled =
+    localReviewPosture !== undefined
+      ? localReviewPosture === "follow_up_issue_creation"
+      : rawDocument.localReviewFollowUpIssueCreationEnabled === true;
+  const localReviewHighSeverityAction =
+    localReviewPosture !== undefined
+      ? localReviewPosture === "repair_high_severity" ? "retry" : "blocked"
+      : readRawLocalReviewHighSeverityAction(rawDocument.localReviewHighSeverityAction) ?? "blocked";
+
+  return summarizeLocalReviewPosture({
+    localReviewPosture,
+    localReviewEnabled,
+    localReviewPolicy,
+    localReviewFollowUpIssueCreationEnabled,
+    localReviewHighSeverityAction,
+  });
 }
 
 function buildTrustPostureFromRaw(
@@ -1091,11 +1185,11 @@ export async function diagnoseSetupReadiness(
     blockers,
     nextActions,
     hostReadiness,
-    providerPosture: buildProviderPosture(configSummary.config),
+    providerPosture: buildProviderPosture(configSummary.config, rawConfig),
     trustPosture: buildTrustPostureFromRaw(rawConfig, configSummary.config),
     modelRoutingPosture,
     localCiContract,
-    localReviewPosture: configSummary.config ? summarizeLocalReviewPosture(configSummary.config) : undefined,
+    localReviewPosture: buildLocalReviewPosture(configSummary.config, rawConfig),
     releaseReadinessGate,
   };
 }


### PR DESCRIPTION
## Summary
- fail closed on shipped starter profile placeholders before config parsing/runtime use
- surface field-specific placeholder replacement guidance in setup-readiness
- document explicit provider-profile validation commands in README

## Verification
- npx tsx --test src/config.test.ts src/setup-readiness.test.ts
- npm run verify:paths
- npm run build
- node dist/index.js doctor --config supervisor.config.example.json (expected fail-closed placeholder guidance)
- npx tsx --test src/execution-safety-docs.test.ts
- npm test

Part of #1821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added profile-specific command examples (Copilot, Codex Connector, CodeRabbit) showing exact commands to run validation, doctor, and status with the shipped profile configs.

* **New Features**
  * Validation now detects unconfigured starter-profile placeholders and shows targeted, field-specific guidance to replace them before proceeding.
  * Setup readiness now derives provider/local-review posture from raw config when appropriate.

* **Tests**
  * Added tests covering placeholder detection, error messaging, and setup-readiness behavior for starter configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->