### PR TITLE
Phase 16.2: Add vibe coding before-after narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The related primitive artifacts are intentionally linked instead of re-explained
 
 Use `codex-supervisor` when you want Codex to work through execution-ready GitHub issues in a durable, explicit loop:
 
-- re-read issue state on each cycle and require fresh PR review facts before action-taking PR transitions
+- re-read issue state on each cycle and require fresh GitHub PR facts before action-taking PR transitions
 - select the next runnable issue instead of trusting chat history
 - run each turn in a dedicated worktree with a persistent issue journal
 - keep moving through draft PR, CI repair, review fixes, and merge
@@ -45,6 +45,7 @@ If you want a disposable first supervised pass before production use, follow the
 If you need to understand what to put in `supervisor.config.json`, jump straight to the [Configuration guide](./docs/configuration.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
 If you need the product primitive framing for the supervised lane beside chat-driven Codex work, read the [Supervised automation lane](./docs/supervised-automation-lane.md) note.
+If you want the same small change shown as an unstructured session versus a supervised loop, read the [Before / After narrative](./docs/vibe-coding-before-after.md).
 If you need the narrower freshness and durability contracts, use [Architecture](./docs/architecture.md) and [Configuration reference](./docs/configuration.md) instead of treating this README as the full runtime spec.
 If you use Codex app Automation around the loop, keep the [Codex app Automation boundary](./docs/automation.md) as the repo-owned contract: Automation orchestrates and records, while `codex-supervisor` remains the implementation executor.
 
@@ -284,6 +285,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Operator dashboard](./docs/operator-dashboard.md): WebUI launch, panel meanings, safe commands, and browser smoke verification
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
+- [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop
 - [Architecture](./docs/architecture.md): core loop, durable state, reconciliations, and safety boundaries
 - [Issue metadata](./docs/issue-metadata.md): canonical issue-body fields, sequencing rules, and execution-ready examples
 - [GSD to GitHub issues](./docs/examples/gsd-to-github-issues.md): how to hand planning output into execution-ready issues

--- a/docs/vibe-coding-before-after.md
+++ b/docs/vibe-coding-before-after.md
@@ -1,0 +1,58 @@
+# Vibe Coding Before / After
+
+This page shows the same small change in two flows. The goal is not to dunk on vibe coding. A live chat session can be useful when a human is exploring, deciding, and steering every step. `codex-supervisor` adds the missing quality layer when that exploration needs to become issue-driven, test-backed, reviewable delivery.
+
+## Same Small Change
+
+Imagine a repository needs one small docs fix: add a link from `README.md` to a new operator note, then prove the link stays valid.
+
+The code delta is intentionally tiny. The difference is the execution surface around it.
+
+## Before: Unstructured Chat Session
+
+In an unstructured chat session, the operator usually writes a prompt such as "add the README link and make sure it works." The assistant edits the file, maybe runs a command, and reports back in the same conversation.
+
+That can be enough for exploratory work, but important facts are easy to leave implicit:
+
+- the exact behavior delta may live only in chat history
+- acceptance criteria may be implied rather than written as an execution-ready GitHub issue
+- local verification may be skipped, broad, or hard to replay
+- review context may be scattered across chat messages instead of attached to a draft PR
+- handoff evidence may disappear when the session is compacted or restarted
+
+The human operator can still impose rigor manually. The problem is that the rigor is not the default shape of the workflow.
+
+## After: Supervised codex-supervisor Loop
+
+With `codex-supervisor`, the same change starts from an execution-ready GitHub issue. The issue names the summary, scope, acceptance criteria, verification, dependency posture, parallelization posture, and execution order before the loop treats it as runnable.
+
+For the README-link change, a supervised run produces concrete artifacts:
+
+- an execution-ready GitHub issue that defines the behavior delta and verification command
+- a per-issue worktree on the issue branch, isolated from unrelated local work
+- an issue journal that records the current hypothesis, changed files, focused commands, failures, and next action
+- a draft PR that makes the delta reviewable by CI, configured review providers, and the human operator
+- local verification output such as a focused docs test, `npm run verify:paths`, and `npm run build`
+- an evidence timeline that records issue state, branch/head facts, PR facts, checks, review facts, and recovery context
+- durable history through the issue, PR, journal, and any release or project notes the operator chooses to maintain
+
+The Codex turn still edits files and runs commands, but it is wrapped in a product contract. The loop re-reads current issue and PR facts instead of treating chat memory as the source of truth.
+
+## Quality Delta
+
+| Surface | Unstructured chat | Supervised loop |
+| --- | --- | --- |
+| Task definition | Prompt text and chat context | Execution-ready GitHub issue |
+| Scope control | Human remembers the boundary | Scope and acceptance criteria are written before execution |
+| Verification | Optional or ad hoc command output | Focused local verification plus configured gates |
+| Reviewability | Diff may stay local until the human packages it | Draft PR is part of the normal path |
+| Evidence | Conversation transcript | Issue journal, evidence timeline, PR facts, checks, and review facts |
+| Continuation | Restart from memory or summarize the chat | Resume from issue state, worktree, journal, and PR evidence |
+
+This is the product value: `codex-supervisor` turns a useful coding assistant into a supervised delivery lane. It does not make the assistant magically correct; it makes the work easier to inspect, replay, repair, and hand off.
+
+## Operator Boundary
+
+`codex-supervisor` does not replace the human operator. The operator still owns repository trust, GitHub author trust, config selection, branch protection, review policy, secrets, and final judgment about whether the work should merge.
+
+The supervisor should not claim unsafe autonomy. It should surface missing prerequisites, malformed issue metadata, failing verification, stale PR facts, review blockers, path-hygiene failures, or manual-review needs instead of guessing success. The quality layer is valuable because it keeps those boundaries visible while Codex handles bounded implementation turns.

--- a/src/readme-docs.test.ts
+++ b/src/readme-docs.test.ts
@@ -11,6 +11,10 @@ async function readJapaneseOverview(): Promise<string> {
   return fs.readFile(path.join(process.cwd(), "docs", "README.ja.md"), "utf8");
 }
 
+async function readDoc(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
 test("README stays lightweight while routing humans and AI agents to the right docs", async () => {
   const content = await readReadme();
 
@@ -82,6 +86,47 @@ test("README first screen positions codex-supervisor as a quality layer", async 
   for (const link of requiredArtifactLinks) {
     assert.ok(firstScreen.includes(link), `expected first screen to link ${link}`);
   }
+});
+
+test("README links to a concrete Before / After narrative for the quality layer", async () => {
+  const [readme, narrative] = await Promise.all([
+    readReadme(),
+    readDoc(path.join("docs", "vibe-coding-before-after.md")),
+  ]);
+
+  const narrativeLink = "[Before / After narrative](./docs/vibe-coding-before-after.md)";
+  assert.ok(readme.includes(narrativeLink), "expected README to link the narrative");
+
+  const requiredHeadings = [
+    "# Vibe Coding Before / After",
+    "## Same Small Change",
+    "## Before: Unstructured Chat Session",
+    "## After: Supervised codex-supervisor Loop",
+    "## Quality Delta",
+    "## Operator Boundary",
+  ];
+  for (const heading of requiredHeadings) {
+    assert.match(narrative, new RegExp(`^${heading}$`, "m"));
+  }
+
+  for (const artifact of [
+    "execution-ready GitHub issue",
+    "per-issue worktree",
+    "issue journal",
+    "draft PR",
+    "local verification",
+    "evidence timeline",
+    "durable history",
+  ]) {
+    assert.match(narrative, new RegExp(artifact, "i"), `expected narrative to name ${artifact}`);
+  }
+
+  assert.match(narrative, /missing quality layer/i);
+  assert.match(narrative, /does not replace the human operator/i);
+  assert.doesNotMatch(narrative, /bypass(?:es)? human/i);
+  assert.doesNotMatch(narrative, /fully autonomous/i);
+  assert.doesNotMatch(narrative, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(narrative, /C:\\Users\\[A-Za-z0-9._-]+\\/);
 });
 
 test("README Quick Start leads with the five-minute playground smoke flow", async () => {


### PR DESCRIPTION
## Summary
- add a public Before / After narrative comparing an unstructured chat session with a supervised codex-supervisor loop
- link the narrative from the README first-screen routing and Docs Map
- add a focused README/docs regression test for the narrative link, headings, artifacts, and operator boundary

## Verification
- npx tsx --test src/readme-docs.test.ts
- npx tsx --test src/readme-docs.test.ts src/hydration-freshness-docs.test.ts
- npm run verify:paths
- npm run build

Closes #1845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Before/After narrative guide comparing unstructured and supervised workflow approaches, including key artifacts and quality boundaries.
  * Updated README with reference links to the new documentation resource.

* **Tests**
  * Added automated tests to validate documentation accuracy and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->