### PR TITLE
Phase 17.4: Publish TypeScript and Node starter profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ For a shipped provider profile, choose the command block that matches the copied
    node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json
    node dist/index.js doctor --config supervisor.config.coderabbit.json
    node dist/index.js status --config supervisor.config.coderabbit.json --why
+
+   node dist/index.js issue-lint <issue-number> --config supervisor.config.typescript-node.json
+   node dist/index.js doctor --config supervisor.config.typescript-node.json
+   node dist/index.js status --config supervisor.config.typescript-node.json --why
    ```
 
 On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path. The tmux scripts use `CODEX_SUPERVISOR_CONFIG`; keep it pointed at the config you validated.
@@ -259,6 +263,7 @@ Choose the review provider profile that matches how PR feedback arrives in your 
 - Copilot profile: [supervisor.config.copilot.json](./supervisor.config.copilot.json)
 - Codex Connector profile: [supervisor.config.codex.json](./supervisor.config.codex.json)
 - CodeRabbit profile: [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
+- TypeScript/Node starter profile: [supervisor.config.typescript-node.json](./supervisor.config.typescript-node.json), with setup notes and a first issue example in [TypeScript and Node starter profile](./docs/examples/typescript-node.md)
 
 Each profile is a starting point. Copy the review provider profile you want, then adjust the rest of `supervisor.config.json` for your repo before you run the supervisor.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ Most operators start from one of these files:
 - [supervisor.config.copilot.json](../supervisor.config.copilot.json)
 - [supervisor.config.codex.json](../supervisor.config.codex.json)
 - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
+- [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json)
 
 The shipped starter configs intentionally surface a short list of high-leverage optional fields in addition to the required baseline. In practice, operators most often need to discover model-routing overrides (`boundedRepairModel*`, `localReviewModel*`), current-head local-review freshness (`trackedPrCurrentHeadLocalReviewRequired`), and repo-owned host contracts (`workspacePreparationCommand`, `localCiCommand`) without reading the full schema first.
 
@@ -143,6 +144,7 @@ Each shipped profile only configures what the supervisor expects to observe. You
 | Copilot | [supervisor.config.copilot.json](../supervisor.config.copilot.json) | Your PR flow already requests or auto-triggers Copilot review. | `copilot-pull-request-reviewer` | Confirm Copilot is enabled for the repo and requested by your normal PR flow. |
 | Codex Connector | [supervisor.config.codex.json](../supervisor.config.codex.json) | The repo is already connected to Codex review and you want that connector to be the trusted review signal. | `chatgpt-codex-connector` | Confirm the connector is installed for the target repo before treating missing review activity as settled. |
 | CodeRabbit | [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json) | You want bounded waiting for current-head CodeRabbit review signals. | `coderabbitai`, `coderabbitai[bot]` | Replace `repoSlug: "REPLACE_ME"` before first run; the placeholder is a fail-closed guardrail. |
+| TypeScript/Node | [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) | Your repo can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [TypeScript and Node starter profile](./examples/typescript-node.md). |
 
 After choosing a starter profile, use the [review-provider settings](#review-and-merge-policy) for the full field list. Keep provider-specific setup outside the supervisor aligned with the same choice instead of copying every provider caveat into this quick comparison.
 

--- a/docs/examples/typescript-node.md
+++ b/docs/examples/typescript-node.md
@@ -1,0 +1,86 @@
+# TypeScript and Node Starter Profile
+
+Use [supervisor.config.typescript-node.json](../../supervisor.config.typescript-node.json) when the managed repo is a TypeScript or Node project that can expose an npm-owned setup command and an npm-owned pre-PR verification command.
+
+## Copy the Profile
+
+```bash
+cp supervisor.config.typescript-node.json supervisor.config.json
+```
+
+Replace these starter placeholders before the first run:
+
+- `repoPath`: absolute path to the managed repository
+- `repoSlug`: GitHub `owner/repo`
+- `workspaceRoot`: directory where issue worktrees should be created
+- `codexBinary`: `codex` or the path to the Codex executable
+
+The copied profile remains invalid until those placeholders are replaced. Validate the edited config before running Codex:
+
+```bash
+node dist/index.js doctor --config <supervisor-config-path>
+node dist/index.js status --config <supervisor-config-path> --why
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+## Expected npm Scripts
+
+The starter profile sets:
+
+```json
+{
+  "workspacePreparationCommand": "npm ci",
+  "localCiCommand": "npm run verify:pre-pr"
+}
+```
+
+`npm ci` is the worktree preparation command. It should succeed in a freshly created issue worktree.
+
+`npm run verify:pre-pr` is the repo-owned local CI gate. It should be defined by the managed repo and return exit code `0` only when the repo's pre-PR checks pass.
+
+One common `package.json` shape is:
+
+```json
+{
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test",
+    "verify:pre-pr": "npm run build && npm run test"
+  }
+}
+```
+
+Do not assume every TypeScript/Node repo has these exact scripts. If your repo uses a different npm-owned setup or verification entrypoint, replace `workspacePreparationCommand` or `localCiCommand` with the repo-owned command before running the supervisor.
+
+## First Issue Example
+
+Create one small issue with the `codex` label before starting the loop:
+
+```md
+## Summary
+Add one focused TypeScript test for the greeting formatter.
+
+## Scope
+- Add a narrow test for the existing greeting formatter behavior.
+- Do not change production formatter behavior unless the test exposes a real defect.
+
+## Acceptance criteria
+- The formatter keeps existing output for a normal display name.
+- The new test is covered by the repo-owned pre-PR command.
+
+## Verification
+- npm run verify:pre-pr
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+```
+
+Run the focused readiness checks before the first supervised pass:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+node dist/index.js run-once --config <supervisor-config-path> --dry-run
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,6 +101,8 @@ The setup/readiness report stays `ready: false` until these required first-run b
 
 The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so operators must replace it before the first run.
 
+For TypeScript and Node repositories, [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) publishes an npm-oriented starter profile. It uses `npm ci` for worktree preparation and `npm run verify:pre-pr` for the repo-owned local CI gate; see the [TypeScript and Node starter profile](./examples/typescript-node.md) for the expected scripts and a first issue example.
+
 ### Explicit trust posture setup
 
 Trust posture setup is a product primitive for trusted solo-lane automation. It packages the authority choices that decide whether the supervisor may turn GitHub-authored text, local repo state, review signals, and configured commands into autonomous Codex work.
@@ -281,7 +283,7 @@ node dist/index.js run-once --config <supervisor-config-path>
 ./scripts/start-loop-tmux.sh
 ```
 
-For a concrete shipped profile, run the same checks against the matching provider config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`.
+For a concrete shipped profile, run the same checks against the matching config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`. For the TypeScript/Node starter, use `supervisor.config.typescript-node.json` after replacing the placeholders and confirming the repo owns `npm run verify:pre-pr`.
 
 Read the command output as a sequence of decisions, not as unrelated logs:
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1608,6 +1608,7 @@ test("shipped example configs recommend block_merge for local review gating", as
     path.join(rootDir, "supervisor.config.copilot.json"),
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
+    path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1624,6 +1625,7 @@ test("shipped starter config profiles keep local review disabled until operators
     path.join(rootDir, "supervisor.config.copilot.json"),
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
+    path.join(rootDir, "supervisor.config.typescript-node.json"),
   ];
 
   for (const examplePath of examplePaths) {
@@ -1639,6 +1641,7 @@ test("shipped example configs keep local-review follow-up issue creation opt-in"
     path.join(rootDir, "supervisor.config.copilot.json"),
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
+    path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1661,6 +1664,7 @@ test("shipped example configs keep local-review same-PR follow-up repair opt-in"
     path.join(rootDir, "supervisor.config.copilot.json"),
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
+    path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1683,6 +1687,7 @@ test("shipped example configs recommend blocked for high-severity local review f
     path.join(rootDir, "supervisor.config.copilot.json"),
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
+    path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1704,6 +1709,7 @@ test("shipped example configs use the issue-scoped journal path template and pre
     path.join(rootDir, "supervisor.config.copilot.json"),
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
+    path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1749,6 +1755,7 @@ test("shipped config profiles declare the intended review bot logins", async () 
     ["supervisor.config.copilot.json", ["copilot-pull-request-reviewer"]],
     ["supervisor.config.codex.json", ["chatgpt-codex-connector"]],
     ["supervisor.config.coderabbit.json", ["coderabbitai", "coderabbitai[bot]"]],
+    ["supervisor.config.typescript-node.json", ["copilot-pull-request-reviewer"]],
   ]);
 
   for (const [relativePath, expectedReviewBotLogins] of expectedProfiles) {
@@ -1776,6 +1783,7 @@ test("shipped starter profiles fail closed with first-run placeholder guidance",
     ["supervisor.config.copilot.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
     ["supervisor.config.codex.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
     ["supervisor.config.coderabbit.json", ["repoSlug"]],
+    ["supervisor.config.typescript-node.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
   ]);
 
   for (const [relativePath, invalidFields] of expectedInvalidFields) {
@@ -1859,6 +1867,42 @@ test("shipped CodeRabbit starter profile adopts the repo-owned local CI gate", a
   const raw = JSON.parse(await fs.readFile(profilePath, "utf8")) as { localCiCommand?: unknown };
 
   assert.equal(raw.localCiCommand, "npm run verify:supervisor-pre-pr");
+});
+
+test("shipped TypeScript and Node starter profile publishes npm setup and verification commands", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const relativePath = "supervisor.config.typescript-node.json";
+  const raw = (await readShippedProfileJson(rootDir, relativePath)) as {
+    workspacePreparationCommand?: unknown;
+    localCiCommand?: unknown;
+    skipTitlePrefixes?: unknown;
+  };
+  const summary = loadConfigSummaryFromDocument(raw, path.join(rootDir, relativePath));
+  const docs = await Promise.all([
+    fs.readFile(path.join(rootDir, "README.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "configuration.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "getting-started.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "examples", "typescript-node.md"), "utf8"),
+  ]);
+
+  assert.equal(raw.workspacePreparationCommand, "npm ci");
+  assert.equal(raw.localCiCommand, "npm run verify:pre-pr");
+  assert.deepEqual(raw.skipTitlePrefixes, ["Epic:"]);
+  assert.equal(summary.status, "invalid_config");
+  assert.deepEqual(summary.invalidFields, ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]);
+
+  for (const content of docs) {
+    assert.match(content, /supervisor\.config\.typescript-node\.json/);
+  }
+
+  const exampleDoc = docs[3] ?? "";
+  assert.match(exampleDoc, /npm ci/);
+  assert.match(exampleDoc, /npm run verify:pre-pr/);
+  assert.match(exampleDoc, /"build": "tsc -p tsconfig\.json"/);
+  assert.match(exampleDoc, /"test": "node --test"/);
+  assert.match(exampleDoc, /do not assume every TypeScript\/Node repo has these exact scripts/i);
+  assert.doesNotMatch(exampleDoc, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(exampleDoc, /C:\\Users\\[A-Za-z0-9._-]+\\/);
 });
 
 test("repo gitignore ignores workstation noise and live issue journals without hiding intentional files", async (t) => {

--- a/supervisor.config.typescript-node.json
+++ b/supervisor.config.typescript-node.json
@@ -1,0 +1,98 @@
+{
+  "repoPath": "/absolute/path/to/managed-repo",
+  "repoSlug": "OWNER/REPO",
+  "defaultBranch": "main",
+  "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
+  "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
+  "codexBinary": "/absolute/path/to/codex",
+  "trustMode": "trusted_repo_and_authors",
+  "executionSafetyMode": "unsandboxed_autonomous",
+  "codexModelStrategy": "inherit",
+  "codexModel": "",
+  "boundedRepairModelStrategy": "",
+  "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
+  "codexReasoningEffortByState": {
+    "planning": "low",
+    "reproducing": "medium",
+    "implementing": "high",
+    "local_review_fix": "medium",
+    "stabilizing": "medium",
+    "draft_pr": "low",
+    "local_review": "low",
+    "repairing_ci": "medium",
+    "resolving_conflict": "high",
+    "addressing_review": "medium"
+  },
+  "codexReasoningEscalateOnRepeatedFailure": true,
+  "sharedMemoryFiles": [
+    "README.md",
+    "docs/architecture.md",
+    "docs/constitution.md",
+    "docs/workflow.md",
+    "docs/decisions.md"
+  ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
+  "localReviewPosture": "off",
+  "localReviewEnabled": false,
+  "localReviewAutoDetect": true,
+  "localReviewRoles": [],
+  "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
+  "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
+  "localReviewFollowUpRepairEnabled": false,
+  "localReviewManualReviewRepairEnabled": false,
+  "localReviewFollowUpIssueCreationEnabled": false,
+  "localReviewHighSeverityAction": "blocked",
+  "reviewBotLogins": [
+    "copilot-pull-request-reviewer"
+  ],
+  "humanReviewBlocksMerge": true,
+  "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  "issueJournalMaxChars": 6000,
+  "issueLabel": "codex",
+  "workspacePreparationCommand": "npm ci",
+  "localCiCommand": "npm run verify:pre-pr",
+  "skipTitlePrefixes": [
+    "Epic:"
+  ],
+  "branchPrefix": "codex/issue-",
+  "pollIntervalSeconds": 120,
+  "copilotReviewWaitMinutes": 10,
+  "copilotReviewTimeoutAction": "continue",
+  "codexExecTimeoutMinutes": 30,
+  "maxCodexAttemptsPerIssue": 30,
+  "maxImplementationAttemptsPerIssue": 30,
+  "maxRepairAttemptsPerIssue": 30,
+  "timeoutRetryLimit": 2,
+  "blockedVerificationRetryLimit": 3,
+  "sameBlockerRepeatLimit": 2,
+  "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
+  "cleanupDoneWorkspacesAfterHours": 24,
+  "mergeMethod": "squash",
+  "draftPrAfterAttempt": 1
+}


### PR DESCRIPTION
## Summary
- add a TypeScript/Node starter config with npm ci preparation and npm run verify:pre-pr local CI
- document placeholder replacement, expected npm scripts, and a first execution-ready issue example
- cover the profile in shipped config placeholder/readiness docs tests

## Verification
- npx tsx --test src/config.test.ts
- npx tsx --test src/setup-readiness.test.ts src/readme-docs.test.ts src/getting-started-docs.test.ts
- npm run verify:paths
- npm run verify:supervisor-pre-pr

Part of #1860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a TypeScript/Node starter profile with pre-optimized supervisor configuration for TypeScript and Node.js projects.

* **Documentation**
  * Added comprehensive setup guides and configuration examples for the TypeScript/Node profile.
  * Extended configuration and getting-started resources with TypeScript/Node workflows and validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->