### PR TITLE
Phase 18.4: Version portable schema artifacts

### DIFF
--- a/docs/codex-automation-connector-boundary.schema.json
+++ b/docs/codex-automation-connector-boundary.schema.json
@@ -4,6 +4,19 @@
   "$ref": "#/$defs/codexAutomationConnectorBoundaryArtifact",
   "artifactName": "codex-supervisor.codex-automation-connector-boundary",
   "artifactVersion": 1,
+  "compatibilityPolicy": {
+    "versionField": "artifactVersion",
+    "enforcementBoundary": "codex-supervisor-executor-safety-gates remain the runtime enforcement boundary for Automation handoff and executor authority.",
+    "additiveChanges": [
+      "Adding optional descriptive fields or new advisory responsibilities is additive when prohibited bypasses and executor authority limits remain unchanged.",
+      "Adding new enum values for allowed responsibilities is additive only when the automation guide keeps them non-executing and operator-gated where required."
+    ],
+    "breakingChanges": [
+      "Removing or weakening prohibited bypasses, non-goals, enforcement boundaries, or operator-confirmation requirements is breaking.",
+      "Changing Automation from orchestration into executor authority is a semantic breaking change."
+    ],
+    "stabilityLimit": "The artifact is versioned with repo tags and does not claim stability beyond existing runtime executor safety gates."
+  },
   "canonicalGuide": "docs/automation.md",
   "enforcementBoundary": "codex-supervisor-executor-safety-gates",
   "description": "Portable connector-style artifact for Codex app Automation. Codex app Automation may evaluate, route, draft, record, notify, and prepare operator evidence, but codex-supervisor remains the implementation executor. Automation must not bypass executor safety gates, issue-lint, fresh PR facts, local CI, or operator confirmations. Multi-repo orchestration and new executor authority stay outside codex-supervisor core.",

--- a/docs/evidence-timeline.schema.json
+++ b/docs/evidence-timeline.schema.json
@@ -3,6 +3,19 @@
   "$id": "https://github.com/TommyKammy/codex-supervisor/docs/evidence-timeline.schema.json",
   "contractName": "codex-supervisor.evidence-timeline",
   "contractVersion": 1,
+  "compatibilityPolicy": {
+    "versionField": "contractVersion",
+    "enforcementBoundary": "IssueRunTimelineExport and syncPostMergeAuditArtifact remain the runtime enforcement boundary for timeline artifacts.",
+    "additiveChanges": [
+      "Adding optional top-level fields, optional event fields, new event types, or new missing-event entries is additive when consumers can ignore unknown fields.",
+      "Adding new fields to examples is additive only when requiredFields and eventRequiredFields do not force existing consumers to provide them."
+    ],
+    "breakingChanges": [
+      "Removing or renaming required timeline or event fields is breaking.",
+      "Changing event outcome semantics, authoritative lifecycle interpretation, or required event ordering is a semantic breaking change."
+    ],
+    "stabilityLimit": "The artifact is versioned with repo tags and does not claim stability beyond the existing runtime timeline export and audit bundle behavior."
+  },
   "runtimeBuilder": "src/timeline-artifacts.ts#buildIssueRunTimelineExport",
   "auditBundleProducer": "src/supervisor/post-merge-audit-artifact.ts#syncPostMergeAuditArtifact",
   "description": "Portable schema for evidence timeline artifacts emitted for supervised agent work. Runtime compatibility stays anchored to IssueRunTimelineExport and the post-merge operator audit bundle; this artifact publishes the stable field contract and a sanitized example for downstream tooling.",

--- a/docs/issue-body-contract.schema.json
+++ b/docs/issue-body-contract.schema.json
@@ -3,6 +3,19 @@
   "$id": "https://github.com/TommyKammy/codex-supervisor/docs/issue-body-contract.schema.json",
   "contractName": "codex-supervisor.issue-body-contract",
   "contractVersion": 1,
+  "compatibilityPolicy": {
+    "versionField": "contractVersion",
+    "enforcementBoundary": "issue-lint and docs/issue-metadata.md remain the runtime enforcement boundary for issue body parsing and readiness.",
+    "additiveChanges": [
+      "Adding optional examples, validation notes, or non-required descriptive fields is additive when issue-lint behavior remains compatible.",
+      "Adding optional metadata documentation is additive only when existing valid issue bodies continue to pass issue-lint."
+    ],
+    "breakingChanges": [
+      "Removing or renaming required sections, scheduling metadata, defaults, or example fields is breaking.",
+      "Changing issue-lint semantics so previously valid codex issue bodies fail requires a new contractVersion and release note."
+    ],
+    "stabilityLimit": "The artifact is versioned with repo tags and does not claim stability beyond the existing runtime issue-lint enforcement."
+  },
   "canonicalGuide": "docs/issue-metadata.md",
   "description": "Portable contract for execution-ready codex issue bodies. Markdown parsing and readiness decisions remain enforced by issue-lint; this artifact publishes the required sections, scheduling metadata, defaults, and validation examples for external tooling.",
   "requiredSections": [

--- a/docs/operator-actions.schema.json
+++ b/docs/operator-actions.schema.json
@@ -4,6 +4,19 @@
   "$ref": "#/$defs/operatorActionVocabularyContract",
   "contractName": "codex-supervisor.operator-actions",
   "contractVersion": 1,
+  "compatibilityPolicy": {
+    "versionField": "contractVersion",
+    "enforcementBoundary": "src/operator-actions.ts remains the runtime enforcement boundary for operator action parsing and selection.",
+    "additiveChanges": [
+      "Adding optional action metadata is additive when existing tokens and meanings remain intact.",
+      "Adding new enum values for action tokens is additive only when status, doctor, WebUI, and docs surfaces can tolerate or render the token."
+    ],
+    "breakingChanges": [
+      "Removing or renaming an action token, surface, or meaning is breaking for external automation.",
+      "Changing a token's operator semantics or selection priority in a way that changes routing is a semantic breaking change."
+    ],
+    "stabilityLimit": "The artifact is versioned with repo tags and does not claim stability beyond existing runtime operator action parsing."
+  },
   "canonicalSource": "src/operator-actions.ts",
   "description": "Portable vocabulary contract for operator action tokens emitted by status, doctor, and WebUI surfaces. Runtime parsing and selection remain backed by src/operator-actions.ts; this artifact lets docs, UI, and external automation consume the token list without scraping TypeScript source.",
   "actions": [

--- a/docs/quality-kit-package-surfaces.md
+++ b/docs/quality-kit-package-surfaces.md
@@ -10,7 +10,7 @@ External users adopt first a templates/docs bundle inside this repository:
 
 - `docs/quality-kit.md` as the primitive map
 - issue metadata docs and the codex execution-ready issue template
-- schema links for the issue body, evidence timeline, operator actions, trust posture, and automation boundary
+- schema links for the issue body, evidence timeline, operator actions, trust posture, supervised state machine, and automation boundary
 - demo and validation docs that show the workflow without requiring a new runtime
 
 This is the smallest package surface because it is copy/paste usable, versioned with the implementation that backs it, and discoverable from the README. It gives a new repo enough structure to author a first supervised issue and validation plan without installing an extra package or trusting a new authority boundary.
@@ -19,7 +19,7 @@ This is the smallest package surface because it is copy/paste usable, versioned 
 
 | Shape | What ships | Adoption friction | Versioning | Release burden | Docs discoverability | New-repo reuse |
 | --- | --- | --- | --- | --- | --- | --- |
-| repo-owned schema collection | Existing JSON schemas plus links from the quality kit map | Low for readers already in this repo; medium for users who only want templates | Versioned with this repo tag | Low while schemas remain implementation-backed | Good when linked from README and docs map | Good for validation references, weaker for first-issue copy/paste |
+| repo-owned schema collection | Existing JSON schemas plus links from the quality kit map | Low for readers already in this repo; medium for users who only want templates | Versioned with this repo tag and each artifact's compatibility policy | Low while schemas remain implementation-backed | Good when linked from README and docs map | Good for validation references, weaker for first-issue copy/paste |
 | npm package metadata | A named package that exposes schemas, template paths, and version metadata | Medium: users must install a package before they see value | Clear semver once package consumers exist | Medium to high: package publish, changelog, provenance, and deprecation policy | Good in package registries, weaker inside docs-first onboarding | Good for automated consumers, premature for manual adopters |
 | templates/docs bundle | Public docs, issue template, checklist, and schema links in this repo | Low: read, copy, adapt, and run repo-relative commands | Versioned with this repo tag and release notes | Low: documentation review plus existing path/link checks | Strong from README, demo docs, and validation checklist | Strong for a first supervised issue and starter repo adoption |
 

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -14,11 +14,20 @@ The public package surface is the docs-first bundle recommended by the [Quality 
 - `docs/evidence-timeline.schema.json`: evidence timeline vocabulary for audit and handoff records
 - `docs/operator-actions.schema.json`: operator action tokens for status, doctor, WebUI, and external automation routing
 - `docs/trust-posture-config.schema.json`: explicit trust and execution-safety posture vocabulary
+- `docs/supervised-automation-state-machine.schema.json`: operator-facing lifecycle vocabulary mapped to runtime `RunState`
 - `docs/codex-automation-connector-boundary.schema.json`: Codex app Automation boundary for orchestration without executor authority
 - `docs/templates/quality-primitives/`: [quality primitive templates](./templates/quality-primitives/README.md) for copying the issue contract, AGENTS.md guidance, local CI gate, evidence timeline, trust posture, and operator action vocabulary into a new repo
 - `docs/examples/self-contained-demo-scenario.md`, `docs/examples/phase-16-dogfood-pr-walkthrough.md`, and `docs/public-demo-validation-checklist.md`: public examples and publishable validation checklist
 
 This surface is intentionally repo-relative and placeholder-driven. It does not publish a cloud service, does not publish a WebUI package, does not publish a provider SDK, and does not expand executor authority beyond the local `codex-supervisor` loop.
+
+## Schema Versioning and Compatibility
+
+Public schema artifacts are versioned with the repository release that ships them. Artifacts named `contractName` use `contractVersion`; the Codex Automation connector boundary uses `artifactVersion` because it is a boundary artifact rather than a runtime contract. Each schema includes a `compatibilityPolicy` that names the version field, the existing runtime enforcement boundary, additive changes, breaking changes, and the stability limit.
+
+Additive changes are optional fields, optional examples, advisory notes, or new vocabulary values that existing consumers can ignore while the current parser, config loader, status model, or executor boundary keeps the same behavior. Breaking changes include removing or renaming mandatory fields, changing mandatory metadata, changing vocabulary semantics, changing lifecycle meaning, weakening prohibited bypasses, or changing which runtime boundary is authoritative.
+
+These schemas do not claim standalone runtime stability beyond what the repository enforces today. Compatibility remains anchored to existing behavior: `issue-lint`, config loading and setup readiness, `src/operator-actions.ts`, `IssueRunTimelineExport`, `RunState`, status/explain rendering, and the executor safety gates.
 
 ## Internal-Only Surfaces
 

--- a/docs/supervised-automation-state-machine.schema.json
+++ b/docs/supervised-automation-state-machine.schema.json
@@ -4,6 +4,19 @@
   "$ref": "#/$defs/supervisedAutomationStateMachineContract",
   "contractName": "codex-supervisor.supervised-automation-state-machine",
   "contractVersion": 1,
+  "compatibilityPolicy": {
+    "versionField": "contractVersion",
+    "enforcementBoundary": "RunState in src/core/types.ts and status/explain rendering remain the runtime enforcement boundary for lifecycle state vocabulary.",
+    "additiveChanges": [
+      "Adding optional descriptive fields or additional evidence notes is additive when stored RunState values and existing public-state mappings remain unchanged.",
+      "Adding new enum values for stored RunState or operator-facing states is additive only when status, explain, WebUI, and evidence timeline surfaces define how to render them."
+    ],
+    "breakingChanges": [
+      "Removing or renaming public states, stored RunState mappings, evidence expectations, or operator action mappings is breaking.",
+      "Changing lifecycle semantics, terminal-state interpretation, or authority boundaries is a semantic breaking change."
+    ],
+    "stabilityLimit": "The artifact is versioned with repo tags and does not claim stability beyond the existing runtime RunState and status/explain behavior."
+  },
   "canonicalSource": "src/core/types.ts",
   "description": "Portable contract for the supervised automation lane state-machine vocabulary. Runtime lifecycle storage remains backed by RunState in src/core/types.ts; this artifact maps those internal states to operator-facing states, evidence expectations, authority boundaries, and published operator action tokens.",
   "publicStates": [

--- a/docs/trust-posture-config.schema.json
+++ b/docs/trust-posture-config.schema.json
@@ -4,6 +4,19 @@
   "$ref": "#/$defs/trustPostureConfigContract",
   "contractName": "codex-supervisor.trust-posture-config",
   "contractVersion": 1,
+  "compatibilityPolicy": {
+    "versionField": "contractVersion",
+    "enforcementBoundary": "config-loader and setup-readiness remain the runtime enforcement boundary for trust posture fields.",
+    "additiveChanges": [
+      "Adding optional config fields, optional setup-readiness detail, or new advisory posture descriptions is additive when existing configs load unchanged.",
+      "Adding new enum values is additive only when the config loader, setup-readiness summary, and docs describe the safe default behavior."
+    ],
+    "breakingChanges": [
+      "Removing, renaming, or making existing config fields required is breaking.",
+      "Changing defaults, dangerous opt-in meaning, or setup-readiness blocking behavior is a semantic breaking change."
+    ],
+    "stabilityLimit": "The artifact is versioned with repo tags and does not claim stability beyond existing runtime config parsing and setup-readiness behavior."
+  },
   "canonicalGuide": "docs/configuration.md",
   "enforcementBoundary": "config-loader-and-setup-readiness",
   "setupReadinessEndpoint": "GET /api/setup-readiness",

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -6,6 +6,14 @@ import test from "node:test";
 const qualityKitPath = path.join("docs", "quality-kit.md");
 const qualityKitPackageSurfacesPath = path.join("docs", "quality-kit-package-surfaces.md");
 const qualityKitTemplatesPath = path.join("docs", "templates", "quality-primitives");
+const publicSchemaArtifactPaths = [
+  "docs/issue-body-contract.schema.json",
+  "docs/trust-posture-config.schema.json",
+  "docs/operator-actions.schema.json",
+  "docs/evidence-timeline.schema.json",
+  "docs/supervised-automation-state-machine.schema.json",
+  "docs/codex-automation-connector-boundary.schema.json",
+];
 
 async function readRepoFile(relativePath: string): Promise<string> {
   return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
@@ -135,6 +143,7 @@ test("quality kit entrypoint defines the public package surface boundary", async
     "docs/evidence-timeline.schema.json",
     "docs/operator-actions.schema.json",
     "docs/trust-posture-config.schema.json",
+    "docs/supervised-automation-state-machine.schema.json",
     "docs/codex-automation-connector-boundary.schema.json",
   ]) {
     assert.match(qualityKit, new RegExp(publicArtifact.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
@@ -158,6 +167,56 @@ test("quality kit entrypoint defines the public package surface boundary", async
     readme,
     /\[AI coding quality kit\]\(\.\/docs\/quality-kit\.md\): compact primitive map and public package surface/i,
   );
+});
+
+test("public schema artifacts publish versioning and compatibility guidance", async () => {
+  const qualityKit = await readRepoFile(qualityKitPath);
+
+  assert.match(qualityKit, /^## Schema Versioning and Compatibility$/m);
+
+  for (const artifactPath of publicSchemaArtifactPaths) {
+    const source = await readRepoFile(artifactPath);
+    const artifact = JSON.parse(source) as {
+      contractVersion?: number;
+      artifactVersion?: number;
+      compatibilityPolicy?: {
+        versionField?: string;
+        enforcementBoundary?: string;
+        additiveChanges?: string[];
+        breakingChanges?: string[];
+        stabilityLimit?: string;
+      };
+    };
+    const versionField = artifact.contractVersion === undefined ? "artifactVersion" : "contractVersion";
+
+    assert.equal(typeof artifact[versionField], "number", `${artifactPath} must expose ${versionField}`);
+    assert.equal(
+      artifact.compatibilityPolicy?.versionField,
+      versionField,
+      `${artifactPath} must identify its version field`,
+    );
+    assert.match(
+      artifact.compatibilityPolicy?.enforcementBoundary ?? "",
+      /issue-lint|config-loader|setup-readiness|src\/operator-actions\.ts|IssueRunTimelineExport|RunState|codex-supervisor-executor-safety-gates/i,
+      `${artifactPath} must anchor compatibility to an existing enforcement boundary`,
+    );
+    assert.ok(
+      (artifact.compatibilityPolicy?.additiveChanges ?? []).some((note) => /additive|optional|new fields|new enum values/i.test(note)),
+      `${artifactPath} must explain additive changes`,
+    );
+    assert.ok(
+      (artifact.compatibilityPolicy?.breakingChanges ?? []).some((note) => /breaking|required|remov|rename|semantic/i.test(note)),
+      `${artifactPath} must explain breaking changes`,
+    );
+    assert.match(
+      artifact.compatibilityPolicy?.stabilityLimit ?? "",
+      /does not claim|not claim|no runtime enforcement|existing runtime|repo tag/i,
+      `${artifactPath} must avoid overstating schema stability`,
+    );
+    assert.doesNotMatch(source, /\/Users\/[A-Za-z0-9._-]+\//);
+    assert.doesNotMatch(source, /\/home\/[A-Za-z0-9._-]+\//);
+    assert.doesNotMatch(source, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+  }
 });
 
 test("quality kit publishes path-safe copyable primitive templates", async () => {


### PR DESCRIPTION
## Summary
- add compatibilityPolicy guidance to each public portable schema artifact
- document additive vs breaking schema changes in the quality kit entrypoint
- include the supervised state-machine schema in the public quality-kit surface

## Verification
- npx tsx --test src/quality-kit-docs.test.ts
- npx tsx --test src/issue-metadata/issue-body-contract-artifact.test.ts src/trust-posture-config-schema-artifact.test.ts src/operator-actions.test.ts src/timeline-artifacts.test.ts src/supervised-automation-lane-docs.test.ts
- npm run verify:supervisor-pre-pr

Part of #1879
Closes #1883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded schema documentation with formal versioning and compatibility policy guidance, including classifications of additive and breaking changes, stability expectations, and runtime enforcement boundaries across all published schema artifacts.

* **New Features**
  * All published schema artifacts now include compatibility policy metadata fields specifying version references, enforcement boundaries, and change categories for improved version management clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->