### PR TITLE
Add Codex Connector addressing-review prompt guidance

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -814,6 +814,50 @@ test("buildCodexPrompt suppresses stale handoff next actions during addressing_r
   assert.match(prompt, /Live review guidance should take priority over stale handoff steps\./);
 });
 
+test("buildCodexPrompt adds Codex Connector P0/P1 must-fix guidance only for Codex Connector addressing_review", () => {
+  const codexContext = {
+    kind: "start",
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "addressing_review" satisfies RunState,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext;
+
+  const codexPrompt = buildCodexPrompt(codexContext);
+
+  assert.match(codexPrompt, /Codex Connector review handling:/);
+  assert.match(codexPrompt, /P0\/P1 Codex Connector findings are supervisor-enforced must-fix findings\./);
+  assert.match(codexPrompt, /Same-head reply-only disagreement does not clear a P0\/P1 finding for merge readiness\./);
+  assert.match(codexPrompt, /make the smallest valid code fix and push a new PR head/);
+  assert.match(codexPrompt, /route it to the existing manual\/operator review path/);
+
+  const coderabbitContext = {
+    ...codexContext,
+    config: createConfig({
+      reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    }),
+  } satisfies AgentTurnContext;
+  const customContext = {
+    ...codexContext,
+    config: createConfig({
+      reviewBotLogins: ["custom-review-bot"],
+    }),
+  } satisfies AgentTurnContext;
+
+  assert.doesNotMatch(buildCodexPrompt(coderabbitContext), /Codex Connector review handling:/);
+  assert.doesNotMatch(buildCodexPrompt(customContext), /Codex Connector review handling:/);
+});
+
 test("buildCodexPrompt keeps explicit operator overrides during addressing_review", () => {
   const prompt = buildCodexPrompt({
     repoSlug: "owner/repo",

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -20,6 +20,7 @@ import type {
   ResumeAgentTurnContext,
   StartAgentTurnContext,
 } from "../supervisor/agent-runner";
+import { reviewProviderProfileFromConfig, type ReviewProviderProfileSummary } from "../core/review-providers";
 
 export interface LocalReviewRepairContext {
   repairIntent?: "same_pr_fix_blocked" | "same_pr_follow_up" | "same_pr_manual_review" | "high_severity_retry" | "unspecified";
@@ -210,6 +211,7 @@ export interface BuildCodexStartPromptInput {
   previousError?: string | null;
   localReviewRepairContext?: LocalReviewRepairContext | null;
   externalReviewMissContext?: ExternalReviewMissContext | null;
+  reviewProviderProfile?: ReviewProviderProfileSummary;
 }
 
 export interface BuildCodexResumePromptInput {
@@ -431,6 +433,16 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
             : ["- No saved external review miss artifact is available for the current PR head."]),
         ]
       : [];
+  const codexConnectorReviewGuidance =
+    input.state === "addressing_review" && input.reviewProviderProfile?.profile === "codex"
+      ? [
+          "Codex Connector review handling:",
+          "- P0/P1 Codex Connector findings are supervisor-enforced must-fix findings.",
+          "- Same-head reply-only disagreement does not clear a P0/P1 finding for merge readiness.",
+          "- If the finding is valid, make the smallest valid code fix and push a new PR head.",
+          "- If a P0/P1 finding conflicts with issue scope or appears unsafe to apply, route it to the existing manual/operator review path instead of self-dismissing it.",
+        ]
+      : [];
   const verificationPolicy = describeVerificationPolicy(
     summarizeChangeRiskDecision({
       issue: input.issue,
@@ -512,6 +524,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     failureSummary,
     ...(localReviewRepairSummary.length > 0 ? ["", ...localReviewRepairSummary] : []),
     ...(externalReviewMissSummary.length > 0 ? ["", ...externalReviewMissSummary] : []),
+    ...(codexConnectorReviewGuidance.length > 0 ? ["", ...codexConnectorReviewGuidance] : []),
     ...((input.alwaysReadFiles.length > 0 || input.onDemandMemoryFiles.length > 0)
       ? [
           "",
@@ -692,6 +705,7 @@ function toStartPromptInput(input: StartAgentTurnContext): BuildCodexStartPrompt
     previousError: input.previousError,
     localReviewRepairContext: input.localReviewRepairContext,
     externalReviewMissContext: input.externalReviewMissContext,
+    reviewProviderProfile: reviewProviderProfileFromConfig(input.config),
   };
 }
 


### PR DESCRIPTION
## Summary
- add Codex Connector-only addressing_review prompt guidance for P0/P1 must-fix handling
- pass the configured review provider profile into start prompt construction
- cover Codex Connector vs CodeRabbit/custom prompt behavior with a focused test

## Verification
- npx tsx --test src/codex/codex-prompt.test.ts
- npx tsx --test src/codex/codex-policy.test.ts
- npm run build
- node dist/index.js issue-lint 1913 --config /Users/tomoakikawada/Dev/codex-supervisor-self/supervisor.config.json