### PR TITLE
Reset Codex Connector convergence on PR head advance

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -687,6 +687,95 @@ test("handlePostTurnPullRequestTransitionsPhase skips duplicate Codex Connector 
   }
 });
 
+test("handlePostTurnPullRequestTransitionsPhase re-requests Codex Connector review for a repaired new head", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-08T04:00:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 1937, title: "Re-request Codex Connector review after repair" });
+    const pr = createPullRequest({
+      number: 1937,
+      title: "Re-request Codex Connector review after repair",
+      isDraft: false,
+      headRefOid: "head-new-1937",
+      currentHeadCiGreenAt: "2026-05-08T03:45:00Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: pr.number,
+      last_head_sha: "head-old-1937",
+      review_wait_started_at: "2026-05-08T03:20:00Z",
+      review_wait_head_sha: "head-old-1937",
+      provider_success_observed_at: "2026-05-08T03:24:00Z",
+      provider_success_head_sha: "head-old-1937",
+      codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+      codex_connector_review_requested_head_sha: "head-old-1937",
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1937"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(comments[0]?.issueNumber, pr.number);
+    assert.match(
+      comments[0]?.body ?? "",
+      new RegExp(
+        `^<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->$`,
+        "m",
+      ),
+    );
+    assert.equal(result.record.last_head_sha, pr.headRefOid);
+    assert.equal(result.record.provider_success_observed_at, null);
+    assert.equal(result.record.provider_success_head_sha, null);
+    assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blockers when refreshed state is waiting_ci", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -298,6 +298,8 @@ test("resetTrackedPrHeadScopedStateOnAdvance does not preserve review bookkeepin
     last_local_review_signature: null,
     repeated_local_review_signature_count: 0,
     latest_local_ci_result: null,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
     external_review_head_sha: null,
     external_review_misses_path: null,
     external_review_matched_findings_count: 0,
@@ -305,6 +307,8 @@ test("resetTrackedPrHeadScopedStateOnAdvance does not preserve review bookkeepin
     external_review_missed_findings_count: 0,
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
@@ -312,6 +316,23 @@ test("resetTrackedPrHeadScopedStateOnAdvance does not preserve review bookkeepin
     processed_review_thread_ids: [],
     processed_review_thread_fingerprints: [],
   });
+});
+
+test("resetTrackedPrHeadScopedStateOnAdvance clears old-head provider success after a PR head advance", () => {
+  const record = createRecord({
+    last_head_sha: "head-old-191",
+    provider_success_observed_at: "2026-05-08T03:24:00Z",
+    provider_success_head_sha: "head-old-191",
+    codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+    codex_connector_review_requested_head_sha: "head-old-191",
+  });
+
+  const patch = resetTrackedPrHeadScopedStateOnAdvance(record, "head-new-191");
+
+  assert.equal(patch.provider_success_observed_at, null);
+  assert.equal(patch.provider_success_head_sha, null);
+  assert.equal(patch.codex_connector_review_requested_observed_at, null);
+  assert.equal(patch.codex_connector_review_requested_head_sha, null);
 });
 
 test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when processed thread markers belong to an older head", () => {
@@ -352,6 +373,8 @@ test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when proc
     last_local_review_signature: null,
     repeated_local_review_signature_count: 0,
     latest_local_ci_result: null,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
     external_review_head_sha: null,
     external_review_misses_path: null,
     external_review_matched_findings_count: 0,
@@ -359,6 +382,8 @@ test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when proc
     external_review_missed_findings_count: 0,
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -104,6 +104,9 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
   const localCiHeadStale =
     record.latest_local_ci_result?.head_sha != null
     && record.latest_local_ci_result.head_sha !== nextHeadSha;
+  const providerSuccessHeadStale =
+    record.provider_success_head_sha != null
+    && record.provider_success_head_sha !== nextHeadSha;
   const codexConnectorReviewRequestHeadStale =
     record.codex_connector_review_requested_head_sha != null
     && record.codex_connector_review_requested_head_sha !== nextHeadSha;
@@ -130,6 +133,7 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     || blockerCommentHeadStale
     || observedHostLocalBlockerHeadStale
     || localCiHeadStale
+    || providerSuccessHeadStale
     || codexConnectorReviewRequestHeadStale
     || processedThreadIdsHeadStale
     || processedThreadFingerprintsHeadStale;
@@ -162,6 +166,12 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
           }
         : {}),
       ...(localCiHeadStale ? { latest_local_ci_result: null } : {}),
+      ...(providerSuccessHeadStale
+        ? {
+            provider_success_observed_at: null,
+            provider_success_head_sha: null,
+          }
+        : {}),
       ...(codexConnectorReviewRequestHeadStale
         ? {
             codex_connector_review_requested_observed_at: null,
@@ -202,6 +212,8 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     last_local_review_signature: null,
     repeated_local_review_signature_count: 0,
     latest_local_ci_result: null,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
     external_review_head_sha: null,
     external_review_misses_path: null,
     external_review_matched_findings_count: 0,


### PR DESCRIPTION
## Summary
- reset old-head provider success when tracked PR head advances
- keep old-head Codex Connector requests from suppressing a new-head fallback request
- add post-turn and lifecycle projection regressions for issue #1937

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts src/pull-request-state-sync.test.ts src/supervisor/supervisor-lifecycle.test.ts src/tracked-pr-lifecycle-projection.test.ts
- npm run build

Closes #1937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced state management to properly track and reset review request observations and provider success states when pull request heads advance to new commits.

* **Tests**
  * Expanded test coverage for pull request head repair scenarios, including validation of state transitions, review request tracking, and stale state detection when PR commits are updated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1943)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->