### PR TITLE
Phase 17.6: Publish Python and CLI starter profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,14 @@ For a shipped provider profile, choose the command block that matches the copied
    node dist/index.js issue-lint <issue-number> --config supervisor.config.nextjs.json
    node dist/index.js doctor --config supervisor.config.nextjs.json
    node dist/index.js status --config supervisor.config.nextjs.json --why
+
+   node dist/index.js issue-lint <issue-number> --config supervisor.config.python-cli.json
+   node dist/index.js doctor --config supervisor.config.python-cli.json
+   node dist/index.js status --config supervisor.config.python-cli.json --why
    ```
 
 The Next.js starter commands above expect an edited copy of `supervisor.config.nextjs.json`, not the shipped starter file. Replace its placeholders before running `issue-lint`, `doctor`, or `status`; see [Getting started](./docs/getting-started.md) for the first-run guidance.
+The Python/CLI starter commands also expect an edited copy of `supervisor.config.python-cli.json`; replace the path and command placeholders with repo-owned setup and pre-PR verification commands first.
 
 On macOS, use `./scripts/start-loop-tmux.sh` to host the loop in a managed `tmux` session, and stop it with `./scripts/stop-loop-tmux.sh`. `./scripts/install-launchd.sh` is not a supported macOS loop path. The tmux scripts use `CODEX_SUPERVISOR_CONFIG`; keep it pointed at the config you validated.
 
@@ -271,6 +276,7 @@ Choose the review provider profile that matches how PR feedback arrives in your 
 - CodeRabbit profile: [supervisor.config.coderabbit.json](./supervisor.config.coderabbit.json)
 - TypeScript/Node starter profile: [supervisor.config.typescript-node.json](./supervisor.config.typescript-node.json), with setup notes and a first issue example in [TypeScript and Node starter profile](./docs/examples/typescript-node.md)
 - Next.js starter profile: [supervisor.config.nextjs.json](./supervisor.config.nextjs.json), with npm local CI mapping and a first issue example in [Next.js starter profile](./docs/examples/nextjs.md)
+- Python/CLI starter profile: [supervisor.config.python-cli.json](./supervisor.config.python-cli.json), with portable command substitution guidance and a first issue example in [Python and CLI starter profile](./docs/examples/python-cli.md)
 
 Each profile is a starting point. Copy the review provider profile you want, then adjust the rest of `supervisor.config.json` for your repo before you run the supervisor.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ Most operators start from one of these files:
 - [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json)
 - [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json)
 - [supervisor.config.nextjs.json](../supervisor.config.nextjs.json)
+- [supervisor.config.python-cli.json](../supervisor.config.python-cli.json)
 
 The shipped starter configs intentionally surface a short list of high-leverage optional fields in addition to the required baseline. In practice, operators most often need to discover model-routing overrides (`boundedRepairModel*`, `localReviewModel*`), current-head local-review freshness (`trackedPrCurrentHeadLocalReviewRequired`), and repo-owned host contracts (`workspacePreparationCommand`, `localCiCommand`) without reading the full schema first.
 
@@ -147,6 +148,7 @@ Each shipped profile only configures what the supervisor expects to observe. You
 | CodeRabbit | [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json) | You want bounded waiting for current-head CodeRabbit review signals. | `coderabbitai`, `coderabbitai[bot]` | Replace `repoSlug: "REPLACE_ME"` before first run; the placeholder is a fail-closed guardrail. |
 | TypeScript/Node | [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) | Your repo can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [TypeScript and Node starter profile](./examples/typescript-node.md). |
 | Next.js | [supervisor.config.nextjs.json](../supervisor.config.nextjs.json) | Your app can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands around the scripts it actually defines. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [Next.js starter profile](./examples/nextjs.md). |
+| Python/CLI | [supervisor.config.python-cli.json](../supervisor.config.python-cli.json) | Your Python package or CLI tool has repo-owned setup and pre-PR verification commands, but not necessarily npm scripts. | `copilot-pull-request-reviewer` | Replace required path placeholders and the command placeholders before first run; see the [Python and CLI starter profile](./examples/python-cli.md). |
 
 After choosing a starter profile, use the [review-provider settings](#review-and-merge-policy) for the full field list. Keep provider-specific setup outside the supervisor aligned with the same choice instead of copying every provider caveat into this quick comparison.
 

--- a/docs/examples/python-cli.md
+++ b/docs/examples/python-cli.md
@@ -1,0 +1,93 @@
+# Python and CLI Starter Profile
+
+Use [supervisor.config.python-cli.json](../../supervisor.config.python-cli.json) when the managed repo is a Python package, Python application, or general CLI tool that does not have a repo-wide npm contract.
+
+## Copy the Profile
+
+```bash
+cp supervisor.config.python-cli.json supervisor.config.json
+```
+
+Replace these starter placeholders before the first run:
+
+- `repoPath`: absolute path to the managed repository
+- `repoSlug`: GitHub `owner/repo`
+- `workspaceRoot`: directory where issue worktrees should be created
+- `codexBinary`: `codex` or the path to the Codex executable
+- `workspacePreparationCommand`: the repo-owned setup command for a fresh issue worktree
+- `localCiCommand`: the repo-owned pre-PR verification command
+
+The copied profile remains invalid until those placeholders are replaced. Validate the edited config before running Codex:
+
+```bash
+node dist/index.js doctor --config <supervisor-config-path>
+node dist/index.js status --config <supervisor-config-path> --why
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+## Substitute Repo-Owned Commands
+
+The starter profile sets:
+
+```json
+{
+  "workspacePreparationCommand": "<replace-with-repo-owned-setup-command>",
+  "localCiCommand": "<replace-with-repo-owned-pre-pr-command>"
+}
+```
+
+Replace `workspacePreparationCommand` with the command your repo owns for preparing a fresh worktree. Common examples include:
+
+```bash
+python -m pip install -e ".[dev]"
+python -m pip install -r requirements-dev.txt
+uv sync --dev
+```
+
+Replace `localCiCommand` with the command your repo owns as the pre-PR gate. Common examples include:
+
+```bash
+python -m pytest
+python -m pytest && python -m build
+python -m unittest
+```
+
+Do not assume every Python package or CLI tool uses these commands. If your repo uses `tox`, `nox`, `hatch`, `poetry`, `uv`, `make`, or another task runner, substitute the repo-owned setup and verification commands before running the supervisor.
+
+Keep `localCiCommand` fail closed: it should return exit code `0` only when the repo's checks are ready for PR progression.
+
+## First Issue Example
+
+Create one small issue with the `codex` label before starting the loop:
+
+<!-- python-cli-first-issue:start -->
+```md
+## Summary
+Add a focused CLI test for the version flag.
+
+## Scope
+- Add or tighten one test for the existing `--version` CLI behavior.
+- Keep command names, packaging metadata, and runtime dependencies unchanged unless the test exposes a real defect.
+- Do not change release or publishing behavior.
+
+## Acceptance criteria
+- The CLI version flag keeps returning the expected version string or package metadata value.
+- The new or updated test is covered by the repo-owned pre-PR command.
+
+## Verification
+- python -m pytest
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+```
+<!-- python-cli-first-issue:end -->
+
+Run the focused readiness checks before the first supervised pass:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+node dist/index.js run-once --config <supervisor-config-path> --dry-run
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,6 +105,8 @@ For TypeScript and Node repositories, [supervisor.config.typescript-node.json](.
 
 For Next.js app repositories, [supervisor.config.nextjs.json](../supervisor.config.nextjs.json) publishes the same npm-owned setup and local CI posture with Next.js-specific script guidance; see the [Next.js starter profile](./examples/nextjs.md) for common `build`, `lint`, and `test` mappings and a first issue example.
 
+For Python packages and CLI tools, [supervisor.config.python-cli.json](../supervisor.config.python-cli.json) publishes a command-substitution starter profile. Replace its setup and pre-PR command placeholders with repo-owned commands before the first run; see the [Python and CLI starter profile](./examples/python-cli.md) for common `pytest`, `build`, and task-runner mappings and a first issue example.
+
 ### Explicit trust posture setup
 
 Trust posture setup is a product primitive for trusted solo-lane automation. It packages the authority choices that decide whether the supervisor may turn GitHub-authored text, local repo state, review signals, and configured commands into autonomous Codex work.
@@ -285,7 +287,7 @@ node dist/index.js run-once --config <supervisor-config-path>
 ./scripts/start-loop-tmux.sh
 ```
 
-For a concrete shipped profile, run the same checks against the matching config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`. For the TypeScript/Node starter, use `supervisor.config.typescript-node.json` after replacing the placeholders and confirming the repo owns `npm run verify:pre-pr`. For the Next.js starter, use `supervisor.config.nextjs.json` after replacing the placeholders and mapping `verify:pre-pr` to the app scripts that actually exist.
+For a concrete shipped profile, run the same checks against the matching config, for example: `node dist/index.js issue-lint <issue-number> --config supervisor.config.coderabbit.json`, `node dist/index.js status --config supervisor.config.coderabbit.json --why`, and `node dist/index.js doctor --config supervisor.config.coderabbit.json`. For the TypeScript/Node starter, use `supervisor.config.typescript-node.json` after replacing the placeholders and confirming the repo owns `npm run verify:pre-pr`. For the Next.js starter, use `supervisor.config.nextjs.json` after replacing the placeholders and mapping `verify:pre-pr` to the app scripts that actually exist. For the Python/CLI starter, use `supervisor.config.python-cli.json` only after replacing the setup and pre-PR command placeholders with commands the managed repo owns.
 
 Read the command output as a sequence of decisions, not as unrelated logs:
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1612,6 +1612,7 @@ test("shipped example configs recommend block_merge for local review gating", as
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "supervisor.config.nextjs.json"),
+    path.join(rootDir, "supervisor.config.python-cli.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1630,6 +1631,7 @@ test("shipped starter config profiles keep local review disabled until operators
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "supervisor.config.nextjs.json"),
+    path.join(rootDir, "supervisor.config.python-cli.json"),
   ];
 
   for (const examplePath of examplePaths) {
@@ -1647,6 +1649,7 @@ test("shipped example configs keep local-review follow-up issue creation opt-in"
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "supervisor.config.nextjs.json"),
+    path.join(rootDir, "supervisor.config.python-cli.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1671,6 +1674,7 @@ test("shipped example configs keep local-review same-PR follow-up repair opt-in"
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "supervisor.config.nextjs.json"),
+    path.join(rootDir, "supervisor.config.python-cli.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1695,6 +1699,7 @@ test("shipped example configs recommend blocked for high-severity local review f
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "supervisor.config.nextjs.json"),
+    path.join(rootDir, "supervisor.config.python-cli.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1718,6 +1723,7 @@ test("shipped example configs use the issue-scoped journal path template and pre
     path.join(rootDir, "supervisor.config.coderabbit.json"),
     path.join(rootDir, "supervisor.config.typescript-node.json"),
     path.join(rootDir, "supervisor.config.nextjs.json"),
+    path.join(rootDir, "supervisor.config.python-cli.json"),
     path.join(rootDir, "docs", "examples", "atlaspm.supervisor.config.example.json"),
   ];
 
@@ -1765,6 +1771,7 @@ test("shipped config profiles declare the intended review bot logins", async () 
     ["supervisor.config.coderabbit.json", ["coderabbitai", "coderabbitai[bot]"]],
     ["supervisor.config.typescript-node.json", ["copilot-pull-request-reviewer"]],
     ["supervisor.config.nextjs.json", ["copilot-pull-request-reviewer"]],
+    ["supervisor.config.python-cli.json", ["copilot-pull-request-reviewer"]],
   ]);
 
   for (const [relativePath, expectedReviewBotLogins] of expectedProfiles) {
@@ -1794,6 +1801,10 @@ test("shipped starter profiles fail closed with first-run placeholder guidance",
     ["supervisor.config.coderabbit.json", ["repoSlug"]],
     ["supervisor.config.typescript-node.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
     ["supervisor.config.nextjs.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
+    [
+      "supervisor.config.python-cli.json",
+      ["repoPath", "repoSlug", "workspaceRoot", "codexBinary", "workspacePreparationCommand", "localCiCommand"],
+    ],
   ]);
 
   for (const [relativePath, invalidFields] of expectedInvalidFields) {
@@ -1962,6 +1973,70 @@ test("shipped Next.js starter profile publishes npm posture and execution-ready 
     createdAt: "2026-04-27T00:00:00Z",
     updatedAt: "2026-04-27T00:00:00Z",
     url: "https://example.com/issues/101",
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+  };
+
+  assert.deepEqual(validateIssueMetadataSyntax(sampleIssue), []);
+  const lint = lintExecutionReadyIssueBody(sampleIssue);
+  assert.equal(lint.isExecutionReady, true);
+  assert.deepEqual(lint.missingRequired, []);
+  assert.deepEqual(lint.missingRecommended, []);
+});
+
+test("shipped Python and CLI starter profile publishes portable command substitution guidance", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const relativePath = "supervisor.config.python-cli.json";
+  const raw = (await readShippedProfileJson(rootDir, relativePath)) as {
+    workspacePreparationCommand?: unknown;
+    localCiCommand?: unknown;
+    skipTitlePrefixes?: unknown;
+  };
+  const summary = loadConfigSummaryFromDocument(raw, path.join(rootDir, relativePath));
+  const docs = await Promise.all([
+    fs.readFile(path.join(rootDir, "README.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "configuration.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "getting-started.md"), "utf8"),
+    fs.readFile(path.join(rootDir, "docs", "examples", "python-cli.md"), "utf8"),
+  ]);
+
+  assert.equal(raw.workspacePreparationCommand, "<replace-with-repo-owned-setup-command>");
+  assert.equal(raw.localCiCommand, "<replace-with-repo-owned-pre-pr-command>");
+  assert.deepEqual(raw.skipTitlePrefixes, ["Epic:"]);
+  assert.equal(summary.status, "invalid_config");
+  assert.deepEqual(summary.invalidFields, [
+    "repoPath",
+    "repoSlug",
+    "workspaceRoot",
+    "codexBinary",
+    "workspacePreparationCommand",
+    "localCiCommand",
+  ]);
+
+  for (const content of docs) {
+    assert.match(content, /supervisor\.config\.python-cli\.json/);
+  }
+
+  const exampleDoc = docs[3] ?? "";
+  assert.match(exampleDoc, /<replace-with-repo-owned-setup-command>/);
+  assert.match(exampleDoc, /<replace-with-repo-owned-pre-pr-command>/);
+  assert.match(exampleDoc, /python -m pytest/);
+  assert.match(exampleDoc, /python -m build/);
+  assert.match(exampleDoc, /do not assume every Python package or CLI tool uses these commands/i);
+  assert.doesNotMatch(exampleDoc, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(exampleDoc, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  const match = exampleDoc.match(
+    /<!-- python-cli-first-issue:start -->\s*```md\s*([\s\S]*?)```\s*<!-- python-cli-first-issue:end -->/,
+  );
+  assert.ok(match, "Python/CLI starter doc must include the marked sample issue body");
+  const sampleIssue: GitHubIssue = {
+    number: 102,
+    title: "Add CLI version flag test",
+    body: match[1].trim(),
+    createdAt: "2026-04-27T00:00:00Z",
+    updatedAt: "2026-04-27T00:00:00Z",
+    url: "https://example.com/issues/102",
     labels: [{ name: "codex" }],
     state: "OPEN",
   };

--- a/src/core/config-validation.ts
+++ b/src/core/config-validation.ts
@@ -22,6 +22,8 @@ const STARTER_PROFILE_PLACEHOLDERS: Record<string, Set<string>> = {
   repoSlug: new Set(["OWNER/REPO", "REPLACE_ME"]),
   workspaceRoot: new Set(["/absolute/path/to/worktrees"]),
   codexBinary: new Set(["/absolute/path/to/codex"]),
+  workspacePreparationCommand: new Set(["<replace-with-repo-owned-setup-command>"]),
+  localCiCommand: new Set(["<replace-with-repo-owned-pre-pr-command>"]),
 };
 
 const WORKSPACE_PREPARATION_SCRIPT_RUNNERS = new Set(["bash", "sh", "node", "bun", "deno", "python", "python3", "ruby", "tsx", "ts-node"]);
@@ -56,7 +58,7 @@ export function isStarterProfilePlaceholder(field: string, value: unknown): bool
 }
 
 export function collectStarterProfilePlaceholderFields(raw: Record<string, unknown>): string[] {
-  return REQUIRED_STRING_CONFIG_FIELDS.filter((field) => isStarterProfilePlaceholder(field, raw[field])) as string[];
+  return Object.keys(STARTER_PROFILE_PLACEHOLDERS).filter((field) => isStarterProfilePlaceholder(field, raw[field]));
 }
 
 export function buildStarterProfilePlaceholderFieldMessage(field: string, value: unknown): string | null {
@@ -73,6 +75,10 @@ export function buildStarterProfilePlaceholderFieldMessage(field: string, value:
       return "Workspace root still contains a starter placeholder. Replace it with the directory where issue worktrees should be created.";
     case "codexBinary":
       return "Codex binary still contains a starter placeholder. Replace it with a PATH command such as codex or the path to the Codex executable.";
+    case "workspacePreparationCommand":
+      return "Workspace preparation command still contains a starter placeholder. Replace it with the repo-owned setup command or clear it intentionally.";
+    case "localCiCommand":
+      return "Local CI command still contains a starter placeholder. Replace it with the repo-owned pre-PR verification command or clear it intentionally.";
     default:
       return `${field} still contains a starter placeholder. Replace it before running the supervisor.`;
   }

--- a/src/setup-readiness.test.ts
+++ b/src/setup-readiness.test.ts
@@ -178,6 +178,44 @@ test("diagnoseSetupReadiness preserves provider-specific posture for copied Code
   );
 });
 
+test("diagnoseSetupReadiness blocks Python/CLI starter command placeholders", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-setup-readiness-python-cli-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const sourcePath = path.join(process.cwd(), "supervisor.config.python-cli.json");
+  const configPath = path.join(root, "supervisor.config.json");
+  await fs.copyFile(sourcePath, configPath);
+
+  const summary = await diagnoseSetupReadiness({
+    configPath,
+    authStatus: async () => ({ ok: true, message: null }),
+  });
+
+  assert.equal(summary.ready, false);
+  assert.equal(summary.overallStatus, "invalid");
+  assert.deepEqual(
+    summary.fields
+      .filter((field) => field.state === "invalid")
+      .map((field) => [field.key, field.message]),
+    [
+      ["repoPath", "Repository path still contains a starter placeholder. Replace it with the absolute path to the managed repository."],
+      ["repoSlug", "Repository slug still contains a starter placeholder. Replace it with the GitHub owner/repo slug for the managed repository."],
+      ["workspaceRoot", "Workspace root still contains a starter placeholder. Replace it with the directory where issue worktrees should be created."],
+      ["codexBinary", "Codex binary still contains a starter placeholder. Replace it with a PATH command such as codex or the path to the Codex executable."],
+      [
+        "workspacePreparationCommand",
+        "Workspace preparation command still contains a starter placeholder. Replace it with the repo-owned setup command or clear it intentionally.",
+      ],
+      [
+        "localCiCommand",
+        "Local CI command still contains a starter placeholder. Replace it with the repo-owned pre-PR verification command or clear it intentionally.",
+      ],
+    ],
+  );
+});
+
 async function createTrackedRepo(root: string): Promise<string> {
   const repoPath = path.join(root, "repo");
   await fs.mkdir(repoPath, { recursive: true });

--- a/supervisor.config.python-cli.json
+++ b/supervisor.config.python-cli.json
@@ -1,0 +1,98 @@
+{
+  "repoPath": "/absolute/path/to/managed-repo",
+  "repoSlug": "OWNER/REPO",
+  "defaultBranch": "main",
+  "workspaceRoot": "/absolute/path/to/worktrees",
+  "stateBackend": "json",
+  "stateFile": "./.local/state.json",
+  "stateBootstrapFile": "",
+  "codexBinary": "/absolute/path/to/codex",
+  "trustMode": "trusted_repo_and_authors",
+  "executionSafetyMode": "unsandboxed_autonomous",
+  "codexModelStrategy": "inherit",
+  "codexModel": "",
+  "boundedRepairModelStrategy": "",
+  "boundedRepairModel": "",
+  "localReviewModelStrategy": "",
+  "localReviewModel": "",
+  "codexReasoningEffortByState": {
+    "planning": "low",
+    "reproducing": "medium",
+    "implementing": "high",
+    "local_review_fix": "medium",
+    "stabilizing": "medium",
+    "draft_pr": "low",
+    "local_review": "low",
+    "repairing_ci": "medium",
+    "resolving_conflict": "high",
+    "addressing_review": "medium"
+  },
+  "codexReasoningEscalateOnRepeatedFailure": true,
+  "sharedMemoryFiles": [
+    "README.md",
+    "docs/architecture.md",
+    "docs/constitution.md",
+    "docs/workflow.md",
+    "docs/decisions.md"
+  ],
+  "gsdEnabled": false,
+  "gsdAutoInstall": false,
+  "gsdInstallScope": "global",
+  "gsdCodexConfigDir": "",
+  "gsdPlanningFiles": [
+    "PROJECT.md",
+    "REQUIREMENTS.md",
+    "ROADMAP.md",
+    "STATE.md"
+  ],
+  "localReviewPosture": "off",
+  "localReviewEnabled": false,
+  "localReviewAutoDetect": true,
+  "localReviewRoles": [],
+  "localReviewArtifactDir": "./.local/reviews",
+  "localReviewConfidenceThreshold": 0.7,
+  "localReviewReviewerThresholds": {
+    "generic": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    },
+    "specialist": {
+      "confidenceThreshold": 0.7,
+      "minimumSeverity": "low"
+    }
+  },
+  "localReviewPolicy": "block_merge",
+  "trackedPrCurrentHeadLocalReviewRequired": false,
+  "localReviewFollowUpRepairEnabled": false,
+  "localReviewManualReviewRepairEnabled": false,
+  "localReviewFollowUpIssueCreationEnabled": false,
+  "localReviewHighSeverityAction": "blocked",
+  "reviewBotLogins": [
+    "copilot-pull-request-reviewer"
+  ],
+  "humanReviewBlocksMerge": true,
+  "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
+  "issueJournalMaxChars": 6000,
+  "issueLabel": "codex",
+  "workspacePreparationCommand": "<replace-with-repo-owned-setup-command>",
+  "localCiCommand": "<replace-with-repo-owned-pre-pr-command>",
+  "skipTitlePrefixes": [
+    "Epic:"
+  ],
+  "branchPrefix": "codex/issue-",
+  "pollIntervalSeconds": 120,
+  "copilotReviewWaitMinutes": 10,
+  "copilotReviewTimeoutAction": "continue",
+  "codexExecTimeoutMinutes": 30,
+  "maxCodexAttemptsPerIssue": 30,
+  "maxImplementationAttemptsPerIssue": 30,
+  "maxRepairAttemptsPerIssue": 30,
+  "timeoutRetryLimit": 2,
+  "blockedVerificationRetryLimit": 3,
+  "sameBlockerRepeatLimit": 2,
+  "sameFailureSignatureRepeatLimit": 3,
+  "maxDoneWorkspaces": 24,
+  "cleanupDoneWorkspacesAfterHours": 24,
+  "mergeMethod": "squash",
+  "draftPrAfterAttempt": 1
+}


### PR DESCRIPTION
## Summary
- Add a Python/CLI starter config with fail-closed setup and pre-PR command placeholders.
- Publish portable setup guidance and a lintable first issue example.
- Extend config and setup-readiness coverage for the new placeholder forms.

## Verification
- npx tsx --test src/config.test.ts --test-name-pattern "Python and CLI starter profile"
- npx tsx --test src/setup-readiness.test.ts --test-name-pattern "Python/CLI starter command placeholders"
- npm run verify:paths
- npm run build

Closes #1862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Introduced Python/CLI starter profile with comprehensive setup guidance and configuration examples
  * Updated getting-started and configuration documentation to include Python/CLI as a supported workflow

* **Tests**
  * Added validation tests for Python/CLI profile configuration and setup readiness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->