### PR TITLE
Add Codex Connector current-head wait diagnostics

### DIFF
--- a/src/supervisor/supervisor-operator-activity-context.ts
+++ b/src/supervisor/supervisor-operator-activity-context.ts
@@ -24,7 +24,7 @@ export interface SupervisorReviewWaitDto {
     | "configured_bot_current_head_signal_wait"
     | "configured_bot_settled_wait";
   status: "active";
-  provider: "coderabbit";
+  provider: "coderabbit" | "codex";
   pauseReason: string;
   recentObservation: string;
   observedAt: string | null;
@@ -341,11 +341,11 @@ export function buildReviewWaitDtos(
   }
 
   const currentHeadSignalWait = configuredBotCurrentHeadSignalWaitWindow(config, pr);
-  if (currentHeadSignalWait.status === "active" && currentHeadSignalWait.provider === "coderabbit") {
+  if (currentHeadSignalWait.status === "active" && currentHeadSignalWait.provider !== "none") {
     reviewWaits.push({
       kind: "configured_bot_current_head_signal_wait",
       status: "active",
-      provider: "coderabbit",
+      provider: currentHeadSignalWait.provider,
       pauseReason: currentHeadSignalWait.pauseReason,
       recentObservation: currentHeadSignalWait.recentObservation,
       observedAt: currentHeadSignalWait.observedAt,

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -401,6 +401,63 @@ test("buildDetailedStatusModel explains when strict CodeRabbit current-head gati
   }
 });
 
+test("buildDetailedStatusModel explains Codex Connector current-head signal waits with Codex provider diagnostics", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:12:00.000Z");
+
+  try {
+    const lines = buildDetailedStatusModel({
+      config: createConfig({
+        reviewBotLogins: ["chatgpt-codex-connector"],
+        configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      }),
+      activeRecord: createRecord({
+        pr_number: 44,
+        state: "waiting_ci",
+        blocked_reason: null,
+        last_error: null,
+        review_wait_started_at: "2026-03-16T00:00:00.000Z",
+        review_wait_head_sha: "deadbeef",
+      }),
+      latestRecord: null,
+      trackedIssueCount: 1,
+      pr: createPullRequest({
+        currentHeadCiGreenAt: "2026-03-16T00:10:00.000Z",
+        configuredBotCurrentHeadObservedAt: null,
+      }),
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [],
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      pendingBotReviewThreads: (innerConfig, innerRecord, innerPr, innerReviewThreads) =>
+        configuredBotReviewThreads(innerConfig, innerReviewThreads).filter(
+          (thread) =>
+            !innerRecord.processed_review_thread_ids.includes(thread.id) &&
+            innerRecord.last_head_sha === innerPr.headRefOid,
+        ),
+      summarizeChecks: (checks) => ({
+        allPassing: checks.every((check) => check.bucket === "pass"),
+        hasPending: checks.some((check) => check.bucket === "pending" || check.bucket === "cancel"),
+        hasFailing: checks.some((check) => check.bucket === "fail"),
+      }),
+      mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
+    });
+
+    assert.ok(
+      lines.includes(
+        "configured_bot_current_head_signal_wait status=active provider=codex pause_reason=awaiting_current_head_signal_after_required_checks recent_observation=required_checks_green observed_at=2026-03-16T00:10:00.000Z configured_wait_minutes=10 wait_until=2026-03-16T00:20:00.000Z",
+      ),
+    );
+    assert.ok(
+      lines.includes(
+        "review_bot_diagnostics status=missing_provider_signal observed_review=none expected_reviewers=chatgpt-codex-connector next_check=provider_setup_or_delivery",
+      ),
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("buildDetailedStatusModel explains when CodeRabbit is re-waiting after a draft skip and ready-for-review", () => {
   const originalNow = Date.now;
   Date.now = () => Date.parse("2026-03-16T00:00:45.000Z");

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   configuredBotInitialGraceWaitWindow,
+  configuredBotCurrentHeadSignalWaitWindow,
   configuredBotSettledWaitWindow,
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
@@ -820,6 +821,37 @@ test("configuredBotInitialGraceWaitWindow reports the active CodeRabbit startup 
         observedAt: "2026-03-16T00:00:00.000Z",
         configuredWaitSeconds: null,
         waitUntil: null,
+      },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("configuredBotCurrentHeadSignalWaitWindow reports an active Codex Connector current-head wait", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:12:00.000Z");
+
+  try {
+    assert.deepEqual(
+      configuredBotCurrentHeadSignalWaitWindow(
+        createConfig({
+          reviewBotLogins: ["chatgpt-codex-connector"],
+          configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+        }),
+        createPr({
+          currentHeadCiGreenAt: "2026-03-16T00:10:00.000Z",
+          configuredBotCurrentHeadObservedAt: null,
+        }),
+      ),
+      {
+        status: "active",
+        provider: "codex",
+        pauseReason: "awaiting_current_head_signal_after_required_checks",
+        recentObservation: "required_checks_green",
+        observedAt: "2026-03-16T00:10:00.000Z",
+        configuredWaitMinutes: 10,
+        waitUntil: "2026-03-16T00:20:00.000Z",
       },
     );
   } finally {

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -14,6 +14,7 @@ import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
 const DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS = 90_000;
+type CurrentHeadSignalWaitProvider = "none" | "coderabbit" | "codex";
 
 function latestConfiguredBotActionableSignalAt(pr: GitHubPullRequest): string | null {
   const candidates = [
@@ -122,6 +123,22 @@ export function configuredReviewBots(config: SupervisorConfig): string[] {
   return configuredReviewBotLogins(config);
 }
 
+function currentHeadSignalWaitProvider(config: SupervisorConfig): Exclude<CurrentHeadSignalWaitProvider, "none"> | null {
+  const providerKinds = configuredReviewProviderKinds(config);
+  if (providerKinds.includes("codex")) {
+    return "codex";
+  }
+  if (providerKinds.includes("coderabbit")) {
+    return "coderabbit";
+  }
+  return null;
+}
+
+function requiresCurrentHeadSignalWait(config: SupervisorConfig): boolean {
+  const provider = currentHeadSignalWaitProvider(config);
+  return provider !== null && (provider === "codex" || config.configuredBotRequireCurrentHeadSignal === true);
+}
+
 function repoHasGitHubActionsWorkflows(repoPath: string): boolean | null {
   try {
     const workflowDir = path.join(repoPath, ".github", "workflows");
@@ -213,16 +230,17 @@ export function configuredBotCurrentHeadSignalWaitWindow(
   pr: GitHubPullRequest,
 ): {
   status: "inactive" | "active" | "expired";
-  provider: "none" | "coderabbit";
+  provider: CurrentHeadSignalWaitProvider;
   pauseReason: "none" | "awaiting_current_head_signal_after_required_checks";
   recentObservation: "none" | "required_checks_green";
   observedAt: string | null;
   configuredWaitMinutes: number | null;
   waitUntil: string | null;
 } {
+  const provider = currentHeadSignalWaitProvider(config);
   if (
-    !configuredReviewProviderKinds(config).includes("coderabbit") ||
-    !config.configuredBotRequireCurrentHeadSignal ||
+    !provider ||
+    !requiresCurrentHeadSignalWait(config) ||
     pr.isDraft ||
     pr.configuredBotCurrentHeadObservedAt ||
     !pr.currentHeadCiGreenAt
@@ -243,7 +261,7 @@ export function configuredBotCurrentHeadSignalWaitWindow(
   if (Number.isNaN(observedAtMs) || !configuredWaitMinutes || configuredWaitMinutes <= 0) {
     return {
       status: "inactive",
-      provider: "coderabbit",
+      provider,
       pauseReason: "awaiting_current_head_signal_after_required_checks",
       recentObservation: "required_checks_green",
       observedAt: pr.currentHeadCiGreenAt,
@@ -255,7 +273,7 @@ export function configuredBotCurrentHeadSignalWaitWindow(
   const waitUntil = new Date(observedAtMs + configuredWaitMinutes * 60_000).toISOString();
   return {
     status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-    provider: "coderabbit",
+    provider,
     pauseReason: "awaiting_current_head_signal_after_required_checks",
     recentObservation: "required_checks_green",
     observedAt: pr.currentHeadCiGreenAt,


### PR DESCRIPTION
## Summary
- recognize Codex Connector as the provider for current-head signal wait diagnostics
- surface provider=codex in detailed status and operator review-wait DTOs
- add focused regression coverage for Codex Connector current-head waits

## Verification
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Part of #1921
Closes #1922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced review orchestration to support additional provider options for quality gate checks.

* **Refactor**
  * Improved and streamlined internal logic for handling review wait conditions across multiple provider types.

* **Tests**
  * Added comprehensive test coverage for new provider support in quality gate scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1926)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->