### PR TITLE
Preserve unresolved stale review bot diagnostics

### DIFF
--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1165,6 +1165,7 @@ test("explain keeps configured-bot success without current-head observation as u
     explanation,
     /^stale_review_bot_remediation issue=#197 pr=#297 reason=stale_review_bot code_ci=green current_head_sha=head-197 processed_on_current_head=yes classification=unresolved_work review_thread_url=https:\/\/example\.test\/pr\/297#discussion_r297 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
   );
+  assert.match(explanation, /^stale_diagnostic kind=stale_review_bot recoverability=provider_outage_suspected$/m);
   assert.doesNotMatch(explanation, /classification=metadata_only/m);
 });
 

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -449,7 +449,10 @@ export async function buildIssueExplainDto(
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
       : null;
-  const staleDiagnosticSummary = record && record.blocked_reason === "stale_review_bot" && !staleReviewBotRemediation
+  const staleDiagnosticSummary =
+    record &&
+    record.blocked_reason === "stale_review_bot" &&
+    staleReviewBotRemediation?.classification !== "metadata_only"
     ? (() => {
       const recoverability = classifyStaleReviewBotRecoverability(record, config);
       return recoverability === null


### PR DESCRIPTION
## Summary
- preserve provider-outage stale diagnostics for unresolved stale review bot remediation
- keep metadata-only remediation suppressing provider-outage wording
- add focused explain diagnostics coverage for the unresolved-work case

## Verification
- npx tsx --test --test-name-pattern "explain keeps configured-bot success without current-head observation as unresolved work|explain classifies handled stale configured-bot review threads as metadata-only" src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build

Closes #1877