### PR TITLE
Avoid stale Codex thread repair loops

### DIFF
--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -9,6 +9,7 @@ import {
   localReviewRequiresManualReview,
   localReviewRetryLoopStalled,
   reviewDecisionAllowsSamePrRepair,
+  hasProcessedReviewThread,
 } from "./review-handling";
 import { shouldRunLocalReview } from "./local-review";
 import {
@@ -21,6 +22,7 @@ import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
+  latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
   pendingBotReviewThreads,
   staleConfiguredBotReviewThreads,
@@ -714,6 +716,75 @@ function effectiveConfiguredBotReviewThreads(
     : effectiveThreads;
 }
 
+function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  configuredThreads: ReviewThread[];
+}): boolean {
+  if (codexConnectorMustFixReviewThreads(args.configuredThreads).length > 0) {
+    return false;
+  }
+
+  if (configuredBotReviewFollowUpState(args.config, args.record, args.pr, args.configuredThreads) === "eligible") {
+    return false;
+  }
+
+  return args.configuredThreads.every(
+    (thread) =>
+      hasProcessedReviewThread(args.record, args.pr, thread) ||
+      !latestReviewCommentAuthorIsAllowedBot(args.config, thread),
+  );
+}
+
+function shouldWaitForCodexConnectorCurrentHeadReview(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  manualThreads: ReviewThread[];
+  unresolvedBotThreads: ReviewThread[];
+  nowMs: number;
+}): boolean {
+  if (
+    !configuredReviewProviderKinds(args.config).includes("codex") ||
+    args.pr.isDraft ||
+    mergeConflictDetected(args.pr) ||
+    args.manualThreads.length > 0 ||
+    validTimestamp(args.pr.configuredBotCurrentHeadObservedAt)
+  ) {
+    return false;
+  }
+
+  const checkSummary = summarizeChecks(args.checks);
+  if (checkSummary.hasFailing || checkSummary.hasPending) {
+    return false;
+  }
+
+  const loadedChecksAreGreen = args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
+  if (!validTimestamp(args.pr.currentHeadCiGreenAt) && !loadedChecksAreGreen) {
+    return false;
+  }
+
+  if (
+    !configuredBotThreadsAllowCodexConnectorCurrentHeadWait({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      configuredThreads: args.unresolvedBotThreads,
+    })
+  ) {
+    return false;
+  }
+
+  const timeout = determineCopilotReviewTimeout(args.config, args.record, args.pr, args.nowMs);
+  return (
+    (configuredBotCurrentHeadSignalPending(args.config, args.record, args.pr) && !timeout.timedOut) ||
+    (timeout.timedOut && timeout.action === "request_review_comment")
+  );
+}
+
 function pullRequestHeadMatchesRecord(record: Pick<IssueRunRecord, "last_head_sha">, pr: GitHubPullRequest): boolean {
   return record.last_head_sha === null || record.last_head_sha === pr.headRefOid;
 }
@@ -863,6 +934,21 @@ export function inferStateFromPullRequest(
 
   if (pr.mergedAt || pr.state === "MERGED") {
     return "done";
+  }
+
+  if (
+    shouldWaitForCodexConnectorCurrentHeadReview({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      manualThreads,
+      unresolvedBotThreads,
+      nowMs,
+    })
+  ) {
+    return "waiting_ci";
   }
 
   if (pr.reviewDecision === "CHANGES_REQUESTED") {

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -446,6 +446,53 @@ test("inferStateFromPullRequest softens unresolved Codex Connector P3 nitpick-on
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), [p3NitpickThread]), "ready_to_merge");
 });
 
+test("inferStateFromPullRequest waits for current-head Codex Connector review instead of reprocessing stale processed nitpicks", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head-a",
+    review_wait_started_at: "2026-03-11T00:00:00Z",
+    review_wait_head_sha: "head-a",
+    copilot_review_timed_out_at: "2026-03-11T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+    currentHeadCiGreenAt: "2026-03-11T00:00:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const p3NitpickThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, passingChecks(), [p3NitpickThread], Date.parse("2026-03-11T00:12:00Z")),
+    "waiting_ci",
+  );
+});
+
 test("inferStateFromPullRequest still blocks same-head configured bot threads when no follow-up progress was recorded", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],


### PR DESCRIPTION
## Summary
- keep processed/non-actionable stale Codex Connector threads from selecting another repair turn when the safe path is current-head review request/wait
- preserve fail-closed boundaries for must-fix Connector findings, manual threads, draft PRs, merge conflicts, and non-green checks
- add a focused regression at the PR state inference boundary

## Verification
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/pull-request-state-provider-wait-policy.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build

Closes #1962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved pull request evaluation logic to better handle CI check status and review thread processing, enabling more intelligent waiting behavior based on code verification signals and configured review criteria.

* **Tests**
  * Added test coverage for pull request state inference with current-head CI integration scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1964)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->