### PR TITLE
Suppress stale review bot no-auto recovery

### DIFF
--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -143,6 +143,7 @@ function parseTrackedPrProgressSnapshotThreadFingerprints(
 export function suppressSameHeadNoProgressReviewThreadRecovery(
   record: Pick<
     IssueRunRecord,
+    | "blocked_reason"
     | "last_head_sha"
     | "last_failure_signature"
     | "last_tracked_pr_progress_snapshot"
@@ -183,6 +184,10 @@ export function suppressSameHeadNoProgressReviewThreadRecovery(
     previousThreadIds.every((threadId, index) => threadId === currentThreadIds[index]);
   const sameBlockingThread =
     typeof failureSignature === "string" && failureSignature.length > 0 && currentThreadIds.includes(failureSignature);
+  const stoppedStaleReviewBotNoAutoRetry =
+    record.blocked_reason === "stale_review_bot" &&
+    typeof failureSignature === "string" &&
+    failureSignature.length > 0;
   const hasComparableThreadGuidanceBaseline =
     previousThreadFingerprints !== null &&
     previousThreadFingerprints.length > 0 &&
@@ -191,17 +196,21 @@ export function suppressSameHeadNoProgressReviewThreadRecovery(
     hasComparableThreadGuidanceBaseline &&
     previousThreadFingerprints.every((fingerprint, index) => fingerprint === currentThreadFingerprints[index]);
 
-  if (!sameThreadIds || !sameBlockingThread) {
+  if (!sameThreadIds || (!sameBlockingThread && !stoppedStaleReviewBotNoAutoRetry)) {
     return {
       shouldSuppress: false,
       progressSummary: null,
     };
   }
 
+  const suppressedProgressSummary = stoppedStaleReviewBotNoAutoRetry
+    ? "recovery_blocked=stale_review_bot_no_auto_retry"
+    : "suppressed_same_head_same_review_thread_blocker";
+
   if (!hasComparableThreadGuidanceBaseline) {
     return {
       shouldSuppress: true,
-      progressSummary: "suppressed_same_head_same_review_thread_blocker",
+      progressSummary: suppressedProgressSummary,
     };
   }
 
@@ -214,7 +223,7 @@ export function suppressSameHeadNoProgressReviewThreadRecovery(
 
   return {
     shouldSuppress: true,
-    progressSummary: "suppressed_same_head_same_review_thread_blocker",
+    progressSummary: suppressedProgressSummary,
   };
 }
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2445,6 +2445,168 @@ test("reconcileRecoverableBlockedIssueStates suppresses same-head tracked PR rec
   assert.deepEqual(recoveryEvents, []);
 });
 
+test("reconcileRecoverableBlockedIssueStates keeps stopped stale_review_bot records blocked when no-auto retry saw no same-head progress", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["codex-connector"],
+    staleConfiguredBotReviewPolicy: "reply_only",
+  });
+  const previousProgressSnapshot = JSON.stringify({
+    headRefOid: "head-191",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    copilotReviewState: null,
+    copilotReviewRequestedAt: null,
+    copilotReviewArrivedAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: null,
+    currentHeadCiGreenAt: "2026-05-12T00:18:00Z",
+    configuredBotRateLimitedAt: null,
+    configuredBotDraftSkipAt: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-05-12T00:10:00Z",
+    checks: ["build:pass:SUCCESS:CI"],
+    unresolvedReviewThreadIds: ["PRRT_thread_1", "PRRT_thread_2", "PRRT_thread_3", "PRRT_thread_4"],
+    unresolvedReviewThreadFingerprints: [
+      "PRRT_thread_1#comment-1",
+      "PRRT_thread_2#comment-2",
+      "PRRT_thread_3#comment-3",
+      "PRRT_thread_4#comment-4",
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        pr_number: 191,
+        last_head_sha: "head-191",
+        last_error:
+          "4 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_kind: null,
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "4 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:codex-connector-p2",
+          command: null,
+          details: [
+            "reviewer=codex-connector severity=P2 processed_on_current_head=yes thread=PRRT_thread_1",
+            "reviewer=codex-connector severity=P2 processed_on_current_head=yes thread=PRRT_thread_2",
+            "reviewer=codex-connector severity=P2 processed_on_current_head=yes thread=PRRT_thread_3",
+            "reviewer=codex-connector severity=P2 processed_on_current_head=yes thread=PRRT_thread_4",
+          ],
+          url: "https://example.test/pr/191",
+          updated_at: "2026-05-12T00:20:00Z",
+        },
+        last_failure_signature: "stalled-bot:codex-connector-p2",
+        repeated_failure_signature_count: 3,
+        last_stale_review_bot_reply_head_sha: "head-191",
+        last_stale_review_bot_reply_signature: "stalled-bot:codex-connector-p2",
+        stale_review_bot_reply_progress_keys: [
+          "PRRT_thread_1@head-191",
+          "PRRT_thread_2@head-191",
+          "PRRT_thread_3@head-191",
+          "PRRT_thread_4@head-191",
+        ],
+        processed_review_thread_ids: [
+          "PRRT_thread_1@head-191",
+          "PRRT_thread_2@head-191",
+          "PRRT_thread_3@head-191",
+          "PRRT_thread_4@head-191",
+        ],
+        processed_review_thread_fingerprints: [
+          "PRRT_thread_1@head-191#comment-1",
+          "PRRT_thread_2@head-191#comment-2",
+          "PRRT_thread_3@head-191#comment-3",
+          "PRRT_thread_4@head-191#comment-4",
+        ],
+        last_tracked_pr_progress_snapshot: previousProgressSnapshot,
+        last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-05-12T00:21:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: "head-191",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-05-12T00:10:00Z",
+  });
+
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-05-12T00:25:00Z",
+      };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: "PRRT_thread_1",
+          comments: { nodes: [{ id: "comment-1", body: "P2 finding 1", createdAt: "2026-05-12T00:11:00Z", url: "https://example.test/pr/191#discussion_r1", author: { login: "codex-connector", typeName: "Bot" } }] },
+        }),
+        createReviewThread({
+          id: "PRRT_thread_2",
+          comments: { nodes: [{ id: "comment-2", body: "P2 finding 2", createdAt: "2026-05-12T00:12:00Z", url: "https://example.test/pr/191#discussion_r2", author: { login: "codex-connector", typeName: "Bot" } }] },
+        }),
+        createReviewThread({
+          id: "PRRT_thread_3",
+          comments: { nodes: [{ id: "comment-3", body: "P2 finding 3", createdAt: "2026-05-12T00:13:00Z", url: "https://example.test/pr/191#discussion_r3", author: { login: "codex-connector", typeName: "Bot" } }] },
+        }),
+        createReviewThread({
+          id: "PRRT_thread_4",
+          comments: { nodes: [{ id: "comment-4", body: "P2 finding 4", createdAt: "2026-05-12T00:14:00Z", url: "https://example.test/pr/191#discussion_r4", author: { login: "codex-connector", typeName: "Bot" } }] },
+        }),
+      ],
+    },
+    stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "addressing_review",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "stale_review_bot");
+  assert.equal(updated.last_tracked_pr_progress_summary, "recovery_blocked=stale_review_bot_no_auto_retry");
+  assert.equal(updated.last_tracked_pr_repeat_failure_decision, "stop_no_progress");
+  assert.equal(updated.last_recovery_reason, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents, []);
+});
+
 test("reconcileRecoverableBlockedIssueStates preserves same-head suppression when older progress snapshots lack review-thread fingerprints", async () => {
   const config = createConfig();
   const previousProgressSnapshot = JSON.stringify({

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -744,6 +744,60 @@ Parallelizable: No
   );
 });
 
+test("buildIssueExplainDto reports stale-review-bot no-auto retry recovery suppression distinctly", async () => {
+  const issue = createIssue({
+    number: 613,
+    title: "Suppressed stale review bot recovery",
+    body: `## Summary
+Keep stale-review-bot no-auto retry stops stable.
+
+## Scope
+- do not restart same-head repair after stale review bot no-auto retry suppression
+
+## Acceptance criteria
+- explain shows the stale review bot no-auto retry recovery block
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-issue-explain.test.ts
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [
+      createRecord({
+        issue_number: 613,
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        last_failure_signature: "stalled-bot:codex-connector-p2",
+        repeated_failure_signature_count: 3,
+        last_tracked_pr_progress_summary: "recovery_blocked=stale_review_bot_no_auto_retry",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    ],
+  });
+
+  const dto = await buildIssueExplainDto(
+    {
+      getIssue: async () => issue,
+      listAllIssues: async () => [issue],
+      listCandidateIssues: async () => [issue],
+    },
+    createConfig(),
+    state,
+    613,
+  );
+
+  const rendered = renderIssueExplainDto(dto);
+  assert.match(
+    rendered,
+    /^tracked_pr_repeat_failure decision=stop_no_progress signal=recovery_blocked=stale_review_bot_no_auto_retry$/m,
+  );
+});
+
 test("buildIssueExplainDto reports same-thread tracked PR blocker guidance changes distinctly", async () => {
   const issue = createIssue({
     number: 612,


### PR DESCRIPTION
## Summary
- keep same-head `stale_review_bot` no-auto retry stops blocked when the unresolved review-thread set and guidance are unchanged
- surface the suppression as `recovery_blocked=stale_review_bot_no_auto_retry` in explain/status --why retryability output
- add regression coverage for the Codex Connector multi-thread no-progress loop

## Verification
- `npx tsx --test src/supervisor/supervisor-lifecycle.test.ts src/tracked-pr-lifecycle-projection.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
- `npm run build`

Closes #1968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status tracking for pull requests blocked by stale review bot feedback when auto-retry is disabled. These pull requests now correctly maintain their blocked state with appropriate status indicators.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1971)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->