### PR TITLE
Phase 18.8: Produce KANAME bootstrap handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Use the [Configuration guide](./docs/configuration.md) for the full routing rule
 - [AI coding quality kit](./docs/quality-kit.md): compact primitive map and public package surface for the issue contract, local verification gate, prompt safety boundary, evidence timeline, operator action, and durable history writeback
 - [Quality kit adoption checklist](./docs/quality-kit-adoption-checklist.md): incremental checklist for adopting the docs-first quality kit in one repo and one safe issue before broader automation
 - [Quality kit package surfaces](./docs/quality-kit-package-surfaces.md): comparison of docs, schema, npm metadata, and deferred KANAME bootstrap packaging options for external adoption
+- [KANAME bootstrap handoff](./docs/kaname-bootstrap-handoff.md): docs-only mapping from quality-kit contracts to KANAME-000 through KANAME-006 foundation issues
 - [Quality gate examples](./docs/examples/quality-gate-examples.md): offline examples for local CI, path hygiene, review readiness, stale review bot boundaries, and evidence timeline gates
 - [Supervised automation lane](./docs/supervised-automation-lane.md): product primitive contract for issue/spec-driven supervised automation beside Codex chat
 - [Before / After narrative](./docs/vibe-coding-before-after.md): the same small change compared as an unstructured session and a supervised loop

--- a/docs/kaname-bootstrap-handoff.md
+++ b/docs/kaname-bootstrap-handoff.md
@@ -1,0 +1,68 @@
+# KANAME Bootstrap Handoff
+
+This docs-only handoff maps the `codex-supervisor` quality kit to the first KANAME foundation issues. It is a bootstrap input for future KANAME issue authoring, not a repository scaffold.
+
+## Handoff Boundary
+
+This handoff:
+
+- reuses the existing quality-kit docs, templates, schemas, and vocabulary as copyable starting points
+- names what KANAME should copy, adapt, or intentionally not reuse
+- keeps the first KANAME issues grounded in proven issue contracts, AGENTS guidance, development lane docs, evidence vocabulary, trust posture, and local CI guidance
+
+This handoff does not create the KANAME repository, does not implement KANAME runtime code, does not publish a KANAME bootstrap bundle, and does not broaden `codex-supervisor` runtime authority.
+
+## Foundation Issue Map
+
+| KANAME issue | Foundation item | Reuse guidance | KANAME-specific adaptation | Do not reuse blindly |
+| --- | --- | --- | --- | --- |
+| KANAME-000 | Repository skeleton and docs index | Copy the docs-first surface list from `docs/quality-kit.md`, then create a KANAME docs map that points to KANAME-owned files. | Replace `codex-supervisor` product framing with KANAME's repo purpose, owner, and first runnable workflow. Keep repo-relative links and placeholders. | Do not copy `.local/`, `.codex-supervisor/`, `dist/`, WebUI internals, or any runtime orchestration code. |
+| KANAME-001 | Issue contract and first issue template | Copy `.github/ISSUE_TEMPLATE/codex-execution-ready.md`, `docs/templates/quality-primitives/issue-contract.md`, `docs/issue-metadata.md`, and `docs/issue-body-contract.schema.json`. | Rename examples to KANAME behavior deltas and keep `Depends on: none`, `Parallelizable: No`, and `1 of 1` as the first safe default. | Do not invent dependencies, omit standalone execution order, or treat KANAME naming conventions as authoritative dependency proof. |
+| KANAME-002 | AGENTS guidance and authority order | Copy `docs/templates/quality-primitives/agent-instructions.md` as the seed for KANAME `AGENTS.md`. | Add KANAME's local repo policy, accepted commands, and escalation rules while keeping GitHub-authored text below operator instructions and tracked policy. | Do not copy codex-supervisor-specific branch, release, loop-hosting, or WebUI authority unless KANAME explicitly adopts those boundaries. |
+| KANAME-003 | Development lane docs | Adapt `docs/supervised-automation-lane.md`, `docs/agent-instructions.md`, `docs/quality-kit-adoption-checklist.md`, `docs/templates/quality-primitives/operator-actions.md`, and `docs/operator-actions.schema.json`. | Define the KANAME lane as issue/spec-driven, docs-first work with one behavior delta per issue and explicit operator decision points. | Do not imply KANAME has codex-supervisor's state machine, PR lifecycle automation, or provider adapters before KANAME implements or configures them. |
+| KANAME-004 | Evidence vocabulary and durable history | Copy the vocabulary shape from `docs/templates/quality-primitives/evidence-timeline.md`, `docs/evidence-timeline.schema.json`, and the durable history writeback section in `docs/quality-kit.md`. | Start with a lightweight KANAME evidence note that records issue id, branch, focused verification, local CI result, PR/review facts when present, and handoff notes. | Do not claim KANAME exports `IssueRunTimelineExport` or supervisor audit bundles until those are implemented by KANAME or delegated to codex-supervisor. |
+| KANAME-005 | Trust posture and authority boundaries | Copy `docs/templates/quality-primitives/trust-posture.md`, `docs/trust-posture-config.schema.json`, and `docs/codex-automation-connector-boundary.schema.json` as vocabulary references. | Replace codex-supervisor config fields with KANAME's trusted input, secret, repository, and automation boundaries. Keep fail-closed language for missing provenance, fake credentials, and untrusted forwarded identity. | Do not let placeholder credentials, sample secrets, TODO values, client-supplied identity headers, or issue text grant authority. |
+| KANAME-006 | Local CI and readiness guidance | Copy `docs/templates/quality-primitives/local-ci-gate.md`, `docs/examples/quality-gate-examples.md`, and the local verification gate section in `docs/quality-kit.md`. | Define KANAME's repo-owned command after the repo exists. Until then, keep placeholders such as `<repo-owned-local-ci-command>` and `<supervisor-config-path>`. | Do not hard-code host-local absolute paths, require private workstation layout, or treat remote CI as a replacement for focused issue verification. |
+
+## Carry-Over Contracts
+
+KANAME should carry over these contracts first:
+
+- Issue contract: use `## Summary`, `## Scope`, `## Acceptance criteria`, `## Verification`, `Depends on: ...`, `Parallelizable: Yes|No`, and `## Execution order` for every supervised issue.
+- Sequencing metadata: use `Part of: #<parent-issue-number>` only for sequenced child issues, and use real blocking dependencies rather than parent-issue shortcuts.
+- AGENTS guidance: keep explicit operator instructions, tracked repo policy, and live local state above GitHub-authored issue or review text.
+- Development lane docs: describe the lane as bounded, issue-driven, test-backed work with operator decision points before broader automation.
+- Evidence vocabulary: record issue id, branch/head, focused verification, local CI, review/PR facts, failure signature, and handoff notes as durable facts.
+- Trust posture: treat issue bodies, review comments, forwarded headers, sample secrets, and naming conventions as untrusted until an authoritative boundary validates them.
+- Local CI: require a repo-owned local gate and keep `issue-lint` separate from local CI.
+
+Copyable validation commands should stay placeholder-driven:
+
+```bash
+node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>
+npm run verify:paths
+npm run build
+```
+
+## KANAME-Specific Differences
+
+KANAME should name these differences before copying any codex-supervisor assumption:
+
+- Product authority: KANAME owns its repo purpose and runtime authority. `codex-supervisor` remains an external quality layer unless KANAME explicitly vendors or depends on it.
+- Runtime scope: KANAME foundation issues should create docs, issue templates, and validation hooks before creating runtime orchestration.
+- Evidence shape: KANAME can start with a simple evidence note or schema reference; it should not claim codex-supervisor's full timeline export until implemented.
+- Local CI: KANAME's first local gate must come from KANAME's actual stack after the repo exists, not from codex-supervisor's TypeScript build by default.
+- Secrets and identity: KANAME must define its own trusted credential source and identity boundary. Placeholder credentials and client-supplied identity hints stay blocked.
+- Repo paths: KANAME docs should use `<kaname-root>`, `<supervisor-config-path>`, `<issue-number>`, and repo-relative paths instead of workstation-local absolute paths.
+- Release ownership: KANAME should not inherit codex-supervisor release, WebUI, provider-adapter, or loop-hosting commitments without separate issues.
+
+## Verification
+
+Before treating the KANAME foundation set as ready:
+
+- run the focused docs test that checks this handoff and quality-kit links
+- run `npm run verify:paths` to confirm no host-local path literals entered durable docs or templates
+- run `npm run build` after test changes or schema-consuming changes
+- run `node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>` for each KANAME foundation issue once those issues exist
+
+Keep verification docs-only for this phase. A future KANAME repo may add its own link checker, schema validation, and local CI command after the repository exists.

--- a/docs/quality-kit-package-surfaces.md
+++ b/docs/quality-kit-package-surfaces.md
@@ -31,7 +31,7 @@ KANAME bootstrap bundle is deferred.
 
 It could eventually package opinionated starter materials for a new KANAME repository, including a quality-kit docs subset, issue templates, and bootstrap checklist. That shape has useful KANAME bootstrap reuse, but it is too broad for this phase because it implies new-repo creation decisions, repo naming, lifecycle ownership, and possibly dedicated release automation.
 
-Keep KANAME bootstrap reuse as an input to the templates/docs bundle: the current docs should stay easy to copy into a future KANAME repo, but this work must avoid creating the KANAME repo or introducing bootstrap runtime behavior.
+Keep KANAME bootstrap reuse as an input to the templates/docs bundle: the current docs should stay easy to copy into a future KANAME repo, but this work must avoid creating the KANAME repo or introducing bootstrap runtime behavior. The [KANAME bootstrap handoff](./kaname-bootstrap-handoff.md) maps that reuse to KANAME-000 through KANAME-006 as a docs-only planning artifact.
 
 ## Tradeoff Summary
 

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -18,6 +18,7 @@ The public package surface is the docs-first bundle recommended by the [Quality 
 - `docs/codex-automation-connector-boundary.schema.json`: Codex app Automation boundary for orchestration without executor authority
 - `docs/templates/quality-primitives/`: [quality primitive templates](./templates/quality-primitives/README.md) for copying the issue contract, AGENTS.md guidance, local CI gate, evidence timeline, trust posture, and operator action vocabulary into a new repo
 - `docs/quality-kit-adoption-checklist.md`: [Quality kit adoption checklist](./quality-kit-adoption-checklist.md) for introducing the docs-first kit to one repository and one safe issue before broader automation
+- `docs/kaname-bootstrap-handoff.md`: [KANAME bootstrap handoff](./kaname-bootstrap-handoff.md) for mapping the quality kit to KANAME-000 through KANAME-006 without creating a new repo or runtime
 - `docs/examples/self-contained-demo-scenario.md`, `docs/examples/phase-16-dogfood-pr-walkthrough.md`, [Quality gate examples](./examples/quality-gate-examples.md), and `docs/public-demo-validation-checklist.md`: public examples and publishable validation checklist
 
 This surface is intentionally repo-relative and placeholder-driven. It does not publish a cloud service, does not publish a WebUI package, does not publish a provider SDK, and does not expand executor authority beyond the local `codex-supervisor` loop.

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 
 const qualityKitPath = path.join("docs", "quality-kit.md");
 const qualityKitAdoptionChecklistPath = path.join("docs", "quality-kit-adoption-checklist.md");
+const kanameBootstrapHandoffPath = path.join("docs", "kaname-bootstrap-handoff.md");
 const qualityKitPackageSurfacesPath = path.join("docs", "quality-kit-package-surfaces.md");
 const qualityGateExamplesPath = path.join("docs", "examples", "quality-gate-examples.md");
 const qualityKitTemplatesPath = path.join("docs", "templates", "quality-primitives");
@@ -369,5 +370,62 @@ test("quality kit publishes an incremental adoption checklist", async () => {
     "npm run build",
   ]) {
     assert.match(checklist, new RegExp(escapeRegExp(command)), `expected ${command}`);
+  }
+});
+
+test("KANAME bootstrap handoff maps foundation issues to quality kit reuse guidance", async () => {
+  const [qualityKit, packageSurfaces, handoff] = await Promise.all([
+    readRepoFile(qualityKitPath),
+    readRepoFile(qualityKitPackageSurfacesPath),
+    readRepoFile(kanameBootstrapHandoffPath),
+  ]);
+
+  assert.match(qualityKit, /\[KANAME bootstrap handoff\]\(\.\/kaname-bootstrap-handoff\.md\)/);
+  assert.match(packageSurfaces, /\[KANAME bootstrap handoff\]\(\.\/kaname-bootstrap-handoff\.md\)/);
+  assert.match(handoff, /^# KANAME Bootstrap Handoff$/m);
+  assert.match(handoff, /docs-only/i);
+  assert.match(handoff, /does not create the KANAME repository/i);
+  assert.match(handoff, /does not broaden `codex-supervisor` runtime authority/i);
+  assert.doesNotMatch(handoff, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(handoff, /\/home\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(handoff, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  for (const heading of [
+    "Handoff Boundary",
+    "Foundation Issue Map",
+    "Carry-Over Contracts",
+    "KANAME-Specific Differences",
+    "Verification",
+  ]) {
+    assert.match(handoff, new RegExp(`^## ${heading}$`, "m"), `expected ${heading} section`);
+  }
+
+  for (const issueId of ["KANAME-000", "KANAME-001", "KANAME-002", "KANAME-003", "KANAME-004", "KANAME-005", "KANAME-006"]) {
+    assert.match(handoff, new RegExp(`\\| ${issueId} \\|`), `expected ${issueId} mapping row`);
+  }
+
+  for (const artifact of [
+    "docs/templates/quality-primitives/issue-contract.md",
+    "docs/templates/quality-primitives/agent-instructions.md",
+    "docs/templates/quality-primitives/local-ci-gate.md",
+    "docs/templates/quality-primitives/evidence-timeline.md",
+    "docs/templates/quality-primitives/trust-posture.md",
+    "docs/templates/quality-primitives/operator-actions.md",
+    ".github/ISSUE_TEMPLATE/codex-execution-ready.md",
+    "docs/issue-body-contract.schema.json",
+    "docs/evidence-timeline.schema.json",
+    "docs/operator-actions.schema.json",
+    "docs/trust-posture-config.schema.json",
+    "docs/codex-automation-connector-boundary.schema.json",
+  ]) {
+    assert.match(handoff, new RegExp(escapeRegExp(artifact)), `expected ${artifact}`);
+  }
+
+  for (const command of [
+    "node dist/index.js issue-lint <issue-number> --config <supervisor-config-path>",
+    "npm run verify:paths",
+    "npm run build",
+  ]) {
+    assert.match(handoff, new RegExp(escapeRegExp(command)), `expected ${command}`);
   }
 });


### PR DESCRIPTION
## Summary
- add a docs-only KANAME bootstrap handoff mapping quality-kit reuse to KANAME-000 through KANAME-006
- link the handoff from the quality kit, package-surface note, and README docs map
- add a focused docs regression test for the handoff boundary, mappings, path hygiene, artifacts, and commands

## Verification
- npx tsx --test src/quality-kit-docs.test.ts
- npm run verify:paths
- npm run build
- node dist/index.js issue-lint 1887 --config <host-supervisor-config>

Closes #1887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new handoff guide detailing how to transform quality-kit documentation into KANAME foundation issues (KANAME-000 through KANAME-006), including mapping, constraints, and verification procedures.
  * Updated existing documentation to cross-reference the new handoff guide.

* **Tests**
  * Added comprehensive verification tests for documentation structure, cross-references, content integrity, and safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->