### PR TITLE
Enforce Codex Connector P-severity review blockers

### DIFF
--- a/src/external-review/external-review-normalization.test.ts
+++ b/src/external-review/external-review-normalization.test.ts
@@ -76,3 +76,59 @@ test("normalizeExternalReviewSignal shapes the selected configured-bot thread si
   assert.equal(finding?.severity, "medium");
   assert.equal(finding?.confidence, 0.75);
 });
+
+test("normalizeExternalReviewSignal treats Codex Connector P1 badge comments as high severity", () => {
+  const thread = createReviewThread({
+    path: "package.json",
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body:
+            "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Restore test execution in pre-PR verification**\n\nThe verification command no longer runs the test suite before merge.",
+          createdAt: "2026-03-12T00:00:00Z",
+          url: "https://example.test/pr/8#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const signal = toExternalReviewThreadSignal(thread, ["chatgpt-codex-connector[bot]"]);
+  const finding = signal ? normalizeExternalReviewSignal(signal) : null;
+
+  assert.equal(finding?.reviewerLogin, "chatgpt-codex-connector[bot]");
+  assert.equal(finding?.file, "package.json");
+  assert.match(finding?.summary ?? "", /P1 Badge/);
+  assert.equal(finding?.severity, "high");
+  assert.ok((finding?.confidence ?? 0) >= 0.9);
+});
+
+test("normalizeExternalReviewSignal treats Codex Connector textual P0 headings as high severity", () => {
+  const thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P0: Do not merge while the authorization bypass remains reachable.",
+          createdAt: "2026-03-12T00:00:00Z",
+          url: "https://example.test/pr/8#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const signal = toExternalReviewThreadSignal(thread, ["chatgpt-codex-connector"]);
+  const finding = signal ? normalizeExternalReviewSignal(signal) : null;
+
+  assert.equal(finding?.reviewerLogin, "chatgpt-codex-connector");
+  assert.equal(finding?.severity, "high");
+  assert.ok((finding?.confidence ?? 0) >= 0.9);
+});

--- a/src/external-review/external-review-normalization.ts
+++ b/src/external-review/external-review-normalization.ts
@@ -32,7 +32,32 @@ function summarizeComment(body: string): string {
   return truncate(sentence, 180) ?? "External review finding";
 }
 
-function inferSeverity(body: string): Exclude<LocalReviewSeverity, "none"> {
+export function isCodexConnectorReviewer(reviewerLogin: string): boolean {
+  return /^chatgpt-codex-connector(?:\[bot\])?$/iu.test(reviewerLogin);
+}
+
+export function extractCodexConnectorPSeverity(body: string): "P0" | "P1" | null {
+  const leadingBody = body.slice(0, 800);
+  const badgeLabel = leadingBody.match(/!\[[^\]]*\b(P[01])\b[^\]]*\]\([^)]*\)/iu)?.[1];
+  if (badgeLabel === "P0" || badgeLabel === "P1") {
+    return badgeLabel;
+  }
+
+  const shieldBadge = leadingBody.match(/https?:\/\/img\.shields\.io\/badge\/(P[01])(?:[-/?#)]|$)/iu)?.[1];
+  if (shieldBadge === "P0" || shieldBadge === "P1") {
+    return shieldBadge;
+  }
+
+  const textHeading = normalizeWhitespace(leadingBody.replace(/<[^>]+>/gu, " ").replace(/[*_`[\]]/gu, " "));
+  const headingLabel = textHeading.match(/^(?:#{1,6}\s*)?(P[01])(?:\s*[:\-]|\s+\b)/iu)?.[1];
+  return headingLabel === "P0" || headingLabel === "P1" ? headingLabel : null;
+}
+
+function inferSeverity(body: string, reviewerLogin: string): Exclude<LocalReviewSeverity, "none"> {
+  if (isCodexConnectorReviewer(reviewerLogin) && extractCodexConnectorPSeverity(body)) {
+    return "high";
+  }
+
   const normalized = body.toLowerCase();
   if (/\b(security|privilege|secret|panic|crash|corrupt|deadlock|critical|data loss)\b/.test(normalized)) {
     return "high";
@@ -45,7 +70,11 @@ function inferSeverity(body: string): Exclude<LocalReviewSeverity, "none"> {
   return "medium";
 }
 
-function inferConfidence(body: string): number {
+function inferConfidence(body: string, reviewerLogin: string): number {
+  if (isCodexConnectorReviewer(reviewerLogin) && extractCodexConnectorPSeverity(body)) {
+    return 0.95;
+  }
+
   const normalized = body.toLowerCase();
   if (/\b(will|can|break|fails?|throws?|incorrect|bug|missing|never|always)\b/.test(normalized)) {
     return 0.9;
@@ -77,8 +106,8 @@ export function normalizeExternalReviewSignal(
     line: signal.line,
     summary: summarizeComment(signal.body),
     rationale,
-    severity: inferSeverity(signal.body),
-    confidence: inferConfidence(signal.body),
+    severity: inferSeverity(signal.body, signal.reviewerLogin),
+    confidence: inferConfidence(signal.body, signal.reviewerLogin),
     url: signal.sourceUrl,
   };
 }

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -300,6 +300,43 @@ test("inferStateFromPullRequest allows one same-head follow-up turn after partia
   assert.equal(inferStateFromPullRequest(config, record, pr, [], [remainingThread]), "addressing_review");
 });
 
+test("inferStateFromPullRequest does not allow same-head follow-up for unresolved Codex Connector P1 findings", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head-a",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+    review_follow_up_head_sha: "head-a",
+    review_follow_up_remaining: 1,
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+  });
+  const p1Thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body:
+            "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Restore test execution in pre-PR verification**",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p1Thread]), "blocked");
+});
+
 test("inferStateFromPullRequest still blocks same-head configured bot threads when no follow-up progress was recorded", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { configuredBotReviewThreads, manualReviewThreads } from "./supervisor/supervisor-reporting";
-import { staleConfiguredBotReviewThreads } from "./review-thread-reporting";
+import {
+  buildStalledBotReviewFailureContext,
+  codexConnectorMustFixReviewThreads,
+  staleConfiguredBotReviewThreads,
+} from "./review-thread-reporting";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -222,4 +226,27 @@ test("staleConfiguredBotReviewThreads treats non-actionable same-head configured
   });
 
   assert.deepEqual(staleConfiguredBotReviewThreads(config, record, pr, [nonActionableSameHeadThread]), [nonActionableSameHeadThread]);
+});
+
+test("codexConnectorMustFixReviewThreads tracks unresolved P1 findings and reports their severity", () => {
+  const p1Thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body:
+            "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Restore test execution in pre-PR verification**",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(codexConnectorMustFixReviewThreads([p1Thread]), [p1Thread]);
+  assert.match(buildStalledBotReviewFailureContext([p1Thread])?.details[0] ?? "", /p_severity=P1/);
 });

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -2,6 +2,7 @@ import { hasProcessedReviewThread } from "./review-handling";
 import { configuredReviewBotLogins } from "./core/review-providers";
 import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
+import { extractCodexConnectorPSeverity, isCodexConnectorReviewer } from "./external-review/external-review-normalization";
 
 function isAllowedReviewBotThread(config: SupervisorConfig, thread: ReviewThread): boolean {
   const configuredLogins = new Set(configuredReviewBotLogins(config).map((login) => login.toLowerCase()));
@@ -24,6 +25,27 @@ export function latestReviewCommentAuthorIsAllowedBot(config: SupervisorConfig, 
 
   const configuredLogins = new Set(configuredReviewBotLogins(config).map((login) => login.toLowerCase()));
   return configuredLogins.has(latestLogin);
+}
+
+function latestCodexConnectorPSeverity(thread: ReviewThread): "P0" | "P1" | null {
+  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
+    const comment = thread.comments.nodes[index];
+    const login = comment.author?.login;
+    if (!login || !isCodexConnectorReviewer(login)) {
+      continue;
+    }
+
+    const pSeverity = extractCodexConnectorPSeverity(comment.body);
+    if (pSeverity) {
+      return pSeverity;
+    }
+  }
+
+  return null;
+}
+
+export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated && latestCodexConnectorPSeverity(thread));
 }
 
 function normalizeReviewCommentWhitespace(value: string): string {
@@ -49,9 +71,11 @@ function renderReviewThreadDetail(thread: ReviewThread, includeAuthor = false): 
   const latestComment = latestReviewComment(thread);
   const location = `${thread.path ?? "unknown"}:${thread.line ?? "?"}`;
   const author = includeAuthor ? ` reviewer=${latestComment?.author?.login ?? "unknown"}` : "";
+  const pSeverity = latestCodexConnectorPSeverity(thread);
+  const severity = pSeverity ? ` p_severity=${pSeverity}` : "";
   const summary = ` summary=${extractReviewCommentSummary(latestComment?.body ?? "")}`;
   const url = latestComment?.url ? ` url=${latestComment.url}` : "";
-  return `${location}${author}${summary}${url}`;
+  return `${location}${author}${severity}${summary}${url}`;
 }
 
 export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
@@ -111,10 +135,14 @@ export function configuredBotReviewFollowUpState(
   pr: Pick<GitHubPullRequest, "headRefOid">,
   reviewThreads: ReviewThread[],
 ): "inactive" | "eligible" | "exhausted" {
-  const unresolvedThreadCount = actionableConfiguredBotReviewThreads(config, reviewThreads).filter(
+  const unresolvedActionableThreads = actionableConfiguredBotReviewThreads(config, reviewThreads).filter(
     (thread) => !thread.isResolved && !thread.isOutdated,
-  ).length;
-  if (unresolvedThreadCount === 0 || record.review_follow_up_head_sha !== pr.headRefOid) {
+  );
+  if (
+    unresolvedActionableThreads.length === 0 ||
+    codexConnectorMustFixReviewThreads(unresolvedActionableThreads).length > 0 ||
+    record.review_follow_up_head_sha !== pr.headRefOid
+  ) {
     return "inactive";
   }
 
@@ -248,7 +276,9 @@ export function buildStalledBotReviewFailureContext(
   const details = reviewThreads.slice(0, 5).map((thread) => {
     const latestComment = latestReviewComment(thread);
     const author = latestComment?.author?.login ?? "unknown";
-    return `reviewer=${author} file=${thread.path ?? "unknown"} line=${thread.line ?? "?"} processed_on_current_head=yes`;
+    const pSeverity = latestCodexConnectorPSeverity(thread);
+    const severity = pSeverity ? ` p_severity=${pSeverity}` : "";
+    return `reviewer=${author} file=${thread.path ?? "unknown"} line=${thread.line ?? "?"}${severity} processed_on_current_head=yes`;
   });
 
   return {

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -18,6 +18,7 @@ import {
 } from "./review-handling";
 import {
   actionableConfiguredBotReviewThreads,
+  codexConnectorMustFixReviewThreads,
   configuredBotReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
 } from "./review-thread-reporting";
@@ -346,6 +347,9 @@ export function nextReviewFollowUpPatch(args: {
   const preRunConfiguredThreads = unresolvedConfiguredBotThreads(args.preRunReviewThreads);
   const postRunConfiguredThreads = unresolvedConfiguredBotThreads(args.postRunReviewThreads);
   if (postRunConfiguredThreads.length === 0) {
+    return defaultPatch;
+  }
+  if (codexConnectorMustFixReviewThreads(postRunConfiguredThreads).length > 0) {
     return defaultPatch;
   }
 


### PR DESCRIPTION
## Summary
- parse Codex Connector P0/P1 badge and heading labels as high-confidence high-severity findings
- keep unresolved Codex Connector P0/P1 threads out of same-head follow-up allowance
- include P severity in configured-bot blocker diagnostics

## Verification
- npx tsx --test src/external-review/external-review-normalization.test.ts
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts
- npx tsx --test src/review-thread-reporting.test.ts
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts
- npx tsx --test src/codex/codex-prompt.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build
- node dist/index.js issue-lint 1910 --config <supervisor-config-path>

Closes #1910