### PR TITLE
Surface Codex Connector re-request diagnostics

### DIFF
--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -355,6 +355,74 @@ test("explain surfaces Codex Connector review-request fallback lifecycle for the
   );
 });
 
+test("explain distinguishes hydrated same-head Codex Connector review requests", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 1958;
+  const prNumber = 2958;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "waiting_ci",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        last_head_sha: "head-1958",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector hydrated request lifecycle",
+    body: executionReadyBody("Explain should report Codex Connector hydrated request lifecycle."),
+    createdAt: "2026-05-08T03:00:00Z",
+    updatedAt: "2026-05-08T03:30:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () =>
+      createPullRequest({
+        number: prNumber,
+        headRefName: branch,
+        headRefOid: "head-1958",
+        currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+        configuredBotCurrentHeadObservedAt: null,
+        codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+        codexConnectorReviewRequestedHeadSha: "head-1958",
+      }),
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^codex_connector_review_fallback status=already_requested provider=codex current_head_sha=head-1958 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1958 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-08T03:19:36\.000Z$/m,
+  );
+  assert.match(
+    explanation,
+    /^codex_connector_convergence status=same_head_request_hydrated provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review$/m,
+  );
+});
+
 test("explain surfaces loop-off as an operator blocker for active tracked work", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 189;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -230,6 +230,70 @@ test("status surfaces Codex Connector review-request fallback lifecycle for the 
     report.detailedStatusLines.join("\n"),
     /^codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^codex_connector_convergence status=re_requested_review provider=codex current_head_sha=head-1925 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review$/m,
+  );
+});
+
+test("status --why distinguishes hydrated same-head Codex Connector review requests", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 1958;
+  const prNumber = 2958;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "waiting_ci",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: "head-1958",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    resolvePullRequestForBranch: async () =>
+      createPullRequest({
+        number: prNumber,
+        headRefName: branch,
+        headRefOid: "head-1958",
+        currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+        configuredBotCurrentHeadObservedAt: null,
+        codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+        codexConnectorReviewRequestedHeadSha: "head-1958",
+      }),
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const report = await supervisor.statusReport({ why: true });
+
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^codex_connector_review_fallback status=already_requested provider=codex current_head_sha=head-1958 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1958 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-08T03:19:36\.000Z$/m,
+  );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^codex_connector_convergence status=same_head_request_hydrated provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review$/m,
+  );
 });
 
 test("status reports effective Codex routing for inherited defaults and explicit overrides", async (t) => {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -981,6 +981,70 @@ test("formatCodexConnectorConvergenceDiagnostic surfaces must-fix convergence st
   );
 });
 
+test("formatCodexConnectorConvergenceDiagnostic distinguishes Codex Connector request lifecycle states", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const pr = createPr({
+    headRefOid: "head-1958",
+    currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+    configuredBotCurrentHeadObservedAt: null,
+  });
+
+  assert.equal(
+    formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: createRecord({
+        state: "waiting_ci",
+        pr_number: pr.number,
+        provider_success_head_sha: null,
+        provider_success_observed_at: null,
+      }),
+      pr,
+      reviewThreads: [],
+    }),
+    "codex_connector_convergence status=missing_current_head_review provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=request_current_head_review",
+  );
+
+  assert.equal(
+    formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: createRecord({
+        state: "waiting_ci",
+        pr_number: pr.number,
+        provider_success_head_sha: null,
+        provider_success_observed_at: null,
+        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+        codex_connector_review_requested_head_sha: "head-1958",
+      }),
+      pr,
+      reviewThreads: [],
+    }),
+    "codex_connector_convergence status=re_requested_review provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review",
+  );
+
+  assert.equal(
+    formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: createRecord({
+        state: "waiting_ci",
+        pr_number: pr.number,
+        provider_success_head_sha: null,
+        provider_success_observed_at: null,
+      }),
+      pr: {
+        ...pr,
+        codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+        codexConnectorReviewRequestedHeadSha: "head-1958",
+      },
+      reviewThreads: [],
+    }),
+    "codex_connector_convergence status=same_head_request_hydrated provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review",
+  );
+});
+
 test("configuredBotInitialGraceWaitWindow reports the active CodeRabbit re-wait after a draft skip when the PR becomes ready", () => {
   const originalNow = Date.now;
   Date.now = () => Date.parse("2026-03-16T00:00:45.000Z");

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -392,6 +392,11 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     args.record.codex_connector_review_requested_observed_at &&
       args.record.codex_connector_review_requested_head_sha === currentHeadSha,
   );
+  const hydratedRequestMatchesCurrentHead = Boolean(
+    !requestMatchesCurrentHead &&
+      args.pr.codexConnectorReviewRequestedAt &&
+      args.pr.codexConnectorReviewRequestedHeadSha === currentHeadSha,
+  );
   const hasCurrentHeadProviderSuccess = Boolean(
     args.record.provider_success_observed_at && args.record.provider_success_head_sha === currentHeadSha,
   );
@@ -405,6 +410,7 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     | "stale_head"
     | "repairing_must_fix"
     | "re_requested_review"
+    | "same_head_request_hydrated"
     | "waiting_review"
     | "missing_current_head_review"
     | "nitpick_only"
@@ -415,7 +421,7 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     | "wait_for_current_head_signal"
     | "repair_must_fix_findings"
     | "wait_for_requested_review"
-    | "request_or_wait_for_current_head_review"
+    | "request_current_head_review"
     | "merge_or_follow_up_nitpicks"
     | "merge_ready";
 
@@ -432,9 +438,13 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     mergeEffect = "blocked";
     nextAction = "repair_must_fix_findings";
   } else if (policy.outcome === "missing_current_head_review") {
-    status = requestMatchesCurrentHead ? "re_requested_review" : "missing_current_head_review";
+    status = requestMatchesCurrentHead
+      ? "re_requested_review"
+      : hydratedRequestMatchesCurrentHead
+        ? "same_head_request_hydrated"
+        : "missing_current_head_review";
     mergeEffect = "blocked";
-    nextAction = requestMatchesCurrentHead ? "wait_for_requested_review" : "request_or_wait_for_current_head_review";
+    nextAction = requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead ? "wait_for_requested_review" : "request_current_head_review";
   } else if (policy.outcome === "nitpick_only") {
     status = "nitpick_only";
     mergeEffect = "nitpick_only";


### PR DESCRIPTION
## Summary
- distinguish Codex Connector missing-current-head review, supervisor-posted re-request, and GitHub-hydrated same-head request states
- make convergence diagnostics use explicit request/wait next actions while keeping merge_effect=blocked
- add status --why, explain, and formatter regression coverage

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npm run build

Resolves #1958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for diagnostic output and status reporting related to review request handling scenarios.

* **Bug Fixes**
  * Enhanced status reporting to better distinguish between different review request states, improving diagnostic accuracy and clarity for users tracking review progress.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1961)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->