### PR TITLE
Fix Codex Connector request fallback without green timestamp

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -494,7 +494,7 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
       title: "Request Codex Connector review after timeout",
       isDraft: false,
       headRefOid: "head-1924",
-      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      currentHeadCiGreenAt: null,
       configuredBotCurrentHeadObservedAt: null,
       codexConnectorReviewRequestedAt: null,
       codexConnectorReviewRequestedHeadSha: null,
@@ -610,6 +610,251 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
     assert.equal(retryResult.record.codex_connector_review_requested_head_sha, pr.headRefOid);
   } finally {
     Date.now = originalDateNow;
+  }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase does not request Codex Connector review on non-green loaded checks without green timestamp", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issue = createIssue({ number: 1951, title: "Suppress Codex Connector request" });
+  const pr = createPullRequest({
+    number: 1951,
+    title: "Suppress Codex Connector request",
+    isDraft: false,
+    headRefOid: "head-1951",
+    currentHeadCiGreenAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+  });
+  const baseRecord = createRecord({
+    issue_number: issue.number,
+    state: "waiting_ci",
+    pr_number: pr.number,
+    last_head_sha: pr.headRefOid,
+    review_wait_started_at: "2026-05-08T03:09:36Z",
+    review_wait_head_sha: pr.headRefOid,
+    copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    copilot_review_timeout_reason:
+      "Configured review bot never produced a current-head signal within 10 minute(s).",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+  });
+
+  const cases: Array<{ name: string; checks: PullRequestCheck[] }> = [
+    {
+      name: "pending",
+      checks: [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }],
+    },
+    {
+      name: "cancelled",
+      checks: [{ name: "merge-queue", state: "CANCELLED", bucket: "cancel", workflow: "CI" }],
+    },
+    {
+      name: "failing",
+      checks: [{ name: "build", state: "FAILURE", bucket: "fail", workflow: "CI" }],
+    },
+  ];
+
+  for (const scenario of cases) {
+    const record = createRecord({ ...baseRecord, issue_number: issue.number });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const commentBodies: string[] = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (_issueNumber, body) => {
+          commentBodies.push(body);
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", `issue-1951-${scenario.name}`),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: scenario.checks,
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads: () => [],
+      manualReviewThreads: () => [],
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(
+      commentBodies.some((body) => body.includes("codex-supervisor:codex-connector-review-request")),
+      false,
+      scenario.name,
+    );
+    assert.equal(result.record.codex_connector_review_requested_head_sha, null, scenario.name);
+  }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase keeps Codex Connector review request suppressed by PR and review blockers without green timestamp", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issue = createIssue({ number: 1951, title: "Blocked Codex Connector request" });
+  const basePr = createPullRequest({
+    number: 1951,
+    title: "Blocked Codex Connector request",
+    isDraft: false,
+    headRefOid: "head-1951",
+    currentHeadCiGreenAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+  });
+  const passingChecks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const blockerThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex",
+          body: "P1: fix this before merge.",
+          createdAt: "2026-05-08T03:30:00Z",
+          url: "https://example.test/pr/1951#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const manualThread = createReviewThread({
+    id: "manual-thread",
+    comments: {
+      nodes: [
+        {
+          id: "comment-human",
+          body: "Please revise this.",
+          createdAt: "2026-05-08T03:30:00Z",
+          url: "https://example.test/pr/1951#discussion_r2",
+          author: {
+            login: "reviewer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const cases: Array<{
+    name: string;
+    pr: ReturnType<typeof createPullRequest>;
+    reviewThreads: ReviewThread[];
+    configuredBotReviewThreads: ReviewThread[];
+    manualReviewThreads: ReviewThread[];
+    mergeConflict: boolean;
+  }> = [
+    {
+      name: "draft",
+      pr: { ...basePr, isDraft: true },
+      reviewThreads: [],
+      configuredBotReviewThreads: [],
+      manualReviewThreads: [],
+      mergeConflict: false,
+    },
+    {
+      name: "merge-conflict",
+      pr: basePr,
+      reviewThreads: [],
+      configuredBotReviewThreads: [],
+      manualReviewThreads: [],
+      mergeConflict: true,
+    },
+    {
+      name: "configured-bot-thread",
+      pr: basePr,
+      reviewThreads: [blockerThread],
+      configuredBotReviewThreads: [blockerThread],
+      manualReviewThreads: [],
+      mergeConflict: false,
+    },
+    {
+      name: "manual-thread",
+      pr: basePr,
+      reviewThreads: [manualThread],
+      configuredBotReviewThreads: [],
+      manualReviewThreads: [manualThread],
+      mergeConflict: false,
+    },
+  ];
+
+  for (const scenario of cases) {
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: scenario.pr.number,
+      last_head_sha: scenario.pr.headRefOid,
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: scenario.pr.headRefOid,
+      copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const commentBodies: string[] = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (_issueNumber, body) => {
+          commentBodies.push(body);
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr: scenario.pr,
+        workspacePath: process.cwd(),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr: scenario.pr,
+        checks: passingChecks,
+        reviewThreads: scenario.reviewThreads,
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads: () => scenario.configuredBotReviewThreads,
+      manualReviewThreads: () => scenario.manualReviewThreads,
+      mergeConflictDetected: () => scenario.mergeConflict,
+    });
+
+    assert.equal(
+      commentBodies.some((body) => body.includes("codex-supervisor:codex-connector-review-request")),
+      false,
+      scenario.name,
+    );
+    assert.equal(result.record.codex_connector_review_requested_head_sha, null, scenario.name);
   }
 });
 

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -356,6 +356,11 @@ function shouldRequestCodexConnectorReviewComment(args: {
   manualReviewThreads: HandlePostTurnPullRequestTransitionsArgs["manualReviewThreads"];
   mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
 }): boolean {
+  const checkSummary = args.summarizeChecks(args.checks);
+  const loadedChecksAreGreen =
+    args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
+  const hasGreenCheckSignal = isValidTimestamp(args.pr.currentHeadCiGreenAt) || loadedChecksAreGreen;
+
   if (
     args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
     !configuredReviewProviderKinds(args.config).includes("codex") ||
@@ -367,12 +372,11 @@ function shouldRequestCodexConnectorReviewComment(args: {
     args.configuredBotReviewThreads(args.config, args.reviewThreads).length > 0 ||
     args.manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
     isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) ||
-    !isValidTimestamp(args.pr.currentHeadCiGreenAt)
+    !hasGreenCheckSignal
   ) {
     return false;
   }
 
-  const checkSummary = args.summarizeChecks(args.checks);
   return !checkSummary.hasPending && !checkSummary.hasFailing;
 }
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -370,6 +370,7 @@ export function buildActiveDetailedStatusLines(
       config,
       record: activeRecord,
       pr,
+      checks,
     });
     if (codexConnectorReviewFallback) {
       lines.push(codexConnectorReviewFallback);

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -474,6 +474,7 @@ export async function buildIssueExplainDto(
         config,
         record,
         pr,
+        checks: explainChecks,
       })
       : null;
   const codexConnectorConvergenceSummary =

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -914,6 +914,22 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
       }),
       "codex_connector_review_fallback status=already_requested provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:21:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-03-16T00:20:00.000Z",
     );
+
+    assert.equal(
+      formatCodexConnectorReviewFallbackDiagnostic({
+        config,
+        record: createRecord({
+          codex_connector_review_requested_observed_at: "2026-03-16T00:21:00.000Z",
+          codex_connector_review_requested_head_sha: "head-340",
+        }),
+        pr: {
+          ...waitingPr,
+          currentHeadCiGreenAt: null,
+        },
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      }),
+      "codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=loaded_checks_passed timeout_action=request_review_comment requested_at=2026-03-16T00:21:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion",
+    );
   } finally {
     Date.now = originalNow;
   }

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -7,7 +7,7 @@ import {
   repoUsesCopilotOnlyReviewBot,
   reviewProviderProfileFromConfig,
 } from "../core/review-providers";
-import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
 import {
   buildCodexConnectorPolicyBlockDiagnostic,
@@ -293,6 +293,7 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
     "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
   >;
   pr: GitHubPullRequest;
+  checks?: PullRequestCheck[];
 }): string | null {
   if (!configuredReviewProviderKinds(args.config).includes("codex")) {
     return null;
@@ -309,6 +310,10 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
   const requestMatchesCurrentHead = Boolean(requestAt && requestHeadSha === args.pr.headRefOid);
   const reviewSignal = currentHeadObservedAt ? "current_head_observed" : "missing";
   const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
+  const loadedChecksAreGreen = Boolean(
+    args.checks && args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass"),
+  );
+  const requiredChecksGreenAt = args.pr.currentHeadCiGreenAt ?? (loadedChecksAreGreen ? "loaded_checks_passed" : "none");
 
   let status:
     | "current_head_observed"
@@ -337,7 +342,7 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
     "provider=codex",
     `current_head_sha=${args.pr.headRefOid}`,
     `current_head_observed_at=${currentHeadObservedAt ?? "none"}`,
-    `required_checks_green_at=${args.pr.currentHeadCiGreenAt ?? "none"}`,
+    `required_checks_green_at=${requiredChecksGreenAt}`,
     `timeout_action=${timeoutAction}`,
     `requested_at=${requestAt ?? "none"}`,
     `requested_head_sha=${requestHeadSha ?? "none"}`,


### PR DESCRIPTION
## Summary
- allow the Codex Connector request-review fallback to use an all-pass loaded checks snapshot when `currentHeadCiGreenAt` is missing
- keep same-head dedupe and suppressors for non-green checks, draft PRs, merge conflicts, configured-bot threads, and manual review threads
- surface `loaded_checks_passed` in status/explain fallback diagnostics for the null timestamp path

## Verification
- `npx tsx --test src/post-turn-pull-request.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
- `npm run build`
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`

Part of #1951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI check green status detection to recognize pass states from multiple sources, enabling more accurate suppression of review requests in edge cases.

* **Tests**
  * Expanded test coverage for review request suppression logic across various CI check states and PR blocking scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1952)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->