### PR TITLE
Phase 17.2: integrate sample issue generation into init

### DIFF
--- a/src/cli/entrypoint.test.ts
+++ b/src/cli/entrypoint.test.ts
@@ -118,6 +118,32 @@ test("runCli routes init before constructing supervisor services", async () => {
   assert.deepEqual(stdout, ["init preview"]);
 });
 
+test("runCli routes sample-issue before constructing supervisor services", async () => {
+  const stdout: string[] = [];
+  let createdSupervisorService = false;
+  let receivedOptions: Record<string, unknown> | undefined;
+
+  await runCli(["sample-issue", "--output", "SAMPLE_ISSUE.md"], {
+    createSupervisorService: () => {
+      createdSupervisorService = true;
+      throw new Error("unexpected createSupervisorService");
+    },
+    handleSampleIssueCommand: async (options) => {
+      receivedOptions = { ...options };
+      return "sample issue output";
+    },
+    writeStdout: (line) => {
+      stdout.push(line);
+    },
+  });
+
+  assert.equal(createdSupervisorService, false);
+  assert.deepEqual(receivedOptions, {
+    outputPath: "SAMPLE_ISSUE.md",
+  });
+  assert.deepEqual(stdout, ["sample issue output"]);
+});
+
 test("runCli fails closed on a stale compiled runtime before constructing supervisor services", async () => {
   let createdSupervisorService = false;
   let createdLoopController = false;

--- a/src/cli/entrypoint.ts
+++ b/src/cli/entrypoint.ts
@@ -9,6 +9,7 @@ import {
 import type { CliOptions } from "../core/types";
 import { parseArgs } from "./parse-args";
 import { handleInitCommand } from "./init-command";
+import { handleSampleIssueCommand } from "./sample-issue-command";
 import { handleReplayCommand } from "./replay-command";
 import {
   createProcessCliIo,
@@ -35,6 +36,7 @@ export interface CliEntrypointDependencies {
   parseArgs?: (argv: string[]) => CliOptions;
   handleReplayCommand?: (options: Pick<CliOptions, "configPath" | "snapshotPath">) => Promise<string>;
   handleInitCommand?: (options: Pick<CliOptions, "configPath" | "dryRun">) => Promise<string>;
+  handleSampleIssueCommand?: (options: { outputPath?: string }) => Promise<string>;
   createCliIo?: () => CliIo;
   handleReplayCorpusCommand?: (
     options: Pick<CliOptions, "configPath" | "corpusPath">,
@@ -78,6 +80,7 @@ export async function runCli(
   const parseCliArgs = dependencies.parseArgs ?? parseArgs;
   const replayCommandHandler = dependencies.handleReplayCommand ?? handleReplayCommand;
   const initCommandHandler = dependencies.handleInitCommand ?? handleInitCommand;
+  const sampleIssueCommandHandler = dependencies.handleSampleIssueCommand ?? handleSampleIssueCommand;
   const createCliIo = dependencies.createCliIo ?? createProcessCliIo;
   const replayCorpusCommandHandler =
     dependencies.handleReplayCorpusCommand ?? handleReplayCorpusCommand;
@@ -111,6 +114,13 @@ export async function runCli(
     writeStdout(await initCommandHandler({
       configPath: options.configPath,
       dryRun: options.dryRun,
+    }));
+    return;
+  }
+
+  if (options.command === "sample-issue") {
+    writeStdout(await sampleIssueCommandHandler({
+      outputPath: options.sampleIssueOutputPath,
     }));
     return;
   }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -9,16 +9,18 @@ Common flags:
   --dry-run                         Plan the next run-once or loop action without executing Codex.
   --why                             Include status decision details. Supported with status only.
   --suggest                         Print a copyable issue metadata skeleton. Supported with issue-lint only.
+  --output <path>                   Write a sample issue body. Supported with sample-issue only.
 
 First run:
   1. node dist/index.js init --dry-run --config <supervisor-config-path>
   2. node dist/index.js init --config <supervisor-config-path>
-  3. node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
-  4. node dist/index.js doctor --config <supervisor-config-path>
-  5. node dist/index.js status --config <supervisor-config-path> --why
-  6. node dist/index.js run-once --config <supervisor-config-path> --dry-run
-  7. node dist/index.js run-once --config <supervisor-config-path>
-  8. node dist/index.js loop --config <supervisor-config-path>
+  3. node dist/index.js sample-issue
+  4. node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+  5. node dist/index.js doctor --config <supervisor-config-path>
+  6. node dist/index.js status --config <supervisor-config-path> --why
+  7. node dist/index.js run-once --config <supervisor-config-path> --dry-run
+  8. node dist/index.js run-once --config <supervisor-config-path>
+  9. node dist/index.js loop --config <supervisor-config-path>
 
 Run commands:
   run-once                          Run one supervisor cycle.
@@ -34,6 +36,8 @@ Inspect commands:
                                     Print a sanitized operator audit bundle.
   issue-lint <issue-number> [--suggest]
                                     Validate an execution-ready issue body.
+  sample-issue [--output SAMPLE_ISSUE.md]
+                                    Preview or write a standalone execution-ready issue body.
   readiness-checklist               Print the release-readiness checklist.
 
 Repair commands:

--- a/src/cli/init-command.test.ts
+++ b/src/cli/init-command.test.ts
@@ -53,6 +53,8 @@ test("handleInitCommand previews a fail-closed scaffold without writing config c
   assert.match(output, /"reviewBotLogins": \[\]/u);
   assert.match(output, /"trustMode": "untrusted_or_mixed"/u);
   assert.match(output, /"executionSafetyMode": "operator_gated"/u);
+  assert.match(output, /^sample_issue_preview_command=node dist\/index\.js sample-issue$/m);
+  assert.match(output, /^sample_issue_file_command=node dist\/index\.js sample-issue --output SAMPLE_ISSUE\.md$/m);
   assert.match(output, /^next_command=node dist\/index\.js issue-lint <issue-number> --config <supervisor-config-path>$/m);
 });
 

--- a/src/cli/init-command.ts
+++ b/src/cli/init-command.ts
@@ -164,6 +164,8 @@ function renderInitResult(args: {
     "trust_posture trustMode=untrusted_or_mixed executionSafetyMode=operator_gated",
     "config_skeleton:",
     JSON.stringify(args.document, null, 2),
+    "sample_issue_preview_command=node dist/index.js sample-issue",
+    "sample_issue_file_command=node dist/index.js sample-issue --output SAMPLE_ISSUE.md",
     "next_command=node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
   ].join("\n");
 }

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -122,6 +122,22 @@ test("parseArgs accepts init preview mode without an issue number", () => {
   });
 });
 
+test("parseArgs accepts sample-issue with explicit file output", () => {
+  assert.deepEqual(parseArgs(["sample-issue", "--output", "SAMPLE_ISSUE.md"]), {
+    command: "sample-issue",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueLintSuggest: false,
+    explainMode: "summary",
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+    sampleIssueOutputPath: "SAMPLE_ISSUE.md",
+  });
+});
+
 test("parseArgs accepts requeue with an issue number", () => {
   assert.deepEqual(parseArgs(["requeue", "123"]), {
     command: "requeue",

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -9,6 +9,15 @@ function readConfigPath(args: string[]): string {
   return configPath;
 }
 
+function readOutputPath(args: string[]): string {
+  const outputPath = args.shift();
+  if (!outputPath || outputPath.startsWith("-")) {
+    throw new Error("The --output flag requires a file path.");
+  }
+
+  return outputPath;
+}
+
 export function parseArgs(argv: string[]): CliOptions {
   const args = [...argv];
   let command: CliOptions["command"] = "run-once";
@@ -23,6 +32,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let snapshotPath: string | undefined;
   let caseId: string | undefined;
   let corpusPath: string | undefined;
+  let sampleIssueOutputPath: string | undefined;
 
   while (args.length > 0) {
     const token = args.shift();
@@ -41,6 +51,7 @@ export function parseArgs(argv: string[]): CliOptions {
       token === "reset-corrupt-json-state" ||
       token === "explain" ||
       token === "issue-lint" ||
+      token === "sample-issue" ||
       token === "readiness-checklist" ||
       token === "init" ||
       token === "doctor" ||
@@ -76,6 +87,11 @@ export function parseArgs(argv: string[]): CliOptions {
 
     if (token === "--suggest") {
       issueLintSuggest = true;
+      continue;
+    }
+
+    if (token === "--output") {
+      sampleIssueOutputPath = readOutputPath(args);
       continue;
     }
 
@@ -134,6 +150,10 @@ export function parseArgs(argv: string[]): CliOptions {
     throw new Error("The --suggest flag is only supported with the issue-lint command.");
   }
 
+  if (sampleIssueOutputPath !== undefined && command !== "sample-issue") {
+    throw new Error("The --output flag is only supported with the sample-issue command.");
+  }
+
   if (timelineRequested && command !== "explain") {
     throw new Error("The --timeline flag is only supported with the explain command.");
   }
@@ -186,5 +206,6 @@ export function parseArgs(argv: string[]): CliOptions {
       command === "replay-corpus" || command === "replay-corpus-promote"
         ? (corpusPath ?? "replay-corpus")
         : undefined,
+    ...(sampleIssueOutputPath === undefined ? {} : { sampleIssueOutputPath }),
   };
 }

--- a/src/cli/sample-issue-command.test.ts
+++ b/src/cli/sample-issue-command.test.ts
@@ -46,7 +46,27 @@ test("handleSampleIssueCommand writes SAMPLE_ISSUE.md only when output is explic
   const output = await handleSampleIssueCommand({ outputPath });
   const written = await fs.readFile(outputPath, "utf8");
 
-  assert.match(output, /^sample_issue_written path=/m);
+  assert.match(output, new RegExp(`^sample_issue_written path=${escapeRegExp(outputPath)}$`, "m"));
+  assert.match(output, new RegExp(`^copy_body_from_file=${escapeRegExp(outputPath)}$`, "m"));
   assert.match(written, /^## Summary$/m);
   assert.match(written, /^Depends on: none$/m);
 });
+
+test("handleSampleIssueCommand refuses to overwrite an existing output file", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-sample-issue-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  const outputPath = path.join(root, "SAMPLE_ISSUE.md");
+  await fs.writeFile(outputPath, "existing body\n", "utf8");
+
+  await assert.rejects(
+    () => handleSampleIssueCommand({ outputPath }),
+    new RegExp(`Refusing to overwrite existing sample issue file: ${escapeRegExp(outputPath)}`, "u"),
+  );
+  assert.equal(await fs.readFile(outputPath, "utf8"), "existing body\n");
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/cli/sample-issue-command.test.ts
+++ b/src/cli/sample-issue-command.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
+import { handleSampleIssueCommand } from "./sample-issue-command";
+
+test("handleSampleIssueCommand previews a standalone sample body that reuses issue-lint metadata", async () => {
+  const output = await handleSampleIssueCommand({});
+
+  assert.match(output, /^## Summary$/m);
+  assert.match(output, /^Depends on: none$/m);
+  assert.match(output, /^Parallelizable: No$/m);
+  assert.match(output, /^## Execution order\n1 of 1$/m);
+  assert.doesNotMatch(output, /Part of:/);
+
+  const filled = output
+    .replace("<one short paragraph describing the intended outcome>", "Add a focused onboarding sample issue.")
+    .replace("<in-scope behavior delta>", "show one execution-ready behavior delta")
+    .replace("<observable completion check>", "sample issue body is ready for issue-lint")
+    .replace("<exact command, test file, or manual check>", "`node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>`");
+  const dto = createIssueLintDto({
+    number: 1,
+    title: "Sample issue",
+    body: filled,
+    createdAt: "2026-04-27T00:00:00Z",
+    updatedAt: "2026-04-27T00:00:00Z",
+    url: "https://example.test/issues/1",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  });
+
+  assert.equal(dto.executionReady, true);
+  assert.deepEqual(dto.missingRequired, []);
+  assert.deepEqual(dto.metadataErrors, []);
+});
+
+test("handleSampleIssueCommand writes SAMPLE_ISSUE.md only when output is explicit", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-sample-issue-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  const outputPath = path.join(root, "SAMPLE_ISSUE.md");
+
+  const output = await handleSampleIssueCommand({ outputPath });
+  const written = await fs.readFile(outputPath, "utf8");
+
+  assert.match(output, /^sample_issue_written path=/m);
+  assert.match(written, /^## Summary$/m);
+  assert.match(written, /^Depends on: none$/m);
+});

--- a/src/cli/sample-issue-command.ts
+++ b/src/cli/sample-issue-command.ts
@@ -6,14 +6,6 @@ export interface SampleIssueCommandOptions {
   outputPath?: string;
 }
 
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    return (await fs.stat(filePath)).isFile();
-  } catch {
-    return false;
-  }
-}
-
 export async function handleSampleIssueCommand(options: SampleIssueCommandOptions): Promise<string> {
   const body = `${buildStandaloneIssueBody()}\n`;
   if (!options.outputPath) {
@@ -21,15 +13,18 @@ export async function handleSampleIssueCommand(options: SampleIssueCommandOption
   }
 
   const outputPath = path.resolve(options.outputPath);
-  if (await fileExists(outputPath)) {
-    throw new Error(`Refusing to overwrite existing sample issue file: ${outputPath}`);
-  }
-
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
-  await fs.writeFile(outputPath, body, "utf8");
+  try {
+    await fs.writeFile(outputPath, body, { encoding: "utf8", flag: "wx" });
+  } catch (error) {
+    if ((error as { code?: string }).code === "EEXIST") {
+      throw new Error(`Refusing to overwrite existing sample issue file: ${outputPath}`);
+    }
+    throw error;
+  }
   return [
     `sample_issue_written path=${outputPath}`,
-    "copy_body_from_file=SAMPLE_ISSUE.md",
+    `copy_body_from_file=${outputPath}`,
     "after_creating_github_issue=node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
   ].join("\n");
 }

--- a/src/cli/sample-issue-command.ts
+++ b/src/cli/sample-issue-command.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { buildStandaloneIssueBody } from "../supervisor/supervisor-selection-issue-lint";
+
+export interface SampleIssueCommandOptions {
+  outputPath?: string;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function handleSampleIssueCommand(options: SampleIssueCommandOptions): Promise<string> {
+  const body = `${buildStandaloneIssueBody()}\n`;
+  if (!options.outputPath) {
+    return body.trimEnd();
+  }
+
+  const outputPath = path.resolve(options.outputPath);
+  if (await fileExists(outputPath)) {
+    throw new Error(`Refusing to overwrite existing sample issue file: ${outputPath}`);
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, body, "utf8");
+  return [
+    `sample_issue_written path=${outputPath}`,
+    "copy_body_from_file=SAMPLE_ISSUE.md",
+    "after_creating_github_issue=node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+  ].join("\n");
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -356,6 +356,7 @@ export interface CliOptions {
     | "reset-corrupt-json-state"
     | "explain"
     | "issue-lint"
+    | "sample-issue"
     | "readiness-checklist"
     | "init"
     | "doctor"
@@ -373,4 +374,5 @@ export interface CliOptions {
   snapshotPath?: string;
   caseId?: string;
   corpusPath?: string;
+  sampleIssueOutputPath?: string;
 }

--- a/src/supervisor/supervisor-selection-issue-lint.ts
+++ b/src/supervisor/supervisor-selection-issue-lint.ts
@@ -121,6 +121,12 @@ function buildIssueLintSuggestionLines(dto: SupervisorIssueLintDto): string[] {
     "suggestion_status=standalone_default",
     "suggestion_note=Conservative standalone skeleton; replace placeholders and do not add Part of unless this issue is a sequenced child.",
     "suggested_repair_skeleton:",
+    ...buildStandaloneIssueBodyLines(),
+  ];
+}
+
+export function buildStandaloneIssueBodyLines(): string[] {
+  return [
     "## Summary",
     "<one short paragraph describing the intended outcome>",
     "",
@@ -139,6 +145,10 @@ function buildIssueLintSuggestionLines(dto: SupervisorIssueLintDto): string[] {
     "## Execution order",
     "1 of 1",
   ];
+}
+
+export function buildStandaloneIssueBody(): string {
+  return buildStandaloneIssueBodyLines().join("\n");
 }
 
 function buildIssueLintRepairGuidance(


### PR DESCRIPTION
## Summary
- add a `sample-issue` CLI command that previews a standalone execution-ready issue body
- add explicit `--output SAMPLE_ISSUE.md` file mode without creating live GitHub issues
- update init/help output so sample issue generation is the obvious next step before `issue-lint`

## Verification
- `npx tsx --test src/cli/init-command.test.ts src/cli/sample-issue-command.test.ts src/cli/parse-args.test.ts src/cli/entrypoint.test.ts`
- `npx tsx --test src/supervisor/supervisor-selection-issue-lint.test.ts`
- `npm run build`
- `node dist/index.js sample-issue`
- `npm run verify:paths`

Closes #1858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sample-issue` CLI command to generate and display sample issues in markdown.
  * Added `--output` flag to write generated sample issues to a file.

* **Documentation**
  * Updated CLI help and initial workflow instructions to include `sample-issue` and usage examples.

* **Tests**
  * Added tests for parsing, routing, init previews, and handler behaviors for `sample-issue`.

* **Refactor**
  * Extracted standalone sample-issue body generation for reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->