### PR TITLE
Fix explain stale review bot remediation classification

### DIFF
--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1062,6 +1062,12 @@ test("explain classifies handled stale configured-bot review threads as metadata
     explanation,
     /^stale_review_bot_remediation issue=#196 pr=#296 reason=stale_review_bot code_ci=green current_head_sha=head-196 processed_on_current_head=yes classification=metadata_only review_thread_url=https:\/\/example\.test\/pr\/296#discussion_r296 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only$/m,
   );
+  assert.match(
+    explanation,
+    /^no_active_tracked_record issue=#196 classification=stale_review_bot_remediation state=blocked reason=metadata_only$/m,
+  );
+  assert.doesNotMatch(explanation, /provider_outage_suspected/);
+  assert.doesNotMatch(explanation, /stale_review_bot_provider_signal_missing/);
 });
 
 test("explain keeps configured-bot success without current-head observation as unresolved work", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -347,10 +347,6 @@ export async function buildIssueExplainDto(
     record,
   });
   const latestRecoverySummary = record ? formatLatestRecoveryStatusLine(record) : null;
-  const noActiveTrackedRecordSummary =
-    record && state.activeIssueNumber === null
-      ? formatNoActiveTrackedRecordClassificationLine(config, record)
-      : null;
   const operatorEventSummary = record ? formatMergedPrConvergenceOperatorEventLine(record) : null;
   const staleRecoveryWarningSummary = record ? buildStaleStabilizingNoPrRecoveryWarningLine(record, config) : null;
   let pr: GitHubPullRequest | null = null;
@@ -449,6 +445,18 @@ export async function buildIssueExplainDto(
         reviewThreads: explainReviewThreads,
       })
       : null;
+  const noActiveTrackedRecordSummary =
+    record && state.activeIssueNumber === null
+      ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
+      : null;
+  const staleDiagnosticSummary = record && record.blocked_reason === "stale_review_bot" && !staleReviewBotRemediation
+    ? (() => {
+      const recoverability = classifyStaleReviewBotRecoverability(record, config);
+      return recoverability === null
+        ? null
+        : ["stale_diagnostic", "kind=stale_review_bot", recoverabilityStatusToken(recoverability)].join(" ");
+    })()
+    : null;
 
   if (matchingSkipPrefix) {
     reasons.push(`skip_title_prefix ${matchingSkipPrefix}`);
@@ -522,14 +530,7 @@ export async function buildIssueExplainDto(
         preMergeEvaluation,
       })
       : null,
-    staleDiagnosticSummary: record && record.blocked_reason === "stale_review_bot"
-      ? (() => {
-        const recoverability = classifyStaleReviewBotRecoverability(record, config);
-        return recoverability === null
-          ? null
-          : ["stale_diagnostic", "kind=stale_review_bot", recoverabilityStatusToken(recoverability)].join(" ");
-      })()
-      : null,
+    staleDiagnosticSummary,
     staleReviewBotRemediation,
     noActiveTrackedRecordSummary,
     trackedPrRetryabilitySummary:


### PR DESCRIPTION
## Summary
- recompute explain no-active tracked-record classification after stale review remediation hydration
- suppress stale provider-outage diagnostic when explain has metadata-only stale review remediation evidence
- tighten metadata-only explain coverage to reject provider-outage wording

## Verification
- npx tsx --test --test-name-pattern "explain classifies handled stale configured-bot review threads as metadata-only" src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-report.test.ts src/operator-actions.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-execution-policy.test.ts src/review-thread-reporting.test.ts src/pull-request-state-policy.test.ts
- npm run build

Closes #1875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic classification and explanations for bot-remediation scenarios
  * Enhanced handling of metadata-only cases with more accurate classification
  * Refined diagnostic messaging to suppress irrelevant signal references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->