### PR TITLE
Classify Codex Connector unresolved current-head threads as metadata-only before retrying repairs (#1974)

### DIFF
--- a/.codex-supervisor/issues/1974/issue-journal.md
+++ b/.codex-supervisor/issues/1974/issue-journal.md
@@ -1,0 +1,58 @@
+# Issue #1974: Classify Codex Connector unresolved current-head threads as metadata-only before retrying repairs
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/codex-supervisor/issues/1974
+- Branch: codex/issue-1974
+- Workspace: .
+- Journal: .codex-supervisor/issues/1974/issue-journal.md
+- Current phase: addressing_review
+- Attempt count: 4 (implementation=3, repair=1)
+- Last head SHA: 533b90c87e8a75bb167ef8100f896d70781d1860
+- Blocked reason: none
+- Last failure signature: PRRT_kwDORgvdZ86Bsx7f|PRRT_kwDORgvdZ86Bsx7r
+- Repeated failure signature count: 1
+- Updated at: 2026-05-13T09:59:43.129Z
+
+## Latest Codex Summary
+Implemented and committed a clean checkpoint on `codex/issue-1974` for issue **#1974**.
+
+- Kept stale-review diagnostics from treating Codex `metadata_only_current_head_converged` as unresolved work in explain output.
+- Kept reply-and-resolve automation gated to safe metadata-only cases (`metadata_only` and `metadata_only_current_head_converged`) in tracked PR persistent status comment flow.
+
+Committed:
+- `533b90c` — `Handle Codex metadata-only stale review thread states`
+
+Also updated `.codex-supervisor/issues/1974/issue-journal.md` with current handoff/verification notes.
+
+- `src/supervisor/supervisor-selection-issue-explain.ts`
+- `src/tracked-pr-status-comment.ts`
+
+Observed test output: the full targeted suite passed (`330` tests).  
+`npm run build` and `issue-lint 1974` both passed.
+
+Summary: Extended classification handling in diagnostics/status paths so metadata-only Codex current-head thread residue is not treated as unresolved work for stale-work repair diagnostics/automation.
+State hint: stabilizing
+Blocked reason: none
+Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/review-thread-reporting.test.ts` (330 passed), `npm run build`, `node dist/index.js issue-lint 1974 --config "$CODEX_SUPERVISOR_CONFIG"` (pass; no blocking test failures)
+Next action: open/update draft PR for this issue branch and continue PR-handoff with this checkpoint hash (`533b90c`); optionally run `status --why`/`explain` on active loop for operator-facing validation.
+Failure signature: PRRT_kwDORgvdZ86Bsx7f|PRRT_kwDORgvdZ86Bsx7r
+
+## Active Failure Context
+- Category: review
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/codex-supervisor/pull/1975#discussion_r3233042086
+- Details:
+  - src/supervisor/stale-review-bot-remediation.ts:116 summary=_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 50384 --- 🏁 Script executed: R... url=https://github.com/TommyKammy/codex-supervisor/pull/1975#discussion_r3233042086
+  - src/supervisor/stale-review-bot-remediation.ts:181 summary=_⚠️ Potential issue_ | _🟡 Minor_ | _⚡ Quick win_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/codex-supervisor Length of output: 50384 --- 🏁 Script executed: R... url=https://github.com/TommyKammy/codex-supervisor/pull/1975#discussion_r3233042096
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis confirmed: remaining Codex review-thread residue should be classified as metadata-only before retrying repairs only when provider-owned evidence proves the current head observation comes from Codex and the policy outcome is either missing-current-head or non-actionable convergence.
+- What changed in this checkpoint: In `src/supervisor/stale-review-bot-remediation.ts`, `codexConnectorCurrentHeadReviewState` now requires `configuredBotCurrentHeadObservationSource === "codex_pr_success_comment"` before reporting `observed`; `classifyCodexMetadataOnly` now explicitly handles `policy.outcome === "nitpick_only"` with the same converged metadata-only path and makes fallback states explicit.
+- Commit: `a244e69`
+- Current blocker: none.
+- Exact verification run: `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/review-thread-reporting.test.ts` (330 passed), `npm run build` (pass), `node dist/index.js issue-lint 1974 --config "$CODEX_SUPERVISOR_CONFIG"` (pass).
+- Next exact step: continue addressing_review with this checkpoint (`a244e69`) and leave PR updated; if required, run `status --why`/`explain` on active loop for final operator-facing confirmation.
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- No remaining issue-specific failures in this turn. Remaining log noise in targeted suites is from intentionally inverted execution-metrics fixture data and expected recoverable warnings.

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -845,7 +845,7 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
   }
 });
 
-test("handlePostTurnPullRequestTransitionsPhase keeps Codex Connector review request suppressed by must-fix Codex threads", async () => {
+test("handlePostTurnPullRequestTransitionsPhase keeps Codex Connector review request suppressed by unprocessed must-fix Codex threads", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],
     configuredBotInitialGraceWaitSeconds: 0,
@@ -891,8 +891,6 @@ test("handlePostTurnPullRequestTransitionsPhase keeps Codex Connector review req
     review_wait_head_sha: pr.headRefOid,
     copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
     copilot_review_timeout_action: "request_review_comment",
-    processed_review_thread_ids: [`${mustFixThread.id}@${pr.headRefOid}`],
-    processed_review_thread_fingerprints: [`${mustFixThread.id}@${pr.headRefOid}#comment-must-fix-codex`],
     codex_connector_review_requested_observed_at: null,
     codex_connector_review_requested_head_sha: null,
   });
@@ -1330,17 +1328,158 @@ test("handlePostTurnPullRequestTransitionsPhase re-requests Codex Connector revi
       mergeConflictDetected: () => false,
     });
 
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0]?.issueNumber, pr.number);
+  assert.equal(
+    comments[0]?.body ?? "",
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
+    );
+    assert.equal(result.record.last_head_sha, pr.headRefOid);
+    assert.equal(result.record.provider_success_observed_at, null);
+    assert.equal(result.record.provider_success_head_sha, null);
+  assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
+  assert.ok(result.record.codex_connector_review_requested_observed_at);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review for processed must-fix metadata residue", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-13T03:40:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 1960, title: "Request Codex Connector review for processed must-fix residue" });
+    const pr = createPullRequest({
+      number: 1960,
+      title: "Request Codex Connector review for processed must-fix residue",
+      isDraft: false,
+      headRefOid: "head-1960",
+      currentHeadCiGreenAt: "2026-05-13T03:30:00Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const mustFixThread = createReviewThread({
+      id: "thread-processed-must-fix",
+      path: "src/example.ts",
+      line: 31,
+      comments: {
+        nodes: [
+          {
+            id: "comment-processed-must-fix",
+            body: "P2: Fix this before another review request.",
+            createdAt: "2026-05-13T03:12:00Z",
+            url: "https://example.test/pr/1960#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "waiting_ci",
+      pr_number: pr.number,
+      last_head_sha: pr.headRefOid,
+      review_wait_started_at: "2026-05-13T03:09:36Z",
+      review_wait_head_sha: pr.headRefOid,
+      copilot_review_timed_out_at: "2026-05-13T03:19:36.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      processed_review_thread_ids: [`${mustFixThread.id}@${pr.headRefOid}`],
+      processed_review_thread_fingerprints: [`${mustFixThread.id}@${pr.headRefOid}#comment-processed-must-fix`],
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1960"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [mustFixThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
     assert.equal(comments.length, 1);
     assert.equal(comments[0]?.issueNumber, pr.number);
     assert.equal(
       comments[0]?.body ?? "",
       `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
     );
-    assert.equal(result.record.last_head_sha, pr.headRefOid);
-    assert.equal(result.record.provider_success_observed_at, null);
-    assert.equal(result.record.provider_success_head_sha, null);
     assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
-    assert.ok(result.record.codex_connector_review_requested_observed_at);
+
+    const retryResult = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async () => {
+          throw new Error("unexpected duplicate request");
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-1960"),
+        state,
+        record: result.record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr: {
+          ...pr,
+          codexConnectorReviewRequestedAt: result.record.codex_connector_review_requested_observed_at,
+          codexConnectorReviewRequestedHeadSha: result.record.codex_connector_review_requested_head_sha,
+        },
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [mustFixThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(retryResult.record.codex_connector_review_requested_head_sha, pr.headRefOid);
   } finally {
     Date.now = originalDateNow;
   }

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -63,6 +63,7 @@ import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import { displayLocalCiCommand } from "./core/config-parsing";
 import { renderCodexConnectorReviewRequestComment } from "./github/github-review-signals";
+import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -397,10 +398,23 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
       )
       .map((thread) => thread.id),
   );
+  const currentHeadConfiguredThreadIds = new Set(
+    args.configuredThreads
+      .filter((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+      .map((thread) => thread.id),
+  );
+  const staleConfiguredThreadIds = new Set(
+    staleConfiguredBotReviewThreads(args.config, args.record, args.pr, args.reviewThreads).map((thread) => thread.id),
+  );
+  const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(args.configuredThreads).map((thread) => thread.id));
 
   if (
-    codexConnectorMustFixReviewThreads(args.configuredThreads).some(
-      (thread) => !staleHeadConfiguredThreadIds.has(thread.id),
+    args.configuredThreads.some(
+      (thread) =>
+        codexMustFixThreadIds.has(thread.id) &&
+        !staleHeadConfiguredThreadIds.has(thread.id) &&
+        !currentHeadConfiguredThreadIds.has(thread.id) &&
+        !staleConfiguredThreadIds.has(thread.id),
     )
   ) {
     return false;
@@ -410,9 +424,6 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
     return false;
   }
 
-  const staleConfiguredThreadIds = new Set(
-    staleConfiguredBotReviewThreads(args.config, args.record, args.pr, args.reviewThreads).map((thread) => thread.id),
-  );
   return args.configuredThreads.every(
     (thread) =>
       staleHeadConfiguredThreadIds.has(thread.id) ||
@@ -435,6 +446,35 @@ function shouldRequestCodexConnectorReviewComment(args: {
 }): boolean {
   const checkSummary = args.summarizeChecks(args.checks);
   const configuredThreads = args.configuredBotReviewThreads(args.config, args.reviewThreads);
+  const staleCodexReviewState = configuredReviewProviderKinds(args.config).includes("codex")
+    ? buildStaleReviewBotRemediation({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        checks: args.checks,
+        reviewThreads: args.reviewThreads,
+      })
+    : null;
+  const isCodexMissingCurrentHeadReview =
+    staleCodexReviewState?.classification === "metadata_only_missing_current_head_review";
+  const isCodexConvergedCurrentHeadReview =
+    staleCodexReviewState?.classification === "metadata_only_current_head_converged";
+  const isCodexMetadataOnly =
+    staleCodexReviewState?.classification === "metadata_only" ||
+    staleCodexReviewState?.classification === "metadata_only_missing_current_head_review" ||
+    staleCodexReviewState?.classification === "metadata_only_current_head_converged";
+
+  if (
+    configuredReviewProviderKinds(args.config).includes("codex") &&
+    !isCodexMissingCurrentHeadReview &&
+    (isCodexConvergedCurrentHeadReview ||
+      isCodexMetadataOnly ||
+      staleCodexReviewState?.classification === "unresolved_work" ||
+      staleCodexReviewState?.classification === "unknown_needs_operator")
+  ) {
+    return false;
+  }
+
   const configuredThreadsAreSafeForCodexRequest = configuredBotThreadsAllowCodexConnectorRequest({
     config: args.config,
     record: args.record,

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -3,9 +3,12 @@ import { hasProcessedReviewThread } from "../review-handling";
 import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
+  codexConnectorMustFixReviewThreads,
+  evaluateCodexConnectorConvergencePolicy,
   manualReviewThreads,
   pendingBotReviewThreads,
 } from "../review-thread-reporting";
+import { configuredReviewProviderKinds } from "../core/review-providers";
 
 export interface StaleReviewBotRemediationDto {
   issueNumber: number;
@@ -14,7 +17,13 @@ export interface StaleReviewBotRemediationDto {
   currentHeadSha: string;
   processedOnCurrentHead: "yes" | "no" | "unknown";
   codeCiState: "green" | "not_green" | "unknown";
-  classification: "metadata_only" | "unresolved_work";
+  classification:
+    | "metadata_only"
+    | "metadata_only_missing_current_head_review"
+    | "metadata_only_current_head_converged"
+    | "unresolved_work"
+    | "unknown_needs_operator";
+  codexCurrentHeadReviewState: "observed" | "requested" | "missing" | "not_applicable";
   reviewThreadUrl: string | null;
   manualNextStep: string;
   summary: string;
@@ -26,6 +35,8 @@ const STALE_REVIEW_BOT_SUMMARY =
   "code_or_ci_green_but_review_thread_metadata_unresolved";
 const STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY =
   "stale_configured_bot_thread_metadata_only";
+const STALE_REVIEW_BOT_METADATA_CURRENT_HEAD_SUMMARY =
+  "stale_configured_bot_thread_metadata_only_pending_current_head_review_request";
 
 function formatTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
@@ -79,6 +90,96 @@ function hasCleanMergeState(pr: GitHubPullRequest): boolean {
   return pr.state === "OPEN" && !pr.isDraft && pr.mergeStateStatus === "CLEAN" && pr.mergeable === "MERGEABLE";
 }
 
+function codexConnectorCurrentHeadReviewState(args: {
+  config: SupervisorConfig | null;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+}): "observed" | "requested" | "missing" | "not_applicable" {
+  if (!args.config || !configuredReviewProviderKinds(args.config).includes("codex")) {
+    return "not_applicable";
+  }
+
+  if (args.pr.configuredBotCurrentHeadObservedAt) {
+    return "observed";
+  }
+
+  const recordRequestedSha = args.record.codex_connector_review_requested_head_sha;
+  const prRequestedSha = args.pr.codexConnectorReviewRequestedHeadSha;
+  if (
+    (args.record.codex_connector_review_requested_observed_at || args.pr.codexConnectorReviewRequestedAt) &&
+    (recordRequestedSha ?? prRequestedSha) === args.pr.headRefOid
+  ) {
+    return "requested";
+  }
+
+  return "missing";
+}
+
+function classifyCodexMetadataOnly(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): Pick<StaleReviewBotRemediationDto, "classification" | "summary"> {
+  const unresolvedWork = {
+    classification: "unresolved_work" as const,
+    summary: STALE_REVIEW_BOT_SUMMARY,
+  };
+
+  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
+  if (configuredThreads.length === 0) {
+    return unresolvedWork;
+  }
+
+  if (
+    manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
+    args.record.last_head_sha !== args.pr.headRefOid ||
+    !allChecksPassing(args.checks) ||
+    !hasCleanMergeState(args.pr) ||
+    pendingBotReviewThreads(args.config, args.record, args.pr, configuredThreads).length > 0 ||
+    configuredBotReviewFollowUpState(args.config, args.record, args.pr, configuredThreads) === "eligible" ||
+    !configuredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+  ) {
+    return unresolvedWork;
+  }
+
+  const policy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, args.reviewThreads);
+  if (!policy) {
+    return {
+      classification: "unknown_needs_operator",
+      summary: STALE_REVIEW_BOT_SUMMARY,
+    };
+  }
+
+  if (policy.outcome === "missing_current_head_review") {
+    return {
+      classification: "metadata_only_missing_current_head_review",
+      summary: STALE_REVIEW_BOT_METADATA_CURRENT_HEAD_SUMMARY,
+    };
+  }
+
+  if (policy.outcome === "must_fix_remaining") {
+    const hasUnprocessedMustFix = codexConnectorMustFixReviewThreads(args.reviewThreads).some(
+      (thread) => !hasProcessedReviewThread(args.record, args.pr, thread),
+    );
+    if (hasUnprocessedMustFix) {
+      return unresolvedWork;
+    }
+    if (!policy.currentHeadObservedAt) {
+      return {
+        classification: "metadata_only_missing_current_head_review",
+        summary: STALE_REVIEW_BOT_METADATA_CURRENT_HEAD_SUMMARY,
+      };
+    }
+  }
+
+  return {
+    classification: "metadata_only_current_head_converged",
+    summary: STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY,
+  };
+}
+
 function classifyRemediation(args: {
   config: SupervisorConfig | null;
   record: IssueRunRecord;
@@ -96,6 +197,16 @@ function classifyRemediation(args: {
 
   const { config, record, pr, checks, reviewThreads } = args;
   const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  if (configuredReviewProviderKinds(config).includes("codex")) {
+    return classifyCodexMetadataOnly({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    });
+  }
+
   if (
     configuredThreads.length === 0 ||
     manualReviewThreads(config, reviewThreads).length > 0 ||
@@ -139,6 +250,13 @@ export function buildStaleReviewBotRemediation(args: {
     checks: args.checks,
     reviewThreads: args.reviewThreads ?? [],
   });
+  const codexCurrentHeadReviewState = args.pr
+    ? codexConnectorCurrentHeadReviewState({
+      config: args.config ?? null,
+      record: args.record,
+      pr: args.pr,
+    })
+    : "not_applicable";
 
   return {
     issueNumber: args.record.issue_number,
@@ -148,6 +266,7 @@ export function buildStaleReviewBotRemediation(args: {
     processedOnCurrentHead: processedOnCurrentHead(args.record),
     codeCiState: codeCiState(args.pr, args.checks),
     classification: classification.classification,
+    codexCurrentHeadReviewState,
     reviewThreadUrl: args.record.last_failure_context?.url ?? null,
     manualNextStep: STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
     summary: classification.summary,
@@ -155,7 +274,7 @@ export function buildStaleReviewBotRemediation(args: {
 }
 
 export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotRemediationDto): string {
-  return [
+  const tokens = [
     "stale_review_bot_remediation",
     `issue=#${remediation.issueNumber}`,
     `pr=${remediation.prNumber === null ? "none" : `#${remediation.prNumber}`}`,
@@ -167,5 +286,9 @@ export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotR
     `review_thread_url=${remediation.reviewThreadUrl ? formatTokenValue(remediation.reviewThreadUrl) : "none"}`,
     `manual_next_step=${remediation.manualNextStep}`,
     `summary=${remediation.summary}`,
-  ].join(" ");
+  ];
+  if (remediation.codexCurrentHeadReviewState !== "not_applicable") {
+    tokens.splice(8, 0, `codex_current_head_review_state=${remediation.codexCurrentHeadReviewState}`);
+  }
+  return tokens.join(" ");
 }

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -99,7 +99,10 @@ function codexConnectorCurrentHeadReviewState(args: {
     return "not_applicable";
   }
 
-  if (args.pr.configuredBotCurrentHeadObservedAt) {
+  if (
+    args.pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
+    args.pr.configuredBotCurrentHeadObservedAt
+  ) {
     return "observed";
   }
 
@@ -174,9 +177,16 @@ function classifyCodexMetadataOnly(args: {
     }
   }
 
+  if (policy.outcome === "converged" || policy.outcome === "nitpick_only") {
+    return {
+      classification: "metadata_only_current_head_converged",
+      summary: STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY,
+    };
+  }
+
   return {
-    classification: "metadata_only_current_head_converged",
-    summary: STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY,
+    classification: "unknown_needs_operator",
+    summary: STALE_REVIEW_BOT_SUMMARY,
   };
 }
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -1,6 +1,7 @@
 import {
   localReviewRetryLoopStalled,
 } from "../review-handling";
+import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
   actionableBotReviewThreads,
   buildCodexConnectorP2P3PolicyDiagnostic,
@@ -208,11 +209,12 @@ export function buildInactiveDetailedStatusLines(
     `latest_record=${formatRecentRecord(latestRecord)}`,
   ];
   let staleReviewBotRemediation: ReturnType<typeof buildStaleReviewBotRemediation> = null;
+  const configTargetsCodex = configuredReviewProviderKinds(config).includes("codex");
   if (
     latestRecord &&
     pr &&
     latestRecord.last_head_sha === pr.headRefOid &&
-    pr.configuredBotCurrentHeadObservedAt &&
+    (pr.configuredBotCurrentHeadObservedAt || configTargetsCodex) &&
     pr.configuredBotCurrentHeadStatusState === "SUCCESS"
   ) {
     staleReviewBotRemediation = buildStaleReviewBotRemediation({

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1092,6 +1092,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
     processedOnCurrentHead: "unknown",
     codeCiState: "green",
     classification: "unresolved_work",
+    codexCurrentHeadReviewState: "not_applicable",
     reviewThreadUrl: "https://example.test/pr/295#discussion_r295",
     manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
     summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
@@ -1305,6 +1306,103 @@ test("explain keeps configured-bot success without current-head observation as u
   );
   assert.match(explanation, /^stale_diagnostic kind=stale_review_bot recoverability=provider_outage_suspected$/m);
   assert.doesNotMatch(explanation, /classification=metadata_only/m);
+});
+
+test("explain classifies processed Codex must-fix residue as missing-current-head review metadata", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  const issueNumber = 198;
+  const prNumber = 398;
+  const headSha = "head-198";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: branchName(fixture.config, issueNumber),
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-198@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-198@${headSha}#comment-198`],
+        last_error:
+          "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-198",
+          command: null,
+          details: ["reviewer=chatgpt-codex-connector file=src/file.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/398#discussion_r398",
+          updated_at: "2026-05-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain Codex processed metadata residue",
+    body: executionReadyBody("Explain should classify Codex must-fix residue as metadata-only pending review."),
+    createdAt: "2026-05-13T00:00:00Z",
+    updatedAt: "2026-05-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branchName(fixture.config, issueNumber),
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    currentHeadCiGreenAt: "2026-05-13T00:19:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const staleMetadataThread = {
+    id: "thread-198",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-198",
+          body: "P2: Fix this stale finding before merge.",
+          createdAt: "2026-05-13T00:05:00Z",
+          url: "https://example.test/pr/398#discussion_r398",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleMetadataThread],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=metadata_only_missing_current_head_review codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only_pending_current_head_review_request$/m,
+  );
 });
 
 test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -920,6 +920,102 @@ test("status --why classifies current-head processed configured-bot success as s
   assert.doesNotMatch(status, /stale_review_bot_provider_signal_missing/);
 });
 
+test("status --why includes codex processed-residue missing-current-head review state", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  const issueNumber = 398;
+  const prNumber = 498;
+  const headSha = "5de0d3844468d4a77cab512f8dcbe46171166c3a";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: "codex/issue-398",
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-398@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-398@${headSha}#comment-398`],
+        last_failure_signature: "stalled-bot:thread-398",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-398",
+          command: null,
+          details: ["reviewer=chatgpt-codex-connector file=src/query.ts line=12 processed_on_current_head=yes"],
+          url: "https://example.test/pr/498#discussion_r398",
+          updated_at: "2026-05-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Status why classifies codex processed residue",
+    body: executionReadyBody("Classify Codex processed residue as missing current-head review metadata."),
+    createdAt: "2026-05-13T00:00:00Z",
+    updatedAt: "2026-05-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: "codex/issue-398",
+    headRefOid: headSha,
+    currentHeadCiGreenAt: "2026-05-13T00:10:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const staleMetadataThread = {
+    id: "thread-398",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/query.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-398",
+          body: "P1: Fix this stale finding before merge.",
+          createdAt: "2026-05-13T00:05:00Z",
+          url: "https://example.test/pr/498#discussion_r398",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleMetadataThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#398 pr=#498 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=metadata_only_missing_current_head_review codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/498#discussion_r398 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only_pending_current_head_review_request$/m,
+  );
+  assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
+});
+
 test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
   const status = renderSupervisorStatusDto({
     gsdSummary: null,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -493,7 +493,9 @@ export async function buildIssueExplainDto(
   const staleDiagnosticSummary =
     record &&
     record.blocked_reason === "stale_review_bot" &&
-    staleReviewBotRemediation?.classification !== "metadata_only"
+    !(staleReviewBotRemediation?.classification === "metadata_only" ||
+      staleReviewBotRemediation?.classification === "metadata_only_missing_current_head_review" ||
+      staleReviewBotRemediation?.classification === "metadata_only_current_head_converged")
     ? (() => {
       const recoverability = classifyStaleReviewBotRecoverability(record, config);
       return recoverability === null

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -844,7 +844,8 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
       : null;
   const canResolveStaleConfiguredBotReview =
     args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
-    staleReviewBotRemediation?.classification === "metadata_only";
+    (staleReviewBotRemediation?.classification === "metadata_only" ||
+      staleReviewBotRemediation?.classification === "metadata_only_current_head_converged");
 
   const canAutoHandleStaleConfiguredBotReview =
     !args.skipAutoHandleStaleConfiguredBotReview &&


### PR DESCRIPTION
Closes #1974
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed a clean checkpoint on `codex/issue-1974` for issue **#1974**.

- Kept stale-review diagnostics from treating Codex `metadata_only_current_head_converged` as unresolved work in explain output.
- Kept reply-and-resolve automation gated to safe metadata-only cases (`metadata_only` and `metadata_only_current_head_converged`) in tracked PR persistent status comment flow.

Committed:
- `533b90c` — `Handle Codex metadata-only stale review thread states`

Also updated `.codex-supervisor/issues/1974/issue-journal.md` with current handoff/verification notes.

- `src/supervisor/supervisor-selection-issue-explain.ts`
- `src/tracked-pr-status-comment.ts`

Observed test output: the full targeted suite passed (`330` tests).  
`npm run build` and `issue-lint 1974` both passed.

Summary: Extended classification handling in diagnostics/status paths so metadata-only Codex current-head thread residue is not treated as unresolved work for stale-work repair diagnostics/automation.
State hint: stabilizing
Blocked reason: none
Tests: `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/review-thread-reporting.test.ts` (330 passed), `npm run build`, `node dist/index.js issue-lint 1974 --config "...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected request-suppression so unprocessed must-fix Codex threads are handled properly and duplicate requests are avoided when processed-residue exists.
  * Improved detection and handling of missing current-head review metadata.

* **Improvements**
  * Expanded diagnostics to include current-head review state.
  * More precise tracking of thread state for Codex review gating.

* **Tests**
  * Added and enhanced tests covering processed-residue, missing current-head metadata, state resets, and suppression behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1975)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->