### PR TITLE
Fix Phase 17 CLI help WebUI setup discovery

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -59,5 +59,7 @@ Replay commands:
 
 Web-oriented commands:
   web                               Start the operator dashboard.
+  node dist/index.js web --config <supervisor-config-path>
+                                    # open /setup
 `;
 }


### PR DESCRIPTION
## Summary
- restore the explicit WebUI setup launch command in CLI help
- keep the Phase 17 first-run command sequence unchanged

## Verification
- npx tsx --test src/validation-checklist-docs.test.ts src/cli/entrypoint.test.ts src/readme-docs.test.ts
- npm run build
- npm test

Fixes #1871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CLI help text with an additional usage example for the `web` command, including configuration options and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->