### PR TITLE
Add Codex Connector policy diagnostics

### DIFF
--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { configuredBotReviewThreads, manualReviewThreads } from "./supervisor/supervisor-reporting";
 import {
+  buildCodexConnectorPolicyBlockDiagnostic,
   buildStalledBotReviewFailureContext,
   codexConnectorMustFixReviewThreads,
   staleConfiguredBotReviewThreads,
@@ -249,4 +250,57 @@ test("codexConnectorMustFixReviewThreads tracks unresolved P1 findings and repor
 
   assert.deepEqual(codexConnectorMustFixReviewThreads([p1Thread]), [p1Thread]);
   assert.match(buildStalledBotReviewFailureContext([p1Thread])?.details[0] ?? "", /p_severity=P1/);
+});
+
+test("buildCodexConnectorPolicyBlockDiagnostic reports the highest-severity thread location", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const p1Thread = createReviewThread({
+    id: "thread-p1",
+    path: "src/policy.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p1",
+          body: "P1: Tighten the diagnostic wording before merge.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p0Thread = createReviewThread({
+    id: "thread-p0",
+    path: "src/auth.ts",
+    line: 24,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p0",
+          body: "P0: Keep the authorization bypass blocked.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(buildCodexConnectorPolicyBlockDiagnostic(config, [p1Thread, p0Thread]), {
+    count: 2,
+    severity: "P0",
+    file: "src/auth.ts",
+    line: "24",
+    threadUrl: "https://example.test/pr/44#discussion_r2",
+    nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+  });
 });

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -78,13 +78,15 @@ export function buildCodexConnectorPolicyBlockDiagnostic(
     return null;
   }
 
-  const firstThread = mustFixThreads[0];
-  const latestComment = latestReviewComment(firstThread);
+  const severity = maxCodexConnectorPSeverity(mustFixThreads);
+  const representativeThread =
+    mustFixThreads.find((thread) => latestCodexConnectorPSeverity(thread) === severity) ?? mustFixThreads[0];
+  const latestComment = latestReviewComment(representativeThread);
   return {
     count: mustFixThreads.length,
-    severity: maxCodexConnectorPSeverity(mustFixThreads),
-    file: formatDiagnosticToken(firstThread.path ?? "unknown"),
-    line: firstThread.line === null ? "unknown" : String(firstThread.line),
+    severity,
+    file: formatDiagnosticToken(representativeThread.path ?? "unknown"),
+    line: representativeThread.line == null ? "unknown" : String(representativeThread.line),
     threadUrl: formatDiagnosticToken(latestComment?.url ?? "none"),
     nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
   };

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -1,5 +1,5 @@
 import { hasProcessedReviewThread } from "./review-handling";
-import { configuredReviewBotLogins } from "./core/review-providers";
+import { configuredReviewBotLogins, configuredReviewProviderKinds } from "./core/review-providers";
 import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
 import { extractCodexConnectorPSeverity, isCodexConnectorReviewer } from "./external-review/external-review-normalization";
@@ -46,6 +46,62 @@ function latestCodexConnectorPSeverity(thread: ReviewThread): "P0" | "P1" | null
 
 export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated && latestCodexConnectorPSeverity(thread));
+}
+
+export interface CodexConnectorPolicyBlockDiagnostic {
+  count: number;
+  severity: "P0" | "P1";
+  file: string;
+  line: string;
+  threadUrl: string;
+  nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path";
+}
+
+function maxCodexConnectorPSeverity(threads: ReviewThread[]): "P0" | "P1" {
+  return threads.some((thread) => latestCodexConnectorPSeverity(thread) === "P0") ? "P0" : "P1";
+}
+
+function formatDiagnosticToken(value: string): string {
+  return value.replace(/\s+/g, "_");
+}
+
+export function buildCodexConnectorPolicyBlockDiagnostic(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): CodexConnectorPolicyBlockDiagnostic | null {
+  if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+
+  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
+  if (mustFixThreads.length === 0) {
+    return null;
+  }
+
+  const firstThread = mustFixThreads[0];
+  const latestComment = latestReviewComment(firstThread);
+  return {
+    count: mustFixThreads.length,
+    severity: maxCodexConnectorPSeverity(mustFixThreads),
+    file: formatDiagnosticToken(firstThread.path ?? "unknown"),
+    line: firstThread.line === null ? "unknown" : String(firstThread.line),
+    threadUrl: formatDiagnosticToken(latestComment?.url ?? "none"),
+    nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+  };
+}
+
+export function formatCodexConnectorPolicyBlockDiagnostic(
+  diagnostic: CodexConnectorPolicyBlockDiagnostic,
+): string {
+  return [
+    "codex_connector_policy_block",
+    `count=${diagnostic.count}`,
+    `severity=${diagnostic.severity}`,
+    `file=${diagnostic.file}`,
+    `line=${diagnostic.line}`,
+    `thread_url=${diagnostic.threadUrl}`,
+    `next_action=${diagnostic.nextAction}`,
+  ].join(" ");
 }
 
 function normalizeReviewCommentWhitespace(value: string): string {

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -3,7 +3,9 @@ import {
 } from "../review-handling";
 import {
   actionableBotReviewThreads,
+  buildCodexConnectorPolicyBlockDiagnostic,
   configuredBotReviewFollowUpState,
+  formatCodexConnectorPolicyBlockDiagnostic,
 } from "../review-thread-reporting";
 import { formatWorkspaceRestoreStatusLine } from "../core/workspace";
 import {
@@ -324,6 +326,10 @@ export function buildActiveDetailedStatusLines(
     });
     if (staleReviewBotRemediation) {
       lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));
+    }
+    const codexConnectorPolicyBlock = buildCodexConnectorPolicyBlockDiagnostic(config, reviewThreads);
+    if (codexConnectorPolicyBlock) {
+      lines.push(formatCodexConnectorPolicyBlockDiagnostic(codexConnectorPolicyBlock));
     }
     const reviewBotProfile = inferReviewBotProfile(config);
     const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1698,6 +1698,88 @@ test("explain reports bootstrap repos as not ready for expected CI and review si
   );
 });
 
+test("explain reports Codex Connector P0 policy blocks with thread diagnostics", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 182;
+  const prNumber = 282;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "stale_review_bot",
+        last_error: "Codex Connector P0 finding remains unresolved.",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector policy diagnostic",
+    body: executionReadyBody("Explain should surface P0 Codex Connector review policy blockers."),
+    createdAt: "2026-03-13T00:05:00Z",
+    updatedAt: "2026-03-13T00:05:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const p0Thread = {
+    id: "thread-p0",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/auth.ts",
+    line: 17,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p0",
+          body: "P0: Do not merge while the authorization bypass remains reachable.",
+          createdAt: "2026-03-11T14:06:00Z",
+          url: "https://example.test/pr/282#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => issue,
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    resolvePullRequestForBranch: async () =>
+      createPullRequest({
+        number: prNumber,
+        headRefName: branch,
+        headRefOid: "head-282",
+        isDraft: false,
+        configuredBotCurrentHeadObservedAt: "2026-03-11T14:05:00Z",
+      }),
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [p0Thread],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+  assert.match(
+    explanation,
+    /^codex_connector_policy_block count=1 severity=P0 file=src\/supervisor\/auth\.ts line=17 thread_url=https:\/\/example\.test\/pr\/282#discussion_r2 next_action=fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path$/m,
+  );
+  assert.match(explanation, /^reason_1=manual_block stale_review_bot$/m);
+});
+
 test("explain degrades gracefully when tracked PR mismatch hydration fails", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 172;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -302,6 +302,83 @@ test("status reports bootstrap repos as not ready for expected CI and review sig
   );
 });
 
+test("status reports Codex Connector P1 policy blocks with thread diagnostics", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 146;
+  const prNumber = 246;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "stale_review_bot",
+        last_error: "Codex Connector P1 finding remains unresolved.",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-246",
+    isDraft: false,
+    configuredBotCurrentHeadObservedAt: "2026-03-11T14:05:00Z",
+  });
+  const p1Thread = {
+    id: "thread-p1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/policy.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p1",
+          body:
+            "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub> Restore fail-closed review handling**",
+          createdAt: "2026-03-11T14:06:00Z",
+          url: "https://example.test/pr/246#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [p1Thread],
+  };
+
+  const status = await supervisor.status({ why: true });
+  assert.match(
+    status,
+    /^codex_connector_policy_block count=1 severity=P1 file=src\/supervisor\/policy\.ts line=42 thread_url=https:\/\/example\.test\/pr\/246#discussion_r1 next_action=fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path$/m,
+  );
+  assert.doesNotMatch(status, /^codex_connector_policy_block .*severity=nitpick_only/m);
+});
+
 test("status surfaces host-migration path repair and journal rehydration from the canonical local journal", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -69,6 +69,10 @@ import {
   formatStaleReviewBotRemediationLine,
   type StaleReviewBotRemediationDto,
 } from "./stale-review-bot-remediation";
+import {
+  buildCodexConnectorPolicyBlockDiagnostic,
+  formatCodexConnectorPolicyBlockDiagnostic,
+} from "../review-thread-reporting";
 import { formatMergedPrConvergenceOperatorEventLine } from "./supervisor-operator-events";
 import { appendRestartRecommendationLine } from "../operator-actions";
 import {
@@ -106,6 +110,7 @@ export interface SupervisorExplainDto {
   activityContext: SupervisorIssueActivityContextDto | null;
   staleDiagnosticSummary?: string | null;
   staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
+  codexConnectorPolicyBlockSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
   trackedPrMismatchSummary: string | null;
@@ -445,6 +450,13 @@ export async function buildIssueExplainDto(
         reviewThreads: explainReviewThreads,
       })
       : null;
+  const codexConnectorPolicyBlockSummary =
+    record && pr && !trackedPrHydrationFailed
+      ? (() => {
+        const diagnostic = buildCodexConnectorPolicyBlockDiagnostic(config, explainReviewThreads);
+        return diagnostic ? formatCodexConnectorPolicyBlockDiagnostic(diagnostic) : null;
+      })()
+      : null;
   const noActiveTrackedRecordSummary =
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
@@ -535,6 +547,7 @@ export async function buildIssueExplainDto(
       : null,
     staleDiagnosticSummary,
     staleReviewBotRemediation,
+    codexConnectorPolicyBlockSummary,
     noActiveTrackedRecordSummary,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary
@@ -608,6 +621,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(localCiStatusLine ? [localCiStatusLine] : []),
     ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
+    ...(dto.codexConnectorPolicyBlockSummary ? [dto.codexConnectorPolicyBlockSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),


### PR DESCRIPTION
## Summary
- add a distinct codex_connector_policy_block diagnostic for Codex Connector P0/P1 review blocks
- surface the diagnostic in both status --why and explain output with severity, file/line, thread URL, and next action
- add focused status/explain regression coverage

## Verification
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build
- node dist/index.js issue-lint 1914 --config <supervisor-config-path>

Part of #1911
Closes #1914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reporting for Codex Connector policy blocks with P0/P1 severity levels.
  * Policy block diagnostics now include affected file locations, line numbers, and thread URLs.
  * Policy block information integrated into supervisor status reports and issue explanations.

* **Tests**
  * Added test coverage for Codex Connector policy block diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->