### PR TITLE
Allow safe Codex review re-request for stale threads

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -11,6 +11,7 @@ import { blockedReasonFromReviewState as resolveBlockedReasonFromReviewState, in
 import type { GitHubClient } from "./github";
 import { findCodexConnectorReviewRequest } from "./github/github-review-signals";
 import type { LocalReviewResult, PreMergeFinalEvaluation, PreMergeResidualFinding } from "./local-review";
+import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
 import {
   createConfig,
   createFailureContext,
@@ -607,6 +608,208 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
   } finally {
     Date.now = originalDateNow;
   }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review despite stale processed Codex threads", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-08T03:35:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 1957, title: "Request Codex Connector review with stale thread" });
+    const pr = createPullRequest({
+      number: 1957,
+      title: "Request Codex Connector review with stale thread",
+      isDraft: false,
+      headRefOid: "head-1957",
+      currentHeadCiGreenAt: null,
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const staleProcessedThread = createReviewThread({
+      id: "thread-stale-codex",
+      path: "src/example.ts",
+      line: 12,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-codex",
+            body: "P3: Nitpick: prefer a clearer helper name.",
+            createdAt: "2026-05-08T03:12:00Z",
+            url: "https://example.test/pr/1957#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: pr.number,
+      last_head_sha: pr.headRefOid,
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: pr.headRefOid,
+      copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      processed_review_thread_ids: [`${staleProcessedThread.id}@${pr.headRefOid}`],
+      processed_review_thread_fingerprints: [`${staleProcessedThread.id}@${pr.headRefOid}#comment-stale-codex`],
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1957"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [staleProcessedThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(comments[0]?.issueNumber, pr.number);
+    assert.equal(
+      comments[0]?.body ?? "",
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
+    );
+    assert.equal(result.record.state, "waiting_ci");
+    assert.notEqual(result.record.state, "ready_to_merge");
+    assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase keeps Codex Connector review request suppressed by must-fix Codex threads", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issue = createIssue({ number: 1958, title: "Suppress Codex Connector request with must-fix thread" });
+  const pr = createPullRequest({
+    number: 1958,
+    title: "Suppress Codex Connector request with must-fix thread",
+    isDraft: false,
+    headRefOid: "head-1958",
+    currentHeadCiGreenAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+  const mustFixThread = createReviewThread({
+    id: "thread-must-fix-codex",
+    path: "src/example.ts",
+    line: 21,
+    comments: {
+      nodes: [
+        {
+          id: "comment-must-fix-codex",
+          body: "P1: Fix this before another review request.",
+          createdAt: "2026-05-08T03:12:00Z",
+          url: "https://example.test/pr/1958#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const record = createRecord({
+    issue_number: issue.number,
+    state: "waiting_ci",
+    pr_number: pr.number,
+    last_head_sha: pr.headRefOid,
+    review_wait_started_at: "2026-05-08T03:09:36Z",
+    review_wait_head_sha: pr.headRefOid,
+    copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    processed_review_thread_ids: [`${mustFixThread.id}@${pr.headRefOid}`],
+    processed_review_thread_fingerprints: [`${mustFixThread.id}@${pr.headRefOid}#comment-must-fix-codex`],
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issue.number,
+    issues: { [String(issue.number)]: record },
+  };
+  const comments: Array<{ issueNumber: number; body: string }> = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (issueNumber, body) => {
+        comments.push({ issueNumber, body });
+      },
+    }),
+    context: createPostTurnContext({
+      issue,
+      pr,
+      workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1958"),
+      state,
+      record,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [mustFixThread],
+    }),
+    derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+      deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+    applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+    blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+      resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+  });
+
+  assert.equal(
+    comments.some((comment) => comment.body.includes("codex-supervisor:codex-connector-review-request")),
+    false,
+  );
+  assert.equal(result.record.codex_connector_review_requested_head_sha, null);
+  assert.notEqual(result.record.state, "ready_to_merge");
 });
 
 test("handlePostTurnPullRequestTransitionsPhase does not request Codex Connector review on non-green loaded checks without green timestamp", async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -6,6 +6,7 @@ import {
   type PreMergeResidualFinding,
 } from "./local-review";
 import {
+  hasProcessedReviewThread,
   localReviewBlocksReady,
   localReviewFailureContext,
   localReviewHighSeverityNeedsBlock,
@@ -44,6 +45,12 @@ import {
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
 import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
+import {
+  codexConnectorMustFixReviewThreads,
+  configuredBotReviewFollowUpState,
+  latestReviewCommentAuthorIsAllowedBot,
+  staleConfiguredBotReviewThreads,
+} from "./review-thread-reporting";
 import { parseIssueMetadata } from "./issue-metadata";
 import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
 import {
@@ -345,6 +352,36 @@ function isValidTimestamp(value: string | null | undefined): boolean {
   return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
 }
 
+function configuredBotThreadsAllowCodexConnectorRequest(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+  configuredThreads: ReviewThread[];
+}): boolean {
+  if (args.configuredThreads.length === 0) {
+    return true;
+  }
+
+  if (codexConnectorMustFixReviewThreads(args.configuredThreads).length > 0) {
+    return false;
+  }
+
+  if (configuredBotReviewFollowUpState(args.config, args.record, args.pr, args.configuredThreads) === "eligible") {
+    return false;
+  }
+
+  const staleConfiguredThreadIds = new Set(
+    staleConfiguredBotReviewThreads(args.config, args.record, args.pr, args.reviewThreads).map((thread) => thread.id),
+  );
+  return args.configuredThreads.every(
+    (thread) =>
+      staleConfiguredThreadIds.has(thread.id) ||
+      (latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
+        hasProcessedReviewThread(args.record, args.pr, thread)),
+  );
+}
+
 function shouldRequestCodexConnectorReviewComment(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -357,6 +394,14 @@ function shouldRequestCodexConnectorReviewComment(args: {
   mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
 }): boolean {
   const checkSummary = args.summarizeChecks(args.checks);
+  const configuredThreads = args.configuredBotReviewThreads(args.config, args.reviewThreads);
+  const configuredThreadsAreSafeForCodexRequest = configuredBotThreadsAllowCodexConnectorRequest({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    reviewThreads: args.reviewThreads,
+    configuredThreads,
+  });
   const loadedChecksAreGreen =
     args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
   const hasGreenCheckSignal = isValidTimestamp(args.pr.currentHeadCiGreenAt) || loadedChecksAreGreen;
@@ -369,7 +414,7 @@ function shouldRequestCodexConnectorReviewComment(args: {
     args.record.codex_connector_review_requested_head_sha === args.pr.headRefOid ||
     args.pr.isDraft ||
     args.mergeConflictDetected(args.pr) ||
-    args.configuredBotReviewThreads(args.config, args.reviewThreads).length > 0 ||
+    !configuredThreadsAreSafeForCodexRequest ||
     args.manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
     isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) ||
     !hasGreenCheckSignal


### PR DESCRIPTION
## Summary
- allow Codex Connector request-review fallback through stale or already processed configured Codex threads
- keep must-fix Codex threads, manual threads, active follow-up repair, non-green checks, and duplicate same-head requests suppressed
- add focused regressions for the allowed stale processed case and the must-fix suppressor

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts src/pull-request-state-thread-reprocessing.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npm run build

Part of #1957