### PR TITLE
Use marked Codex Connector fallback requests

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -9,6 +9,7 @@ import { IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorStateFile } f
 import { derivePullRequestLifecycleSnapshot as deriveSupervisorPullRequestLifecycleSnapshot } from "./supervisor/supervisor-lifecycle";
 import { blockedReasonFromReviewState as resolveBlockedReasonFromReviewState, inferStateFromPullRequest } from "./pull-request-state";
 import type { GitHubClient } from "./github";
+import { findCodexConnectorReviewRequest } from "./github/github-review-signals";
 import type { LocalReviewResult, PreMergeFinalEvaluation, PreMergeResidualFinding } from "./local-review";
 import {
   createConfig,
@@ -547,7 +548,28 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
 
     assert.equal(comments.length, 1);
     assert.equal(comments[0]?.issueNumber, pr.number);
-    assert.equal(comments[0]?.body, "@codex review");
+    assert.match(
+      comments[0]?.body ?? "",
+      new RegExp(
+        `^<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->$`,
+        "m",
+      ),
+    );
+    assert.match(comments[0]?.body ?? "", /^@codex review$/m);
+    assert.deepEqual(
+      findCodexConnectorReviewRequest(
+        [
+          {
+            authorLogin: "codex-supervisor[bot]",
+            createdAt: "2026-05-08T03:30:00Z",
+            body: comments[0]?.body ?? null,
+            viewerDidAuthor: true,
+          },
+        ],
+        { issueNumber: issue.number, prNumber: pr.number, headSha: pr.headRefOid },
+      ),
+      { requestedAt: "2026-05-08T03:30:00Z", headSha: pr.headRefOid },
+    );
     assert.equal(result.record.state, "waiting_ci");
     assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
     assert.ok(result.record.codex_connector_review_requested_observed_at);
@@ -586,6 +608,80 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
 
     assert.equal(comments.length, 1);
     assert.equal(retryResult.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase skips duplicate Codex Connector request when GitHub comments hydrate current-head marker", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-08T03:45:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 1924, title: "Hydrated Codex Connector request" });
+    const pr = createPullRequest({
+      number: 1924,
+      title: "Hydrated Codex Connector request",
+      isDraft: false,
+      headRefOid: "head-1924",
+      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+      codexConnectorReviewRequestedHeadSha: "head-1924",
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: pr.number,
+      last_head_sha: pr.headRefOid,
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: pr.headRefOid,
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async () => {
+          throw new Error("unexpected duplicate Codex Connector request");
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: "/tmp/workspaces/issue-1924",
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(result.record.codex_connector_review_requested_observed_at, "2026-05-08T03:30:00Z");
+    assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
   } finally {
     Date.now = originalDateNow;
   }

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -52,6 +52,7 @@ import {
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import { configuredReviewProviderKinds } from "./core/review-providers";
+import { renderCodexConnectorReviewRequestComment } from "./github/github-review-signals";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -430,7 +431,14 @@ async function maybeRequestCodexConnectorReviewComment(args: {
     if (!args.github.addIssueComment) {
       throw new Error("GitHub comment transport unavailable");
     }
-    await args.github.addIssueComment(args.pr.number, "@codex review");
+    await args.github.addIssueComment(
+      args.pr.number,
+      renderCodexConnectorReviewRequestComment({
+        issueNumber: args.record.issue_number,
+        prNumber: args.pr.number,
+        headSha: args.pr.headRefOid,
+      }),
+    );
   } catch (error) {
     const failureContext = buildCodexConnectorReviewRequestFailureContext({ pr: args.pr, error });
     const blockedRecord = args.stateStore.touch(args.record, {


### PR DESCRIPTION
## Summary
- Post Codex Connector fallback review requests with the existing supervisor machine marker.
- Preserve the exact `@codex review` trigger line while embedding issue, PR, and head identity.
- Tighten regression coverage for marker rehydration and duplicate suppression from hydrated GitHub comments.

## Verification
- `npx tsx --test src/post-turn-pull-request.test.ts`
- `npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts src/pull-request-state-sync.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-review-bot.test.ts`
- `npm run verify:supervisor-pre-pr`

Closes #1931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevents duplicate Codex Connector review requests when GitHub comment data is processed.

* **Tests**
  * Enhanced test assertions to verify structured comment formatting with metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1932)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->