### PR TITLE
Add Next.js starter profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ For a shipped provider profile, choose the command block that matches the copied
    node dist/index.js issue-lint <issue-number> --config supervisor.config.typescript-node.json
    node dist/index.js doctor --config supervisor.config.typescript-node.json
    node dist/index.js status --config supervisor.config.typescript-node.json --why
+
+   node dist/index.js issue-lint <issue-number> --config supervisor.config.nextjs.json
+   node dist/index.js doctor --config supervisor.config.nextjs.json
+   node dist/index.js status --config supervisor.config.nextjs.json --why
    ```
 
 On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path. The tmux scripts use `CODEX_SUPERVISOR_CONFIG`; keep it pointed at the config you validated.
@@ -264,6 +268,7 @@ Choose the review provider profile that matches how PR feedback arrives in your 
 - Codex Connector profile: [supervisor.config.codex.json](./supervisor.config.codex.json)
 - CodeRabbit profile: [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
 - TypeScript/Node starter profile: [supervisor.config.typescript-node.json](./supervisor.config.typescript-node.json), with setup notes and a first issue example in [TypeScript and Node starter profile](./docs/examples/typescript-node.md)
+- Next.js starter profile: [supervisor.config.nextjs.json](./supervisor.config.nextjs.json), with npm local CI mapping and a first issue example in [Next.js starter profile](./docs/examples/nextjs.md)
 
 Each profile is a starting point. Copy the review provider profile you want, then adjust the rest of `supervisor.config.json` for your repo before you run the supervisor.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ For a shipped provider profile, choose the command block that matches the copied
    node dist/index.js status --config supervisor.config.nextjs.json --why
    ```
 
+The Next.js starter commands above expect an edited copy of `supervisor.config.nextjs.json`, not the shipped starter file. Replace its placeholders before running `issue-lint`, `doctor`, or `status`; see [Getting started](./docs/getting-started.md) for the first-run guidance.
+
 On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path. The tmux scripts use `CODEX_SUPERVISOR_CONFIG`; keep it pointed at the config you validated.
 
 If you want the local operator dashboard, start the WebUI against the same config:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ Most operators start from one of these files:
 - [supervisor.config.codex.json](../supervisor.config.codex.json)
 - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
 - [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json)
+- [supervisor.config.nextjs.json](../supervisor.config.nextjs.json)
 
 The shipped starter configs intentionally surface a short list of high-leverage optional fields in addition to the required baseline. In practice, operators most often need to discover model-routing overrides (`boundedRepairModel*`, `localReviewModel*`), current-head local-review freshness (`trackedPrCurrentHeadLocalReviewRequired`), and repo-owned host contracts (`workspacePreparationCommand`, `localCiCommand`) without reading the full schema first.
 
@@ -145,6 +146,7 @@ Each shipped profile only configures what the supervisor expects to observe. You
 | Codex Connector | [supervisor.config.codex.json](../supervisor.config.codex.json) | The repo is already connected to Codex review and you want that connector to be the trusted review signal. | `chatgpt-codex-connector` | Confirm the connector is installed for the target repo before treating missing review activity as settled. |
 | CodeRabbit | [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json) | You want bounded waiting for current-head CodeRabbit review signals. | `coderabbitai`, `coderabbitai[bot]` | Replace `repoSlug: "REPLACE_ME"` before first run; the placeholder is a fail-closed guardrail. |
 | TypeScript/Node | [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) | Your repo can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [TypeScript and Node starter profile](./examples/typescript-node.md). |
+| Next.js | [supervisor.config.nextjs.json](../supervisor.config.nextjs.json) | Your app can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands around the scripts it actually defines. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [Next.js starter profile](./examples/nextjs.md). |
 
 After choosing a starter profile, use the [review-provider settings](#review-and-merge-policy) for the full field list. Keep provider-specific setup outside the supervisor aligned with the same choice instead of copying every provider caveat into this quick comparison.
 

--- a/docs/examples/nextjs.md
+++ b/docs/examples/nextjs.md
@@ -1,0 +1,90 @@
+# Next.js Starter Profile
+
+Use [supervisor.config.nextjs.json](../../supervisor.config.nextjs.json) when the managed repo is a Next.js app that can expose an npm-owned install step and a single npm-owned pre-PR verification command.
+
+## Copy the Profile
+
+```bash
+cp supervisor.config.nextjs.json supervisor.config.json
+```
+
+Replace these starter placeholders before the first run:
+
+- `repoPath`: absolute path to the managed repository
+- `repoSlug`: GitHub `owner/repo`
+- `workspaceRoot`: directory where issue worktrees should be created
+- `codexBinary`: `codex` or the path to the Codex executable
+
+The copied profile remains invalid until those placeholders are replaced. Validate the edited config before running Codex:
+
+```bash
+node dist/index.js doctor --config <supervisor-config-path>
+node dist/index.js status --config <supervisor-config-path> --why
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+## Expected npm Scripts
+
+The starter profile sets:
+
+```json
+{
+  "workspacePreparationCommand": "npm ci",
+  "localCiCommand": "npm run verify:pre-pr"
+}
+```
+
+`npm ci` is the worktree preparation command. It should succeed in a freshly created issue worktree.
+
+`npm run verify:pre-pr` is the repo-owned local CI gate. It should be defined by the managed repo and return exit code `0` only when the app's pre-PR checks pass.
+
+One common `package.json` shape is:
+
+```json
+{
+  "scripts": {
+    "build": "next build",
+    "lint": "next lint",
+    "test": "vitest run",
+    "verify:pre-pr": "npm run lint && npm run test && npm run build"
+  }
+}
+```
+
+Do not assume every Next.js app defines all of these scripts. If your app has no test suite yet, keep `verify:pre-pr` to the repo-owned checks that actually exist, such as `npm run lint && npm run build`. If your app uses `pnpm`, `yarn`, or a custom task runner, replace `workspacePreparationCommand` and `localCiCommand` with the repo-owned commands before running the supervisor.
+
+## First Issue Example
+
+Create one small issue with the `codex` label before starting the loop:
+
+<!-- nextjs-first-issue:start -->
+```md
+## Summary
+Add a focused metadata test for the article page.
+
+## Scope
+- Add or tighten one test for the existing article page metadata behavior.
+- Keep the page route, data model, and visual layout unchanged unless the test exposes a real defect.
+- Do not add new runtime framework dependencies.
+
+## Acceptance criteria
+- The article page metadata keeps the expected title and description for a representative article fixture.
+- The new or updated test is covered by the repo-owned pre-PR command.
+
+## Verification
+- npm run verify:pre-pr
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+```
+<!-- nextjs-first-issue:end -->
+
+Run the focused readiness checks before the first supervised pass:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+node dist/index.js run-once --config <supervisor-config-path> --dry-run
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,6 +103,8 @@ The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` plac
 
 For TypeScript and Node repositories, [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) publishes an npm-oriented starter profile. It uses `npm ci` for worktree preparation and `npm run verify:pre-pr` for the repo-owned local CI gate; see the [TypeScript and Node starter profile](./examples/typescript-node.md) for the expected scripts and a first issue example.
 
+For Next.js app repositories, [supervisor.config.nextjs.json](../supervisor.config.nextjs.json) publishes the same npm-owned setup and local CI posture with Next.js-specific script guidance; see the [Next.js starter profile](./examples/nextjs.md) for common `build`, `lint`, and `test` mappings and a first issue example.
+
 ### Explicit trust posture setup
 
 Trust posture setup is a product primitive for trusted solo-lane automation. It packages the authority choices that decide whether the supervisor may turn GitHub-authored text, local repo state, review signals, and configured commands into autonomous Codex work.
@@ -283,7 +285,7 @@ node dist/index.js run-once --config <supervisor-config-path>
 ./scripts/start-loop-tmux.sh
 ```
 
-For a concrete shipped profile, run the same checks against the matching config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`. For the TypeScript/Node starter, use `supervisor.config.typescript-node.json` after replacing the placeholders and confirming the repo owns `npm run verify:pre-pr`.
+For a concrete shipped profile, run the same checks against the matching config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`. For the TypeScript/Node starter, use `supervisor.config.typescript-node.json` after replacing the placeholders and confirming the repo owns `npm run verify:pre-pr`. For the Next.js starter, use `supervisor.config.nextjs.json` after replacing the placeholders and mapping `verify:pre-pr` to the app scripts that actually exist.
 
 Read the command output as a sequence of decisions, not as unrelated logs:
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -16,6 +16,8 @@ import {
   summarizeLocalCiContract,
 } from "./core/config";
 import type { LocalCiContractSummary, SupervisorConfig } from "./core/config-types";
+import type { GitHubIssue } from "./core/types";
+import { lintExecutionReadyIssueBody, validateIssueMetadataSyntax } from "./issue-metadata";
 import { buildSetupConfigPreview } from "./setup-config-preview";
 import { updateSetupConfig } from "./setup-config-write";
 
@@ -1609,6 +1611,7 @@ test("shipped example configs recommend block_merge for local review gating", as
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
+    path.join(rootDir, "supervisor.config.nextjs.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1626,6 +1629,7 @@ test("shipped starter config profiles keep local review disabled until operators
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
+    path.join(rootDir, "supervisor.config.nextjs.json"),
   ];
 
   for (const examplePath of examplePaths) {
@@ -1642,6 +1646,7 @@ test("shipped example configs keep local-review follow-up issue creation opt-in"
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
+    path.join(rootDir, "supervisor.config.nextjs.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1665,6 +1670,7 @@ test("shipped example configs keep local-review same-PR follow-up repair opt-in"
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
+    path.join(rootDir, "supervisor.config.nextjs.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1688,6 +1694,7 @@ test("shipped example configs recommend blocked for high-severity local review f
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
+    path.join(rootDir, "supervisor.config.nextjs.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1710,6 +1717,7 @@ test("shipped example configs use the issue-scoped journal path template and pre
     path.join(rootDir, "supervisor.config.codex.json"),
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
+    path.join(rootDir, "supervisor.config.nextjs.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1756,6 +1764,7 @@ test("shipped config profiles declare the intended review bot logins", async () 
     ["supervisor.config.codex.json", ["chatgpt-codex-connector"]],
     ["supervisor.config.coderabbit.json", ["coderabbitai", "coderabbitai[bot]"]],
     ["supervisor.config.typescript-node.json", ["copilot-pull-request-reviewer"]],
+    ["supervisor.config.nextjs.json", ["copilot-pull-request-reviewer"]],
   ]);
 
   for (const [relativePath, expectedReviewBotLogins] of expectedProfiles) {
@@ -1784,6 +1793,7 @@ test("shipped starter profiles fail closed with first-run placeholder guidance",
     ["supervisor.config.codex.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
     ["supervisor.config.coderabbit.json", ["repoSlug"]],
     ["supervisor.config.typescript-node.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
+    ["supervisor.config.nextjs.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
   ]);
 
   for (const [relativePath, invalidFields] of expectedInvalidFields) {
@@ -1903,6 +1913,64 @@ test("shipped TypeScript and Node starter profile publishes npm setup and verifi
   assert.match(exampleDoc, /do not assume every TypeScript\/Node repo has these exact scripts/i);
   assert.doesNotMatch(exampleDoc, /\/Users\/[A-Za-z0-9._-]+\//);
   assert.doesNotMatch(exampleDoc, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+});
+
+test("shipped Next.js starter profile publishes npm posture and execution-ready first issue", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const relativePath = "supervisor.config.nextjs.json";
+  const raw = (await readShippedProfileJson(rootDir, relativePath)) as {
+    workspacePreparationCommand?: unknown;
+    localCiCommand?: unknown;
+    skipTitlePrefixes?: unknown;
+  };
+  const summary = loadConfigSummaryFromDocument(raw, path.join(rootDir, relativePath));
+  const docs = await Promise.all([
+    fs.readFile(path.join(rootDir, "README.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "configuration.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "getting-started.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "examples", "nextjs.md"), "utf8"),
+  ]);
+
+  assert.equal(raw.workspacePreparationCommand, "npm ci");
+  assert.equal(raw.localCiCommand, "npm run verify:pre-pr");
+  assert.deepEqual(raw.skipTitlePrefixes, ["Epic:"]);
+  assert.equal(summary.status, "invalid_config");
+  assert.deepEqual(summary.invalidFields, ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]);
+
+  for (const content of docs) {
+    assert.match(content, /supervisor\.config\.nextjs\.json/);
+  }
+
+  const exampleDoc = docs[3] ?? "";
+  assert.match(exampleDoc, /npm ci/);
+  assert.match(exampleDoc, /npm run verify:pre-pr/);
+  assert.match(exampleDoc, /npm run build/);
+  assert.match(exampleDoc, /npm run lint/);
+  assert.match(exampleDoc, /npm run test/);
+  assert.match(exampleDoc, /do not assume every Next\.js app defines all of these scripts/i);
+  assert.doesNotMatch(exampleDoc, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(exampleDoc, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  const match = exampleDoc.match(
+    /<!-- nextjs-first-issue:start -->\s*```md\s*([\s\S]*?)```\s*<!-- nextjs-first-issue:end -->/,
+  );
+  assert.ok(match, "Next.js starter doc must include the marked sample issue body");
+  const sampleIssue: GitHubIssue = {
+    number: 101,
+    title: "Add metadata test for article page",
+    body: match[1].trim(),
+    createdAt: "2026-04-27T00:00:00Z",
+    updatedAt: "2026-04-27T00:00:00Z",
+    url: "https://example.com/issues/101",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+
+  assert.deepEqual(validateIssueMetadataSyntax(sampleIssue), []);
+  const lint = lintExecutionReadyIssueBody(sampleIssue);
+  assert.equal(lint.isExecutionReady, true);
+  assert.deepEqual(lint.missingRequired, []);
+  assert.deepEqual(lint.missingRecommended, []);
 });
 
 test("repo gitignore ignores workstation noise and live issue journals without hiding intentional files", async (t) => {

--- a/src/readme-docs.test.ts
+++ b/src/readme-docs.test.ts
@@ -182,6 +182,20 @@ test("README docs map links to the self-contained demo scenario", async () => {
   );
 });
 
+test("README says Next.js starter commands require an edited config copy", async () => {
+  const content = await readReadme();
+  const nextjsBlockStart = content.indexOf("node dist/index.js issue-lint <issue-number> --config supervisor.config.nextjs.json");
+  const macosStart = content.indexOf("On macOS, use `./scripts/start-loop-tmux.sh`");
+  assert.notEqual(nextjsBlockStart, -1, "expected README to include Next.js starter commands");
+  assert.ok(macosStart > nextjsBlockStart, "expected macOS guidance to follow provider profile commands");
+
+  const nextjsGuidance = content.slice(nextjsBlockStart, macosStart);
+  assert.match(nextjsGuidance, /edited copy of `supervisor\.config\.nextjs\.json`/i);
+  assert.match(nextjsGuidance, /not the shipped starter file/i);
+  assert.match(nextjsGuidance, /Replace its placeholders before running `issue-lint`, `doctor`, or `status`/);
+  assert.match(nextjsGuidance, /\[Getting started\]\(\.\/docs\/getting-started\.md\)/);
+});
+
 test("README.ja stays lightweight while routing humans and AI agents to the right docs", async () => {
   const content = await readJapaneseOverview();
 

--- a/supervisor.config.nextjs.json
+++ b/supervisor.config.nextjs.json
@@ -1,0 +1,98 @@
+{
+  "repoPath": "/absolute/path/to/managed-repo",
+  "repoSlug": "OWNER/REPO",
+  "defaultBranch": "main",
+  "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
+  "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
+  "codexBinary": "/absolute/path/to/codex",
+  "trustMode": "trusted_repo_and_authors",
+  "executionSafetyMode": "unsandboxed_autonomous",
+  "codexModelStrategy": "inherit",
+  "codexModel": "",
+  "boundedRepairModelStrategy": "",
+  "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
+  "codexReasoningEffortByState": {
+    "planning": "low",
+    "reproducing": "medium",
+    "implementing": "high",
+    "local_review_fix": "medium",
+    "stabilizing": "medium",
+    "draft_pr": "low",
+    "local_review": "low",
+    "repairing_ci": "medium",
+    "resolving_conflict": "high",
+    "addressing_review": "medium"
+  },
+  "codexReasoningEscalateOnRepeatedFailure": true,
+  "sharedMemoryFiles": [
+    "README.md",
+    "docs/architecture.md",
+    "docs/constitution.md",
+    "docs/workflow.md",
+    "docs/decisions.md"
+  ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
+  "localReviewPosture": "off",
+  "localReviewEnabled": false,
+  "localReviewAutoDetect": true,
+  "localReviewRoles": [],
+  "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
+  "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
+  "localReviewFollowUpRepairEnabled": false,
+  "localReviewManualReviewRepairEnabled": false,
+  "localReviewFollowUpIssueCreationEnabled": false,
+  "localReviewHighSeverityAction": "blocked",
+  "reviewBotLogins": [
+    "copilot-pull-request-reviewer"
+  ],
+  "humanReviewBlocksMerge": true,
+  "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  "issueJournalMaxChars": 6000,
+  "issueLabel": "codex",
+  "workspacePreparationCommand": "npm ci",
+  "localCiCommand": "npm run verify:pre-pr",
+  "skipTitlePrefixes": [
+    "Epic:"
+  ],
+  "branchPrefix": "codex/issue-",
+  "pollIntervalSeconds": 120,
+  "copilotReviewWaitMinutes": 10,
+  "copilotReviewTimeoutAction": "continue",
+  "codexExecTimeoutMinutes": 30,
+  "maxCodexAttemptsPerIssue": 30,
+  "maxImplementationAttemptsPerIssue": 30,
+  "maxRepairAttemptsPerIssue": 30,
+  "timeoutRetryLimit": 2,
+  "blockedVerificationRetryLimit": 3,
+  "sameBlockerRepeatLimit": 2,
+  "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
+  "cleanupDoneWorkspacesAfterHours": 24,
+  "mergeMethod": "squash",
+  "draftPrAfterAttempt": 1
+}


### PR DESCRIPTION
## Summary
- add a fail-closed Next.js starter supervisor profile
- document npm setup/local CI mapping and a copyable first issue example
- guard the profile and issue example with focused config/docs tests

## Verification
- npx tsx --test src/config.test.ts
- npx tsx --test src/readme-docs.test.ts src/getting-started-docs.test.ts src/execution-safety-docs.test.ts
- npm run verify:paths
- npm run build

Part of #1861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Next.js starter configuration/profile for managed Next.js repos with ready-to-run commands and validation guidance.

* **Documentation**
  * New Next.js setup guide and first-issue example; README, getting-started, and configuration docs updated to reference the Next.js profile and placeholder-edit prerequisite.

* **Tests**
  * Added tests to validate the Next.js starter profile, docs guidance, and first-run command snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->