### PR TITLE
Phase 16.5 quality kit primitive docs map

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you want the setup flow, first-run commands, and operator decisions, start wi
 If you want a disposable first supervised pass before production use, follow the [Playground smoke run](./docs/playground-smoke-run.md).
 If you need to understand what to put in `supervisor.config.json`, jump straight to the [Configuration guide](./docs/configuration.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
+If you need the compact public primitive map, read the [AI coding quality kit](./docs/quality-kit.md).
 If you need the product primitive framing for the supervised lane beside chat-driven Codex work, read the [Supervised automation lane](./docs/supervised-automation-lane.md) note.
 If you want the same small change shown as an unstructured session versus a supervised loop, read the [Before / After narrative](./docs/vibe-coding-before-after.md).
 If you want to see the supervised PR lifecycle annotated with Phase 16's own dogfooding flow, read the [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md).
@@ -285,6 +286,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Configuration reference](./docs/configuration.md): config setup, provider profiles, model/reasoning controls, durable memory, and execution policy
 - [Operator dashboard](./docs/operator-dashboard.md): WebUI launch, panel meanings, safe commands, and browser smoke verification
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
+- [AI coding quality kit](./docs/quality-kit.md): compact primitive map for the issue contract, local verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop
 - [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md): annotated supervised PR lifecycle from the repo's own demo-material phase using sanitized public-safe placeholders

--- a/docs/examples/phase-16-dogfood-pr-walkthrough.md
+++ b/docs/examples/phase-16-dogfood-pr-walkthrough.md
@@ -2,6 +2,8 @@
 
 This walkthrough shows how a Phase 16 supervised issue becomes a reviewable PR with durable evidence. It is a docs artifact, not a new runner or a credentialed demo. A new reader can follow the lifecycle offline without running `codex-supervisor` or authenticating to GitHub.
 
+For the compact primitive map that names the quality surfaces in this walkthrough, read the [AI coding quality kit](../quality-kit.md).
+
 ## Provenance
 
 Phase 16 is the repository's own supervised-demo-material phase. The most faithful source is the live supervised PR flow that produces these docs. Because this page must be publishable without workstation-local paths, private config values, or live GitHub credentials, the walkthrough uses a sanitized equivalent of that flow:

--- a/docs/examples/self-contained-demo-scenario.md
+++ b/docs/examples/self-contained-demo-scenario.md
@@ -2,6 +2,8 @@
 
 This publishable demo uses one realistic `codex` issue and shows the quality artifacts a normal supervised run produces. It is safe to read offline, copy into docs, or use for screenshots because all commands are repo-relative or placeholder-based and no live GitHub credentials are needed to validate the Markdown itself.
 
+For the compact primitive map behind those artifacts, read the [AI coding quality kit](../quality-kit.md).
+
 Use the scenario as a walkthrough script, not as a hidden policy source. The canonical issue-body rules still live in [Issue metadata](../issue-metadata.md).
 
 ## Demo issue body

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -1,0 +1,85 @@
+# AI Coding Quality Kit
+
+This public product overview maps the implemented `codex-supervisor` primitives that turn Codex work into issue-driven, test-backed, reviewable delivery. It is adoption-oriented: use it to see what each primitive does and where the repo already backs it with docs, schema artifacts, or tests.
+
+The kit is intentionally small. It does not introduce new runtime primitives, and it points to existing artifacts instead of restating Phase 15 schema content.
+
+## Issue Contract
+
+An Issue Contract turns a GitHub issue into a bounded execution input. The issue must name the behavior delta, scope, acceptance criteria, verification, dependency posture, parallelization posture, and execution order before the supervisor treats it as runnable.
+
+Backed by:
+
+- [Issue metadata](./issue-metadata.md)
+- [issue body contract](./issue-body-contract.schema.json)
+- [codex issue template](../.github/ISSUE_TEMPLATE/codex-execution-ready.md)
+- `src/supervisor/supervisor-selection-issue-lint.test.ts`
+- `src/demo-scenario-docs.test.ts`
+
+## Local Verification Gate
+
+The Local Verification Gate keeps a change from advancing on prose alone. Focused issue verification, configured local CI, path hygiene, and build checks provide current-head evidence before PR publication or ready-for-review promotion.
+
+Backed by:
+
+- [Configuration reference](./configuration.md)
+- [Local review reference](./local-review.md)
+- [Release readiness checklist](./validation-checklist.md)
+- `src/local-ci.test.ts`
+- `src/tracked-pr-local-ci-publication-gate.test.ts`
+- `src/post-turn-pull-request.test.ts`
+
+## Prompt Safety Boundary
+
+The Prompt Safety Boundary is the trust posture around text that Codex receives. GitHub-authored issue bodies, PR review comments, and similar text are execution inputs, not supervisor policy; the operator must choose a trusted repo, author lane, config, and execution-safety posture before autonomous runs are appropriate.
+
+Backed by:
+
+- [AI agent handoff](./agent-instructions.md)
+- [trust posture](./trust-posture-config.schema.json)
+- [Architecture](./architecture.md)
+- [Codex app Automation boundary](./automation.md)
+- `src/codex/codex-prompt.test.ts`
+- `src/local-review/prompt.test.ts`
+
+## Evidence Timeline
+
+The Evidence Timeline records what happened so an operator, reviewer, or future Codex session can audit the run. It ties issue state, branch and head facts, PR state, checks, review facts, local verification, failure signatures, and journal handoff to durable records instead of chat memory.
+
+Backed by:
+
+- [evidence timeline](./evidence-timeline.schema.json)
+- [self-contained demo scenario](./examples/self-contained-demo-scenario.md)
+- [Phase 16 dogfood PR walkthrough](./examples/phase-16-dogfood-pr-walkthrough.md)
+- `src/timeline-artifacts.test.ts`
+- `src/operator-audit-bundle.test.ts`
+
+## Operator Action
+
+Operator Action is explicit human control over the lane. It covers setup choices, missing prerequisites, loop hosting, recovery acknowledgement, risky cleanup, local CI adoption, follow-up issue confirmation, and manual review decisions.
+
+Backed by:
+
+- [Operator actions](./operator-actions.schema.json)
+- [Operator dashboard](./operator-dashboard.md)
+- [Getting started](./getting-started.md)
+- [Supervised automation lane](./supervised-automation-lane.md)
+- `src/operator-actions.test.ts`
+- `src/supervisor/supervisor-diagnostics-status-selection.test.ts`
+
+## Durable History Writeback
+
+Durable History Writeback preserves the facts needed after thread loss, process restart, release review, or future planning. The active issue journal carries short-horizon working notes; GitHub issues, PRs, evidence timeline entries, and operator-maintained project notes carry longer-lived history.
+
+Backed by:
+
+- [Supervised automation lane](./supervised-automation-lane.md)
+- [Architecture](./architecture.md)
+- [self-contained demo scenario](./examples/self-contained-demo-scenario.md)
+- [Codex app Automation boundary](./automation.md)
+- `src/journal.test.ts`
+- `src/supervisor/supervisor-recovery-reconciliation.test.ts`
+
+## Reading Path
+
+Start with this map when you need the product primitive vocabulary. Then use [Getting started](./getting-started.md) for first-run operation, [Issue metadata](./issue-metadata.md) for authoring, [Configuration reference](./configuration.md) for trust and local verification posture, and [Architecture](./architecture.md) for the runtime boundaries.

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const qualityKitPath = path.join("docs", "quality-kit.md");
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+test("quality kit map publishes the primitive overview and source anchors", async () => {
+  const qualityKit = await readRepoFile(qualityKitPath);
+
+  assert.match(qualityKit, /^# AI Coding Quality Kit$/m);
+  assert.match(qualityKit, /public product overview/i);
+  assert.doesNotMatch(qualityKit, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(qualityKit, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  const requiredPrimitives = [
+    "Issue Contract",
+    "Local Verification Gate",
+    "Prompt Safety Boundary",
+    "Evidence Timeline",
+    "Operator Action",
+    "Durable History Writeback",
+  ];
+
+  for (const primitive of requiredPrimitives) {
+    assert.match(qualityKit, new RegExp(`^## ${primitive}$`, "m"), `expected ${primitive} section`);
+  }
+
+  const requiredLinks = [
+    "[Issue metadata](./issue-metadata.md)",
+    "[issue body contract](./issue-body-contract.schema.json)",
+    "[Configuration reference](./configuration.md)",
+    "[Local review reference](./local-review.md)",
+    "[AI agent handoff](./agent-instructions.md)",
+    "[trust posture](./trust-posture-config.schema.json)",
+    "[evidence timeline](./evidence-timeline.schema.json)",
+    "[Operator actions](./operator-actions.schema.json)",
+    "[Supervised automation lane](./supervised-automation-lane.md)",
+    "[Architecture](./architecture.md)",
+    "[self-contained demo scenario](./examples/self-contained-demo-scenario.md)",
+  ];
+
+  for (const link of requiredLinks) {
+    assert.ok(qualityKit.includes(link), `expected quality kit map to link ${link}`);
+  }
+
+  assert.doesNotMatch(
+    qualityKit,
+    /\b(properties|definitions|required|enum|oneOf|anyOf|allOf)\b/i,
+    "quality kit map should not duplicate schema internals",
+  );
+});
+
+test("README and demo docs discover the quality kit map", async () => {
+  const [readme, demo, walkthrough] = await Promise.all([
+    readRepoFile("README.md"),
+    readRepoFile("docs/examples/self-contained-demo-scenario.md"),
+    readRepoFile("docs/examples/phase-16-dogfood-pr-walkthrough.md"),
+  ]);
+
+  assert.match(readme, /\[AI coding quality kit\]\(\.\/docs\/quality-kit\.md\)/i);
+  assert.match(demo, /\[AI coding quality kit\]\(\.\.\/quality-kit\.md\)/i);
+  assert.match(walkthrough, /\[AI coding quality kit\]\(\.\.\/quality-kit\.md\)/i);
+});


### PR DESCRIPTION
## Summary
- add a compact AI coding quality kit docs map for the six Phase 16.5 primitives
- link the map from README and demo walkthrough docs
- add focused docs discovery coverage for primitive sections and artifact links

## Verification
- npx tsx --test src/quality-kit-docs.test.ts
- npx tsx --test src/readme-docs.test.ts src/demo-scenario-docs.test.ts src/quality-kit-docs.test.ts
- npm run verify:paths
- npm run build

Part of #1848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new quality reference guide providing an overview of key concepts and their relationships
  * Updated navigation in README and example walkthroughs to direct users to the new reference guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->