### PR TITLE
Track idempotent Codex Connector review requests

### DIFF
--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -101,6 +101,8 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     merge_readiness_last_evaluated_at: value.merge_readiness_last_evaluated_at ?? null,
     copilot_review_requested_observed_at: value.copilot_review_requested_observed_at ?? null,
     copilot_review_requested_head_sha: value.copilot_review_requested_head_sha ?? null,
+    codex_connector_review_requested_observed_at: value.codex_connector_review_requested_observed_at ?? null,
+    codex_connector_review_requested_head_sha: value.codex_connector_review_requested_head_sha ?? null,
     copilot_review_timed_out_at: value.copilot_review_timed_out_at ?? null,
     copilot_review_timeout_action: value.copilot_review_timeout_action ?? null,
     copilot_review_timeout_reason: value.copilot_review_timeout_reason ?? null,

--- a/src/core/state-store.ts
+++ b/src/core/state-store.ts
@@ -93,6 +93,14 @@ export class StateStore {
         hasOwn(patch, "copilot_review_requested_head_sha")
           ? patch.copilot_review_requested_head_sha ?? null
           : record.copilot_review_requested_head_sha ?? null,
+      codex_connector_review_requested_observed_at:
+        hasOwn(patch, "codex_connector_review_requested_observed_at")
+          ? patch.codex_connector_review_requested_observed_at ?? null
+          : record.codex_connector_review_requested_observed_at ?? null,
+      codex_connector_review_requested_head_sha:
+        hasOwn(patch, "codex_connector_review_requested_head_sha")
+          ? patch.codex_connector_review_requested_head_sha ?? null
+          : record.codex_connector_review_requested_head_sha ?? null,
       copilot_review_timed_out_at:
         hasOwn(patch, "copilot_review_timed_out_at")
           ? patch.copilot_review_timed_out_at ?? null

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -223,6 +223,8 @@ export interface IssueRunRecord {
   merge_readiness_last_evaluated_at?: string | null;
   copilot_review_requested_observed_at: string | null;
   copilot_review_requested_head_sha: string | null;
+  codex_connector_review_requested_observed_at?: string | null;
+  codex_connector_review_requested_head_sha?: string | null;
   copilot_review_timed_out_at: string | null;
   copilot_review_timeout_action: CopilotReviewTimeoutAction | null;
   copilot_review_timeout_reason: string | null;

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -1,5 +1,6 @@
 import {
   buildConfiguredBotReviewSummary as summarizeConfiguredBotReviewSignals,
+  CodexConnectorReviewRequestIdentity,
   ConfiguredBotReviewSummary,
   CopilotReviewLifecycleFacts,
 } from "./github-review-signals";
@@ -49,6 +50,7 @@ export interface PullRequestCopilotReviewLifecycleResponse {
     nodes?: Array<{
       createdAt?: string | null;
       body?: string | null;
+      viewerDidAuthor?: boolean | null;
       author?: {
         login?: string | null;
       } | null;
@@ -250,6 +252,7 @@ export function mapCopilotReviewLifecycleFacts(
         authorLogin: normalizeLogin(comment?.author?.login ?? null),
         createdAt: comment?.createdAt ?? null,
         body: comment?.body ?? null,
+        viewerDidAuthor: comment?.viewerDidAuthor ?? null,
       })) ?? [],
     statusContexts:
       lifecycle?.commits?.nodes?.flatMap((node) => {
@@ -322,8 +325,14 @@ export function buildConfiguredBotReviewSummary(
   lifecycle: PullRequestCopilotReviewLifecycleResponse | null | undefined,
   reviewBotLogins: string[],
   currentHeadOid?: string | null,
+  codexConnectorReviewRequestIdentity?: CodexConnectorReviewRequestIdentity | null,
 ): ConfiguredBotReviewSummary {
-  return summarizeConfiguredBotReviewSignals(mapCopilotReviewLifecycleFacts(lifecycle), reviewBotLogins, currentHeadOid);
+  return summarizeConfiguredBotReviewSignals(
+    mapCopilotReviewLifecycleFacts(lifecycle),
+    reviewBotLogins,
+    currentHeadOid,
+    codexConnectorReviewRequestIdentity,
+  );
 }
 
 export function applyConfiguredBotReviewSummary(
@@ -335,6 +344,8 @@ export function applyConfiguredBotReviewSummary(
     copilotReviewState: summary?.lifecycle.state ?? null,
     copilotReviewRequestedAt: summary?.lifecycle.requestedAt ?? null,
     copilotReviewArrivedAt: summary?.lifecycle.arrivedAt ?? null,
+    codexConnectorReviewRequestedAt: summary?.codexConnectorReviewRequest?.requestedAt ?? null,
+    codexConnectorReviewRequestedHeadSha: summary?.codexConnectorReviewRequest?.headSha ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -206,6 +206,64 @@ test("GitHubPullRequestHydrator keeps configured-bot top-level review strength s
   assert.equal(pr?.configuredBotTopLevelReviewSubmittedAt, "2026-03-13T02:03:04Z");
 });
 
+test("GitHubPullRequestHydrator hydrates supervisor-authored Codex Connector review request markers for the current head", async () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  let lifecycleQuery: string | null = null;
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      lifecycleQuery = args.find((arg) => arg.startsWith("query=")) ?? null;
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: {
+                  nodes: [
+                    {
+                      createdAt: "2026-03-13T01:00:00Z",
+                      body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-old -->\n@codex review",
+                      viewerDidAuthor: true,
+                      author: { login: "codex-supervisor[bot]" },
+                    },
+                    {
+                      createdAt: "2026-03-13T01:05:00Z",
+                      body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-44 -->\n@codex review",
+                      viewerDidAuthor: true,
+                      author: { login: "codex-supervisor[bot]" },
+                    },
+                    {
+                      createdAt: "2026-03-13T01:06:00Z",
+                      body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-44 -->\n@codex review",
+                      viewerDidAuthor: false,
+                      author: { login: "octocat" },
+                    },
+                  ],
+                },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+                commits: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest());
+
+  assert.ok(lifecycleQuery);
+  assert.match(lifecycleQuery, /viewerDidAuthor/);
+  assert.equal(pr?.codexConnectorReviewRequestedAt, "2026-03-13T01:05:00Z");
+  assert.equal(pr?.codexConnectorReviewRequestedHeadSha, "head-44");
+});
+
 test("GitHubPullRequestHydrator hydrates Copilot arrival from long review threads without truncating comments to 20", async () => {
   const config = createConfig();
   let lifecycleQuery: string | null = null;

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -65,6 +65,7 @@ class ConfiguredBotReviewSummaryCache {
         currentHeadCiGreenAt: null,
         rateLimitWarningAt: null,
         draftSkipAt: null,
+        codexConnectorReviewRequest: null,
       }),
     };
     const lifecyclePromise = lifecyclePromiseFactory()
@@ -205,6 +206,7 @@ export class GitHubPullRequestHydrator {
               nodes {
                 createdAt
                 body
+                viewerDidAuthor
                 author {
                   login
                 }
@@ -322,7 +324,12 @@ export class GitHubPullRequestHydrator {
       };
     }>(result.stdout, `gh api graphql copilot review lifecycle pr=${prNumber}`);
 
-    return buildConfiguredBotReviewSummary(payload.data?.repository?.pullRequest, this.config.reviewBotLogins, currentHeadOid);
+    return buildConfiguredBotReviewSummary(
+      payload.data?.repository?.pullRequest,
+      this.config.reviewBotLogins,
+      currentHeadOid,
+      { prNumber, headSha: currentHeadOid },
+    );
   }
 }
 

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildConfiguredBotReviewSummary,
+  findCodexConnectorReviewRequest,
+  renderCodexConnectorReviewRequestComment,
   CopilotReviewLifecycleFacts,
   inferCopilotReviewLifecycle,
 } from "./github-review-signals";
@@ -23,6 +25,80 @@ test("inferCopilotReviewLifecycle returns not_requested when no Copilot signal e
     requestedAt: null,
     arrivedAt: null,
   });
+});
+
+test("renderCodexConnectorReviewRequestComment emits a machine marker and exact Codex trigger", () => {
+  const body = renderCodexConnectorReviewRequestComment({
+    issueNumber: 1923,
+    prNumber: 44,
+    headSha: "head-current",
+  });
+
+  assert.match(
+    body,
+    /<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->/,
+  );
+  assert.match(body, /^@codex review$/m);
+});
+
+test("findCodexConnectorReviewRequest matches only supervisor-authored markers for the current PR head", () => {
+  const current = findCodexConnectorReviewRequest(
+    [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T01:00:00Z",
+        body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->\n@codex review",
+        viewerDidAuthor: true,
+      },
+      {
+        authorLogin: "octocat",
+        createdAt: "2026-03-13T01:01:00Z",
+        body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->\n@codex review",
+        viewerDidAuthor: false,
+      },
+      {
+        authorLogin: "codex-supervisor[bot]",
+        createdAt: "2026-03-13T01:02:00Z",
+        body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-old -->\n@codex review",
+        viewerDidAuthor: true,
+      },
+      {
+        authorLogin: "codex-supervisor[bot]",
+        createdAt: "2026-03-13T01:03:00Z",
+        body: "<!-- codex-supervisor:tracked-pr-status-comment issue=1923 pr=44 kind=status -->\n@codex review",
+        viewerDidAuthor: true,
+      },
+    ],
+    {
+      issueNumber: 1923,
+      prNumber: 44,
+      headSha: "head-current",
+    },
+  );
+
+  assert.deepEqual(current, {
+    requestedAt: "2026-03-13T01:00:00Z",
+    headSha: "head-current",
+  });
+
+  assert.equal(
+    findCodexConnectorReviewRequest(
+      [
+        {
+          authorLogin: "codex-supervisor[bot]",
+          createdAt: "2026-03-13T01:02:00Z",
+          body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-old -->\n@codex review",
+          viewerDidAuthor: true,
+        },
+      ],
+      {
+        issueNumber: 1923,
+        prNumber: 44,
+        headSha: "head-current",
+      },
+    ),
+    null,
+  );
 });
 
 test("inferCopilotReviewLifecycle returns requested when Copilot was requested but has not reviewed", () => {

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -30,6 +30,7 @@ export interface CopilotReviewLifecycleFacts {
     authorLogin: string | null;
     createdAt: string | null;
     body: string | null;
+    viewerDidAuthor?: boolean | null;
   }>;
   statusContexts?: Array<{
     creatorLogin: string | null;
@@ -70,6 +71,7 @@ export interface ConfiguredBotTopLevelReviewSummary {
 export interface ConfiguredBotReviewSummary {
   lifecycle: CopilotReviewLifecycle;
   topLevelReview: ConfiguredBotTopLevelReviewSummary;
+  codexConnectorReviewRequest?: CodexConnectorReviewRequestObservation | null;
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
   currentHeadStatusState: string | null;
@@ -84,6 +86,94 @@ export type ConfiguredBotCurrentHeadObservationSource =
   | "status_context"
   | "codex_pr_success_comment"
   | null;
+
+export interface CodexConnectorReviewRequestObservation {
+  requestedAt: string | null;
+  headSha: string;
+}
+
+export interface CodexConnectorReviewRequestIdentity {
+  issueNumber?: number | null;
+  prNumber: number;
+  headSha: string;
+}
+
+const CODEX_CONNECTOR_REVIEW_REQUEST_MARKER = "codex-supervisor:codex-connector-review-request";
+
+function markerValue(value: string | number): string {
+  return String(value).replace(/[\s<>]/g, "");
+}
+
+export function renderCodexConnectorReviewRequestComment(
+  identity: CodexConnectorReviewRequestIdentity & { issueNumber: number },
+): string {
+  const issue = markerValue(identity.issueNumber);
+  const pr = markerValue(identity.prNumber);
+  const head = markerValue(identity.headSha);
+  return [
+    `<!-- ${CODEX_CONNECTOR_REVIEW_REQUEST_MARKER} issue=${issue} pr=${pr} head=${head} -->`,
+    "@codex review",
+  ].join("\n");
+}
+
+function parseCodexConnectorReviewRequestMarker(
+  body: string | null | undefined,
+): { issueNumber: number | null; prNumber: number; headSha: string } | null {
+  const markerPattern =
+    /<!--\s*codex-supervisor:codex-connector-review-request\s+issue=(\d+)\s+pr=(\d+)\s+head=([^\s>]+)\s*-->/;
+  const match = markerPattern.exec(body ?? "");
+  if (!match) {
+    return null;
+  }
+
+  const issueNumber = Number.parseInt(match[1] ?? "", 10);
+  const prNumber = Number.parseInt(match[2] ?? "", 10);
+  const headSha = match[3]?.trim() ?? "";
+  if (!Number.isInteger(issueNumber) || !Number.isInteger(prNumber) || !headSha) {
+    return null;
+  }
+
+  return { issueNumber, prNumber, headSha };
+}
+
+export function findCodexConnectorReviewRequest(
+  issueComments: CopilotReviewLifecycleFacts["issueComments"],
+  identity: CodexConnectorReviewRequestIdentity,
+): CodexConnectorReviewRequestObservation | null {
+  const normalizedHeadSha = identity.headSha.trim();
+  if (!normalizedHeadSha || !Number.isInteger(identity.prNumber)) {
+    return null;
+  }
+
+  let latest: CodexConnectorReviewRequestObservation | null = null;
+  let latestMs = 0;
+  for (const comment of issueComments) {
+    if (comment.viewerDidAuthor !== true || !/^@codex review$/m.test(comment.body ?? "")) {
+      continue;
+    }
+
+    const marker = parseCodexConnectorReviewRequestMarker(comment.body);
+    if (
+      !marker ||
+      marker.prNumber !== identity.prNumber ||
+      marker.headSha !== normalizedHeadSha ||
+      (identity.issueNumber !== undefined && identity.issueNumber !== null && marker.issueNumber !== identity.issueNumber)
+    ) {
+      continue;
+    }
+
+    const createdAtMs = parseTimestamp(comment.createdAt);
+    if (!latest || createdAtMs >= latestMs) {
+      latest = {
+        requestedAt: comment.createdAt,
+        headSha: marker.headSha,
+      };
+      latestMs = createdAtMs;
+    }
+  }
+
+  return latest;
+}
 
 function parseTimestamp(value: string | null | undefined): number {
   if (!value) {
@@ -665,11 +755,17 @@ export function buildConfiguredBotReviewSummary(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
   currentHeadOid?: string | null,
+  codexConnectorReviewRequestIdentity?: CodexConnectorReviewRequestIdentity | null,
 ): ConfiguredBotReviewSummary {
   const currentHeadObservation = inferConfiguredBotCurrentHeadObservation(facts, reviewBotLogins, currentHeadOid);
   return {
     lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
     topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
+    ...(codexConnectorReviewRequestIdentity
+      ? {
+          codexConnectorReviewRequest: findCodexConnectorReviewRequest(facts.issueComments, codexConnectorReviewRequestIdentity),
+        }
+      : {}),
     currentHeadObservedAt: currentHeadObservation.observedAt,
     currentHeadObservationSource: currentHeadObservation.source,
     currentHeadStatusState: inferConfiguredBotCurrentHeadStatusState(facts, reviewBotLogins, currentHeadOid),

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -32,6 +32,8 @@ export interface GitHubPullRequest {
   copilotReviewState?: CopilotReviewState | null;
   copilotReviewRequestedAt?: string | null;
   copilotReviewArrivedAt?: string | null;
+  codexConnectorReviewRequestedAt?: string | null;
+  codexConnectorReviewRequestedHeadSha?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -123,6 +123,10 @@ function createLifecycleSnapshot(
     nextState,
     failureContext: null,
     reviewWaitPatch: {},
+    codexConnectorRequestObservationPatch: {
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    },
     copilotRequestObservationPatch: {},
     mergeLatencyVisibilityPatch: {
       provider_success_observed_at: null,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -80,6 +80,10 @@ export interface PullRequestLifecycleSnapshot {
   copilotRequestObservationPatch: Partial<
     Pick<IssueRunRecord, "copilot_review_requested_observed_at" | "copilot_review_requested_head_sha">
   >;
+  codexConnectorRequestObservationPatch?: Pick<
+    IssueRunRecord,
+    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+  >;
   mergeLatencyVisibilityPatch: Pick<
     IssueRunRecord,
     "provider_success_observed_at" | "provider_success_head_sha" | "merge_readiness_last_evaluated_at"
@@ -386,6 +390,7 @@ async function applyTrackedPrLifecycleState(args: {
   const updatedRecord = args.stateStore.touch(args.record, {
     pr_number: args.pr.number,
     ...refreshedLifecycle.reviewWaitPatch,
+    ...refreshedLifecycle.codexConnectorRequestObservationPatch,
     ...refreshedLifecycle.copilotRequestObservationPatch,
     merge_readiness_last_evaluated_at: refreshedLifecycle.mergeLatencyVisibilityPatch.merge_readiness_last_evaluated_at,
     provider_success_head_sha: refreshedLifecycle.mergeLatencyVisibilityPatch.provider_success_head_sha,

--- a/src/pull-request-state-sync.test.ts
+++ b/src/pull-request-state-sync.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  syncCodexConnectorReviewRequestObservation,
   syncCopilotReviewRequestObservation,
   syncReviewWaitWindow,
 } from "./pull-request-state-sync";
@@ -81,5 +82,45 @@ test("syncCopilotReviewRequestObservation clears a stale same-head observation o
   assert.deepEqual(patch, {
     copilot_review_requested_observed_at: null,
     copilot_review_requested_head_sha: null,
+  });
+});
+
+test("syncCodexConnectorReviewRequestObservation preserves one request per current PR head", () => {
+  const current = syncCodexConnectorReviewRequestObservation(
+    createRecord({
+      issue_number: 1923,
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    }),
+    createPullRequest({
+      number: 44,
+      headRefOid: "head-current",
+      codexConnectorReviewRequestedAt: "2026-03-13T01:00:00Z",
+      codexConnectorReviewRequestedHeadSha: "head-current",
+    }),
+  );
+
+  assert.deepEqual(current, {
+    codex_connector_review_requested_observed_at: "2026-03-13T01:00:00Z",
+    codex_connector_review_requested_head_sha: "head-current",
+  });
+
+  const stale = syncCodexConnectorReviewRequestObservation(
+    createRecord({
+      issue_number: 1923,
+      codex_connector_review_requested_observed_at: "2026-03-13T00:00:00Z",
+      codex_connector_review_requested_head_sha: "head-old",
+    }),
+    createPullRequest({
+      number: 44,
+      headRefOid: "head-current",
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    }),
+  );
+
+  assert.deepEqual(stale, {
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
   });
 });

--- a/src/pull-request-state-sync.ts
+++ b/src/pull-request-state-sync.ts
@@ -68,6 +68,39 @@ export function syncCopilotReviewRequestObservation(
   };
 }
 
+export function syncCodexConnectorReviewRequestObservation(
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): Pick<
+  IssueRunRecord,
+  "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+> {
+  if (
+    pr.codexConnectorReviewRequestedAt &&
+    pr.codexConnectorReviewRequestedHeadSha === pr.headRefOid
+  ) {
+    return {
+      codex_connector_review_requested_observed_at: pr.codexConnectorReviewRequestedAt,
+      codex_connector_review_requested_head_sha: pr.headRefOid,
+    };
+  }
+
+  if (
+    record.codex_connector_review_requested_observed_at &&
+    record.codex_connector_review_requested_head_sha === pr.headRefOid
+  ) {
+    return {
+      codex_connector_review_requested_observed_at: record.codex_connector_review_requested_observed_at,
+      codex_connector_review_requested_head_sha: record.codex_connector_review_requested_head_sha,
+    };
+  }
+
+  return {
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+  };
+}
+
 export function syncCopilotReviewTimeoutState(
   config: SupervisorConfig,
   record: IssueRunRecord,

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -7,6 +7,7 @@ export {
   syncMergeLatencyVisibility,
 } from "./pull-request-state-policy";
 export {
+  syncCodexConnectorReviewRequestObservation,
   syncCopilotReviewRequestObservation,
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -954,6 +954,7 @@ export async function executeCodexTurnPhase(
         record = stateStore.touch(record, {
           pr_number: pr?.number ?? null,
           ...(postRunSnapshot?.reviewWaitPatch ?? {}),
+          ...(postRunSnapshot?.codexConnectorRequestObservationPatch ?? {}),
           ...(postRunSnapshot?.copilotRequestObservationPatch ?? {}),
           ...(postRunSnapshot?.copilotTimeoutPatch ?? {}),
           ...processedReviewThreadPatch,

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -369,6 +369,7 @@ export function derivePullRequestLifecycleSnapshot(
     nextState: inferStateFromPullRequest(config, finalizedRecordForState, pr, checks, reviewThreads),
     failureContext: inferFailureContext(config, finalizedRecordForState, pr, checks, reviewThreads),
     reviewWaitPatch: trackedPrProjection.reviewWaitPatch,
+    codexConnectorRequestObservationPatch: trackedPrProjection.codexConnectorReviewRequestObservationPatch,
     copilotRequestObservationPatch: trackedPrProjection.copilotReviewRequestObservationPatch,
     mergeLatencyVisibilityPatch,
     copilotTimeoutPatch: trackedPrProjection.copilotReviewTimeoutPatch,

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -11,6 +11,7 @@ import {
   inferStateFromPullRequest,
 } from "./pull-request-state";
 import {
+  syncCodexConnectorReviewRequestObservation,
   syncCopilotReviewRequestObservation,
   syncCopilotReviewTimeoutState,
   syncReviewWaitWindow,
@@ -26,6 +27,7 @@ interface ProjectTrackedPrLifecycleArgs {
   inferStateFromPullRequest?: typeof inferStateFromPullRequest;
   blockedReasonForLifecycleState?: typeof blockedReasonForLifecycleState;
   syncReviewWaitWindow?: typeof syncReviewWaitWindow;
+  syncCodexConnectorReviewRequestObservation?: typeof syncCodexConnectorReviewRequestObservation;
   syncCopilotReviewRequestObservation?: typeof syncCopilotReviewRequestObservation;
   syncCopilotReviewTimeoutState?: typeof syncCopilotReviewTimeoutState;
 }
@@ -34,6 +36,10 @@ export interface TrackedPrLifecycleProjection {
   recordForState: IssueRunRecord;
   reviewWaitPatch: Partial<IssueRunRecord>;
   copilotReviewRequestObservationPatch: Partial<IssueRunRecord>;
+  codexConnectorReviewRequestObservationPatch: Pick<
+    IssueRunRecord,
+    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+  >;
   copilotReviewTimeoutPatch: Pick<
     IssueRunRecord,
     "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
@@ -98,6 +104,9 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
   const localCiHeadStale =
     record.latest_local_ci_result?.head_sha != null
     && record.latest_local_ci_result.head_sha !== nextHeadSha;
+  const codexConnectorReviewRequestHeadStale =
+    record.codex_connector_review_requested_head_sha != null
+    && record.codex_connector_review_requested_head_sha !== nextHeadSha;
   const processedThreadIdsHeadStale = processedReviewThreadIdsStaleForHead(
     record.processed_review_thread_ids ?? [],
     nextHeadSha,
@@ -121,6 +130,7 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     || blockerCommentHeadStale
     || observedHostLocalBlockerHeadStale
     || localCiHeadStale
+    || codexConnectorReviewRequestHeadStale
     || processedThreadIdsHeadStale
     || processedThreadFingerprintsHeadStale;
   const sameTrackedHead = record.last_head_sha === nextHeadSha;
@@ -152,6 +162,12 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
           }
         : {}),
       ...(localCiHeadStale ? { latest_local_ci_result: null } : {}),
+      ...(codexConnectorReviewRequestHeadStale
+        ? {
+            codex_connector_review_requested_observed_at: null,
+            codex_connector_review_requested_head_sha: null,
+          }
+        : {}),
       ...(observedHostLocalBlockerHeadStale
         ? {
             last_observed_host_local_pr_blocker_signature: null,
@@ -193,6 +209,8 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     external_review_missed_findings_count: 0,
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
@@ -206,6 +224,8 @@ export function projectTrackedPrLifecycle(args: ProjectTrackedPrLifecycleArgs): 
   const inferStateFromPullRequestImpl = args.inferStateFromPullRequest ?? inferStateFromPullRequest;
   const blockedReasonForLifecycleStateImpl = args.blockedReasonForLifecycleState ?? blockedReasonForLifecycleState;
   const syncReviewWaitWindowImpl = args.syncReviewWaitWindow ?? syncReviewWaitWindow;
+  const syncCodexConnectorReviewRequestObservationImpl =
+    args.syncCodexConnectorReviewRequestObservation ?? syncCodexConnectorReviewRequestObservation;
   const syncCopilotReviewRequestObservationImpl =
     args.syncCopilotReviewRequestObservation ?? syncCopilotReviewRequestObservation;
   const syncCopilotReviewTimeoutStateImpl =
@@ -224,10 +244,15 @@ export function projectTrackedPrLifecycle(args: ProjectTrackedPrLifecycleArgs): 
     projectionSeedRecord,
     args.pr,
   );
+  const codexConnectorReviewRequestObservationPatch = syncCodexConnectorReviewRequestObservationImpl(
+    projectionSeedRecord,
+    args.pr,
+  );
   const copilotReviewTimeoutPatch = syncCopilotReviewTimeoutStateImpl(args.config, projectionSeedRecord, args.pr);
   const recordForState: IssueRunRecord = {
     ...projectionSeedRecord,
     ...reviewWaitPatch,
+    ...codexConnectorReviewRequestObservationPatch,
     ...copilotReviewRequestObservationPatch,
     ...copilotReviewTimeoutPatch,
   };
@@ -243,6 +268,7 @@ export function projectTrackedPrLifecycle(args: ProjectTrackedPrLifecycleArgs): 
     recordForState,
     reviewWaitPatch,
     copilotReviewRequestObservationPatch,
+    codexConnectorReviewRequestObservationPatch,
     copilotReviewTimeoutPatch,
     nextState,
     nextBlockedReason:


### PR DESCRIPTION
## Summary
- add a machine-managed Codex Connector review request marker that renders the exact @codex review trigger
- hydrate supervisor-authored PR comments for the current head using viewerDidAuthor and expose the detected request on the PR model
- persist head-scoped Codex Connector review request observations in issue-run state

## Verification
- npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts src/supervisor/supervisor-lifecycle.test.ts src/pull-request-state-sync.test.ts
- npm run build

Part of #1923