### PR TITLE
Phase 18.2: Define quality kit package surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want the setup flow, first-run commands, and operator decisions, start wi
 If you want a disposable first supervised pass before production use, follow the [Playground smoke run](./docs/playground-smoke-run.md).
 If you need to understand what to put in `supervisor.config.json`, jump straight to the [Configuration guide](./docs/configuration.md).
 If you are an AI agent entering the repo, start with the [AI agent handoff](./docs/agent-instructions.md) before reading the detailed references.
-If you need the compact public primitive map, read the [AI coding quality kit](./docs/quality-kit.md).
+If you need the compact public primitive map and package-surface boundary, read the [AI coding quality kit](./docs/quality-kit.md).
 If you need the product primitive framing for the supervised lane beside chat-driven Codex work, read the [Supervised automation lane](./docs/supervised-automation-lane.md) note.
 If you want the same small change shown as an unstructured session versus a supervised loop, read the [Before / After narrative](./docs/vibe-coding-before-after.md).
 If you want to see the supervised PR lifecycle annotated with Phase 16's own dogfooding flow, read the [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md).
@@ -304,7 +304,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Configuration reference](./docs/configuration.md): config setup, provider profiles, model/reasoning controls, durable memory, and execution policy
 - [Operator dashboard](./docs/operator-dashboard.md): WebUI launch, panel meanings, safe commands, and browser smoke verification
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
-- [AI coding quality kit](./docs/quality-kit.md): compact primitive map for the issue contract, local verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback
+- [AI coding quality kit](./docs/quality-kit.md): compact primitive map and public package surface for the issue contract, local verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback
 - [Quality kit package surfaces](./docs/quality-kit-package-surfaces.md): comparison of docs, schema, npm metadata, and deferred KANAME bootstrap packaging options for external adoption
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -4,6 +4,31 @@ This public product overview maps the implemented `codex-supervisor` primitives 
 
 The kit is intentionally small. It does not introduce new runtime primitives, and it points to existing artifacts instead of restating Phase 15 schema content.
 
+## Public Package Surface
+
+The public package surface is the docs-first bundle recommended by the [Quality kit package surfaces](./quality-kit-package-surfaces.md) Phase 18.1 package-surface comparison. External adopters should treat these artifacts as the stable, copyable quality-kit surface:
+
+- `docs/quality-kit.md`: primitive map and adoption entrypoint
+- `docs/issue-metadata.md` and `.github/ISSUE_TEMPLATE/codex-execution-ready.md`: issue authoring contract and copyable execution-ready template
+- `docs/issue-body-contract.schema.json`: machine-readable issue-body field contract
+- `docs/evidence-timeline.schema.json`: evidence timeline vocabulary for audit and handoff records
+- `docs/operator-actions.schema.json`: operator action tokens for status, doctor, WebUI, and external automation routing
+- `docs/trust-posture-config.schema.json`: explicit trust and execution-safety posture vocabulary
+- `docs/codex-automation-connector-boundary.schema.json`: Codex app Automation boundary for orchestration without executor authority
+- `docs/examples/self-contained-demo-scenario.md`, `docs/examples/phase-16-dogfood-pr-walkthrough.md`, and `docs/public-demo-validation-checklist.md`: public examples and publishable validation checklist
+
+This surface is intentionally repo-relative and placeholder-driven. It does not publish a cloud service, does not publish a WebUI package, does not publish a provider SDK, and does not expand executor authority beyond the local `codex-supervisor` loop.
+
+## Internal-Only Surfaces
+
+The following surfaces may support or validate the kit, but external adopters should not depend on them as package contracts:
+
+- `src/**/*.ts`, `src/**/*.test.ts`, and `dist/`: implementation, regression tests, and compiled runtime output
+- `.codex-supervisor/` and `.local/`: issue-local supervisor state, journals, generated memory, and host-local runtime data
+- WebUI routes, backend DTO shapes, and browser helper internals beyond the published operator action and automation-boundary schema artifacts
+- provider-specific runner internals, review-provider adapters, and local CI orchestration details that are configured through `supervisor.config.json`
+- KANAME bootstrap bundle or KANAME handoff artifacts: future reusable inputs may consume this docs-first bundle, but this phase does not publish a KANAME repository scaffold, lifecycle owner, release workflow, or bootstrap runtime
+
 ## Issue Contract
 
 An Issue Contract turns a GitHub issue into a bounded execution input. The issue must name the behavior delta, scope, acceptance criteria, verification, dependency posture, parallelization posture, and execution order before the supervisor treats it as runnable.

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -113,3 +113,44 @@ test("quality kit package surface comparison names the smallest adoption surface
   assert.match(comparison, /no authority expansion/i);
   assert.match(readme, /\[Quality kit package surfaces\]\(\.\/docs\/quality-kit-package-surfaces\.md\)/i);
 });
+
+test("quality kit entrypoint defines the public package surface boundary", async () => {
+  const qualityKit = await readRepoFile(qualityKitPath);
+  const readme = await readRepoFile("README.md");
+
+  assert.match(qualityKit, /^## Public Package Surface$/m);
+  assert.match(qualityKit, /^## Internal-Only Surfaces$/m);
+  assert.match(qualityKit, /Phase 18\.1 package-surface comparison/i);
+  assert.match(qualityKit, /\[Quality kit package surfaces\]\(\.\/quality-kit-package-surfaces\.md\)/);
+
+  for (const publicArtifact of [
+    "docs/quality-kit.md",
+    ".github/ISSUE_TEMPLATE/codex-execution-ready.md",
+    "docs/issue-body-contract.schema.json",
+    "docs/evidence-timeline.schema.json",
+    "docs/operator-actions.schema.json",
+    "docs/trust-posture-config.schema.json",
+    "docs/codex-automation-connector-boundary.schema.json",
+  ]) {
+    assert.match(qualityKit, new RegExp(publicArtifact.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  for (const internalSurface of [
+    "src/**/*.ts",
+    "dist/",
+    ".codex-supervisor/",
+    ".local/",
+    "WebUI",
+    "KANAME",
+  ]) {
+    assert.match(qualityKit, new RegExp(internalSurface.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  assert.match(qualityKit, /does not publish a cloud service/i);
+  assert.match(qualityKit, /does not publish a provider SDK/i);
+  assert.match(qualityKit, /does not expand executor authority/i);
+  assert.match(
+    readme,
+    /\[AI coding quality kit\]\(\.\/docs\/quality-kit\.md\): compact primitive map and public package surface/i,
+  );
+});


### PR DESCRIPTION
## Summary
- define the docs-first public package surface in the quality kit entrypoint
- distinguish internal-only implementation, state, WebUI, provider, and KANAME bootstrap surfaces
- route README readers to the quality kit package-surface boundary while keeping Phase 18.1 as the comparison reference

## Verification
- npx tsx --test src/quality-kit-docs.test.ts
- npm run verify:paths
- npm run build

Part of #1879
Closes #1881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify the AI coding quality kit's public package surface components
  * Added explicit guidance defining stable external-facing artifacts and internal-only components
* **Tests**
  * Introduced validation tests to enforce documented package boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->