### PR TITLE
Harden quality kit package entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you want the same small change shown as an unstructured session versus a supe
 If you want to see the supervised PR lifecycle annotated with Phase 16's own dogfooding flow, read the [Phase 16 dogfood PR walkthrough](./docs/examples/phase-16-dogfood-pr-walkthrough.md).
 If you need the narrower freshness and durability contracts, use [Architecture](./docs/architecture.md) and [Configuration reference](./docs/configuration.md) instead of treating this README as the full runtime spec.
 If you use Codex app Automation around the loop, keep the [Codex app Automation boundary](./docs/automation.md) as the repo-owned contract: Automation orchestrates and records, while `codex-supervisor` remains the implementation executor.
+The quality kit is a docs-first adoption surface in this repository, not published as an npm package or stable package API; use the repo-relative docs, schemas, templates, and `node dist/index.js ...` CLI commands above as the supported entrypoints.
 
 ## Who It Is For
 

--- a/docs/quality-kit-package-surfaces.md
+++ b/docs/quality-kit-package-surfaces.md
@@ -15,6 +15,8 @@ External users adopt first a templates/docs bundle inside this repository:
 
 This is the smallest package surface because it is copy/paste usable, versioned with the implementation that backs it, and discoverable from the README. It gives a new repo enough structure to author a first supervised issue and validation plan without installing an extra package or trusting a new authority boundary.
 
+For this phase, `codex-supervisor` is not published as an npm package. The package metadata remains private and repo-linked so local CLI commands stay coherent without advertising a stable npm package API.
+
 ## Viable Package Shapes
 
 | Shape | What ships | Adoption friction | Versioning | Release burden | Docs discoverability | New-repo reuse |

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -20,6 +20,7 @@ The public package surface is the docs-first bundle recommended by the [Quality 
 - `docs/examples/self-contained-demo-scenario.md`, `docs/examples/phase-16-dogfood-pr-walkthrough.md`, [Quality gate examples](./examples/quality-gate-examples.md), and `docs/public-demo-validation-checklist.md`: public examples and publishable validation checklist
 
 This surface is intentionally repo-relative and placeholder-driven. It does not publish a cloud service, does not publish a WebUI package, does not publish a provider SDK, and does not expand executor authority beyond the local `codex-supervisor` loop.
+It also does not publish an npm package or stable package API in this phase; the `package.json` metadata remains private and points readers back to this repository and docs-first surface.
 
 ## Schema Versioning and Compatibility
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "codex-supervisor",
       "version": "0.1.7",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.6.0",
         "playwright-core": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "codex-supervisor",
   "version": "0.1.7",
   "private": true,
-  "description": "Minimal GitHub issue/PR/CI supervisor using codex exec and gh.",
+  "description": "Issue-driven Codex quality layer for supervised GitHub PR delivery.",
+  "license": "MIT",
+  "homepage": "https://github.com/TommyKammy/codex-supervisor#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TommyKammy/codex-supervisor.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TommyKammy/codex-supervisor/issues"
+  },
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "prebuild": "npm run clean",

--- a/src/package-metadata-docs.test.ts
+++ b/src/package-metadata-docs.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  description?: string;
+  license?: string;
+  homepage?: string;
+  repository?: string | { type?: string; url?: string; directory?: string };
+  bugs?: { url?: string };
+  bin?: unknown;
+  exports?: unknown;
+  files?: unknown;
+  scripts?: Record<string, string>;
+}
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function readPackageJson(): Promise<PackageJson> {
+  return JSON.parse(await readRepoFile("package.json")) as PackageJson;
+}
+
+test("package metadata matches the docs-first quality kit surface", async () => {
+  const [packageJson, readme, qualityKit, packageSurfaces] = await Promise.all([
+    readPackageJson(),
+    readRepoFile("README.md"),
+    readRepoFile(path.join("docs", "quality-kit.md")),
+    readRepoFile(path.join("docs", "quality-kit-package-surfaces.md")),
+  ]);
+
+  assert.equal(packageJson.name, "codex-supervisor");
+  assert.equal(packageJson.private, true, "quality kit is not published as an npm package in this phase");
+  assert.match(packageJson.description ?? "", /quality layer/i);
+  assert.equal(packageJson.license, "MIT");
+  assert.equal(packageJson.homepage, "https://github.com/TommyKammy/codex-supervisor#readme");
+  assert.deepEqual(packageJson.repository, {
+    type: "git",
+    url: "git+https://github.com/TommyKammy/codex-supervisor.git",
+  });
+  assert.deepEqual(packageJson.bugs, {
+    url: "https://github.com/TommyKammy/codex-supervisor/issues",
+  });
+
+  assert.equal(packageJson.bin, undefined, "private docs-first package should not advertise an npm CLI bin");
+  assert.equal(packageJson.exports, undefined, "private docs-first package should not advertise stable package API exports");
+  assert.equal(packageJson.files, undefined, "private docs-first package should not imply a publishable npm payload");
+  assert.equal(packageJson.scripts?.start, "node dist/index.js");
+  assert.equal(packageJson.scripts?.dev, "tsx src/index.ts");
+
+  for (const docsSource of [readme, qualityKit, packageSurfaces]) {
+    assert.match(docsSource, /docs-first/i);
+    assert.match(docsSource, /not (?:published|publish) as an npm package|does not publish an npm package/i);
+    assert.doesNotMatch(docsSource, /npm install (?:-g\s+)?codex-supervisor/i);
+  }
+
+  assert.match(readme, /\[AI coding quality kit\]\(\.\/docs\/quality-kit\.md\)/i);
+  assert.match(qualityKit, /external adopters should treat these artifacts as the stable, copyable quality-kit surface/i);
+});


### PR DESCRIPTION
## Summary
- align package metadata with the docs-first quality kit positioning
- document that the selected public surface is repo-hosted docs/templates/schemas, not a published npm package API
- add a focused package/docs regression test for the public entrypoint contract

## Verification
- npx tsx --test src/package-metadata-docs.test.ts
- npx tsx --test src/quality-kit-docs.test.ts src/readme-docs.test.ts src/package-metadata-docs.test.ts
- npm run verify:paths
- npm run build
- npm run verify:subprocess-safety
- npm test

Closes #1885