### PR TITLE
Add Codex Connector convergence policy

### DIFF
--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -16,8 +16,10 @@ import {
   summarizeChecks,
 } from "./supervisor/supervisor-reporting";
 import {
+  codexConnectorNitpickOnlyReviewThreads,
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
+  evaluateCodexConnectorConvergencePolicy,
   manualReviewThreads,
   pendingBotReviewThreads,
   staleConfiguredBotReviewThreads,
@@ -700,9 +702,15 @@ function effectiveConfiguredBotReviewThreads(
   reviewThreads: ReviewThread[],
 ): ReviewThread[] {
   const unresolvedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads);
-  return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, unresolvedConfiguredBotThreads)
-    ? unresolvedConfiguredBotThreads.filter((thread) => !isIssueJournalThreadPath(thread))
-    : unresolvedConfiguredBotThreads;
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, unresolvedConfiguredBotThreads);
+  const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(unresolvedConfiguredBotThreads));
+  const effectiveThreads =
+    codexConnectorPolicy?.outcome === "nitpick_only" || codexConnectorPolicy?.outcome === "converged"
+      ? unresolvedConfiguredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread))
+      : unresolvedConfiguredBotThreads;
+  return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, effectiveThreads)
+    ? effectiveThreads.filter((thread) => !isIssueJournalThreadPath(thread))
+    : effectiveThreads;
 }
 
 function pullRequestHeadMatchesRecord(record: Pick<IssueRunRecord, "last_head_sha">, pr: GitHubPullRequest): boolean {
@@ -722,7 +730,14 @@ function hasConfiguredProviderSuccess(
     return false;
   }
 
-  if (configuredBotReviewThreads(config, reviewThreads).length > 0) {
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, reviewThreads);
+  if (codexConnectorPolicy?.outcome === "must_fix_remaining" || codexConnectorPolicy?.outcome === "missing_current_head_review") {
+    return false;
+  }
+
+  const configuredBotThreads = configuredBotReviewThreads(config, reviewThreads);
+  const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(configuredBotThreads));
+  if (configuredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread)).length > 0) {
     return false;
   }
 

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -6,6 +6,7 @@ import {
   createPullRequest,
   createRecord,
   createReviewThread,
+  passingChecks,
 } from "./pull-request-state-test-helpers";
 
 test("inferStateFromPullRequest keeps an unresolved configured bot thread blocked on the same head after processing", () => {
@@ -335,6 +336,79 @@ test("inferStateFromPullRequest does not allow same-head follow-up for unresolve
   });
 
   assert.equal(inferStateFromPullRequest(config, record, pr, [], [p1Thread]), "blocked");
+});
+
+test("inferStateFromPullRequest blocks same-head follow-up for unresolved Codex Connector P2 findings", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head-a",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+    review_follow_up_head_sha: "head-a",
+    review_follow_up_remaining: 1,
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+    configuredBotCurrentHeadObservedAt: "2026-03-11T00:05:00Z",
+  });
+  const p2Thread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p2Thread]), "blocked");
+});
+
+test("inferStateFromPullRequest softens unresolved Codex Connector P3 nitpick-only findings for merge readiness", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head-a",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+    configuredBotCurrentHeadObservedAt: "2026-03-11T00:05:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+  });
+  const p3NitpickThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), [p3NitpickThread]), "ready_to_merge");
 });
 
 test("inferStateFromPullRequest still blocks same-head configured bot threads when no follow-up progress was recorded", () => {

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -7,6 +7,7 @@ import {
   actionableBotReviewThreads,
   buildStalledBotReviewFailureContext,
   codexConnectorMustFixReviewThreads,
+  evaluateCodexConnectorConvergencePolicy,
   staleConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
@@ -290,6 +291,65 @@ test("codexConnectorMustFixReviewThreads tracks unresolved P1 findings and repor
   assert.match(buildStalledBotReviewFailureContext([p1Thread])?.details[0] ?? "", /p_severity=P1/);
 });
 
+test("codexConnectorMustFixReviewThreads treats P2 and escalated P3 findings as must-fix", () => {
+  const p2Thread = createReviewThread({
+    id: "thread-p2",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3NitpickThread = createReviewThread({
+    id: "thread-p3-softened",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-softened",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3RiskThread = createReviewThread({
+    id: "thread-p3-escalated",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-escalated",
+          body: "P3: This cleanup can cause a regression in the restore failure path.",
+          createdAt: "2026-03-11T00:02:00Z",
+          url: "https://example.test/pr/44#discussion_r5",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(codexConnectorMustFixReviewThreads([p2Thread, p3NitpickThread, p3RiskThread]), [
+    p2Thread,
+    p3RiskThread,
+  ]);
+});
+
 test("buildCodexConnectorPolicyBlockDiagnostic reports the highest-severity thread location", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],
@@ -402,6 +462,56 @@ test("buildCodexConnectorP2P3PolicyDiagnostic distinguishes actionable, softened
     p3Softened: 1,
     p3Escalated: 1,
   });
+});
+
+test("evaluateCodexConnectorConvergencePolicy separates missing, must-fix, nitpick-only, and converged outcomes", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const currentHeadPr = {
+    configuredBotCurrentHeadObservedAt: "2026-03-11T00:04:00Z",
+  };
+  const p2Thread = createReviewThread({
+    id: "thread-p2",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3NitpickThread = createReviewThread({
+    id: "thread-p3-softened",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-softened",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(evaluateCodexConnectorConvergencePolicy(config, { configuredBotCurrentHeadObservedAt: null }, [])?.outcome, "missing_current_head_review");
+  assert.equal(evaluateCodexConnectorConvergencePolicy(config, currentHeadPr, [p2Thread])?.outcome, "must_fix_remaining");
+  assert.equal(
+    evaluateCodexConnectorConvergencePolicy(config, { configuredBotCurrentHeadObservedAt: null }, [p3NitpickThread])?.outcome,
+    "missing_current_head_review",
+  );
+  assert.equal(evaluateCodexConnectorConvergencePolicy(config, currentHeadPr, [p3NitpickThread])?.outcome, "nitpick_only");
+  assert.equal(evaluateCodexConnectorConvergencePolicy(config, currentHeadPr, [])?.outcome, "converged");
 });
 
 test("actionableBotReviewThreads treats Codex Connector P2 as actionable by default", () => {

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -1,5 +1,9 @@
 import { hasProcessedReviewThread } from "./review-handling";
-import { configuredReviewBotLogins, configuredReviewProviderKinds } from "./core/review-providers";
+import {
+  configuredReviewBotLogins,
+  configuredReviewProviderKinds,
+  normalizeReviewProviderLogin,
+} from "./core/review-providers";
 import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
 import {
@@ -10,9 +14,9 @@ import {
 } from "./external-review/external-review-normalization";
 
 function isAllowedReviewBotThread(config: SupervisorConfig, thread: ReviewThread): boolean {
-  const configuredLogins = new Set(configuredReviewBotLogins(config).map((login) => login.toLowerCase()));
+  const configuredLogins = new Set(configuredReviewBotLogins(config));
   return thread.comments.nodes.some((comment) => {
-    const login = comment.author?.login?.toLowerCase();
+    const login = normalizeReviewProviderLogin(comment.author?.login);
     return Boolean(login && configuredLogins.has(login));
   });
 }
@@ -23,12 +27,12 @@ export function latestReviewComment(thread: ReviewThread) {
 
 export function latestReviewCommentAuthorIsAllowedBot(config: SupervisorConfig, thread: ReviewThread): boolean {
   const latestComment = latestReviewComment(thread);
-  const latestLogin = latestComment?.author?.login?.toLowerCase();
+  const latestLogin = normalizeReviewProviderLogin(latestComment?.author?.login);
   if (!latestLogin) {
     return false;
   }
 
-  const configuredLogins = new Set(configuredReviewBotLogins(config).map((login) => login.toLowerCase()));
+  const configuredLogins = new Set(configuredReviewBotLogins(config));
   return configuredLogins.has(latestLogin);
 }
 
@@ -59,16 +63,30 @@ function latestCodexConnectorPSeverity(thread: ReviewThread): CodexConnectorPSev
   return latestCodexConnectorReviewComment(thread)?.severity ?? null;
 }
 
+function isCodexConnectorMustFixReviewThread(thread: ReviewThread): boolean {
+  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+  if (!latestCodexConnectorReview || thread.isResolved || thread.isOutdated) {
+    return false;
+  }
+
+  if (
+    latestCodexConnectorReview.severity === "P0" ||
+    latestCodexConnectorReview.severity === "P1" ||
+    latestCodexConnectorReview.severity === "P2"
+  ) {
+    return true;
+  }
+
+  return latestCodexConnectorReview.severity === "P3" && hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body);
+}
+
 export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
-  return reviewThreads.filter((thread) => {
-    const pSeverity = latestCodexConnectorPSeverity(thread);
-    return !thread.isResolved && !thread.isOutdated && (pSeverity === "P0" || pSeverity === "P1");
-  });
+  return reviewThreads.filter(isCodexConnectorMustFixReviewThread);
 }
 
 export interface CodexConnectorPolicyBlockDiagnostic {
   count: number;
-  severity: "P0" | "P1";
+  severity: CodexConnectorPSeverity;
   file: string;
   line: string;
   threadUrl: string;
@@ -81,8 +99,28 @@ export interface CodexConnectorP2P3PolicyDiagnostic {
   p3Escalated: number;
 }
 
-function maxCodexConnectorPSeverity(threads: ReviewThread[]): "P0" | "P1" {
-  return threads.some((thread) => latestCodexConnectorPSeverity(thread) === "P0") ? "P0" : "P1";
+export type CodexConnectorConvergencePolicyOutcome =
+  | "missing_current_head_review"
+  | "must_fix_remaining"
+  | "nitpick_only"
+  | "converged";
+
+export interface CodexConnectorConvergencePolicyResult {
+  outcome: CodexConnectorConvergencePolicyOutcome;
+  currentHeadObservedAt: string | null;
+  mustFixCount: number;
+  nitpickCount: number;
+}
+
+function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {
+  return { P0: 0, P1: 1, P2: 2, P3: 3 }[severity];
+}
+
+function maxCodexConnectorPSeverity(threads: ReviewThread[]): CodexConnectorPSeverity {
+  return threads
+    .map((thread) => latestCodexConnectorPSeverity(thread))
+    .filter((severity): severity is CodexConnectorPSeverity => severity !== null)
+    .sort((left, right) => codexConnectorPSeverityRank(left) - codexConnectorPSeverityRank(right))[0] ?? "P3";
 }
 
 function isSoftenedCodexConnectorP3Thread(thread: ReviewThread): boolean {
@@ -93,8 +131,69 @@ function isSoftenedCodexConnectorP3Thread(thread: ReviewThread): boolean {
   );
 }
 
+export function codexConnectorNitpickOnlyReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter(
+    (thread) => !thread.isResolved && !thread.isOutdated && isSoftenedCodexConnectorP3Thread(thread),
+  );
+}
+
 function formatDiagnosticToken(value: string): string {
   return value.replace(/\s+/g, "_");
+}
+
+function validPolicyTimestamp(value: string | null | undefined): string | null {
+  if (!value || Number.isNaN(Date.parse(value))) {
+    return null;
+  }
+
+  return value;
+}
+
+export function evaluateCodexConnectorConvergencePolicy(
+  config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "configuredBotCurrentHeadObservedAt">,
+  reviewThreads: ReviewThread[],
+): CodexConnectorConvergencePolicyResult | null {
+  if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+
+  const mustFixCount = codexConnectorMustFixReviewThreads(reviewThreads).length;
+  const nitpickCount = codexConnectorNitpickOnlyReviewThreads(reviewThreads).length;
+  const currentHeadObservedAt = validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  if (mustFixCount > 0) {
+    return {
+      outcome: "must_fix_remaining",
+      currentHeadObservedAt,
+      mustFixCount,
+      nitpickCount,
+    };
+  }
+
+  if (!currentHeadObservedAt) {
+    return {
+      outcome: "missing_current_head_review",
+      currentHeadObservedAt: null,
+      mustFixCount,
+      nitpickCount,
+    };
+  }
+
+  if (nitpickCount > 0) {
+    return {
+      outcome: "nitpick_only",
+      currentHeadObservedAt,
+      mustFixCount,
+      nitpickCount,
+    };
+  }
+
+  return {
+    outcome: "converged",
+    currentHeadObservedAt,
+    mustFixCount,
+    nitpickCount,
+  };
 }
 
 export function buildCodexConnectorPolicyBlockDiagnostic(

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -495,7 +495,7 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
   const status = await supervisor.status({ why: true });
   assert.match(
     status,
-    /^codex_connector_policy_block count=1 severity=P1 file=src\/supervisor\/policy\.ts line=42 thread_url=https:\/\/example\.test\/pr\/246#discussion_r1 next_action=fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path$/m,
+    /^codex_connector_policy_block count=3 severity=P1 file=src\/supervisor\/policy\.ts line=42 thread_url=https:\/\/example\.test\/pr\/246#discussion_r1 next_action=fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path$/m,
   );
   assert.match(status, /^codex_connector_policy_review p2_actionable=1 p3_softened=1 p3_escalated=1$/m);
   assert.doesNotMatch(status, /^codex_connector_policy_block .*severity=nitpick_only/m);


### PR DESCRIPTION
## Summary
- add a typed Codex Connector convergence policy result for missing current-head review, must-fix, nitpick-only, and converged outcomes
- classify P0/P1/P2 plus risk-worded P3 findings as must-fix while softening low-risk P3 nitpicks only after current-head evidence
- normalize Codex Connector bot aliases in configured-bot thread handling

## Verification
- npx tsx --test src/review-thread-reporting.test.ts src/pull-request-state-provider-wait-policy.test.ts src/pull-request-state-thread-reprocessing.test.ts src/github/github-review-signals.test.ts
- npm run build

Part of #1935