### PR TITLE
Surface Codex Connector convergence diagnostics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -587,6 +587,8 @@ Repositories that want automatic Codex Connector review first and an explicit re
 
 With that opt-in, a timed-out current-head wait may post `@codex review` once for the current PR head. That request only asks Codex Connector to review; it is not treated as a successful review signal or review completion by itself. `status --why` and `explain <issue>` report `codex_connector_review_fallback` with the current PR head, the configured timeout action, and whether the supervisor is still waiting, already requested review for that head, or has a real current-head connector signal.
 
+`status --why` and `explain <issue>` also report `codex_connector_convergence` for tracked PRs using the Codex Connector profile. The line summarizes the current PR head, latest connector signal head, highest unresolved severity, unresolved finding count, merge effect, and next expected operator or supervisor action. Common states are `waiting_review`, `re_requested_review`, `repairing_must_fix`, `nitpick_only`, `stale_head`, and `converged`. If stored success evidence contradicts the current policy result, the line reports `contradictory_evidence` and keeps merge blocked so the operator can inspect the connector state instead of treating partial evidence as convergence.
+
 Use `configuredBotCurrentHeadSignalTimeoutAction: "block"` for non-mutating block-only operation, or `"continue"` only when missing Codex Connector current-head activity should be diagnosed without blocking merge progression.
 
 ### CodeRabbit waits

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -26,6 +26,7 @@ import {
   configuredReviewBots,
   configuredReviewStatusLabel,
   externalSignalReadinessDiagnostics,
+  formatCodexConnectorConvergenceDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
   inferReviewBotProfile,
   reviewBotDiagnostics,
@@ -372,6 +373,15 @@ export function buildActiveDetailedStatusLines(
     });
     if (codexConnectorReviewFallback) {
       lines.push(codexConnectorReviewFallback);
+    }
+    const codexConnectorConvergence = formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: activeRecord,
+      pr,
+      reviewThreads,
+    });
+    if (codexConnectorConvergence) {
+      lines.push(codexConnectorConvergence);
     }
     lines.push(`pr_hydration provenance=${pr.hydrationProvenance ?? "unknown"} head_sha=${pr.headRefOid}`);
     lines.push(

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -349,6 +349,10 @@ test("explain surfaces Codex Connector review-request fallback lifecycle for the
     explanation,
     /^codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
+  assert.match(
+    explanation,
+    /^codex_connector_convergence status=re_requested_review provider=codex current_head_sha=head-1925 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review$/m,
+  );
 });
 
 test("explain surfaces loop-off as an operator blocker for active tracked work", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -37,6 +37,7 @@ import {
 } from "./supervisor-detailed-status-assembly";
 import {
   externalSignalReadinessDiagnostics,
+  formatCodexConnectorConvergenceDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
 } from "./supervisor-status-review-bot";
 import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
@@ -115,6 +116,7 @@ export interface SupervisorExplainDto {
   staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
   codexConnectorPolicyBlockSummary?: string | null;
   codexConnectorReviewFallbackSummary?: string | null;
+  codexConnectorConvergenceSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
   trackedPrMismatchSummary: string | null;
@@ -469,6 +471,15 @@ export async function buildIssueExplainDto(
         pr,
       })
       : null;
+  const codexConnectorConvergenceSummary =
+    record && pr && !trackedPrHydrationFailed
+      ? formatCodexConnectorConvergenceDiagnostic({
+        config,
+        record,
+        pr,
+        reviewThreads: explainReviewThreads,
+      })
+      : null;
   const noActiveTrackedRecordSummary =
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
@@ -561,6 +572,7 @@ export async function buildIssueExplainDto(
     staleReviewBotRemediation,
     codexConnectorPolicyBlockSummary,
     codexConnectorReviewFallbackSummary,
+    codexConnectorConvergenceSummary,
     noActiveTrackedRecordSummary,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary
@@ -636,6 +648,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
     ...(dto.codexConnectorPolicyBlockSummary ? [dto.codexConnectorPolicyBlockSummary] : []),
     ...(dto.codexConnectorReviewFallbackSummary ? [dto.codexConnectorReviewFallbackSummary] : []),
+    ...(dto.codexConnectorConvergenceSummary ? [dto.codexConnectorConvergenceSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -453,6 +453,11 @@ test("buildDetailedStatusModel explains Codex Connector current-head signal wait
         "review_bot_diagnostics status=missing_provider_signal observed_review=none expected_reviewers=chatgpt-codex-connector next_check=provider_setup_or_delivery",
       ),
     );
+    assert.ok(
+      lines.includes(
+        "codex_connector_convergence status=waiting_review provider=codex current_head_sha=deadbeef current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_current_head_signal",
+      ),
+    );
   } finally {
     Date.now = originalNow;
   }
@@ -552,6 +557,11 @@ test("buildDetailedStatusModel reports stale provider signal diagnostics with re
   assert.ok(
     lines.includes(
       "review_bot_diagnostics status=stale_provider_signal observed_review=stale_external_review_record expected_reviewers=chatgpt-codex-connector next_check=wait_for_current_head_signal recent_observation=external_review_record:head-old->head-new",
+    ),
+  );
+  assert.ok(
+    lines.includes(
+      "codex_connector_convergence status=stale_head provider=codex current_head_sha=head-new current_head_observed_at=none latest_signal_head_sha=head-old highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_current_head_signal",
     ),
   );
 });

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -10,6 +10,7 @@ import {
   configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
   externalSignalReadinessDiagnostics,
+  formatCodexConnectorConvergenceDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
   configuredReviewStatusLabel,
   inferReviewBotProfile,
@@ -916,6 +917,52 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
   } finally {
     Date.now = originalNow;
   }
+});
+
+test("formatCodexConnectorConvergenceDiagnostic surfaces must-fix convergence state", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const pr = createPr({
+    headRefOid: "head-1939",
+    configuredBotCurrentHeadObservedAt: "2026-05-08T03:24:00Z",
+    configuredBotCurrentHeadStatusState: "COMMENTED",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-05-08T03:25:00Z",
+  });
+  const mustFixThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P1: Fix this before merge.",
+          createdAt: "2026-05-08T03:25:00Z",
+          url: "https://example.test/pr/1939#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: createRecord({
+        state: "local_review_fix",
+        pr_number: pr.number,
+        provider_success_head_sha: null,
+        provider_success_observed_at: null,
+      }),
+      pr,
+      reviewThreads: [mustFixThread],
+    }),
+    "codex_connector_convergence status=repairing_must_fix provider=codex current_head_sha=head-1939 current_head_observed_at=2026-05-08T03:24:00Z latest_signal_head_sha=head-1939 highest_severity=P1 finding_count=1 merge_effect=blocked next_action=repair_must_fix_findings",
+  );
 });
 
 test("configuredBotInitialGraceWaitWindow reports the active CodeRabbit re-wait after a draft skip when the PR becomes ready", () => {

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -9,6 +9,10 @@ import {
 } from "../core/review-providers";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
+import {
+  buildCodexConnectorPolicyBlockDiagnostic,
+  evaluateCodexConnectorConvergencePolicy,
+} from "../review-thread-reporting";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
@@ -340,6 +344,119 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
     `review_signal=${reviewSignal}`,
     "note=request_comment_is_not_review_completion",
   ].join(" ") + waitUntilSuffix;
+}
+
+export function formatCodexConnectorConvergenceDiagnostic(args: {
+  config: SupervisorConfig;
+  record: Pick<
+    IssueRunRecord,
+    | "state"
+    | "provider_success_head_sha"
+    | "provider_success_observed_at"
+    | "external_review_head_sha"
+    | "codex_connector_review_requested_observed_at"
+    | "codex_connector_review_requested_head_sha"
+  >;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+}): string | null {
+  if (!configuredReviewProviderKinds(args.config).includes("codex")) {
+    return null;
+  }
+
+  const policy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, args.reviewThreads);
+  if (!policy) {
+    return null;
+  }
+
+  const currentHeadSha = args.pr.headRefOid;
+  const staleSignalHeadSha =
+    args.record.provider_success_head_sha && args.record.provider_success_head_sha !== currentHeadSha
+      ? args.record.provider_success_head_sha
+      : args.record.external_review_head_sha && args.record.external_review_head_sha !== currentHeadSha
+        ? args.record.external_review_head_sha
+        : null;
+  const latestSignalHeadSha =
+    staleSignalHeadSha ??
+    (args.record.provider_success_head_sha === currentHeadSha
+      ? args.record.provider_success_head_sha
+      : policy.currentHeadObservedAt
+        ? currentHeadSha
+        : "none");
+  const requestMatchesCurrentHead = Boolean(
+    args.record.codex_connector_review_requested_observed_at &&
+      args.record.codex_connector_review_requested_head_sha === currentHeadSha,
+  );
+  const hasCurrentHeadProviderSuccess = Boolean(
+    args.record.provider_success_observed_at && args.record.provider_success_head_sha === currentHeadSha,
+  );
+  const findingCount = policy.mustFixCount + policy.nitpickCount;
+  const policyBlock = buildCodexConnectorPolicyBlockDiagnostic(args.config, args.reviewThreads);
+  const highestSeverity =
+    policyBlock?.severity ?? (policy.nitpickCount > 0 ? "nitpick_only" : "none");
+
+  let status:
+    | "contradictory_evidence"
+    | "stale_head"
+    | "repairing_must_fix"
+    | "re_requested_review"
+    | "waiting_review"
+    | "missing_current_head_review"
+    | "nitpick_only"
+    | "converged";
+  let mergeEffect: "blocked" | "nitpick_only" | "ready";
+  let nextAction:
+    | "fail_closed_inspect_connector_state"
+    | "wait_for_current_head_signal"
+    | "repair_must_fix_findings"
+    | "wait_for_requested_review"
+    | "request_or_wait_for_current_head_review"
+    | "merge_or_follow_up_nitpicks"
+    | "merge_ready";
+
+  if (hasCurrentHeadProviderSuccess && policy.outcome !== "converged" && policy.outcome !== "nitpick_only") {
+    status = "contradictory_evidence";
+    mergeEffect = "blocked";
+    nextAction = "fail_closed_inspect_connector_state";
+  } else if (staleSignalHeadSha) {
+    status = "stale_head";
+    mergeEffect = "blocked";
+    nextAction = "wait_for_current_head_signal";
+  } else if (policy.outcome === "must_fix_remaining") {
+    status = "repairing_must_fix";
+    mergeEffect = "blocked";
+    nextAction = "repair_must_fix_findings";
+  } else if (policy.outcome === "missing_current_head_review") {
+    status = requestMatchesCurrentHead ? "re_requested_review" : "missing_current_head_review";
+    mergeEffect = "blocked";
+    nextAction = requestMatchesCurrentHead ? "wait_for_requested_review" : "request_or_wait_for_current_head_review";
+  } else if (policy.outcome === "nitpick_only") {
+    status = "nitpick_only";
+    mergeEffect = "nitpick_only";
+    nextAction = "merge_or_follow_up_nitpicks";
+  } else {
+    status = "converged";
+    mergeEffect = "ready";
+    nextAction = "merge_ready";
+  }
+
+  const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
+  if (status === "missing_current_head_review" && waitWindow.status === "active") {
+    status = "waiting_review";
+    nextAction = "wait_for_current_head_signal";
+  }
+
+  return [
+    `codex_connector_convergence status=${status}`,
+    "provider=codex",
+    `current_head_sha=${currentHeadSha}`,
+    `current_head_observed_at=${policy.currentHeadObservedAt ?? "none"}`,
+    `latest_signal_head_sha=${latestSignalHeadSha}`,
+    `highest_severity=${highestSeverity}`,
+    `finding_count=${findingCount}`,
+    `merge_effect=${mergeEffect}`,
+    `next_action=${nextAction}`,
+  ].join(" ");
 }
 
 export function configuredBotInitialGraceWaitWindow(


### PR DESCRIPTION
## Summary
- add a shared codex_connector_convergence diagnostic for Codex Connector tracked PRs
- surface the line in status --why and explain <issue>
- document the operator-visible convergence states and fail-closed contradictory evidence behavior

## Verification
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts
- npm run build

Part of #1939