### PR TITLE
Handle exhausted Codex Connector stale threads

### DIFF
--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -785,6 +785,33 @@ function shouldWaitForCodexConnectorCurrentHeadReview(args: {
   );
 }
 
+function processedCodexConnectorMustFixThreadsExhaustedRepeatBudget(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  manualThreads: ReviewThread[];
+  codexConnectorMustFixThreads: ReviewThread[];
+}): boolean {
+  if (
+    !configuredReviewProviderKinds(args.config).includes("codex") ||
+    args.codexConnectorMustFixThreads.length === 0 ||
+    args.manualThreads.length > 0 ||
+    args.record.last_tracked_pr_repeat_failure_decision !== "stop_no_progress"
+  ) {
+    return false;
+  }
+
+  const checkSummary = summarizeChecks(args.checks);
+  if (checkSummary.hasFailing || checkSummary.hasPending || mergeConflictDetected(args.pr)) {
+    return false;
+  }
+
+  return args.codexConnectorMustFixThreads.every((thread) =>
+    hasProcessedReviewThread(args.record, args.pr, thread),
+  );
+}
+
 function pullRequestHeadMatchesRecord(record: Pick<IssueRunRecord, "last_head_sha">, pr: GitHubPullRequest): boolean {
   return record.last_head_sha === null || record.last_head_sha === pr.headRefOid;
 }
@@ -960,6 +987,19 @@ export function inferStateFromPullRequest(
       pr.configuredBotTopLevelReviewStrength === "nitpick_only" &&
       unresolvedBotThreads.length === 0 &&
       manualThreads.length === 0;
+
+    if (
+      processedCodexConnectorMustFixThreadsExhaustedRepeatBudget({
+        config,
+        record,
+        pr,
+        checks,
+        manualThreads,
+        codexConnectorMustFixThreads,
+      })
+    ) {
+      return "blocked";
+    }
 
     if (unresolvedBotThreads.length > 0 || pr.configuredBotTopLevelReviewStrength === "blocking") {
       if (

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -785,6 +785,8 @@ function shouldWaitForCodexConnectorCurrentHeadReview(args: {
   );
 }
 
+// Blocks already-processed Codex Connector must-fix threads once the tracked PR
+// repeat budget has made a no-progress stop decision.
 function processedCodexConnectorMustFixThreadsExhaustedRepeatBudget(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -375,6 +375,72 @@ test("inferStateFromPullRequest routes unresolved Codex Connector P2 findings in
   assert.equal(inferStateFromPullRequest(config, record, pr, [], [p2Thread]), "addressing_review");
 });
 
+test("inferStateFromPullRequest blocks processed Codex Connector P2 duplicates after the repeat budget is exhausted", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    sameFailureSignatureRepeatLimit: 3,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head-a",
+    last_failure_signature: "stalled-bot:thread-1|stalled-bot:thread-2",
+    repeated_failure_signature_count: 3,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: ["thread-1@head-a", "thread-2@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1", "thread-2@head-a#comment-2"],
+    review_follow_up_head_sha: "head-a",
+    review_follow_up_remaining: 0,
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+    currentHeadCiGreenAt: "2026-03-11T00:05:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-03-11T00:06:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const p2Threads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+            createdAt: "2026-03-11T00:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-2",
+      line: 24,
+      comments: {
+        nodes: [
+          {
+            id: "comment-2",
+            body: "P2: Keep restore failure cleanup atomic.",
+            createdAt: "2026-03-11T00:06:00Z",
+            url: "https://example.test/pr/44#discussion_r2",
+            author: {
+              login: "chatgpt-codex-connector[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), p2Threads), "blocked");
+});
+
 test("inferStateFromPullRequest routes escalated Codex Connector P3 findings into same-PR repair", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector[bot]"],

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -301,6 +301,43 @@ test("inferStateFromPullRequest allows one same-head follow-up turn after partia
   assert.equal(inferStateFromPullRequest(config, record, pr, [], [remainingThread]), "addressing_review");
 });
 
+test("inferStateFromPullRequest blocks same-head follow-up when the tracked PR repeat budget already stopped", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head-a",
+    processed_review_thread_ids: ["thread-1@head-a"],
+    processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    review_follow_up_head_sha: "head-a",
+    review_follow_up_remaining: 1,
+  });
+  const pr = createPullRequest({
+    reviewDecision: "CHANGES_REQUESTED",
+    headRefOid: "head-a",
+  });
+  const remainingThread = createReviewThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Still unresolved.",
+          createdAt: "2026-03-11T00:05:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "copilot-pull-request-reviewer",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, [], [remainingThread]), "blocked");
+});
+
 test("inferStateFromPullRequest routes unresolved Codex Connector P1 findings into same-PR repair", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector[bot]"],

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -7,6 +7,7 @@ import {
   actionableBotReviewThreads,
   buildStalledBotReviewFailureContext,
   codexConnectorMustFixReviewThreads,
+  configuredBotReviewFollowUpState,
   evaluateCodexConnectorConvergencePolicy,
   staleConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
@@ -99,6 +100,7 @@ function createReviewRecord(
       | "last_head_sha"
       | "review_follow_up_head_sha"
       | "review_follow_up_remaining"
+      | "last_tracked_pr_repeat_failure_decision"
     >
   > = {},
 ): Pick<
@@ -108,6 +110,7 @@ function createReviewRecord(
   | "last_head_sha"
   | "review_follow_up_head_sha"
   | "review_follow_up_remaining"
+  | "last_tracked_pr_repeat_failure_decision"
 > {
   return {
     processed_review_thread_ids: [],
@@ -115,6 +118,7 @@ function createReviewRecord(
     last_head_sha: "head123",
     review_follow_up_head_sha: null,
     review_follow_up_remaining: 0,
+    last_tracked_pr_repeat_failure_decision: null,
     ...overrides,
   };
 }
@@ -134,6 +138,23 @@ test("configuredBotReviewThreads normalizes configured bot logins before classif
 
   assert.equal(configuredBotReviewThreads(config, [thread]).length, 1);
   assert.equal(manualReviewThreads(config, [thread]).length, 0);
+});
+
+test("configuredBotReviewFollowUpState treats repeat-stop records as exhausted even if follow-up budget remains", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+  });
+  const record = createReviewRecord({
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+    review_follow_up_head_sha: "head123",
+    review_follow_up_remaining: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const thread = createReviewThread();
+
+  assert.equal(configuredBotReviewFollowUpState(config, record, createPr(), [thread]), "exhausted");
+  assert.deepEqual(actionableBotReviewThreads(config, record, createPr(), [thread]), []);
 });
 
 test("staleConfiguredBotReviewThreads requires current-head processing evidence before classifying stale bot blockers", () => {

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -386,7 +386,8 @@ export function pendingBotReviewThreads(
 
 export function configuredBotReviewFollowUpState(
   config: SupervisorConfig,
-  record: Pick<IssueRunRecord, "review_follow_up_head_sha" | "review_follow_up_remaining">,
+  record: Pick<IssueRunRecord, "review_follow_up_head_sha" | "review_follow_up_remaining"> &
+    Partial<Pick<IssueRunRecord, "last_tracked_pr_repeat_failure_decision">>,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   reviewThreads: ReviewThread[],
 ): "inactive" | "eligible" | "exhausted" {
@@ -395,9 +396,16 @@ export function configuredBotReviewFollowUpState(
   );
   if (
     unresolvedActionableThreads.length === 0 ||
-    codexConnectorMustFixReviewThreads(unresolvedActionableThreads).length > 0 ||
     record.review_follow_up_head_sha !== pr.headRefOid
   ) {
+    return "inactive";
+  }
+
+  if (record.last_tracked_pr_repeat_failure_decision === "stop_no_progress") {
+    return "exhausted";
+  }
+
+  if (codexConnectorMustFixReviewThreads(unresolvedActionableThreads).length > 0) {
     return "inactive";
   }
 


### PR DESCRIPTION
## Summary
- Block already-processed Codex Connector must-fix duplicate threads after the tracked PR repeat-stop decision is recorded.
- Add a focused regression for processed duplicate P2 Codex Connector threads on the current head.

## Verification
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts
- npx tsx --test src/pull-request-state-thread-reprocessing.test.ts src/pull-request-state-provider-wait-policy.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build

Closes #1966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request state logic to mark PRs as blocked when repeat retry limits are exhausted and all configured findings have been processed; follow-up threads now reflect exhausted/blocked status correctly.

* **Tests**
  * Added and updated tests covering follow-up/exhausted behavior and PR state evaluation when repeat budgets are stopped.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1967)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1967)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->