### PR TITLE
Publish Codex Automation boundary artifact

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,9 @@ Today the supervisor invokes Codex with `--dangerously-bypass-approvals-and-sand
 
 The same fail-open vs fail-closed distinction applies to state recovery guidance: missing JSON state can bootstrap, but corrupted JSON state should be surfaced to the operator through diagnostics and recovery flow, not silently reused as if it were trustworthy state.
 
-Codex app Automation is an orchestration boundary around this loop. It can watch loop state, evaluate merges, draft confirm-required follow-up issues, and record Obsidian history, but codex-supervisor remains the implementation executor. Automation is not an executor replacement, and it must preserve quiet-when-no-change behavior, no destructive git operations, and the same issue metadata, path hygiene, review, branch, and merge safety gates described here.
+Codex app Automation is an orchestration boundary around this loop. It can evaluate state, route actionable changes, draft confirm-required follow-up issues, record Obsidian history, notify the operator, and prepare operator-facing evidence, but codex-supervisor remains the implementation executor. Automation is not an executor replacement, and it must preserve quiet-when-no-change behavior, no destructive git operations, and the same issue metadata, path hygiene, review, branch, merge, and local CI safety gates described here.
+
+Automation must not bypass executor safety gates, issue-lint, fresh PR facts, local CI, or operator confirmations. Multi-repo orchestration and new executor authority stay outside codex-supervisor core.
 
 ## Main reconciliations
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -7,10 +7,13 @@ record support around the loop. Keep the implementation turn, issue worktree,
 journal, PR lifecycle, CI repair loop, review handling, and merge safety inside
 the supervisor-owned flow.
 
+The portable connector-style artifact is [Codex Automation connector boundary](./codex-automation-connector-boundary.schema.json). It publishes the stable responsibility vocabulary for external automation while keeping the enforcement boundary inside `codex-supervisor`.
+
 ## Roles
 
 - Loop Watcher: reads roadmap, GitHub issue and PR state, local status, loop
-  runtime state, and supervisor diagnostics; reports only actionable changes.
+  runtime state, and supervisor diagnostics; routes or notifies only actionable
+  changes.
 - Merge Evaluator: inspects recently merged work against the roadmap and local
   repository state before declaring a phase complete or identifying a narrow
   follow-up.
@@ -19,6 +22,13 @@ the supervisor-owned flow.
   preserve canonical issue metadata.
 - Obsidian Recorder: updates external development history or operating notes
   after real issue, PR, verification, or phase state changes.
+- Operator Evidence Preparer: prepares operator-facing evidence from current
+  issue, PR, CI, review, and local status facts without treating that evidence
+  as execution authority.
+
+External automation may evaluate, route, draft, record, notify, and prepare
+operator-facing evidence. It may not execute implementation changes, decide
+merge readiness, or turn advisory context into supervisor authority.
 
 ## Safety Contract
 
@@ -38,6 +48,11 @@ fresh GitHub PR facts, review-provider boundaries, branch protection, head-SHA
 matching, local config drift, and fail-closed trust-boundary behavior remain
 supervisor requirements.
 
+Automation must not bypass executor safety gates, issue-lint, fresh PR facts,
+local CI, or operator confirmations. Operator confirmations include follow-up
+issue creation, destructive cleanup, recovery acknowledgement, and any manual
+review decision that the supervisor has surfaced as a prerequisite.
+
 ## Explicit Non-Goals
 
 - Do not move implementation execution from `codex-supervisor` into Codex app
@@ -46,6 +61,8 @@ supervisor requirements.
 - Do not add metadata-only review auto-resolve.
 - Do not run broad path repair as an Automation default.
 - Do not broaden the solo automation lane into multi-user governance.
+- Do not put multi-repo orchestration in codex-supervisor core.
+- Do not grant Codex app Automation new executor authority.
 
 ## Portable References
 

--- a/docs/codex-automation-connector-boundary.schema.json
+++ b/docs/codex-automation-connector-boundary.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TommyKammy/codex-supervisor/docs/codex-automation-connector-boundary.schema.json",
+  "$ref": "#/$defs/codexAutomationConnectorBoundaryArtifact",
+  "artifactName": "codex-supervisor.codex-automation-connector-boundary",
+  "artifactVersion": 1,
+  "canonicalGuide": "docs/automation.md",
+  "enforcementBoundary": "codex-supervisor-executor-safety-gates",
+  "description": "Portable connector-style artifact for Codex app Automation. Codex app Automation may evaluate, route, draft, record, notify, and prepare operator evidence, but codex-supervisor remains the implementation executor. Automation must not bypass executor safety gates, issue-lint, fresh PR facts, local CI, or operator confirmations. Multi-repo orchestration and new executor authority stay outside codex-supervisor core.",
+  "allowedResponsibilities": [
+    "evaluate",
+    "route",
+    "draft",
+    "record",
+    "notify",
+    "prepare_operator_evidence"
+  ],
+  "prohibitedBypasses": [
+    "executor_safety_gates",
+    "issue_lint",
+    "fresh_pr_facts",
+    "local_ci",
+    "operator_confirmations"
+  ],
+  "nonGoals": [
+    "new_executor_authority",
+    "multi_repo_orchestration_in_core"
+  ],
+  "$defs": {
+    "codexAutomationConnectorBoundaryArtifact": {
+      "type": "object",
+      "required": [
+        "artifactName",
+        "artifactVersion",
+        "canonicalGuide",
+        "enforcementBoundary",
+        "allowedResponsibilities",
+        "prohibitedBypasses",
+        "nonGoals"
+      ],
+      "properties": {
+        "artifactName": {
+          "const": "codex-supervisor.codex-automation-connector-boundary"
+        },
+        "artifactVersion": {
+          "const": 1
+        },
+        "canonicalGuide": {
+          "const": "docs/automation.md"
+        },
+        "enforcementBoundary": {
+          "const": "codex-supervisor-executor-safety-gates"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allowedResponsibilities": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "evaluate",
+              "route",
+              "draft",
+              "record",
+              "notify",
+              "prepare_operator_evidence"
+            ]
+          },
+          "minItems": 6,
+          "uniqueItems": true
+        },
+        "prohibitedBypasses": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "executor_safety_gates",
+              "issue_lint",
+              "fresh_pr_facts",
+              "local_ci",
+              "operator_confirmations"
+            ]
+          },
+          "minItems": 5,
+          "uniqueItems": true
+        },
+        "nonGoals": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "new_executor_authority",
+              "multi_repo_orchestration_in_core"
+            ]
+          },
+          "minItems": 2,
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/supervised-automation-lane.md
+++ b/docs/supervised-automation-lane.md
@@ -85,7 +85,7 @@ Responsibility stays split across the product surfaces:
 - GitHub: owns the task contract, PR discussion, review facts, merge record, linked follow-up backlog, and release-facing issue/PR evidence.
 - CLI: owns commands and operator-visible handoffs such as `status`, `explain`, `issue-lint`, verification output, failure signatures, and the per-issue journal.
 - WebUI: presents the same authoritative lane state and evidence timeline for inspection, triage, and continuation, without becoming a separate source of truth.
-- Codex app Automation: may watch state, evaluate completed work, draft confirm-required follow-up issues, and prepare durable note patches, but it must not replace `codex-supervisor` as the implementation executor.
+- Codex app Automation: may evaluate state, route actionable changes, draft confirm-required follow-up issues, record durable note patches, notify the operator, and prepare operator-facing evidence, but it must not replace `codex-supervisor` as the implementation executor.
 - durable notes: capture long-lived project memory such as development history, release notes, roadmap changes, operator decisions, follow-up backlog context, and incident/recovery notes.
 
 Writeback should place each fact in the surface that owns it. Development history records what changed and why it matters for future continuation. Release notes collect user-facing changes and verification evidence after merge. Roadmap notes track planned or deferred product direction. Operator decisions record trust, scope, recovery, and manual-review choices that should not be re-decided from stale chat. Follow-up backlog entries should stay narrow and execution-ready. Incident/recovery notes should preserve the failure signature, authoritative state, cleanup result, and next safe action.
@@ -109,8 +109,10 @@ Durable writeback is also a path-hygiene surface. Publishable guidance should us
 - GitHub-authored issue bodies, review comments, and summaries are untrusted execution inputs until the operator has chosen a trusted repo and author lane.
 - Codex app Automation may orchestrate around the lane, but `codex-supervisor` remains the implementation executor.
 - The lane does not create new automation authority beyond the operator-selected config and repo workflow.
+- Codex app Automation must not bypass executor safety gates, issue-lint, fresh PR facts, local CI, or operator confirmations.
 - The lane does not default-enable follow-up issue creation; follow-ups remain confirm-required and scoped to one behavior delta.
 - The lane should preserve trusted solo-lane automation and should not recast the product as broad multi-user governance.
+- Multi-repo orchestration and new executor authority stay outside codex-supervisor core.
 - Fresh PR review facts, branch protection, head-SHA matching, local path hygiene, and issue metadata remain safety surfaces.
 
 ## Current Behavior Anchors

--- a/src/supervised-automation-lane-docs.test.ts
+++ b/src/supervised-automation-lane-docs.test.ts
@@ -267,26 +267,39 @@ test("Codex Automation connector boundary artifact agrees with lane docs and gra
   assert.equal(artifact.canonicalGuide, "docs/automation.md");
   assert.equal(artifact.enforcementBoundary, "codex-supervisor-executor-safety-gates");
 
-  for (const responsibility of ["evaluate", "route", "draft", "record", "notify", "prepare_operator_evidence"]) {
-    assert.ok(
-      artifact.allowedResponsibilities.includes(responsibility),
-      `${responsibility} must be published as an allowed connector responsibility`,
-    );
-  }
+  const expectedResponsibilities = [
+    "evaluate",
+    "route",
+    "draft",
+    "record",
+    "notify",
+    "prepare_operator_evidence",
+  ];
+  assert.deepEqual(
+    sortedValues(artifact.allowedResponsibilities),
+    sortedValues(expectedResponsibilities),
+    "allowedResponsibilities must match the published connector vocabulary exactly",
+  );
 
-  for (const prohibited of [
+  const expectedProhibitedBypasses = [
     "executor_safety_gates",
     "issue_lint",
     "fresh_pr_facts",
     "local_ci",
     "operator_confirmations",
-  ]) {
-    assert.ok(artifact.prohibitedBypasses.includes(prohibited), `${prohibited} must remain non-bypassable`);
-  }
+  ];
+  assert.deepEqual(
+    sortedValues(artifact.prohibitedBypasses),
+    sortedValues(expectedProhibitedBypasses),
+    "prohibitedBypasses must match the published non-bypassable set exactly",
+  );
 
-  for (const nonGoal of ["new_executor_authority", "multi_repo_orchestration_in_core"]) {
-    assert.ok(artifact.nonGoals.includes(nonGoal), `${nonGoal} must stay outside the connector boundary`);
-  }
+  const expectedNonGoals = ["new_executor_authority", "multi_repo_orchestration_in_core"];
+  assert.deepEqual(
+    sortedValues(artifact.nonGoals),
+    sortedValues(expectedNonGoals),
+    "nonGoals must match the published exclusions exactly",
+  );
 
   for (const source of [artifactSource, automationGuide, laneNote, architecture]) {
     assert.match(source, /`?codex-supervisor`? remains the implementation executor/i);

--- a/src/supervised-automation-lane-docs.test.ts
+++ b/src/supervised-automation-lane-docs.test.ts
@@ -18,6 +18,16 @@ interface PublishedStateMachineContract {
   }>;
 }
 
+interface CodexAutomationConnectorBoundaryArtifact {
+  artifactName: string;
+  artifactVersion: number;
+  canonicalGuide: string;
+  enforcementBoundary: string;
+  allowedResponsibilities: string[];
+  prohibitedBypasses: string[];
+  nonGoals: string[];
+}
+
 function sortedValues(values: Iterable<string>): string[] {
   return [...values].sort((left, right) => left.localeCompare(right));
 }
@@ -241,4 +251,53 @@ test("supervised automation lane defines durable project memory writeback respon
   assert.match(note, /placeholder/i);
   assert.doesNotMatch(note, /\/Users\/[A-Za-z0-9._-]+\//);
   assert.doesNotMatch(note, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+});
+
+test("Codex Automation connector boundary artifact agrees with lane docs and grants no executor authority", async () => {
+  const [artifactSource, automationGuide, laneNote, architecture] = await Promise.all([
+    readRepoFile("docs/codex-automation-connector-boundary.schema.json"),
+    readRepoFile("docs/automation.md"),
+    readRepoFile("docs/supervised-automation-lane.md"),
+    readRepoFile("docs/architecture.md"),
+  ]);
+  const artifact = JSON.parse(artifactSource) as CodexAutomationConnectorBoundaryArtifact;
+
+  assert.equal(artifact.artifactName, "codex-supervisor.codex-automation-connector-boundary");
+  assert.equal(artifact.artifactVersion, 1);
+  assert.equal(artifact.canonicalGuide, "docs/automation.md");
+  assert.equal(artifact.enforcementBoundary, "codex-supervisor-executor-safety-gates");
+
+  for (const responsibility of ["evaluate", "route", "draft", "record", "notify", "prepare_operator_evidence"]) {
+    assert.ok(
+      artifact.allowedResponsibilities.includes(responsibility),
+      `${responsibility} must be published as an allowed connector responsibility`,
+    );
+  }
+
+  for (const prohibited of [
+    "executor_safety_gates",
+    "issue_lint",
+    "fresh_pr_facts",
+    "local_ci",
+    "operator_confirmations",
+  ]) {
+    assert.ok(artifact.prohibitedBypasses.includes(prohibited), `${prohibited} must remain non-bypassable`);
+  }
+
+  for (const nonGoal of ["new_executor_authority", "multi_repo_orchestration_in_core"]) {
+    assert.ok(artifact.nonGoals.includes(nonGoal), `${nonGoal} must stay outside the connector boundary`);
+  }
+
+  for (const source of [artifactSource, automationGuide, laneNote, architecture]) {
+    assert.match(source, /`?codex-supervisor`? remains the implementation executor/i);
+    assert.match(source, /must not bypass/i);
+    assert.match(source, /issue-lint/i);
+    assert.match(source, /fresh (GitHub )?PR facts/i);
+    assert.match(source, /local CI/i);
+    assert.match(source, /operator confirmations/i);
+    assert.match(source, /multi-repo orchestration/i);
+    assert.match(source, /new executor authority/i);
+    assert.doesNotMatch(source, /\/Users\/[A-Za-z0-9._-]+\//);
+    assert.doesNotMatch(source, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+  }
 });


### PR DESCRIPTION
## Summary
- publish a connector-style Codex Automation boundary artifact
- align automation, supervised-lane, and architecture docs on allowed responsibilities and non-goals
- add docs drift coverage for the artifact, non-bypassable gates, and executor-authority boundary

Closes #1836

## Verification
- npx tsx --test src/supervised-automation-lane-docs.test.ts
- npm run verify:paths
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified automation scope with explicit responsibility boundaries, operator-facing evidence preparation, and tightened safety constraints (prohibited bypasses, required operator confirmations)
  * Introduced a standardized connector contract for external automation integrations and stated exclusions (no multi-repo orchestration or new executor authority)

* **Tests**
  * Added integration test to enforce documentation consistency with the automation contract and connector artifact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->