### PR TITLE
Publish quality gate examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [Local review reference](./docs/local-review.md): local review policies, role selection, artifacts, thresholds, and committed guardrails
 - [AI coding quality kit](./docs/quality-kit.md): compact primitive map and public package surface for the issue contract, local verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback
 - [Quality kit package surfaces](./docs/quality-kit-package-surfaces.md): comparison of docs, schema, npm metadata, and deferred KANAME bootstrap packaging options for external adoption
+- [Quality gate examples](./docs/examples/quality-gate-examples.md): offline examples for local CI, path hygiene, review readiness, stale review bot boundaries, and evidence timeline gates
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop
 - [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md): annotated supervised PR lifecycle from the repo's own demo-material phase using sanitized public-safe placeholders

--- a/docs/examples/quality-gate-examples.md
+++ b/docs/examples/quality-gate-examples.md
@@ -1,0 +1,161 @@
+# Quality Gate Examples
+
+These examples show how the quality-kit gates improve AI coding outcomes before merge. They are readable offline, do not require live GitHub credentials, and use placeholder inputs instead of host-specific paths, secrets, or provider-owned IDs.
+
+Use them as adoption examples for another repository. They explain the gate shape, the AI failure it catches, the copyable command, and the evidence a reviewer should expect before trusting the result.
+
+## Local CI
+
+Local CI is the first proof that the current head still satisfies the repo-owned contract. It catches generated code that looks plausible in chat but fails the actual TypeScript build, test runner, or configured project checks.
+
+Example adoption shape:
+
+```bash
+npm run verify:paths
+npm run verify:subprocess-safety
+npm run build
+```
+
+Expected quality improvement:
+
+- Codex must report concrete command output instead of saying that a change "should compile."
+- Reviewers can compare the PR head against the same local gate before ready-for-review promotion.
+- Failed checks become repair input for the next turn rather than hidden follow-up work.
+
+Offline evidence to record:
+
+```md
+Gate: local-ci
+Command: npm run build
+Outcome: passed
+Head: <commit-sha>
+```
+
+## Path Hygiene
+
+Path hygiene blocks publishable artifacts that leak workstation-local absolute paths. The examples, issue bodies, docs, and prompts should prefer placeholders such as `<codex-supervisor-root>`, `<supervisor-config-path>`, and `CODEX_SUPERVISOR_CONFIG`.
+
+Example adoption shape:
+
+```bash
+npm run verify:paths
+```
+
+Good publishable guidance:
+
+```bash
+CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js status
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+```
+
+Expected quality improvement:
+
+- AI output can include exact commands without leaking a maintainer home directory.
+- Durable docs remain copyable across machines and CI runners.
+- A path finding blocks publication until the tracked content is repaired.
+
+Offline evidence to record:
+
+```md
+Gate: path-hygiene
+Command: npm run verify:paths
+Outcome: passed
+Finding: none
+```
+
+## Review Readiness
+
+Review readiness separates "the code changed" from "the PR is ready for another person or bot to review." It should require a valid issue contract, focused local verification, and a review boundary that treats GitHub-authored text as untrusted context.
+
+Example adoption shape:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+npm run verify:paths
+npm run build
+```
+
+Expected quality improvement:
+
+- The issue body proves scope, acceptance criteria, dependencies, parallelization posture, and execution order before work is delegated.
+- The PR is not promoted only because Codex finished a turn.
+- Missing verification, ambiguous dependencies, or malformed metadata stay visible before merge.
+
+Offline evidence to record:
+
+```md
+Gate: review-readiness
+Issue: <issue-number>
+Issue lint: passed
+Local verification: passed
+Review boundary: GitHub-authored text treated as untrusted context
+```
+
+## Stale Review Bot Remediation Boundary
+
+A SafeQuery-shaped metadata-only stale review bot case is a quality-surface example, not permission to broaden review automation. The safe case is narrow: a configured review bot left a review thread whose latest actionable provider signal is no longer present on the current head, and the remaining state is only stale metadata that has already been reconciled by the supervisor.
+
+Handled example:
+
+```md
+Case: SafeQuery-shaped metadata-only stale review bot
+Current head: <commit-sha>
+Configured review bot: <configured-review-bot-login>
+Thread state: unresolved in provider metadata
+Latest provider signal on current head: none
+Supervisor conclusion: metadata-only handled review state
+Action: keep the reconciliation evidence; do not treat the stale metadata as a current code blocker
+```
+
+Blocked example:
+
+```md
+Case: genuine unresolved provider-signal
+Current head: <commit-sha>
+Configured review bot: <configured-review-bot-login>
+Thread state: unresolved
+Latest provider signal on current head: actionable comment exists
+Supervisor conclusion: unresolved review blocker
+Action: must stay unresolved until the code is fixed, the bot thread is resolved, or an operator records a manual review decision
+```
+
+Expected quality improvement:
+
+- Stale metadata does not trap the lane when current-head provider evidence is gone.
+- A genuine unresolved provider-signal must stay unresolved and block readiness.
+- Provider outages, missing review facts, or unauthenticated reads fail closed instead of being interpreted as safe.
+
+Offline evidence to record:
+
+```md
+Gate: stale-review-bot-boundary
+Source: review-provider-metadata
+Current-head signal: <none|actionable-comment>
+Outcome: <handled-metadata-only|blocked-unresolved-provider-signal>
+```
+
+## Evidence Timeline
+
+The evidence timeline gives future operators and reviewers a compact audit trail. It should show which gate ran, the head it applied to, the outcome, the remediation target, and the next action.
+
+Example adoption shape:
+
+```bash
+node dist/index.js explain <issue-number> --timeline --config <supervisor-config-path>
+```
+
+Expected quality improvement:
+
+- A later Codex session can resume from durable facts instead of reconstructing chat history.
+- Failed gates identify the remediation target before the next turn starts.
+- Reviewers can see whether local CI, path hygiene, review readiness, and stale review bot decisions applied to the same head.
+
+Offline evidence to record:
+
+```md
+timeline_event index=1 type=issue_body outcome=available head_sha=<commit-sha> summary="Issue body snapshot is available."
+timeline_event index=2 type=local_ci outcome=passed head_sha=<commit-sha> summary="Build passed."
+timeline_event index=3 type=review outcome=blocked head_sha=<commit-sha> remediation_target=review_provider_signal next_action=fix_or_manual_review
+```
+
+Do not stitch together timeline events from different heads as if they prove one ready state. If a read set is mixed or incomplete, record the ambiguity and rerun the gate against a single committed snapshot.

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -17,7 +17,7 @@ The public package surface is the docs-first bundle recommended by the [Quality 
 - `docs/supervised-automation-state-machine.schema.json`: operator-facing lifecycle vocabulary mapped to runtime `RunState`
 - `docs/codex-automation-connector-boundary.schema.json`: Codex app Automation boundary for orchestration without executor authority
 - `docs/templates/quality-primitives/`: [quality primitive templates](./templates/quality-primitives/README.md) for copying the issue contract, AGENTS.md guidance, local CI gate, evidence timeline, trust posture, and operator action vocabulary into a new repo
-- `docs/examples/self-contained-demo-scenario.md`, `docs/examples/phase-16-dogfood-pr-walkthrough.md`, and `docs/public-demo-validation-checklist.md`: public examples and publishable validation checklist
+- `docs/examples/self-contained-demo-scenario.md`, `docs/examples/phase-16-dogfood-pr-walkthrough.md`, [Quality gate examples](./examples/quality-gate-examples.md), and `docs/public-demo-validation-checklist.md`: public examples and publishable validation checklist
 
 This surface is intentionally repo-relative and placeholder-driven. It does not publish a cloud service, does not publish a WebUI package, does not publish a provider SDK, and does not expand executor authority beyond the local `codex-supervisor` loop.
 
@@ -60,6 +60,7 @@ Backed by:
 - [Configuration reference](./configuration.md)
 - [Local review reference](./local-review.md)
 - [Release readiness checklist](./validation-checklist.md)
+- [Quality gate examples](./examples/quality-gate-examples.md)
 - `src/local-ci.test.ts`
 - `src/tracked-pr-local-ci-publication-gate.test.ts`
 - `src/post-turn-pull-request.test.ts`
@@ -84,6 +85,7 @@ The Evidence Timeline records what happened so an operator, reviewer, or future 
 Backed by:
 
 - [evidence timeline](./evidence-timeline.schema.json)
+- [Quality gate examples](./examples/quality-gate-examples.md)
 - [self-contained demo scenario](./examples/self-contained-demo-scenario.md)
 - [Phase 16 dogfood PR walkthrough](./examples/phase-16-dogfood-pr-walkthrough.md)
 - `src/timeline-artifacts.test.ts`

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 
 const qualityKitPath = path.join("docs", "quality-kit.md");
 const qualityKitPackageSurfacesPath = path.join("docs", "quality-kit-package-surfaces.md");
+const qualityGateExamplesPath = path.join("docs", "examples", "quality-gate-examples.md");
 const qualityKitTemplatesPath = path.join("docs", "templates", "quality-primitives");
 const publicSchemaArtifactPaths = [
   "docs/issue-body-contract.schema.json",
@@ -266,4 +267,48 @@ test("quality kit publishes path-safe copyable primitive templates", async () =>
   const trustPosture = await readRepoFile(path.join(qualityKitTemplatesPath, "trust-posture.md"));
   assert.match(trustPosture, /GitHub-authored text is untrusted context/i);
   assert.match(trustPosture, /does not grant executor authority/i);
+});
+
+test("quality gate examples publish offline adoption scenarios with safe review boundaries", async () => {
+  const [qualityKit, readme, examples] = await Promise.all([
+    readRepoFile(qualityKitPath),
+    readRepoFile("README.md"),
+    readRepoFile(qualityGateExamplesPath),
+  ]);
+
+  assert.match(qualityKit, /\[Quality gate examples\]\(\.\/examples\/quality-gate-examples\.md\)/);
+  assert.match(readme, /\[Quality gate examples\]\(\.\/docs\/examples\/quality-gate-examples\.md\)/);
+  assert.match(examples, /^# Quality Gate Examples$/m);
+  assert.match(examples, /readable offline/i);
+  assert.match(examples, /do not require live GitHub credentials/i);
+  assert.doesNotMatch(examples, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(examples, /\/home\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(examples, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  for (const heading of [
+    "Local CI",
+    "Path Hygiene",
+    "Review Readiness",
+    "Stale Review Bot Remediation Boundary",
+    "Evidence Timeline",
+  ]) {
+    assert.match(examples, new RegExp(`^## ${heading}$`, "m"), `expected ${heading} example`);
+  }
+
+  for (const command of [
+    "npm run verify:paths",
+    "npm run verify:subprocess-safety",
+    "npm run build",
+    "node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+    "node dist/index.js explain <issue-number> --timeline --config <supervisor-config-path>",
+  ]) {
+    assert.match(examples, new RegExp(escapeRegExp(command)), `expected ${command}`);
+  }
+
+  assert.match(examples, /SafeQuery-shaped metadata-only stale review bot/i);
+  assert.match(examples, /metadata-only handled review state/i);
+  assert.match(examples, /genuine unresolved provider-signal/i);
+  assert.match(examples, /must stay unresolved/i);
+  assert.doesNotMatch(examples, /metadata-only review auto-resolve/i);
+  assert.doesNotMatch(examples, /provider-outage suppression/i);
 });


### PR DESCRIPTION
## Summary
- Add offline quality gate examples for local CI, path hygiene, review readiness, stale review bot remediation boundaries, and evidence timeline checks
- Link the example from README and the quality kit public package surface
- Add docs test coverage for the example, links, commands, review-boundary wording, and path-literal hygiene

## Verification
- npx tsx --test src/quality-kit-docs.test.ts
- npm run verify:paths
- npm run verify:subprocess-safety
- npm run build
- npm test

Issue-lint note: `node dist/index.js issue-lint 1884 --config supervisor.config.coderabbit.json` is blocked in this worktree because the checked-in starter profile still contains placeholder repository settings.

Closes #1884