### PR TITLE
Codify Codex Connector P2/P3 review policy

### DIFF
--- a/src/external-review/external-review-normalization.test.ts
+++ b/src/external-review/external-review-normalization.test.ts
@@ -132,3 +132,53 @@ test("normalizeExternalReviewSignal treats Codex Connector textual P0 headings a
   assert.equal(finding?.severity, "high");
   assert.ok((finding?.confidence ?? 0) >= 0.9);
 });
+
+test("normalizeExternalReviewSignal treats Codex Connector P2 comments as actionable severity", () => {
+  const thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P2: This retry path drops the verification failure and can report success after tests fail.",
+          createdAt: "2026-03-12T00:00:00Z",
+          url: "https://example.test/pr/8#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const signal = toExternalReviewThreadSignal(thread, ["chatgpt-codex-connector"]);
+  const finding = signal ? normalizeExternalReviewSignal(signal) : null;
+
+  assert.equal(finding?.severity, "medium");
+  assert.ok((finding?.confidence ?? 0) >= 0.8);
+});
+
+test("normalizeExternalReviewSignal escalates Codex Connector P3 comments with stronger risk wording", () => {
+  const thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P3: This looks like a formatting cleanup, but it can cause a regression in state restore.",
+          createdAt: "2026-03-12T00:00:00Z",
+          url: "https://example.test/pr/8#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const signal = toExternalReviewThreadSignal(thread, ["chatgpt-codex-connector"]);
+  const finding = signal ? normalizeExternalReviewSignal(signal) : null;
+
+  assert.equal(finding?.severity, "medium");
+  assert.ok((finding?.confidence ?? 0) >= 0.8);
+});

--- a/src/external-review/external-review-normalization.ts
+++ b/src/external-review/external-review-normalization.ts
@@ -36,26 +36,46 @@ export function isCodexConnectorReviewer(reviewerLogin: string): boolean {
   return /^chatgpt-codex-connector(?:\[bot\])?$/iu.test(reviewerLogin);
 }
 
-export function extractCodexConnectorPSeverity(body: string): "P0" | "P1" | null {
+export type CodexConnectorPSeverity = "P0" | "P1" | "P2" | "P3";
+
+export function extractCodexConnectorPSeverity(body: string): CodexConnectorPSeverity | null {
   const leadingBody = body.slice(0, 800);
-  const badgeLabel = leadingBody.match(/!\[[^\]]*\b(P[01])\b[^\]]*\]\([^)]*\)/iu)?.[1];
-  if (badgeLabel === "P0" || badgeLabel === "P1") {
+  const badgeLabel = leadingBody.match(/!\[[^\]]*\b(P[0-3])\b[^\]]*\]\([^)]*\)/iu)?.[1];
+  if (isCodexConnectorPSeverity(badgeLabel)) {
     return badgeLabel;
   }
 
-  const shieldBadge = leadingBody.match(/https?:\/\/img\.shields\.io\/badge\/(P[01])(?:[-/?#)]|$)/iu)?.[1];
-  if (shieldBadge === "P0" || shieldBadge === "P1") {
+  const shieldBadge = leadingBody.match(/https?:\/\/img\.shields\.io\/badge\/(P[0-3])(?:[-/?#)]|$)/iu)?.[1];
+  if (isCodexConnectorPSeverity(shieldBadge)) {
     return shieldBadge;
   }
 
   const textHeading = normalizeWhitespace(leadingBody.replace(/<[^>]+>/gu, " ").replace(/[*_`[\]]/gu, " "));
-  const headingLabel = textHeading.match(/^(?:#{1,6}\s*)?(P[01])(?:\s*[:\-]|\s+\b)/iu)?.[1];
-  return headingLabel === "P0" || headingLabel === "P1" ? headingLabel : null;
+  const headingLabel = textHeading.match(/^(?:#{1,6}\s*)?(P[0-3])(?:\s*[:\-]|\s+\b)/iu)?.[1];
+  return isCodexConnectorPSeverity(headingLabel) ? headingLabel : null;
+}
+
+function isCodexConnectorPSeverity(value: string | undefined): value is CodexConnectorPSeverity {
+  return value === "P0" || value === "P1" || value === "P2" || value === "P3";
+}
+
+export function hasCodexConnectorStrongRiskWording(body: string): boolean {
+  const normalized = body.toLowerCase();
+  return /\b(correctness|correct|incorrect|safety|unsafe|security|auth|authorization|permission|privilege|secret|data[- ]?loss|verification|verify|test|tests|fails?|failure|broken|bug|issue|error|warning|missing|regression|risk|leak|panic|crash|deadlock|corrupt)\b/u.test(
+    normalized,
+  );
 }
 
 function inferSeverity(body: string, reviewerLogin: string): Exclude<LocalReviewSeverity, "none"> {
-  if (isCodexConnectorReviewer(reviewerLogin) && extractCodexConnectorPSeverity(body)) {
+  const codexConnectorPSeverity = isCodexConnectorReviewer(reviewerLogin) ? extractCodexConnectorPSeverity(body) : null;
+  if (codexConnectorPSeverity === "P0" || codexConnectorPSeverity === "P1") {
     return "high";
+  }
+  if (codexConnectorPSeverity === "P2") {
+    return "medium";
+  }
+  if (codexConnectorPSeverity === "P3" && hasCodexConnectorStrongRiskWording(body)) {
+    return "medium";
   }
 
   const normalized = body.toLowerCase();
@@ -71,8 +91,12 @@ function inferSeverity(body: string, reviewerLogin: string): Exclude<LocalReview
 }
 
 function inferConfidence(body: string, reviewerLogin: string): number {
-  if (isCodexConnectorReviewer(reviewerLogin) && extractCodexConnectorPSeverity(body)) {
+  const codexConnectorPSeverity = isCodexConnectorReviewer(reviewerLogin) ? extractCodexConnectorPSeverity(body) : null;
+  if (codexConnectorPSeverity === "P0" || codexConnectorPSeverity === "P1") {
     return 0.95;
+  }
+  if (codexConnectorPSeverity === "P2" || (codexConnectorPSeverity === "P3" && hasCodexConnectorStrongRiskWording(body))) {
+    return 0.9;
   }
 
   const normalized = body.toLowerCase();

--- a/src/external-review/external-review-signal-heuristics.test.ts
+++ b/src/external-review/external-review-signal-heuristics.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyConfiguredBotTopLevelReviewStrength } from "./external-review-signal-heuristics";
+
+test("classifyConfiguredBotTopLevelReviewStrength preserves nitpick-only softening for style-only changes requests", () => {
+  assert.equal(
+    classifyConfiguredBotTopLevelReviewStrength({
+      state: "CHANGES_REQUESTED",
+      body: "Nitpick: prefer a shorter helper name for readability.",
+    }),
+    "nitpick_only",
+  );
+});
+
+test("classifyConfiguredBotTopLevelReviewStrength keeps stronger changes requests blocking", () => {
+  assert.equal(
+    classifyConfiguredBotTopLevelReviewStrength({
+      state: "CHANGES_REQUESTED",
+      body: "Nitpick: this can cause a regression in the restore failure path.",
+    }),
+    "blocking",
+  );
+});

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import { configuredBotReviewThreads, manualReviewThreads } from "./supervisor/supervisor-reporting";
 import {
   buildCodexConnectorPolicyBlockDiagnostic,
+  buildCodexConnectorP2P3PolicyDiagnostic,
+  actionableBotReviewThreads,
   buildStalledBotReviewFailureContext,
   codexConnectorMustFixReviewThreads,
   staleConfiguredBotReviewThreads,
@@ -83,6 +85,42 @@ function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread
         },
       ],
     },
+    ...overrides,
+  };
+}
+
+function createReviewRecord(
+  overrides: Partial<
+    Pick<
+      IssueRunRecord,
+      | "processed_review_thread_ids"
+      | "processed_review_thread_fingerprints"
+      | "last_head_sha"
+      | "review_follow_up_head_sha"
+      | "review_follow_up_remaining"
+    >
+  > = {},
+): Pick<
+  IssueRunRecord,
+  | "processed_review_thread_ids"
+  | "processed_review_thread_fingerprints"
+  | "last_head_sha"
+  | "review_follow_up_head_sha"
+  | "review_follow_up_remaining"
+> {
+  return {
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+    last_head_sha: "head123",
+    review_follow_up_head_sha: null,
+    review_follow_up_remaining: 0,
+    ...overrides,
+  };
+}
+
+function createPr(overrides: Partial<Pick<GitHubPullRequest, "headRefOid">> = {}): Pick<GitHubPullRequest, "headRefOid"> {
+  return {
+    headRefOid: "head123",
     ...overrides,
   };
 }
@@ -303,4 +341,137 @@ test("buildCodexConnectorPolicyBlockDiagnostic reports the highest-severity thre
     threadUrl: "https://example.test/pr/44#discussion_r2",
     nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
   });
+});
+
+test("buildCodexConnectorP2P3PolicyDiagnostic distinguishes actionable, softened, and escalated outcomes", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const p2Thread = createReviewThread({
+    id: "thread-p2",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Repair the retry path before reporting verification success.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3NitpickThread = createReviewThread({
+    id: "thread-p3-softened",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-softened",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3RiskThread = createReviewThread({
+    id: "thread-p3-escalated",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-escalated",
+          body: "P3: This cleanup can cause a regression in the restore failure path.",
+          createdAt: "2026-03-11T00:02:00Z",
+          url: "https://example.test/pr/44#discussion_r5",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(buildCodexConnectorP2P3PolicyDiagnostic(config, [p2Thread, p3NitpickThread, p3RiskThread]), {
+    p2Actionable: 1,
+    p3Softened: 1,
+    p3Escalated: 1,
+  });
+});
+
+test("actionableBotReviewThreads treats Codex Connector P2 as actionable by default", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const record = createReviewRecord();
+  const pr = createPr();
+  const p2Thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Repair the retry path so failed verification cannot be reported as success.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(actionableBotReviewThreads(config, record, pr, [p2Thread]), [p2Thread]);
+});
+
+test("actionableBotReviewThreads softens Codex Connector P3 only without stronger risk wording", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const record = createReviewRecord();
+  const pr = createPr();
+  const p3NitpickThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(actionableBotReviewThreads(config, record, pr, [p3NitpickThread]), []);
+});
+
+test("actionableBotReviewThreads escalates Codex Connector P3 with stronger wording", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const record = createReviewRecord();
+  const pr = createPr();
+  const p3RiskThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3",
+          body: "P3: This cleanup can cause a regression in the restore failure path.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r5",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(actionableBotReviewThreads(config, record, pr, [p3RiskThread]), [p3RiskThread]);
 });

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -2,7 +2,12 @@ import { hasProcessedReviewThread } from "./review-handling";
 import { configuredReviewBotLogins, configuredReviewProviderKinds } from "./core/review-providers";
 import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
-import { extractCodexConnectorPSeverity, isCodexConnectorReviewer } from "./external-review/external-review-normalization";
+import {
+  type CodexConnectorPSeverity,
+  extractCodexConnectorPSeverity,
+  hasCodexConnectorStrongRiskWording,
+  isCodexConnectorReviewer,
+} from "./external-review/external-review-normalization";
 
 function isAllowedReviewBotThread(config: SupervisorConfig, thread: ReviewThread): boolean {
   const configuredLogins = new Set(configuredReviewBotLogins(config).map((login) => login.toLowerCase()));
@@ -27,7 +32,10 @@ export function latestReviewCommentAuthorIsAllowedBot(config: SupervisorConfig, 
   return configuredLogins.has(latestLogin);
 }
 
-function latestCodexConnectorPSeverity(thread: ReviewThread): "P0" | "P1" | null {
+function latestCodexConnectorReviewComment(thread: ReviewThread): {
+  severity: CodexConnectorPSeverity;
+  body: string;
+} | null {
   for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
     const comment = thread.comments.nodes[index];
     const login = comment.author?.login;
@@ -37,15 +45,25 @@ function latestCodexConnectorPSeverity(thread: ReviewThread): "P0" | "P1" | null
 
     const pSeverity = extractCodexConnectorPSeverity(comment.body);
     if (pSeverity) {
-      return pSeverity;
+      return {
+        severity: pSeverity,
+        body: comment.body,
+      };
     }
   }
 
   return null;
 }
 
+function latestCodexConnectorPSeverity(thread: ReviewThread): CodexConnectorPSeverity | null {
+  return latestCodexConnectorReviewComment(thread)?.severity ?? null;
+}
+
 export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
-  return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated && latestCodexConnectorPSeverity(thread));
+  return reviewThreads.filter((thread) => {
+    const pSeverity = latestCodexConnectorPSeverity(thread);
+    return !thread.isResolved && !thread.isOutdated && (pSeverity === "P0" || pSeverity === "P1");
+  });
 }
 
 export interface CodexConnectorPolicyBlockDiagnostic {
@@ -57,8 +75,22 @@ export interface CodexConnectorPolicyBlockDiagnostic {
   nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path";
 }
 
+export interface CodexConnectorP2P3PolicyDiagnostic {
+  p2Actionable: number;
+  p3Softened: number;
+  p3Escalated: number;
+}
+
 function maxCodexConnectorPSeverity(threads: ReviewThread[]): "P0" | "P1" {
   return threads.some((thread) => latestCodexConnectorPSeverity(thread) === "P0") ? "P0" : "P1";
+}
+
+function isSoftenedCodexConnectorP3Thread(thread: ReviewThread): boolean {
+  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+  return (
+    latestCodexConnectorReview?.severity === "P3" &&
+    !hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)
+  );
 }
 
 function formatDiagnosticToken(value: string): string {
@@ -92,6 +124,40 @@ export function buildCodexConnectorPolicyBlockDiagnostic(
   };
 }
 
+export function buildCodexConnectorP2P3PolicyDiagnostic(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): CodexConnectorP2P3PolicyDiagnostic | null {
+  if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+
+  const diagnostic: CodexConnectorP2P3PolicyDiagnostic = {
+    p2Actionable: 0,
+    p3Softened: 0,
+    p3Escalated: 0,
+  };
+
+  for (const thread of reviewThreads) {
+    if (thread.isResolved || thread.isOutdated) {
+      continue;
+    }
+
+    const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+    if (latestCodexConnectorReview?.severity === "P2") {
+      diagnostic.p2Actionable += 1;
+    } else if (latestCodexConnectorReview?.severity === "P3") {
+      if (hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)) {
+        diagnostic.p3Escalated += 1;
+      } else {
+        diagnostic.p3Softened += 1;
+      }
+    }
+  }
+
+  return diagnostic.p2Actionable > 0 || diagnostic.p3Softened > 0 || diagnostic.p3Escalated > 0 ? diagnostic : null;
+}
+
 export function formatCodexConnectorPolicyBlockDiagnostic(
   diagnostic: CodexConnectorPolicyBlockDiagnostic,
 ): string {
@@ -103,6 +169,15 @@ export function formatCodexConnectorPolicyBlockDiagnostic(
     `line=${diagnostic.line}`,
     `thread_url=${diagnostic.threadUrl}`,
     `next_action=${diagnostic.nextAction}`,
+  ].join(" ");
+}
+
+export function formatCodexConnectorP2P3PolicyDiagnostic(diagnostic: CodexConnectorP2P3PolicyDiagnostic): string {
+  return [
+    "codex_connector_policy_review",
+    `p2_actionable=${diagnostic.p2Actionable}`,
+    `p3_softened=${diagnostic.p3Softened}`,
+    `p3_escalated=${diagnostic.p3Escalated}`,
   ].join(" ");
 }
 
@@ -152,7 +227,7 @@ export function actionableConfiguredBotReviewThreads(
   reviewThreads: ReviewThread[],
 ): ReviewThread[] {
   return configuredBotReviewThreads(config, reviewThreads).filter((thread) =>
-    latestReviewCommentAuthorIsAllowedBot(config, thread),
+    latestReviewCommentAuthorIsAllowedBot(config, thread) && !isSoftenedCodexConnectorP3Thread(thread),
   );
 }
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -3,8 +3,10 @@ import {
 } from "../review-handling";
 import {
   actionableBotReviewThreads,
+  buildCodexConnectorP2P3PolicyDiagnostic,
   buildCodexConnectorPolicyBlockDiagnostic,
   configuredBotReviewFollowUpState,
+  formatCodexConnectorP2P3PolicyDiagnostic,
   formatCodexConnectorPolicyBlockDiagnostic,
 } from "../review-thread-reporting";
 import { formatWorkspaceRestoreStatusLine } from "../core/workspace";
@@ -330,6 +332,10 @@ export function buildActiveDetailedStatusLines(
     const codexConnectorPolicyBlock = buildCodexConnectorPolicyBlockDiagnostic(config, reviewThreads);
     if (codexConnectorPolicyBlock) {
       lines.push(formatCodexConnectorPolicyBlockDiagnostic(codexConnectorPolicyBlock));
+    }
+    const codexConnectorP2P3Policy = buildCodexConnectorP2P3PolicyDiagnostic(config, reviewThreads);
+    if (codexConnectorP2P3Policy) {
+      lines.push(formatCodexConnectorP2P3PolicyDiagnostic(codexConnectorP2P3Policy));
     }
     const reviewBotProfile = inferReviewBotProfile(config);
     const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -357,6 +357,69 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
       ],
     },
   };
+  const p2Thread = {
+    id: "thread-p2",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/retry.ts",
+    line: 50,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Repair the retry path so failed verification cannot be reported as success.",
+          createdAt: "2026-03-11T14:07:00Z",
+          url: "https://example.test/pr/246#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+  const p3NitpickThread = {
+    id: "thread-p3-softened",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/naming.ts",
+    line: 60,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-softened",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T14:08:00Z",
+          url: "https://example.test/pr/246#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+  const p3RiskThread = {
+    id: "thread-p3-escalated",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/restore.ts",
+    line: 70,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-escalated",
+          body: "P3: This cleanup can cause a regression in the restore failure path.",
+          createdAt: "2026-03-11T14:09:00Z",
+          url: "https://example.test/pr/246#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
 
   const supervisor = new Supervisor({
     ...fixture.config,
@@ -368,7 +431,7 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
     getPullRequestIfExists: async () => pr,
     resolvePullRequestForBranch: async () => pr,
     getChecks: async () => [],
-    getUnresolvedReviewThreads: async () => [p1Thread],
+    getUnresolvedReviewThreads: async () => [p1Thread, p2Thread, p3NitpickThread, p3RiskThread],
   };
 
   const status = await supervisor.status({ why: true });
@@ -376,6 +439,7 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
     status,
     /^codex_connector_policy_block count=1 severity=P1 file=src\/supervisor\/policy\.ts line=42 thread_url=https:\/\/example\.test\/pr\/246#discussion_r1 next_action=fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path$/m,
   );
+  assert.match(status, /^codex_connector_policy_review p2_actionable=1 p3_softened=1 p3_escalated=1$/m);
   assert.doesNotMatch(status, /^codex_connector_policy_block .*severity=nitpick_only/m);
 });
 


### PR DESCRIPTION
## Summary
- codify Codex Connector P2/P3 severity extraction and actionability rules
- soften P3 only when it has no stronger risk wording
- add P2/P3 diagnostics separate from P0/P1 policy blocks

## Tests
- npx tsx --test src/external-review/external-review-signal-heuristics.test.ts
- npx tsx --test src/review-thread-reporting.test.ts
- npx tsx --test src/external-review/external-review-normalization.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build
- npm run verify:paths
- node dist/index.js issue-lint 1915 --config <supervisor-config-path>

Part of #1911
Closes #1915