### PR TITLE
Phase 17.1: Add codex-supervisor init CLI command

### DIFF
--- a/src/cli/entrypoint.test.ts
+++ b/src/cli/entrypoint.test.ts
@@ -91,6 +91,33 @@ test("runCli prints the readiness checklist regardless of caller cwd", { concurr
   assert.match(stdout.join("\n"), /^# Release Readiness Checklist/m);
 });
 
+test("runCli routes init before constructing supervisor services", async () => {
+  const stdout: string[] = [];
+  let createdSupervisorService = false;
+  let receivedOptions: Record<string, unknown> | undefined;
+
+  await runCli(["init", "--config", "supervisor.config.json", "--dry-run"], {
+    createSupervisorService: () => {
+      createdSupervisorService = true;
+      throw new Error("unexpected createSupervisorService");
+    },
+    handleInitCommand: async (options) => {
+      receivedOptions = { ...options };
+      return "init preview";
+    },
+    writeStdout: (line) => {
+      stdout.push(line);
+    },
+  });
+
+  assert.equal(createdSupervisorService, false);
+  assert.deepEqual(receivedOptions, {
+    configPath: "supervisor.config.json",
+    dryRun: true,
+  });
+  assert.deepEqual(stdout, ["init preview"]);
+});
+
 test("runCli fails closed on a stale compiled runtime before constructing supervisor services", async () => {
   let createdSupervisorService = false;
   let createdLoopController = false;

--- a/src/cli/entrypoint.ts
+++ b/src/cli/entrypoint.ts
@@ -8,6 +8,7 @@ import {
 } from "../supervisor";
 import type { CliOptions } from "../core/types";
 import { parseArgs } from "./parse-args";
+import { handleInitCommand } from "./init-command";
 import { handleReplayCommand } from "./replay-command";
 import {
   createProcessCliIo,
@@ -33,6 +34,7 @@ export interface CliEntrypointDependencies {
   assertRuntimeFreshness?: () => Promise<void>;
   parseArgs?: (argv: string[]) => CliOptions;
   handleReplayCommand?: (options: Pick<CliOptions, "configPath" | "snapshotPath">) => Promise<string>;
+  handleInitCommand?: (options: Pick<CliOptions, "configPath" | "dryRun">) => Promise<string>;
   createCliIo?: () => CliIo;
   handleReplayCorpusCommand?: (
     options: Pick<CliOptions, "configPath" | "corpusPath">,
@@ -75,6 +77,7 @@ export async function runCli(
   const runtimeFreshnessGuard = dependencies.assertRuntimeFreshness ?? assertRuntimeFreshness;
   const parseCliArgs = dependencies.parseArgs ?? parseArgs;
   const replayCommandHandler = dependencies.handleReplayCommand ?? handleReplayCommand;
+  const initCommandHandler = dependencies.handleInitCommand ?? handleInitCommand;
   const createCliIo = dependencies.createCliIo ?? createProcessCliIo;
   const replayCorpusCommandHandler =
     dependencies.handleReplayCorpusCommand ?? handleReplayCorpusCommand;
@@ -101,6 +104,14 @@ export async function runCli(
 
   if (options.command === "readiness-checklist") {
     writeStdout(await readReadinessChecklist());
+    return;
+  }
+
+  if (options.command === "init") {
+    writeStdout(await initCommandHandler({
+      configPath: options.configPath,
+      dryRun: options.dryRun,
+    }));
     return;
   }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -11,11 +11,11 @@ Common flags:
   --suggest                         Print a copyable issue metadata skeleton. Supported with issue-lint only.
 
 First run:
-  1. node dist/index.js help
-  2. node dist/index.js web --config <supervisor-config-path>  # open /setup
-  3. node dist/index.js doctor --config <supervisor-config-path>
-  4. node dist/index.js status --config <supervisor-config-path> --why
-  5. node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+  1. node dist/index.js init --dry-run --config <supervisor-config-path>
+  2. node dist/index.js init --config <supervisor-config-path>
+  3. node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+  4. node dist/index.js doctor --config <supervisor-config-path>
+  5. node dist/index.js status --config <supervisor-config-path> --why
   6. node dist/index.js run-once --config <supervisor-config-path> --dry-run
   7. node dist/index.js run-once --config <supervisor-config-path>
   8. node dist/index.js loop --config <supervisor-config-path>
@@ -25,6 +25,7 @@ Run commands:
   loop                              Keep running supervisor cycles until stopped.
 
 Inspect commands:
+  init [--dry-run]                  Create or preview a starter supervisor config.
   status [--why]                    Show queue, PR, CI, review, and loop state.
   doctor                            Check local configuration and repository prerequisites.
   explain <issue-number>            Explain supervisor readiness for one issue.

--- a/src/cli/init-command.test.ts
+++ b/src/cli/init-command.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { handleInitCommand } from "./init-command";
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+test("handleInitCommand previews a fail-closed scaffold without writing config content", { concurrency: false }, async (t) => {
+  const originalCwd = process.cwd();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-init-preview-"));
+  t.after(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  git(root, "init", "--initial-branch", "main");
+  git(root, "remote", "add", "origin", "git@github.com:example/project.git");
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify(
+      {
+        private: true,
+        scripts: {
+          build: "tsc -p tsconfig.json",
+          "verify:pre-pr": "npm run build",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await fs.writeFile(path.join(root, "package-lock.json"), "{}\n", "utf8");
+  process.chdir(root);
+
+  const output = await handleInitCommand({
+    configPath: "supervisor.config.json",
+    dryRun: true,
+  });
+
+  await assert.rejects(fs.stat(path.join(root, "supervisor.config.json")), { code: "ENOENT" });
+  assert.match(output, /^codex_supervisor_init mode=preview writes_config=false/m);
+  assert.match(output, /^repo_identity repo_slug=example\/project default_branch=main$/m);
+  assert.match(output, /^package_scripts detected=build,verify:pre-pr$/m);
+  assert.match(output, /^workspace_preparation_candidate command=npm ci$/m);
+  assert.match(output, /^local_ci_candidate command=npm run verify:pre-pr$/m);
+  assert.match(output, /"repoPath": "\."/u);
+  assert.match(output, /"reviewBotLogins": \[\]/u);
+  assert.match(output, /"trustMode": "untrusted_or_mixed"/u);
+  assert.match(output, /"executionSafetyMode": "operator_gated"/u);
+  assert.match(output, /^next_command=node dist\/index\.js issue-lint <issue-number> --config <supervisor-config-path>$/m);
+});
+
+test("handleInitCommand writes the scaffold once and refuses to overwrite existing config", { concurrency: false }, async (t) => {
+  const originalCwd = process.cwd();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-init-write-"));
+  t.after(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  git(root, "init", "--initial-branch", "main");
+  process.chdir(root);
+  const configPath = path.join(root, "supervisor.config.json");
+
+  const output = await handleInitCommand({
+    configPath,
+    dryRun: false,
+  });
+  const written = JSON.parse(await fs.readFile(configPath, "utf8")) as Record<string, unknown>;
+
+  assert.match(output, /^codex_supervisor_init mode=write writes_config=true/m);
+  assert.equal(written.repoPath, ".");
+  assert.equal(written.repoSlug, "OWNER/REPO");
+  assert.equal(written.localCiCommand, "");
+  assert.deepEqual(written.reviewBotLogins, []);
+
+  await assert.rejects(
+    handleInitCommand({
+      configPath,
+      dryRun: false,
+    }),
+    /Refusing to overwrite existing supervisor config/u,
+  );
+});

--- a/src/cli/init-command.ts
+++ b/src/cli/init-command.ts
@@ -1,0 +1,190 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveConfigPath } from "../core/config";
+import { writeJsonAtomic } from "../core/utils";
+
+export interface InitCommandOptions {
+  configPath?: string;
+  dryRun: boolean;
+}
+
+interface InitDetection {
+  repoSlug: string;
+  defaultBranch: string;
+  packageScripts: string[];
+  workspacePreparationCandidate: string | null;
+  localCiCandidate: string | null;
+}
+
+const LOCAL_CI_SCRIPT_CANDIDATES = ["verify:pre-pr", "verify:supervisor-pre-pr", "ci:local", "test", "build"];
+
+function runGit(args: string[], cwd: string): string | null {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function repoSlugFromRemote(remoteUrl: string | null): string | null {
+  if (remoteUrl === null) {
+    return null;
+  }
+
+  const normalized = remoteUrl.trim().replace(/\.git$/u, "");
+  const httpsMatch = normalized.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)$/u);
+  if (httpsMatch?.[1]) {
+    return httpsMatch[1];
+  }
+
+  const sshMatch = normalized.match(/^git@github\.com:([^/]+\/[^/]+)$/u);
+  return sshMatch?.[1] ?? null;
+}
+
+async function readPackageScripts(repoPath: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.readFile(path.join(repoPath, "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const scripts = (parsed as { scripts?: unknown }).scripts;
+    return scripts && typeof scripts === "object" && !Array.isArray(scripts)
+      ? scripts as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function detectInitContext(repoPath: string): Promise<InitDetection> {
+  const remoteSlug = repoSlugFromRemote(runGit(["remote", "get-url", "origin"], repoPath));
+  const defaultBranch =
+    runGit(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], repoPath)?.replace(/^origin\//u, "") ??
+    runGit(["branch", "--show-current"], repoPath) ??
+    "main";
+  const packageScripts = await readPackageScripts(repoPath);
+  const packageScriptNames = Object.keys(packageScripts).sort();
+  const localCiScript = LOCAL_CI_SCRIPT_CANDIDATES.find((scriptName) => {
+    const command = packageScripts[scriptName];
+    return typeof command === "string" && command.trim() !== "";
+  });
+  const workspacePreparationCandidate = await fileExists(path.join(repoPath, "package-lock.json"))
+    ? "npm ci"
+    : await fileExists(path.join(repoPath, "pnpm-lock.yaml"))
+      ? "pnpm install --frozen-lockfile"
+      : await fileExists(path.join(repoPath, "yarn.lock"))
+        ? "yarn install --frozen-lockfile"
+        : null;
+
+  return {
+    repoSlug: remoteSlug ?? "OWNER/REPO",
+    defaultBranch,
+    packageScripts: packageScriptNames,
+    workspacePreparationCandidate,
+    localCiCandidate: localCiScript ? `npm run ${localCiScript}` : null,
+  };
+}
+
+function buildInitConfig(detection: InitDetection): Record<string, unknown> {
+  return {
+    repoPath: ".",
+    repoSlug: detection.repoSlug,
+    defaultBranch: detection.defaultBranch,
+    workspaceRoot: "./.local/worktrees",
+    stateBackend: "json",
+    stateFile: "./.local/state.json",
+    codexBinary: "codex",
+    trustMode: "untrusted_or_mixed",
+    executionSafetyMode: "operator_gated",
+    reviewBotLogins: [],
+    localReviewPosture: "off",
+    localReviewEnabled: false,
+    localReviewAutoDetect: true,
+    localReviewPolicy: "block_merge",
+    trackedPrCurrentHeadLocalReviewRequired: false,
+    localReviewFollowUpRepairEnabled: false,
+    localReviewManualReviewRepairEnabled: false,
+    localReviewFollowUpIssueCreationEnabled: false,
+    localReviewHighSeverityAction: "blocked",
+    staleConfiguredBotReviewPolicy: "diagnose_only",
+    issueJournalRelativePath: ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+    issueJournalMaxChars: 6000,
+    issueLabel: "codex",
+    workspacePreparationCommand: "",
+    localCiCommand: "",
+    localCiCandidateDismissed: false,
+    skipTitlePrefixes: ["Epic:"],
+    branchPrefix: "codex/issue-",
+    pollIntervalSeconds: 120,
+    codexExecTimeoutMinutes: 30,
+    maxImplementationAttemptsPerIssue: 30,
+    maxRepairAttemptsPerIssue: 30,
+    timeoutRetryLimit: 2,
+    blockedVerificationRetryLimit: 3,
+    sameBlockerRepeatLimit: 2,
+    sameFailureSignatureRepeatLimit: 3,
+    maxDoneWorkspaces: 24,
+    cleanupDoneWorkspacesAfterHours: 24,
+    cleanupOrphanedWorkspacesAfterHours: 24,
+    mergeMethod: "squash",
+    draftPrAfterAttempt: 1,
+  };
+}
+
+function renderInitResult(args: {
+  configPath: string;
+  dryRun: boolean;
+  detection: InitDetection;
+  document: Record<string, unknown>;
+}): string {
+  const mode = args.dryRun ? "preview" : "write";
+  const writesConfig = args.dryRun ? "false" : "true";
+  const packageScripts = args.detection.packageScripts.length === 0 ? "none" : args.detection.packageScripts.join(",");
+  return [
+    `codex_supervisor_init mode=${mode} writes_config=${writesConfig} config_path=${args.configPath}`,
+    `repo_identity repo_slug=${args.detection.repoSlug} default_branch=${args.detection.defaultBranch}`,
+    `package_scripts detected=${packageScripts}`,
+    `workspace_preparation_candidate command=${args.detection.workspacePreparationCandidate ?? "none"}`,
+    `local_ci_candidate command=${args.detection.localCiCandidate ?? "none"}`,
+    "review_provider_placeholder reviewBotLogins=[]",
+    "trust_posture trustMode=untrusted_or_mixed executionSafetyMode=operator_gated",
+    "config_skeleton:",
+    JSON.stringify(args.document, null, 2),
+    "next_command=node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+  ].join("\n");
+}
+
+export async function handleInitCommand(options: InitCommandOptions): Promise<string> {
+  const configPath = resolveConfigPath(options.configPath);
+  const detection = await detectInitContext(process.cwd());
+  const document = buildInitConfig(detection);
+
+  if (!options.dryRun) {
+    if (await fileExists(configPath)) {
+      throw new Error(`Refusing to overwrite existing supervisor config: ${configPath}`);
+    }
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await writeJsonAtomic(configPath, document);
+  }
+
+  return renderInitResult({
+    configPath,
+    dryRun: options.dryRun,
+    detection,
+    document,
+  });
+}

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -107,6 +107,21 @@ test("parseArgs accepts readiness-checklist without an issue number", () => {
   });
 });
 
+test("parseArgs accepts init preview mode without an issue number", () => {
+  assert.deepEqual(parseArgs(["init", "--dry-run"]), {
+    command: "init",
+    configPath: undefined,
+    dryRun: true,
+    why: false,
+    issueLintSuggest: false,
+    explainMode: "summary",
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+  });
+});
+
 test("parseArgs accepts requeue with an issue number", () => {
   assert.deepEqual(parseArgs(["requeue", "123"]), {
     command: "requeue",

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -42,6 +42,7 @@ export function parseArgs(argv: string[]): CliOptions {
       token === "explain" ||
       token === "issue-lint" ||
       token === "readiness-checklist" ||
+      token === "init" ||
       token === "doctor" ||
       token === "web" ||
       token === "replay" ||

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -357,6 +357,7 @@ export interface CliOptions {
     | "explain"
     | "issue-lint"
     | "readiness-checklist"
+    | "init"
     | "doctor"
     | "web"
     | "replay"


### PR DESCRIPTION
## Summary
- add `codex-supervisor init` parsing and pre-runtime routing
- add an init handler that previews or writes a fail-closed starter config skeleton
- detect repo identity, package scripts, local CI/workspace-prep candidates while leaving safety-sensitive choices disabled or placeholder-based

## Verification
- npx tsx --test src/cli/init-command.test.ts src/cli/parse-args.test.ts src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts
- npx tsx --test src/cli/parse-args.test.ts src/cli/entrypoint.test.ts src/cli/supervisor-runtime.test.ts
- npm run build
- npm run verify:paths

Part of #1857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `init` command to generate supervisor configuration files. Automatically detects repository information, Git origin remote, and available package scripts. Use the `--dry-run` flag to preview the configuration without writing to disk.

* **Documentation**
  * Updated CLI help text to establish the `init` command as the recommended first step in the application setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->