### PR TITLE
Introduce Codex Connector provider profile boundary

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1146,7 +1146,7 @@ test("loadConfig maps reviewBotLogins into the internal configuredReviewProvider
       stateFile: "./state.json",
       codexBinary: "codex",
       branchPrefix: "codex/issue-",
-      reviewBotLogins: ["CodeRabbitAI", "coderabbitai[bot]", "chatgpt-codex-connector"],
+      reviewBotLogins: ["CodeRabbitAI", "coderabbitai[bot]", "chatgpt-codex-connector", "chatgpt-codex-connector[bot]"],
     }),
     "utf8",
   );

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -20,7 +20,7 @@ import {
 } from "../local-review/types";
 import { RunState } from "./types";
 import { DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH } from "./journal";
-import { mapConfiguredReviewProviders } from "./review-providers";
+import { mapConfiguredReviewProviders, normalizeReviewBotLogins } from "./review-providers";
 import { isValidGitRefName, resolveMaybeRelative } from "./utils";
 import { DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW } from "./config-constants";
 
@@ -535,11 +535,11 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
       : [],
     approvedTrackedTopLevelEntries: parseApprovedTrackedTopLevelEntries(raw.approvedTrackedTopLevelEntries),
     staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
-    reviewBotLogins: Array.isArray(raw.reviewBotLogins)
-      ? raw.reviewBotLogins
-          .filter((value): value is string => typeof value === "string" && value.trim() !== "")
-          .map((value) => value.trim().toLowerCase())
-      : ["copilot-pull-request-reviewer"],
+    reviewBotLogins: normalizeReviewBotLogins(
+      Array.isArray(raw.reviewBotLogins)
+        ? raw.reviewBotLogins.filter((value): value is string => typeof value === "string")
+        : ["copilot-pull-request-reviewer"],
+    ),
     configuredReviewProviders: mapConfiguredReviewProviders(
       Array.isArray(raw.reviewBotLogins)
         ? raw.reviewBotLogins.filter((value): value is string => typeof value === "string")

--- a/src/core/review-providers.test.ts
+++ b/src/core/review-providers.test.ts
@@ -99,6 +99,14 @@ test("mapConfiguredReviewProviders preserves compatibility with existing reviewB
       signalSource: "copilot_lifecycle",
     },
   ]);
+
+  assert.deepEqual(mapConfiguredReviewProviders(["chatgpt-codex-connector", "chatgpt-codex-connector[bot]"]), [
+    {
+      kind: "codex",
+      reviewerLogins: ["chatgpt-codex-connector"],
+      signalSource: "review_threads",
+    },
+  ]);
 });
 
 test("reviewProviderProfileFromConfig summarizes the mapped internal provider model", () => {
@@ -111,6 +119,16 @@ test("reviewProviderProfileFromConfig summarizes the mapped internal provider mo
 
   assert.deepEqual(
     reviewProviderProfileFromConfig(createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] })),
+    {
+      profile: "codex",
+      provider: "chatgpt-codex-connector",
+      reviewers: ["chatgpt-codex-connector"],
+      signalSource: "review_threads",
+    },
+  );
+
+  assert.deepEqual(
+    reviewProviderProfileFromConfig(createConfig({ reviewBotLogins: ["chatgpt-codex-connector[bot]"] })),
     {
       profile: "codex",
       provider: "chatgpt-codex-connector",

--- a/src/core/review-providers.ts
+++ b/src/core/review-providers.ts
@@ -6,6 +6,7 @@ import {
 
 const COPILOT_REVIEWER_LOGIN = "copilot-pull-request-reviewer";
 const CODEX_REVIEWER_LOGIN = "chatgpt-codex-connector";
+const CODEX_REVIEWER_LOGIN_ALIASES = [CODEX_REVIEWER_LOGIN, "chatgpt-codex-connector[bot]"] as const;
 const CODERABBIT_REVIEWER_LOGINS = ["coderabbitai", "coderabbitai[bot]"] as const;
 
 export type ReviewProviderProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
@@ -31,8 +32,27 @@ function trimReviewBotLogins(reviewBotLogins: string[]): string[] {
   return reviewBotLogins.map((login) => login.trim()).filter((login) => login.length > 0);
 }
 
+export function isCodexConnectorLogin(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return CODEX_REVIEWER_LOGIN_ALIASES.includes(normalized as (typeof CODEX_REVIEWER_LOGIN_ALIASES)[number]);
+}
+
+export function normalizeReviewProviderLogin(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (isCodexConnectorLogin(normalized)) {
+    return CODEX_REVIEWER_LOGIN;
+  }
+  return normalized;
+}
+
 export function normalizeReviewBotLogins(reviewBotLogins: string[]): string[] {
-  const normalized = trimReviewBotLogins(reviewBotLogins).map((login) => login.toLowerCase());
+  const normalized = trimReviewBotLogins(reviewBotLogins).flatMap((login) => {
+    const normalizedLogin = normalizeReviewProviderLogin(login);
+    return normalizedLogin ? [normalizedLogin] : [];
+  });
   return Array.from(new Set(normalized));
 }
 
@@ -40,7 +60,7 @@ function providerKindForLogin(login: string): ConfiguredReviewProviderKind {
   if (login === COPILOT_REVIEWER_LOGIN) {
     return "copilot";
   }
-  if (login === CODEX_REVIEWER_LOGIN) {
+  if (isCodexConnectorLogin(login)) {
     return "codex";
   }
   if (CODERABBIT_REVIEWER_LOGINS.includes(login as (typeof CODERABBIT_REVIEWER_LOGINS)[number])) {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -990,6 +990,55 @@ test("buildConfiguredBotReviewSummary treats Codex Connector PR conversation suc
   });
 });
 
+test("buildConfiguredBotReviewSummary normalizes Codex Connector bot aliases across config and activity", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: ["chatgpt-codex-connector[bot]"],
+    reviews: [
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        submittedAt: "2026-05-08T03:23:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "Nitpick: this branch still skips the provider guard.",
+      },
+    ],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-05-08T03:24:00Z",
+        body: "Codex review completed successfully for this pull request. No issues found.",
+      },
+    ],
+    statusContexts: [],
+    timeline: [
+      {
+        type: "requested",
+        createdAt: "2026-05-08T03:22:00Z",
+        reviewerLogin: "chatgpt-codex-connector[bot]",
+      },
+    ],
+  };
+
+  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector[bot]"], "head-44"), {
+    lifecycle: {
+      state: "arrived",
+      requestedAt: "2026-05-08T03:22:00Z",
+      arrivedAt: "2026-05-08T03:23:00Z",
+    },
+    topLevelReview: {
+      strength: null,
+      submittedAt: null,
+    },
+    currentHeadObservedAt: "2026-05-08T03:24:00Z",
+    currentHeadObservationSource: "codex_pr_success_comment",
+    currentHeadStatusState: null,
+    currentHeadCiGreenAt: null,
+    rateLimitWarningAt: null,
+    draftSkipAt: null,
+  });
+});
+
 test("buildConfiguredBotReviewSummary recognizes live Codex Connector no-major-issues wording", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -5,7 +5,11 @@ import {
   isDraftSkipReviewText,
   isRateLimitReviewText,
 } from "../external-review/external-review-signal-heuristics";
-import { normalizeReviewBotLogins } from "../core/review-providers";
+import {
+  isCodexConnectorLogin,
+  normalizeReviewBotLogins,
+  normalizeReviewProviderLogin,
+} from "../core/review-providers";
 import type { CopilotReviewState } from "./types";
 
 export interface CopilotReviewLifecycleFacts {
@@ -91,17 +95,11 @@ function parseTimestamp(value: string | null | undefined): number {
 }
 
 function normalizeLogin(value: string | null | undefined): string | null {
-  const trimmed = value?.trim().toLowerCase();
-  return trimmed ? trimmed : null;
+  return normalizeReviewProviderLogin(value);
 }
 
 function isCodeRabbitLogin(value: string | null | undefined): boolean {
   return (normalizeLogin(value) ?? "").includes("coderabbit");
-}
-
-function isCodexConnectorLogin(value: string | null | undefined): boolean {
-  const normalized = normalizeLogin(value);
-  return normalized === "chatgpt-codex-connector" || normalized === "chatgpt-codex-connector[bot]";
 }
 
 function hasConfiguredCodexConnectorLogin(configuredReviewBots: Set<string>): boolean {
@@ -237,19 +235,22 @@ function summarizeConfiguredBotRequestWindow(
   latestRemovedByBot: Map<string, string | null>;
 } {
   const requestedTimes = timeline
-    .filter((event) => event.type === "requested" && event.reviewerLogin && configuredReviewBots.has(event.reviewerLogin))
+    .filter((event) => {
+      const reviewerLogin = normalizeLogin(event.reviewerLogin);
+      return event.type === "requested" && reviewerLogin && configuredReviewBots.has(reviewerLogin);
+    })
     .map((event) => event.createdAt);
   const latestRequestedAt = latestTimestamp(requestedTimes);
 
   const activeRequestStarts = Array.from(configuredReviewBots).flatMap((botLogin) => {
     const botLatestRequestedAt = latestTimestamp(
       timeline
-        .filter((event) => event.type === "requested" && event.reviewerLogin === botLogin)
+        .filter((event) => event.type === "requested" && normalizeLogin(event.reviewerLogin) === botLogin)
         .map((event) => event.createdAt),
     );
     const botLatestRemovedAt = latestTimestamp(
       timeline
-        .filter((event) => event.type === "removed" && event.reviewerLogin === botLogin)
+        .filter((event) => event.type === "removed" && normalizeLogin(event.reviewerLogin) === botLogin)
         .map((event) => event.createdAt),
     );
 
@@ -265,7 +266,7 @@ function summarizeConfiguredBotRequestWindow(
       botLogin,
       latestTimestamp(
         timeline
-          .filter((event) => event.type === "removed" && event.reviewerLogin === botLogin)
+          .filter((event) => event.type === "removed" && normalizeLogin(event.reviewerLogin) === botLogin)
           .map((event) => event.createdAt),
       ),
     );

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -191,6 +191,13 @@ test("inferReviewBotProfile identifies configured provider patterns", () => {
       signalSource: "review_threads",
     },
   );
+
+  assert.deepEqual(inferReviewBotProfile(createConfig({ reviewBotLogins: ["chatgpt-codex-connector[bot]"] })), {
+    profile: "codex",
+    provider: "chatgpt-codex-connector",
+    reviewers: ["chatgpt-codex-connector"],
+    signalSource: "review_threads",
+  });
 });
 
 test("reviewBotDiagnostics tracks observed review signal precedence", () => {


### PR DESCRIPTION
## Summary
- normalize Codex Connector actor aliases through the shared review-provider boundary
- route config parsing and GitHub review signal login matching through the same provider login normalization
- add focused regression coverage for Codex/CodeRabbit profile isolation and Codex Connector PR signal handling

## Verification
- npx tsx --test src/core/review-providers.test.ts src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/config.test.ts
- npm run build
- git diff --check
- node dist/index.js issue-lint 1912 --config "/Users/tomoakikawada/Dev/codex-supervisor-self/supervisor.config.coderabbit.json"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of review bot login normalization to properly deduplicate and recognize bot account aliases (e.g., treating `chatgpt-codex-connector` and `chatgpt-codex-connector[bot]` as the same reviewer).

* **Tests**
  * Expanded test coverage to verify correct normalization and deduplication of bot login aliases across configuration parsing and review tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->