### PR TITLE
Add first-run doctor summary

### DIFF
--- a/src/cli/entrypoint.ts
+++ b/src/cli/entrypoint.ts
@@ -23,7 +23,7 @@ import { assertRuntimeFreshness } from "../build-freshness";
 
 type SupervisorRuntimeOptions = Pick<
   CliOptions,
-  "command" | "dryRun" | "why" | "issueLintSuggest" | "explainMode" | "issueNumber"
+  "command" | "dryRun" | "why" | "issueLintSuggest" | "explainMode" | "issueNumber" | "firstRunDoctorSummary"
 >;
 
 async function readReadinessChecklist(): Promise<string> {
@@ -157,6 +157,7 @@ export async function runCli(
       issueLintSuggest: options.issueLintSuggest,
       explainMode: options.explainMode,
       issueNumber: options.issueNumber,
+      ...(options.firstRunDoctorSummary ? { firstRunDoctorSummary: true } : {}),
     },
     {
       service,

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -8,6 +8,7 @@ Common flags:
   --config <supervisor-config-path>  Use an explicit supervisor config file.
   --dry-run                         Plan the next run-once or loop action without executing Codex.
   --why                             Include status decision details. Supported with status only.
+  --first-run                       Print beginner first-run readiness. Supported with doctor only.
   --suggest                         Print a copyable issue metadata skeleton. Supported with issue-lint only.
   --output <path>                   Write a sample issue body. Supported with sample-issue only.
 
@@ -16,11 +17,12 @@ First run:
   2. node dist/index.js init --config <supervisor-config-path>
   3. node dist/index.js sample-issue
   4. node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
-  5. node dist/index.js doctor --config <supervisor-config-path>
-  6. node dist/index.js status --config <supervisor-config-path> --why
-  7. node dist/index.js run-once --config <supervisor-config-path> --dry-run
-  8. node dist/index.js run-once --config <supervisor-config-path>
-  9. node dist/index.js loop --config <supervisor-config-path>
+  5. node dist/index.js doctor --first-run --config <supervisor-config-path>
+  6. node dist/index.js doctor --config <supervisor-config-path>
+  7. node dist/index.js status --config <supervisor-config-path> --why
+  8. node dist/index.js run-once --config <supervisor-config-path> --dry-run
+  9. node dist/index.js run-once --config <supervisor-config-path>
+  10. node dist/index.js loop --config <supervisor-config-path>
 
 Run commands:
   run-once                          Run one supervisor cycle.
@@ -29,7 +31,7 @@ Run commands:
 Inspect commands:
   init [--dry-run]                  Create or preview a starter supervisor config.
   status [--why]                    Show queue, PR, CI, review, and loop state.
-  doctor                            Check local configuration and repository prerequisites.
+  doctor [--first-run]              Check local configuration and repository prerequisites.
   explain <issue-number>            Explain supervisor readiness for one issue.
   explain <issue-number> --timeline Show the issue-run evidence timeline.
   explain <issue-number> --audit-bundle

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -47,6 +47,22 @@ test("parseArgs accepts doctor as a command", () => {
   });
 });
 
+test("parseArgs accepts doctor first-run summary mode", () => {
+  assert.deepEqual(parseArgs(["doctor", "--first-run"]), {
+    command: "doctor",
+    configPath: undefined,
+    dryRun: false,
+    why: false,
+    issueLintSuggest: false,
+    explainMode: "summary",
+    issueNumber: undefined,
+    snapshotPath: undefined,
+    caseId: undefined,
+    corpusPath: undefined,
+    firstRunDoctorSummary: true,
+  });
+});
+
 test("parseArgs accepts web as a command", () => {
   assert.deepEqual(parseArgs(["web"]), {
     command: "web",
@@ -393,6 +409,13 @@ test("parseArgs rejects suggest mode outside issue-lint", () => {
   assert.throws(
     () => parseArgs(["status", "--suggest"]),
     /The --suggest flag is only supported with the issue-lint command\./,
+  );
+});
+
+test("parseArgs rejects first-run summary mode outside doctor", () => {
+  assert.throws(
+    () => parseArgs(["status", "--first-run"]),
+    /The --first-run flag is only supported with the doctor command\./,
   );
 });
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -33,6 +33,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let caseId: string | undefined;
   let corpusPath: string | undefined;
   let sampleIssueOutputPath: string | undefined;
+  let firstRunDoctorSummary = false;
 
   while (args.length > 0) {
     const token = args.shift();
@@ -95,6 +96,11 @@ export function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (token === "--first-run") {
+      firstRunDoctorSummary = true;
+      continue;
+    }
+
     if (token === "--timeline") {
       timelineRequested = true;
       continue;
@@ -154,6 +160,10 @@ export function parseArgs(argv: string[]): CliOptions {
     throw new Error("The --output flag is only supported with the sample-issue command.");
   }
 
+  if (firstRunDoctorSummary && command !== "doctor") {
+    throw new Error("The --first-run flag is only supported with the doctor command.");
+  }
+
   if (timelineRequested && command !== "explain") {
     throw new Error("The --timeline flag is only supported with the explain command.");
   }
@@ -207,5 +217,6 @@ export function parseArgs(argv: string[]): CliOptions {
         ? (corpusPath ?? "replay-corpus")
         : undefined,
     ...(sampleIssueOutputPath === undefined ? {} : { sampleIssueOutputPath }),
+    ...(firstRunDoctorSummary ? { firstRunDoctorSummary } : {}),
   };
 }

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { LockHandle } from "../core/lock";
 import type { SupervisorConfig } from "../core/types";
+import type { SetupReadinessReport } from "../setup-readiness";
 import type { SupervisorIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
 import type { SupervisorStatusDto } from "../supervisor/supervisor-status-report";
 import { runSupervisorCycle, runSupervisorCommand } from "./supervisor-runtime";
@@ -46,6 +47,81 @@ function createStatusDto(overrides: Partial<SupervisorStatusDto> = {}): Supervis
     readinessLines: [],
     whyLines: [],
     warning: null,
+    ...overrides,
+  };
+}
+
+function createSetupReadinessReport(overrides: Partial<SetupReadinessReport> = {}): SetupReadinessReport {
+  return {
+    kind: "setup_readiness",
+    ready: false,
+    overallStatus: "missing",
+    configPath: "supervisor.config.json",
+    fields: [
+      {
+        key: "repoPath",
+        label: "Repository path",
+        state: "configured",
+        value: null,
+        message: "Repository path is configured.",
+        required: true,
+        metadata: { source: "config", editable: true, valueType: "directory_path" },
+      },
+      {
+        key: "repoSlug",
+        label: "Repository slug",
+        state: "configured",
+        value: "owner/repo",
+        message: "Repository slug is configured.",
+        required: true,
+        metadata: { source: "config", editable: true, valueType: "repo_slug" },
+      },
+      {
+        key: "defaultBranch",
+        label: "Default branch",
+        state: "configured",
+        value: "main",
+        message: "Default branch is configured.",
+        required: true,
+        metadata: { source: "config", editable: true, valueType: "git_ref" },
+      },
+      {
+        key: "workspaceRoot",
+        label: "Workspace root",
+        state: "configured",
+        value: null,
+        message: "Workspace root is configured.",
+        required: true,
+        metadata: { source: "config", editable: true, valueType: "directory_path" },
+      },
+    ],
+    blockers: [],
+    nextActions: [
+      {
+        action: "fix_config",
+        source: "missing_trust_mode",
+        priority: 100,
+        required: true,
+        summary: "Trust mode needs an explicit first-run setup decision.",
+        fieldKeys: ["trustMode"],
+      },
+    ],
+    hostReadiness: { overallStatus: "pass", checks: [] },
+    providerPosture: {
+      profile: "codex",
+      provider: "codex",
+      reviewers: ["chatgpt-codex-connector"],
+      signalSource: "reviewBotLogins",
+      configured: true,
+      summary: "Codex review provider is configured.",
+    },
+    trustPosture: {
+      trustMode: "trusted_repo_and_authors",
+      executionSafetyMode: "unsandboxed_autonomous",
+      warning: null,
+      configured: false,
+      summary: "Trust posture needs an explicit first-run setup decision.",
+    },
     ...overrides,
   };
 }
@@ -578,6 +654,65 @@ test("runSupervisorCommand routes query commands through the supervisor service 
   assert.deepEqual(calls, ["status:true"]);
   assert.equal(stdout.length, 1);
   assert.match(stdout[0] ?? "", /status output/);
+});
+
+test("runSupervisorCommand renders doctor first-run summary from setup readiness", async () => {
+  const stdout: string[] = [];
+  const calls: string[] = [];
+
+  await runSupervisorCommand(
+    { command: "doctor", dryRun: false, why: false, firstRunDoctorSummary: true },
+    {
+      service: {
+        config: {} as SupervisorConfig,
+        pollIntervalMs: async () => 50,
+        runOnce: async () => {
+          calls.push("runOnce");
+          throw new Error("unexpected runOnce");
+        },
+        queryStatus: async () => {
+          calls.push("status");
+          return createStatusDto();
+        },
+        queryExplain: async () => {
+          calls.push("explain");
+          throw new Error("unexpected queryExplain");
+        },
+        runRecoveryAction: async () => {
+          calls.push("recovery");
+          throw new Error("unexpected runRecoveryAction");
+        },
+        pruneOrphanedWorkspaces: async () => {
+          calls.push("pruneOrphanedWorkspaces");
+          throw new Error("unexpected pruneOrphanedWorkspaces");
+        },
+        resetCorruptJsonState: async () => {
+          calls.push("resetCorruptJsonState");
+          throw new Error("unexpected resetCorruptJsonState");
+        },
+        queryIssueLint: async () => {
+          calls.push("issueLint");
+          return createIssueLintDto();
+        },
+        queryDoctor: async () => {
+          calls.push("doctor");
+          throw new Error("unexpected queryDoctor");
+        },
+        querySetupReadiness: async () => {
+          calls.push("setupReadiness");
+          return createSetupReadinessReport();
+        },
+      },
+      writeStdout: (line) => {
+        stdout.push(line);
+      },
+    },
+  );
+
+  assert.deepEqual(calls, ["setupReadiness"]);
+  assert.equal(stdout.length, 1);
+  assert.match(stdout[0] ?? "", /^first_run_readiness ready=false overall=missing/m);
+  assert.match(stdout[0] ?? "", /^first_run_next_action action=fix_config source=missing_trust_mode required=true/m);
 });
 
 test("runSupervisorCommand renders explain audit bundles as JSON", async () => {

--- a/src/cli/supervisor-runtime.ts
+++ b/src/cli/supervisor-runtime.ts
@@ -18,6 +18,7 @@ import {
 } from "../supervisor/supervisor-selection-status";
 import { renderIssueLintDto } from "../supervisor/supervisor-selection-issue-lint";
 import { isCorruptJsonFailClosedMessage } from "../supervisor/supervisor";
+import { renderFirstRunDoctorSummary } from "../setup-readiness";
 import type { SupervisorLoopController } from "../supervisor/supervisor-loop-controller";
 import type { SupervisorService } from "../supervisor/supervisor-service";
 import { renderSupervisorStatusDto } from "../supervisor/supervisor-status-report";
@@ -123,7 +124,7 @@ export async function runSupervisorCycle(
 }
 
 export async function runSupervisorCommand(
-  options: Pick<CliOptions, "dryRun" | "why" | "explainMode" | "issueNumber"> & {
+  options: Pick<CliOptions, "dryRun" | "why" | "explainMode" | "issueNumber" | "firstRunDoctorSummary"> & {
     command: SupervisorRuntimeCommand;
     issueLintSuggest?: boolean;
   },
@@ -230,6 +231,13 @@ export async function runSupervisorCommand(
   }
 
   if (options.command === "doctor") {
+    if (options.firstRunDoctorSummary) {
+      if (!service.querySetupReadiness) {
+        throw new Error("Missing setup readiness support.");
+      }
+      writeStdout(renderFirstRunDoctorSummary(await service.querySetupReadiness()));
+      return;
+    }
     writeStdout(renderDoctorReport(await service.queryDoctor()));
     return;
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -375,4 +375,5 @@ export interface CliOptions {
   caseId?: string;
   corpusPath?: string;
   sampleIssueOutputPath?: string;
+  firstRunDoctorSummary?: boolean;
 }

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { diagnoseSetupReadiness } from "./setup-readiness";
+import { diagnoseSetupReadiness, renderFirstRunDoctorSummary } from "./setup-readiness";
 
 test("setup-readiness imports shared diagnostic DTOs instead of doctor raw types", async () => {
   const content = await fs.readFile(path.join(process.cwd(), "src", "setup-readiness.ts"), "utf8");
@@ -60,6 +60,74 @@ test("diagnoseSetupReadiness explains copied starter profile placeholders as fir
     summary.nextActions.find((action) => action.source === "invalid_repo_slug")?.summary ?? "",
     /replace it with the GitHub owner\/repo slug/i,
   );
+});
+
+test("renderFirstRunDoctorSummary orders beginner blockers and emits one next action", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = await createTrackedRepo(root);
+  await fs.writeFile(
+    path.join(repoPath, "package.json"),
+    JSON.stringify({ private: true, scripts: { "verify:pre-pr": "tsx --test" } }, null, 2),
+    "utf8",
+  );
+  execFileSync("git", ["add", "package.json"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-m", "add local ci script"], {
+    cwd: repoPath,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@example.com",
+      GIT_COMMITTER_NAME: "Codex",
+      GIT_COMMITTER_EMAIL: "codex@example.com",
+    },
+  });
+
+  const workspaceRoot = path.join(root, "workspaces");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify(
+      buildConfigDocument({
+        repoPath,
+        workspaceRoot,
+        stateFile: path.join(root, "state.json"),
+        workspacePreparationCommand: undefined,
+        includeTrustPosture: false,
+      }),
+    ),
+    "utf8",
+  );
+
+  const report = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: false, message: "not logged in" }),
+  });
+  const summary = renderFirstRunDoctorSummary(report);
+
+  assert.equal((summary.match(/^first_run_next_action /gm) ?? []).length, 1);
+
+  const orderedPhrases = [
+    "first_run_repo_identity",
+    "first_run_config_placeholders status=clear",
+    "first_run_local_ci status=optional",
+    "first_run_trust_posture status=blocked",
+    "first_run_github_auth status=blocked",
+    "first_run_next_action action=fix_config source=missing_trust_mode required=true",
+    "first_run_next_command command=node dist/index.js init --config <supervisor-config-path>; node dist/index.js sample-issue --output <sample-issue-path>; node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+  ];
+  let lastIndex = -1;
+  for (const phrase of orderedPhrases) {
+    const index = summary.indexOf(phrase);
+    assert.notEqual(index, -1, `expected first-run summary to include ${phrase}`);
+    assert.ok(index > lastIndex, `expected ${phrase} after the previous first-run summary section`);
+    lastIndex = index;
+  }
+  assert.doesNotMatch(summary, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("diagnoseSetupReadiness preserves provider-specific posture for copied CodeRabbit starter profile", async (t) => {

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -115,10 +115,10 @@ test("renderFirstRunDoctorSummary orders beginner blockers and emits one next ac
     "first_run_repo_identity",
     "first_run_config_placeholders status=clear",
     "first_run_local_ci status=optional",
-    "first_run_trust_posture status=blocked",
+    "first_run_trust_posture status=blocked summary=unknown",
     "first_run_github_auth status=blocked",
     "first_run_next_action action=fix_config source=missing_trust_mode required=true",
-    "first_run_next_command command=node dist/index.js init --config <supervisor-config-path>; node dist/index.js sample-issue --output <sample-issue-path>; node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+    "first_run_next_command command=node dist/index.js init --config <supervisor-config-path>",
   ];
   let lastIndex = -1;
   for (const phrase of orderedPhrases) {
@@ -127,6 +127,26 @@ test("renderFirstRunDoctorSummary orders beginner blockers and emits one next ac
     assert.ok(index > lastIndex, `expected ${phrase} after the previous first-run summary section`);
     lastIndex = index;
   }
+  assert.doesNotMatch(summary, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("renderFirstRunDoctorSummary treats missing host diagnostics as unknown GitHub auth", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const report = await diagnoseSetupReadiness({
+    configPath: path.join(root, "supervisor.config.json"),
+    authStatus: async () => {
+      throw new Error("auth check should not run without a loaded config");
+    },
+  });
+  const summary = renderFirstRunDoctorSummary(report);
+
+  assert.match(summary, /^first_run_trust_posture status=blocked summary=unknown$/m);
+  assert.match(summary, /^first_run_github_auth status=unknown summary=none$/m);
+  assert.match(summary, /^first_run_next_command command=node dist\/index\.js init --config <supervisor-config-path>$/m);
   assert.doesNotMatch(summary, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -1150,6 +1150,47 @@ function firstRunSectionStatus(hasBlocker: boolean, fallback: FirstRunSummarySta
   return hasBlocker ? "blocked" : fallback;
 }
 
+function deriveFirstRunTrustSummary(report: SetupReadinessReport): string {
+  const trustMode = setupFieldValue(report, "trustMode");
+  const executionSafetyMode = setupFieldValue(report, "executionSafetyMode");
+  if (
+    report.trustPosture.configured !== true ||
+    setupFieldStatus(report, "trustMode") !== "configured" ||
+    setupFieldStatus(report, "executionSafetyMode") !== "configured" ||
+    !VALID_TRUST_MODES.has(trustMode as TrustMode) ||
+    !VALID_EXECUTION_SAFETY_MODES.has(executionSafetyMode as ExecutionSafetyMode)
+  ) {
+    return "unknown";
+  }
+
+  return trustMode === "trusted_repo_and_authors" && executionSafetyMode === "unsandboxed_autonomous"
+    ? "Trusted inputs with unsandboxed autonomous execution. This is appropriate only for a trusted solo-lane repository and trusted GitHub authors."
+    : "Trust posture avoids the default unsandboxed trusted-input assumption.";
+}
+
+function firstRunGitHubAuthStatus(report: SetupReadinessReport, githubAuthBlocked: boolean): FirstRunSummaryStatus {
+  if (githubAuthBlocked) {
+    return "blocked";
+  }
+
+  const githubAuthCheck = report.hostReadiness.checks.find((check) => check.name === "github_auth");
+  return githubAuthCheck?.status === "pass" ? "clear" : "unknown";
+}
+
+function firstRunNextCommand(nextAction: SetupReadinessNextAction): string | null {
+  if (nextAction.action === "fix_config") {
+    return nextAction.source === "host_github_auth"
+      ? "gh auth status --hostname github.com"
+      : "node dist/index.js init --config <supervisor-config-path>";
+  }
+
+  if (nextAction.action === "continue") {
+    return "node dist/index.js sample-issue --output <sample-issue-path>";
+  }
+
+  return null;
+}
+
 function selectFirstRunNextAction(report: SetupReadinessReport): SetupReadinessNextAction {
   const orderedSourcePrefixes = [
     "invalid_repo_path",
@@ -1202,6 +1243,7 @@ export function renderFirstRunDoctorSummary(report: SetupReadinessReport): strin
     );
   const githubAuthBlocked = report.blockers.some((blocker) => blocker.code === "host_github_auth");
   const nextAction = selectFirstRunNextAction(report);
+  const nextCommand = firstRunNextCommand(nextAction);
   const lines = [
     `first_run_readiness ready=${report.ready} overall=${report.overallStatus}`,
     [
@@ -1227,11 +1269,11 @@ export function renderFirstRunDoctorSummary(report: SetupReadinessReport): strin
     [
       "first_run_trust_posture",
       `status=${firstRunSectionStatus(trustBlocked)}`,
-      `summary=${sanitizeFirstRunSummaryValue(report.trustPosture.summary)}`,
+      `summary=${sanitizeFirstRunSummaryValue(deriveFirstRunTrustSummary(report))}`,
     ].join(" "),
     [
       "first_run_github_auth",
-      `status=${firstRunSectionStatus(githubAuthBlocked)}`,
+      `status=${firstRunGitHubAuthStatus(report, githubAuthBlocked)}`,
       `summary=${firstRunBlockerSummary(report, (blocker) => blocker.code === "host_github_auth")}`,
     ].join(" "),
     [
@@ -1241,7 +1283,7 @@ export function renderFirstRunDoctorSummary(report: SetupReadinessReport): strin
       `required=${nextAction.required}`,
       `summary=${sanitizeFirstRunSummaryValue(nextAction.summary)}`,
     ].join(" "),
-    "first_run_next_command command=node dist/index.js init --config <supervisor-config-path>; node dist/index.js sample-issue --output <sample-issue-path>; node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+    ...(nextCommand === null ? [] : [`first_run_next_command command=${nextCommand}`]),
   ];
 
   return lines.join("\n");

--- a/src/setup-readiness.ts
+++ b/src/setup-readiness.ts
@@ -198,6 +198,8 @@ export interface SetupReadinessReport {
   releaseReadinessGate?: ReleaseReadinessGateSummary;
 }
 
+type FirstRunSummaryStatus = "blocked" | "clear" | "optional" | "ready" | "unknown";
+
 interface DiagnoseSetupReadinessArgs {
   configPath?: string;
   authStatus?: () => Promise<{ ok: boolean; message: string | null }>;
@@ -1116,6 +1118,133 @@ function overallStatusFromFields(
   }
 
   return "configured";
+}
+
+function sanitizeFirstRunSummaryValue(value: string): string {
+  return value.replace(/\r?\n/g, "\\n");
+}
+
+function setupFieldStatus(
+  report: SetupReadinessReport,
+  key: SetupReadinessFieldKey,
+): SetupFieldState | "unknown" {
+  return report.fields.find((field) => field.key === key)?.state ?? "unknown";
+}
+
+function setupFieldValue(
+  report: SetupReadinessReport,
+  key: SetupReadinessFieldKey,
+): string {
+  return report.fields.find((field) => field.key === key)?.value ?? "none";
+}
+
+function firstRunBlockerSummary(
+  report: SetupReadinessReport,
+  predicate: (blocker: SetupReadinessBlocker) => boolean,
+): string {
+  const blocker = report.blockers.find(predicate);
+  return blocker ? sanitizeFirstRunSummaryValue(blocker.message) : "none";
+}
+
+function firstRunSectionStatus(hasBlocker: boolean, fallback: FirstRunSummaryStatus = "clear"): FirstRunSummaryStatus {
+  return hasBlocker ? "blocked" : fallback;
+}
+
+function selectFirstRunNextAction(report: SetupReadinessReport): SetupReadinessNextAction {
+  const orderedSourcePrefixes = [
+    "invalid_repo_path",
+    "invalid_repo_slug",
+    "invalid_workspace_root",
+    "invalid_codex_binary",
+    "invalid_",
+    "missing_repo_path",
+    "missing_repo_slug",
+    "missing_workspace_root",
+    "missing_codex_binary",
+    "missing_",
+    "host_github_auth",
+    "host_codex_cli",
+    "host_worktrees",
+  ];
+  const requiredActions = report.nextActions.filter((action) => action.required);
+  for (const prefix of orderedSourcePrefixes) {
+    const action = requiredActions.find((candidate) => candidate.source.startsWith(prefix));
+    if (action) {
+      return action;
+    }
+  }
+
+  return requiredActions[0] ?? report.nextActions[0] ?? {
+    action: "continue",
+    source: "setup_readiness",
+    priority: 0,
+    required: false,
+    summary: "No setup blockers or advisory setup decisions remain; continue normal supervisor operation.",
+    fieldKeys: [],
+  };
+}
+
+export function renderFirstRunDoctorSummary(report: SetupReadinessReport): string {
+  const placeholderBlockers = report.blockers.filter((blocker) =>
+    blocker.code.startsWith("invalid_") &&
+    blocker.message.toLowerCase().includes("starter placeholder")
+  );
+  const localCiCommand = report.localCiContract?.recommendedCommand ?? report.localCiContract?.command ?? "none";
+  const localCiStatus: FirstRunSummaryStatus =
+    report.localCiContract?.configured === true
+      ? "ready"
+      : report.localCiContract?.source === "repo_script_candidate"
+        ? "optional"
+        : "clear";
+  const trustBlocked = report.trustPosture.configured === false ||
+    report.blockers.some((blocker) =>
+      blocker.fieldKeys.includes("trustMode") || blocker.fieldKeys.includes("executionSafetyMode")
+    );
+  const githubAuthBlocked = report.blockers.some((blocker) => blocker.code === "host_github_auth");
+  const nextAction = selectFirstRunNextAction(report);
+  const lines = [
+    `first_run_readiness ready=${report.ready} overall=${report.overallStatus}`,
+    [
+      "first_run_repo_identity",
+      `repo_slug=${sanitizeFirstRunSummaryValue(setupFieldValue(report, "repoSlug"))}`,
+      `default_branch=${setupFieldStatus(report, "defaultBranch")}`,
+      `repo_path=${setupFieldStatus(report, "repoPath")}`,
+      `workspace_root=${setupFieldStatus(report, "workspaceRoot")}`,
+    ].join(" "),
+    [
+      "first_run_config_placeholders",
+      `status=${firstRunSectionStatus(placeholderBlockers.length > 0)}`,
+      `count=${placeholderBlockers.length}`,
+      `summary=${placeholderBlockers.length === 0 ? "none" : sanitizeFirstRunSummaryValue(placeholderBlockers[0]!.message)}`,
+    ].join(" "),
+    [
+      "first_run_local_ci",
+      `status=${localCiStatus}`,
+      `configured=${report.localCiContract?.configured === true}`,
+      `command=${sanitizeFirstRunSummaryValue(localCiCommand)}`,
+      `summary=${sanitizeFirstRunSummaryValue(report.localCiContract?.summary ?? "Local CI posture was not reported.")}`,
+    ].join(" "),
+    [
+      "first_run_trust_posture",
+      `status=${firstRunSectionStatus(trustBlocked)}`,
+      `summary=${sanitizeFirstRunSummaryValue(report.trustPosture.summary)}`,
+    ].join(" "),
+    [
+      "first_run_github_auth",
+      `status=${firstRunSectionStatus(githubAuthBlocked)}`,
+      `summary=${firstRunBlockerSummary(report, (blocker) => blocker.code === "host_github_auth")}`,
+    ].join(" "),
+    [
+      "first_run_next_action",
+      `action=${nextAction.action}`,
+      `source=${nextAction.source}`,
+      `required=${nextAction.required}`,
+      `summary=${sanitizeFirstRunSummaryValue(nextAction.summary)}`,
+    ].join(" "),
+    "first_run_next_command command=node dist/index.js init --config <supervisor-config-path>; node dist/index.js sample-issue --output <sample-issue-path>; node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+  ];
+
+  return lines.join("\n");
 }
 
 export async function diagnoseSetupReadiness(


### PR DESCRIPTION
## Summary
- add `doctor --first-run` to render a beginner-oriented setup-readiness summary
- group repo identity, config placeholders, local CI, trust posture, GitHub auth, and one next action
- keep default detailed `doctor` output unchanged

## Verification
- `npx tsx --test src/doctor.test.ts src/setup-readiness.test.ts`
- `npx tsx --test src/cli/supervisor-runtime.test.ts src/cli/parse-args.test.ts`
- `npm run build`

Part of #1859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--first-run` option for the `doctor` command that displays a streamlined first-run setup readiness summary.

* **Documentation**
  * CLI help updated to document the new `--first-run` flag and its usage with `doctor`.

* **Tests**
  * Added tests for `--first-run` parsing and for rendering the first-run readiness summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->