### PR TITLE
Fix path hygiene scan for gitlink entries

### DIFF
--- a/src/workstation-local-paths.test.ts
+++ b/src/workstation-local-paths.test.ts
@@ -525,6 +525,44 @@ test("findForbiddenWorkstationLocalPaths skips tracked files omitted by sparse c
   );
 });
 
+test("findForbiddenWorkstationLocalPaths skips gitlink entries whose worktree path is a directory", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  const docsPath = path.join(repoPath, "docs", "guide.md");
+  const gitlinkPath = ".oh-my-opencode";
+  await fs.mkdir(path.dirname(docsPath), { recursive: true });
+  await fs.writeFile(docsPath, `Visible leak: ${buildUnixHomePath("alice", "dev", "private-repo")}\n`, "utf8");
+  git(repoPath, "add", "docs/guide.md");
+  git(repoPath, "update-index", "--add", "--cacheinfo", `160000,${git(repoPath, "rev-parse", "HEAD").trim()},${gitlinkPath}`);
+  await fs.mkdir(path.join(repoPath, gitlinkPath), { recursive: true });
+
+  assert.match(git(repoPath, "ls-files", "-s", gitlinkPath).trimEnd(), /^160000 [0-9a-f]{40} 0\t\.oh-my-opencode$/u);
+
+  const findings = await findForbiddenWorkstationLocalPaths(repoPath);
+
+  assert.deepEqual(
+    findings.map((finding) => ({
+      filePath: finding.filePath,
+      line: finding.line,
+      prefix: finding.prefix,
+      reason: finding.reason,
+      match: finding.match,
+    })),
+    [
+      {
+        filePath: "docs/guide.md",
+        line: 1,
+        prefix: "/home/<user>/",
+        reason: "Linux user home directory",
+        match: buildUnixHomePath("alice", "dev", "private-repo"),
+      },
+    ],
+  );
+});
+
 test("findForbiddenWorkstationLocalPaths flags tracked supervisor-generated artifacts by path", async (t) => {
   const repoPath = await createTrackedRepo();
   t.after(async () => {

--- a/src/workstation-local-paths.ts
+++ b/src/workstation-local-paths.ts
@@ -144,8 +144,13 @@ export function classifyWorkstationLocalPathCandidate(candidate: string): Workst
   };
 }
 
-function gitTrackedFiles(workspacePath: string): string[] {
-  const result = spawnSync("git", ["-C", workspacePath, "ls-files", "-z"], {
+interface GitTrackedEntry {
+  filePath: string;
+  mode: string;
+}
+
+function gitTrackedEntries(workspacePath: string): GitTrackedEntry[] {
+  const result = spawnSync("git", ["-C", workspacePath, "ls-files", "-s", "-z"], {
     encoding: "utf8",
   });
   if (result.status !== 0) {
@@ -155,7 +160,22 @@ function gitTrackedFiles(workspacePath: string): string[] {
   return result.stdout
     .split("\0")
     .filter((entry) => entry.length > 0)
-    .map((entry) => normalizeRepoRelativePath(entry));
+    .map((entry) => {
+      const tabIndex = entry.indexOf("\t");
+      if (tabIndex < 0) {
+        throw new Error(`unexpected git ls-files entry format: ${entry}`);
+      }
+      const metadata = entry.slice(0, tabIndex);
+      const [mode] = metadata.split(" ");
+      if (!mode) {
+        throw new Error(`unexpected git ls-files entry metadata: ${metadata}`);
+      }
+
+      return {
+        filePath: normalizeRepoRelativePath(entry.slice(tabIndex + 1)),
+        mode,
+      };
+    });
 }
 
 function isBinary(contents: Buffer): boolean {
@@ -382,13 +402,16 @@ export async function findForbiddenWorkstationLocalPaths(
     publishablePathAllowlistMarkers?: readonly string[];
   },
 ): Promise<WorkstationLocalPathMatch[]> {
-  const trackedFiles = gitTrackedFiles(workspacePath);
+  const trackedEntries = gitTrackedEntries(workspacePath);
   const normalizedExcludedPaths = new Set([...excludedPaths].map((entry) => normalizeRepoRelativePath(entry)));
   const publishablePathAllowlistMarkers = options?.publishablePathAllowlistMarkers ?? [];
   const findings: WorkstationLocalPathMatch[] = [];
 
-  for (const filePath of trackedFiles) {
+  for (const { filePath, mode } of trackedEntries) {
     if (normalizedExcludedPaths.has(filePath)) {
+      continue;
+    }
+    if (mode === "160000") {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- parse tracked entries from `git ls-files -s -z` so the path hygiene scanner can see Git modes
- skip `160000` gitlink entries before reading file contents
- add a focused regression with a gitlink directory while confirming ordinary tracked text leaks are still reported

Fixes #1900

## Verification
- `npx tsx --test src/workstation-local-paths.test.ts`
- `npx tsx --test src/post-turn-pull-request.test.ts`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workstation path scanning to correctly skip linked repository entries during forbidden path detection.

* **Tests**
  * Added test coverage for proper handling of linked repositories in path scanning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->