### PR TITLE
Fix Codex Connector stale-head rereview request

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1346,6 +1346,151 @@ test("handlePostTurnPullRequestTransitionsPhase re-requests Codex Connector revi
   }
 });
 
+test("handlePostTurnPullRequestTransitionsPhase re-requests Codex Connector review when stale-head Codex must-fix threads remain", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-13T04:00:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 1972, title: "Re-request Codex Connector review after stale-head repair" });
+    const oldHead = "head-old-1972";
+    const pr = createPullRequest({
+      number: 1972,
+      title: "Re-request Codex Connector review after stale-head repair",
+      isDraft: false,
+      headRefOid: "head-new-1972",
+      currentHeadCiGreenAt: "2026-05-13T03:45:00Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const staleMustFixThread = createReviewThread({
+      id: "thread-stale-codex-must-fix",
+      path: "src/repaired.ts",
+      line: 24,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-codex-must-fix",
+            body: "P1: Fix this stale-head issue before merge.",
+            createdAt: "2026-05-13T03:12:00Z",
+            url: "https://example.test/pr/1972#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: pr.number,
+      last_head_sha: oldHead,
+      review_wait_started_at: "2026-05-13T03:20:00Z",
+      review_wait_head_sha: oldHead,
+      copilot_review_timed_out_at: "2026-05-13T03:30:00.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      codex_connector_review_requested_observed_at: "2026-05-13T03:30:00Z",
+      codex_connector_review_requested_head_sha: oldHead,
+      processed_review_thread_ids: [`${staleMustFixThread.id}@${oldHead}`],
+      processed_review_thread_fingerprints: [`${staleMustFixThread.id}@${oldHead}#comment-stale-codex-must-fix`],
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1972"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [staleMustFixThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(
+      comments[0]?.body ?? "",
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
+    );
+    assert.equal(result.record.state, "waiting_ci");
+    assert.notEqual(result.record.state, "ready_to_merge");
+    assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+
+    const retryPr = {
+      ...pr,
+      codexConnectorReviewRequestedAt: result.record.codex_connector_review_requested_observed_at,
+      codexConnectorReviewRequestedHeadSha: result.record.codex_connector_review_requested_head_sha,
+    };
+    const retryResult = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr: retryPr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1972"),
+        state,
+        record: result.record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr: retryPr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [staleMustFixThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(retryResult.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blockers when refreshed state is waiting_ci", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -7,6 +7,7 @@ import {
 } from "./local-review";
 import {
   hasProcessedReviewThread,
+  latestReviewThreadCommentFingerprint,
   localReviewBlocksReady,
   localReviewFailureContext,
   localReviewHighSeverityNeedsBlock,
@@ -353,6 +354,29 @@ function isValidTimestamp(value: string | null | undefined): boolean {
   return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
 }
 
+function hasProcessedReviewThreadOnNonCurrentHead(
+  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+): boolean {
+  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
+  if (!latestCommentFingerprint) {
+    return false;
+  }
+
+  const processedKeys = new Set(record.processed_review_thread_ids ?? []);
+  const fingerprintPrefix = `${thread.id}@`;
+  const fingerprintSuffix = `#${latestCommentFingerprint}`;
+  return (record.processed_review_thread_fingerprints ?? []).some((key) => {
+    if (!key.startsWith(fingerprintPrefix) || !key.endsWith(fingerprintSuffix)) {
+      return false;
+    }
+
+    const headSha = key.slice(fingerprintPrefix.length, key.length - fingerprintSuffix.length);
+    return Boolean(headSha && headSha !== pr.headRefOid && processedKeys.has(`${thread.id}@${headSha}`));
+  });
+}
+
 function configuredBotThreadsAllowCodexConnectorRequest(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -364,7 +388,21 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
     return true;
   }
 
-  if (codexConnectorMustFixReviewThreads(args.configuredThreads).length > 0) {
+  const staleHeadConfiguredThreadIds = new Set(
+    args.configuredThreads
+      .filter(
+        (thread) =>
+          latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
+          hasProcessedReviewThreadOnNonCurrentHead(args.record, args.pr, thread),
+      )
+      .map((thread) => thread.id),
+  );
+
+  if (
+    codexConnectorMustFixReviewThreads(args.configuredThreads).some(
+      (thread) => !staleHeadConfiguredThreadIds.has(thread.id),
+    )
+  ) {
     return false;
   }
 
@@ -377,6 +415,7 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
   );
   return args.configuredThreads.every(
     (thread) =>
+      staleHeadConfiguredThreadIds.has(thread.id) ||
       staleConfiguredThreadIds.has(thread.id) ||
       (latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
         hasProcessedReviewThread(args.record, args.pr, thread)),


### PR DESCRIPTION
## Summary
- allow Codex Connector fallback review requests when unresolved configured-bot threads are explicitly processed stale-head feedback
- preserve current-head must-fix suppression and current-head request marker dedupe
- add regression coverage for stale-head Codex must-fix threads on a repaired new head

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "stale-head Codex must-fix"
- npx tsx --test src/post-turn-pull-request.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Closes #1972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of code review requests when pull request heads change, ensuring review requests are properly re-initiated when previous review threads remain unresolved on outdated commits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1973)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->