### PR TITLE
Docs: compare quality kit package surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Operator dashboard](./docs/operator-dashboard.md): WebUI launch, panel meanings, safe commands, and browser smoke verification
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
 - [AI coding quality kit](./docs/quality-kit.md): compact primitive map for the issue contract, local verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback
+- [Quality kit package surfaces](./docs/quality-kit-package-surfaces.md): comparison of docs, schema, npm metadata, and deferred KANAME bootstrap packaging options for external adoption
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop
 - [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md): annotated supervised PR lifecycle from the repo's own demo-material phase using sanitized public-safe placeholders

--- a/docs/quality-kit-package-surfaces.md
+++ b/docs/quality-kit-package-surfaces.md
@@ -1,0 +1,49 @@
+# AI Coding Quality Kit Package Surfaces
+
+This note compares concrete public packaging shapes for the AI coding quality kit before the project commits to a larger distribution surface.
+
+The packaging goal is narrow: help external users understand and copy the issue contract, verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback described in [AI Coding Quality Kit](./quality-kit.md). This package surface means no runtime orchestration, no WebUI, no provider SDK, and no authority expansion.
+
+## Recommended Smallest Surface
+
+External users adopt first a templates/docs bundle inside this repository:
+
+- `docs/quality-kit.md` as the primitive map
+- issue metadata docs and the codex execution-ready issue template
+- schema links for the issue body, evidence timeline, operator actions, trust posture, and automation boundary
+- demo and validation docs that show the workflow without requiring a new runtime
+
+This is the smallest package surface because it is copy/paste usable, versioned with the implementation that backs it, and discoverable from the README. It gives a new repo enough structure to author a first supervised issue and validation plan without installing an extra package or trusting a new authority boundary.
+
+## Viable Package Shapes
+
+| Shape | What ships | Adoption friction | Versioning | Release burden | Docs discoverability | New-repo reuse |
+| --- | --- | --- | --- | --- | --- | --- |
+| repo-owned schema collection | Existing JSON schemas plus links from the quality kit map | Low for readers already in this repo; medium for users who only want templates | Versioned with this repo tag | Low while schemas remain implementation-backed | Good when linked from README and docs map | Good for validation references, weaker for first-issue copy/paste |
+| npm package metadata | A named package that exposes schemas, template paths, and version metadata | Medium: users must install a package before they see value | Clear semver once package consumers exist | Medium to high: package publish, changelog, provenance, and deprecation policy | Good in package registries, weaker inside docs-first onboarding | Good for automated consumers, premature for manual adopters |
+| templates/docs bundle | Public docs, issue template, checklist, and schema links in this repo | Low: read, copy, adapt, and run repo-relative commands | Versioned with this repo tag and release notes | Low: documentation review plus existing path/link checks | Strong from README, demo docs, and validation checklist | Strong for a first supervised issue and starter repo adoption |
+
+## Deferred Shape
+
+KANAME bootstrap bundle is deferred.
+
+It could eventually package opinionated starter materials for a new KANAME repository, including a quality-kit docs subset, issue templates, and bootstrap checklist. That shape has useful KANAME bootstrap reuse, but it is too broad for this phase because it implies new-repo creation decisions, repo naming, lifecycle ownership, and possibly dedicated release automation.
+
+Keep KANAME bootstrap reuse as an input to the templates/docs bundle: the current docs should stay easy to copy into a future KANAME repo, but this work must avoid creating the KANAME repo or introducing bootstrap runtime behavior.
+
+## Tradeoff Summary
+
+| Decision point | Templates/docs bundle | Repo-owned schema collection | npm package metadata | KANAME bootstrap bundle |
+| --- | --- | --- | --- | --- |
+| adoption friction | Lowest for external users who want to inspect and copy the kit first | Low for schema consumers, higher for operators who need prose and examples | Higher until automated package consumption exists | Highest because it asks users to accept a repo bootstrap shape |
+| versioning | Follows repo tags and docs review | Follows repo tags and schema changes | Strong semver story, but only after package ownership is real | Requires separate bootstrap version policy |
+| release burden | Existing docs and focused docs checks are enough | Existing schema review plus links are enough | Requires publish workflow, package provenance, and consumer compatibility notes | Requires bootstrap release process and support expectations |
+| copy/paste usability | Strong: issue template, docs, and checklists are directly reusable | Partial: schemas validate, but do not explain the full operating path | Weak for humans unless paired with docs | Strong later, but too opinionated now |
+| docs discoverability | Strong through README and demo links | Good when schemas stay linked from the quality kit | Depends on registry plus README links | Depends on a new repo that does not exist yet |
+| new-repo reuse | Good for manual adoption and first issue authoring | Good for validation adapters | Good for automation after demand is proven | Best fit for a later KANAME-specific bootstrap phase |
+
+## KANAME Bootstrap Reuse
+
+The templates/docs bundle should keep future KANAME bootstrap reuse cheap by using repo-relative links, placeholder config paths such as `<supervisor-config-path>`, and reusable primitives instead of host-local examples.
+
+Do not make the quality kit depend on KANAME. KANAME can later consume this bundle, but the public package surface for this phase remains a small docs-first surface owned by `codex-supervisor`.

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import test from "node:test";
 
 const qualityKitPath = path.join("docs", "quality-kit.md");
+const qualityKitPackageSurfacesPath = path.join("docs", "quality-kit-package-surfaces.md");
 
 async function readRepoFile(relativePath: string): Promise<string> {
   return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
@@ -65,4 +66,50 @@ test("README and demo docs discover the quality kit map", async () => {
   assert.match(readme, /\[AI coding quality kit\]\(\.\/docs\/quality-kit\.md\)/i);
   assert.match(demo, /\[AI coding quality kit\]\(\.\.\/quality-kit\.md\)/i);
   assert.match(walkthrough, /\[AI coding quality kit\]\(\.\.\/quality-kit\.md\)/i);
+});
+
+test("quality kit package surface comparison names the smallest adoption surface", async () => {
+  const comparison = await readRepoFile(qualityKitPackageSurfacesPath);
+  const readme = await readRepoFile("README.md");
+
+  assert.match(comparison, /^# AI Coding Quality Kit Package Surfaces$/m);
+  assert.doesNotMatch(comparison, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(comparison, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  for (const heading of [
+    "Recommended Smallest Surface",
+    "Viable Package Shapes",
+    "Deferred Shape",
+    "Tradeoff Summary",
+    "KANAME Bootstrap Reuse",
+  ]) {
+    assert.match(comparison, new RegExp(`^## ${heading}$`, "m"), `expected ${heading} section`);
+  }
+
+  for (const packageShape of [
+    "repo-owned schema collection",
+    "npm package metadata",
+    "templates/docs bundle",
+    "KANAME bootstrap bundle",
+  ]) {
+    assert.match(comparison, new RegExp(packageShape, "i"), `expected ${packageShape} to be compared`);
+  }
+
+  for (const tradeoff of [
+    "adoption friction",
+    "versioning",
+    "release burden",
+    "copy/paste",
+    "docs discoverability",
+    "new-repo reuse",
+  ]) {
+    assert.match(comparison, new RegExp(tradeoff, "i"), `expected ${tradeoff} tradeoff`);
+  }
+
+  assert.match(comparison, /external users adopt first/i);
+  assert.match(comparison, /no runtime orchestration/i);
+  assert.match(comparison, /no WebUI/i);
+  assert.match(comparison, /no provider SDK/i);
+  assert.match(comparison, /no authority expansion/i);
+  assert.match(readme, /\[Quality kit package surfaces\]\(\.\/docs\/quality-kit-package-surfaces\.md\)/i);
 });


### PR DESCRIPTION
## Summary
- add a public comparison artifact for AI coding quality kit package-surface options
- recommend the docs/templates bundle as the smallest external adoption surface
- cover deferred KANAME bootstrap reuse without adding runtime behavior

## Verification
- npx tsx --test src/quality-kit-docs.test.ts
- npm run verify:paths
- npm run build

Part of #1880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new documentation detailing packaging and distribution options for the Quality Kit, including comparisons across different adoption approaches and versioning considerations.
  * Updated documentation index to include the new packaging guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->