### PR TITLE
Fix ready promotion path hygiene diff scoping

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2376,6 +2376,102 @@ test("handlePostTurnPullRequestTransitionsPhase forwards publishable allowlist m
   assert.equal(result.record.blocked_reason, null);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase scopes ready-promotion path hygiene to PR changed files", async (t) => {
+  const workspacePath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(workspacePath, "docs"), { recursive: true });
+  await fs.writeFile(
+    path.join(workspacePath, "docs", "baseline.md"),
+    `Baseline note: ${SAMPLE_UNIX_WORKSTATION_PATH}\n`,
+    "utf8",
+  );
+  git(workspacePath, "add", "docs/baseline.md");
+  git(workspacePath, "commit", "-m", "seed baseline finding");
+  git(workspacePath, "push", "origin", "main");
+  git(workspacePath, "checkout", "-b", "codex/issue-102");
+  await fs.writeFile(path.join(workspacePath, "docs", "changed.md"), "No local path here.\n", "utf8");
+  git(workspacePath, "add", "docs/changed.md");
+  git(workspacePath, "commit", "-m", "change unrelated file");
+  git(workspacePath, "push", "-u", "origin", "codex/issue-102");
+  const headSha = git(workspacePath, "rev-parse", "HEAD").trim();
+
+  const config = createConfig();
+  const issue = createIssue({ title: "Ignore baseline-only path findings" });
+  const draftPr = createPullRequest({
+    title: "Ignore baseline-only path findings",
+    isDraft: true,
+    headRefName: "codex/issue-102",
+    headRefOid: headSha,
+  });
+  const readyPr = createPullRequest({
+    title: "Ignore baseline-only path findings",
+    isDraft: false,
+    headRefName: "codex/issue-102",
+    headRefOid: headSha,
+  });
+  const record = createRecord({
+    state: "draft_pr",
+    pr_number: draftPr.number,
+    last_head_sha: headSha,
+    branch: "codex/issue-102",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": createRecord({ ...record }) },
+  };
+
+  let readyCalls = 0;
+  let snapshotLoads = 0;
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      markPullRequestReady: async (prNumber: number) => {
+        assert.equal(prNumber, draftPr.number);
+        readyCalls += 1;
+      },
+    }),
+    context: createPostTurnContext({
+      issue,
+      pr: draftPr,
+      workspacePath,
+      state,
+      record,
+    }),
+    derivePullRequestLifecycleSnapshot: (currentRecord, pr) =>
+      createLifecycleSnapshot(currentRecord, pr.isDraft ? "draft_pr" : "pr_open"),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: () => ({
+      hasPending: false,
+      hasFailing: false,
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr: snapshotLoads === 1 ? draftPr : readyPr,
+        checks: [],
+        reviewThreads: [] satisfies ReviewThread[],
+      };
+    },
+  });
+
+  assert.equal(readyCalls, 1);
+  assert.equal(result.record.state, "pr_open");
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(result.record.last_failure_signature, null);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-local path hygiene blocks tracked ready promotion", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -33,6 +33,7 @@ import { nowIso, truncate } from "./core/utils";
 import { type LocalCiCommandRunner } from "./local-ci";
 import {
   buildWorkstationLocalPathFailureContext,
+  listReadyPromotionChangedFilePaths,
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
 } from "./workstation-local-path-gate";
@@ -316,6 +317,7 @@ export interface HandlePostTurnPullRequestTransitionsArgs {
     workspacePath: string;
     gateLabel: string;
     publishablePathAllowlistMarkers?: readonly string[];
+    readyPromotionChangedFilePaths?: readonly string[];
   }) => Promise<WorkstationLocalPathGateResult>;
   emitEvent?: SupervisorEventSink;
   loadOpenPullRequestSnapshot?: (prNumber: number) => Promise<{
@@ -670,10 +672,23 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     !localReviewBlocksReady(config, record, refreshed.pr) &&
     !options.dryRun
   ) {
+    const readyPromotionChangedFilePaths =
+      listReadyPromotionChangedFilePaths({
+        workspacePath,
+        baseRef: `origin/${config.defaultBranch}`,
+        headRef: refreshed.pr.headRefName,
+      }) ??
+      listReadyPromotionChangedFilePaths({
+        workspacePath,
+        baseRef: config.defaultBranch,
+        headRef: refreshed.pr.headRefName,
+      }) ??
+      undefined;
     const pathHygieneGate = await runWorkstationLocalPathGateImpl({
       workspacePath,
       gateLabel: `before marking PR #${refreshed.pr.number} ready`,
       publishablePathAllowlistMarkers: config.publishablePathAllowlistMarkers,
+      readyPromotionChangedFilePaths,
     });
     const pathHygieneDecision = deriveReadyPromotionPathHygieneDecision({
       record,

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { runWorkstationLocalPathGate } from "./workstation-local-path-gate";
+import {
+  listReadyPromotionChangedFilePaths,
+  runWorkstationLocalPathGate,
+} from "./workstation-local-path-gate";
 
 const SAMPLE_FORBIDDEN_PATH = ["", "home", "alice", "dev", "private-repo"].join("/");
 const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
@@ -99,6 +102,23 @@ function extractRenderedFindingLines(stderr: string): string[] {
 
   return findingLines;
 }
+
+test("ready-promotion changed-file listing preserves filenames with embedded newlines", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  git(repoPath, "checkout", "-b", "codex/issue-newline-path");
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, "docs", "a\nb.md"), "fixture\n", "utf8");
+  git(repoPath, "add", "docs/a\nb.md");
+  git(repoPath, "commit", "-m", "add newline filename");
+
+  assert.deepEqual(listReadyPromotionChangedFilePaths({ workspacePath: repoPath, baseRef: "main" }), [
+    "docs/a\nb.md",
+  ]);
+});
 
 test("workstation-local path detector flags tracked durable artifacts and allows explicit exclusions", async (t) => {
   const repoPath = await createTrackedRepo();

--- a/src/workstation-local-path-detector.test.ts
+++ b/src/workstation-local-path-detector.test.ts
@@ -230,6 +230,93 @@ test("runtime gate reuses the CLI finding rendering for workstation-local path v
   assert.deepEqual(gateResult.failureContext?.details, renderedFindings);
 });
 
+test("runtime gate can scope ready promotion blockers to changed files while surfacing baseline maintenance findings", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, "docs", "baseline.md"), `Workspace note: ${SAMPLE_FORBIDDEN_PATH}\n`, "utf8");
+  await fs.writeFile(path.join(repoPath, "docs", "changed.md"), "No local path here.\n", "utf8");
+  git(repoPath, "add", "docs/baseline.md", "docs/changed.md");
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before marking PR #116 ready",
+    readyPromotionChangedFilePaths: ["docs/changed.md"],
+  });
+
+  assert.equal(gateResult.ok, true);
+  assert.equal(gateResult.failureContext, null);
+  assert.deepEqual(gateResult.readyPromotionMaintenanceFindingDetails, [
+    `- docs/baseline.md:1 matched /home/<user>/ (Linux user home directory) via ${JSON.stringify(SAMPLE_FORBIDDEN_PATH)}. Remediation: rewrite the path repo-relatively or redact the operator-local absolute path`,
+  ]);
+});
+
+test("runtime gate blocks ready promotion when a changed file still contains a workstation-local path", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, "docs", "changed.md"), `Workspace note: ${SAMPLE_FORBIDDEN_PATH}\n`, "utf8");
+  git(repoPath, "add", "docs/changed.md");
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before marking PR #116 ready",
+    readyPromotionChangedFilePaths: ["docs/changed.md"],
+  });
+
+  assert.equal(gateResult.ok, false);
+  assert.match(gateResult.failureContext?.summary ?? "", /workstation-local path hygiene before marking PR #116 ready/);
+  assert.deepEqual(gateResult.failureContext?.details, [
+    `- docs/changed.md:1 matched /home/<user>/ (Linux user home directory) via ${JSON.stringify(SAMPLE_FORBIDDEN_PATH)}. Remediation: rewrite the path repo-relatively or redact the operator-local absolute path`,
+  ]);
+});
+
+test("runtime gate keeps trusted generated durable artifacts fail-closed outside the changed-file scope", async (t) => {
+  const repoPath = await createTrackedRepo();
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(path.join(repoPath, "docs"), { recursive: true });
+  await fs.writeFile(
+    path.join(repoPath, "docs", "generated-summary.md"),
+    [
+      TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+      "",
+      `Generated note: ${SAMPLE_FORBIDDEN_PATH}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(path.join(repoPath, "docs", "changed.md"), "No local path here.\n", "utf8");
+  git(repoPath, "add", "docs/generated-summary.md", "docs/changed.md");
+
+  const gateResult = await runWorkstationLocalPathGate({
+    workspacePath: repoPath,
+    gateLabel: "before marking PR #116 ready",
+    readyPromotionChangedFilePaths: ["docs/changed.md"],
+  });
+
+  assert.equal(gateResult.ok, true);
+  assert.deepEqual(gateResult.rewrittenTrustedGeneratedArtifactPaths, ["docs/generated-summary.md"]);
+  assert.deepEqual(gateResult.readyPromotionMaintenanceFindingDetails, []);
+  assert.equal(
+    await fs.readFile(path.join(repoPath, "docs", "generated-summary.md"), "utf8"),
+    [
+      TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER,
+      "",
+      "Generated note: <redacted-local-path>",
+      "",
+    ].join("\n"),
+  );
+});
+
 test("verify:paths and runtime gate honor configured same-line publishable allowlist markers", async (t) => {
   const repoPath = await createTrackedRepo();
   const configDir = await fs.mkdtemp(path.join(os.tmpdir(), "workstation-local-path-config-"));

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -67,6 +67,7 @@ export function listReadyPromotionChangedFilePaths(args: {
   const changedFiles = gitOutput(args.workspacePath, [
     "diff",
     "--name-only",
+    "-z",
     "--diff-filter=ACMRTUXB",
     `${mergeBase.stdout.trim()}...${headRef}`,
   ]);
@@ -75,8 +76,9 @@ export function listReadyPromotionChangedFilePaths(args: {
   }
 
   return changedFiles.stdout
-    .split(/\r?\n/)
-    .map((entry) => normalizeRepoRelativePath(entry.trim()))
+    .split("\0")
+    .filter((entry) => entry.length > 0)
+    .map((entry) => normalizeRepoRelativePath(entry))
     .filter((entry) => entry.length > 0);
 }
 

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import fs from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import { FailureContext } from "./core/types";
 import { nowIso } from "./core/utils";
 import {
@@ -25,12 +26,58 @@ export interface WorkstationLocalPathGateResult {
   rewrittenJournalPaths?: string[];
   rewrittenTrustedGeneratedArtifactPaths?: string[];
   actionablePublishableFilePaths?: string[];
+  readyPromotionMaintenanceFindingDetails?: string[];
 }
 
 function normalizeRepoRelativePath(filePath: string): string {
   return path.posix
     .normalize(filePath.replace(/\\/g, "/"))
     .replace(/^(?:\.\/)+/, "");
+}
+
+function gitOutput(
+  workspacePath: string,
+  args: string[],
+): { ok: true; stdout: string } | { ok: false; stderr: string } {
+  const result = spawnSync("git", ["-C", workspacePath, ...args], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return { ok: false, stderr: result.stderr || result.stdout || "" };
+  }
+
+  return { ok: true, stdout: result.stdout };
+}
+
+export function listReadyPromotionChangedFilePaths(args: {
+  workspacePath: string;
+  baseRef: string;
+  headRef?: string;
+}): string[] | null {
+  const headRef = args.headRef ?? "HEAD";
+  const mergeBase = gitOutput(args.workspacePath, [
+    "merge-base",
+    args.baseRef,
+    headRef,
+  ]);
+  if (!mergeBase.ok) {
+    return null;
+  }
+
+  const changedFiles = gitOutput(args.workspacePath, [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACMRTUXB",
+    `${mergeBase.stdout.trim()}...${headRef}`,
+  ]);
+  if (!changedFiles.ok) {
+    return null;
+  }
+
+  return changedFiles.stdout
+    .split(/\r?\n/)
+    .map((entry) => normalizeRepoRelativePath(entry.trim()))
+    .filter((entry) => entry.length > 0);
 }
 
 function isSupervisorOwnedDurableJournalPath(filePath: string): boolean {
@@ -374,6 +421,7 @@ export async function runWorkstationLocalPathGate(args: {
   workspacePath: string;
   gateLabel: string;
   publishablePathAllowlistMarkers?: readonly string[];
+  readyPromotionChangedFilePaths?: readonly string[];
 }): Promise<WorkstationLocalPathGateResult> {
   const detectorOptions = {
     publishablePathAllowlistMarkers: args.publishablePathAllowlistMarkers ?? [],
@@ -435,11 +483,21 @@ export async function runWorkstationLocalPathGate(args: {
       rewrittenJournalPaths,
       rewrittenTrustedGeneratedArtifactPaths,
       actionablePublishableFilePaths: [],
+      readyPromotionMaintenanceFindingDetails: [],
     };
   }
 
+  const readyPromotionChangedFilePathSet =
+    args.readyPromotionChangedFilePaths === undefined
+      ? null
+      : new Set(
+          args.readyPromotionChangedFilePaths.map((entry) =>
+            normalizeRepoRelativePath(entry),
+          ),
+        );
   const categorizedFindings = await Promise.all(
     findings.map(async (finding) => ({
+      finding,
       filePath: finding.filePath,
       category: await categorizeWorkstationLocalArtifact(
         args.workspacePath,
@@ -447,19 +505,59 @@ export async function runWorkstationLocalPathGate(args: {
       ),
     })),
   );
+  const blockingFindings =
+    readyPromotionChangedFilePathSet === null
+      ? findings
+      : categorizedFindings
+          .filter(
+            (entry) =>
+              entry.category !== "publishable_tracked_content" ||
+              readyPromotionChangedFilePathSet.has(entry.filePath),
+          )
+          .map((entry) => entry.finding);
+  const maintenanceFindings =
+    readyPromotionChangedFilePathSet === null
+      ? []
+      : categorizedFindings
+          .filter(
+            (entry) =>
+              entry.category === "publishable_tracked_content" &&
+              !readyPromotionChangedFilePathSet.has(entry.filePath),
+          )
+          .map((entry) => entry.finding);
+
+  if (
+    blockingFindings.length === 0 &&
+    journalNormalizationErrors.length === 0 &&
+    trustedGeneratedArtifactNormalizationErrors.length === 0
+  ) {
+    return {
+      ok: true,
+      failureContext: null,
+      rewrittenJournalPaths,
+      rewrittenTrustedGeneratedArtifactPaths,
+      actionablePublishableFilePaths: [],
+      readyPromotionMaintenanceFindingDetails: maintenanceFindings.map(
+        formatWorkstationLocalPathMatch,
+      ),
+    };
+  }
+
   const actionablePublishableFilePaths =
     journalNormalizationErrors.length === 0 &&
     trustedGeneratedArtifactNormalizationErrors.length === 0 &&
-    categorizedFindings.length > 0 &&
+    blockingFindings.length > 0 &&
     categorizedFindings.every(
-      (entry) => entry.category === "publishable_tracked_content",
+      (entry) =>
+        !blockingFindings.includes(entry.finding) ||
+        entry.category === "publishable_tracked_content",
     )
-      ? [...new Set(categorizedFindings.map((entry) => entry.filePath))].sort(
+      ? [...new Set(blockingFindings.map((finding) => finding.filePath))].sort(
           (left, right) => left.localeCompare(right),
         )
       : [];
 
-  const remediationSummary = summarizeWorkstationLocalPathMatches(findings);
+  const remediationSummary = summarizeWorkstationLocalPathMatches(blockingFindings);
   return {
     ok: false,
     failureContext: buildWorkstationLocalPathFailureContext({
@@ -467,13 +565,13 @@ export async function runWorkstationLocalPathGate(args: {
       details: [
         ...journalNormalizationErrors,
         ...trustedGeneratedArtifactNormalizationErrors,
-        ...findings.map(formatWorkstationLocalPathMatch),
+        ...blockingFindings.map(formatWorkstationLocalPathMatch),
       ],
       summary:
         (await summarizeWorkstationLocalPathRemediation({
           workspacePath: args.workspacePath,
           gateLabel: args.gateLabel,
-          findings,
+          findings: blockingFindings,
           journalNormalizationErrors,
           trustedGeneratedArtifactNormalizationErrors,
           rewrittenJournalPaths,
@@ -486,5 +584,8 @@ export async function runWorkstationLocalPathGate(args: {
     rewrittenJournalPaths,
     rewrittenTrustedGeneratedArtifactPaths,
     actionablePublishableFilePaths,
+    readyPromotionMaintenanceFindingDetails: maintenanceFindings.map(
+      formatWorkstationLocalPathMatch,
+    ),
   };
 }


### PR DESCRIPTION
## Summary
- Scope ready-promotion workstation-local path hygiene blockers to the tracked PR changed files.
- Keep full-worktree behavior for generic path gates and keep trusted durable artifact normalization fail-closed.
- Add focused regression coverage for baseline-only findings, changed-file blockers, and post-turn ready promotion.

## Verification
- npx tsx --test src/workstation-local-path-detector.test.ts src/workstation-local-paths.test.ts src/post-turn-pull-request.test.ts src/tracked-pr-status-comment.test.ts
- npm run verify:supervisor-pre-pr

Fixes #1927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * PR validation now scopes path hygiene checks to files changed in the pull request, preventing unrelated file issues from affecting approval.

* **Tests**
  * Added integration tests for PR transition workflows and scoped validation detection scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1946)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->