### PR TITLE
Expose unpublished local repair commits after publication gate failure (#1981)

### DIFF
--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1792,6 +1792,80 @@ test("explain keeps same-head host-local ready-promotion blockers current when t
   );
 });
 
+test("explain reports unpublished local repair commits after publication gate failure", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 190;
+  const prNumber = 290;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "verification",
+        last_error:
+          "Tracked durable artifacts failed workstation-local path hygiene before marking PR #290 ready.",
+        last_head_sha: "head-local-290",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_host_local_pr_blocker_comment_signature:
+          "workstation-local-path-hygiene-failed|gate=workstation_local_path_hygiene|failure=workstation-local-path-hygiene-failed|target=tracked_publishable_content",
+        last_host_local_pr_blocker_comment_head_sha: "head-local-290",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain publication failure before push",
+    body: executionReadyBody("Explain should show unpublished local repairs when publication fails before push."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-pr-290",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^tracked_pr_ready_promotion_blocked issue=#190 pr=#290 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    explanation,
+    /^tracked_pr_ready_promotion_gate issue=#190 pr=#290 gate=workstation_local_path_hygiene remediation_target=tracked_publishable_content summary=Tracked durable artifacts failed workstation-local path hygiene before marking PR #290 ready\.$/m,
+  );
+  assert.match(
+    explanation,
+    /^tracked_pr_local_repair_commit_unpublished issue=#190 pr=#290 local_repair_commit_unpublished=head-local-290 local_head_sha=head-local-290 remote_head_sha=head-pr-290 publication_gate=failed publication_gate_name=workstation_local_path_hygiene failure_signature=workstation-local-path-hygiene-failed$/m,
+  );
+});
+
 test("explain distinguishes repairable ready-promotion path hygiene blockers queued for repair", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 178;

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -4324,6 +4324,78 @@ test("status distinguishes repairable ready-promotion path hygiene blockers queu
   );
 });
 
+test("status reports unpublished local repair commits when publication fails before push", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 190;
+  const prNumber = 290;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        blocked_reason: "verification",
+        last_error:
+          "Tracked durable artifacts failed workstation-local path hygiene before marking PR #290 ready.",
+        last_head_sha: "head-local-290",
+        last_failure_signature: "workstation-local-path-hygiene-failed",
+        last_host_local_pr_blocker_comment_signature:
+          "workstation-local-path-hygiene-failed|gate=workstation_local_path_hygiene|failure=workstation-local-path-hygiene-failed|target=tracked_publishable_content",
+        last_host_local_pr_blocker_comment_head_sha: "head-local-290",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked publication failure before push",
+    body: executionReadyBody("Surface publication-gate failures where the fix stays local-only."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const draftPr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-pr-290",
+    isDraft: true,
+  });
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    localCiCommand: "npm run verify:paths",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => draftPr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status();
+  assert.match(
+    status,
+    /^tracked_pr_ready_promotion_blocked issue=#190 pr=#290 recoverability=stale_but_recoverable github_state=draft_pr local_state=blocked local_blocked_reason=verification stale_local_blocker=yes$/m,
+  );
+  assert.match(
+    status,
+    /^tracked_pr_ready_promotion_gate issue=#190 pr=#290 gate=workstation_local_path_hygiene remediation_target=tracked_publishable_content summary=Tracked durable artifacts failed workstation-local path hygiene before marking PR #290 ready\.$/m,
+  );
+  assert.match(
+    status,
+    /^tracked_pr_local_repair_commit_unpublished issue=#190 pr=#290 local_repair_commit_unpublished=head-local-290 local_head_sha=head-local-290 remote_head_sha=head-pr-290 publication_gate=failed publication_gate_name=workstation_local_path_hygiene failure_signature=workstation-local-path-hygiene-failed$/m,
+  );
+});
+
 test("status surfaces baseline-only ready-promotion path hygiene findings as maintenance context", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 180;

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -121,6 +121,7 @@ export interface SupervisorExplainDto {
   trackedPrRetryabilitySummary?: string | null;
   trackedPrReadyPromotionMaintenanceSummary?: string | null;
   trackedPrMismatchSummary: string | null;
+  trackedPrMismatchDetailLines?: string[];
   externalSignalReadinessSummary?: string | null;
   recoveryGuidance: string | null;
   loopRuntimeBlockerSummary?: string | null;
@@ -592,6 +593,7 @@ export async function buildIssueExplainDto(
         : null,
     trackedPrReadyPromotionMaintenanceSummary,
     trackedPrMismatchSummary: trackedPrMismatch?.summaryLine ?? null,
+    trackedPrMismatchDetailLines: trackedPrMismatch?.detailLines ?? [],
     externalSignalReadinessSummary,
     recoveryGuidance: trackedPrMismatch?.guidanceLine ?? null,
     selectionReason,
@@ -662,6 +664,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
     ...(dto.trackedPrReadyPromotionMaintenanceSummary ? [dto.trackedPrReadyPromotionMaintenanceSummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),
+    ...(dto.trackedPrMismatchDetailLines ? dto.trackedPrMismatchDetailLines : []),
     ...(dto.externalSignalReadinessSummary ? [dto.externalSignalReadinessSummary] : []),
     ...(dto.recoveryGuidance ? [dto.recoveryGuidance] : []),
     ...(dto.loopRuntimeBlockerSummary ? [dto.loopRuntimeBlockerSummary] : []),

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -205,6 +205,80 @@ function deriveWorkstationLocalPathHygieneRemediationTarget(
   return REMEDIATION_TARGET_TRACKED_PUBLISHABLE_CONTENT;
 }
 
+function isWorkstationLocalPathHygienePublicationFailure(record: IssueRunRecord): boolean {
+  return (
+    isWorkstationLocalPathHygieneFailureSignature(record.last_failure_signature)
+    || (record.last_error ?? "").includes("workstation-local path hygiene before marking PR")
+  );
+}
+
+function hasFreshLocalHeadPublicationEvidence(record: IssueRunRecord, localHeadSha: string | null): boolean {
+  if (localHeadSha === null) {
+    return false;
+  }
+
+  if (
+    record.latest_local_ci_result?.outcome === "failed"
+    && record.latest_local_ci_result.head_sha === localHeadSha
+  ) {
+    return true;
+  }
+
+  if (
+    record.last_observed_host_local_pr_blocker_head_sha === localHeadSha
+    && typeof record.last_observed_host_local_pr_blocker_signature === "string"
+    && record.last_observed_host_local_pr_blocker_signature.length > 0
+    && !record.last_observed_host_local_pr_blocker_signature.startsWith("cleared:")
+  ) {
+    return true;
+  }
+
+  return (
+    record.last_host_local_pr_blocker_comment_head_sha === localHeadSha
+    && typeof record.last_host_local_pr_blocker_comment_signature === "string"
+    && record.last_host_local_pr_blocker_comment_signature.length > 0
+    && !record.last_host_local_pr_blocker_comment_signature.startsWith("cleared:")
+  );
+}
+
+function buildUnpublishedLocalRepairCommitLines(
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+): string[] {
+  const localHeadSha = record.last_head_sha ?? null;
+  const remoteHeadSha = pr.headRefOid ?? null;
+
+  if (localHeadSha === null || remoteHeadSha === null) {
+    return [];
+  }
+
+  if (localHeadSha === remoteHeadSha) {
+    return [];
+  }
+
+  if (!isWorkstationLocalPathHygienePublicationFailure(record)) {
+    return [];
+  }
+
+  if (!hasFreshLocalHeadPublicationEvidence(record, localHeadSha)) {
+    return [];
+  }
+
+  return [
+    [
+      "tracked_pr_local_repair_commit_unpublished",
+      `issue=#${record.issue_number}`,
+      `pr=#${record.pr_number}`,
+      `local_repair_commit_unpublished=${localHeadSha}`,
+      `local_head_sha=${localHeadSha}`,
+      `remote_head_sha=${remoteHeadSha}`,
+      "publication_gate=failed",
+      "publication_gate_name=workstation_local_path_hygiene",
+      `failure_signature=${record.last_failure_signature ?? "unknown"}`,
+    ].join(" "),
+  ];
+}
+
 function readyPromotionGateSummary(
   config: SupervisorConfig,
   record: IssueRunRecord,
@@ -236,10 +310,7 @@ function readyPromotionGateSummary(
     };
   }
 
-  if (
-    isWorkstationLocalPathHygieneFailureSignature(record.last_failure_signature) ||
-    (record.last_error ?? "").includes("workstation-local path hygiene before marking PR")
-  ) {
+  if (isWorkstationLocalPathHygienePublicationFailure(record)) {
     const remediationTarget = deriveWorkstationLocalPathHygieneRemediationTarget(record);
     const pathHygieneSummary = record.last_error ?? summary;
     return {
@@ -255,6 +326,7 @@ function readyPromotionGateSummary(
           `remediation_target=${remediationTarget}`,
           `summary=${pathHygieneSummary.replace(/\r?\n/g, "\\n")}`,
         ].join(" "),
+        ...buildUnpublishedLocalRepairCommitLines(record, pr),
         ...buildTimelineArtifactDetailLines(record),
       ],
     };

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -247,8 +247,9 @@ function buildUnpublishedLocalRepairCommitLines(
 ): string[] {
   const localHeadSha = record.last_head_sha ?? null;
   const remoteHeadSha = pr.headRefOid ?? null;
+  const prNumber = record.pr_number;
 
-  if (localHeadSha === null || remoteHeadSha === null) {
+  if (localHeadSha === null || remoteHeadSha === null || prNumber === null) {
     return [];
   }
 
@@ -268,7 +269,7 @@ function buildUnpublishedLocalRepairCommitLines(
     [
       "tracked_pr_local_repair_commit_unpublished",
       `issue=#${record.issue_number}`,
-      `pr=#${record.pr_number}`,
+      `pr=#${prNumber}`,
       `local_repair_commit_unpublished=${localHeadSha}`,
       `local_head_sha=${localHeadSha}`,
       `remote_head_sha=${remoteHeadSha}`,


### PR DESCRIPTION
Closes #1981
This PR was opened by codex-supervisor.
Latest Codex summary:

Summary: Implemented issue-1981 diagnostics to surface unpublished local repair commits when publication is blocked by the local path hygiene gate before push, and committed as `02d53cf` on `codex/issue-1981`. Changes:
- `src/supervisor/tracked-pr-mismatch.ts`: added publication-failure detection + stale local-head evidence checks and now emits `tracked_pr_local_repair_commit_unpublished ...` with safe metadata (`local_head_sha`, `remote_head_sha`, `publication_gate`, `publication_gate_name`, `failure_signature`).
- `src/supervisor/supervisor-selection-issue-explain.ts`: propagated mismatch detail lines into `explain` output so it aligns with `status --why`.
- `src/supervisor/supervisor-diagnostics-status-selection.test.ts`: added focused status regression for unpublished local repair after pre-push publication failure.
- `src/supervisor/supervisor-diagnostics-explain.test.ts`: added focused explain regression for the same scenario.
- Updated `.codex-supervisor/issues/1981/issue-journal.md` with working hypothesis, what changed, commands run, and next step.

State hint: implementing
Blocked reason: none
Tests: `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts` ✅ (131 pass, 0 fail); `npx tsx --test src/run-once-turn-execution.test.ts src/tracked-pr-status-comment.test.ts` ✅ (24 pass, 0 fail); `npm run build` initially failed (`tsc: com...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostics: explanations and status now report unpublished local repair commits with local vs remote head SHAs and the publication-gate failure details when a tracked PR's publication fails.

* **Tests**
  * Added coverage ensuring explanations and status output include the new unpublished-local-repair-commit diagnostics and related gate failure information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1983)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->