### PR TITLE
Phase 16.3: Self-contained demo scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop
 - [Architecture](./docs/architecture.md): core loop, durable state, reconciliations, and safety boundaries
 - [Issue metadata](./docs/issue-metadata.md): canonical issue-body fields, sequencing rules, and execution-ready examples
+- [Self-contained demo scenario](./docs/examples/self-contained-demo-scenario.md): publishable walkthrough artifact with a realistic issue body, expected verification, PR outcome, and evidence timeline references
 - [GSD to GitHub issues](./docs/examples/gsd-to-github-issues.md): how to hand planning output into execution-ready issues
 - [Atlas example](./docs/examples/atlaspm.md): a concrete config and workflow example
 - [Release readiness checklist](./docs/validation-checklist.md): advisory minimum, recommended, and sufficient release-readiness checks

--- a/docs/examples/self-contained-demo-scenario.md
+++ b/docs/examples/self-contained-demo-scenario.md
@@ -1,0 +1,125 @@
+# Self-contained Demo Scenario
+
+This publishable demo uses one realistic `codex` issue and shows the quality artifacts a normal supervised run produces. It is safe to read offline, copy into docs, or use for screenshots because all commands are repo-relative or placeholder-based and no live GitHub credentials are needed to validate the Markdown itself.
+
+Use the scenario as a walkthrough script, not as a hidden policy source. The canonical issue-body rules still live in [Issue metadata](../issue-metadata.md).
+
+## Demo issue body
+
+Create a `codex`-labeled issue with this body in a sandbox repository when you want a live walkthrough. For offline validation, read this block and run the local docs test named below.
+
+<!-- self-contained-demo-issue:start -->
+```md
+## Summary
+Add a quick filter to the issue journal viewer so operators can scan only verification notes.
+
+## Scope
+- add one filter control to the existing issue journal viewer
+- filter journal rows by verification-related text without changing how journal files are written
+- keep all existing journal entries visible when the filter is cleared
+
+Part of: #100
+Depends on: #99
+Parallelizable: No
+
+## Execution order
+3 of 4
+
+## Acceptance criteria
+- operators can toggle a verification-only view from the issue journal viewer
+- the unfiltered journal view still shows every existing note in chronological order
+- the filter does not mutate issue journal files or supervisor state
+
+## Verification
+- `npm test -- src/issue-journal-viewer.test.ts`
+- `npm run verify:paths`
+- `npm run build`
+```
+<!-- self-contained-demo-issue:end -->
+
+Expected metadata properties:
+
+- sequenced child issue using canonical `Part of: #100`
+- real dependency on the prior child issue via `Depends on: #99`
+- `Parallelizable: No` because this modifies an operator-facing journal view
+- concrete `3 of 4` execution order
+- one behavior delta: filtering the existing journal viewer
+
+## Expected local verification
+
+Before the supervisor runs the issue, validate the issue body with:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+During or after the run, the local verification evidence should include:
+
+```bash
+npm test -- src/issue-journal-viewer.test.ts
+npm run verify:paths
+npm run build
+```
+
+Equivalent environment-variable form:
+
+```bash
+export CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>
+node dist/index.js issue-lint <issue-number> --config "$CODEX_SUPERVISOR_CONFIG"
+```
+
+Expected local result:
+
+```text
+issue-lint: execution_ready=yes issue=#<issue-number>
+focused_tests: passed command="npm test -- src/issue-journal-viewer.test.ts"
+path_hygiene: passed command="npm run verify:paths"
+build: passed command="npm run build"
+```
+
+## Expected PR outcome
+
+A successful walkthrough should produce these reviewable artifacts:
+
+- branch: `codex/issue-<issue-number>`
+- draft PR title: `Add issue journal quick filter`
+- changed files: implementation, focused test, and any narrow docs or fixture update needed for the filter
+- issue journal: a per-issue handoff with hypothesis, changed files, commands run, and next action
+- local verification: focused test, path hygiene, and build results recorded at the current head
+- review: configured provider or local review evidence attached to the current head
+- merge: the PR remains draft until configured readiness gates pass, then becomes mergeable only after CI/review policy allows it
+
+The scenario does not require real credentials to inspect the expected artifacts. Live PR creation, CI, review, and merge evidence only appear when the same issue is run against a real configured sandbox repository.
+
+## Evidence timeline references
+
+The supervisor evidence timeline is the public audit trail for the run. A complete demo should be able to point to these event types:
+
+| Event | Expected demo reference |
+| --- | --- |
+| `reservation` | issue run reservation for `codex/issue-<issue-number>` |
+| `issue_body` | snapshot of the execution-ready issue body above |
+| `pr_created` | draft PR created for the issue branch |
+| `local_ci` | focused test, `npm run verify:paths`, and `npm run build` results |
+| `review` | local review or configured review-provider outcome for the current head |
+| `github_ci` | sandbox repository CI result, when the live sandbox has CI configured |
+| `merge` | merge timestamp, when the sandbox PR is merged |
+| `terminal_state` | final supervisor state such as `done` |
+
+Screenshot-friendly timeline line:
+
+```text
+timeline_artifact issue=#<issue-number> pr=#<pr-number> type=verification_result gate=local_ci outcome=passed head_sha=<head-sha> next_action=continue command=npm run build summary=Focused test, path hygiene, and build passed.
+```
+
+## Offline validation
+
+Validate the demo artifacts without GitHub credentials:
+
+```bash
+npx tsx --test src/demo-scenario-docs.test.ts
+npm run verify:paths
+npm run build
+```
+
+The docs test checks that the embedded issue body is execution-ready according to the same issue metadata parser used by `issue-lint`.

--- a/src/demo-scenario-docs.test.ts
+++ b/src/demo-scenario-docs.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { lintExecutionReadyIssueBody, validateIssueMetadataSyntax } from "./issue-metadata";
+import type { GitHubIssue } from "./core/types";
+
+const demoPath = path.join("docs", "examples", "self-contained-demo-scenario.md");
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function extractDemoIssueBody(content: string): string {
+  const match = content.match(
+    /<!-- self-contained-demo-issue:start -->\s*```md\s*([\s\S]*?)```\s*<!-- self-contained-demo-issue:end -->/,
+  );
+  assert.ok(match, "self-contained demo must include the marked sample issue body");
+  return match[1].trim();
+}
+
+function createDemoIssue(body: string): GitHubIssue {
+  return {
+    number: 101,
+    title: "Add issue journal quick filter",
+    body,
+    createdAt: "2026-04-27T00:00:00Z",
+    updatedAt: "2026-04-27T00:00:00Z",
+    url: "https://example.com/issues/101",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+}
+
+test("self-contained demo scenario publishes the expected offline quality artifacts", async () => {
+  const demo = await readRepoFile(demoPath);
+
+  assert.match(demo, /^# Self-contained Demo Scenario$/m);
+  assert.match(demo, /## Demo issue body/);
+  assert.match(demo, /## Expected local verification/);
+  assert.match(demo, /## Expected PR outcome/);
+  assert.match(demo, /## Evidence timeline references/);
+  assert.match(demo, /issue journal/i);
+  assert.match(demo, /draft PR/i);
+  assert.match(demo, /local verification/i);
+  assert.match(demo, /evidence timeline/i);
+  assert.match(demo, /review/i);
+  assert.match(demo, /merge/i);
+  assert.match(demo, /node dist\/index\.js issue-lint <issue-number> --config <supervisor-config-path>/);
+  assert.match(demo, /CODEX_SUPERVISOR_CONFIG/);
+  assert.doesNotMatch(demo, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(demo, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+});
+
+test("self-contained demo issue body is execution-ready metadata", async () => {
+  const demo = await readRepoFile(demoPath);
+  const sampleIssue = createDemoIssue(extractDemoIssueBody(demo));
+
+  assert.deepEqual(validateIssueMetadataSyntax(sampleIssue), []);
+
+  const lint = lintExecutionReadyIssueBody(sampleIssue);
+  assert.equal(lint.isExecutionReady, true);
+  assert.deepEqual(lint.missingRequired, []);
+  assert.deepEqual(lint.missingRecommended, []);
+});

--- a/src/readme-docs.test.ts
+++ b/src/readme-docs.test.ts
@@ -173,6 +173,15 @@ test("README Quick Start leads with the five-minute playground smoke flow", asyn
   assert.doesNotMatch(quickStart, /--config \/path\/to\//);
 });
 
+test("README docs map links to the self-contained demo scenario", async () => {
+  const content = await readReadme();
+
+  assert.match(
+    content,
+    /\[Self-contained demo scenario\]\(\.\/docs\/examples\/self-contained-demo-scenario\.md\)/,
+  );
+});
+
 test("README.ja stays lightweight while routing humans and AI agents to the right docs", async () => {
   const content = await readJapaneseOverview();
 


### PR DESCRIPTION
## Summary
- add a publishable self-contained demo scenario under docs/examples
- validate the embedded demo issue body with the issue metadata parser
- link the demo from the README docs map

## Verification
- npx tsx --test src/demo-scenario-docs.test.ts
- npx tsx --test src/readme-docs.test.ts
- npm run verify:paths
- npm run build
- npm test

Closes #1846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new self-contained demo scenario guide featuring a complete walkthrough with realistic examples, verification procedures, expected outcomes, and offline validation methods for local testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->