### PR TITLE
Classify verified no-source-change Codex threads

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -150,6 +150,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       "localReviewFollowUpIssueCreationEnabled",
       "localReviewHighSeverityAction",
       "staleConfiguredBotReviewPolicy",
+      "verifiedNoSourceChangeReviewThreadAutoResolve",
       "approvedTrackedTopLevelEntries",
     ].map((field) => [field, getConfigFieldPostureMetadata(field)?.tier]),
     [
@@ -158,6 +159,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       ["localReviewFollowUpIssueCreationEnabled", "dangerous_explicit_opt_in"],
       ["localReviewHighSeverityAction", "dangerous_explicit_opt_in"],
       ["staleConfiguredBotReviewPolicy", "dangerous_explicit_opt_in"],
+      ["verifiedNoSourceChangeReviewThreadAutoResolve", "dangerous_explicit_opt_in"],
       ["approvedTrackedTopLevelEntries", "dangerous_explicit_opt_in"],
     ],
   );

--- a/src/core/config-field-posture.ts
+++ b/src/core/config-field-posture.ts
@@ -120,6 +120,7 @@ const CONFIG_FIELD_POSTURE_METADATA_ENTRIES = [
   dangerousExplicitOptIn("localReviewFollowUpIssueCreationEnabled", "Automated local-review follow-up issue creation opt-in."),
   dangerousExplicitOptIn("localReviewHighSeverityAction", "High-severity local-review autonomous action posture."),
   dangerousExplicitOptIn("staleConfiguredBotReviewPolicy", "Configured-bot stale-thread reply or resolve behavior."),
+  dangerousExplicitOptIn("verifiedNoSourceChangeReviewThreadAutoResolve", "Verified no-source-change review-thread auto-resolution opt-in."),
   dangerousExplicitOptIn("approvedTrackedTopLevelEntries", "Approved tracked top-level repository skeleton entries."),
 ] as const;
 

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -544,6 +544,7 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
       : [],
     approvedTrackedTopLevelEntries: parseApprovedTrackedTopLevelEntries(raw.approvedTrackedTopLevelEntries),
     staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
+    verifiedNoSourceChangeReviewThreadAutoResolve: raw.verifiedNoSourceChangeReviewThreadAutoResolve === true,
     reviewBotLogins: normalizeReviewBotLogins(
       Array.isArray(raw.reviewBotLogins)
         ? raw.reviewBotLogins.filter((value): value is string => typeof value === "string")

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -190,6 +190,7 @@ export interface SupervisorConfig {
   publishablePathAllowlistMarkers?: string[];
   approvedTrackedTopLevelEntries?: string[];
   staleConfiguredBotReviewPolicy?: StaleConfiguredBotReviewPolicy;
+  verifiedNoSourceChangeReviewThreadAutoResolve?: boolean;
   reviewBotLogins: string[];
   configuredReviewProviders?: ConfiguredReviewProvider[];
   humanReviewBlocksMerge: boolean;

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4394,6 +4394,145 @@ test("handlePostTurnPullRequestTransitionsPhase replies and resolves stale confi
   assert.equal(resolveCalls.length, 2);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-change Codex threads and requests current-head review when enabled", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Resolve verified no-source-change Codex thread residue" });
+  const pr = createPullRequest({
+    title: "Tracked PR verified no-source-change Codex residue",
+    number: 1985,
+    isDraft: false,
+    headRefOid: "head-1985",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-15T00:10:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "blocked",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        blocked_reason: "stale_review_bot",
+        copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
+        copilot_review_timeout_action: "request_review_comment",
+        processed_review_thread_ids: [`thread-codex@${pr.headRefOid}`],
+        processed_review_thread_fingerprints: [`thread-codex@${pr.headRefOid}#comment-codex`],
+      }),
+    },
+  };
+  const staleBotFailureContext = {
+    ...createFailureContext(
+      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    ),
+    signature: "stalled-bot:thread-codex",
+    details: ["reviewer=chatgpt-codex-connector file=src/review.ts line=7 p_severity=P1 processed_on_current_head=yes"],
+    url: "https://example.test/pr/1985#discussion_r1985",
+  };
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-codex",
+      path: "src/review.ts",
+      line: 7,
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P1: This finding was verified as no source change needed.",
+            createdAt: "2026-05-15T00:05:00Z",
+            url: "https://example.test/pr/1985#discussion_r1985",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  const requestComments: string[] = [];
+  let snapshotLoads = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 1985001,
+          nodeId: "IC_kwDO1985",
+          url: "https://example.test/pr/1985#issuecomment-1985001",
+        };
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : staleBotFailureContext,
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
+          copilot_review_timeout_action: "request_review_comment",
+          copilot_review_timeout_reason: "current_head_signal_timeout",
+        },
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: snapshotLoads <= 2 ? reviewThreads : [],
+      };
+    },
+  });
+
+  assert.equal(result.record.state, "waiting_ci");
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex"]);
+  assert.deepEqual(resolveCalls, ["thread-codex"]);
+  assert.match(replyCalls[0]?.body ?? "", /reason=verified_no_source_change_auto_resolve/);
+  assert.match(replyCalls[0]?.body ?? "", /issue=#102 pr=#1985 head=head-1985 thread=thread-codex/);
+  assert.equal(requestComments.length, 1);
+  assert.match(requestComments[0] ?? "", /@codex review/);
+  assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1985 head=head-1985/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase does not resolve stale configured-bot review threads until metadata-only evidence is satisfied", async () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -473,15 +473,19 @@ function codexConnectorReviewRequestAction(args: {
     staleCodexReviewState?.classification === "metadata_only_missing_current_head_review";
   const isCodexConvergedCurrentHeadReview =
     staleCodexReviewState?.classification === "metadata_only_current_head_converged";
+  const isCodexVerifiedNoSourceChangeThreadResolution =
+    staleCodexReviewState?.classification === "verified_no_source_change_pending_thread_resolution";
   const isCodexMetadataOnly =
     staleCodexReviewState?.classification === "metadata_only" ||
     staleCodexReviewState?.classification === "metadata_only_missing_current_head_review" ||
-    staleCodexReviewState?.classification === "metadata_only_current_head_converged";
+    staleCodexReviewState?.classification === "metadata_only_current_head_converged" ||
+    isCodexVerifiedNoSourceChangeThreadResolution;
 
   if (
     configuredReviewProviderKinds(args.config).includes("codex") &&
     !isCodexMissingCurrentHeadReview &&
     (isCodexConvergedCurrentHeadReview ||
+      isCodexVerifiedNoSourceChangeThreadResolution ||
       isCodexMetadataOnly ||
       staleCodexReviewState?.classification === "unresolved_work" ||
       staleCodexReviewState?.classification === "unknown_needs_operator")
@@ -1226,7 +1230,8 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   const staleReviewBotReplySignature =
     effectiveFailureContext?.signature ?? trackedPrStatusComments.TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
   const shouldRefreshAfterReplyAndResolve =
-    config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
+    (config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
+      config.verifiedNoSourceChangeReviewThreadAutoResolve === true) &&
     record.state === "blocked" &&
     record.blocked_reason === "stale_review_bot" &&
     record.last_stale_review_bot_reply_head_sha === postReady.pr.headRefOid &&
@@ -1283,6 +1288,23 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           skipAutoHandleStaleConfiguredBotReview: true,
         });
       }
+      record = await maybeRequestCodexConnectorReviewComment({
+        config,
+        stateStore,
+        state,
+        github,
+        record,
+        pr: postReady.pr,
+        checks: postReady.checks,
+        reviewThreads: postReady.reviewThreads,
+        syncJournal,
+        applyFailureSignature: args.applyFailureSignature,
+        blockedReasonFromReviewState: args.blockedReasonFromReviewState,
+        summarizeChecks: args.summarizeChecks,
+        configuredBotReviewThreads: args.configuredBotReviewThreads,
+        manualReviewThreads: args.manualReviewThreads,
+        mergeConflictDetected: args.mergeConflictDetected,
+      });
     }
   }
   if (

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -21,6 +21,7 @@ export interface StaleReviewBotRemediationDto {
     | "metadata_only"
     | "metadata_only_missing_current_head_review"
     | "metadata_only_current_head_converged"
+    | "verified_no_source_change_pending_thread_resolution"
     | "unresolved_work"
     | "unknown_needs_operator";
   codexCurrentHeadReviewState: "observed" | "requested" | "missing" | "not_applicable";
@@ -37,6 +38,10 @@ const STALE_REVIEW_BOT_METADATA_ONLY_SUMMARY =
   "stale_configured_bot_thread_metadata_only";
 const STALE_REVIEW_BOT_METADATA_CURRENT_HEAD_SUMMARY =
   "stale_configured_bot_thread_metadata_only_pending_current_head_review_request";
+const VERIFIED_NO_SOURCE_CHANGE_MANUAL_NEXT_STEP =
+  "resolve_verified_configured_bot_threads_then_rerun_supervisor";
+const VERIFIED_NO_SOURCE_CHANGE_SUMMARY =
+  "verified_no_source_change_configured_bot_thread_resolution_pending";
 
 function formatTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
@@ -171,8 +176,8 @@ function classifyCodexMetadataOnly(args: {
     }
     if (!policy.currentHeadObservedAt) {
       return {
-        classification: "metadata_only_missing_current_head_review",
-        summary: STALE_REVIEW_BOT_METADATA_CURRENT_HEAD_SUMMARY,
+        classification: "verified_no_source_change_pending_thread_resolution",
+        summary: VERIFIED_NO_SOURCE_CHANGE_SUMMARY,
       };
     }
   }
@@ -278,7 +283,10 @@ export function buildStaleReviewBotRemediation(args: {
     classification: classification.classification,
     codexCurrentHeadReviewState,
     reviewThreadUrl: args.record.last_failure_context?.url ?? null,
-    manualNextStep: STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
+    manualNextStep:
+      classification.classification === "verified_no_source_change_pending_thread_resolution"
+        ? VERIFIED_NO_SOURCE_CHANGE_MANUAL_NEXT_STEP
+        : STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
     summary: classification.summary,
   };
 }

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1401,7 +1401,7 @@ test("explain classifies processed Codex must-fix residue as missing-current-hea
 
   assert.match(
     explanation,
-    /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=metadata_only_missing_current_head_review codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only_pending_current_head_review_request$/m,
+    /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1011,7 +1011,7 @@ test("status --why includes codex processed-residue missing-current-head review 
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#398 pr=#498 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=metadata_only_missing_current_head_review codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/498#discussion_r398 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only_pending_current_head_review_request$/m,
+    /^stale_review_bot_remediation issue=#398 pr=#498 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/498#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
   );
   assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
 });

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -496,7 +496,8 @@ export async function buildIssueExplainDto(
     record.blocked_reason === "stale_review_bot" &&
     !(staleReviewBotRemediation?.classification === "metadata_only" ||
       staleReviewBotRemediation?.classification === "metadata_only_missing_current_head_review" ||
-      staleReviewBotRemediation?.classification === "metadata_only_current_head_converged")
+      staleReviewBotRemediation?.classification === "metadata_only_current_head_converged" ||
+      staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution")
     ? (() => {
       const recoverability = classifyStaleReviewBotRecoverability(record, config);
       return recoverability === null

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -52,6 +52,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     localReviewHighSeverityAction: "retry",
     publishablePathAllowlistMarkers: [],
     staleConfiguredBotReviewPolicy: "diagnose_only",
+    verifiedNoSourceChangeReviewThreadAutoResolve: false,
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,
     issueJournalRelativePath: ".codex-supervisor/issue-journal.md",

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -538,10 +538,12 @@ async function publishTrackedPrStatusComment(args: {
 }
 
 function buildStaleConfiguredBotReplyBody(args: {
+  issueNumber: number;
   pr: GitHubPullRequest;
   thread: ReviewThread;
   failureContext: FailureContext | null;
   resolveAfterReply: boolean;
+  reasonCode?: string;
 }): string {
   const latestComment = latestReviewComment(args.thread);
   const location = `${args.thread.path ?? "unknown"}:${args.thread.line ?? "?"}`;
@@ -555,9 +557,12 @@ function buildStaleConfiguredBotReplyBody(args: {
   const sourceLine = sourceLink ? ` Source: ${sourceLink}` : "";
   return [
     `The supervisor reprocessed this configured-bot finding on the current head \`${args.pr.headRefOid}\` and classified it as stale.`,
+    `Audit: issue=#${args.issueNumber} pr=#${args.pr.number} head=${args.pr.headRefOid} thread=${args.thread.id} reason=${args.reasonCode ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT}.`,
     `Evidence: ${evidenceLine}.${sourceLine}`,
     args.resolveAfterReply
-      ? "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
+      ? args.reasonCode === "verified_no_source_change_auto_resolve"
+        ? "Under the configured verified no-source-change auto-resolve opt-in, the supervisor is auto-resolving this thread now."
+        : "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
       : "Leaving thread resolution to a human operator.",
   ].join("\n\n");
 }
@@ -613,6 +618,7 @@ async function maybeHandleTrackedPrStaleConfiguredBotReview(args: {
   config: SupervisorConfig;
   failureContext: FailureContext | null;
   resolveAfterReply: boolean;
+  reasonCode?: string;
 }): Promise<IssueRunRecord> {
   if (!args.github.replyToReviewThread) {
     return args.record;
@@ -656,10 +662,12 @@ async function maybeHandleTrackedPrStaleConfiguredBotReview(args: {
       });
       if (!replyProgressKeys.has(replyKey)) {
         const replyBody = buildStaleConfiguredBotReplyBody({
+          issueNumber: record.issue_number,
           pr: args.pr,
           thread: replyThread,
           failureContext: args.failureContext,
           resolveAfterReply: args.resolveAfterReply,
+          reasonCode: args.reasonCode,
         });
         await args.github.replyToReviewThread(replyThread.id, replyBody);
         record = await persistStaleConfiguredBotReviewProgress({
@@ -886,6 +894,9 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
     (staleReviewBotRemediation?.classification === "metadata_only" ||
       staleReviewBotRemediation?.classification === "metadata_only_current_head_converged");
+  const canResolveVerifiedNoSourceChangeThreadResolution =
+    args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
+    staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution";
 
   const canAutoHandleStaleConfiguredBotReview =
     !args.skipAutoHandleStaleConfiguredBotReview &&
@@ -896,7 +907,8 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     !args.summarizeChecks(args.checks).hasPending &&
     !args.summarizeChecks(args.checks).hasFailing &&
     (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
-      args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve");
+      args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
+      canResolveVerifiedNoSourceChangeThreadResolution);
 
   let currentRecord = args.record;
   if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
@@ -910,7 +922,10 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
       syncJournal: args.syncJournal,
       config: args.config,
       failureContext: args.failureContext,
-      resolveAfterReply: canResolveStaleConfiguredBotReview,
+      resolveAfterReply: canResolveStaleConfiguredBotReview || canResolveVerifiedNoSourceChangeThreadResolution,
+      reasonCode: canResolveVerifiedNoSourceChangeThreadResolution
+        ? "verified_no_source_change_auto_resolve"
+        : TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
     });
     currentRecord = repliedRecord;
     const replyHandled =

--- a/src/turn-execution-test-helpers.ts
+++ b/src/turn-execution-test-helpers.ts
@@ -43,6 +43,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     publishablePathAllowlistMarkers: [],
     approvedTrackedTopLevelEntries: undefined,
     staleConfiguredBotReviewPolicy: "diagnose_only",
+    verifiedNoSourceChangeReviewThreadAutoResolve: false,
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,
     issueJournalRelativePath: ".codex-supervisor/issue-journal.md",


### PR DESCRIPTION
## Summary
- classify processed current-head Codex Connector must-fix residue as verified no-source-change pending thread resolution
- add disabled-by-default verified no-source-change auto-resolve opt-in with audited thread replies
- refresh after auto-resolution and reuse the existing Codex review request flow

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-pr-review-blockers.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/post-turn-pull-request.test.ts src/tracked-pr-status-comment.test.ts src/config.test.ts src/core/state-store-normalization.test.ts
- npm run build
- node dist/index.js issue-lint 1985 --config <host codex supervisor config>