### PR TITLE
Recover Codex PR comment timeout signals

### DIFF
--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -336,6 +336,7 @@ export function applyConfiguredBotReviewSummary(
     copilotReviewRequestedAt: summary?.lifecycle.requestedAt ?? null,
     copilotReviewArrivedAt: summary?.lifecycle.arrivedAt ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
+    configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,
     currentHeadCiGreenAt: summary?.currentHeadCiGreenAt ?? null,
     configuredBotRateLimitedAt: summary?.rateLimitWarningAt ?? null,

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -812,6 +812,57 @@ test("GitHubPullRequestHydrator extends current-head observation with later acti
   assert.equal(observedAt, "2026-03-13T02:04:00Z");
 });
 
+test("GitHubPullRequestHydrator maps Codex Connector PR conversation success comments to current-head observations", async () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [],
+                },
+                comments: {
+                  nodes: [
+                    {
+                      createdAt: "2026-05-08T03:24:00Z",
+                      body: "Codex review completed successfully for this pull request. No issues found.",
+                      author: {
+                        login: "chatgpt-codex-connector",
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+
+  assert.equal(pr?.configuredBotCurrentHeadObservedAt, "2026-05-08T03:24:00Z");
+  assert.equal(pr?.configuredBotCurrentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(pr?.copilotReviewArrivedAt, null);
+});
+
 test("GitHubPullRequestHydrator extends current-head observation with later weakly anchored CodeRabbit review comments", async () => {
   const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
   const hydrator = new GitHubPullRequestHydrator(config, async (args) => {

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -60,6 +60,7 @@ class ConfiguredBotReviewSummaryCache {
         lifecycle: { state: "not_requested", requestedAt: null, arrivedAt: null },
         topLevelReview: { strength: null, submittedAt: null },
         currentHeadObservedAt: null,
+        currentHeadObservationSource: null,
         currentHeadStatusState: null,
         currentHeadCiGreenAt: null,
         rateLimitWarningAt: null,

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1002,13 +1002,18 @@ test("buildConfiguredBotReviewSummary rejects non-success and non-configured PR 
         body: "Codex is still reviewing this pull request.",
       },
       {
-        authorLogin: "codex",
+        authorLogin: "chatgpt-codex-connector",
         createdAt: "2026-05-08T03:25:00Z",
+        body: "Review completed. Critical issues found.",
+      },
+      {
+        authorLogin: "codex",
+        createdAt: "2026-05-08T03:26:00Z",
         body: "Codex review completed successfully for this pull request. No issues found.",
       },
       {
         authorLogin: "coderabbitai[bot]",
-        createdAt: "2026-05-08T03:26:00Z",
+        createdAt: "2026-05-08T03:27:00Z",
         body: "Codex review completed successfully for this pull request. No issues found.",
       },
     ],

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -342,6 +342,7 @@ test("buildConfiguredBotReviewSummary treats actionable configured-bot issue com
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -382,6 +383,7 @@ test("buildConfiguredBotReviewSummary keeps top-level review strength scoped to 
       submittedAt: "2026-03-13T02:03:04Z",
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -415,6 +417,7 @@ test("buildConfiguredBotReviewSummary treats configured-bot rate limit issue com
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: "2026-03-13T03:15:00Z",
@@ -459,6 +462,7 @@ test("buildConfiguredBotReviewSummary records draft-skip issue comments distinct
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -503,6 +507,7 @@ test("buildConfiguredBotReviewSummary ignores configured-bot draft-skip signals 
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -547,6 +552,7 @@ test("buildConfiguredBotReviewSummary ignores configured-bot rate limit warnings
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -600,6 +606,7 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadObservationSource: "review_thread_comment",
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -642,6 +649,7 @@ test("buildConfiguredBotReviewSummary treats summary-only configured-bot reviews
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:02:00Z",
+    currentHeadObservationSource: "review",
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -688,6 +696,7 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadObservationSource: "review_thread_comment",
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -729,6 +738,7 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadObservationSource: "review_thread_comment",
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -770,6 +780,7 @@ test("buildConfiguredBotReviewSummary keeps weakly anchored CodeRabbit review co
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -811,6 +822,7 @@ test("buildConfiguredBotReviewSummary ignores late configured-bot closed-PR foll
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:02:00Z",
+    currentHeadObservationSource: "review",
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -852,6 +864,7 @@ test("buildConfiguredBotReviewSummary leaves current-head observation empty when
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -896,6 +909,7 @@ test("buildConfiguredBotReviewSummary treats current-head CodeRabbit status cont
       submittedAt: null,
     },
     currentHeadObservedAt: "2026-03-13T02:04:00Z",
+    currentHeadObservationSource: "status_context",
     currentHeadStatusState: "SUCCESS",
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -933,6 +947,87 @@ test("buildConfiguredBotReviewSummary ignores CodeRabbit status contexts when on
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
+    currentHeadStatusState: null,
+    currentHeadCiGreenAt: null,
+    rateLimitWarningAt: null,
+    draftSkipAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary treats Codex Connector PR conversation success comments as current-head observations", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-05-08T03:24:00Z",
+        body: "Codex review completed successfully for this pull request. No issues found.",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-05-08T03:24:00Z",
+    currentHeadObservationSource: "codex_pr_success_comment",
+    currentHeadStatusState: null,
+    currentHeadCiGreenAt: null,
+    rateLimitWarningAt: null,
+    draftSkipAt: null,
+  });
+});
+
+test("buildConfiguredBotReviewSummary rejects non-success and non-configured PR conversation comments as Codex Connector observations", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-05-08T03:24:00Z",
+        body: "Codex is still reviewing this pull request.",
+      },
+      {
+        authorLogin: "codex",
+        createdAt: "2026-05-08T03:25:00Z",
+        body: "Codex review completed successfully for this pull request. No issues found.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-05-08T03:26:00Z",
+        body: "Codex review completed successfully for this pull request. No issues found.",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,
@@ -1041,6 +1136,7 @@ test("buildConfiguredBotReviewSummary records the current-head CI-green timestam
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: "2026-03-13T02:05:00Z",
     rateLimitWarningAt: null,
@@ -1096,6 +1192,7 @@ test("buildConfiguredBotReviewSummary leaves current-head CI-green timestamp emp
       submittedAt: null,
     },
     currentHeadObservedAt: null,
+    currentHeadObservationSource: null,
     currentHeadStatusState: null,
     currentHeadCiGreenAt: null,
     rateLimitWarningAt: null,

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -191,7 +191,7 @@ function isCodexConnectorPrSuccessCommentText(value: string | null | undefined):
   const mentionsCompletion = /\b(successfully completed|completed successfully|review completed|finished review|review is complete|reviewed this pull request)\b/.test(
     normalized,
   );
-  const mentionsSuccess = /\b(success|successful|complete|completed|no issues found|no actionable issues|looks good)\b/.test(normalized);
+  const mentionsSuccess = /\b(success|successful|no issues found|no actionable issues|looks good)\b/.test(normalized);
 
   return mentionsReviewScope && mentionsCompletion && mentionsSuccess;
 }

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -67,11 +67,19 @@ export interface ConfiguredBotReviewSummary {
   lifecycle: CopilotReviewLifecycle;
   topLevelReview: ConfiguredBotTopLevelReviewSummary;
   currentHeadObservedAt: string | null;
+  currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
   currentHeadStatusState: string | null;
   currentHeadCiGreenAt: string | null;
   rateLimitWarningAt: string | null;
   draftSkipAt: string | null;
 }
+
+export type ConfiguredBotCurrentHeadObservationSource =
+  | "review"
+  | "review_thread_comment"
+  | "status_context"
+  | "codex_pr_success_comment"
+  | null;
 
 function parseTimestamp(value: string | null | undefined): number {
   if (!value) {
@@ -89,6 +97,10 @@ function normalizeLogin(value: string | null | undefined): string | null {
 
 function isCodeRabbitLogin(value: string | null | undefined): boolean {
   return (normalizeLogin(value) ?? "").includes("coderabbit");
+}
+
+function isCodexConnectorLogin(value: string | null | undefined): boolean {
+  return normalizeLogin(value) === "chatgpt-codex-connector";
 }
 
 function hasConfiguredCodeRabbitLogin(configuredReviewBots: Set<string>): boolean {
@@ -167,6 +179,21 @@ function latestTimestamp(values: Array<string | null | undefined>): string | nul
   }
 
   return latest;
+}
+
+function isCodexConnectorPrSuccessCommentText(value: string | null | undefined): boolean {
+  const normalized = value?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
+  if (!normalized) {
+    return false;
+  }
+
+  const mentionsReviewScope = /\b(review|reviewed|analysis|checked|pull request|pr)\b/.test(normalized);
+  const mentionsCompletion = /\b(successfully completed|completed successfully|review completed|finished review|review is complete|reviewed this pull request)\b/.test(
+    normalized,
+  );
+  const mentionsSuccess = /\b(success|successful|complete|completed|no issues found|no actionable issues|looks good)\b/.test(normalized);
+
+  return mentionsReviewScope && mentionsCompletion && mentionsSuccess;
 }
 
 function summarizeConfiguredBotRequestWindow(
@@ -333,59 +360,79 @@ function inferConfiguredBotTopLevelReviewSummary(
   return latestConfiguredReview;
 }
 
-function inferConfiguredBotCurrentHeadObservedAt(
+function inferConfiguredBotCurrentHeadObservation(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
   currentHeadOid: string | null | undefined,
-): string | null {
+): { observedAt: string | null; source: ConfiguredBotCurrentHeadObservationSource } {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
-    return null;
+    return { observedAt: null, source: null };
   }
 
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
-    return null;
+    return { observedAt: null, source: null };
   }
 
-  const currentHeadReviewTimes = facts.reviews.flatMap((review) => {
+  const currentHeadObservations: Array<{ observedAt: string | null | undefined; source: NonNullable<ConfiguredBotCurrentHeadObservationSource> }> = [];
+  for (const review of facts.reviews) {
     const authorLogin = normalizeLogin(review.authorLogin);
-    return authorLogin &&
+    if (
+      authorLogin &&
       configuredReviewBots.has(authorLogin) &&
       review.commitOid === normalizedCurrentHeadOid
-      ? [review.submittedAt]
-      : [];
-  });
+    ) {
+      currentHeadObservations.push({ observedAt: review.submittedAt, source: "review" });
+    }
+  }
 
-  const currentHeadCommentTimes = facts.comments.flatMap((comment) => {
+  for (const comment of facts.comments) {
     const authorLogin = normalizeLogin(comment.authorLogin);
-    return authorLogin &&
+    if (
+      authorLogin &&
       configuredReviewBots.has(authorLogin) &&
       comment.originalCommitOid === normalizedCurrentHeadOid
-      ? [comment.createdAt]
-      : [];
-  });
-
-  const currentHeadStatusContextTimes = (facts.statusContexts ?? []).flatMap((statusContext) =>
-    statusContext.commitOid === normalizedCurrentHeadOid &&
-    isConfiguredBotStatusContextActivity({
-      creatorLogin: statusContext.creatorLogin,
-      context: statusContext.context,
-      description: statusContext.description,
-      configuredReviewBots,
-    })
-      ? [statusContext.createdAt]
-      : [],
-  );
-
-  const latestStrongCurrentHeadObservedAt = latestTimestamp([
-    ...currentHeadReviewTimes,
-    ...currentHeadCommentTimes,
-    ...currentHeadStatusContextTimes,
-  ]);
-  if (!latestStrongCurrentHeadObservedAt) {
-    return null;
+    ) {
+      currentHeadObservations.push({ observedAt: comment.createdAt, source: "review_thread_comment" });
+    }
   }
+
+  for (const statusContext of facts.statusContexts ?? []) {
+    if (
+      statusContext.commitOid === normalizedCurrentHeadOid &&
+      isConfiguredBotStatusContextActivity({
+        creatorLogin: statusContext.creatorLogin,
+        context: statusContext.context,
+        description: statusContext.description,
+        configuredReviewBots,
+      })
+    ) {
+      currentHeadObservations.push({ observedAt: statusContext.createdAt, source: "status_context" });
+    }
+  }
+
+  if (configuredReviewBots.has("chatgpt-codex-connector")) {
+    for (const comment of facts.issueComments) {
+      const authorLogin = normalizeLogin(comment.authorLogin);
+      if (
+        authorLogin &&
+        isCodexConnectorLogin(authorLogin) &&
+        isCodexConnectorPrSuccessCommentText(comment.body)
+      ) {
+        currentHeadObservations.push({ observedAt: comment.createdAt, source: "codex_pr_success_comment" });
+      }
+    }
+  }
+
+  const latestStrongCurrentHeadObservedAt = latestTimestamp(currentHeadObservations.map((observation) => observation.observedAt));
+  if (!latestStrongCurrentHeadObservedAt) {
+    return { observedAt: null, source: null };
+  }
+  const latestStrongCurrentHeadObservationSource =
+    currentHeadObservations
+      .filter((observation) => observation.observedAt === latestStrongCurrentHeadObservedAt)
+      .at(-1)?.source ?? null;
 
   const latestStrongCurrentHeadObservedAtMs = parseTimestamp(latestStrongCurrentHeadObservedAt);
   const weaklyAnchoredCodeRabbitCommentTimes = facts.comments.flatMap((comment) => {
@@ -408,11 +455,16 @@ function inferConfiguredBotCurrentHeadObservedAt(
       : [];
   });
 
-  return latestTimestamp([
+  const latestObservedAt = latestTimestamp([
     latestStrongCurrentHeadObservedAt,
     ...weaklyAnchoredCodeRabbitCommentTimes,
     ...followUpIssueCommentTimes,
   ]);
+
+  return {
+    observedAt: latestObservedAt,
+    source: latestObservedAt === latestStrongCurrentHeadObservedAt ? latestStrongCurrentHeadObservationSource : "review_thread_comment",
+  };
 }
 
 function inferConfiguredBotCurrentHeadStatusState(
@@ -581,10 +633,12 @@ export function buildConfiguredBotReviewSummary(
   reviewBotLogins: string[],
   currentHeadOid?: string | null,
 ): ConfiguredBotReviewSummary {
+  const currentHeadObservation = inferConfiguredBotCurrentHeadObservation(facts, reviewBotLogins, currentHeadOid);
   return {
     lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
     topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
-    currentHeadObservedAt: inferConfiguredBotCurrentHeadObservedAt(facts, reviewBotLogins, currentHeadOid),
+    currentHeadObservedAt: currentHeadObservation.observedAt,
+    currentHeadObservationSource: currentHeadObservation.source,
     currentHeadStatusState: inferConfiguredBotCurrentHeadStatusState(facts, reviewBotLogins, currentHeadOid),
     currentHeadCiGreenAt: inferCurrentHeadCiGreenAt(facts, currentHeadOid),
     rateLimitWarningAt: inferConfiguredBotRateLimitWarningAt(facts, reviewBotLogins),

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -33,6 +33,7 @@ export interface GitHubPullRequest {
   copilotReviewRequestedAt?: string | null;
   copilotReviewArrivedAt?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
+  configuredBotCurrentHeadObservationSource?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;
   currentHeadCiGreenAt?: string | null;
   configuredBotRateLimitedAt?: string | null;

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -331,6 +331,23 @@ function validTimestamp(value: string | null | undefined): string | null {
   return Number.isNaN(Date.parse(value)) ? null : value;
 }
 
+function currentHeadObservationSatisfiesActiveWait(
+  record: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">,
+  pr: GitHubPullRequest,
+): boolean {
+  if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
+    return true;
+  }
+
+  const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  const waitStartedAt = validTimestamp(record.review_wait_started_at);
+  if (!observedAt || !waitStartedAt || record.review_wait_head_sha !== pr.headRefOid) {
+    return false;
+  }
+
+  return Date.parse(observedAt) >= Date.parse(waitStartedAt);
+}
+
 function shouldWaitForConfiguredBotInitialGracePeriod(
   config: SupervisorConfig,
   pr: GitHubPullRequest,
@@ -512,7 +529,11 @@ function configuredBotCurrentHeadSignalWaitStartAt(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
 ): string | null {
-  if (!requiresConfiguredBotCurrentHeadSignal(config) || pr.isDraft || validTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
+  if (
+    !requiresConfiguredBotCurrentHeadSignal(config) ||
+    pr.isDraft ||
+    (validTimestamp(pr.configuredBotCurrentHeadObservedAt) && currentHeadObservationSatisfiesActiveWait(record, pr))
+  ) {
     return null;
   }
 

--- a/src/pull-request-state-provider-wait-policy.test.ts
+++ b/src/pull-request-state-provider-wait-policy.test.ts
@@ -175,6 +175,78 @@ test("inferStateFromPullRequest fails closed for Codex Connector when current-he
   });
 });
 
+test("inferStateFromPullRequest fails closed for stale Codex Connector PR conversation success comments before the active wait", () => {
+  withStubbedDateNow("2026-05-08T03:30:00Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "block",
+    });
+    const record = createRecord({
+      state: "pr_open",
+      last_head_sha: "head-pr-4",
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: "head-pr-4",
+    });
+
+    const pr = createPullRequest({
+      number: 4,
+      createdAt: "2026-05-08T03:00:00Z",
+      headRefOid: "head-pr-4",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-05-08T03:08:00Z",
+      configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+      configuredBotTopLevelReviewSubmittedAt: null,
+    });
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, [], []), "blocked");
+    assert.equal(blockedReasonFromReviewState(config, record, pr, [], []), "review_bot_timeout");
+  });
+});
+
+test("inferStateFromPullRequest accepts Codex Connector PR conversation success comments after the active wait", () => {
+  withStubbedDateNow("2026-05-08T03:30:00Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "block",
+    });
+    const record = createRecord({
+      state: "pr_open",
+      last_head_sha: "head-pr-4",
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: "head-pr-4",
+    });
+
+    const pr = createPullRequest({
+      number: 4,
+      createdAt: "2026-05-08T03:00:00Z",
+      headRefOid: "head-pr-4",
+      isDraft: false,
+      reviewDecision: null,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      copilotReviewState: "not_requested",
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-05-08T03:24:00Z",
+      configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+      configuredBotTopLevelReviewSubmittedAt: null,
+    });
+
+    assert.equal(inferStateFromPullRequest(config, record, pr, [], []), "ready_to_merge");
+    assert.equal(blockedReasonFromReviewState(config, record, pr, [], []), null);
+  });
+});
+
 test("inferStateFromPullRequest allows merge after the Copilot propagation grace window expires", () => {
   withStubbedDateNow("2026-03-13T05:42:42Z", () => {
     const config = createConfig({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -523,6 +523,100 @@ test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tr
   assert.match(recoveryEvents[0]?.reason ?? "", /tracked_pr_lifecycle_recovered/);
 });
 
+test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tracked PR after late Codex Connector PR comment success", async () => {
+  const record = createReviewBotTimeoutTrackedPrRecord();
+  const state: SupervisorStateFile = createSupervisorState({ issues: [record] });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async () => createTrackedPrRecoveryPullRequest({
+        configuredBotCurrentHeadObservedAt: "2026-03-13T00:13:00Z",
+        configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+      }),
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:14:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createCodexConnectorRecoveryConfig(),
+    [],
+  );
+
+  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["366"]?.state, "ready_to_merge");
+  assert.equal(state.issues["366"]?.blocked_reason, null);
+  assert.match(recoveryEvents[0]?.reason ?? "", /tracked_pr_lifecycle_recovered/);
+});
+
+test("reconcileTrackedMergedButOpenIssues leaves review_bot_timeout blocked for stale Codex Connector PR comment success", async () => {
+  const record = createReviewBotTimeoutTrackedPrRecord();
+  const state: SupervisorStateFile = createSupervisorState({ issues: [record] });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async () => createTrackedPrRecoveryPullRequest({
+        configuredBotCurrentHeadObservedAt: "2026-03-12T23:59:00Z",
+        configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+      }),
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-03-13T00:14:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    createCodexConnectorRecoveryConfig(),
+    [],
+  );
+
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+  assert.equal(state.issues["366"]?.state, "blocked");
+  assert.equal(state.issues["366"]?.blocked_reason, "review_bot_timeout");
+});
+
 test("reconcileTrackedMergedButOpenIssues leaves review_bot_timeout blocked when late provider signal is on a changed head", async () => {
   const record = createReviewBotTimeoutTrackedPrRecord();
   const state: SupervisorStateFile = createSupervisorState({ issues: [record] });

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -224,6 +224,24 @@ test("reviewBotDiagnostics tracks observed review signal precedence", () => {
 
   assert.deepEqual(
     reviewBotDiagnostics(
+      config,
+      createRecord(),
+      createPr({
+        configuredBotCurrentHeadObservedAt: "2026-05-08T03:24:00Z",
+        configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+      }),
+      [],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "review_signal_observed",
+      observedReview: "codex_pr_success_comment",
+      nextCheck: "none",
+    },
+  );
+
+  assert.deepEqual(
+    reviewBotDiagnostics(
       createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
       createRecord(),
       createPr({ copilotReviewState: "requested" }),

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -377,6 +377,10 @@ export function summarizeObservedReviewSignal(
     return { observedReview: "external_review_record", hasSignal: true };
   }
 
+  if (pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" && pr.configuredBotCurrentHeadObservedAt) {
+    return { observedReview: "codex_pr_success_comment", hasSignal: true };
+  }
+
   const lifecycleState = pr.copilotReviewState ?? "not_requested";
   if (lifecycleState === "arrived") {
     return { observedReview: "copilot_arrived", hasSignal: true };


### PR DESCRIPTION
## Summary
- Recognize configured Codex Connector PR conversation success comments as a distinct current-head provider signal.
- Require Codex PR-comment observations to occur after the same-head active review wait before timeout recovery can use them.
- Add focused hydration, policy, recovery, and diagnostics coverage for the PR-comment signal shape.

## Verification
- npx tsx --test src/github/github-review-signals.test.ts
- npx tsx --test src/github/github-pull-request-hydrator.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/pull-request-state-provider-wait-policy.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npm run build
- node dist/index.js issue-lint 1906 --config <supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observation source tracking for configured bot reviews to identify how and where review signals originate.
  * Implemented support for recognizing Codex Connector review completion signals from PR conversation comments.
  * Enhanced review timeout logic to better handle observations based on their source and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->