### PR TITLE
Fix Codex profile CodeRabbit status isolation

### DIFF
--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -903,6 +903,43 @@ test("buildConfiguredBotReviewSummary treats current-head CodeRabbit status cont
   });
 });
 
+test("buildConfiguredBotReviewSummary ignores CodeRabbit status contexts when only Codex Connector is configured", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [],
+    statusContexts: [
+      {
+        creatorLogin: "coderabbitai",
+        context: "CodeRabbit",
+        description: "CodeRabbit finished preparing its review.",
+        state: "SUCCESS",
+        createdAt: "2026-03-13T02:04:00Z",
+        commitOid: "head-44",
+      },
+    ],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: null,
+    currentHeadStatusState: null,
+    currentHeadCiGreenAt: null,
+    rateLimitWarningAt: null,
+    draftSkipAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary scopes current-head status state to CodeRabbit-specific contexts", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -91,6 +91,10 @@ function isCodeRabbitLogin(value: string | null | undefined): boolean {
   return (normalizeLogin(value) ?? "").includes("coderabbit");
 }
 
+function hasConfiguredCodeRabbitLogin(configuredReviewBots: Set<string>): boolean {
+  return Array.from(configuredReviewBots).some((login) => isCodeRabbitLogin(login));
+}
+
 function isConfiguredBotStatusContextActivity(args: {
   creatorLogin: string | null | undefined;
   context: string | null | undefined;
@@ -104,7 +108,10 @@ function isConfiguredBotStatusContextActivity(args: {
 
   const normalizedContext = (args.context ?? "").trim().toLowerCase();
   const normalizedDescription = (args.description ?? "").trim().toLowerCase();
-  return normalizedContext.includes("coderabbit") || normalizedDescription.includes("coderabbit");
+  return (
+    hasConfiguredCodeRabbitLogin(args.configuredReviewBots) &&
+    (normalizedContext.includes("coderabbit") || normalizedDescription.includes("coderabbit"))
+  );
 }
 
 function isCodeRabbitStatusContext(args: {


### PR DESCRIPTION
## Summary
- require a configured CodeRabbit login before CodeRabbit status context text can count as configured-bot current-head activity
- add a regression proving Codex-only profiles ignore CodeRabbit SUCCESS status contexts
- preserve existing CodeRabbit-profile status-context behavior

## Verification
- npx tsx --test src/github/github-review-signals.test.ts
- npx tsx --test src/pull-request-state-provider-wait-policy.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts
- npm run build

Closes #1898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering logic for configured review bot signals to ensure review status updates are only recognized from properly configured bots.

* **Tests**
  * Expanded test coverage for review signal filtering scenarios with different bot configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->