### PR TITLE
Publish portable issue body contract schema

### DIFF
--- a/docs/issue-body-contract.schema.json
+++ b/docs/issue-body-contract.schema.json
@@ -68,6 +68,7 @@
       "type": "object",
       "required": [
         "contractName",
+        "contractVersion",
         "canonicalGuide",
         "requiredSections",
         "standaloneDefaults",
@@ -77,6 +78,9 @@
       "properties": {
         "contractName": {
           "const": "codex-supervisor.issue-body-contract"
+        },
+        "contractVersion": {
+          "const": 1
         },
         "canonicalGuide": {
           "const": "docs/issue-metadata.md"

--- a/docs/issue-body-contract.schema.json
+++ b/docs/issue-body-contract.schema.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TommyKammy/codex-supervisor/docs/issue-body-contract.schema.json",
+  "contractName": "codex-supervisor.issue-body-contract",
+  "contractVersion": 1,
+  "canonicalGuide": "docs/issue-metadata.md",
+  "description": "Portable contract for execution-ready codex issue bodies. Markdown parsing and readiness decisions remain enforced by issue-lint; this artifact publishes the required sections, scheduling metadata, defaults, and validation examples for external tooling.",
+  "requiredSections": [
+    "Summary",
+    "Scope",
+    "Acceptance criteria",
+    "Verification"
+  ],
+  "standaloneDefaults": {
+    "dependsOn": "none",
+    "parallelizable": "No",
+    "executionOrder": "1 of 1",
+    "partOf": null
+  },
+  "sequencedChildMetadata": {
+    "partOfPattern": "Part of: #<parent-issue-number>",
+    "dependsOnPattern": "Depends on: none|#<blocking-issue-number>[, #<blocking-issue-number>...]",
+    "parallelizable": "No",
+    "executionOrderPattern": "N of M"
+  },
+  "validationNotes": [
+    "Use docs/issue-metadata.md as the canonical human guide.",
+    "Use issue-lint as the enforcement boundary for Markdown parsing, duplicate metadata, malformed scheduling fields, and label-gated readiness.",
+    "Do not add Part of for standalone 1 of 1 issues unless the issue truly belongs to an epic and readiness rules require it.",
+    "Use Parallelizable: No unless parallel execution is explicitly safe."
+  ],
+  "examples": [
+    {
+      "name": "valid standalone codex issue",
+      "kind": "standalone",
+      "valid": true,
+      "body": "## Summary\nPublish a portable issue body contract artifact for external tooling.\n\n## Scope\n- add the contract artifact and keep existing issue-lint behavior unchanged\n\n## Acceptance criteria\n- the artifact lists required sections and standalone scheduling defaults\n\n## Verification\n- `npx tsx --test src/issue-metadata/issue-body-contract-artifact.test.ts`\n\nDepends on: none\nParallelizable: No\n\n## Execution order\n1 of 1"
+    },
+    {
+      "name": "valid sequenced child codex issue",
+      "kind": "sequenced-child",
+      "valid": true,
+      "body": "## Summary\nPublish child issue metadata examples for the portable contract.\n\n## Scope\n- document sequenced child metadata while preserving the issue-lint boundary\n\nPart of: #1830\nDepends on: #1831\nParallelizable: No\n\n## Execution order\n2 of 6\n\n## Acceptance criteria\n- child examples include canonical Part of, Depends on, Parallelizable, and Execution order metadata\n\n## Verification\n- `npx tsx --test src/issue-metadata/issue-body-contract-artifact.test.ts`"
+    },
+    {
+      "name": "invalid standalone missing scheduling metadata",
+      "kind": "standalone",
+      "valid": false,
+      "expectedMissingRequired": [
+        "depends on",
+        "parallelizable",
+        "execution order"
+      ],
+      "body": "## Summary\nPublish a portable issue body contract artifact.\n\n## Scope\n- add the contract artifact and keep lint behavior unchanged\n\n## Acceptance criteria\n- missing scheduling metadata fails issue-lint\n\n## Verification\n- `npx tsx --test src/issue-metadata/issue-body-contract-artifact.test.ts`"
+    },
+    {
+      "name": "invalid child with legacy parent syntax",
+      "kind": "sequenced-child",
+      "valid": false,
+      "expectedMissingRequired": [
+        "part of"
+      ],
+      "body": "## Summary\nPublish child issue metadata examples for the portable contract.\n\n## Scope\n- keep canonical child metadata required for codex-labeled sequenced work\n\nPart of #1830\nDepends on: #1831\nParallelizable: No\n\n## Execution order\n2 of 6\n\n## Acceptance criteria\n- legacy Part of syntax remains blocked for sequenced codex issues\n\n## Verification\n- `npx tsx --test src/issue-metadata/issue-body-contract-artifact.test.ts`"
+    }
+  ],
+  "$defs": {
+    "issueBodyContract": {
+      "type": "object",
+      "required": [
+        "contractName",
+        "canonicalGuide",
+        "requiredSections",
+        "standaloneDefaults",
+        "sequencedChildMetadata",
+        "examples"
+      ],
+      "properties": {
+        "contractName": {
+          "const": "codex-supervisor.issue-body-contract"
+        },
+        "canonicalGuide": {
+          "const": "docs/issue-metadata.md"
+        },
+        "requiredSections": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "Summary",
+              "Scope",
+              "Acceptance criteria",
+              "Verification"
+            ]
+          },
+          "minItems": 4,
+          "uniqueItems": true
+        },
+        "standaloneDefaults": {
+          "type": "object",
+          "required": [
+            "dependsOn",
+            "parallelizable",
+            "executionOrder",
+            "partOf"
+          ],
+          "properties": {
+            "dependsOn": {
+              "const": "none"
+            },
+            "parallelizable": {
+              "enum": [
+                "No",
+                "Yes"
+              ]
+            },
+            "executionOrder": {
+              "const": "1 of 1"
+            },
+            "partOf": {
+              "type": "null"
+            }
+          },
+          "additionalProperties": false
+        },
+        "sequencedChildMetadata": {
+          "type": "object",
+          "required": [
+            "partOfPattern",
+            "dependsOnPattern",
+            "parallelizable",
+            "executionOrderPattern"
+          ],
+          "properties": {
+            "partOfPattern": {
+              "type": "string"
+            },
+            "dependsOnPattern": {
+              "type": "string"
+            },
+            "parallelizable": {
+              "enum": [
+                "No",
+                "Yes"
+              ]
+            },
+            "executionOrderPattern": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/example"
+          },
+          "minItems": 4
+        }
+      }
+    },
+    "example": {
+      "type": "object",
+      "required": [
+        "name",
+        "kind",
+        "valid",
+        "body"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "standalone",
+            "sequenced-child"
+          ]
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "body": {
+          "type": "string"
+        },
+        "expectedMissingRequired": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expectedMetadataErrors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/issue-metadata.md
+++ b/docs/issue-metadata.md
@@ -6,6 +6,8 @@ It explains which fields `codex-supervisor` reads, how scheduling uses them, and
 
 Trust boundary note: GitHub-authored issue bodies, PR review comments, review summaries, and related GitHub text are execution inputs. They tell the supervisor and Codex what to do next, so they are part of the execution-safety trust boundary rather than neutral metadata.
 
+Machine-readable contract: external tooling can read [`docs/issue-body-contract.schema.json`](issue-body-contract.schema.json) for the portable field list, standalone defaults, sequenced child metadata shape, and validation examples. `issue-lint` remains the enforcement boundary for Markdown parsing and readiness behavior.
+
 ## Start here
 
 If you are new to `codex-supervisor`, do not start by inventing your own structure. Copy one finished example first, then replace the placeholders.

--- a/src/issue-metadata/issue-body-contract-artifact.test.ts
+++ b/src/issue-metadata/issue-body-contract-artifact.test.ts
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { GitHubIssue } from "../core/types";
+import { createIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
+
+interface IssueBodyExample {
+  name: string;
+  kind: "standalone" | "sequenced-child";
+  valid: boolean;
+  body: string;
+  expectedMissingRequired?: string[];
+  expectedMetadataErrors?: string[];
+}
+
+interface IssueBodyContract {
+  contractName: string;
+  canonicalGuide: string;
+  requiredSections: string[];
+  standaloneDefaults: {
+    dependsOn: string;
+    parallelizable: "No" | "Yes";
+    executionOrder: string;
+    partOf: null;
+  };
+  sequencedChildMetadata: {
+    partOfPattern: string;
+    dependsOnPattern: string;
+    parallelizable: "No" | "Yes";
+    executionOrderPattern: string;
+  };
+  examples: IssueBodyExample[];
+}
+
+const contractPath = resolve(process.cwd(), "docs/issue-body-contract.schema.json");
+
+function readContract(): IssueBodyContract {
+  return JSON.parse(readFileSync(contractPath, "utf8")) as IssueBodyContract;
+}
+
+function createIssue(body: string): GitHubIssue {
+  return {
+    number: 100,
+    title: "Contract example",
+    body,
+    createdAt: "2026-04-27T00:00:00Z",
+    updatedAt: "2026-04-27T00:00:00Z",
+    url: "https://example.com/issues/100",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+}
+
+test("published issue body contract captures required sections and scheduling shapes", () => {
+  const contract = readContract();
+
+  assert.equal(contract.contractName, "codex-supervisor.issue-body-contract");
+  assert.equal(contract.canonicalGuide, "docs/issue-metadata.md");
+  assert.deepEqual(contract.requiredSections, [
+    "Summary",
+    "Scope",
+    "Acceptance criteria",
+    "Verification",
+  ]);
+  assert.deepEqual(contract.standaloneDefaults, {
+    dependsOn: "none",
+    parallelizable: "No",
+    executionOrder: "1 of 1",
+    partOf: null,
+  });
+  assert.match(contract.sequencedChildMetadata.partOfPattern, /Part of/u);
+  assert.match(contract.sequencedChildMetadata.dependsOnPattern, /Depends on/u);
+  assert.match(contract.sequencedChildMetadata.executionOrderPattern, /N of M/u);
+});
+
+test("published issue body contract examples match issue-lint behavior", () => {
+  const contract = readContract();
+
+  assert.ok(
+    contract.examples.some((example) => example.kind === "standalone" && example.valid),
+    "contract must include a valid standalone example",
+  );
+  assert.ok(
+    contract.examples.some((example) => example.kind === "sequenced-child" && example.valid),
+    "contract must include a valid sequenced child example",
+  );
+  assert.ok(
+    contract.examples.some((example) => !example.valid),
+    "contract must include at least one invalid example",
+  );
+
+  for (const example of contract.examples) {
+    const lint = createIssueLintDto(createIssue(example.body));
+    assert.equal(lint.executionReady, example.valid, example.name);
+    assert.deepEqual(
+      lint.missingRequired,
+      example.expectedMissingRequired ?? [],
+      `${example.name} missingRequired`,
+    );
+    assert.deepEqual(
+      lint.metadataErrors,
+      example.expectedMetadataErrors ?? [],
+      `${example.name} metadataErrors`,
+    );
+  }
+});

--- a/src/issue-metadata/issue-body-contract-artifact.test.ts
+++ b/src/issue-metadata/issue-body-contract-artifact.test.ts
@@ -16,6 +16,7 @@ interface IssueBodyExample {
 
 interface IssueBodyContract {
   contractName: string;
+  contractVersion: number;
   canonicalGuide: string;
   requiredSections: string[];
   standaloneDefaults: {
@@ -56,6 +57,7 @@ test("published issue body contract captures required sections and scheduling sh
   const contract = readContract();
 
   assert.equal(contract.contractName, "codex-supervisor.issue-body-contract");
+  assert.equal(contract.contractVersion, 1);
   assert.equal(contract.canonicalGuide, "docs/issue-metadata.md");
   assert.deepEqual(contract.requiredSections, [
     "Summary",


### PR DESCRIPTION
## Summary
- add a portable JSON contract artifact for execution-ready issue body metadata
- include valid and invalid standalone/child examples checked against issue-lint behavior
- reference the artifact from docs/issue-metadata.md without changing parser or lint enforcement

## Verification
- npx tsx --test src/issue-metadata/issue-body-contract-artifact.test.ts
- npx tsx --test src/issue-metadata/issue-metadata-parser.test.ts src/issue-metadata/issue-metadata.test.ts src/issue-metadata/issue-metadata-gates.test.ts src/supervisor/supervisor-selection-issue-lint.test.ts src/supervisor/supervisor-diagnostics-issue-lint-readiness.test.ts src/supervisor/supervisor-diagnostics-issue-lint-metadata.test.ts
- npm run build
- npm run verify:paths

Part of #1831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a machine-readable specification contract for issue body formatting, including standalone defaults and sequenced-child metadata requirements with validation examples.
  * Updated documentation to reference the new issue body contract specification.

* **Tests**
  * Added comprehensive test suite validating issue body contract specifications against real-world examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->