### PR TITLE
Publish portable operator action vocabulary

### DIFF
--- a/docs/operator-actions.schema.json
+++ b/docs/operator-actions.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TommyKammy/codex-supervisor/docs/operator-actions.schema.json",
+  "$ref": "#/$defs/operatorActionVocabularyContract",
+  "contractName": "codex-supervisor.operator-actions",
+  "contractVersion": 1,
+  "canonicalSource": "src/operator-actions.ts",
+  "description": "Portable vocabulary contract for operator action tokens emitted by status, doctor, and WebUI surfaces. Runtime parsing and selection remain backed by src/operator-actions.ts; this artifact lets docs, UI, and external automation consume the token list without scraping TypeScript source.",
+  "actions": [
+    {
+      "action": "continue",
+      "surfaces": ["status", "doctor", "webui"],
+      "meaning": "No blocking operator action was detected; continue normal supervisor operation."
+    },
+    {
+      "action": "restart_loop",
+      "surfaces": ["status", "webui"],
+      "meaning": "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance."
+    },
+    {
+      "action": "fix_config",
+      "surfaces": ["status", "doctor", "webui"],
+      "meaning": "Repair host prerequisites, setup fields, workspace-preparation configuration, or incomplete local CI visibility before continuing."
+    },
+    {
+      "action": "adopt_local_ci",
+      "surfaces": ["doctor", "webui"],
+      "meaning": "A repo-owned local CI candidate exists; configure it before relying on local verification posture."
+    },
+    {
+      "action": "dismiss_local_ci",
+      "surfaces": ["webui"],
+      "meaning": "Explicitly dismiss a repo-owned local CI recommendation when local CI should remain unset."
+    },
+    {
+      "action": "manual_review",
+      "surfaces": ["status", "doctor", "webui"],
+      "meaning": "A tracked path or diagnostic warning requires human judgment before automation should continue."
+    },
+    {
+      "action": "resolve_stale_review_bot",
+      "surfaces": ["status", "webui"],
+      "meaning": "Code or CI is green but stale configured-bot review thread metadata still blocks the tracked PR; inspect and resolve the exact thread or leave a manual note."
+    },
+    {
+      "action": "provider_outage_suspected",
+      "surfaces": ["status", "webui"],
+      "meaning": "Required checks are green but the configured review provider has not reported on the current head; wait, verify provider delivery, or escalate to manual review."
+    },
+    {
+      "action": "safe_to_ignore",
+      "surfaces": ["doctor", "webui"],
+      "meaning": "A dismissed or already-completed advisory signal does not require operator action."
+    }
+  ],
+  "$defs": {
+    "operatorActionVocabularyContract": {
+      "type": "object",
+      "required": [
+        "contractName",
+        "contractVersion",
+        "canonicalSource",
+        "actions"
+      ],
+      "properties": {
+        "contractName": {
+          "const": "codex-supervisor.operator-actions"
+        },
+        "contractVersion": {
+          "const": 1
+        },
+        "canonicalSource": {
+          "const": "src/operator-actions.ts"
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/operatorAction"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "operatorAction": {
+      "type": "object",
+      "required": [
+        "action",
+        "surfaces",
+        "meaning"
+      ],
+      "properties": {
+        "action": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "surfaces": {
+          "type": "array",
+          "items": {
+            "enum": ["status", "doctor", "webui"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "meaning": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -169,6 +169,18 @@ export function describeLoopOffTrackedWorkRestartActionTitle(): string {
   return "Restart the supported loop host";
 }
 
+export const operatorActionDashboardTitles: Record<OperatorActionToken, string> = {
+  continue: "Observe and refresh",
+  restart_loop: describeLoopOffTrackedWorkRestartActionTitle(),
+  fix_config: "Fix supervisor configuration",
+  adopt_local_ci: "Adopt local CI contract",
+  dismiss_local_ci: "Dismiss local CI recommendation",
+  manual_review: "Complete manual review",
+  resolve_stale_review_bot: "Resolve stale review metadata",
+  provider_outage_suspected: "Check review provider delivery",
+  safe_to_ignore: "No operator action required",
+};
+
 export function describeLoopOffTrackedWorkRestartExpectation(): string {
   return "Restart the supported loop host; expect loop_runtime state=running before tracked work advances.";
 }
@@ -781,18 +793,6 @@ export function buildPrimaryActionSummary(args: {
   const loopOffTrackedWorkBlocker = describeLoopOffTrackedWorkBlocker(args.status);
   const operatorAction = selectRenderedOperatorAction(args.status);
 
-  function titleForOperatorAction(action: DashboardOperatorActionToken): string {
-    if (action === "fix_config") return "Fix supervisor configuration";
-    if (action === "restart_loop") return describeLoopOffTrackedWorkRestartActionTitle();
-    if (action === "adopt_local_ci") return "Adopt local CI contract";
-    if (action === "dismiss_local_ci") return "Dismiss local CI recommendation";
-    if (action === "manual_review") return "Complete manual review";
-    if (action === "resolve_stale_review_bot") return "Resolve stale review metadata";
-    if (action === "provider_outage_suspected") return "Check review provider delivery";
-    if (action === "safe_to_ignore") return "No operator action required";
-    return "Observe and refresh";
-  }
-
   if (!args.hasSuccessfulRefresh) {
     return {
       title: "Wait for the first refresh",
@@ -816,7 +816,7 @@ export function buildPrimaryActionSummary(args: {
 
   if (operatorAction !== null && operatorAction.action !== "continue") {
     return {
-      title: titleForOperatorAction(operatorAction.action),
+      title: operatorActionDashboardTitles[operatorAction.action],
       detail: operatorAction.summary,
     };
   }

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -1,12 +1,38 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   buildStatusOperatorCockpitViewModel,
+  operatorActionVocabulary,
   parseOperatorActionLine,
   type RestartRecommendation,
   selectRestartRecommendation,
   selectStatusOperatorAction,
+  validOperatorActions,
 } from "./operator-actions";
+import { operatorActionDashboardTitles } from "./backend/webui-dashboard-browser-logic";
+
+interface PublishedOperatorActionVocabulary {
+  contractName: string;
+  contractVersion: number;
+  canonicalSource: string;
+  actions: Array<{
+    action: string;
+    surfaces: string[];
+    meaning: string;
+  }>;
+}
+
+const operatorActionContractPath = resolve(process.cwd(), "docs/operator-actions.schema.json");
+
+function readPublishedOperatorActionVocabulary(): PublishedOperatorActionVocabulary {
+  return JSON.parse(readFileSync(operatorActionContractPath, "utf8")) as PublishedOperatorActionVocabulary;
+}
+
+function sortedTokens(tokens: Iterable<string>): string[] {
+  return [...tokens].sort((left, right) => left.localeCompare(right));
+}
 
 function requireRestartRecommendation(recommendation: RestartRecommendation | null): RestartRecommendation {
   if (recommendation === null) {
@@ -55,6 +81,36 @@ test("selectRestartRecommendation classifies every restart recommendation catego
       ],
     })).category,
     "manual_review_before_restart",
+  );
+});
+
+test("published operator action artifact matches the typed vocabulary", () => {
+  const contract = readPublishedOperatorActionVocabulary();
+
+  assert.equal(contract.contractName, "codex-supervisor.operator-actions");
+  assert.equal(contract.contractVersion, 1);
+  assert.equal(contract.canonicalSource, "src/operator-actions.ts");
+  assert.deepEqual(contract.actions, operatorActionVocabulary);
+  assert.deepEqual(sortedTokens(Object.keys(validOperatorActions)), sortedTokens(operatorActionVocabulary.map((entry) => entry.action)));
+});
+
+test("operator action docs and WebUI labels cannot reference tokens outside the shared vocabulary", () => {
+  const vocabulary = new Set<string>(operatorActionVocabulary.map((entry) => entry.action));
+  const docs = readFileSync(resolve(process.cwd(), "docs/getting-started.md"), "utf8");
+  const documentedTokens = [
+    ...docs.matchAll(/\b(?:operator_action|doctor_operator_action) action=([a-z0-9_]+)/gu),
+  ].map((match) => match[1]);
+
+  assert.ok(documentedTokens.length > 0, "getting-started docs should include operator action examples");
+  assert.deepEqual(
+    documentedTokens.filter((token) => !vocabulary.has(token)),
+    [],
+    "docs must not document action tokens outside src/operator-actions.ts",
+  );
+  assert.deepEqual(
+    sortedTokens(Object.keys(operatorActionDashboardTitles)),
+    sortedTokens(vocabulary),
+    "WebUI operator action titles must cover the shared action vocabulary exactly",
   );
 });
 

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -1,9 +1,9 @@
 import type { LocalCiContractSummary } from "./core/types";
 
 export interface OperatorActionVocabularyEntry {
-  action: string;
-  surfaces: Array<"status" | "doctor" | "webui">;
-  meaning: string;
+  readonly action: string;
+  readonly surfaces: ReadonlyArray<"status" | "doctor" | "webui">;
+  readonly meaning: string;
 }
 
 export const operatorActionVocabulary = [

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -1,15 +1,64 @@
 import type { LocalCiContractSummary } from "./core/types";
 
-export type OperatorActionToken =
-  | "continue"
-  | "restart_loop"
-  | "fix_config"
-  | "adopt_local_ci"
-  | "dismiss_local_ci"
-  | "manual_review"
-  | "resolve_stale_review_bot"
-  | "provider_outage_suspected"
-  | "safe_to_ignore";
+export interface OperatorActionVocabularyEntry {
+  action: string;
+  surfaces: Array<"status" | "doctor" | "webui">;
+  meaning: string;
+}
+
+export const operatorActionVocabulary = [
+  {
+    action: "continue",
+    surfaces: ["status", "doctor", "webui"],
+    meaning: "No blocking operator action was detected; continue normal supervisor operation.",
+  },
+  {
+    action: "restart_loop",
+    surfaces: ["status", "webui"],
+    meaning:
+      "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance.",
+  },
+  {
+    action: "fix_config",
+    surfaces: ["status", "doctor", "webui"],
+    meaning:
+      "Repair host prerequisites, setup fields, workspace-preparation configuration, or incomplete local CI visibility before continuing.",
+  },
+  {
+    action: "adopt_local_ci",
+    surfaces: ["doctor", "webui"],
+    meaning: "A repo-owned local CI candidate exists; configure it before relying on local verification posture.",
+  },
+  {
+    action: "dismiss_local_ci",
+    surfaces: ["webui"],
+    meaning: "Explicitly dismiss a repo-owned local CI recommendation when local CI should remain unset.",
+  },
+  {
+    action: "manual_review",
+    surfaces: ["status", "doctor", "webui"],
+    meaning: "A tracked path or diagnostic warning requires human judgment before automation should continue.",
+  },
+  {
+    action: "resolve_stale_review_bot",
+    surfaces: ["status", "webui"],
+    meaning:
+      "Code or CI is green but stale configured-bot review thread metadata still blocks the tracked PR; inspect and resolve the exact thread or leave a manual note.",
+  },
+  {
+    action: "provider_outage_suspected",
+    surfaces: ["status", "webui"],
+    meaning:
+      "Required checks are green but the configured review provider has not reported on the current head; wait, verify provider delivery, or escalate to manual review.",
+  },
+  {
+    action: "safe_to_ignore",
+    surfaces: ["doctor", "webui"],
+    meaning: "A dismissed or already-completed advisory signal does not require operator action.",
+  },
+] as const satisfies readonly OperatorActionVocabularyEntry[];
+
+export type OperatorActionToken = typeof operatorActionVocabulary[number]["action"];
 
 export interface OperatorAction {
   action: OperatorActionToken;
@@ -86,17 +135,9 @@ const doctorFallbackOperatorAction: OperatorAction = {
   summary: "No blocking doctor action was detected; continue normal supervisor operation.",
 };
 
-export const validOperatorActions: Record<OperatorActionToken, true> = {
-  continue: true,
-  restart_loop: true,
-  fix_config: true,
-  adopt_local_ci: true,
-  dismiss_local_ci: true,
-  manual_review: true,
-  resolve_stale_review_bot: true,
-  provider_outage_suspected: true,
-  safe_to_ignore: true,
-};
+export const validOperatorActions = Object.fromEntries(
+  operatorActionVocabulary.map((entry) => [entry.action, true]),
+) as Record<OperatorActionToken, true>;
 
 export function parseOperatorActionPriority(priorityValue: string | null): number {
   return priorityValue !== null && /^-?\d+$/u.test(priorityValue)


### PR DESCRIPTION
## Summary
- publish `docs/operator-actions.schema.json` as the portable operator action vocabulary contract
- derive the runtime action token type and validation map from the exported typed vocabulary
- add drift checks for the published artifact, getting-started docs action examples, and WebUI action titles

Closes #1833

## Verification
- `test -f docs/operator-actions.schema.json` failed before implementation as the focused repro
- `npx tsx --test src/operator-actions.test.ts`
- `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts src/backend/webui-dashboard-browser-view-model.test.ts`
- `npx tsx --test src/doctor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-report.test.ts`
- `npm run verify:paths`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a formal schema for the operator actions vocabulary (identifiers, surfaces, meanings).

* **Tests**
  * Added end-to-end checks to keep documentation, schema, and code vocabulary in sync and ensure examples use valid actions.

* **Refactor**
  * Centralized operator action vocabulary and unified dashboard titles to ensure consistent action names and labels in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->