### PR TITLE
Surface baseline ready path hygiene diagnostics

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -284,6 +284,8 @@ export interface IssueRunRecord {
   last_tracked_pr_repeat_failure_decision?: "retry_on_progress" | "stop_no_progress" | null;
   last_observed_host_local_pr_blocker_signature?: string | null;
   last_observed_host_local_pr_blocker_head_sha?: string | null;
+  ready_promotion_maintenance_finding_details?: string[];
+  ready_promotion_maintenance_head_sha?: string | null;
   last_host_local_pr_blocker_comment_signature?: string | null;
   last_host_local_pr_blocker_comment_head_sha?: string | null;
   last_stale_review_bot_reply_signature?: string | null;

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2470,6 +2470,11 @@ test("handlePostTurnPullRequestTransitionsPhase scopes ready-promotion path hygi
   assert.equal(result.record.state, "pr_open");
   assert.equal(result.record.blocked_reason, null);
   assert.equal(result.record.last_failure_signature, null);
+  assert.equal(result.record.ready_promotion_maintenance_finding_details?.length, 1);
+  assert.match(
+    result.record.ready_promotion_maintenance_finding_details?.[0] ?? "",
+    new RegExp(`^\\- docs/baseline\\.md:1 matched /${"home"}/<user>/ .*Remediation: rewrite the path repo-relatively`),
+  );
 });
 
 test("handlePostTurnPullRequestTransitionsPhase comments once when workstation-local path hygiene blocks tracked ready promotion", async (t) => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -719,6 +719,19 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       };
     }
 
+    if (
+      pathHygieneDecision.maintenanceFindingDetails.length > 0 ||
+      (record.ready_promotion_maintenance_finding_details?.length ?? 0) > 0
+    ) {
+      record = stateStore.touch(record, {
+        ready_promotion_maintenance_finding_details: pathHygieneDecision.maintenanceFindingDetails,
+        ready_promotion_maintenance_head_sha: refreshed.pr.headRefOid ?? null,
+      });
+      state.issues[String(record.issue_number)] = record;
+      await stateStore.save(state);
+      await syncJournal(record);
+    }
+
     const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(
       workspacePath,
       pathHygieneDecision.rewrittenTrackedPaths,

--- a/src/ready-promotion-gate.ts
+++ b/src/ready-promotion-gate.ts
@@ -16,6 +16,7 @@ export type ReadyPromotionPathHygieneDecision =
   | {
       kind: "passed";
       rewrittenTrackedPaths: string[];
+      maintenanceFindingDetails: string[];
     }
   | {
       kind: "repair";
@@ -61,6 +62,7 @@ export function deriveReadyPromotionPathHygieneDecision(args: {
         ...(args.gate.rewrittenJournalPaths ?? []),
         ...(args.gate.rewrittenTrustedGeneratedArtifactPaths ?? []),
       ],
+      maintenanceFindingDetails: args.gate.readyPromotionMaintenanceFindingDetails ?? [],
     };
   }
 

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1706,6 +1706,75 @@ test("explain distinguishes repairable ready-promotion path hygiene blockers que
   );
 });
 
+test("explain surfaces baseline-only ready-promotion path hygiene findings as maintenance context", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 180;
+  const prNumber = 280;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "pr_open",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: null,
+        last_error: null,
+        last_head_sha: "head-ready-280",
+        last_failure_signature: null,
+        ready_promotion_maintenance_head_sha: "head-ready-280",
+        ready_promotion_maintenance_finding_details: [
+          `docs/baseline.md:1 matched /${"home"}/placeholder via "<workstation-local>"`,
+        ],
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked baseline path maintenance context",
+    body: executionReadyBody("Explain baseline-only ready-promotion path findings."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const openPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-ready-280",
+    isDraft: false,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => openPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+  assert.match(
+    explanation,
+    new RegExp(
+      `^tracked_pr_ready_promotion_maintenance issue=#180 pr=#280 gate=workstation_local_path_hygiene readiness=ignored_for_current_pr maintenance=yes findings=1 head_sha=head-ready-280 summary=Baseline-only workstation-local path findings were ignored for current-PR readiness but remain maintenance debt\\. first_finding=docs\\/baseline\\.md:1 matched /${"home"}\\/placeholder via "<workstation-local>"$`,
+      "m",
+    ),
+  );
+  assert.doesNotMatch(explanation, /ready_promotion_blocked_workstation_local_path_hygiene/);
+});
+
 test("explain reports bootstrap repos as not ready for expected CI and review signals", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 181;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -4164,6 +4164,74 @@ test("status distinguishes repairable ready-promotion path hygiene blockers queu
   );
 });
 
+test("status surfaces baseline-only ready-promotion path hygiene findings as maintenance context", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 180;
+  const prNumber = 280;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "pr_open",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: null,
+        last_error: null,
+        last_head_sha: "head-ready-280",
+        last_failure_signature: null,
+        ready_promotion_maintenance_head_sha: "head-ready-280",
+        ready_promotion_maintenance_finding_details: [
+          `docs/baseline.md:1 matched /${"home"}/placeholder via "<workstation-local>"`,
+        ],
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked baseline path maintenance context",
+    body: executionReadyBody("Surface baseline-only ready-promotion path findings."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const openPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-ready-280",
+    isDraft: false,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => openPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status();
+  assert.match(
+    status,
+    new RegExp(
+      `^tracked_pr_ready_promotion_maintenance issue=#180 pr=#280 gate=workstation_local_path_hygiene readiness=ignored_for_current_pr maintenance=yes findings=1 head_sha=head-ready-280 summary=Baseline-only workstation-local path findings were ignored for current-PR readiness but remain maintenance debt\\. first_finding=docs\\/baseline\\.md:1 matched /${"home"}\\/placeholder via "<workstation-local>"$`,
+      "m",
+    ),
+  );
+  assert.doesNotMatch(status, /ready_promotion_blocked_workstation_local_path_hygiene/);
+});
+
 test("status surfaces host-local CI blocker details for tracked PR mismatches", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 171;

--- a/src/supervisor/supervisor-read-only-reporting.ts
+++ b/src/supervisor/supervisor-read-only-reporting.ts
@@ -36,7 +36,11 @@ import {
   renderGitHubRateLimitLine,
   type SupervisorStatusDto,
 } from "./supervisor-status-report";
-import { buildTrackedPrMismatch, shouldHydrateTrackedPrDiagnostics } from "./tracked-pr-mismatch";
+import {
+  buildTrackedPrMismatch,
+  buildTrackedPrReadyPromotionMaintenanceLines,
+  shouldHydrateTrackedPrDiagnostics,
+} from "./tracked-pr-mismatch";
 import {
   buildLoopOffTrackedWorkBlocker,
   buildMacOsLoopHostWarning,
@@ -279,6 +283,7 @@ export async function buildSupervisorStatusReport(args: {
       if (statusRecords.latestRecord?.issue_number === record.issue_number) {
         latestTrackedPrHydration = { pr, checks, reviewThreads };
       }
+      trackedPrMismatchLines.push(...buildTrackedPrReadyPromotionMaintenanceLines(record, pr));
       const mismatch = buildTrackedPrMismatch(config, record, pr, checks, reviewThreads);
       if (!mismatch) {
         continue;

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -42,7 +42,7 @@ import {
 } from "./supervisor-status-review-bot";
 import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
 import { formatInventoryRefreshDiagnosticLines, formatInventoryRefreshStatusLine } from "../inventory-refresh-state";
-import { buildTrackedPrMismatch } from "./tracked-pr-mismatch";
+import { buildTrackedPrMismatch, buildTrackedPrReadyPromotionMaintenanceLines } from "./tracked-pr-mismatch";
 import {
   BlockedReason,
   GitHubIssue,
@@ -119,6 +119,7 @@ export interface SupervisorExplainDto {
   codexConnectorConvergenceSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
+  trackedPrReadyPromotionMaintenanceSummary?: string | null;
   trackedPrMismatchSummary: string | null;
   externalSignalReadinessSummary?: string | null;
   recoveryGuidance: string | null;
@@ -425,6 +426,10 @@ export async function buildIssueExplainDto(
     record && pr && !trackedPrHydrationFailed
       ? buildTrackedPrMismatch(config, record, pr, explainChecks, explainReviewThreads)
       : null;
+  const trackedPrReadyPromotionMaintenanceSummary =
+    record && pr && !trackedPrHydrationFailed
+      ? buildTrackedPrReadyPromotionMaintenanceLines(record, pr)[0] ?? null
+      : null;
   const externalSignalReadinessSummary =
     record && pr && !trackedPrHydrationFailed
       ? (() => {
@@ -582,6 +587,7 @@ export async function buildIssueExplainDto(
           `signal=${record.last_tracked_pr_progress_summary.replace(/\s+/g, "_")}`,
         ].join(" ")
         : null,
+    trackedPrReadyPromotionMaintenanceSummary,
     trackedPrMismatchSummary: trackedPrMismatch?.summaryLine ?? null,
     externalSignalReadinessSummary,
     recoveryGuidance: trackedPrMismatch?.guidanceLine ?? null,
@@ -651,6 +657,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.codexConnectorConvergenceSummary ? [dto.codexConnectorConvergenceSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
+    ...(dto.trackedPrReadyPromotionMaintenanceSummary ? [dto.trackedPrReadyPromotionMaintenanceSummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),
     ...(dto.externalSignalReadinessSummary ? [dto.externalSignalReadinessSummary] : []),
     ...(dto.recoveryGuidance ? [dto.recoveryGuidance] : []),

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -46,6 +46,31 @@ export interface TrackedPrMismatch {
   detailLines: string[];
 }
 
+export function buildTrackedPrReadyPromotionMaintenanceLines(
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): string[] {
+  const details = record.ready_promotion_maintenance_finding_details ?? [];
+  if (details.length === 0) {
+    return [];
+  }
+
+  return [
+    [
+      "tracked_pr_ready_promotion_maintenance",
+      `issue=#${record.issue_number}`,
+      `pr=#${pr.number}`,
+      "gate=workstation_local_path_hygiene",
+      "readiness=ignored_for_current_pr",
+      "maintenance=yes",
+      `findings=${details.length}`,
+      `head_sha=${record.ready_promotion_maintenance_head_sha ?? pr.headRefOid ?? "unknown"}`,
+      "summary=Baseline-only workstation-local path findings were ignored for current-PR readiness but remain maintenance debt.",
+      `first_finding=${details[0]?.replace(/\r?\n/g, "\\n")}`,
+    ].join(" "),
+  ];
+}
+
 export function shouldHydrateTrackedPrDiagnostics(
   record: IssueRunRecord,
 ): record is IssueRunRecord & { pr_number: number } {


### PR DESCRIPTION
## Summary
- persist baseline-only ready-promotion path hygiene maintenance details when ready promotion passes
- surface the recorded maintenance context in status and explain diagnostics
- keep changed-file path hygiene blockers and ready promotion behavior unchanged

## Verification
- npx tsx --test src/workstation-local-path-detector.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/tracked-pr-status-comment.test.ts
- npm run verify:supervisor-pre-pr

Closes #1947