### PR TITLE
Request Codex Connector review after signal timeout (#1924)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ These fields control how the supervisor waits on CI, review bots, human review, 
 - `configuredBotSettledWaitSeconds`
 - `configuredBotRequireCurrentHeadSignal`
 - `configuredBotCurrentHeadSignalTimeoutMinutes`
-- `configuredBotCurrentHeadSignalTimeoutAction`
+- `configuredBotCurrentHeadSignalTimeoutAction` (`continue`, `block`, or Codex Connector-only `request_review_comment`)
 - `localReviewEnabled`
 - `localReviewPolicy`
 - `trackedPrCurrentHeadLocalReviewRequired`
@@ -473,7 +473,7 @@ Default note:
 - `configuredBotSettledWaitSeconds`
 - `configuredBotRequireCurrentHeadSignal`
 - `configuredBotCurrentHeadSignalTimeoutMinutes`
-- `configuredBotCurrentHeadSignalTimeoutAction`
+- `configuredBotCurrentHeadSignalTimeoutAction` (`continue`, `block`, or Codex Connector-only `request_review_comment`)
 - `localReviewEnabled`
 - `localReviewPosture`
 - `localReviewAutoDetect`

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1311,6 +1311,35 @@ test("loadConfig accepts strict current-head configured-bot signal settings", as
   assert.equal(config.configuredBotCurrentHeadSignalTimeoutAction, "block");
 });
 
+test("loadConfig accepts Codex Connector review request timeout action", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const configPath = path.join(tempDir, "supervisor.config.json");
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./.local/worktrees",
+      stateBackend: "json",
+      stateFile: "./.local/state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotCurrentHeadSignalTimeoutMinutes: 12,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+  assert.equal(config.configuredBotCurrentHeadSignalTimeoutAction, "request_review_comment");
+});
+
 test("loadConfig accepts explicit stale configured-bot reply_only policy", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -45,7 +45,11 @@ const VALID_STALE_CONFIGURED_BOT_REVIEW_POLICIES = new Set<StaleConfiguredBotRev
   "reply_only",
   "reply_and_resolve",
 ]);
-const VALID_COPILOT_REVIEW_TIMEOUT_ACTIONS = new Set<CopilotReviewTimeoutAction>(["continue", "block"]);
+const VALID_COPILOT_REVIEW_TIMEOUT_ACTIONS = new Set<CopilotReviewTimeoutAction>([
+  "continue",
+  "block",
+  "request_review_comment",
+]);
 const VALID_LOCAL_REVIEW_MINIMUM_SEVERITIES = new Set<LocalReviewReviewerThresholdConfig["minimumSeverity"]>(["low", "medium", "high"]);
 const VALID_RUN_STATES = new Set<RunState>([
   "queued",

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -17,7 +17,7 @@ export type LocalReviewPosturePreset =
   | "follow_up_issue_creation";
 export type ReleaseReadinessGatePosture = "advisory" | "block_release_publication";
 export type StaleConfiguredBotReviewPolicy = "diagnose_only" | "reply_only" | "reply_and_resolve";
-export type CopilotReviewTimeoutAction = "continue" | "block";
+export type CopilotReviewTimeoutAction = "continue" | "block" | "request_review_comment";
 export type ConfiguredReviewProviderKind = "copilot" | "codex" | "coderabbit" | "custom";
 export type ConfiguredReviewSignalSource = "copilot_lifecycle" | "review_threads";
 

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -477,6 +477,120 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
   assert.equal(syncJournalCalls, 3);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review once after current-head signal timeout", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-08T03:30:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ title: "Request Codex Connector review after timeout" });
+    const pr = createPullRequest({
+      number: 1924,
+      title: "Request Codex Connector review after timeout",
+      isDraft: false,
+      headRefOid: "head-1924",
+      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: pr.number,
+      last_head_sha: pr.headRefOid,
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: pr.headRefOid,
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: "/tmp/workspaces/issue-1924",
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(comments[0]?.issueNumber, pr.number);
+    assert.equal(comments[0]?.body, "@codex review");
+    assert.equal(result.record.state, "waiting_ci");
+    assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+    assert.equal(result.record.blocked_reason, null);
+
+    const retryResult = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: "/tmp/workspaces/issue-1924",
+        state,
+        record: result.record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(retryResult.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blockers when refreshed state is waiting_ci", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -51,6 +51,7 @@ import {
 } from "./post-turn-pull-request-policy";
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+import { configuredReviewProviderKinds } from "./core/review-providers";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -335,6 +336,133 @@ async function loadOpenPullRequestSnapshot(
   const checks = await github.getChecks(prNumber);
   const reviewThreads = await github.getUnresolvedReviewThreads(prNumber);
   return { pr, checks, reviewThreads };
+}
+
+function isValidTimestamp(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+function shouldRequestCodexConnectorReviewComment(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  summarizeChecks: HandlePostTurnPullRequestTransitionsArgs["summarizeChecks"];
+  configuredBotReviewThreads: HandlePostTurnPullRequestTransitionsArgs["configuredBotReviewThreads"];
+  manualReviewThreads: HandlePostTurnPullRequestTransitionsArgs["manualReviewThreads"];
+  mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
+}): boolean {
+  if (
+    args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
+    !configuredReviewProviderKinds(args.config).includes("codex") ||
+    args.record.copilot_review_timeout_action !== "request_review_comment" ||
+    !args.record.copilot_review_timed_out_at ||
+    args.record.codex_connector_review_requested_head_sha === args.pr.headRefOid ||
+    args.pr.isDraft ||
+    args.mergeConflictDetected(args.pr) ||
+    args.configuredBotReviewThreads(args.config, args.reviewThreads).length > 0 ||
+    args.manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
+    isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) ||
+    !isValidTimestamp(args.pr.currentHeadCiGreenAt)
+  ) {
+    return false;
+  }
+
+  const checkSummary = args.summarizeChecks(args.checks);
+  return !checkSummary.hasPending && !checkSummary.hasFailing;
+}
+
+function buildCodexConnectorReviewRequestFailureContext(args: {
+  pr: GitHubPullRequest;
+  error: unknown;
+}): FailureContext {
+  const message = args.error instanceof Error ? args.error.message : String(args.error);
+  return {
+    category: "blocked",
+    summary: `Failed to request Codex Connector review for PR #${args.pr.number}.`,
+    signature: `codex-connector-review-request-failed:${args.pr.headRefOid}`,
+    command: null,
+    details: [
+      `head=${args.pr.headRefOid}`,
+      `mutation=add_pr_comment`,
+      `error=${truncate(message, 500) ?? "unknown error"}`,
+    ],
+    url: args.pr.url,
+    updated_at: nowIso(),
+  };
+}
+
+async function maybeRequestCodexConnectorReviewComment(args: {
+  config: SupervisorConfig;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  github: Partial<Pick<GitHubClient, "addIssueComment">>;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  syncJournal: IssueJournalSync;
+  applyFailureSignature: HandlePostTurnPullRequestTransitionsArgs["applyFailureSignature"];
+  blockedReasonFromReviewState: HandlePostTurnPullRequestTransitionsArgs["blockedReasonFromReviewState"];
+  summarizeChecks: HandlePostTurnPullRequestTransitionsArgs["summarizeChecks"];
+  configuredBotReviewThreads: HandlePostTurnPullRequestTransitionsArgs["configuredBotReviewThreads"];
+  manualReviewThreads: HandlePostTurnPullRequestTransitionsArgs["manualReviewThreads"];
+  mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
+}): Promise<IssueRunRecord> {
+  if (
+    !shouldRequestCodexConnectorReviewComment({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads,
+      summarizeChecks: args.summarizeChecks,
+      configuredBotReviewThreads: args.configuredBotReviewThreads,
+      manualReviewThreads: args.manualReviewThreads,
+      mergeConflictDetected: args.mergeConflictDetected,
+    })
+  ) {
+    return args.record;
+  }
+
+  try {
+    if (!args.github.addIssueComment) {
+      throw new Error("GitHub comment transport unavailable");
+    }
+    await args.github.addIssueComment(args.pr.number, "@codex review");
+  } catch (error) {
+    const failureContext = buildCodexConnectorReviewRequestFailureContext({ pr: args.pr, error });
+    const blockedRecord = args.stateStore.touch(args.record, {
+      state: "blocked",
+      last_error: truncate(failureContext.summary, 1000),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason:
+        args.blockedReasonFromReviewState(args.record, args.pr, args.checks, args.reviewThreads) ?? "review_bot_timeout",
+    });
+    args.state.issues[String(blockedRecord.issue_number)] = blockedRecord;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(blockedRecord);
+    return blockedRecord;
+  }
+
+  const updatedRecord = args.stateStore.touch(args.record, {
+    state: "waiting_ci",
+    codex_connector_review_requested_observed_at: nowIso(),
+    codex_connector_review_requested_head_sha: args.pr.headRefOid,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_kind: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+    repeated_failure_signature_count: 0,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
 }
 
 async function applyTrackedPrLifecycleState(args: {
@@ -791,6 +919,26 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   });
   record = lifecycleResult.record;
   let effectiveFailureContext = lifecycleResult.effectiveFailureContext;
+  record = await maybeRequestCodexConnectorReviewComment({
+    config,
+    stateStore,
+    state,
+    github,
+    record,
+    pr: postReady.pr,
+    checks: postReady.checks,
+    reviewThreads: postReady.reviewThreads,
+    syncJournal,
+    applyFailureSignature: args.applyFailureSignature,
+    blockedReasonFromReviewState: args.blockedReasonFromReviewState,
+    summarizeChecks: args.summarizeChecks,
+    configuredBotReviewThreads: args.configuredBotReviewThreads,
+    manualReviewThreads: args.manualReviewThreads,
+    mergeConflictDetected: args.mergeConflictDetected,
+  });
+  if (record.state === "blocked" && record.last_failure_context?.signature?.startsWith("codex-connector-review-request-failed:")) {
+    effectiveFailureContext = record.last_failure_context;
+  }
   record = await trackedPrStatusComments.maybeCommentOnTrackedPrPersistentStatus({
     github,
     stateStore,

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -1001,6 +1001,10 @@ export function inferStateFromPullRequest(
     return "blocked";
   }
 
+  if (copilotTimeout.timedOut && copilotTimeout.action === "request_review_comment") {
+    return "waiting_ci";
+  }
+
   if (shouldWaitForConfiguredBotLatestHeadRearm(config, record, pr, nowMs)) {
     return "waiting_ci";
   }

--- a/src/pull-request-state-provider-wait-policy.test.ts
+++ b/src/pull-request-state-provider-wait-policy.test.ts
@@ -548,6 +548,36 @@ test("inferStateFromPullRequest blocks after a strict CodeRabbit current-head si
   });
 });
 
+test("inferStateFromPullRequest keeps waiting after an opted-in Codex Connector review request timeout", () => {
+  withStubbedDateNow("2026-05-08T03:30:00Z", () => {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const record = createRecord({
+      state: "waiting_ci",
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: "head123",
+    });
+
+    assert.equal(
+      inferStateFromPullRequest(
+        config,
+        record,
+        createPullRequest({
+          currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+          configuredBotCurrentHeadObservedAt: null,
+        }),
+        passingChecks(),
+        [],
+      ),
+      "waiting_ci",
+    );
+  });
+});
+
 test("inferStateFromPullRequest does not spend strict CodeRabbit timeout budget before checks turn green", () => {
   withStubbedDateNow("2026-03-11T00:11:00Z", () => {
     const config = createConfig({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -9331,6 +9331,8 @@ test("buildTrackedPrStaleFailureConvergencePatch isolates persisted tracked PR r
     external_review_missed_findings_count: 0,
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,


### PR DESCRIPTION
Closes #1924

This PR was opened by codex-supervisor.

Summary:
- adds the opt-in `request_review_comment` current-head signal timeout action for Codex Connector
- posts exactly one `@codex review` PR comment per head after the missing-signal timeout and records the request
- keeps waiting for an actual current-head Codex Connector signal and fails closed if comment publication fails

Verification:
- `npx tsx --test src/pull-request-state-provider-wait-policy.test.ts src/post-turn-pull-request.test.ts src/config.test.ts`
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-status-review-bot.test.ts`
- `npm run build`