### PR TITLE
Phase 16.4: add dogfood PR walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you need to understand what to put in `supervisor.config.json`, jump straight
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
 If you need the product primitive framing for the supervised lane beside chat-driven Codex work, read the [Supervised automation lane](./docs/supervised-automation-lane.md) note.
 If you want the same small change shown as an unstructured session versus a supervised loop, read the [Before / After narrative](./docs/vibe-coding-before-after.md).
+If you want to see the supervised PR lifecycle annotated with Phase 16's own dogfooding flow, read the [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md).
 If you need the narrower freshness and durability contracts, use [Architecture](./docs/architecture.md) and [Configuration reference](./docs/configuration.md) instead of treating this README as the full runtime spec.
 If you use Codex app Automation around the loop, keep the [Codex app Automation boundary](./docs/automation.md) as the repo-owned contract: Automation orchestrates and records, while `codex-supervisor` remains the implementation executor.
 
@@ -286,6 +287,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop
+- [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md): annotated supervised PR lifecycle from the repo's own demo-material phase using sanitized public-safe placeholders
 - [Architecture](./docs/architecture.md): core loop, durable state, reconciliations, and safety boundaries
 - [Issue metadata](./docs/issue-metadata.md): canonical issue-body fields, sequencing rules, and execution-ready examples
 - [Self-contained demo scenario](./docs/examples/self-contained-demo-scenario.md): publishable walkthrough artifact with a realistic issue body, expected verification, PR outcome, and evidence timeline references

--- a/docs/examples/phase-16-dogfood-pr-walkthrough.md
+++ b/docs/examples/phase-16-dogfood-pr-walkthrough.md
@@ -1,0 +1,83 @@
+# Phase 16 Dogfood PR Walkthrough
+
+This walkthrough shows how a Phase 16 supervised issue becomes a reviewable PR with durable evidence. It is a docs artifact, not a new runner or a credentialed demo. A new reader can follow the lifecycle offline without running `codex-supervisor` or authenticating to GitHub.
+
+## Provenance
+
+Phase 16 is the repository's own supervised-demo-material phase. The most faithful source is the live supervised PR flow that produces these docs. Because this page must be publishable without workstation-local paths, private config values, or live GitHub credentials, the walkthrough uses a sanitized equivalent of that flow:
+
+- issue: `#<issue-number>` from the Phase 16 sequence
+- branch: `codex/issue-<issue-number>`
+- PR: `#<pr-number>` once the supervisor opens the draft PR
+- head: `<head-sha>` from the current branch head
+- config: `<supervisor-config-path>` or `CODEX_SUPERVISOR_CONFIG`
+
+The sanitized equivalent preserves the product contract: execution-ready issue metadata, per-issue worktree, issue journal, local verification, draft PR review, configured review provider signals, operator actions, and evidence timeline entries all remain visible as separate lifecycle surfaces.
+
+## Lifecycle Walkthrough
+
+| Step | What happens | Evidence to look for | Annotation |
+| --- | --- | --- | --- |
+| 1. Issue becomes runnable | The operator writes a `codex` issue with `## Summary`, `## Scope`, `## Acceptance criteria`, `## Verification`, `Depends on`, `Parallelizable`, and `## Execution order`. Sequenced Phase 16 children also include `Part of: #<epic-number>`. | GitHub issue body and `issue-lint` output. | `issue-lint` is the readiness boundary; it validates metadata before the loop treats the issue as runnable. |
+| 2. Supervisor reserves the issue | The loop selects the next unblocked Phase 16 child and creates or reuses the isolated issue branch and worktree. | Issue journal handoff, branch name, and evidence timeline reservation event. | The issue journal records the active hypothesis and next exact step, while the evidence timeline records the run-level lifecycle fact. |
+| 3. Codex implements the bounded delta | Codex edits only the files needed for the issue. For this walkthrough, the bounded delta is public docs material and focused docs tests. | Changed files on `codex/issue-<issue-number>` and the issue journal's `Files touched` field. | The issue scope remains the authority; the docs page does not expand executor authority or introduce a demo runner. |
+| 4. Local verification runs | The worktree proves the docs behavior before PR progression. | Focused docs test, `npm run verify:paths`, and `npm run build`. | Local verification is current-head evidence, not a prose claim. Path hygiene specifically blocks workstation-local paths and private config values. |
+| 5. Draft PR is opened | The branch becomes reviewable as a draft PR. | Draft PR URL, PR head SHA, changed-file list, and CI check rollup when available. | The draft PR is the review surface for humans, CI, and configured review provider signals. |
+| 6. Review provider signals settle | The configured provider posts or withholds review on the current head. | Review comments, review summaries, or local review artifacts linked to the same head SHA. | Review provider signals are inputs, not trusted policy. The supervisor must still honor local safeguards and fresh PR facts. |
+| 7. Operator action resolves the boundary | The operator decides whether to continue, request a fix, wait for CI, or merge after gates pass. | Operator action record, PR state transition, and issue journal handoff. | Operator actions remain explicit; the walkthrough does not require live credentials to read or validate the docs. |
+| 8. Terminal evidence is durable | The issue reaches a terminal state such as `done`, or the journal explains the blocker. | Evidence timeline terminal event, issue journal, PR outcome, and release or history notes if maintained. | Later sessions recover from durable state and GitHub facts instead of chat memory. |
+
+Focused readiness command:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+Equivalent environment-variable form:
+
+```bash
+export CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>
+node dist/index.js issue-lint <issue-number> --config "$CODEX_SUPERVISOR_CONFIG"
+```
+
+Focused verification for this docs walkthrough:
+
+```bash
+npx tsx --test src/demo-scenario-docs.test.ts src/readme-docs.test.ts
+npm run verify:paths
+npm run build
+```
+
+## Artifact Contracts
+
+Use the current repo contracts instead of this page as policy:
+
+- [Issue metadata](../issue-metadata.md) (`docs/issue-metadata.md`) defines execution-ready issue bodies and `issue-lint` expectations.
+- [Issue body contract](../issue-body-contract.schema.json) (`docs/issue-body-contract.schema.json`) publishes the portable issue-body field shape for external tooling.
+- [Evidence timeline schema](../evidence-timeline.schema.json) (`docs/evidence-timeline.schema.json`) publishes the run evidence contract.
+- [Operator actions schema](../operator-actions.schema.json) (`docs/operator-actions.schema.json`) publishes the operator action contract.
+- [Architecture](../architecture.md) (`docs/architecture.md`) explains the loop, durable state, PR freshness, and safety boundaries.
+- [Automation boundary](../automation.md) (`docs/automation.md`) explains why orchestration must not bypass executor gates, local CI, issue-lint, fresh PR facts, or operator confirmations.
+
+## Sanitization Boundary
+
+This page intentionally uses placeholders rather than local machine values:
+
+- use `<supervisor-config-path>` instead of a host-specific config path
+- use `<codex-supervisor-root>` when a root placeholder is needed
+- use `#<issue-number>`, `#<pr-number>`, and `<head-sha>` for GitHub-specific facts
+- keep secrets, private config values, and workstation-local absolute paths out of publishable Markdown
+
+If a future Phase 16 PR provides public evidence that can be cited safely, update the placeholders with public issue or PR numbers only when doing so does not embed private host details. Otherwise, keep the sanitized equivalent: it demonstrates the same supervised lifecycle without turning local operational facts into docs.
+
+## Read Offline
+
+A new reader should be able to read this walkthrough and understand the PR lifecycle without running the supervisor:
+
+1. The issue body becomes runnable only after `issue-lint` accepts the metadata.
+2. The supervisor creates an isolated branch, worktree, and issue journal.
+3. Codex implements one bounded behavior delta.
+4. Local verification proves the current head before PR progression.
+5. The draft PR gathers CI, review provider signals, and human review.
+6. Operator actions decide when to continue, fix, wait, or merge.
+7. The evidence timeline and issue journal preserve what happened for later recovery and audit.

--- a/docs/vibe-coding-before-after.md
+++ b/docs/vibe-coding-before-after.md
@@ -26,6 +26,8 @@ The human operator can still impose rigor manually. The problem is that the rigo
 
 With `codex-supervisor`, the same change starts from an execution-ready GitHub issue. The issue names the summary, scope, acceptance criteria, verification, dependency posture, parallelization posture, and execution order before the loop treats it as runnable.
 
+For an annotated version of the same lifecycle using Phase 16's own supervised demo-material work, read the [Phase 16 dogfood PR walkthrough](./examples/phase-16-dogfood-pr-walkthrough.md).
+
 For the README-link change, a supervised run produces concrete artifacts:
 
 - an execution-ready GitHub issue that defines the behavior delta and verification command

--- a/src/demo-scenario-docs.test.ts
+++ b/src/demo-scenario-docs.test.ts
@@ -6,6 +6,7 @@ import { lintExecutionReadyIssueBody, validateIssueMetadataSyntax } from "./issu
 import type { GitHubIssue } from "./core/types";
 
 const demoPath = path.join("docs", "examples", "self-contained-demo-scenario.md");
+const dogfoodWalkthroughPath = path.join("docs", "examples", "phase-16-dogfood-pr-walkthrough.md");
 
 async function readRepoFile(relativePath: string): Promise<string> {
   return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
@@ -62,4 +63,51 @@ test("self-contained demo issue body is execution-ready metadata", async () => {
   assert.equal(lint.isExecutionReady, true);
   assert.deepEqual(lint.missingRequired, []);
   assert.deepEqual(lint.missingRecommended, []);
+});
+
+test("Phase 16 dogfood PR walkthrough is linked and annotates the supervised lifecycle", async () => {
+  const [readme, beforeAfter, walkthrough] = await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/vibe-coding-before-after.md"),
+    readRepoFile(dogfoodWalkthroughPath),
+  ]);
+
+  assert.match(readme, /\[Phase 16 dogfood PR walkthrough\]\(\.\/docs\/examples\/phase-16-dogfood-pr-walkthrough\.md\)/);
+  assert.match(
+    beforeAfter,
+    /\[Phase 16 dogfood PR walkthrough\]\(\.\/examples\/phase-16-dogfood-pr-walkthrough\.md\)/,
+  );
+
+  const requiredHeadings = [
+    "# Phase 16 Dogfood PR Walkthrough",
+    "## Provenance",
+    "## Lifecycle Walkthrough",
+    "## Artifact Contracts",
+    "## Sanitization Boundary",
+    "## Read Offline",
+  ];
+  for (const heading of requiredHeadings) {
+    assert.match(walkthrough, new RegExp(`^${heading}$`, "m"));
+  }
+
+  for (const annotation of [
+    "issue-lint",
+    "local verification",
+    "review provider",
+    "operator action",
+    "evidence timeline",
+    "draft PR",
+    "issue journal",
+    "docs/issue-metadata.md",
+    "docs/evidence-timeline.schema.json",
+    "docs/operator-actions.schema.json",
+  ]) {
+    assert.match(walkthrough, new RegExp(annotation, "i"), `expected walkthrough to annotate ${annotation}`);
+  }
+
+  assert.match(walkthrough, /Phase 16/i);
+  assert.match(walkthrough, /sanitized equivalent/i);
+  assert.match(walkthrough, /node dist\/index\.js issue-lint <issue-number> --config <supervisor-config-path>/);
+  assert.doesNotMatch(walkthrough, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(walkthrough, /C:\\Users\\[A-Za-z0-9._-]+\\/);
 });


### PR DESCRIPTION
## Summary
- add a Phase 16 dogfood PR walkthrough using sanitized placeholders
- link the walkthrough from README and the Before / After narrative
- add a focused docs contract test for the walkthrough and links

## Verification
- npx tsx --test src/demo-scenario-docs.test.ts src/readme-docs.test.ts
- npm run verify:paths
- npm run build

Part of #1843
Refs #1847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new example walkthrough guide demonstrating an annotated supervised PR lifecycle with step-by-step instructions and verification commands.
  * Updated navigation and cross-references across documentation to point to the new walkthrough.

* **Tests**
  * Added validation tests to ensure documentation consistency and completeness across related guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->