### PR TITLE
Phase 15.2: Publish trust posture config schema artifact

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,6 +352,8 @@ Operator prerequisite:
 
 Setup/readiness treats `trustMode` and `executionSafetyMode` as explicit first-run decisions. `status` and `doctor` render the same posture with `trust_mode=...`, `execution_safety_mode=...`, `doctor_posture`, and, for unsandboxed trusted execution, `execution_safety_warning`. Unsandboxed autonomous execution requires trusted GitHub authors as part of the operator-owned posture.
 
+Machine-readable contract: external setup tooling can read [`docs/trust-posture-config.schema.json`](trust-posture-config.schema.json) for the portable trust posture field list, local CI posture states, review provider posture boundary, trust/safety combinations, and dangerous opt-ins. Config loading and setup/readiness remain the enforcement boundary.
+
 | `trustMode` | `executionSafetyMode` | Posture | Operator meaning | Status and doctor vocabulary |
 | --- | --- | --- | --- | --- |
 | `trusted_repo_and_authors` | `operator_gated` | Safe | The repo and GitHub authors are trusted. Use this as an explicit conservative posture marker; trust checks are already satisfied for trusted inputs. | `trust_mode=trusted_repo_and_authors`, `execution_safety_mode=operator_gated`; no unsandboxed warning. |

--- a/docs/trust-posture-config.schema.json
+++ b/docs/trust-posture-config.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/TommyKammy/codex-supervisor/docs/trust-posture-config.schema.json",
+  "$ref": "#/$defs/trustPostureConfigContract",
   "contractName": "codex-supervisor.trust-posture-config",
   "contractVersion": 1,
   "canonicalGuide": "docs/configuration.md",
@@ -277,6 +278,16 @@
             "type": "string"
           },
           "minItems": 1
+        },
+        "localCiPostures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/localCiPosture"
+          },
+          "minItems": 1
+        },
+        "reviewProviderPosture": {
+          "$ref": "#/$defs/reviewProviderPosture"
         }
       }
     },
@@ -342,6 +353,61 @@
           "type": "boolean"
         },
         "operatorMeaning": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "localCiPosture": {
+      "type": "object",
+      "required": [
+        "source",
+        "configured",
+        "summary"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "config",
+            "repo_script_candidate",
+            "dismissed_repo_script_candidate"
+          ]
+        },
+        "configured": {
+          "type": "boolean"
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "reviewProviderPosture": {
+      "type": "object",
+      "required": [
+        "configuredWhen",
+        "signalSources",
+        "operatorAuthorityBoundary"
+      ],
+      "properties": {
+        "configuredWhen": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "signalSources": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "copilot_lifecycle",
+              "review_threads"
+            ]
+          },
+          "minItems": 1
+        },
+        "operatorAuthorityBoundary": {
           "type": "string"
         }
       },

--- a/docs/trust-posture-config.schema.json
+++ b/docs/trust-posture-config.schema.json
@@ -1,0 +1,351 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TommyKammy/codex-supervisor/docs/trust-posture-config.schema.json",
+  "contractName": "codex-supervisor.trust-posture-config",
+  "contractVersion": 1,
+  "canonicalGuide": "docs/configuration.md",
+  "enforcementBoundary": "config-loader-and-setup-readiness",
+  "setupReadinessEndpoint": "GET /api/setup-readiness",
+  "description": "Portable contract for the operator-owned trust posture fields in supervisor config. The config loader and setup readiness report remain the enforcement boundary; this artifact publishes the machine-readable field choices, authority boundaries, and dangerous opt-ins for external setup tooling.",
+  "fields": [
+    {
+      "field": "trustMode",
+      "values": [
+        "trusted_repo_and_authors",
+        "untrusted_or_mixed"
+      ],
+      "default": "trusted_repo_and_authors",
+      "requiredBySetupReadiness": true,
+      "operatorAuthorityBoundary": "Operator declares whether the managed repository and GitHub authors that can provide execution text are trusted.",
+      "setupReadinessSurface": "trustPosture"
+    },
+    {
+      "field": "executionSafetyMode",
+      "values": [
+        "unsandboxed_autonomous",
+        "operator_gated"
+      ],
+      "default": "unsandboxed_autonomous",
+      "requiredBySetupReadiness": true,
+      "operatorAuthorityBoundary": "Operator declares whether Codex may run autonomously in the current execution-safety posture or must stay gated by operator action.",
+      "setupReadinessSurface": "trustPosture",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "workspacePreparationCommand",
+      "default": null,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator adopts a repo-owned setup command that prepares preserved issue worktrees before host-local CI runs.",
+      "setupReadinessSurface": "fields.workspacePreparationCommand"
+    },
+    {
+      "field": "localCiCommand",
+      "default": null,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator adopts a repo-owned local CI command as the fail-closed local publication gate; detected scripts remain advisory until configured.",
+      "setupReadinessSurface": "localCiContract"
+    },
+    {
+      "field": "localCiCandidateDismissed",
+      "default": false,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator explicitly acknowledges that a detected repo-owned local CI candidate should remain non-blocking for this supervisor profile.",
+      "setupReadinessSurface": "localCiContract"
+    },
+    {
+      "field": "configuredReviewProviders",
+      "default": null,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator binds review-provider posture to explicit provider identities and signal sources instead of trusting arbitrary review text.",
+      "setupReadinessSurface": "providerPosture"
+    },
+    {
+      "field": "reviewBotLogins",
+      "default": [],
+      "requiredBySetupReadiness": true,
+      "operatorAuthorityBoundary": "Operator declares which review bot identities can contribute configured review-provider signals.",
+      "setupReadinessSurface": "providerPosture"
+    },
+    {
+      "field": "localReviewPosture",
+      "values": [
+        "off",
+        "advisory",
+        "block_merge",
+        "repair_high_severity",
+        "follow_up_issue_creation"
+      ],
+      "default": "off",
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator selects whether local review is disabled, advisory, merge-blocking, or allowed to expand into repair or follow-up issue workflows.",
+      "setupReadinessSurface": "localReviewPosture",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "localReviewFollowUpRepairEnabled",
+      "default": false,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator explicitly allows same-PR repair for local-review follow-up eligible findings.",
+      "setupReadinessSurface": "configPostureGroups.dangerous_explicit_opt_in",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "localReviewManualReviewRepairEnabled",
+      "default": false,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator explicitly allows same-PR repair for current-head manual-review-blocked local-review residuals.",
+      "setupReadinessSurface": "configPostureGroups.dangerous_explicit_opt_in",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "localReviewFollowUpIssueCreationEnabled",
+      "default": false,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator explicitly allows eligible local-review findings to create follow-up issues.",
+      "setupReadinessSurface": "configPostureGroups.dangerous_explicit_opt_in",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "localReviewHighSeverityAction",
+      "values": [
+        "blocked",
+        "retry"
+      ],
+      "default": "blocked",
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator decides whether verifier-confirmed high-severity local-review findings stay blocked or may trigger bounded repair retries.",
+      "setupReadinessSurface": "localReviewPosture",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "staleConfiguredBotReviewPolicy",
+      "values": [
+        "diagnose_only",
+        "reply_only",
+        "reply_and_resolve"
+      ],
+      "default": "diagnose_only",
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator decides whether stale configured-bot review threads are only diagnosed or can receive replies and resolution actions.",
+      "setupReadinessSurface": "configPostureGroups.dangerous_explicit_opt_in",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "approvedTrackedTopLevelEntries",
+      "default": null,
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator explicitly expands the approved tracked repository skeleton entries used by path hygiene checks.",
+      "setupReadinessSurface": "configPostureGroups.dangerous_explicit_opt_in",
+      "dangerousOptIn": true
+    },
+    {
+      "field": "releaseReadinessGate",
+      "values": [
+        "advisory",
+        "block_release_publication"
+      ],
+      "default": "advisory",
+      "requiredBySetupReadiness": false,
+      "operatorAuthorityBoundary": "Operator decides whether release-readiness remains advisory or can block release publication only.",
+      "setupReadinessSurface": "releaseReadinessGate",
+      "dangerousOptIn": true
+    }
+  ],
+  "trustSafetyCombinations": [
+    {
+      "trustMode": "trusted_repo_and_authors",
+      "executionSafetyMode": "operator_gated",
+      "posture": "safe",
+      "dangerousOptIn": false,
+      "operatorMeaning": "Trusted repo and trusted GitHub authors are declared, while execution still stays operator gated."
+    },
+    {
+      "trustMode": "untrusted_or_mixed",
+      "executionSafetyMode": "operator_gated",
+      "posture": "cautious",
+      "dangerousOptIn": false,
+      "operatorMeaning": "Repo or author trust is mixed or unclear, so execution remains gated and issues need explicit trusted-input signals."
+    },
+    {
+      "trustMode": "trusted_repo_and_authors",
+      "executionSafetyMode": "unsandboxed_autonomous",
+      "posture": "dangerous_opt_in",
+      "dangerousOptIn": true,
+      "operatorMeaning": "Unsandboxed autonomous execution is allowed only because the operator has explicitly trusted the repo and GitHub authors."
+    },
+    {
+      "trustMode": "untrusted_or_mixed",
+      "executionSafetyMode": "unsandboxed_autonomous",
+      "posture": "dangerous",
+      "dangerousOptIn": true,
+      "operatorMeaning": "Untrusted or mixed GitHub-authored inputs are combined with unsandboxed autonomous execution; investigate before starting the loop."
+    }
+  ],
+  "dangerousOptIns": [
+    "executionSafetyMode: unsandboxed_autonomous",
+    "localReviewPosture: repair_high_severity",
+    "localReviewPosture: follow_up_issue_creation",
+    "localReviewFollowUpRepairEnabled",
+    "localReviewManualReviewRepairEnabled",
+    "localReviewFollowUpIssueCreationEnabled",
+    "localReviewHighSeverityAction: retry",
+    "staleConfiguredBotReviewPolicy: reply_only|reply_and_resolve",
+    "approvedTrackedTopLevelEntries",
+    "releaseReadinessGate: block_release_publication"
+  ],
+  "localCiPostures": [
+    {
+      "source": "config",
+      "configured": false,
+      "summary": "No repo-owned local CI contract is configured."
+    },
+    {
+      "source": "repo_script_candidate",
+      "configured": false,
+      "summary": "Repo-owned local CI candidate exists but localCiCommand is unset."
+    },
+    {
+      "source": "dismissed_repo_script_candidate",
+      "configured": false,
+      "summary": "Repo-owned local CI candidate was intentionally dismissed; localCiCommand remains unset and non-blocking."
+    },
+    {
+      "source": "config",
+      "configured": true,
+      "summary": "Repo-owned local CI contract is configured."
+    }
+  ],
+  "reviewProviderPosture": {
+    "configuredWhen": [
+      "reviewBotLogins contains at least one configured provider login",
+      "configuredReviewProviders contains at least one provider with reviewerLogins and signalSource"
+    ],
+    "signalSources": [
+      "copilot_lifecycle",
+      "review_threads"
+    ],
+    "operatorAuthorityBoundary": "Provider signals are trusted only for configured provider identities and signal sources; raw review text is not an authority boundary by itself."
+  },
+  "$defs": {
+    "trustPostureConfigContract": {
+      "type": "object",
+      "required": [
+        "contractName",
+        "contractVersion",
+        "canonicalGuide",
+        "enforcementBoundary",
+        "setupReadinessEndpoint",
+        "fields",
+        "trustSafetyCombinations",
+        "dangerousOptIns",
+        "localCiPostures",
+        "reviewProviderPosture"
+      ],
+      "properties": {
+        "contractName": {
+          "const": "codex-supervisor.trust-posture-config"
+        },
+        "contractVersion": {
+          "const": 1
+        },
+        "canonicalGuide": {
+          "const": "docs/configuration.md"
+        },
+        "enforcementBoundary": {
+          "const": "config-loader-and-setup-readiness"
+        },
+        "setupReadinessEndpoint": {
+          "const": "GET /api/setup-readiness"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/field"
+          },
+          "minItems": 1
+        },
+        "trustSafetyCombinations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/trustSafetyCombination"
+          },
+          "minItems": 4
+        },
+        "dangerousOptIns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "field": {
+      "type": "object",
+      "required": [
+        "field",
+        "operatorAuthorityBoundary",
+        "setupReadinessSurface"
+      ],
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {},
+        "requiredBySetupReadiness": {
+          "type": "boolean"
+        },
+        "operatorAuthorityBoundary": {
+          "type": "string"
+        },
+        "setupReadinessSurface": {
+          "type": "string"
+        },
+        "dangerousOptIn": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "trustSafetyCombination": {
+      "type": "object",
+      "required": [
+        "trustMode",
+        "executionSafetyMode",
+        "posture",
+        "dangerousOptIn",
+        "operatorMeaning"
+      ],
+      "properties": {
+        "trustMode": {
+          "enum": [
+            "trusted_repo_and_authors",
+            "untrusted_or_mixed"
+          ]
+        },
+        "executionSafetyMode": {
+          "enum": [
+            "unsandboxed_autonomous",
+            "operator_gated"
+          ]
+        },
+        "posture": {
+          "type": "string"
+        },
+        "dangerousOptIn": {
+          "type": "boolean"
+        },
+        "operatorMeaning": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/trust-posture-config-schema-artifact.test.ts
+++ b/src/trust-posture-config-schema-artifact.test.ts
@@ -28,6 +28,13 @@ interface TrustPostureCombination {
 }
 
 interface TrustPostureConfigSchema {
+  $ref: string;
+  $defs: {
+    trustPostureConfigContract: {
+      required: string[];
+      properties: Record<string, unknown>;
+    };
+  };
   contractName: string;
   contractVersion: number;
   canonicalGuide: string;
@@ -53,6 +60,11 @@ function readSchema(): TrustPostureConfigSchema {
 test("published trust posture config schema captures the portable contract fields", () => {
   const schema = readSchema();
 
+  assert.equal(schema.$ref, "#/$defs/trustPostureConfigContract");
+  assert.ok(schema.$defs.trustPostureConfigContract.required.includes("localCiPostures"));
+  assert.ok(schema.$defs.trustPostureConfigContract.required.includes("reviewProviderPosture"));
+  assert.ok(schema.$defs.trustPostureConfigContract.properties.localCiPostures);
+  assert.ok(schema.$defs.trustPostureConfigContract.properties.reviewProviderPosture);
   assert.equal(schema.contractName, "codex-supervisor.trust-posture-config");
   assert.equal(schema.contractVersion, 1);
   assert.equal(schema.canonicalGuide, "docs/configuration.md");

--- a/src/trust-posture-config-schema-artifact.test.ts
+++ b/src/trust-posture-config-schema-artifact.test.ts
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { diagnoseSetupReadiness } from "./setup-readiness";
+import {
+  summarizeLocalCiContract,
+  summarizeLocalReviewPosture,
+  summarizeReleaseReadinessGate,
+  summarizeTrustDiagnostics,
+} from "./core/config";
+
+interface TrustPostureConfigField {
+  field: string;
+  values?: string[];
+  default?: string | boolean | null;
+  requiredBySetupReadiness?: boolean;
+  operatorAuthorityBoundary: string;
+  setupReadinessSurface: string;
+  dangerousOptIn?: boolean;
+}
+
+interface TrustPostureCombination {
+  trustMode: string;
+  executionSafetyMode: string;
+  posture: string;
+  dangerousOptIn: boolean;
+}
+
+interface TrustPostureConfigSchema {
+  contractName: string;
+  contractVersion: number;
+  canonicalGuide: string;
+  enforcementBoundary: string;
+  setupReadinessEndpoint: string;
+  fields: TrustPostureConfigField[];
+  trustSafetyCombinations: TrustPostureCombination[];
+  dangerousOptIns: string[];
+  localCiPostures: Array<{ source: string; configured: boolean; summary: string }>;
+  reviewProviderPosture: {
+    configuredWhen: string[];
+    signalSources: string[];
+    operatorAuthorityBoundary: string;
+  };
+}
+
+const schemaPath = resolve(process.cwd(), "docs/trust-posture-config.schema.json");
+
+function readSchema(): TrustPostureConfigSchema {
+  return JSON.parse(readFileSync(schemaPath, "utf8")) as TrustPostureConfigSchema;
+}
+
+test("published trust posture config schema captures the portable contract fields", () => {
+  const schema = readSchema();
+
+  assert.equal(schema.contractName, "codex-supervisor.trust-posture-config");
+  assert.equal(schema.contractVersion, 1);
+  assert.equal(schema.canonicalGuide, "docs/configuration.md");
+  assert.equal(schema.enforcementBoundary, "config-loader-and-setup-readiness");
+  assert.equal(schema.setupReadinessEndpoint, "GET /api/setup-readiness");
+
+  const fields = new Map(schema.fields.map((field) => [field.field, field]));
+  assert.deepEqual(fields.get("trustMode")?.values, ["trusted_repo_and_authors", "untrusted_or_mixed"]);
+  assert.equal(fields.get("trustMode")?.requiredBySetupReadiness, true);
+  assert.deepEqual(fields.get("executionSafetyMode")?.values, ["unsandboxed_autonomous", "operator_gated"]);
+  assert.equal(fields.get("executionSafetyMode")?.requiredBySetupReadiness, true);
+  assert.equal(fields.get("localCiCommand")?.setupReadinessSurface, "localCiContract");
+  assert.equal(fields.get("configuredReviewProviders")?.setupReadinessSurface, "providerPosture");
+
+  for (const field of ["localReviewFollowUpRepairEnabled", "localReviewManualReviewRepairEnabled", "localReviewFollowUpIssueCreationEnabled"]) {
+    assert.equal(fields.get(field)?.dangerousOptIn, true, `${field} must stay visibly separate from defaults`);
+  }
+  assert.deepEqual(schema.dangerousOptIns, [
+    "executionSafetyMode: unsandboxed_autonomous",
+    "localReviewPosture: repair_high_severity",
+    "localReviewPosture: follow_up_issue_creation",
+    "localReviewFollowUpRepairEnabled",
+    "localReviewManualReviewRepairEnabled",
+    "localReviewFollowUpIssueCreationEnabled",
+    "localReviewHighSeverityAction: retry",
+    "staleConfiguredBotReviewPolicy: reply_only|reply_and_resolve",
+    "approvedTrackedTopLevelEntries",
+    "releaseReadinessGate: block_release_publication",
+  ]);
+});
+
+test("published trust posture config schema maps to current validation and readiness behavior", async () => {
+  const schema = readSchema();
+  const combinations = schema.trustSafetyCombinations.map((entry) => ({
+    trustMode: entry.trustMode,
+    executionSafetyMode: entry.executionSafetyMode,
+    dangerousOptIn: entry.dangerousOptIn,
+  }));
+
+  assert.deepEqual(combinations, [
+    { trustMode: "trusted_repo_and_authors", executionSafetyMode: "operator_gated", dangerousOptIn: false },
+    { trustMode: "untrusted_or_mixed", executionSafetyMode: "operator_gated", dangerousOptIn: false },
+    { trustMode: "trusted_repo_and_authors", executionSafetyMode: "unsandboxed_autonomous", dangerousOptIn: true },
+    { trustMode: "untrusted_or_mixed", executionSafetyMode: "unsandboxed_autonomous", dangerousOptIn: true },
+  ]);
+
+  assert.equal(
+    summarizeTrustDiagnostics({
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }).warning !== null,
+    true,
+  );
+  assert.equal(
+    summarizeTrustDiagnostics({
+      trustMode: "untrusted_or_mixed",
+      executionSafetyMode: "operator_gated",
+      issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    }).warning,
+    null,
+  );
+
+  assert.equal(summarizeLocalCiContract({}).source, "config");
+  assert.equal(summarizeLocalCiContract({ localCiCommand: "npm run verify:pre-pr" }).configured, true);
+  assert.equal(
+    summarizeLocalReviewPosture({
+      localReviewPosture: "repair_high_severity",
+      localReviewEnabled: true,
+      localReviewPolicy: "block_merge",
+      localReviewFollowUpIssueCreationEnabled: false,
+      localReviewHighSeverityAction: "retry",
+    }).autoRepair,
+    "high_severity_only",
+  );
+  assert.equal(summarizeReleaseReadinessGate({ releaseReadinessGate: "block_release_publication" }).canBlock[0], "release_publication");
+
+  const readiness = await diagnoseSetupReadiness({
+    configPath: resolve(process.cwd(), "supervisor.config.example.json"),
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+  assert.deepEqual(
+    readiness.fields
+      .filter((field) => field.key === "trustMode" || field.key === "executionSafetyMode")
+      .map((field) => [field.key, field.metadata.valueType, field.required]),
+    [
+      ["trustMode", "trust_mode", true],
+      ["executionSafetyMode", "execution_safety_mode", true],
+    ],
+  );
+});


### PR DESCRIPTION
## Summary
- publish a portable trust posture config schema artifact
- document the artifact from the configuration reference
- add focused schema tests that map the artifact back to current config/readiness behavior

## Verification
- npx tsx --test src/trust-posture-config-schema-artifact.test.ts
- npx tsx --test src/trust-posture-config-schema-artifact.test.ts src/config.test.ts src/setup-readiness.test.ts
- npm run build
- npm run verify:paths
- npx tsx --test src/execution-safety-docs.test.ts src/getting-started-docs.test.ts

Part of #1830. Depends on #1831. Closes #1832.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a machine-readable trust posture configuration schema (formalizes fields, allowed values, combinations, dangerous opt-ins, local CI postures, and review-provider posture) for operator-owned configuration.

* **Documentation**
  * Configuration guide updated to reference the new schema and clarify setup/readiness enforcement boundaries.

* **Tests**
  * Added validation tests that verify schema contract integrity, expected field values/flags, combination rules, and readiness/diagnostic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->