### PR TITLE
Route Codex Connector must-fix findings to repair

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { buildCodexPrompt, buildCodexResumePrompt, shouldUseCompactResumePrompt } from "./codex-prompt";
 import { FailureContext, GitHubIssue, RunState } from "../core/types";
 import type { AgentTurnContext } from "../supervisor/agent-runner";
-import { createConfig } from "../turn-execution-test-helpers";
+import { createConfig, createPullRequest, createReviewThread } from "../turn-execution-test-helpers";
 
 const issue: GitHubIssue = {
   number: 46,
@@ -814,7 +814,30 @@ test("buildCodexPrompt suppresses stale handoff next actions during addressing_r
   assert.match(prompt, /Live review guidance should take priority over stale handoff steps\./);
 });
 
-test("buildCodexPrompt adds Codex Connector P0/P1 must-fix guidance only for Codex Connector addressing_review", () => {
+test("buildCodexPrompt adds structured Codex Connector must-fix guidance only for Codex Connector addressing_review", () => {
+  const pr = createPullRequest({
+    number: 144,
+    headRefOid: "head-connector-144",
+  });
+  const p2Thread = createReviewThread({
+    id: "thread-p2",
+    path: "src/restore.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/144#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
   const codexContext = {
     kind: "start",
     config: createConfig({
@@ -825,9 +848,9 @@ test("buildCodexPrompt adds Codex Connector P0/P1 must-fix guidance only for Cod
     branch: "codex/issue-46",
     workspacePath: "/tmp/workspaces/issue-46",
     state: "addressing_review" satisfies RunState,
-    pr: null,
+    pr,
     checks: [],
-    reviewThreads: [],
+    reviewThreads: [p2Thread],
     alwaysReadFiles: [],
     onDemandMemoryFiles: [],
     journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
@@ -836,10 +859,19 @@ test("buildCodexPrompt adds Codex Connector P0/P1 must-fix guidance only for Cod
   const codexPrompt = buildCodexPrompt(codexContext);
 
   assert.match(codexPrompt, /Codex Connector review handling:/);
-  assert.match(codexPrompt, /P0\/P1 Codex Connector findings are supervisor-enforced must-fix findings\./);
-  assert.match(codexPrompt, /Same-head reply-only disagreement does not clear a P0\/P1 finding for merge readiness\./);
+  assert.match(codexPrompt, /P0\/P1\/P2 and escalated P3 Codex Connector findings are supervisor-enforced must-fix findings\./);
+  assert.match(codexPrompt, /Same-head reply-only disagreement does not clear a must-fix finding for merge readiness\./);
+  assert.match(codexPrompt, /P3 nitpick-only findings are not enough by themselves to require a same-PR repair pass\./);
   assert.match(codexPrompt, /make the smallest valid code fix and push a new PR head/);
   assert.match(codexPrompt, /route it to the existing manual\/operator review path/);
+  assert.match(codexPrompt, /Policy: Codex Connector must_fix_remaining/);
+  assert.match(codexPrompt, /Severity: P2/);
+  assert.match(codexPrompt, /PR: #144/);
+  assert.match(codexPrompt, /Head SHA: head-connector-144/);
+  assert.match(codexPrompt, /Source URL: https:\/\/example\.test\/pr\/144#discussion_r2/);
+  assert.match(codexPrompt, /File: src\/restore\.ts/);
+  assert.match(codexPrompt, /Line range: 42/);
+  assert.match(codexPrompt, /Summary: P2: Preserve failed restore cleanup as a blocking verification failure\./);
 
   const coderabbitContext = {
     ...codexContext,

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -21,6 +21,7 @@ import type {
   StartAgentTurnContext,
 } from "../supervisor/agent-runner";
 import { reviewProviderProfileFromConfig, type ReviewProviderProfileSummary } from "../core/review-providers";
+import { buildCodexConnectorMustFixFindingDetails } from "../review-thread-reporting";
 
 export interface LocalReviewRepairContext {
   repairIntent?: "same_pr_fix_blocked" | "same_pr_follow_up" | "same_pr_manual_review" | "high_severity_retry" | "unspecified";
@@ -433,14 +434,28 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
             : ["- No saved external review miss artifact is available for the current PR head."]),
         ]
       : [];
+  const codexConnectorMustFixFindingDetails =
+    input.state === "addressing_review" && input.reviewProviderProfile?.profile === "codex"
+      ? buildCodexConnectorMustFixFindingDetails({
+          pr: input.pr,
+          reviewThreads: input.reviewThreads,
+        })
+      : [];
   const codexConnectorReviewGuidance =
     input.state === "addressing_review" && input.reviewProviderProfile?.profile === "codex"
       ? [
           "Codex Connector review handling:",
-          "- P0/P1 Codex Connector findings are supervisor-enforced must-fix findings.",
-          "- Same-head reply-only disagreement does not clear a P0/P1 finding for merge readiness.",
+          "- P0/P1/P2 and escalated P3 Codex Connector findings are supervisor-enforced must-fix findings.",
+          "- Same-head reply-only disagreement does not clear a must-fix finding for merge readiness.",
+          "- P3 nitpick-only findings are not enough by themselves to require a same-PR repair pass.",
           "- If the finding is valid, make the smallest valid code fix and push a new PR head.",
-          "- If a P0/P1 finding conflicts with issue scope or appears unsafe to apply, route it to the existing manual/operator review path instead of self-dismissing it.",
+          "- If a must-fix finding conflicts with issue scope or appears unsafe to apply, route it to the existing manual/operator review path instead of self-dismissing it.",
+          ...(codexConnectorMustFixFindingDetails.length > 0
+            ? [
+                "Codex Connector must-fix findings:",
+                ...codexConnectorMustFixFindingDetails,
+              ]
+            : []),
         ]
       : [];
   const verificationPolicy = describeVerificationPolicy(

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -17,6 +17,7 @@ import {
 } from "./supervisor/supervisor-reporting";
 import {
   codexConnectorNitpickOnlyReviewThreads,
+  codexConnectorMustFixReviewThreads,
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
@@ -857,6 +858,7 @@ export function inferStateFromPullRequest(
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
+  const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
   const checkSummary = summarizeChecks(checks);
 
   if (pr.mergedAt || pr.state === "MERGED") {
@@ -874,6 +876,16 @@ export function inferStateFromPullRequest(
       manualThreads.length === 0;
 
     if (unresolvedBotThreads.length > 0 || pr.configuredBotTopLevelReviewStrength === "blocking") {
+      if (
+        codexConnectorMustFixThreads.length > 0 &&
+        !checkSummary.hasFailing &&
+        !checkSummary.hasPending &&
+        (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
+        !mergeConflictDetected(pr)
+      ) {
+        return "addressing_review";
+      }
+
       return "blocked";
     }
 
@@ -938,6 +950,16 @@ export function inferStateFromPullRequest(
     !mergeConflictDetected(pr)
   ) {
     return "local_review_fix";
+  }
+
+  if (
+    codexConnectorMustFixThreads.length > 0 &&
+    !checkSummary.hasFailing &&
+    !checkSummary.hasPending &&
+    (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
+    !mergeConflictDetected(pr)
+  ) {
+    return "addressing_review";
   }
 
   if (checkSummary.hasFailing) {

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -301,7 +301,7 @@ test("inferStateFromPullRequest allows one same-head follow-up turn after partia
   assert.equal(inferStateFromPullRequest(config, record, pr, [], [remainingThread]), "addressing_review");
 });
 
-test("inferStateFromPullRequest does not allow same-head follow-up for unresolved Codex Connector P1 findings", () => {
+test("inferStateFromPullRequest routes unresolved Codex Connector P1 findings into same-PR repair", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector[bot]"],
   });
@@ -335,10 +335,10 @@ test("inferStateFromPullRequest does not allow same-head follow-up for unresolve
     },
   });
 
-  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p1Thread]), "blocked");
+  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p1Thread]), "addressing_review");
 });
 
-test("inferStateFromPullRequest blocks same-head follow-up for unresolved Codex Connector P2 findings", () => {
+test("inferStateFromPullRequest routes unresolved Codex Connector P2 findings into same-PR repair", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector[bot]"],
   });
@@ -372,7 +372,42 @@ test("inferStateFromPullRequest blocks same-head follow-up for unresolved Codex 
     },
   });
 
-  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p2Thread]), "blocked");
+  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p2Thread]), "addressing_review");
+});
+
+test("inferStateFromPullRequest routes escalated Codex Connector P3 findings into same-PR repair", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head-a",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+    configuredBotCurrentHeadObservedAt: "2026-03-11T00:05:00Z",
+  });
+  const p3RiskThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P3: This is blocking because the restore path can leave partial durable state after failure.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, [], [p3RiskThread]), "addressing_review");
 });
 
 test("inferStateFromPullRequest softens unresolved Codex Connector P3 nitpick-only findings for merge readiness", () => {

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -36,7 +36,7 @@ export function latestReviewCommentAuthorIsAllowedBot(config: SupervisorConfig, 
   return configuredLogins.has(latestLogin);
 }
 
-function latestCodexConnectorReviewComment(thread: ReviewThread): {
+export function latestCodexConnectorReviewComment(thread: ReviewThread): {
   severity: CodexConnectorPSeverity;
   body: string;
 } | null {
@@ -308,6 +308,28 @@ function renderReviewThreadDetail(thread: ReviewThread, includeAuthor = false): 
   const summary = ` summary=${extractReviewCommentSummary(latestComment?.body ?? "")}`;
   const url = latestComment?.url ? ` url=${latestComment.url}` : "";
   return `${location}${author}${severity}${summary}${url}`;
+}
+
+export function buildCodexConnectorMustFixFindingDetails(args: {
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+  reviewThreads: ReviewThread[];
+}): string[] {
+  return codexConnectorMustFixReviewThreads(args.reviewThreads).map((thread, index) => {
+    const latestComment = latestReviewComment(thread);
+    const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+    const lineRange = thread.line == null ? "unknown" : String(thread.line);
+    return [
+      `- Finding ${index + 1}`,
+      `  Policy: Codex Connector must_fix_remaining`,
+      `  Severity: ${latestCodexConnectorReview?.severity ?? "unknown"}`,
+      `  PR: ${args.pr ? `#${args.pr.number}` : "unknown"}`,
+      `  Head SHA: ${args.pr?.headRefOid ?? "unknown"}`,
+      `  Source URL: ${latestComment?.url ?? "n/a"}`,
+      `  File: ${thread.path ?? "unknown"}`,
+      `  Line range: ${lineRange}`,
+      `  Summary: ${extractReviewCommentSummary(latestComment?.body ?? "")}`,
+    ].join("\n");
+  });
 }
 
 export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -89,6 +89,45 @@ test("selectReviewThreadsForTurn re-includes same-head configured-bot threads wh
   assert.equal(selected[0]?.id, "thread-1");
 });
 
+test("selectReviewThreadsForTurn re-includes processed Codex Connector must-fix threads for same-PR repair", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/44#discussion_r2",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0]?.id, "thread-1");
+});
+
 test("selectReviewThreadsForTurn does not reopen same-head follow-up when stale bookkeeping remains for non-actionable configured-bot threads", () => {
   const selected = selectReviewThreadsForTurn({
     config: createConfig({

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -88,6 +88,11 @@ export function selectReviewThreadsForTurn(args: {
     return pendingThreads;
   }
 
+  const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(actionableFollowUpThreads);
+  if (codexConnectorMustFixThreads.length > 0) {
+    return codexConnectorMustFixThreads;
+  }
+
   return (
     args.record.review_follow_up_head_sha === currentPr.headRefOid &&
     (args.record.review_follow_up_remaining ?? 0) > 0 &&


### PR DESCRIPTION
## Summary
- route Codex Connector P0/P1/P2/escalated-P3 must-fix findings into same-PR review repair instead of generic blocking
- keep current-head Codex Connector must-fix threads in the repair prompt even after a same-head processing pass
- add structured prompt context for policy, severity, PR/head, source URL, file, line, and summary

## Verification
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/post-turn-pull-request.test.ts src/codex/codex-prompt.test.ts src/review-thread-reporting.test.ts
- npm run build

Part of #1936