### PR TITLE
Put @codex review before connector marker

### DIFF
--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -230,7 +230,7 @@ test("GitHubPullRequestHydrator hydrates supervisor-authored Codex Connector rev
                     },
                     {
                       createdAt: "2026-03-13T01:05:00Z",
-                      body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-44 -->\n@codex review",
+                      body: "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-44 -->",
                       viewerDidAuthor: true,
                       author: { login: "codex-supervisor[bot]" },
                     },

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -27,39 +27,38 @@ test("inferCopilotReviewLifecycle returns not_requested when no Copilot signal e
   });
 });
 
-test("renderCodexConnectorReviewRequestComment emits a machine marker and exact Codex trigger", () => {
+test("renderCodexConnectorReviewRequestComment starts with the exact Codex trigger before the machine marker", () => {
   const body = renderCodexConnectorReviewRequestComment({
     issueNumber: 1923,
     prNumber: 44,
     headSha: "head-current",
   });
 
-  assert.match(
+  assert.equal(
     body,
-    /<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->/,
+    "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->",
   );
-  assert.match(body, /^@codex review$/m);
 });
 
-test("findCodexConnectorReviewRequest matches only supervisor-authored markers for the current PR head", () => {
+test("findCodexConnectorReviewRequest matches trigger-first supervisor-authored markers for the current PR head", () => {
   const current = findCodexConnectorReviewRequest(
     [
       {
         authorLogin: "coderabbitai[bot]",
         createdAt: "2026-03-13T01:00:00Z",
-        body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->\n@codex review",
+        body: "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->",
         viewerDidAuthor: true,
       },
       {
         authorLogin: "octocat",
         createdAt: "2026-03-13T01:01:00Z",
-        body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->\n@codex review",
+        body: "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->",
         viewerDidAuthor: false,
       },
       {
         authorLogin: "codex-supervisor[bot]",
         createdAt: "2026-03-13T01:02:00Z",
-        body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-old -->\n@codex review",
+        body: "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-old -->",
         viewerDidAuthor: true,
       },
       {
@@ -98,6 +97,30 @@ test("findCodexConnectorReviewRequest matches only supervisor-authored markers f
       },
     ),
     null,
+  );
+});
+
+test("findCodexConnectorReviewRequest still hydrates historical marker-first request comments", () => {
+  assert.deepEqual(
+    findCodexConnectorReviewRequest(
+      [
+        {
+          authorLogin: "codex-supervisor[bot]",
+          createdAt: "2026-03-13T01:00:00Z",
+          body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->\n@codex review",
+          viewerDidAuthor: true,
+        },
+      ],
+      {
+        issueNumber: 1923,
+        prNumber: 44,
+        headSha: "head-current",
+      },
+    ),
+    {
+      requestedAt: "2026-03-13T01:00:00Z",
+      headSha: "head-current",
+    },
   );
 });
 

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -111,8 +111,9 @@ export function renderCodexConnectorReviewRequestComment(
   const pr = markerValue(identity.prNumber);
   const head = markerValue(identity.headSha);
   return [
-    `<!-- ${CODEX_CONNECTOR_REVIEW_REQUEST_MARKER} issue=${issue} pr=${pr} head=${head} -->`,
     "@codex review",
+    "",
+    `<!-- ${CODEX_CONNECTOR_REVIEW_REQUEST_MARKER} issue=${issue} pr=${pr} head=${head} -->`,
   ].join("\n");
 }
 

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -548,14 +548,10 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
 
     assert.equal(comments.length, 1);
     assert.equal(comments[0]?.issueNumber, pr.number);
-    assert.match(
+    assert.equal(
       comments[0]?.body ?? "",
-      new RegExp(
-        `^<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->$`,
-        "m",
-      ),
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
     );
-    assert.match(comments[0]?.body ?? "", /^@codex review$/m);
     assert.deepEqual(
       findCodexConnectorReviewRequest(
         [
@@ -1004,12 +1000,9 @@ test("handlePostTurnPullRequestTransitionsPhase re-requests Codex Connector revi
 
     assert.equal(comments.length, 1);
     assert.equal(comments[0]?.issueNumber, pr.number);
-    assert.match(
+    assert.equal(
       comments[0]?.body ?? "",
-      new RegExp(
-        `^<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->$`,
-        "m",
-      ),
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
     );
     assert.equal(result.record.last_head_sha, pr.headRefOid);
     assert.equal(result.record.provider_success_observed_at, null);


### PR DESCRIPTION
## Summary
- Render Codex Connector fallback request comments with `@codex review` as the first line.
- Keep the supervisor marker in the same body after the trigger for idempotency and hydration.
- Tighten regression coverage for trigger-first rendering while preserving historical marker-first hydration.

## Verification
- `npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-review-bot.test.ts`
- `npm run build`

Closes #1953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and assertions to reflect changes in Codex Connector review request comment formatting.
  * Enhanced tests to verify exact comment structure and handle both current and legacy comment formats.

* **Style**
  * Modified the formatting and ordering of Codex Connector review request comment components for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1954)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->