### PR TITLE
Avoid URL path false positives in path hygiene

### DIFF
--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -163,6 +163,7 @@ test("findForbiddenWorkstationLocalPaths keeps file URLs to workstation homes bl
     path.join(repoPath, "docs", "guide.md"),
     [
       `Linux file URL: file://${buildUnixHomePath("alice", "dev", "private-repo")}`,
+      `Linux file URL with authority: file://localhost${buildUnixHomePath("alice", "dev", "private-repo")}`,
       `macOS file URL: file://${buildMacHomePath("alice", "Dev", "private-repo")}`,
       `Windows file URL: file://${buildWindowsHomePath("Alice", "private-repo")}`,
       "",
@@ -192,16 +193,62 @@ test("findForbiddenWorkstationLocalPaths keeps file URLs to workstation homes bl
       {
         filePath: "docs/guide.md",
         line: 2,
+        prefix: "/home/<user>/",
+        reason: "Linux user home directory",
+        match: buildUnixHomePath("alice", "dev", "private-repo"),
+      },
+      {
+        filePath: "docs/guide.md",
+        line: 3,
         prefix: "/Users/<user>/",
         reason: "macOS user home directory",
         match: buildMacHomePath("alice", "Dev", "private-repo"),
       },
       {
         filePath: "docs/guide.md",
-        line: 3,
+        line: 4,
         prefix: "C:\\Users\\<user>\\",
         reason: "Windows user home directory",
         match: buildWindowsHomePath("Alice", "private-repo"),
+      },
+    ],
+  );
+});
+
+test("findForbiddenWorkstationLocalPaths checks boundaries per compound path segment", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "docs", "guide.md"),
+    [
+      `Mixed token: https://example.test${buildUnixHomePath("alice", "docs")}:${buildUnixHomePath("bob", "private-repo")}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "docs/guide.md");
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath);
+
+  assert.deepEqual(
+    findings.map((finding) => ({
+      filePath: finding.filePath,
+      line: finding.line,
+      prefix: finding.prefix,
+      reason: finding.reason,
+      match: finding.match,
+    })),
+    [
+      {
+        filePath: "docs/guide.md",
+        line: 1,
+        prefix: "/home/<user>/",
+        reason: "Linux user home directory",
+        match: buildUnixHomePath("bob", "private-repo"),
       },
     ],
   );

--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -130,6 +130,83 @@ test("findForbiddenWorkstationLocalPaths ignores /home/node container paths whil
   );
 });
 
+test("findForbiddenWorkstationLocalPaths ignores HTTP URL path segments that resemble Linux homes", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "docs", "guide.md"),
+    [
+      `Public callback: https://example.test${buildUnixHomePath("alice", "dev", "private-repo")}/status`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "docs/guide.md");
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath);
+
+  assert.deepEqual(findings, []);
+});
+
+test("findForbiddenWorkstationLocalPaths keeps file URLs to workstation homes blocked", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "docs", "guide.md"),
+    [
+      `Linux file URL: file://${buildUnixHomePath("alice", "dev", "private-repo")}`,
+      `macOS file URL: file://${buildMacHomePath("alice", "Dev", "private-repo")}`,
+      `Windows file URL: file://${buildWindowsHomePath("Alice", "private-repo")}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  git(repoPath, "add", "docs/guide.md");
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath);
+
+  assert.deepEqual(
+    findings.map((finding) => ({
+      filePath: finding.filePath,
+      line: finding.line,
+      prefix: finding.prefix,
+      reason: finding.reason,
+      match: finding.match,
+    })),
+    [
+      {
+        filePath: "docs/guide.md",
+        line: 1,
+        prefix: "/home/<user>/",
+        reason: "Linux user home directory",
+        match: buildUnixHomePath("alice", "dev", "private-repo"),
+      },
+      {
+        filePath: "docs/guide.md",
+        line: 2,
+        prefix: "/Users/<user>/",
+        reason: "macOS user home directory",
+        match: buildMacHomePath("alice", "Dev", "private-repo"),
+      },
+      {
+        filePath: "docs/guide.md",
+        line: 3,
+        prefix: "C:\\Users\\<user>\\",
+        reason: "Windows user home directory",
+        match: buildWindowsHomePath("Alice", "private-repo"),
+      },
+    ],
+  );
+});
+
 test("findForbiddenWorkstationLocalPaths still reports workstation homes inside colon-delimited Unix path lists", async (t) => {
   const repoPath = await createTrackedRepo();
   t.after(async () => {

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -40,6 +40,7 @@ const PATH_TOKEN_BOUNDARY_CHARS = new Set([
 // without weakening workstation-home detection for typical developer paths.
 const KNOWN_CONTAINER_HOME_OWNERS = new Set(["node"]);
 const UNIX_HOME_OWNER_PATTERN = new RegExp(`^${escapeForRegex(UNIX_HOME_PREFIX)}([^/]+)(?:/|$)`);
+const FILE_URL_SCHEME = "file:";
 
 export interface WorkstationLocalPathClassification {
   blocked: boolean;
@@ -171,15 +172,43 @@ function hasPathTokenBoundaryBeforeCandidate(line: string, candidateIndex: numbe
   }
 
   const prefix = line.slice(0, candidateIndex);
-  if (prefix.endsWith(FILE_URL_PREFIX)) {
+  if (hasFileUrlPathBoundaryBeforeCandidate(prefix)) {
     return true;
   }
 
   return PATH_TOKEN_BOUNDARY_CHARS.has(line[candidateIndex - 1]);
 }
 
-function splitCompoundCandidate(candidate: string): string[] {
-  const parts: string[] = [];
+function hasFileUrlPathBoundaryBeforeCandidate(prefix: string): boolean {
+  const schemeIndex = prefix.lastIndexOf(FILE_URL_SCHEME);
+  if (schemeIndex < 0) {
+    return false;
+  }
+
+  if (schemeIndex > 0 && !PATH_TOKEN_BOUNDARY_CHARS.has(prefix[schemeIndex - 1])) {
+    return false;
+  }
+
+  const schemeSuffix = prefix.slice(schemeIndex + FILE_URL_SCHEME.length);
+  if (schemeSuffix.length === 0) {
+    return true;
+  }
+
+  if (!schemeSuffix.startsWith("//")) {
+    return false;
+  }
+
+  const authority = schemeSuffix.slice(FILE_URL_PREFIX.length - FILE_URL_SCHEME.length);
+  return !/[\\\s"'`<>]/.test(authority);
+}
+
+interface CompoundCandidateSegment {
+  value: string;
+  offset: number;
+}
+
+function splitCompoundCandidate(candidate: string): CompoundCandidateSegment[] {
+  const parts: CompoundCandidateSegment[] = [];
   let segmentStart = 0;
 
   for (let index = 1; index < candidate.length; index += 1) {
@@ -192,12 +221,18 @@ function splitCompoundCandidate(candidate: string): string[] {
       continue;
     }
 
-    parts.push(candidate.slice(segmentStart, index - 1));
+    parts.push({
+      value: candidate.slice(segmentStart, index - 1),
+      offset: segmentStart,
+    });
     segmentStart = index;
   }
 
-  parts.push(candidate.slice(segmentStart));
-  return parts.filter((part) => part.length > 0);
+  parts.push({
+    value: candidate.slice(segmentStart),
+    offset: segmentStart,
+  });
+  return parts.filter((part) => part.value.length > 0);
 }
 
 function lineContainsConfiguredAllowlistMarker(line: string, markers: readonly string[]): boolean {
@@ -220,11 +255,13 @@ function collectMatches(
       pattern.regex.lastIndex = 0;
       for (const match of line.matchAll(pattern.regex)) {
         const candidateIndex = match.index ?? 0;
-        if (!hasPathTokenBoundaryBeforeCandidate(line, candidateIndex)) {
-          continue;
-        }
+        for (const segment of splitCompoundCandidate(match[0])) {
+          const segmentStartIndex = candidateIndex + segment.offset;
+          if (!hasPathTokenBoundaryBeforeCandidate(line, segmentStartIndex)) {
+            continue;
+          }
 
-        for (const candidate of splitCompoundCandidate(match[0])) {
+          const candidate = segment.value;
           const classification = pattern.classify(candidate);
           if (!classification?.blocked) {
             continue;

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -17,6 +17,25 @@ const WINDOWS_USERS_PREFIX = `C:${WINDOWS_PATH_SEPARATOR}${"Users"}${WINDOWS_PAT
 const PATH_TOKEN_PATTERN = String.raw`[^\s"'` + "`" + String.raw`<>]+`;
 const COMPOUND_PATH_SEPARATORS = new Set([":", ";"]);
 const ABSOLUTE_PATH_PREFIXES = [UNIX_HOME_PREFIX, MACOS_USERS_PREFIX, WINDOWS_USERS_PREFIX] as const;
+const FILE_URL_PREFIX = "file://";
+const PATH_TOKEN_BOUNDARY_CHARS = new Set([
+  " ",
+  "\t",
+  "\r",
+  "\n",
+  "\"",
+  "'",
+  "`",
+  "<",
+  ">",
+  "=",
+  ":",
+  ";",
+  ",",
+  "(",
+  "[",
+  "{",
+]);
 // Keep this allowlist intentionally short so container defaults stop tripping the gate
 // without weakening workstation-home detection for typical developer paths.
 const KNOWN_CONTAINER_HOME_OWNERS = new Set(["node"]);
@@ -146,6 +165,19 @@ function startsWithAbsolutePathPrefix(candidate: string, index: number): boolean
   return ABSOLUTE_PATH_PREFIXES.some((prefix) => candidate.startsWith(prefix, index));
 }
 
+function hasPathTokenBoundaryBeforeCandidate(line: string, candidateIndex: number): boolean {
+  if (candidateIndex <= 0) {
+    return true;
+  }
+
+  const prefix = line.slice(0, candidateIndex);
+  if (prefix.endsWith(FILE_URL_PREFIX)) {
+    return true;
+  }
+
+  return PATH_TOKEN_BOUNDARY_CHARS.has(line[candidateIndex - 1]);
+}
+
 function splitCompoundCandidate(candidate: string): string[] {
   const parts: string[] = [];
   let segmentStart = 0;
@@ -187,6 +219,11 @@ function collectMatches(
     for (const pattern of CANDIDATE_PATTERNS) {
       pattern.regex.lastIndex = 0;
       for (const match of line.matchAll(pattern.regex)) {
+        const candidateIndex = match.index ?? 0;
+        if (!hasPathTokenBoundaryBeforeCandidate(line, candidateIndex)) {
+          continue;
+        }
+
         for (const candidate of splitCompoundCandidate(match[0])) {
           const classification = pattern.classify(candidate);
           if (!classification?.blocked) {


### PR DESCRIPTION
## Summary
- require a path-token boundary before workstation-local home path candidates
- keep file URLs and real standalone/compound workstation-local paths blocked
- add regression coverage for HTTP URL path false positives and file URL blocking

## Verification
- npx tsx --test src/workstation-local-paths.test.ts
- npm test -- src/workstation-local-paths.test.ts
- npm test -- src/post-turn-pull-request.test.ts
- npm run verify:paths
- npm run build

Closes #1896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boundary checks to avoid false positives when path-like strings appear inside URLs; retains blocking for workstation home paths in file:// contexts across Linux, macOS, and Windows.
* **Tests**
  * Added tests covering HTTP/HTTPS ignores, file:// blocking, and delimiter/boundary behavior within compound tokens to ensure accurate detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->