### PR TITLE
Surface Codex Connector review-request fallback lifecycle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ Each shipped profile only configures what the supervisor expects to observe. You
 | Profile | Start from | Choose when | Supervisor watches | First-run caveat |
 | --- | --- | --- | --- | --- |
 | Copilot | [supervisor.config.copilot.json](../supervisor.config.copilot.json) | Your PR flow already requests or auto-triggers Copilot review. | `copilot-pull-request-reviewer` | Confirm Copilot is enabled for the repo and requested by your normal PR flow. |
-| Codex Connector | [supervisor.config.codex.json](../supervisor.config.codex.json) | The repo is already connected to Codex review and you want that connector to be the trusted review signal. | `chatgpt-codex-connector` current-head activity | Missing connector activity is fail-closed; confirm the connector is installed for the target repo before running merge automation. |
+| Codex Connector | [supervisor.config.codex.json](../supervisor.config.codex.json) | The repo is already connected to Codex review and you want that connector to be the trusted review signal. | `chatgpt-codex-connector` current-head activity, plus optional `@codex review` fallback request. | Missing connector activity is fail-closed; confirm the connector is installed for the target repo before running merge automation. |
 | CodeRabbit | [supervisor.config.coderabbit.json](../supervisor.config.coderabbit.json) | You want bounded waiting for current-head CodeRabbit review signals. | `coderabbitai`, `coderabbitai[bot]` | Replace `repoSlug: "REPLACE_ME"` before first run; the placeholder is a fail-closed guardrail. |
 | TypeScript/Node | [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) | Your repo can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [TypeScript and Node starter profile](./examples/typescript-node.md). |
 | Next.js | [supervisor.config.nextjs.json](../supervisor.config.nextjs.json) | Your app can expose npm-owned `npm ci` setup and `npm run verify:pre-pr` verification commands around the scripts it actually defines. | `copilot-pull-request-reviewer` | Replace required path and repo placeholders, then confirm the managed repo defines `verify:pre-pr`; see the [Next.js starter profile](./examples/nextjs.md). |
@@ -570,9 +570,24 @@ Operational notes:
 
 ### Codex Connector waits
 
-The Codex Connector profile is observer-only. The supervisor does not trigger `@codex` or request review in this profile; it waits for review, comment, thread, status, or current-head observation from `chatgpt-codex-connector`.
+The default Codex Connector profile is diagnose/block oriented: it waits for review, comment, thread, status, or current-head observation from `chatgpt-codex-connector`, and `configuredBotCurrentHeadSignalTimeoutAction: "block"` keeps missing current-head activity fail-closed.
 
 If a merge-critical PR has no Codex Connector signal for the current head, the supervisor keeps the PR out of `ready_to_merge` and blocks after the configured current-head signal timeout. Empty checks, empty reviews, empty review requests, and no PR comments are not enough to satisfy the connector review contract.
+
+Repositories that want automatic Codex Connector review first and an explicit request fallback second can opt in to comment posting:
+
+```json
+{
+  "reviewBotLogins": ["chatgpt-codex-connector"],
+  "configuredBotRequireCurrentHeadSignal": true,
+  "configuredBotCurrentHeadSignalTimeoutMinutes": 10,
+  "configuredBotCurrentHeadSignalTimeoutAction": "request_review_comment"
+}
+```
+
+With that opt-in, a timed-out current-head wait may post `@codex review` once for the current PR head. That request only asks Codex Connector to review; it is not treated as a successful review signal or review completion by itself. `status --why` and `explain <issue>` report `codex_connector_review_fallback` with the current PR head, the configured timeout action, and whether the supervisor is still waiting, already requested review for that head, or has a real current-head connector signal.
+
+Use `configuredBotCurrentHeadSignalTimeoutAction: "block"` for non-mutating block-only operation, or `"continue"` only when missing Codex Connector current-head activity should be diagnosed without blocking merge progression.
 
 ### CodeRabbit waits
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -26,6 +26,7 @@ import {
   configuredReviewBots,
   configuredReviewStatusLabel,
   externalSignalReadinessDiagnostics,
+  formatCodexConnectorReviewFallbackDiagnostic,
   inferReviewBotProfile,
   reviewBotDiagnostics,
 } from "./supervisor-status-review-bot";
@@ -364,6 +365,14 @@ export function buildActiveDetailedStatusLines(
     lines.push(
       `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
     );
+    const codexConnectorReviewFallback = formatCodexConnectorReviewFallbackDiagnostic({
+      config,
+      record: activeRecord,
+      pr,
+    });
+    if (codexConnectorReviewFallback) {
+      lines.push(codexConnectorReviewFallback);
+    }
     lines.push(`pr_hydration provenance=${pr.hydrationProvenance ?? "unknown"} head_sha=${pr.headRefOid}`);
     lines.push(
       `configured_bot_top_level_review strength=${pr.configuredBotTopLevelReviewStrength ?? "none"} submitted_at=${pr.configuredBotTopLevelReviewSubmittedAt ?? "none"} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads)}`,

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -285,6 +285,72 @@ test("explain surfaces merged PR convergence as an operator event for a tracked 
   );
 });
 
+test("explain surfaces Codex Connector review-request fallback lifecycle for the tracked PR", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 1925;
+  const prNumber = 2925;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "waiting_ci",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        last_head_sha: "head-1925",
+        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+        codex_connector_review_requested_head_sha: "head-1925",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector fallback lifecycle",
+    body: executionReadyBody("Explain should report Codex Connector fallback lifecycle."),
+    createdAt: "2026-05-08T03:00:00Z",
+    updatedAt: "2026-05-08T03:30:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () =>
+      createPullRequest({
+        number: prNumber,
+        headRefName: branch,
+        headRefOid: "head-1925",
+        currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+        configuredBotCurrentHeadObservedAt: null,
+        codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+        codexConnectorReviewRequestedHeadSha: "head-1925",
+      }),
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-08T03:19:36\.000Z$/m,
+  );
+});
+
 test("explain surfaces loop-off as an operator blocker for active tracked work", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 189;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -174,6 +174,64 @@ test("status surfaces the default trust posture and execution-safety warning", a
   );
 });
 
+test("status surfaces Codex Connector review-request fallback lifecycle for the active PR", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 1925;
+  const prNumber = 2925;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "waiting_ci",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: "head-1925",
+        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+        codex_connector_review_requested_head_sha: "head-1925",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    resolvePullRequestForBranch: async () =>
+      createPullRequest({
+        number: prNumber,
+        headRefName: branch,
+        headRefOid: "head-1925",
+        currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+        configuredBotCurrentHeadObservedAt: null,
+        codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+        codexConnectorReviewRequestedHeadSha: "head-1925",
+      }),
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport({ why: true });
+
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-08T03:19:36\.000Z$/m,
+  );
+});
+
 test("status reports effective Codex routing for inherited defaults and explicit overrides", async (t) => {
   const fixture = await createSupervisorFixture();
   const codexHome = path.join(path.dirname(fixture.repoPath), "codex-home");

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -35,7 +35,10 @@ import {
   formatLatestRecoveryStatusLine,
   formatNoActiveTrackedRecordClassificationLine,
 } from "./supervisor-detailed-status-assembly";
-import { externalSignalReadinessDiagnostics } from "./supervisor-status-review-bot";
+import {
+  externalSignalReadinessDiagnostics,
+  formatCodexConnectorReviewFallbackDiagnostic,
+} from "./supervisor-status-review-bot";
 import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
 import { formatInventoryRefreshDiagnosticLines, formatInventoryRefreshStatusLine } from "../inventory-refresh-state";
 import { buildTrackedPrMismatch } from "./tracked-pr-mismatch";
@@ -111,6 +114,7 @@ export interface SupervisorExplainDto {
   staleDiagnosticSummary?: string | null;
   staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
   codexConnectorPolicyBlockSummary?: string | null;
+  codexConnectorReviewFallbackSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
   trackedPrMismatchSummary: string | null;
@@ -457,6 +461,14 @@ export async function buildIssueExplainDto(
         return diagnostic ? formatCodexConnectorPolicyBlockDiagnostic(diagnostic) : null;
       })()
       : null;
+  const codexConnectorReviewFallbackSummary =
+    record && pr && !trackedPrHydrationFailed
+      ? formatCodexConnectorReviewFallbackDiagnostic({
+        config,
+        record,
+        pr,
+      })
+      : null;
   const noActiveTrackedRecordSummary =
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
@@ -548,6 +560,7 @@ export async function buildIssueExplainDto(
     staleDiagnosticSummary,
     staleReviewBotRemediation,
     codexConnectorPolicyBlockSummary,
+    codexConnectorReviewFallbackSummary,
     noActiveTrackedRecordSummary,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary
@@ -622,6 +635,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
     ...(dto.codexConnectorPolicyBlockSummary ? [dto.codexConnectorPolicyBlockSummary] : []),
+    ...(dto.codexConnectorReviewFallbackSummary ? [dto.codexConnectorReviewFallbackSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -10,6 +10,7 @@ import {
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
   externalSignalReadinessDiagnostics,
+  formatCodexConnectorReviewFallbackDiagnostic,
   configuredReviewStatusLabel,
   inferReviewBotProfile,
   reviewBotDiagnostics,
@@ -853,6 +854,64 @@ test("configuredBotCurrentHeadSignalWaitWindow reports an active Codex Connector
         configuredWaitMinutes: 10,
         waitUntil: "2026-03-16T00:20:00.000Z",
       },
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait and request states", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-03-16T00:12:00.000Z");
+
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const waitingPr = createPr({
+      headRefOid: "head-340",
+      currentHeadCiGreenAt: "2026-03-16T00:10:00.000Z",
+      configuredBotCurrentHeadObservedAt: null,
+    });
+
+    assert.equal(
+      formatCodexConnectorReviewFallbackDiagnostic({
+        config,
+        record: createRecord(),
+        pr: waitingPr,
+      }),
+      "codex_connector_review_fallback status=waiting_current_head_signal provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-03-16T00:20:00.000Z",
+    );
+
+    assert.equal(
+      formatCodexConnectorReviewFallbackDiagnostic({
+        config,
+        record: createRecord({
+          codex_connector_review_requested_observed_at: "2026-03-16T00:21:00.000Z",
+          codex_connector_review_requested_head_sha: "head-340",
+        }),
+        pr: {
+          ...waitingPr,
+          codexConnectorReviewRequestedAt: "2026-03-16T00:21:00.000Z",
+          codexConnectorReviewRequestedHeadSha: "head-340",
+        },
+      }),
+      "codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:21:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-03-16T00:20:00.000Z",
+    );
+
+    assert.equal(
+      formatCodexConnectorReviewFallbackDiagnostic({
+        config,
+        record: createRecord(),
+        pr: {
+          ...waitingPr,
+          codexConnectorReviewRequestedAt: "2026-03-16T00:21:00.000Z",
+          codexConnectorReviewRequestedHeadSha: "head-340",
+        },
+      }),
+      "codex_connector_review_fallback status=already_requested provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:21:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-03-16T00:20:00.000Z",
     );
   } finally {
     Date.now = originalNow;

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -282,6 +282,66 @@ export function configuredBotCurrentHeadSignalWaitWindow(
   };
 }
 
+export function formatCodexConnectorReviewFallbackDiagnostic(args: {
+  config: SupervisorConfig;
+  record: Pick<
+    IssueRunRecord,
+    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+  >;
+  pr: GitHubPullRequest;
+}): string | null {
+  if (!configuredReviewProviderKinds(args.config).includes("codex")) {
+    return null;
+  }
+
+  const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
+  const currentHeadObservedAt = args.pr.configuredBotCurrentHeadObservedAt ?? null;
+  const recordRequestAt = args.record.codex_connector_review_requested_observed_at ?? null;
+  const recordRequestHeadSha = args.record.codex_connector_review_requested_head_sha ?? null;
+  const prRequestAt = args.pr.codexConnectorReviewRequestedAt ?? null;
+  const prRequestHeadSha = args.pr.codexConnectorReviewRequestedHeadSha ?? null;
+  const requestAt = recordRequestAt ?? prRequestAt;
+  const requestHeadSha = recordRequestHeadSha ?? prRequestHeadSha;
+  const requestMatchesCurrentHead = Boolean(requestAt && requestHeadSha === args.pr.headRefOid);
+  const reviewSignal = currentHeadObservedAt ? "current_head_observed" : "missing";
+  const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
+
+  let status:
+    | "current_head_observed"
+    | "waiting_current_head_signal"
+    | "timeout_elapsed"
+    | "request_posted"
+    | "already_requested"
+    | "missing_current_head_signal";
+  if (currentHeadObservedAt) {
+    status = "current_head_observed";
+  } else if (requestMatchesCurrentHead && recordRequestAt) {
+    status = "request_posted";
+  } else if (requestMatchesCurrentHead) {
+    status = "already_requested";
+  } else if (waitWindow.status === "active") {
+    status = "waiting_current_head_signal";
+  } else if (waitWindow.status === "expired") {
+    status = "timeout_elapsed";
+  } else {
+    status = "missing_current_head_signal";
+  }
+
+  const waitUntilSuffix = waitWindow.waitUntil ? ` wait_until=${waitWindow.waitUntil}` : "";
+  return [
+    `codex_connector_review_fallback status=${status}`,
+    "provider=codex",
+    `current_head_sha=${args.pr.headRefOid}`,
+    `current_head_observed_at=${currentHeadObservedAt ?? "none"}`,
+    `required_checks_green_at=${args.pr.currentHeadCiGreenAt ?? "none"}`,
+    `timeout_action=${timeoutAction}`,
+    `requested_at=${requestAt ?? "none"}`,
+    `requested_head_sha=${requestHeadSha ?? "none"}`,
+    `review_signal=${reviewSignal}`,
+    "note=request_comment_is_not_review_completion",
+  ].join(" ") + waitUntilSuffix;
+}
+
 export function configuredBotInitialGraceWaitWindow(
   config: SupervisorConfig,
   pr: GitHubPullRequest,


### PR DESCRIPTION
## Summary
- add provider-specific Codex Connector fallback lifecycle diagnostics to status/explain
- keep request comments distinct from successful review signals
- document the opt-in request fallback and non-mutating alternatives

## Verification
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts src/config.test.ts
- npm run build

Closes #1925