### PR TITLE
Harden Codex repair stale-thread recovery

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -151,6 +151,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       "localReviewHighSeverityAction",
       "staleConfiguredBotReviewPolicy",
       "verifiedNoSourceChangeReviewThreadAutoResolve",
+      "verifiedCurrentHeadRepairReviewThreadAutoResolve",
       "approvedTrackedTopLevelEntries",
     ].map((field) => [field, getConfigFieldPostureMetadata(field)?.tier]),
     [
@@ -160,6 +161,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       ["localReviewHighSeverityAction", "dangerous_explicit_opt_in"],
       ["staleConfiguredBotReviewPolicy", "dangerous_explicit_opt_in"],
       ["verifiedNoSourceChangeReviewThreadAutoResolve", "dangerous_explicit_opt_in"],
+      ["verifiedCurrentHeadRepairReviewThreadAutoResolve", "dangerous_explicit_opt_in"],
       ["approvedTrackedTopLevelEntries", "dangerous_explicit_opt_in"],
     ],
   );
@@ -352,6 +354,8 @@ test("loadConfig keeps local review disabled by default while using the opiniona
   assert.equal(config.localReviewFollowUpIssueCreationEnabled, false);
   assert.equal(config.localReviewHighSeverityAction, "blocked");
   assert.equal(config.staleConfiguredBotReviewPolicy, "diagnose_only");
+  assert.equal(config.verifiedNoSourceChangeReviewThreadAutoResolve, false);
+  assert.equal(config.verifiedCurrentHeadRepairReviewThreadAutoResolve, false);
 });
 
 test("loadConfig keeps release readiness advisory by default", async (t) => {

--- a/src/core/config-field-posture.ts
+++ b/src/core/config-field-posture.ts
@@ -121,6 +121,7 @@ const CONFIG_FIELD_POSTURE_METADATA_ENTRIES = [
   dangerousExplicitOptIn("localReviewHighSeverityAction", "High-severity local-review autonomous action posture."),
   dangerousExplicitOptIn("staleConfiguredBotReviewPolicy", "Configured-bot stale-thread reply or resolve behavior."),
   dangerousExplicitOptIn("verifiedNoSourceChangeReviewThreadAutoResolve", "Verified no-source-change review-thread auto-resolution opt-in."),
+  dangerousExplicitOptIn("verifiedCurrentHeadRepairReviewThreadAutoResolve", "Verified current-head repair review-thread auto-resolution opt-in."),
   dangerousExplicitOptIn("approvedTrackedTopLevelEntries", "Approved tracked top-level repository skeleton entries."),
 ] as const;
 

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -545,6 +545,7 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
     approvedTrackedTopLevelEntries: parseApprovedTrackedTopLevelEntries(raw.approvedTrackedTopLevelEntries),
     staleConfiguredBotReviewPolicy: parseStaleConfiguredBotReviewPolicy(raw.staleConfiguredBotReviewPolicy),
     verifiedNoSourceChangeReviewThreadAutoResolve: raw.verifiedNoSourceChangeReviewThreadAutoResolve === true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: raw.verifiedCurrentHeadRepairReviewThreadAutoResolve === true,
     reviewBotLogins: normalizeReviewBotLogins(
       Array.isArray(raw.reviewBotLogins)
         ? raw.reviewBotLogins.filter((value): value is string => typeof value === "string")

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -191,6 +191,7 @@ export interface SupervisorConfig {
   approvedTrackedTopLevelEntries?: string[];
   staleConfiguredBotReviewPolicy?: StaleConfiguredBotReviewPolicy;
   verifiedNoSourceChangeReviewThreadAutoResolve?: boolean;
+  verifiedCurrentHeadRepairReviewThreadAutoResolve?: boolean;
   reviewBotLogins: string[];
   configuredReviewProviders?: ConfiguredReviewProvider[];
   humanReviewBlocksMerge: boolean;

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4533,6 +4533,155 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
   assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1985 head=head-1985/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads only with the repair opt-in", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Resolve verified current-head repair Codex thread residue" });
+  const pr = createPullRequest({
+    title: "Tracked PR verified current-head repair Codex residue",
+    number: 1988,
+    isDraft: false,
+    headRefOid: "head-1988",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-15T00:10:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "blocked",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+        blocked_reason: "stale_review_bot",
+        copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
+        copilot_review_timeout_action: "request_review_comment",
+        processed_review_thread_ids: [`thread-codex-repair@${pr.headRefOid}`],
+        processed_review_thread_fingerprints: [`thread-codex-repair@${pr.headRefOid}#comment-codex-repair`],
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Focused verifier passed after the repair commit.",
+          ran_at: "2026-05-15T00:18:00Z",
+          head_sha: pr.headRefOid,
+          execution_mode: "shell",
+          command: "npm test -- src/post-turn-pull-request.test.ts",
+          failure_class: null,
+          remediation_target: null,
+        },
+      }),
+    },
+  };
+  const staleBotFailureContext = {
+    ...createFailureContext(
+      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    ),
+    signature: "stalled-bot:thread-codex-repair",
+    details: ["reviewer=chatgpt-codex-connector file=src/review.ts line=7 p_severity=P1 processed_on_current_head=yes"],
+    url: "https://example.test/pr/1988#discussion_r1988",
+  };
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-codex-repair",
+      path: "src/review.ts",
+      line: 7,
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex-repair",
+            body: "P1: Verify the repair covers this finding before merge.",
+            createdAt: "2026-05-15T00:05:00Z",
+            url: "https://example.test/pr/1988#discussion_r1988",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  const requestComments: string[] = [];
+  let snapshotLoads = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 1988001,
+          nodeId: "IC_kwDO1988",
+          url: "https://example.test/pr/1988#issuecomment-1988001",
+        };
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : staleBotFailureContext,
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
+          copilot_review_timeout_action: "request_review_comment",
+          copilot_review_timeout_reason: "current_head_signal_timeout",
+        },
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: snapshotLoads <= 2 ? reviewThreads : [],
+      };
+    },
+  });
+
+  assert.equal(result.record.state, "waiting_ci");
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-repair"]);
+  assert.deepEqual(resolveCalls, ["thread-codex-repair"]);
+  assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
+  assert.doesNotMatch(replyCalls[0]?.body ?? "", /verified_no_source_change_auto_resolve/);
+  assert.equal(requestComments.length, 1);
+  assert.match(requestComments[0] ?? "", /@codex review/);
+  assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1988 head=head-1988/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase does not resolve stale configured-bot review threads until metadata-only evidence is satisfied", async () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -475,17 +475,21 @@ function codexConnectorReviewRequestAction(args: {
     staleCodexReviewState?.classification === "metadata_only_current_head_converged";
   const isCodexVerifiedNoSourceChangeThreadResolution =
     staleCodexReviewState?.classification === "verified_no_source_change_pending_thread_resolution";
+  const isCodexVerifiedCurrentHeadRepairThreadResolution =
+    staleCodexReviewState?.classification === "verified_current_head_repair_pending_thread_resolution";
   const isCodexMetadataOnly =
     staleCodexReviewState?.classification === "metadata_only" ||
     staleCodexReviewState?.classification === "metadata_only_missing_current_head_review" ||
     staleCodexReviewState?.classification === "metadata_only_current_head_converged" ||
-    isCodexVerifiedNoSourceChangeThreadResolution;
+    isCodexVerifiedNoSourceChangeThreadResolution ||
+    isCodexVerifiedCurrentHeadRepairThreadResolution;
 
   if (
     configuredReviewProviderKinds(args.config).includes("codex") &&
     !isCodexMissingCurrentHeadReview &&
     (isCodexConvergedCurrentHeadReview ||
       isCodexVerifiedNoSourceChangeThreadResolution ||
+      isCodexVerifiedCurrentHeadRepairThreadResolution ||
       isCodexMetadataOnly ||
       staleCodexReviewState?.classification === "unresolved_work" ||
       staleCodexReviewState?.classification === "unknown_needs_operator")
@@ -1231,7 +1235,8 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     effectiveFailureContext?.signature ?? trackedPrStatusComments.TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
   const shouldRefreshAfterReplyAndResolve =
     (config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
-      config.verifiedNoSourceChangeReviewThreadAutoResolve === true) &&
+      config.verifiedNoSourceChangeReviewThreadAutoResolve === true ||
+      config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true) &&
     record.state === "blocked" &&
     record.blocked_reason === "stale_review_bot" &&
     record.last_stale_review_bot_reply_head_sha === postReady.pr.headRefOid &&

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -22,10 +22,12 @@ export interface StaleReviewBotRemediationDto {
     | "metadata_only_missing_current_head_review"
     | "metadata_only_current_head_converged"
     | "verified_no_source_change_pending_thread_resolution"
+    | "verified_current_head_repair_pending_thread_resolution"
     | "unresolved_work"
     | "unknown_needs_operator";
   codexCurrentHeadReviewState: "observed" | "requested" | "missing" | "not_applicable";
   reviewThreadUrl: string | null;
+  verificationEvidenceSummary: string | null;
   manualNextStep: string;
   summary: string;
 }
@@ -42,6 +44,16 @@ const VERIFIED_NO_SOURCE_CHANGE_MANUAL_NEXT_STEP =
   "resolve_verified_configured_bot_threads_then_rerun_supervisor";
 const VERIFIED_NO_SOURCE_CHANGE_SUMMARY =
   "verified_no_source_change_configured_bot_thread_resolution_pending";
+const VERIFIED_CURRENT_HEAD_REPAIR_MANUAL_NEXT_STEP =
+  "resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor";
+const VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY =
+  "verified_current_head_repair_configured_bot_thread_resolution_pending";
+
+interface StaleReviewBotClassification {
+  classification: StaleReviewBotRemediationDto["classification"];
+  summary: string;
+  verificationEvidenceSummary?: string | null;
+}
 
 function formatTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
@@ -123,13 +135,35 @@ function codexConnectorCurrentHeadReviewState(args: {
   return "missing";
 }
 
+function currentHeadVerificationEvidenceSummary(
+  record: Pick<IssueRunRecord, "latest_local_ci_result" | "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): string | null {
+  const latestLocalCi = record.latest_local_ci_result;
+  if (latestLocalCi?.outcome === "passed" && latestLocalCi.head_sha === pr.headRefOid) {
+    return latestLocalCi.summary || latestLocalCi.command || "current_head_local_ci_passed";
+  }
+
+  const timelineEvidence = (record.timeline_artifacts ?? []).find(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid,
+  );
+  if (timelineEvidence) {
+    return timelineEvidence.summary || timelineEvidence.command || "current_head_verification_passed";
+  }
+
+  return null;
+}
+
 function classifyCodexMetadataOnly(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
   pr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
-}): Pick<StaleReviewBotRemediationDto, "classification" | "summary"> {
+}): StaleReviewBotClassification {
   const unresolvedWork = {
     classification: "unresolved_work" as const,
     summary: STALE_REVIEW_BOT_SUMMARY,
@@ -174,6 +208,14 @@ function classifyCodexMetadataOnly(args: {
     if (hasUnprocessedMustFix) {
       return unresolvedWork;
     }
+    const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(args.record, args.pr);
+    if (verificationEvidenceSummary) {
+      return {
+        classification: "verified_current_head_repair_pending_thread_resolution",
+        summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
+        verificationEvidenceSummary,
+      };
+    }
     if (!policy.currentHeadObservedAt) {
       return {
         classification: "verified_no_source_change_pending_thread_resolution",
@@ -201,7 +243,7 @@ function classifyRemediation(args: {
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
-}): Pick<StaleReviewBotRemediationDto, "classification" | "summary"> {
+}): StaleReviewBotClassification {
   const unresolvedWork = {
     classification: "unresolved_work" as const,
     summary: STALE_REVIEW_BOT_SUMMARY,
@@ -283,8 +325,11 @@ export function buildStaleReviewBotRemediation(args: {
     classification: classification.classification,
     codexCurrentHeadReviewState,
     reviewThreadUrl: args.record.last_failure_context?.url ?? null,
+    verificationEvidenceSummary: classification.verificationEvidenceSummary ?? null,
     manualNextStep:
-      classification.classification === "verified_no_source_change_pending_thread_resolution"
+      classification.classification === "verified_current_head_repair_pending_thread_resolution"
+        ? VERIFIED_CURRENT_HEAD_REPAIR_MANUAL_NEXT_STEP
+        : classification.classification === "verified_no_source_change_pending_thread_resolution"
         ? VERIFIED_NO_SOURCE_CHANGE_MANUAL_NEXT_STEP
         : STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
     summary: classification.summary,
@@ -307,6 +352,13 @@ export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotR
   ];
   if (remediation.codexCurrentHeadReviewState !== "not_applicable") {
     tokens.splice(8, 0, `codex_current_head_review_state=${remediation.codexCurrentHeadReviewState}`);
+  }
+  if (remediation.verificationEvidenceSummary) {
+    tokens.splice(
+      tokens.length - 1,
+      0,
+      `verification_evidence=${formatTokenValue(remediation.verificationEvidenceSummary).replace(/\s+/gu, "_")}`,
+    );
   }
   return tokens.join(" ");
 }

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1094,6 +1094,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
     classification: "unresolved_work",
     codexCurrentHeadReviewState: "not_applicable",
     reviewThreadUrl: "https://example.test/pr/295#discussion_r295",
+    verificationEvidenceSummary: null,
     manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
     summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
   });

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1016,6 +1016,112 @@ test("status --why includes codex processed-residue missing-current-head review 
   assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
 });
 
+test("status --why distinguishes codex verified current-head repair residue from no-source-change residue", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  const issueNumber = 399;
+  const prNumber = 499;
+  const headSha = "76060523f803ebe25832cb2c355aaaa9530502f3";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: "codex/issue-399",
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        blocked_reason: "stale_review_bot",
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-399@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-399@${headSha}#comment-399`],
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Focused verifier passed after the repair commit.",
+          ran_at: "2026-05-13T00:18:00Z",
+          head_sha: headSha,
+          execution_mode: "shell",
+          command: "npm test -- src/supervisor/supervisor-diagnostics-status-selection.test.ts",
+          failure_class: null,
+          remediation_target: null,
+        },
+        last_failure_signature: "stalled-bot:thread-399",
+        last_failure_context: {
+          category: "manual",
+          summary:
+            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+          signature: "stalled-bot:thread-399",
+          command: null,
+          details: ["reviewer=chatgpt-codex-connector file=scripts/verify-closeout.sh line=124 processed_on_current_head=yes"],
+          url: "https://example.test/pr/499#discussion_r399",
+          updated_at: "2026-05-13T00:20:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Status why classifies Codex verified repair residue",
+    body: executionReadyBody("Classify verified Codex repair residue separately from no-source-change residue."),
+    createdAt: "2026-05-13T00:00:00Z",
+    updatedAt: "2026-05-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: "codex/issue-399",
+    headRefOid: headSha,
+    currentHeadCiGreenAt: "2026-05-13T00:19:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const staleMetadataThread = {
+    id: "thread-399",
+    isResolved: false,
+    isOutdated: false,
+    path: "scripts/verify-closeout.sh",
+    line: 124,
+    comments: {
+      nodes: [
+        {
+          id: "comment-399",
+          body: "P2: Cover the production-secret closeout overclaim.",
+          createdAt: "2026-05-13T00:05:00Z",
+          url: "https://example.test/pr/499#discussion_r399",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "focused verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleMetadataThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#399 pr=#499 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f3 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/499#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
+});
+
 test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
   const status = renderSupervisorStatusDto({
     gsdSummary: null,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -497,7 +497,8 @@ export async function buildIssueExplainDto(
     !(staleReviewBotRemediation?.classification === "metadata_only" ||
       staleReviewBotRemediation?.classification === "metadata_only_missing_current_head_review" ||
       staleReviewBotRemediation?.classification === "metadata_only_current_head_converged" ||
-      staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution")
+      staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution" ||
+      staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution")
     ? (() => {
       const recoverability = classifyStaleReviewBotRecoverability(record, config);
       return recoverability === null

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -53,6 +53,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     publishablePathAllowlistMarkers: [],
     staleConfiguredBotReviewPolicy: "diagnose_only",
     verifiedNoSourceChangeReviewThreadAutoResolve: false,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: false,
     reviewBotLogins: [],
     humanReviewBlocksMerge: true,
     issueJournalRelativePath: ".codex-supervisor/issue-journal.md",

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -562,6 +562,8 @@ function buildStaleConfiguredBotReplyBody(args: {
     args.resolveAfterReply
       ? args.reasonCode === "verified_no_source_change_auto_resolve"
         ? "Under the configured verified no-source-change auto-resolve opt-in, the supervisor is auto-resolving this thread now."
+        : args.reasonCode === "verified_current_head_repair_auto_resolve"
+          ? "Under the configured verified current-head repair auto-resolve opt-in, the supervisor is auto-resolving this thread now."
         : "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
       : "Leaving thread resolution to a human operator.",
   ].join("\n\n");
@@ -897,6 +899,9 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
   const canResolveVerifiedNoSourceChangeThreadResolution =
     args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
     staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution";
+  const canResolveVerifiedCurrentHeadRepairThreadResolution =
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution";
 
   const canAutoHandleStaleConfiguredBotReview =
     !args.skipAutoHandleStaleConfiguredBotReview &&
@@ -908,7 +913,8 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     !args.summarizeChecks(args.checks).hasFailing &&
     (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
       args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
-      canResolveVerifiedNoSourceChangeThreadResolution);
+      canResolveVerifiedNoSourceChangeThreadResolution ||
+      canResolveVerifiedCurrentHeadRepairThreadResolution);
 
   let currentRecord = args.record;
   if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
@@ -922,8 +928,13 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
       syncJournal: args.syncJournal,
       config: args.config,
       failureContext: args.failureContext,
-      resolveAfterReply: canResolveStaleConfiguredBotReview || canResolveVerifiedNoSourceChangeThreadResolution,
-      reasonCode: canResolveVerifiedNoSourceChangeThreadResolution
+      resolveAfterReply:
+        canResolveStaleConfiguredBotReview ||
+        canResolveVerifiedNoSourceChangeThreadResolution ||
+        canResolveVerifiedCurrentHeadRepairThreadResolution,
+      reasonCode: canResolveVerifiedCurrentHeadRepairThreadResolution
+        ? "verified_current_head_repair_auto_resolve"
+        : canResolveVerifiedNoSourceChangeThreadResolution
         ? "verified_no_source_change_auto_resolve"
         : TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
     });


### PR DESCRIPTION
## Summary
- add a separate Codex Connector `verified_current_head_repair_pending_thread_resolution` stale-thread classification
- add the dedicated `verifiedCurrentHeadRepairReviewThreadAutoResolve` opt-in and route it through reply/resolve/retry refresh
- cover disabled diagnostics and enabled auto-resolve paths with focused regression tests

## Verification
- `npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/tracked-pr-status-comment.test.ts src/supervisor/supervisor-execution-policy.test.ts src/review-thread-reporting.test.ts src/config.test.ts src/core/state-store-normalization.test.ts`
- `npm run build`
- `npm run verify:paths`
- `node dist/index.js issue-lint 1988 --config <supervisor-config-path>`

Closes #1988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to enable auto-resolution of verified current-head repair review threads.
  * Enhanced review thread classification to differentiate verified current-head repairs from other review states.
  * Added verification evidence tracking for repair-related review diagnostics.

* **Tests**
  * Extended test coverage for auto-resolution behavior and repair thread handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->