### PR TITLE
Use fresh review hydration for tracked PR reconciliation

### DIFF
--- a/src/recovery-active-reconciliation.ts
+++ b/src/recovery-active-reconciliation.ts
@@ -124,7 +124,11 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
   issueLockPath: (issueNumber: number) => string;
   sessionLockPath: (sessionId: string) => string;
   sameFailureSignatureRepeatLimit?: number;
-  resolvePullRequestForBranch?: (branch: string, trackedPrNumber: number | null) => Promise<GitHubPullRequest | null>;
+  resolvePullRequestForBranch?: (
+    branch: string,
+    trackedPrNumber: number | null,
+    options?: { purpose?: "status" | "action" },
+  ) => Promise<GitHubPullRequest | null>;
   classifyStaleStabilizingNoPrBranchState?: (
     record: IssueRunRecord,
   ) => Promise<StaleStabilizingNoPrBranchState>;
@@ -231,7 +235,7 @@ export async function reconcileStaleActiveIssueReservationInModule(args: {
 
   const matchedPullRequest =
     record.state === "stabilizing" && args.resolvePullRequestForBranch
-      ? await args.resolvePullRequestForBranch(record.branch, record.pr_number)
+      ? await args.resolvePullRequestForBranch(record.branch, record.pr_number, { purpose: "action" })
       : null;
   const staleNoPrBranchState =
     record.state === "stabilizing" && matchedPullRequest === null && args.classifyStaleStabilizingNoPrBranchState

--- a/src/recovery-family-boundaries.test.ts
+++ b/src/recovery-family-boundaries.test.ts
@@ -11,6 +11,7 @@ import { normalizeRecoveryEntrypointResult } from "./recovery-entrypoint-result"
 import { type RecoveryEvent } from "./run-once-cycle-prelude";
 import {
   createIssue,
+  createPullRequest,
   createRecord,
   createSupervisorState,
 } from "./supervisor/supervisor-test-helpers";
@@ -83,6 +84,55 @@ test("active recovery boundary clears a stale active reservation without loading
     recoveryEvents[0]?.reason,
     "stale_state_cleanup: cleared stale active reservation after issue lock was missing",
   );
+});
+
+test("active stabilizing recovery resolves tracked PRs with action-grade hydration", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-active-pr-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const record = createRecord({
+    issue_number: 367,
+    state: "stabilizing",
+    branch: "codex/issue-367",
+    pr_number: 467,
+    workspace: tempDir,
+    codex_session_id: null,
+  });
+  const state = createSupervisorState({
+    activeIssueNumber: 367,
+    issues: [record],
+  });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileStaleActiveIssueReservationInModule({
+    state,
+    stateStore: {
+      touch,
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    issueLockPath: (issueNumber) => path.join(tempDir, `issue-${issueNumber}.lock`),
+    sessionLockPath: (sessionId) => path.join(tempDir, `${sessionId}.lock`),
+    resolvePullRequestForBranch: async (branch, trackedPrNumber, options) => {
+      assert.equal(branch, "codex/issue-367");
+      assert.equal(trackedPrNumber, 467);
+      assert.equal(options?.purpose, "action");
+      return createPullRequest({
+        number: 467,
+        headRefName: "codex/issue-367",
+      });
+    },
+    buildRecoveryEvent,
+    applyRecoveryEvent,
+  });
+
+  assert.equal(saveCalls, 1);
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["367"]?.pr_number, 467);
+  assert.equal(recoveryEvents[0]?.reason, "stale_state_cleanup: cleared stale active reservation after issue lock was missing");
 });
 
 test("historical recovery boundary downgrades stale no-PR done records", async () => {

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -816,7 +816,7 @@ export async function reconcileRecoverableBlockedIssueStates(
       record.blocked_reason === "handoff_missing" &&
       record.pr_number !== null
     ) {
-      const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);
+      const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number, { purpose: "action" });
       const repairContext = trackedPullRequest
         ? queuedReadyPromotionPathHygieneRepairContext(record, trackedPullRequest)
         : null;
@@ -903,7 +903,7 @@ export async function reconcileRecoverableBlockedIssueStates(
         shouldReconcileTrackedPrStaleReviewBot(record, config)
       )
     ) {
-      const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number);
+      const trackedPullRequest = await github.getPullRequestIfExists(record.pr_number, { purpose: "action" });
       if (!trackedPullRequest || !isOpenPullRequestImpl(trackedPullRequest)) {
         continue;
       }
@@ -1140,7 +1140,11 @@ export async function reconcileStaleActiveIssueReservation(args: {
   issueLockPath: (issueNumber: number) => string;
   sessionLockPath: (sessionId: string) => string;
   sameFailureSignatureRepeatLimit?: number;
-  resolvePullRequestForBranch?: (branch: string, trackedPrNumber: number | null) => Promise<import("./core/types").GitHubPullRequest | null>;
+  resolvePullRequestForBranch?: (
+    branch: string,
+    trackedPrNumber: number | null,
+    options?: { purpose?: "status" | "action" },
+  ) => Promise<import("./core/types").GitHubPullRequest | null>;
   classifyStaleStabilizingNoPrBranchState?: (
     record: IssueRunRecord,
   ) => Promise<StaleStabilizingNoPrBranchState>;

--- a/src/recovery-tracked-pr-reconciliation.test.ts
+++ b/src/recovery-tracked-pr-reconciliation.test.ts
@@ -2,7 +2,178 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { type IssueRunRecord, type SupervisorStateFile } from "./core/types";
 import { reconcileTrackedMergedButOpenIssues } from "./recovery-reconciliation";
+import { reconcileStaleFailedTrackedPrRecord } from "./recovery-tracked-pr-reconciliation";
+import {
+  blockedReasonForLifecycleState,
+  isOpenPullRequest,
+} from "./supervisor/supervisor-lifecycle";
+import { inferFailureContext } from "./supervisor/supervisor-failure-context";
 import { createConfig, createPullRequest, createRecord } from "./supervisor/supervisor-test-helpers";
+import { inferGitHubWaitStep, inferStateFromPullRequest } from "./pull-request-state";
+import {
+  syncCopilotReviewRequestObservation,
+  syncCopilotReviewTimeoutState,
+  syncReviewWaitWindow,
+} from "./pull-request-state-sync";
+
+test("reconcileTrackedMergedButOpenIssues uses action-grade hydration for merge-critical lifecycle refresh", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotRequireCurrentHeadSignal: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutAction: "block",
+  });
+  const record = createRecord({
+    issue_number: 1949,
+    state: "blocked",
+    branch: "codex/issue-1949",
+    pr_number: 2499,
+    blocked_reason: "review_bot_timeout",
+    last_head_sha: "head-current",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: { "1949": record },
+  };
+  let saveCalls = 0;
+
+  await reconcileTrackedMergedButOpenIssues(
+    {
+      getPullRequestIfExists: async (prNumber, options) => {
+        assert.equal(prNumber, 2499);
+        assert.equal(options?.purpose, "action");
+        return createPullRequest({
+          number: 2499,
+          state: "OPEN",
+          isDraft: false,
+          headRefName: "codex/issue-1949",
+          headRefOid: "head-current",
+          mergeStateStatus: "CLEAN",
+          reviewDecision: "APPROVED",
+          currentHeadCiGreenAt: "2026-05-10T23:39:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-05-10T23:40:00Z",
+          configuredBotCurrentHeadStatusState: "SUCCESS",
+        });
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      closeIssue: async () => {
+        throw new Error("unexpected closeIssue call");
+      },
+      closePullRequest: async () => {
+        throw new Error("unexpected closePullRequest call");
+      },
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getMergedPullRequestsClosingIssue: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-05-10T23:41:00Z",
+        };
+      },
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [],
+  );
+
+  assert.equal(saveCalls, 1);
+  assert.equal(state.issues["1949"]?.state, "ready_to_merge");
+  assert.equal(state.issues["1949"]?.blocked_reason, null);
+});
+
+test("reconcileStaleFailedTrackedPrRecord uses action-grade hydration before mutating stale review timeout state", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotRequireCurrentHeadSignal: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutAction: "block",
+  });
+  const record = createRecord({
+    issue_number: 1950,
+    state: "blocked",
+    branch: "codex/issue-1950",
+    pr_number: 2500,
+    blocked_reason: "review_bot_timeout",
+    last_head_sha: "head-current",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: { "1950": record },
+  };
+
+  const recoveryEvent = await reconcileStaleFailedTrackedPrRecord(
+    {
+      getPullRequestIfExists: async (prNumber, options) => {
+        assert.equal(prNumber, 2500);
+        assert.equal(options?.purpose, "action");
+        return createPullRequest({
+          number: 2500,
+          state: "OPEN",
+          isDraft: false,
+          headRefName: "codex/issue-1950",
+          headRefOid: "head-current",
+          mergeStateStatus: "CLEAN",
+          reviewDecision: "APPROVED",
+          currentHeadCiGreenAt: "2026-05-10T23:39:00Z",
+          configuredBotCurrentHeadObservedAt: "2026-05-10T23:40:00Z",
+          configuredBotCurrentHeadStatusState: "SUCCESS",
+        });
+      },
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-05-10T23:41:00Z",
+        };
+      },
+      save: async () => {
+        throw new Error("unexpected save call");
+      },
+    },
+    state,
+    config,
+    record,
+    {
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+      inferGitHubWaitStep,
+    },
+    {
+      buildRecoveryEvent: (issueNumber, reason) => ({
+        issueNumber,
+        reason,
+        at: "2026-05-10T23:41:00Z",
+      }),
+      applyRecoveryEvent: (patch, event) => ({
+        ...patch,
+        last_recovery_reason: event.reason,
+        last_recovery_at: event.at,
+      }),
+    },
+  );
+
+  assert.ok(recoveryEvent);
+  assert.equal(state.issues["1950"]?.state, "ready_to_merge");
+  assert.equal(state.issues["1950"]?.blocked_reason, null);
+});
 
 test("reconcileTrackedMergedButOpenIssues default pass stops after recoverable tracked PR records in a mixed state", async () => {
   const recoverableRecords = [

--- a/src/recovery-tracked-pr-reconciliation.test.ts
+++ b/src/recovery-tracked-pr-reconciliation.test.ts
@@ -99,7 +99,7 @@ test("reconcileStaleFailedTrackedPrRecord uses action-grade hydration before mut
   });
   const record = createRecord({
     issue_number: 1950,
-    state: "blocked",
+    state: "failed",
     branch: "codex/issue-1950",
     pr_number: 2500,
     blocked_reason: "review_bot_timeout",

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -384,7 +384,7 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
       continue;
     }
 
-    const trackedPullRequest = await github.getPullRequestIfExists(trackedPrNumber);
+    const trackedPullRequest = await github.getPullRequestIfExists(trackedPrNumber, { purpose: "action" });
     if (trackedPullRequest && !matchesTrackedBranch(record, trackedPullRequest)) {
       if (state.activeIssueNumber === record.issue_number) {
         continue;
@@ -662,7 +662,7 @@ export async function reconcileStaleFailedTrackedPrRecord(
     return null;
   }
 
-  const pr = await github.getPullRequestIfExists(trackedPrNumber);
+  const pr = await github.getPullRequestIfExists(trackedPrNumber, { purpose: "action" });
   if (!pr || !deps.isOpenPullRequest(pr)) {
     return null;
   }

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -1075,8 +1075,8 @@ export class Supervisor {
         issueLockPath: (issueNumber) => this.lockPath("issues", `issue-${issueNumber}`),
         sessionLockPath: (sessionId) => this.lockPath("sessions", `session-${sessionId}`),
         sameFailureSignatureRepeatLimit: this.config.sameFailureSignatureRepeatLimit,
-        resolvePullRequestForBranch: (branch, trackedPrNumber) =>
-          this.github.resolvePullRequestForBranch(branch, trackedPrNumber),
+        resolvePullRequestForBranch: (branch, trackedPrNumber, options) =>
+          this.github.resolvePullRequestForBranch(branch, trackedPrNumber, options),
         classifyStaleStabilizingNoPrBranchState: (record) =>
           this.classifyStaleStabilizingNoPrBranchState(record),
       }),


### PR DESCRIPTION
## Summary
- use action-grade PR hydration for mutating tracked PR reconciliation paths
- pass action hydration through stale active stabilizing PR resolution
- add focused regressions proving review-timeout recovery uses fresh action evidence

## Verification
- npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/recovery-family-boundaries.test.ts
- npx tsx --test src/recovery-tracked-pr-reconciliation.test.ts src/run-once-cycle-prelude.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npx tsx --test src/github/github.test.ts src/github/github-pull-request-hydrator.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run verify:supervisor-pre-pr

Fixes #1949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced pull request resolution with additional context parameters for improved reconciliation workflows.
* **Tests**
  * Added test coverage for stale reservation cleanup and tracked PR reconciliation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1950)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->