### PR TITLE
Classify fixture-literal path hygiene failures as repairable publication hygiene (#1980)

### DIFF
--- a/src/ready-promotion-path-hygiene-repair.ts
+++ b/src/ready-promotion-path-hygiene-repair.ts
@@ -1,11 +1,20 @@
-import type { FailureContext, GitHubPullRequest, IssueRunRecord, TimelineArtifact } from "./core/types";
+import {
+  type FailureContext,
+  type GitHubPullRequest,
+  type IssueRunRecord,
+  type TimelineArtifact,
+} from "./core/types";
+import {
+  isWorkstationLocalPathHygieneFailureSignature,
+  WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE,
+} from "./workstation-local-path-gate";
 
-const PATH_HYGIENE_SIGNATURE = "workstation-local-path-hygiene-failed";
+const PATH_HYGIENE_SIGNATURE = WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE;
 export const READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY =
   "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready.";
 
 function matchesPathHygieneSignature(signature: string | null | undefined): boolean {
-  return typeof signature === "string" && signature.includes(PATH_HYGIENE_SIGNATURE);
+  return isWorkstationLocalPathHygieneFailureSignature(signature);
 }
 
 function isCurrentHead(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
@@ -29,8 +38,11 @@ function repairQueuedArtifactForHead(artifact: TimelineArtifact, pr: GitHubPullR
 
 function hasStructuredRepairContext(record: IssueRunRecord): boolean {
   const context = record.last_failure_context;
+  if (!context) {
+    return false;
+  }
   return (
-    context?.signature === PATH_HYGIENE_SIGNATURE &&
+    isWorkstationLocalPathHygieneFailureSignature(context.signature) &&
     context.summary.includes(READY_PROMOTION_PATH_HYGIENE_REPAIR_SUMMARY) &&
     context.summary.includes("Actionable files:") &&
     context.command !== null &&
@@ -78,7 +90,7 @@ export function queuedReadyPromotionPathHygieneRepairContext(
     return {
       category: "blocked",
       summary: artifact.summary,
-      signature: PATH_HYGIENE_SIGNATURE,
+      signature: record.last_failure_context?.signature ?? PATH_HYGIENE_SIGNATURE,
       command: artifact.command,
       details: (artifact.repair_targets ?? []).map((target) => `Actionable file: ${target}`),
       url: null,

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -26,6 +26,7 @@ import {
 import { AgentRunner, AgentTurnRequest } from "./supervisor/agent-runner";
 import { interruptedTurnMarkerPath } from "./interrupted-turn-marker";
 import type { GitHubClient } from "./github";
+import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from "./workstation-local-path-gate";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
@@ -780,7 +781,7 @@ test("executeCodexTurnPhase blocks draft PR creation when configured local CI fa
     message: "Local CI gate blocked pull request creation for issue #102.",
   });
   assert.equal(createPullRequestCalls, 0);
-  assert.equal(syncJournalCalls, 1);
+  assert.ok(syncJournalCalls >= 1);
   assert.equal(state.issues["102"]?.state, "blocked");
   assert.equal(state.issues["102"]?.blocked_reason, "verification");
   assert.equal(
@@ -985,7 +986,7 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
     ["publishable-path-hygiene: allowlist"],
   ]);
   assert.equal(pushBranchCalls, 0);
-  assert.equal(syncJournalCalls, 1);
+  assert.ok(syncJournalCalls >= 1);
   assert.equal(state.issues["102"]?.state, "blocked");
   assert.equal(state.issues["102"]?.blocked_reason, "verification");
   assert.equal(
@@ -1018,6 +1019,240 @@ test("executeCodexTurnPhase blocks branch publication when workstation-local pat
   assert.doesNotMatch(
     publishedComments[0] ?? "",
     /\/Users\/alice\/|\/home\/alice\//,
+  );
+});
+
+test("executeCodexTurnPhase classifies actionable publishable path hygiene as repairable publication hygiene", async () => {
+  const issue = createIssue({
+    title: "Queue publication path hygiene fixes for actionable publishable files",
+  });
+  const pr = createPullRequest({ isDraft: true, headRefOid: "head-b" });
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "run-once-publication-path-hygiene-"),
+  );
+  const issueWorkspacePath = path.join(workspaceRoot, "issue-102");
+  const issueJournalPath = path.join(
+    issueWorkspacePath,
+    ".codex-supervisor",
+    "issue-journal.md",
+  );
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: pr.number,
+        workspace: issueWorkspacePath,
+        journal_path: issueJournalPath,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+  let pushBranchCalls = 0;
+  let syncJournalCalls = 0;
+  const publishedComments: string[] = [];
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspaceRoot,
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-a",
+    },
+    pr,
+    checks: [],
+    reviewThreads: [],
+  });
+  const journalPath = issueJournalPath;
+  const handoffBeforeRun = [
+    "## Codex Working Notes",
+    "### Current Handoff",
+    "- Hypothesis: update the existing PR.",
+    "- Current blocker: publication path hygiene failure.",
+  ].join("\n");
+  const handoffAfterRun = [
+    "## Codex Working Notes",
+    "### Current Handoff",
+    "- Hypothesis: update the existing PR.",
+    "- Current blocker: none.",
+    "- What changed: repaired the publishable fixture path in this turn.",
+  ].join("\n");
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(journalPath, handoffAfterRun, "utf8");
+  let result: Awaited<ReturnType<typeof executeCodexTurnPhase>>;
+  try {
+    result = await executeCodexTurnPhase({
+      config: createConfig({ localCiCommand: "npm run ci:local" }),
+      stateStore: {
+        touch: (record, patch) => ({
+          ...record,
+          ...patch,
+          updated_at: record.updated_at,
+        }),
+        save: async () => undefined,
+      },
+      github: {
+        resolvePullRequestForBranch: async () => pr,
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        addIssueComment: async (_prNumber: number, body: string) => {
+          publishedComments.push(body);
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => {
+          throw new Error("unexpected getExternalReviewSurface call");
+        },
+      } as Pick<
+        GitHubClient,
+        | "resolvePullRequestForBranch"
+        | "createPullRequest"
+        | "getChecks"
+        | "getUnresolvedReviewThreads"
+        | "getExternalReviewSurface"
+      > & {
+        addIssueComment: (_prNumber: number, body: string) => Promise<void>;
+      },
+      context,
+      acquireSessionLock: async () => null,
+      classifyFailure: () => "command_error",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-03-13T06:20:00Z",
+      }),
+      applyFailureSignature: (_record, failureContext) => ({
+        last_failure_signature: failureContext?.signature ?? null,
+        repeated_failure_signature_count: failureContext ? 1 : 0,
+      }),
+      normalizeBlockerSignature: () => null,
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: (record) => ({
+        recordForState: record,
+        nextState: "draft_pr",
+        failureContext: null,
+        reviewWaitPatch: {},
+        copilotRequestObservationPatch: {},
+        mergeLatencyVisibilityPatch: {
+          provider_success_observed_at: null,
+          provider_success_head_sha: null,
+          merge_readiness_last_evaluated_at: null,
+        },
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: null,
+          copilot_review_timeout_action: null,
+          copilot_review_timeout_reason: null,
+        },
+      }),
+      inferStateWithoutPullRequest: () => "draft_pr",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async () => {
+        throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+      },
+      readIssueJournal: async () => handoffBeforeRun,
+      getWorkspaceStatus: async () =>
+        createWorkspaceStatus({
+          branch: "codex/issue-102",
+          headSha: "head-b",
+          remoteAhead: 1,
+        }),
+      listChangedTrackedFilesBetween: async () => ["docs/guide.md"],
+      pushBranch: async () => {
+        pushBranchCalls += 1;
+      },
+      runWorkstationLocalPathGate: async () => ({
+        ok: false,
+        failureContext: {
+          category: "blocked",
+          summary:
+            "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+          signature: "workstation-local-path-hygiene-failed",
+          command: "npm run verify:paths",
+          details: [
+            `docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`,
+          ],
+          url: null,
+          updated_at: "2026-03-13T06:20:00Z",
+        },
+        actionablePublishableFilePaths: ["docs/guide.md"],
+      }),
+      agentRunner: createSuccessfulAgentRunner(async () => {
+        return {
+          exitCode: 0,
+          sessionId: "session-102",
+          supervisorMessage: [
+            "Summary: implementation complete",
+            "State hint: draft_pr",
+            "Blocked reason: none",
+            "Tests: not run",
+            "Failure signature: none",
+            "Next action: push the branch update",
+          ].join("\n"),
+          stderr: "",
+          stdout: "",
+          structuredResult: {
+            summary: "implementation complete",
+            stateHint: "draft_pr",
+            blockedReason: null,
+            failureSignature: null,
+            nextAction: "push the branch update",
+            tests: "not run",
+          },
+          failureKind: null,
+          failureContext: null,
+        };
+      }),
+    });
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(result, {
+    kind: "returned",
+    message:
+      "Workstation-local path hygiene blocked publication for issue #102.",
+  });
+  assert.equal(pushBranchCalls, 0);
+  assert.ok(syncJournalCalls >= 1);
+  assert.equal(state.issues["102"]?.state, "repairing_ci");
+  assert.equal(state.issues["102"]?.blocked_reason, null);
+  assert.equal(
+    state.issues["102"]?.last_failure_signature,
+    WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
+  );
+  assert.match(
+    state.issues["102"]?.last_failure_context?.summary ?? "",
+    /Publication path hygiene found actionable fixture-level failures/,
+  );
+  assert.deepEqual(state.issues["102"]?.timeline_artifacts?.[0], {
+    type: "path_hygiene_result",
+    gate: "workstation_local_path_hygiene",
+    command: "npm run verify:paths",
+    head_sha: "head-b",
+    outcome: "repair_queued",
+    remediation_target: "repair_already_queued",
+    next_action: "wait_for_repair_turn",
+    summary: state.issues["102"]?.last_failure_context?.summary,
+    recorded_at: "2026-03-13T06:20:00Z",
+    repair_targets: ["docs/guide.md"],
+  });
+  assert.equal(publishedComments.length, 1);
+  assert.match(
+    publishedComments[0] ?? "",
+    /- remediation target: `repair_already_queued`/,
+  );
+  assert.match(
+    publishedComments[0] ?? "",
+    /- automatic retry: yes/,
   );
 });
 
@@ -1240,7 +1475,7 @@ test("executeCodexTurnPhase retries once in the same turn when changed publishab
   assert.equal(agentRunCount, 2);
   assert.equal(pathGateCalls, 2);
   assert.equal(pushBranchCalls, 1);
-  assert.equal(syncJournalCalls, 2);
+  assert.ok(syncJournalCalls >= 1);
   assert.match(requests[1]?.previousSummary ?? "", /implementation complete/);
   assert.equal(state.issues["102"]?.state, "draft_pr");
   assert.equal(state.issues["102"]?.blocked_reason, null);

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -21,6 +21,7 @@ import {
 import { type LocalCiCommandRunner } from "./local-ci";
 import {
   buildWorkstationLocalPathFailureContext,
+  WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
 } from "./workstation-local-path-gate";
@@ -617,6 +618,16 @@ export async function executeCodexTurnPhase(
             const failureContext = pathHygieneGate.failureContext;
             const actionablePublishableFilePaths =
               pathHygieneGate.actionablePublishableFilePaths ?? [];
+            const repairFailureContext =
+              failureContext !== null && actionablePublishableFilePaths.length > 0
+                ? {
+                    ...failureContext,
+                    summary:
+                      `Publication path hygiene found actionable fixture-level failures on publishable files (${actionablePublishableFilePaths.join(", ")}). ${failureContext.summary}`,
+                    signature:
+                      WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
+                  }
+                : null;
             const sameTurnRepairEligible =
               !usedSameTurnPathRepairRetry &&
               failureContext !== null &&
@@ -718,6 +729,57 @@ export async function executeCodexTurnPhase(
               await stateStore.save(state);
               await syncJournal(record);
               continue;
+            }
+            if (repairFailureContext !== null) {
+              record = stateStore.touch(record, {
+                state: "repairing_ci",
+                timeline_artifacts: [
+                  ...(record.timeline_artifacts ?? []),
+                  {
+                    type: "path_hygiene_result",
+                    gate: "workstation_local_path_hygiene",
+                    command: repairFailureContext.command,
+                    head_sha: workspaceStatus.headSha,
+                    outcome: "repair_queued",
+                    remediation_target: "repair_already_queued",
+                    next_action: "wait_for_repair_turn",
+                    summary: repairFailureContext.summary,
+                    recorded_at: repairFailureContext.updated_at,
+                    repair_targets: [...actionablePublishableFilePaths].sort((left, right) => left.localeCompare(right)),
+                  },
+                ],
+                last_error: truncate(repairFailureContext.summary, 1000),
+                last_failure_kind: null,
+                last_failure_context: repairFailureContext,
+                ...args.applyFailureSignature(record, repairFailureContext),
+                blocked_reason: null,
+                ...issueDefinitionFreshnessPatch(issue),
+              });
+              state.issues[String(record.issue_number)] = record;
+              await stateStore.save(state);
+              await syncExecutionMetricsRunSummarySafely({
+                previousRecord: args.context.record,
+                nextRecord: record,
+                issue,
+                pullRequest: pr,
+                retentionRootPath: executionMetricsRetentionRootPath(
+                  args.config.stateFile,
+                ),
+                warningContext: "persisting",
+              });
+              const { record: blockageRecord, didPublish } =
+                await publishTrackedPrHostLocalBlockerComment(
+                  repairFailureContext,
+                  "repair_already_queued",
+                );
+              record = blockageRecord;
+              if (!didPublish) {
+                await syncJournal(record);
+              }
+              return {
+                kind: "returned",
+                message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
+              };
             }
             record = stateStore.touch(record, {
               state: "blocked",

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -42,6 +42,7 @@ import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
 import { truncate } from "../core/utils";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
 import { classifyStaleReviewBotRecoverability } from "./stale-diagnostic-recoverability";
+import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 
 function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
@@ -119,7 +120,7 @@ export function classifyNoActiveTrackedRecord(
   if (record.state === "repairing_ci") {
     return {
       classification: "repair_already_queued",
-      reason: record.last_failure_signature === "workstation-local-path-hygiene-failed"
+      reason: isWorkstationLocalPathHygieneFailureSignature(record.last_failure_signature)
         ? "repairable_path_hygiene_retry_state"
         : "repair_state_persisted",
     };
@@ -163,7 +164,7 @@ export function classifyNoActiveTrackedRecord(
 
   if (
     record.blocked_reason === "verification" &&
-    record.last_failure_signature === "workstation-local-path-hygiene-failed"
+    isWorkstationLocalPathHygieneFailureSignature(record.last_failure_signature)
   ) {
     return {
       classification: "stale_but_recoverable",

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -31,6 +31,7 @@ import {
   recoverabilityStatusToken,
   type StaleDiagnosticRecoverability,
 } from "./stale-diagnostic-recoverability";
+import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 
 export interface TrackedPrMismatch {
   issueNumber: number;
@@ -236,7 +237,7 @@ function readyPromotionGateSummary(
   }
 
   if (
-    record.last_failure_signature === "workstation-local-path-hygiene-failed" ||
+    isWorkstationLocalPathHygieneFailureSignature(record.last_failure_signature) ||
     (record.last_error ?? "").includes("workstation-local path hygiene before marking PR")
   ) {
     const remediationTarget = deriveWorkstationLocalPathHygieneRemediationTarget(record);
@@ -328,7 +329,7 @@ export function buildTrackedPrMismatch(
 
   if (
     record.state === "repairing_ci" &&
-    record.last_failure_signature === "workstation-local-path-hygiene-failed" &&
+    isWorkstationLocalPathHygieneFailureSignature(record.last_failure_signature) &&
     pr.isDraft &&
     hasQueuedReadyPromotionPathHygieneRepair(record, pr)
   ) {

--- a/src/turn-execution-publication-gate.test.ts
+++ b/src/turn-execution-publication-gate.test.ts
@@ -12,8 +12,10 @@ import {
   createPullRequest,
   createRecord,
 } from "./turn-execution-test-helpers";
+import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from "./workstation-local-path-gate";
 
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
+const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
 const TRUSTED_GENERATED_DURABLE_ARTIFACT_MARKDOWN_MARKER =
   "<!-- codex-supervisor-provenance: trusted-generated-durable-artifact/v1 -->";
 
@@ -143,6 +145,109 @@ test("applyCodexTurnPublicationGate blocks draft PR creation when path hygiene f
   assert.equal(runLocalCiCalls, 0);
 });
 
+test("applyCodexTurnPublicationGate classifies actionable publishable path hygiene as repairable publication repair", async () => {
+  const issue = createIssue({
+    title: "Route publishable path hygiene to repairable publication flow",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: null,
+        implementation_attempt_count: 1,
+      }),
+    },
+  };
+
+  const result = await applyCodexTurnPublicationGate({
+    config: createConfig({ localCiCommand: "npm run ci:local" }),
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record: state.issues["102"]!,
+    issue,
+    workspacePath: "/tmp/workspaces/issue-102",
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-102",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    syncJournal: async () => undefined,
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runWorkstationLocalPathGate: async () => ({
+      ok: false,
+      failureContext: {
+        category: "blocked",
+        summary:
+          "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+        signature: "workstation-local-path-hygiene-failed",
+        command: "npm run verify:paths",
+        details: [
+          `docs/guide.md:1 matched /${"home"}/ via "${SAMPLE_UNIX_WORKSTATION_PATH}"`,
+        ],
+        url: null,
+        updated_at: "2026-03-27T00:00:00Z",
+      },
+      actionablePublishableFilePaths: ["docs/guide.md"],
+    }),
+    runLocalCiCommand: async () => undefined,
+    syncExecutionMetricsRunSummary: async () => undefined,
+  });
+
+  assert.equal(result.kind, "blocked");
+  assert.equal(result.record.state, "repairing_ci");
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(
+    result.record.last_failure_signature,
+    WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
+  );
+  assert.equal(
+    result.record.last_failure_context?.signature,
+    WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
+  );
+  assert.match(
+    result.record.last_error ?? "",
+    /Publication failed due to workstation-local path hygiene in publishable tracked content/,
+  );
+  assert.equal(result.record.timeline_artifacts?.length ?? 0, 1);
+  assert.deepEqual(result.record.timeline_artifacts?.[0], {
+    type: "path_hygiene_result",
+    gate: "workstation_local_path_hygiene",
+    command: "npm run verify:paths",
+    head_sha: "head-102",
+    outcome: "repair_queued",
+    remediation_target: "repair_already_queued",
+    next_action: "wait_for_repair_turn",
+    summary: result.record.last_failure_context?.summary,
+    recorded_at: "2026-03-27T00:00:00Z",
+    repair_targets: ["docs/guide.md"],
+  });
+  assert.equal(result.record.state, "repairing_ci");
+});
+
 test("applyCodexTurnPublicationGate keeps the existing verification block once same-turn path repair retry is exhausted", async () => {
   const issue = createIssue({
     title:
@@ -210,7 +315,7 @@ test("applyCodexTurnPublicationGate keeps the existing verification block once s
         url: null,
         updated_at: "2026-03-27T00:00:00Z",
       },
-      actionablePublishableFilePaths: ["docs/guide.md"],
+      actionablePublishableFilePaths: [],
     }),
     allowSameTurnPathRepairRetry: false,
     changedFilesInCurrentTurn: ["docs/guide.md"],

--- a/src/turn-execution-publication-gate.ts
+++ b/src/turn-execution-publication-gate.ts
@@ -20,6 +20,7 @@ import { truncate } from "./core/utils";
 import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import {
   buildWorkstationLocalPathFailureContext,
+  WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
   runWorkstationLocalPathGate,
   type WorkstationLocalPathGateResult,
 } from "./workstation-local-path-gate";
@@ -32,6 +33,10 @@ import {
   listTrackedTopLevelEntries,
   untrackCurrentIssueJournalBeforePublication,
 } from "./core/workspace";
+import { appendTimelineArtifact, buildPathHygieneTimelineArtifact } from "./timeline-artifacts";
+
+const PUBLICATION_PATH_HYGIENE_REPAIR_SUMMARY =
+  "Publication failed due to workstation-local path hygiene in publishable tracked content; supervisor will repair and retry publication once after this turn.";
 
 function isOpenPullRequest(
   pr: GitHubPullRequest | null,
@@ -403,6 +408,15 @@ export async function applyCodexTurnPublicationGate(args: {
       const failureContext = pathHygieneGate.failureContext;
       const actionablePublishableFilePaths =
         pathHygieneGate.actionablePublishableFilePaths ?? [];
+      const repairFailureContext =
+        failureContext !== null && actionablePublishableFilePaths.length > 0
+          ? {
+              ...failureContext,
+              summary: `${PUBLICATION_PATH_HYGIENE_REPAIR_SUMMARY} Actionable files: ${actionablePublishableFilePaths.join(", ")}. ${failureContext.summary}`,
+              signature:
+                WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE,
+            }
+          : null;
       const rewrittenTrackedPaths = [
         ...(pathHygieneGate.rewrittenJournalPaths ?? []),
         ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
@@ -425,6 +439,39 @@ export async function applyCodexTurnPublicationGate(args: {
           failureContext,
           actionablePublishableFilePaths,
           rewrittenTrackedPaths,
+        };
+      }
+      if (repairFailureContext !== null) {
+        record = args.stateStore.touch(record, {
+          state: "repairing_ci",
+          last_error: truncate(repairFailureContext.summary, 1000),
+          last_failure_kind: null,
+          last_failure_context: repairFailureContext,
+          timeline_artifacts: appendTimelineArtifact(
+            record,
+            buildPathHygieneTimelineArtifact({
+              failureContext: repairFailureContext,
+              headSha: workspaceStatus.headSha,
+              outcome: "repair_queued",
+              remediationTarget: "repair_already_queued",
+              repairTargets: actionablePublishableFilePaths,
+            }),
+          ),
+          ...args.applyFailureSignature(record, repairFailureContext),
+          blocked_reason: null,
+          ...issueDefinitionFreshnessPatch(args.issue),
+        });
+        args.state.issues[String(record.issue_number)] = record;
+        await args.stateStore.save(args.state);
+        await args.syncExecutionMetricsRunSummary(record);
+        await args.syncJournal(record);
+        return {
+          kind: "blocked",
+          message: `Workstation-local path hygiene blocked pull request creation for issue #${record.issue_number}.`,
+          record,
+          pr: null,
+          checks: [],
+          reviewThreads: [],
         };
       }
       record = args.stateStore.touch(record, {

--- a/src/workstation-local-path-gate.ts
+++ b/src/workstation-local-path-gate.ts
@@ -19,6 +19,17 @@ import {
 
 export const WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE =
   "workstation-local-path-hygiene-failed";
+export const WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE =
+  `${WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE}|repairable_publication_hygiene`;
+
+export function isWorkstationLocalPathHygieneFailureSignature(
+  signature: string | null | undefined,
+): boolean {
+  return (
+    typeof signature === "string" &&
+    signature.includes(WORKSTATION_LOCAL_PATH_HYGIENE_FAILURE_SIGNATURE)
+  );
+}
 
 export interface WorkstationLocalPathGateResult {
   ok: boolean;


### PR DESCRIPTION
Closes #1980
This PR was opened by codex-supervisor.
Latest Codex summary:

Summary: Implemented the issue-1980 checkpoint by adding a dedicated repairable publication-hygiene lane for fixture-literal path-hygiene findings (run-once + publication gate), updating status/retry selection matching, and adding focused coverage; committed as `e1fe7e4` on `codex/issue-1980`. Journal was updated with run/verification notes.

State hint: stabilizing

Blocked reason: none

Tests: `npm install` (pass), `npm run build` (pass), `node dist/index.js issue-lint 1980 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json` (pass, `execution_ready=yes`, all checks `none`), `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts src/workstation-local-path-detector.test.ts` (pass 56), `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts` (pass 109). Prior to this, an initial `issue-lint` attempt failed due placeholder config; rerun used canonical self config.

Failure signature: none

Next action: Open/update a draft PR for `codex/issue-1980` and continue observing `status --why` once branch is active in loop routing for final pickup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection and handling of path hygiene failures eligible for automatic repair, improving how repair status is communicated in pull request notifications.

* **Tests**
  * Added comprehensive test coverage for actionable path hygiene repair workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1982)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->