### PR TITLE
Persist Codex Connector request comment identity

### DIFF
--- a/src/core/state-store-normalization.test.ts
+++ b/src/core/state-store-normalization.test.ts
@@ -157,4 +157,8 @@ test("normalizeStateForLoad defaults Codex Connector retry bookkeeping", () => {
   assert.equal(loaded.issues["1976"]?.codex_connector_review_request_retry_count, 0);
   assert.equal(loaded.issues["1976"]?.codex_connector_review_request_retry_head_sha, null);
   assert.equal(loaded.issues["1976"]?.codex_connector_review_request_last_retried_at, null);
+  assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_identity_status, null);
+  assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_database_id, null);
+  assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_node_id, null);
+  assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_url, null);
 });

--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -106,6 +106,16 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     codex_connector_review_request_retry_count: value.codex_connector_review_request_retry_count ?? 0,
     codex_connector_review_request_retry_head_sha: value.codex_connector_review_request_retry_head_sha ?? null,
     codex_connector_review_request_last_retried_at: value.codex_connector_review_request_last_retried_at ?? null,
+    codex_connector_review_request_comment_identity_status:
+      value.codex_connector_review_request_comment_identity_status ?? null,
+    codex_connector_review_request_comment_database_id:
+      typeof value.codex_connector_review_request_comment_database_id === "number"
+        ? value.codex_connector_review_request_comment_database_id
+        : null,
+    codex_connector_review_request_comment_node_id:
+      value.codex_connector_review_request_comment_node_id ?? null,
+    codex_connector_review_request_comment_url:
+      value.codex_connector_review_request_comment_url ?? null,
     copilot_review_timed_out_at: value.copilot_review_timed_out_at ?? null,
     copilot_review_timeout_action: value.copilot_review_timeout_action ?? null,
     copilot_review_timeout_reason: value.copilot_review_timeout_reason ?? null,

--- a/src/core/state-store.ts
+++ b/src/core/state-store.ts
@@ -111,6 +111,22 @@ export class StateStore {
         hasOwn(patch, "codex_connector_review_request_last_retried_at")
           ? patch.codex_connector_review_request_last_retried_at ?? null
           : record.codex_connector_review_request_last_retried_at ?? null,
+      codex_connector_review_request_comment_identity_status:
+        hasOwn(patch, "codex_connector_review_request_comment_identity_status")
+          ? patch.codex_connector_review_request_comment_identity_status ?? null
+          : record.codex_connector_review_request_comment_identity_status ?? null,
+      codex_connector_review_request_comment_database_id:
+        hasOwn(patch, "codex_connector_review_request_comment_database_id")
+          ? patch.codex_connector_review_request_comment_database_id ?? null
+          : record.codex_connector_review_request_comment_database_id ?? null,
+      codex_connector_review_request_comment_node_id:
+        hasOwn(patch, "codex_connector_review_request_comment_node_id")
+          ? patch.codex_connector_review_request_comment_node_id ?? null
+          : record.codex_connector_review_request_comment_node_id ?? null,
+      codex_connector_review_request_comment_url:
+        hasOwn(patch, "codex_connector_review_request_comment_url")
+          ? patch.codex_connector_review_request_comment_url ?? null
+          : record.codex_connector_review_request_comment_url ?? null,
       copilot_review_timed_out_at:
         hasOwn(patch, "copilot_review_timed_out_at")
           ? patch.copilot_review_timed_out_at ?? null

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -115,6 +115,7 @@ export interface TimelineArtifact {
 }
 
 export type FailureKind = "timeout" | "command_error" | "codex_exit" | "codex_failed" | null;
+export type CommentIdentityStatus = "available" | "unavailable" | null;
 
 export type FailureContextCategory =
   | "checks"
@@ -228,6 +229,10 @@ export interface IssueRunRecord {
   codex_connector_review_request_retry_count?: number;
   codex_connector_review_request_retry_head_sha?: string | null;
   codex_connector_review_request_last_retried_at?: string | null;
+  codex_connector_review_request_comment_identity_status?: CommentIdentityStatus;
+  codex_connector_review_request_comment_database_id?: number | null;
+  codex_connector_review_request_comment_node_id?: string | null;
+  codex_connector_review_request_comment_url?: string | null;
   copilot_review_timed_out_at: string | null;
   copilot_review_timeout_action: CopilotReviewTimeoutAction | null;
   copilot_review_timeout_reason: string | null;

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -48,8 +48,11 @@ export interface PullRequestCopilotReviewLifecycleResponse {
   } | null;
   comments?: {
     nodes?: Array<{
+      id?: string | null;
+      databaseId?: number | null;
       createdAt?: string | null;
       body?: string | null;
+      url?: string | null;
       viewerDidAuthor?: boolean | null;
       author?: {
         login?: string | null;
@@ -249,9 +252,12 @@ export function mapCopilotReviewLifecycleFacts(
       ) ?? [],
     issueComments:
       lifecycle?.comments?.nodes?.map((comment) => ({
+        id: comment?.id ?? null,
+        databaseId: comment?.databaseId ?? null,
         authorLogin: normalizeLogin(comment?.author?.login ?? null),
         createdAt: comment?.createdAt ?? null,
         body: comment?.body ?? null,
+        url: comment?.url ?? null,
         viewerDidAuthor: comment?.viewerDidAuthor ?? null,
       })) ?? [],
     statusContexts:
@@ -346,6 +352,9 @@ export function applyConfiguredBotReviewSummary(
     copilotReviewArrivedAt: summary?.lifecycle.arrivedAt ?? null,
     codexConnectorReviewRequestedAt: summary?.codexConnectorReviewRequest?.requestedAt ?? null,
     codexConnectorReviewRequestedHeadSha: summary?.codexConnectorReviewRequest?.headSha ?? null,
+    codexConnectorReviewRequestCommentDatabaseId: summary?.codexConnectorReviewRequest?.commentDatabaseId ?? null,
+    codexConnectorReviewRequestCommentNodeId: summary?.codexConnectorReviewRequest?.commentNodeId ?? null,
+    codexConnectorReviewRequestCommentUrl: summary?.codexConnectorReviewRequest?.commentUrl ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,

--- a/src/github/github-mutations.ts
+++ b/src/github/github-mutations.ts
@@ -1,7 +1,7 @@
 import { IssueRunRecord, SupervisorConfig } from "../core/types";
 import { CommandResult } from "../core/command";
 import { parseJson, truncate } from "../core/utils";
-import type { GitHubIssue, GitHubPullRequest } from "./types";
+import type { GitHubIssue, GitHubIssueCommentIdentity, GitHubPullRequest } from "./types";
 
 const POST_CREATE_PR_LOOKUP_RETRY_LIMIT = 2;
 const POST_CREATE_PR_LOOKUP_BASE_DELAY_MS = 200;
@@ -16,6 +16,12 @@ interface GitHubRestIssue {
   state: string;
   labels?: Array<{ name: string }>;
   pull_request?: unknown;
+}
+
+interface GitHubRestIssueComment {
+  id?: number | null;
+  node_id?: string | null;
+  html_url?: string | null;
 }
 
 export class GitHubMutationClient {
@@ -120,16 +126,25 @@ export class GitHubMutationClient {
     );
   }
 
-  async addIssueComment(issueNumber: number, body: string): Promise<void> {
-    await this.runGhCommand([
-      "issue",
-      "comment",
-      String(issueNumber),
-      "--repo",
-      this.config.repoSlug,
-      "--body",
-      body,
+  async addIssueComment(issueNumber: number, body: string): Promise<GitHubIssueCommentIdentity | null> {
+    const { owner, repo } = this.repoOwnerAndName();
+    const result = await this.runGhCommand([
+      "api",
+      `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      "--method",
+      "POST",
+      "-f",
+      `body=${body}`,
     ]);
+    const created = parseJson<GitHubRestIssueComment>(
+      result.stdout,
+      `gh api repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    );
+    return {
+      databaseId: typeof created.id === "number" ? created.id : null,
+      nodeId: created.node_id ?? null,
+      url: created.html_url ?? null,
+    };
   }
 
   async updateIssueComment(commentDatabaseId: number, body: string): Promise<void> {

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -223,14 +223,20 @@ test("GitHubPullRequestHydrator hydrates supervisor-authored Codex Connector rev
                 comments: {
                   nodes: [
                     {
+                      id: "IC_old_request",
+                      databaseId: 44000,
                       createdAt: "2026-03-13T01:00:00Z",
                       body: "<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-old -->\n@codex review",
+                      url: "https://github.com/owner/repo/issues/44#issuecomment-44000",
                       viewerDidAuthor: true,
                       author: { login: "codex-supervisor[bot]" },
                     },
                     {
+                      id: "IC_current_request",
+                      databaseId: 44001,
                       createdAt: "2026-03-13T01:05:00Z",
                       body: "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-44 -->",
+                      url: "https://github.com/owner/repo/issues/44#issuecomment-44001",
                       viewerDidAuthor: true,
                       author: { login: "codex-supervisor[bot]" },
                     },
@@ -262,6 +268,9 @@ test("GitHubPullRequestHydrator hydrates supervisor-authored Codex Connector rev
   assert.match(lifecycleQuery, /viewerDidAuthor/);
   assert.equal(pr?.codexConnectorReviewRequestedAt, "2026-03-13T01:05:00Z");
   assert.equal(pr?.codexConnectorReviewRequestedHeadSha, "head-44");
+  assert.equal(pr?.codexConnectorReviewRequestCommentDatabaseId, 44001);
+  assert.equal(pr?.codexConnectorReviewRequestCommentNodeId, "IC_current_request");
+  assert.equal(pr?.codexConnectorReviewRequestCommentUrl, "https://github.com/owner/repo/issues/44#issuecomment-44001");
 });
 
 test("GitHubPullRequestHydrator hydrates Copilot arrival from long review threads without truncating comments to 20", async () => {

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -204,8 +204,11 @@ export class GitHubPullRequestHydrator {
             }
             comments(last: 100) {
               nodes {
+                id
+                databaseId
                 createdAt
                 body
+                url
                 viewerDidAuthor
                 author {
                   login

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -45,8 +45,11 @@ test("findCodexConnectorReviewRequest matches trigger-first supervisor-authored 
     [
       {
         authorLogin: "coderabbitai[bot]",
+        id: "IC_request_current",
+        databaseId: 44001,
         createdAt: "2026-03-13T01:00:00Z",
         body: "@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=1923 pr=44 head=head-current -->",
+        url: "https://github.com/owner/repo/issues/44#issuecomment-44001",
         viewerDidAuthor: true,
       },
       {
@@ -78,6 +81,9 @@ test("findCodexConnectorReviewRequest matches trigger-first supervisor-authored 
   assert.deepEqual(current, {
     requestedAt: "2026-03-13T01:00:00Z",
     headSha: "head-current",
+    commentDatabaseId: 44001,
+    commentNodeId: "IC_request_current",
+    commentUrl: "https://github.com/owner/repo/issues/44#issuecomment-44001",
   });
 
   assert.equal(
@@ -120,6 +126,9 @@ test("findCodexConnectorReviewRequest still hydrates historical marker-first req
     {
       requestedAt: "2026-03-13T01:00:00Z",
       headSha: "head-current",
+      commentDatabaseId: null,
+      commentNodeId: null,
+      commentUrl: null,
     },
   );
 });

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -27,9 +27,12 @@ export interface CopilotReviewLifecycleFacts {
     originalCommitOid?: string | null;
   }>;
   issueComments: Array<{
+    id?: string | null;
+    databaseId?: number | null;
     authorLogin: string | null;
     createdAt: string | null;
     body: string | null;
+    url?: string | null;
     viewerDidAuthor?: boolean | null;
   }>;
   statusContexts?: Array<{
@@ -90,6 +93,9 @@ export type ConfiguredBotCurrentHeadObservationSource =
 export interface CodexConnectorReviewRequestObservation {
   requestedAt: string | null;
   headSha: string;
+  commentDatabaseId: number | null;
+  commentNodeId: string | null;
+  commentUrl: string | null;
 }
 
 export interface CodexConnectorReviewRequestIdentity {
@@ -168,6 +174,9 @@ export function findCodexConnectorReviewRequest(
       latest = {
         requestedAt: comment.createdAt,
         headSha: marker.headSha,
+        commentDatabaseId: typeof comment.databaseId === "number" ? comment.databaseId : null,
+        commentNodeId: comment.id ?? null,
+        commentUrl: comment.url ?? null,
       };
       latestMs = createdAtMs;
     }

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -13,7 +13,15 @@ import {
   PullRequestReviewSurfaceOptions,
 } from "./github-review-surface";
 import { GitHubTransport, isGitHubRateLimitFailure } from "./github-transport";
-import type { GitHubIssue, GitHubPullRequest, IssueComment, PullRequestCheck, PullRequestReview, ReviewThread } from "./types";
+import type {
+  GitHubIssue,
+  GitHubIssueCommentIdentity,
+  GitHubPullRequest,
+  IssueComment,
+  PullRequestCheck,
+  PullRequestReview,
+  ReviewThread,
+} from "./types";
 
 export { isTransientGitHubCommandFailure } from "./github-transport";
 export { isGitHubRateLimitFailure } from "./github-transport";
@@ -24,6 +32,7 @@ export type {
   CopilotReviewState,
   ExternalReviewActor,
   GitHubIssue,
+  GitHubIssueCommentIdentity,
   GitHubLabel,
   GitHubPullRequest,
   IssueComment,
@@ -176,7 +185,7 @@ export class GitHubClient {
     return this.mutations.markPullRequestReady(prNumber);
   }
 
-  async addIssueComment(issueNumber: number, body: string): Promise<void> {
+  async addIssueComment(issueNumber: number, body: string): Promise<GitHubIssueCommentIdentity | null | void> {
     return this.mutations.addIssueComment(issueNumber, body);
   }
 

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -34,6 +34,9 @@ export interface GitHubPullRequest {
   copilotReviewArrivedAt?: string | null;
   codexConnectorReviewRequestedAt?: string | null;
   codexConnectorReviewRequestedHeadSha?: string | null;
+  codexConnectorReviewRequestCommentDatabaseId?: number | null;
+  codexConnectorReviewRequestCommentNodeId?: string | null;
+  codexConnectorReviewRequestCommentUrl?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;
@@ -98,4 +101,10 @@ export interface IssueComment {
   url: string | null;
   author: ExternalReviewActor | null;
   viewerDidAuthor?: boolean | null;
+}
+
+export interface GitHubIssueCommentIdentity {
+  databaseId: number | null;
+  nodeId: string | null;
+  url: string | null;
 }

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -522,6 +522,11 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
       github: createDefaultGithub({
         addIssueComment: async (issueNumber, body) => {
           comments.push({ issueNumber, body });
+          return {
+            databaseId: 1976001,
+            nodeId: "IC_kwDOissue1976_request",
+            url: "https://github.com/owner/repo/issues/1976#issuecomment-1976001",
+          };
         },
       }),
       context: createPostTurnContext({
@@ -565,11 +570,24 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
         ],
         { issueNumber: issue.number, prNumber: pr.number, headSha: pr.headRefOid },
       ),
-      { requestedAt: "2026-05-08T03:30:00Z", headSha: pr.headRefOid },
+      {
+        requestedAt: "2026-05-08T03:30:00Z",
+        headSha: pr.headRefOid,
+        commentDatabaseId: null,
+        commentNodeId: null,
+        commentUrl: null,
+      },
     );
     assert.equal(result.record.state, "waiting_ci");
     assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
     assert.ok(result.record.codex_connector_review_requested_observed_at);
+    assert.equal(result.record.codex_connector_review_request_comment_identity_status, "available");
+    assert.equal(result.record.codex_connector_review_request_comment_database_id, 1976001);
+    assert.equal(result.record.codex_connector_review_request_comment_node_id, "IC_kwDOissue1976_request");
+    assert.equal(
+      result.record.codex_connector_review_request_comment_url,
+      "https://github.com/owner/repo/issues/1976#issuecomment-1976001",
+    );
     assert.equal(result.record.blocked_reason, null);
 
     const retryResult = await handlePostTurnPullRequestTransitionsPhase({
@@ -578,6 +596,11 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
       github: createDefaultGithub({
         addIssueComment: async (issueNumber, body) => {
           comments.push({ issueNumber, body });
+          return {
+            databaseId: 1924001,
+            nodeId: "IC_kwDOissue1924_request",
+            url: "https://github.com/owner/repo/issues/1924#issuecomment-1924001",
+          };
         },
       }),
       context: createPostTurnContext({
@@ -661,6 +684,11 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
       github: createDefaultGithub({
         addIssueComment: async (issueNumber, body) => {
           comments.push({ issueNumber, body });
+          return {
+            databaseId: 1924001,
+            nodeId: "IC_kwDOissue1924_request",
+            url: "https://github.com/owner/repo/issues/1924#issuecomment-1924001",
+          };
         },
       }),
       context: createPostTurnContext({
@@ -693,6 +721,13 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
     assert.equal(result.record.codex_connector_review_request_retry_count, 1);
     assert.equal(result.record.codex_connector_review_request_retry_head_sha, pr.headRefOid);
     assert.ok(result.record.codex_connector_review_request_last_retried_at);
+    assert.equal(result.record.codex_connector_review_request_comment_identity_status, "available");
+    assert.equal(result.record.codex_connector_review_request_comment_database_id, 1924001);
+    assert.equal(result.record.codex_connector_review_request_comment_node_id, "IC_kwDOissue1924_request");
+    assert.equal(
+      result.record.codex_connector_review_request_comment_url,
+      "https://github.com/owner/repo/issues/1924#issuecomment-1924001",
+    );
 
     const duplicateCycle = await handlePostTurnPullRequestTransitionsPhase({
       config,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -640,7 +640,7 @@ async function maybeRequestCodexConnectorReviewComment(args: {
     if (!args.github.addIssueComment) {
       throw new Error("GitHub comment transport unavailable");
     }
-    await args.github.addIssueComment(
+    const commentIdentity = await args.github.addIssueComment(
       args.pr.number,
       renderCodexConnectorReviewRequestCommentForAction({
         action: requestAction,
@@ -650,6 +650,46 @@ async function maybeRequestCodexConnectorReviewComment(args: {
         headSha: args.pr.headRefOid,
       }),
     );
+    const commentIdentityPatch: Partial<IssueRunRecord> = commentIdentity
+      ? {
+          codex_connector_review_request_comment_identity_status: "available",
+          codex_connector_review_request_comment_database_id: commentIdentity.databaseId,
+          codex_connector_review_request_comment_node_id: commentIdentity.nodeId,
+          codex_connector_review_request_comment_url: commentIdentity.url,
+        }
+      : {
+          codex_connector_review_request_comment_identity_status: "unavailable",
+          codex_connector_review_request_comment_database_id: null,
+          codex_connector_review_request_comment_node_id: null,
+          codex_connector_review_request_comment_url: null,
+        };
+
+    const requestedAt = nowIso();
+    const updatedRecord = args.stateStore.touch(args.record, {
+      state: "waiting_ci",
+      codex_connector_review_requested_observed_at:
+        requestAction.kind === "initial"
+          ? requestedAt
+          : args.record.codex_connector_review_requested_observed_at ?? args.pr.codexConnectorReviewRequestedAt ?? requestedAt,
+      codex_connector_review_requested_head_sha: args.pr.headRefOid,
+      codex_connector_review_request_retry_count:
+        requestAction.kind === "retry" ? requestAction.retryAttempt : 0,
+      codex_connector_review_request_retry_head_sha:
+        requestAction.kind === "retry" ? args.pr.headRefOid : null,
+      codex_connector_review_request_last_retried_at:
+        requestAction.kind === "retry" ? requestedAt : null,
+      ...commentIdentityPatch,
+      blocked_reason: null,
+      last_error: null,
+      last_failure_kind: null,
+      last_failure_context: null,
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    });
+    args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(updatedRecord);
+    return updatedRecord;
   } catch (error) {
     const failureContext = buildCodexConnectorReviewRequestFailureContext({ pr: args.pr, error });
     const blockedRecord = args.stateStore.touch(args.record, {
@@ -667,31 +707,6 @@ async function maybeRequestCodexConnectorReviewComment(args: {
     return blockedRecord;
   }
 
-  const requestedAt = nowIso();
-  const updatedRecord = args.stateStore.touch(args.record, {
-    state: "waiting_ci",
-    codex_connector_review_requested_observed_at:
-      requestAction.kind === "initial"
-        ? requestedAt
-        : args.record.codex_connector_review_requested_observed_at ?? args.pr.codexConnectorReviewRequestedAt ?? requestedAt,
-    codex_connector_review_requested_head_sha: args.pr.headRefOid,
-    codex_connector_review_request_retry_count:
-      requestAction.kind === "retry" ? requestAction.retryAttempt : 0,
-    codex_connector_review_request_retry_head_sha:
-      requestAction.kind === "retry" ? args.pr.headRefOid : null,
-    codex_connector_review_request_last_retried_at:
-      requestAction.kind === "retry" ? requestedAt : null,
-    blocked_reason: null,
-    last_error: null,
-    last_failure_kind: null,
-    last_failure_context: null,
-    last_failure_signature: null,
-    repeated_failure_signature_count: 0,
-  });
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
 }
 
 async function applyTrackedPrLifecycleState(args: {

--- a/src/pull-request-state-sync.test.ts
+++ b/src/pull-request-state-sync.test.ts
@@ -97,12 +97,19 @@ test("syncCodexConnectorReviewRequestObservation preserves one request per curre
       headRefOid: "head-current",
       codexConnectorReviewRequestedAt: "2026-03-13T01:00:00Z",
       codexConnectorReviewRequestedHeadSha: "head-current",
+      codexConnectorReviewRequestCommentDatabaseId: 44001,
+      codexConnectorReviewRequestCommentNodeId: "IC_head_current",
+      codexConnectorReviewRequestCommentUrl: "https://github.com/owner/repo/issues/44#issuecomment-44001",
     }),
   );
 
   assert.deepEqual(current, {
     codex_connector_review_requested_observed_at: "2026-03-13T01:00:00Z",
     codex_connector_review_requested_head_sha: "head-current",
+    codex_connector_review_request_comment_identity_status: "available",
+    codex_connector_review_request_comment_database_id: 44001,
+    codex_connector_review_request_comment_node_id: "IC_head_current",
+    codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/44#issuecomment-44001",
   });
 
   const stale = syncCodexConnectorReviewRequestObservation(
@@ -122,5 +129,42 @@ test("syncCodexConnectorReviewRequestObservation preserves one request per curre
   assert.deepEqual(stale, {
     codex_connector_review_requested_observed_at: null,
     codex_connector_review_requested_head_sha: null,
+    codex_connector_review_request_comment_identity_status: null,
+    codex_connector_review_request_comment_database_id: null,
+    codex_connector_review_request_comment_node_id: null,
+    codex_connector_review_request_comment_url: null,
+  });
+});
+
+test("syncCodexConnectorReviewRequestObservation clears request identity after current-head signal", () => {
+  const cleared = syncCodexConnectorReviewRequestObservation(
+    createRecord({
+      issue_number: 1923,
+      codex_connector_review_requested_observed_at: "2026-03-13T01:00:00Z",
+      codex_connector_review_requested_head_sha: "head-current",
+      codex_connector_review_request_comment_identity_status: "available",
+      codex_connector_review_request_comment_database_id: 44001,
+      codex_connector_review_request_comment_node_id: "IC_head_current",
+      codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/44#issuecomment-44001",
+    }),
+    createPullRequest({
+      number: 44,
+      headRefOid: "head-current",
+      configuredBotCurrentHeadObservedAt: "2026-03-13T01:10:00Z",
+      codexConnectorReviewRequestedAt: "2026-03-13T01:00:00Z",
+      codexConnectorReviewRequestedHeadSha: "head-current",
+      codexConnectorReviewRequestCommentDatabaseId: 44001,
+      codexConnectorReviewRequestCommentNodeId: "IC_head_current",
+      codexConnectorReviewRequestCommentUrl: "https://github.com/owner/repo/issues/44#issuecomment-44001",
+    }),
+  );
+
+  assert.deepEqual(cleared, {
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    codex_connector_review_request_comment_identity_status: null,
+    codex_connector_review_request_comment_database_id: null,
+    codex_connector_review_request_comment_node_id: null,
+    codex_connector_review_request_comment_url: null,
   });
 });

--- a/src/pull-request-state-sync.ts
+++ b/src/pull-request-state-sync.ts
@@ -73,8 +73,24 @@ export function syncCodexConnectorReviewRequestObservation(
   pr: GitHubPullRequest,
 ): Pick<
   IssueRunRecord,
-  "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+  | "codex_connector_review_requested_observed_at"
+  | "codex_connector_review_requested_head_sha"
+  | "codex_connector_review_request_comment_identity_status"
+  | "codex_connector_review_request_comment_database_id"
+  | "codex_connector_review_request_comment_node_id"
+  | "codex_connector_review_request_comment_url"
 > {
+  if (pr.configuredBotCurrentHeadObservedAt) {
+    return {
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+      codex_connector_review_request_comment_identity_status: null,
+      codex_connector_review_request_comment_database_id: null,
+      codex_connector_review_request_comment_node_id: null,
+      codex_connector_review_request_comment_url: null,
+    };
+  }
+
   if (
     pr.codexConnectorReviewRequestedAt &&
     pr.codexConnectorReviewRequestedHeadSha === pr.headRefOid
@@ -82,6 +98,29 @@ export function syncCodexConnectorReviewRequestObservation(
     return {
       codex_connector_review_requested_observed_at: pr.codexConnectorReviewRequestedAt,
       codex_connector_review_requested_head_sha: pr.headRefOid,
+      codex_connector_review_request_comment_identity_status:
+        pr.codexConnectorReviewRequestCommentDatabaseId ||
+        pr.codexConnectorReviewRequestCommentNodeId ||
+        pr.codexConnectorReviewRequestCommentUrl
+          ? "available"
+          : record.codex_connector_review_requested_head_sha === pr.headRefOid
+            ? record.codex_connector_review_request_comment_identity_status ?? null
+            : null,
+      codex_connector_review_request_comment_database_id:
+        pr.codexConnectorReviewRequestCommentDatabaseId ??
+        (record.codex_connector_review_requested_head_sha === pr.headRefOid
+          ? record.codex_connector_review_request_comment_database_id ?? null
+          : null),
+      codex_connector_review_request_comment_node_id:
+        pr.codexConnectorReviewRequestCommentNodeId ??
+        (record.codex_connector_review_requested_head_sha === pr.headRefOid
+          ? record.codex_connector_review_request_comment_node_id ?? null
+          : null),
+      codex_connector_review_request_comment_url:
+        pr.codexConnectorReviewRequestCommentUrl ??
+        (record.codex_connector_review_requested_head_sha === pr.headRefOid
+          ? record.codex_connector_review_request_comment_url ?? null
+          : null),
     };
   }
 
@@ -92,12 +131,24 @@ export function syncCodexConnectorReviewRequestObservation(
     return {
       codex_connector_review_requested_observed_at: record.codex_connector_review_requested_observed_at,
       codex_connector_review_requested_head_sha: record.codex_connector_review_requested_head_sha,
+      codex_connector_review_request_comment_identity_status:
+        record.codex_connector_review_request_comment_identity_status ?? null,
+      codex_connector_review_request_comment_database_id:
+        record.codex_connector_review_request_comment_database_id ?? null,
+      codex_connector_review_request_comment_node_id:
+        record.codex_connector_review_request_comment_node_id ?? null,
+      codex_connector_review_request_comment_url:
+        record.codex_connector_review_request_comment_url ?? null,
     };
   }
 
   return {
     codex_connector_review_requested_observed_at: null,
     codex_connector_review_requested_head_sha: null,
+    codex_connector_review_request_comment_identity_status: null,
+    codex_connector_review_request_comment_database_id: null,
+    codex_connector_review_request_comment_node_id: null,
+    codex_connector_review_request_comment_url: null,
   };
 }
 

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -347,7 +347,7 @@ test("explain surfaces Codex Connector review-request fallback lifecycle for the
 
   assert.match(
     explanation,
-    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
+    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=unavailable next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
   assert.match(
     explanation,
@@ -415,7 +415,7 @@ test("explain distinguishes hydrated same-head Codex Connector review requests",
 
   assert.match(
     explanation,
-    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1958 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1958 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
+    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1958 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1958 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=unavailable next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
   assert.match(
     explanation,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -228,7 +228,7 @@ test("status surfaces Codex Connector review-request fallback lifecycle for the 
 
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
+    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=unavailable next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),
@@ -288,7 +288,7 @@ test("status --why distinguishes hydrated same-head Codex Connector review reque
 
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1958 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1958 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
+    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1958 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1958 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=unavailable next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -924,10 +924,14 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
           codex_connector_review_request_retry_count: 0,
           codex_connector_review_request_retry_head_sha: null,
           codex_connector_review_request_last_retried_at: null,
+          codex_connector_review_request_comment_identity_status: "available",
+          codex_connector_review_request_comment_database_id: 340001,
+          codex_connector_review_request_comment_node_id: "IC_kwDOhead340",
+          codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/340#issuecomment-340001",
         }),
         pr: waitingPr,
       }),
-      "codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-03-16T00:10:00.000Z next_action=retry_request_review_comment wait_until=2026-03-16T00:20:00.000Z",
+      "codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-03-16T00:10:00.000Z request_comment_identity=database_id=340001,node_id=IC_kwDOhead340,url=https://github.com/owner/repo/issues/340#issuecomment-340001 next_action=retry_request_review_comment wait_until=2026-03-16T00:20:00.000Z",
     );
 
     assert.equal(
@@ -942,7 +946,7 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
         }),
         pr: waitingPr,
       }),
-      "codex_connector_review_fallback status=request_retry_exhausted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=exhausted retry_count=1 retry_limit=1 retry_wait_until=2026-03-16T00:11:00.000Z next_action=operator_manual_review wait_until=2026-03-16T00:20:00.000Z",
+      "codex_connector_review_fallback status=request_retry_exhausted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=exhausted retry_count=1 retry_limit=1 retry_wait_until=2026-03-16T00:11:00.000Z request_comment_identity=unavailable next_action=operator_manual_review wait_until=2026-03-16T00:20:00.000Z",
     );
 
     assert.equal(

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -305,6 +305,10 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
     | "codex_connector_review_request_retry_count"
     | "codex_connector_review_request_retry_head_sha"
     | "codex_connector_review_request_last_retried_at"
+    | "codex_connector_review_request_comment_identity_status"
+    | "codex_connector_review_request_comment_database_id"
+    | "codex_connector_review_request_comment_node_id"
+    | "codex_connector_review_request_comment_url"
   >;
   pr: GitHubPullRequest;
   checks?: PullRequestCheck[];
@@ -383,6 +387,14 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
   }
 
   const waitUntilSuffix = waitWindow.waitUntil ? ` wait_until=${waitWindow.waitUntil}` : "";
+  const commentIdentity =
+    args.record.codex_connector_review_request_comment_identity_status === "available"
+      ? [
+          `database_id=${args.record.codex_connector_review_request_comment_database_id ?? "none"}`,
+          `node_id=${args.record.codex_connector_review_request_comment_node_id ?? "none"}`,
+          `url=${args.record.codex_connector_review_request_comment_url ?? "none"}`,
+        ].join(",")
+      : "unavailable";
   const retryStatusSuffix =
     status === "request_posted_no_current_head_signal" || status === "request_retry_exhausted"
       ? [
@@ -390,6 +402,7 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
           `retry_count=${retryCount}`,
           `retry_limit=${retryLimit}`,
           `retry_wait_until=${retryWaitUntil ?? "none"}`,
+          `request_comment_identity=${commentIdentity}`,
           `next_action=${status === "request_retry_exhausted" ? "operator_manual_review" : "retry_request_review_comment"}`,
         ].join(" ")
       : "";

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -312,6 +312,10 @@ test("resetTrackedPrHeadScopedStateOnAdvance does not preserve review bookkeepin
     codex_connector_review_request_retry_count: 0,
     codex_connector_review_request_retry_head_sha: null,
     codex_connector_review_request_last_retried_at: null,
+    codex_connector_review_request_comment_identity_status: null,
+    codex_connector_review_request_comment_database_id: null,
+    codex_connector_review_request_comment_node_id: null,
+    codex_connector_review_request_comment_url: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,
@@ -331,6 +335,10 @@ test("resetTrackedPrHeadScopedStateOnAdvance clears old-head provider success af
     codex_connector_review_request_retry_count: 1,
     codex_connector_review_request_retry_head_sha: "head-old-191",
     codex_connector_review_request_last_retried_at: "2026-05-08T03:45:00Z",
+    codex_connector_review_request_comment_identity_status: "available",
+    codex_connector_review_request_comment_database_id: 191001,
+    codex_connector_review_request_comment_node_id: "IC_head_old_191",
+    codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/191#issuecomment-191001",
   });
 
   const patch = resetTrackedPrHeadScopedStateOnAdvance(record, "head-new-191");
@@ -342,6 +350,10 @@ test("resetTrackedPrHeadScopedStateOnAdvance clears old-head provider success af
   assert.equal(patch.codex_connector_review_request_retry_count, 0);
   assert.equal(patch.codex_connector_review_request_retry_head_sha, null);
   assert.equal(patch.codex_connector_review_request_last_retried_at, null);
+  assert.equal(patch.codex_connector_review_request_comment_identity_status, null);
+  assert.equal(patch.codex_connector_review_request_comment_database_id, null);
+  assert.equal(patch.codex_connector_review_request_comment_node_id, null);
+  assert.equal(patch.codex_connector_review_request_comment_url, null);
 });
 
 test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when processed thread markers belong to an older head", () => {
@@ -396,6 +408,10 @@ test("resetTrackedPrHeadScopedStateOnAdvance clears review bookkeeping when proc
     codex_connector_review_request_retry_count: 0,
     codex_connector_review_request_retry_head_sha: null,
     codex_connector_review_request_last_retried_at: null,
+    codex_connector_review_request_comment_identity_status: null,
+    codex_connector_review_request_comment_database_id: null,
+    codex_connector_review_request_comment_node_id: null,
+    codex_connector_review_request_comment_url: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -180,6 +180,10 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
         ? {
             codex_connector_review_requested_observed_at: null,
             codex_connector_review_requested_head_sha: null,
+            codex_connector_review_request_comment_identity_status: null,
+            codex_connector_review_request_comment_database_id: null,
+            codex_connector_review_request_comment_node_id: null,
+            codex_connector_review_request_comment_url: null,
           }
         : {}),
       ...(codexConnectorReviewRequestRetryHeadStale
@@ -187,6 +191,10 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
             codex_connector_review_request_retry_count: 0,
             codex_connector_review_request_retry_head_sha: null,
             codex_connector_review_request_last_retried_at: null,
+            codex_connector_review_request_comment_identity_status: null,
+            codex_connector_review_request_comment_database_id: null,
+            codex_connector_review_request_comment_node_id: null,
+            codex_connector_review_request_comment_url: null,
           }
         : {}),
       ...(observedHostLocalBlockerHeadStale
@@ -237,6 +245,10 @@ export function resetTrackedPrHeadScopedStateOnAdvance(
     codex_connector_review_request_retry_count: 0,
     codex_connector_review_request_retry_head_sha: null,
     codex_connector_review_request_last_retried_at: null,
+    codex_connector_review_request_comment_identity_status: null,
+    codex_connector_review_request_comment_database_id: null,
+    codex_connector_review_request_comment_node_id: null,
+    codex_connector_review_request_comment_url: null,
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
     last_host_local_pr_blocker_comment_signature: null,


### PR DESCRIPTION
Closes #1984

## Summary
- persist latest Codex Connector request/retry comment identity in tracked PR state
- hydrate request comment identity from GitHub comment markers when available
- surface request comment identity in retry-related status/explain diagnostics

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/tracked-pr-lifecycle-projection.test.ts src/config.test.ts src/core/state-store-normalization.test.ts
- npx tsx --test src/github/github-review-signals.test.ts src/github/github-pull-request-hydrator.test.ts src/pull-request-state-sync.test.ts
- npx tsx --test src/pull-request-state-sync.test.ts && npm run build
- npm run build
- node dist/index.js issue-lint 1984 --config <active-codex-supervisor-config>

Note: repo starter config still fails closed until placeholders are replaced; issue-lint passed with the active supervisor config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Codex Connector review request tracking to capture and persist GitHub comment identity metadata (database ID, node ID, and URL) when review comments are created.
  * State synchronization now preserves and manages comment identity data across system updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1986)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->