### PR TITLE
Extract Codex Connector tracked-PR review fixture helpers

### DIFF
--- a/src/codex-connector-tracked-pr-test-helpers.ts
+++ b/src/codex-connector-tracked-pr-test-helpers.ts
@@ -1,0 +1,134 @@
+import type { FailureContext, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread } from "./core/types";
+
+export const CODEX_CONNECTOR_REVIEW_BOT_LOGIN = "chatgpt-codex-connector";
+
+const STALE_REVIEW_BOT_SUMMARY =
+  "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.";
+
+type CodexConnectorTrackedReviewScenarioOptions = {
+  issueNumber: number;
+  prNumber: number;
+  headSha: string;
+  branch?: string;
+  threadId: string;
+  commentId: string;
+  path: string;
+  line: number;
+  commentBody: string;
+  discussionUrl: string;
+  severity?: string;
+  verifiedRepair?: {
+    summary: string;
+    ranAt: string;
+    command: string;
+  };
+};
+
+export function createCodexConnectorTrackedReviewResidueScenario({
+  issueNumber,
+  prNumber,
+  headSha,
+  branch = `codex/issue-${issueNumber}`,
+  threadId,
+  commentId,
+  path,
+  line,
+  commentBody,
+  discussionUrl,
+  severity = "P1",
+  verifiedRepair,
+}: CodexConnectorTrackedReviewScenarioOptions): {
+  recordPatch: Partial<IssueRunRecord>;
+  pullRequestPatch: Partial<GitHubPullRequest>;
+  reviewThread: ReviewThread;
+  staleReviewFailureContext: FailureContext;
+  passingChecks: PullRequestCheck[];
+} {
+  const reviewDetail = `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${path} line=${line} p_severity=${severity} processed_on_current_head=yes`;
+  const recordPatch: Partial<IssueRunRecord> = {
+    issue_number: issueNumber,
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
+    copilot_review_timeout_action: "request_review_comment",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    last_failure_signature: `stalled-bot:${threadId}`,
+    last_failure_context: {
+      category: "manual",
+      summary: STALE_REVIEW_BOT_SUMMARY,
+      signature: `stalled-bot:${threadId}`,
+      command: null,
+      details: [reviewDetail],
+      url: discussionUrl,
+      updated_at: "2026-05-15T00:20:00Z",
+    },
+  };
+  if (verifiedRepair) {
+    recordPatch.latest_local_ci_result = {
+      outcome: "passed",
+      summary: verifiedRepair.summary,
+      ran_at: verifiedRepair.ranAt,
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: verifiedRepair.command,
+      failure_class: null,
+      remediation_target: null,
+    };
+  }
+
+  return {
+    recordPatch,
+    pullRequestPatch: {
+      number: prNumber,
+      title: verifiedRepair
+        ? "Tracked PR verified current-head repair Codex residue"
+        : "Tracked PR verified no-source-change Codex residue",
+      isDraft: false,
+      headRefName: branch,
+      headRefOid: headSha,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      currentHeadCiGreenAt: verifiedRepair ? "2026-05-15T00:19:00Z" : "2026-05-15T00:10:00Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+      configuredBotTopLevelReviewStrength: null,
+    },
+    reviewThread: {
+      id: threadId,
+      isResolved: false,
+      isOutdated: false,
+      path,
+      line,
+      comments: {
+        nodes: [
+          {
+            id: commentId,
+            body: commentBody,
+            createdAt: "2026-05-15T00:05:00Z",
+            url: discussionUrl,
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+    staleReviewFailureContext: {
+      category: "manual",
+      summary: STALE_REVIEW_BOT_SUMMARY,
+      signature: `stalled-bot:${threadId}`,
+      command: null,
+      details: [reviewDetail],
+      url: discussionUrl,
+      updated_at: "2026-05-15T00:20:00Z",
+    },
+    passingChecks: [
+      { name: verifiedRepair ? "focused verifier" : "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+    ],
+  };
+}

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -13,6 +13,10 @@ import { findCodexConnectorReviewRequest } from "./github/github-review-signals"
 import type { LocalReviewResult, PreMergeFinalEvaluation, PreMergeResidualFinding } from "./local-review";
 import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
 import {
+  CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+  createCodexConnectorTrackedReviewResidueScenario,
+} from "./codex-connector-tracked-pr-test-helpers";
+import {
   createConfig,
   createFailureContext,
   createIssue,
@@ -4396,68 +4400,30 @@ test("handlePostTurnPullRequestTransitionsPhase replies and resolves stale confi
 
 test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-change Codex threads and requests current-head review when enabled", async () => {
   const config = createConfig({
-    reviewBotLogins: ["chatgpt-codex-connector"],
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
     verifiedNoSourceChangeReviewThreadAutoResolve: true,
   });
   const issue = createIssue({ title: "Resolve verified no-source-change Codex thread residue" });
-  const pr = createPullRequest({
-    title: "Tracked PR verified no-source-change Codex residue",
-    number: 1985,
-    isDraft: false,
-    headRefOid: "head-1985",
-    mergeStateStatus: "CLEAN",
-    mergeable: "MERGEABLE",
-    currentHeadCiGreenAt: "2026-05-15T00:10:00Z",
-    configuredBotCurrentHeadObservedAt: null,
-    configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotTopLevelReviewStrength: null,
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 1985,
+    headSha: "head-1985",
+    threadId: "thread-codex",
+    commentId: "comment-codex",
+    path: "src/review.ts",
+    line: 7,
+    commentBody: "P1: This finding was verified as no source change needed.",
+    discussionUrl: "https://example.test/pr/1985#discussion_r1985",
   });
+  const pr = createPullRequest(scenario.pullRequestPatch);
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
-      "102": createRecord({
-        issue_number: 102,
-        state: "blocked",
-        pr_number: pr.number,
-        last_head_sha: pr.headRefOid,
-        blocked_reason: "stale_review_bot",
-        copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
-        copilot_review_timeout_action: "request_review_comment",
-        processed_review_thread_ids: [`thread-codex@${pr.headRefOid}`],
-        processed_review_thread_fingerprints: [`thread-codex@${pr.headRefOid}#comment-codex`],
-      }),
+      "102": createRecord(scenario.recordPatch),
     },
   };
-  const staleBotFailureContext = {
-    ...createFailureContext(
-      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-    ),
-    signature: "stalled-bot:thread-codex",
-    details: ["reviewer=chatgpt-codex-connector file=src/review.ts line=7 p_severity=P1 processed_on_current_head=yes"],
-    url: "https://example.test/pr/1985#discussion_r1985",
-  };
-  const reviewThreads = [
-    createReviewThread({
-      id: "thread-codex",
-      path: "src/review.ts",
-      line: 7,
-      comments: {
-        nodes: [
-          {
-            id: "comment-codex",
-            body: "P1: This finding was verified as no source change needed.",
-            createdAt: "2026-05-15T00:05:00Z",
-            url: "https://example.test/pr/1985#discussion_r1985",
-            author: {
-              login: "chatgpt-codex-connector",
-              typeName: "Bot",
-            },
-          },
-        ],
-      },
-    }),
-  ] satisfies ReviewThread[];
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
   const replyCalls: Array<{ threadId: string; body: string }> = [];
   const resolveCalls: string[] = [];
   const requestComments: string[] = [];
@@ -4491,7 +4457,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
     }),
     derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
       createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
-        failureContext: currentReviewThreads.length === 0 ? null : staleBotFailureContext,
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
         copilotTimeoutPatch: {
           copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
           copilot_review_timeout_action: "request_review_comment",
@@ -4517,7 +4483,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
       snapshotLoads += 1;
       return {
         pr,
-        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        checks: scenario.passingChecks,
         reviewThreads: snapshotLoads <= 2 ? reviewThreads : [],
       };
     },
@@ -4535,78 +4501,35 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
 
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads only with the repair opt-in", async () => {
   const config = createConfig({
-    reviewBotLogins: ["chatgpt-codex-connector"],
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
     verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
   });
   const issue = createIssue({ title: "Resolve verified current-head repair Codex thread residue" });
-  const pr = createPullRequest({
-    title: "Tracked PR verified current-head repair Codex residue",
-    number: 1988,
-    isDraft: false,
-    headRefOid: "head-1988",
-    mergeStateStatus: "CLEAN",
-    mergeable: "MERGEABLE",
-    currentHeadCiGreenAt: "2026-05-15T00:10:00Z",
-    configuredBotCurrentHeadObservedAt: null,
-    configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotTopLevelReviewStrength: null,
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 1988,
+    headSha: "head-1988",
+    threadId: "thread-codex-repair",
+    commentId: "comment-codex-repair",
+    path: "src/review.ts",
+    line: 7,
+    commentBody: "P1: Verify the repair covers this finding before merge.",
+    discussionUrl: "https://example.test/pr/1988#discussion_r1988",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npm test -- src/post-turn-pull-request.test.ts",
+    },
   });
+  const pr = createPullRequest(scenario.pullRequestPatch);
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
-      "102": createRecord({
-        issue_number: 102,
-        state: "blocked",
-        pr_number: pr.number,
-        last_head_sha: pr.headRefOid,
-        blocked_reason: "stale_review_bot",
-        copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
-        copilot_review_timeout_action: "request_review_comment",
-        processed_review_thread_ids: [`thread-codex-repair@${pr.headRefOid}`],
-        processed_review_thread_fingerprints: [`thread-codex-repair@${pr.headRefOid}#comment-codex-repair`],
-        latest_local_ci_result: {
-          outcome: "passed",
-          summary: "Focused verifier passed after the repair commit.",
-          ran_at: "2026-05-15T00:18:00Z",
-          head_sha: pr.headRefOid,
-          execution_mode: "shell",
-          command: "npm test -- src/post-turn-pull-request.test.ts",
-          failure_class: null,
-          remediation_target: null,
-        },
-      }),
+      "102": createRecord(scenario.recordPatch),
     },
   };
-  const staleBotFailureContext = {
-    ...createFailureContext(
-      "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-    ),
-    signature: "stalled-bot:thread-codex-repair",
-    details: ["reviewer=chatgpt-codex-connector file=src/review.ts line=7 p_severity=P1 processed_on_current_head=yes"],
-    url: "https://example.test/pr/1988#discussion_r1988",
-  };
-  const reviewThreads = [
-    createReviewThread({
-      id: "thread-codex-repair",
-      path: "src/review.ts",
-      line: 7,
-      comments: {
-        nodes: [
-          {
-            id: "comment-codex-repair",
-            body: "P1: Verify the repair covers this finding before merge.",
-            createdAt: "2026-05-15T00:05:00Z",
-            url: "https://example.test/pr/1988#discussion_r1988",
-            author: {
-              login: "chatgpt-codex-connector",
-              typeName: "Bot",
-            },
-          },
-        ],
-      },
-    }),
-  ] satisfies ReviewThread[];
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
   const replyCalls: Array<{ threadId: string; body: string }> = [];
   const resolveCalls: string[] = [];
   const requestComments: string[] = [];
@@ -4640,7 +4563,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
     }),
     derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
       createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
-        failureContext: currentReviewThreads.length === 0 ? null : staleBotFailureContext,
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
         copilotTimeoutPatch: {
           copilot_review_timed_out_at: "2026-05-15T00:20:00Z",
           copilot_review_timeout_action: "request_review_comment",
@@ -4666,7 +4589,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
       snapshotLoads += 1;
       return {
         pr,
-        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        checks: scenario.passingChecks,
         reviewThreads: snapshotLoads <= 2 ? reviewThreads : [],
       };
     },

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -15,6 +15,10 @@ import {
   git,
 } from "./supervisor-test-helpers";
 import {
+  CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+  createCodexConnectorTrackedReviewResidueScenario,
+} from "../codex-connector-tracked-pr-test-helpers";
+import {
   clearCurrentReconciliationPhase,
   writeCurrentReconciliationPhase,
 } from "./supervisor-reconciliation-phase";
@@ -922,35 +926,28 @@ test("status --why classifies current-head processed configured-bot success as s
 
 test("status --why includes codex processed-residue missing-current-head review state", async (t) => {
   const fixture = await createSupervisorFixture();
-  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
   const issueNumber = 398;
   const prNumber = 498;
   const headSha = "5de0d3844468d4a77cab512f8dcbe46171166c3a";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-398",
+    commentId: "comment-398",
+    path: "src/query.ts",
+    line: 12,
+    commentBody: "P1: Fix this stale finding before merge.",
+    discussionUrl: "https://example.test/pr/498#discussion_r398",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
     issues: {
       [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "blocked",
-        branch: "codex/issue-398",
+        ...scenario.recordPatch,
         workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         journal_path: null,
-        pr_number: prNumber,
-        blocked_reason: "stale_review_bot",
-        last_head_sha: headSha,
-        processed_review_thread_ids: [`thread-398@${headSha}`],
-        processed_review_thread_fingerprints: [`thread-398@${headSha}#comment-398`],
-        last_failure_signature: "stalled-bot:thread-398",
-        last_failure_context: {
-          category: "manual",
-          summary:
-            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-          signature: "stalled-bot:thread-398",
-          command: null,
-          details: ["reviewer=chatgpt-codex-connector file=src/query.ts line=12 processed_on_current_head=yes"],
-          url: "https://example.test/pr/498#discussion_r398",
-          updated_at: "2026-05-13T00:20:00Z",
-        },
       }),
     },
   };
@@ -966,44 +963,15 @@ test("status --why includes codex processed-residue missing-current-head review 
     labels: [],
     state: "OPEN",
   };
-  const pr = createPullRequest({
-    number: prNumber,
-    headRefName: "codex/issue-398",
-    headRefOid: headSha,
-    currentHeadCiGreenAt: "2026-05-13T00:10:00Z",
-    configuredBotCurrentHeadObservedAt: null,
-    configuredBotCurrentHeadStatusState: "SUCCESS",
-    mergeStateStatus: "CLEAN",
-    mergeable: "MERGEABLE",
-  });
-  const staleMetadataThread = {
-    id: "thread-398",
-    isResolved: false,
-    isOutdated: false,
-    path: "src/query.ts",
-    line: 12,
-    comments: {
-      nodes: [
-        {
-          id: "comment-398",
-          body: "P1: Fix this stale finding before merge.",
-          createdAt: "2026-05-13T00:05:00Z",
-          url: "https://example.test/pr/498#discussion_r398",
-          author: {
-            login: "chatgpt-codex-connector",
-            typeName: "Bot",
-          },
-        },
-      ],
-    },
-  };
+  const pr = createPullRequest(scenario.pullRequestPatch);
+  const staleMetadataThread = scenario.reviewThread;
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     listCandidateIssues: async () => [trackedIssue],
     listAllIssues: async () => [trackedIssue],
     getPullRequestIfExists: async () => pr,
-    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getChecks: async () => scenario.passingChecks,
     getUnresolvedReviewThreads: async () => [staleMetadataThread],
   };
 
@@ -1018,45 +986,34 @@ test("status --why includes codex processed-residue missing-current-head review 
 
 test("status --why distinguishes codex verified current-head repair residue from no-source-change residue", async (t) => {
   const fixture = await createSupervisorFixture();
-  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
   const issueNumber = 399;
   const prNumber = 499;
   const headSha = "76060523f803ebe25832cb2c355aaaa9530502f3";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-399",
+    commentId: "comment-399",
+    path: "scripts/verify-closeout.sh",
+    line: 124,
+    commentBody: "P2: Cover the production-secret closeout overclaim.",
+    discussionUrl: "https://example.test/pr/499#discussion_r399",
+    severity: "P2",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-13T00:18:00Z",
+      command: "npm test -- src/supervisor/supervisor-diagnostics-status-selection.test.ts",
+    },
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
     issues: {
       [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "blocked",
-        branch: "codex/issue-399",
+        ...scenario.recordPatch,
         workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         journal_path: null,
-        pr_number: prNumber,
-        blocked_reason: "stale_review_bot",
-        last_head_sha: headSha,
-        processed_review_thread_ids: [`thread-399@${headSha}`],
-        processed_review_thread_fingerprints: [`thread-399@${headSha}#comment-399`],
-        latest_local_ci_result: {
-          outcome: "passed",
-          summary: "Focused verifier passed after the repair commit.",
-          ran_at: "2026-05-13T00:18:00Z",
-          head_sha: headSha,
-          execution_mode: "shell",
-          command: "npm test -- src/supervisor/supervisor-diagnostics-status-selection.test.ts",
-          failure_class: null,
-          remediation_target: null,
-        },
-        last_failure_signature: "stalled-bot:thread-399",
-        last_failure_context: {
-          category: "manual",
-          summary:
-            "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-          signature: "stalled-bot:thread-399",
-          command: null,
-          details: ["reviewer=chatgpt-codex-connector file=scripts/verify-closeout.sh line=124 processed_on_current_head=yes"],
-          url: "https://example.test/pr/499#discussion_r399",
-          updated_at: "2026-05-13T00:20:00Z",
-        },
       }),
     },
   };
@@ -1072,44 +1029,15 @@ test("status --why distinguishes codex verified current-head repair residue from
     labels: [],
     state: "OPEN",
   };
-  const pr = createPullRequest({
-    number: prNumber,
-    headRefName: "codex/issue-399",
-    headRefOid: headSha,
-    currentHeadCiGreenAt: "2026-05-13T00:19:00Z",
-    configuredBotCurrentHeadObservedAt: null,
-    configuredBotCurrentHeadStatusState: "SUCCESS",
-    mergeStateStatus: "CLEAN",
-    mergeable: "MERGEABLE",
-  });
-  const staleMetadataThread = {
-    id: "thread-399",
-    isResolved: false,
-    isOutdated: false,
-    path: "scripts/verify-closeout.sh",
-    line: 124,
-    comments: {
-      nodes: [
-        {
-          id: "comment-399",
-          body: "P2: Cover the production-secret closeout overclaim.",
-          createdAt: "2026-05-13T00:05:00Z",
-          url: "https://example.test/pr/499#discussion_r399",
-          author: {
-            login: "chatgpt-codex-connector",
-            typeName: "Bot",
-          },
-        },
-      ],
-    },
-  };
+  const pr = createPullRequest(scenario.pullRequestPatch);
+  const staleMetadataThread = scenario.reviewThread;
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     listCandidateIssues: async () => [trackedIssue],
     listAllIssues: async () => [trackedIssue],
     getPullRequestIfExists: async () => pr,
-    getChecks: async () => [{ name: "focused verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getChecks: async () => scenario.passingChecks,
     getUnresolvedReviewThreads: async () => [staleMetadataThread],
   };
 


### PR DESCRIPTION
## Summary
- add shared Codex Connector tracked review residue test helpers
- migrate representative #1985/#1988 no-source-change and verified current-head repair tests to the helper
- keep changes test-only with no production behavior changes

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build
- CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint 1991 --config "$CODEX_SUPERVISOR_CONFIG"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to use shared scenario helpers, improving test maintainability and consistency across multiple test files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/1993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->