### PR TITLE
Fix idle stale review bot remediation status

### DIFF
--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -74,6 +74,7 @@ export type NoActiveTrackedRecordClassification =
   | "repair_already_queued"
   | "safe_to_ignore"
   | "manual_review_required"
+  | "stale_review_bot_remediation"
   | "stale_already_handled"
   | "provider_outage_suspected";
 
@@ -99,6 +100,7 @@ function activeTrackedWorkState(record: IssueRunRecord): boolean {
 export function classifyNoActiveTrackedRecord(
   config: BuildDetailedStatusModelArgs["config"],
   record: IssueRunRecord,
+  staleReviewBotRemediation?: ReturnType<typeof buildStaleReviewBotRemediation>,
 ): { classification: NoActiveTrackedRecordClassification; reason: string } {
   if (record.state === "done") {
     return {
@@ -124,6 +126,13 @@ export function classifyNoActiveTrackedRecord(
   }
 
   if (record.blocked_reason === "stale_review_bot") {
+    if (staleReviewBotRemediation) {
+      return {
+        classification: "stale_review_bot_remediation",
+        reason: staleReviewBotRemediation.classification,
+      };
+    }
+
     const recoverability = classifyStaleReviewBotRecoverability(record, config);
     if (recoverability === "stale_already_handled") {
       return {
@@ -164,12 +173,13 @@ export function classifyNoActiveTrackedRecord(
 export function formatNoActiveTrackedRecordClassificationLine(
   config: BuildDetailedStatusModelArgs["config"],
   record: IssueRunRecord | null,
+  staleReviewBotRemediation?: ReturnType<typeof buildStaleReviewBotRemediation>,
 ): string | null {
   if (!record) {
     return null;
   }
 
-  const classification = classifyNoActiveTrackedRecord(config, record);
+  const classification = classifyNoActiveTrackedRecord(config, record, staleReviewBotRemediation);
   return [
     "no_active_tracked_record",
     `issue=#${record.issue_number}`,
@@ -180,17 +190,39 @@ export function formatNoActiveTrackedRecordClassificationLine(
 }
 
 export function buildInactiveDetailedStatusLines(
-  args: Pick<BuildDetailedStatusModelArgs, "config" | "latestRecord" | "latestRecoveryRecord" | "trackedIssueCount">,
+  args: Pick<
+    BuildDetailedStatusModelArgs,
+    "config" | "latestRecord" | "latestRecoveryRecord" | "trackedIssueCount" | "pr" | "checks" | "reviewThreads"
+  >,
 ): string[] {
-  const { config, latestRecord, latestRecoveryRecord = null, trackedIssueCount } = args;
+  const { config, latestRecord, latestRecoveryRecord = null, trackedIssueCount, pr, checks, reviewThreads } = args;
   const lines = [
     "No active issue.",
     `tracked_issues=${trackedIssueCount}`,
     `latest_record=${formatRecentRecord(latestRecord)}`,
   ];
-  const classificationLine = formatNoActiveTrackedRecordClassificationLine(config, latestRecord);
+  let staleReviewBotRemediation: ReturnType<typeof buildStaleReviewBotRemediation> = null;
+  if (
+    latestRecord &&
+    pr &&
+    latestRecord.last_head_sha === pr.headRefOid &&
+    pr.configuredBotCurrentHeadObservedAt &&
+    pr.configuredBotCurrentHeadStatusState === "SUCCESS"
+  ) {
+    staleReviewBotRemediation = buildStaleReviewBotRemediation({
+      config,
+      record: latestRecord,
+      pr,
+      checks,
+      reviewThreads,
+    });
+  }
+  const classificationLine = formatNoActiveTrackedRecordClassificationLine(config, latestRecord, staleReviewBotRemediation);
   if (classificationLine) {
     lines.push(classificationLine);
+  }
+  if (staleReviewBotRemediation) {
+    lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));
   }
 
   if (latestRecoveryRecord?.last_recovery_reason && latestRecoveryRecord.last_recovery_at) {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -550,6 +550,113 @@ test("renderSupervisorStatusDto maps stale configured-bot remediation to the roo
   );
 });
 
+test("status --why classifies current-head processed configured-bot success as stale metadata remediation while idle", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["coderabbitai", "coderabbitai[bot]"];
+  const issueNumber = 365;
+  const prNumber = 372;
+  const headSha = "5de0d3844468d4a77cab512f8dcbe46171166c3a";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: "codex/issue-365",
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-365@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-365@${headSha}#comment-365`],
+        last_failure_signature: "stalled-bot:thread-365",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-365",
+          command: null,
+          details: ["reviewer=coderabbitai[bot] file=src/query.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/372#discussion_r365",
+          updated_at: "2026-04-25T00:20:00Z",
+        },
+        updated_at: "2026-04-25T07:20:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "SafeQuery shaped stale configured bot metadata",
+    body: executionReadyBody("Classify stale configured-bot metadata precisely while idle."),
+    createdAt: "2026-04-25T00:00:00Z",
+    updatedAt: "2026-04-25T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: "codex/issue-365",
+    headRefOid: headSha,
+    currentHeadCiGreenAt: "2026-04-25T00:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-04-25T00:11:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const staleMetadataThread = {
+    id: "thread-365",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/query.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-365",
+          body: "Please address this stale finding.",
+          createdAt: "2026-04-25T00:05:00Z",
+          url: "https://example.test/pr/372#discussion_r365",
+          author: {
+            login: "coderabbitai[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleMetadataThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(status, /^No active issue\.$/m);
+  assert.match(
+    status,
+    /^no_active_tracked_record issue=#365 classification=stale_review_bot_remediation state=blocked reason=metadata_only$/m,
+  );
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#365 pr=#372 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=metadata_only review_thread_url=https:\/\/example\.test\/pr\/372#discussion_r365 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only$/m,
+  );
+  assert.match(status, /^operator_action action=resolve_stale_review_bot /m);
+  assert.doesNotMatch(status, /provider_outage_suspected/);
+  assert.doesNotMatch(status, /stale_review_bot_provider_signal_missing/);
+});
+
 test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
   const status = renderSupervisorStatusDto({
     gsdSummary: null,

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -2,7 +2,10 @@ import { summarizeCadenceDiagnostics, summarizeLocalCiContract, summarizeTrustDi
 import { StateStore } from "../core/state-store";
 import {
   CliOptions,
+  GitHubPullRequest,
   GitHubRateLimitTelemetry,
+  PullRequestCheck,
+  ReviewThread,
   StateLoadFinding,
   SupervisorConfig,
   SupervisorStateFile,
@@ -253,6 +256,11 @@ export async function buildSupervisorStatusReport(args: {
       waitStep: reconciliationSnapshot.waitStep,
     };
   const trackedPrMismatchLines: string[] = [];
+  let latestTrackedPrHydration: {
+    pr: GitHubPullRequest;
+    checks: PullRequestCheck[];
+    reviewThreads: ReviewThread[];
+  } | null = null;
   const trackedMergedBacklogLine = buildTrackedMergedButOpenBacklogDiagnosticLine(state);
 
   for (const record of Object.values(state.issues)) {
@@ -268,6 +276,9 @@ export async function buildSupervisorStatusReport(args: {
 
       const checks = await github.getChecks(pr.number);
       const reviewThreads = await github.getUnresolvedReviewThreads(pr.number);
+      if (statusRecords.latestRecord?.issue_number === record.issue_number) {
+        latestTrackedPrHydration = { pr, checks, reviewThreads };
+      }
       const mismatch = buildTrackedPrMismatch(config, record, pr, checks, reviewThreads);
       if (!mismatch) {
         continue;
@@ -286,9 +297,9 @@ export async function buildSupervisorStatusReport(args: {
       latestRecord: statusRecords.latestRecord,
       latestRecoveryRecord: statusRecords.latestRecoveryRecord,
       trackedIssueCount: statusRecords.trackedIssueCount,
-      pr: null,
-      checks: [],
-      reviewThreads: [],
+      pr: latestTrackedPrHydration?.pr ?? null,
+      checks: latestTrackedPrHydration?.checks ?? [],
+      reviewThreads: latestTrackedPrHydration?.reviewThreads ?? [],
       manualReviewThreads,
       configuredBotReviewThreads,
       pendingBotReviewThreads,


### PR DESCRIPTION
## Summary
- classify idle stale_review_bot records with current-head configured-bot success as stale review remediation instead of provider outage
- reuse already-hydrated latest tracked PR facts for no-active status details
- add a SafeQuery-shaped status regression with processed unresolved configured-bot metadata

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-report.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/operator-actions.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts src/review-thread-reporting.test.ts src/pull-request-state-policy.test.ts
- npm run build

Fixes #1873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added remediation guidance for pull requests blocked by stale review bot situations

* **Improvements**
  * Enhanced status reporting to include pull request checks and review thread information for more complete diagnostic visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->