### PR TITLE
Recognize live Codex Connector success comments

### DIFF
--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -863,6 +863,57 @@ test("GitHubPullRequestHydrator maps Codex Connector PR conversation success com
   assert.equal(pr?.copilotReviewArrivedAt, null);
 });
 
+test("GitHubPullRequestHydrator maps live Codex Connector no-major-issues comments with bot author suffix", async () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: {
+                  nodes: [],
+                },
+                reviews: {
+                  nodes: [],
+                },
+                comments: {
+                  nodes: [
+                    {
+                      createdAt: "2026-05-08T04:44:37Z",
+                      body: "Codex Review: Didn't find any major issues. :tada:",
+                      author: {
+                        login: "chatgpt-codex-connector[bot]",
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: {
+                  nodes: [],
+                },
+                timelineItems: {
+                  nodes: [],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+
+  assert.equal(pr?.configuredBotCurrentHeadObservedAt, "2026-05-08T04:44:37Z");
+  assert.equal(pr?.configuredBotCurrentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(pr?.copilotReviewArrivedAt, null);
+});
+
 test("GitHubPullRequestHydrator extends current-head observation with later weakly anchored CodeRabbit review comments", async () => {
   const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
   const hydrator = new GitHubPullRequestHydrator(config, async (args) => {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -999,7 +999,7 @@ test("buildConfiguredBotReviewSummary recognizes live Codex Connector no-major-i
       {
         authorLogin: "chatgpt-codex-connector[bot]",
         createdAt: "2026-05-08T04:43:37Z",
-        body: "Codex Review: no blocking issues.",
+        body: "Codex Review: no major issues found.",
       },
       {
         authorLogin: "chatgpt-codex-connector[bot]",
@@ -1050,6 +1050,11 @@ test("buildConfiguredBotReviewSummary rejects non-success and non-configured PR 
         authorLogin: "chatgpt-codex-connector",
         createdAt: "2026-05-08T03:25:30Z",
         body: "Codex Review: Found major issues that need changes.",
+      },
+      {
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-05-08T03:25:45Z",
+        body: "Codex Review: no major issues found, but found blocking problems.",
       },
       {
         authorLogin: "codex",

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -990,6 +990,46 @@ test("buildConfiguredBotReviewSummary treats Codex Connector PR conversation suc
   });
 });
 
+test("buildConfiguredBotReviewSummary recognizes live Codex Connector no-major-issues wording", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-05-08T04:43:37Z",
+        body: "Codex Review: no blocking issues.",
+      },
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-05-08T04:44:37Z",
+        body: "Codex Review: Didn't find any major issues. :tada:",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], "head-44"), {
+    lifecycle: {
+      state: "not_requested",
+      requestedAt: null,
+      arrivedAt: null,
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-05-08T04:44:37Z",
+    currentHeadObservationSource: "codex_pr_success_comment",
+    currentHeadStatusState: null,
+    currentHeadCiGreenAt: null,
+    rateLimitWarningAt: null,
+    draftSkipAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary rejects non-success and non-configured PR conversation comments as Codex Connector observations", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],
@@ -1005,6 +1045,11 @@ test("buildConfiguredBotReviewSummary rejects non-success and non-configured PR 
         authorLogin: "chatgpt-codex-connector",
         createdAt: "2026-05-08T03:25:00Z",
         body: "Review completed. Critical issues found.",
+      },
+      {
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-05-08T03:25:30Z",
+        body: "Codex Review: Found major issues that need changes.",
       },
       {
         authorLogin: "codex",

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -100,7 +100,12 @@ function isCodeRabbitLogin(value: string | null | undefined): boolean {
 }
 
 function isCodexConnectorLogin(value: string | null | undefined): boolean {
-  return normalizeLogin(value) === "chatgpt-codex-connector";
+  const normalized = normalizeLogin(value);
+  return normalized === "chatgpt-codex-connector" || normalized === "chatgpt-codex-connector[bot]";
+}
+
+function hasConfiguredCodexConnectorLogin(configuredReviewBots: Set<string>): boolean {
+  return Array.from(configuredReviewBots).some((login) => isCodexConnectorLogin(login));
 }
 
 function hasConfiguredCodeRabbitLogin(configuredReviewBots: Set<string>): boolean {
@@ -188,12 +193,28 @@ function isCodexConnectorPrSuccessCommentText(value: string | null | undefined):
   }
 
   const mentionsReviewScope = /\b(review|reviewed|analysis|checked|pull request|pr)\b/.test(normalized);
-  const mentionsCompletion = /\b(successfully completed|completed successfully|review completed|finished review|review is complete|reviewed this pull request)\b/.test(
-    normalized,
-  );
-  const mentionsSuccess = /\b(success|successful|no issues found|no actionable issues|looks good)\b/.test(normalized);
+  const reportsIssues =
+    /\b(?:found|identified|detected)\s+(?:\w+\s+){0,3}(?:issues?|problems?|concerns?)\b/.test(normalized) ||
+    /\b(?:critical|major|blocking|actionable)\s+(?:issues?|problems?|concerns?)\s+(?:found|identified|detected|reported)\b/.test(
+      normalized,
+    );
+  if (reportsIssues) {
+    return false;
+  }
 
-  return mentionsReviewScope && mentionsCompletion && mentionsSuccess;
+  const mentionsCompletion =
+    /\b(successfully completed|completed successfully|review completed|finished review|review is complete|reviewed this pull request)\b/.test(
+      normalized,
+    );
+  const mentionsSuccess = /\b(success|successful|no issues found|no actionable issues|looks good)\b/.test(normalized);
+  const mentionsNoIssueSuccess =
+    /\bno\s+(?:major|actionable|blocking|critical)\s+issues?\b/.test(normalized) ||
+    /\bno\s+(?:major|actionable|blocking|critical)?\s*issues?\s+(?:found|detected|identified|reported)\b/.test(normalized) ||
+    /\b(?:didn't|did not|doesn't|does not)\s+(?:find|detect|identify|see)\s+(?:any\s+)?(?:major|actionable|blocking|critical)?\s*issues?\b/.test(
+      normalized,
+    );
+
+  return mentionsReviewScope && ((mentionsCompletion && mentionsSuccess) || mentionsNoIssueSuccess);
 }
 
 function summarizeConfiguredBotRequestWindow(
@@ -412,7 +433,7 @@ function inferConfiguredBotCurrentHeadObservation(
     }
   }
 
-  if (configuredReviewBots.has("chatgpt-codex-connector")) {
+  if (hasConfiguredCodexConnectorLogin(configuredReviewBots)) {
     for (const comment of facts.issueComments) {
       const authorLogin = normalizeLogin(comment.authorLogin);
       if (

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -193,13 +193,30 @@ function isCodexConnectorPrSuccessCommentText(value: string | null | undefined):
   }
 
   const mentionsReviewScope = /\b(review|reviewed|analysis|checked|pull request|pr)\b/.test(normalized);
-  const reportsIssues =
-    /\b(?:found|identified|detected)\s+(?:\w+\s+){0,3}(?:issues?|problems?|concerns?)\b/.test(normalized) ||
-    /\b(?:critical|major|blocking|actionable)\s+(?:issues?|problems?|concerns?)\s+(?:found|identified|detected|reported)\b/.test(
+  const mentionsNoIssueSuccess =
+    /\bno\s+(?:major|actionable|blocking|critical)\s+issues?\b/.test(normalized) ||
+    /\bno\s+(?:major|actionable|blocking|critical)?\s*issues?\s+(?:found|detected|identified|reported)\b/.test(normalized) ||
+    /\b(?:didn't|did not|doesn't|does not)\s+(?:find|detect|identify|see)\s+(?:any\s+)?(?:major|actionable|blocking|critical)?\s*issues?\b/.test(
       normalized,
+    );
+  const issueReportText = normalized
+    .replace(/\bno\s+(?:major|actionable|blocking|critical)\s+issues?\b/g, " ")
+    .replace(/\bno\s+(?:major|actionable|blocking|critical)?\s*issues?\s+(?:found|detected|identified|reported)\b/g, " ")
+    .replace(
+      /\b(?:didn't|did not|doesn't|does not)\s+(?:find|detect|identify|see)\s+(?:any\s+)?(?:major|actionable|blocking|critical)?\s*issues?\b/g,
+      " ",
+    );
+
+  const reportsIssues =
+    /\b(?:found|identified|detected)\s+(?:\w+\s+){0,3}(?:issues?|problems?|concerns?)\b/.test(issueReportText) ||
+    /\b(?:critical|major|blocking|actionable)\s+(?:issues?|problems?|concerns?)\s+(?:found|identified|detected|reported)\b/.test(
+      issueReportText,
     );
   if (reportsIssues) {
     return false;
+  }
+  if (mentionsNoIssueSuccess) {
+    return mentionsReviewScope;
   }
 
   const mentionsCompletion =
@@ -207,14 +224,8 @@ function isCodexConnectorPrSuccessCommentText(value: string | null | undefined):
       normalized,
     );
   const mentionsSuccess = /\b(success|successful|no issues found|no actionable issues|looks good)\b/.test(normalized);
-  const mentionsNoIssueSuccess =
-    /\bno\s+(?:major|actionable|blocking|critical)\s+issues?\b/.test(normalized) ||
-    /\bno\s+(?:major|actionable|blocking|critical)?\s*issues?\s+(?:found|detected|identified|reported)\b/.test(normalized) ||
-    /\b(?:didn't|did not|doesn't|does not)\s+(?:find|detect|identify|see)\s+(?:any\s+)?(?:major|actionable|blocking|critical)?\s*issues?\b/.test(
-      normalized,
-    );
 
-  return mentionsReviewScope && ((mentionsCompletion && mentionsSuccess) || mentionsNoIssueSuccess);
+  return mentionsReviewScope && mentionsCompletion && mentionsSuccess;
 }
 
 function summarizeConfiguredBotRequestWindow(


### PR DESCRIPTION
## Summary
- Recognize the live Codex Connector success wording from PR conversations as a current-head provider signal.
- Treat both chatgpt-codex-connector and chatgpt-codex-connector[bot] as the configured Codex Connector identity.
- Keep issue-found, in-progress, non-configured, and unrelated bot comments rejected.

## Verification
- npx tsx --test src/github/github-review-signals.test.ts
- npx tsx --test src/github/github-pull-request-hydrator.test.ts
- npx tsx --test src/pull-request-state-provider-wait-policy.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npm run build
- git diff --check
- node dist/index.js issue-lint 1908 --config ../../../supervisor.config.json

Closes #1908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved detection of code review completion status from review comments
- Enhanced support for bot integrations with alternate naming conventions
- Refined pattern matching to better distinguish between reviews that found issues versus those completed without major findings

**Tests**
- Expanded test coverage for review signal detection with different bot configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->