### PR TITLE
Extract stale review-bot diagnostics presenter

### DIFF
--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -1,0 +1,31 @@
+import {
+  formatStaleReviewBotTokenValue,
+  type StaleReviewBotRemediationDto,
+} from "./stale-review-bot-remediation";
+
+export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotRemediationDto): string {
+  const tokens = [
+    "stale_review_bot_remediation",
+    `issue=#${remediation.issueNumber}`,
+    `pr=${remediation.prNumber === null ? "none" : `#${remediation.prNumber}`}`,
+    `reason=${remediation.reasonCode}`,
+    `code_ci=${remediation.codeCiState}`,
+    `current_head_sha=${formatStaleReviewBotTokenValue(remediation.currentHeadSha)}`,
+    `processed_on_current_head=${remediation.processedOnCurrentHead}`,
+    `classification=${remediation.classification}`,
+    `review_thread_url=${remediation.reviewThreadUrl ? formatStaleReviewBotTokenValue(remediation.reviewThreadUrl) : "none"}`,
+    `manual_next_step=${remediation.manualNextStep}`,
+    `summary=${remediation.summary}`,
+  ];
+  if (remediation.codexCurrentHeadReviewState !== "not_applicable") {
+    tokens.splice(8, 0, `codex_current_head_review_state=${remediation.codexCurrentHeadReviewState}`);
+  }
+  if (remediation.verificationEvidenceSummary) {
+    tokens.splice(
+      tokens.length - 1,
+      0,
+      `verification_evidence=${formatStaleReviewBotTokenValue(remediation.verificationEvidenceSummary).replace(/\s+/gu, "_")}`,
+    );
+  }
+  return tokens.join(" ");
+}

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -55,7 +55,7 @@ interface StaleReviewBotClassification {
   verificationEvidenceSummary?: string | null;
 }
 
-function formatTokenValue(value: string): string {
+export function formatStaleReviewBotTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
 }
 
@@ -334,31 +334,4 @@ export function buildStaleReviewBotRemediation(args: {
         : STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
     summary: classification.summary,
   };
-}
-
-export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotRemediationDto): string {
-  const tokens = [
-    "stale_review_bot_remediation",
-    `issue=#${remediation.issueNumber}`,
-    `pr=${remediation.prNumber === null ? "none" : `#${remediation.prNumber}`}`,
-    `reason=${remediation.reasonCode}`,
-    `code_ci=${remediation.codeCiState}`,
-    `current_head_sha=${formatTokenValue(remediation.currentHeadSha)}`,
-    `processed_on_current_head=${remediation.processedOnCurrentHead}`,
-    `classification=${remediation.classification}`,
-    `review_thread_url=${remediation.reviewThreadUrl ? formatTokenValue(remediation.reviewThreadUrl) : "none"}`,
-    `manual_next_step=${remediation.manualNextStep}`,
-    `summary=${remediation.summary}`,
-  ];
-  if (remediation.codexCurrentHeadReviewState !== "not_applicable") {
-    tokens.splice(8, 0, `codex_current_head_review_state=${remediation.codexCurrentHeadReviewState}`);
-  }
-  if (remediation.verificationEvidenceSummary) {
-    tokens.splice(
-      tokens.length - 1,
-      0,
-      `verification_evidence=${formatTokenValue(remediation.verificationEvidenceSummary).replace(/\s+/gu, "_")}`,
-    );
-  }
-  return tokens.join(" ");
 }

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -34,8 +34,8 @@ import {
 } from "./supervisor-status-review-bot";
 import {
   buildStaleReviewBotRemediation,
-  formatStaleReviewBotRemediationLine,
 } from "./stale-review-bot-remediation";
+import { formatStaleReviewBotRemediationLine } from "./stale-review-bot-diagnostics-presenter";
 import { buildIssueActivityContext, formatLocalCiStatusLine } from "./supervisor-operator-activity-context";
 import type { IssueRunRecord } from "../core/types";
 import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
@@ -327,9 +327,11 @@ export function buildActiveDetailedStatusLines(
 
   if (pr) {
     const staleReviewBotRemediation = buildStaleReviewBotRemediation({
+      config,
       record: activeRecord,
       pr,
       checks,
+      reviewThreads,
     });
     if (staleReviewBotRemediation) {
       lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -13,6 +13,10 @@ import {
   executionReadyBody,
   git,
 } from "./supervisor-test-helpers";
+import {
+  CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+  createCodexConnectorTrackedReviewResidueScenario,
+} from "../codex-connector-tracked-pr-test-helpers";
 
 async function writeExternalReviewDigest(args: {
   artifactPath: string;
@@ -1404,6 +1408,71 @@ test("explain classifies processed Codex must-fix residue as missing-current-hea
     explanation,
     /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
   );
+});
+
+test("explain distinguishes Codex verified current-head repair residue from no-source-change residue", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  const issueNumber = 199;
+  const prNumber = 399;
+  const headSha = "head-199";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-199",
+    commentId: "comment-199",
+    path: "src/repair.ts",
+    line: 42,
+    commentBody: "P1: Verify the repaired authorization guard before merge.",
+    discussionUrl: "https://example.test/pr/399#discussion_r399",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts",
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain Codex verified repair metadata residue",
+    body: executionReadyBody("Explain should classify verified Codex repair residue distinctly."),
+    createdAt: "2026-05-15T00:00:00Z",
+    updatedAt: "2026-05-15T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => scenario.passingChecks,
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^stale_review_bot_remediation issue=#199 pr=#399 reason=stale_review_bot code_ci=green current_head_sha=head-199 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/399#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.doesNotMatch(explanation, /classification=verified_no_source_change_pending_thread_resolution/);
 });
 
 test("explain marks tracked stale configured-bot blockers runnable after reply_and_resolve is enabled", async () => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1050,6 +1050,71 @@ test("status --why distinguishes codex verified current-head repair residue from
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });
 
+test("status --why uses the shared stale review-bot presenter for active verified repair residue", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  const issueNumber = 400;
+  const prNumber = 500;
+  const headSha = "76060523f803ebe25832cb2c355aaaa9530502f4";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-400",
+    commentId: "comment-400",
+    path: "src/auth-boundary.ts",
+    line: 91,
+    commentBody: "P1: Prove the repaired auth boundary is covered before merge.",
+    discussionUrl: "https://example.test/pr/500#discussion_r400",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts",
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Status why active Codex verified repair residue",
+    body: executionReadyBody("Status should classify active verified Codex repair residue distinctly."),
+    createdAt: "2026-05-15T00:00:00Z",
+    updatedAt: "2026-05-15T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => scenario.passingChecks,
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
+});
+
 test("renderSupervisorStatusDto sanitizes loop runtime host and timestamp tokens", () => {
   const status = renderSupervisorStatusDto({
     gsdSummary: null,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -70,9 +70,9 @@ import {
 } from "./stale-diagnostic-recoverability";
 import {
   buildStaleReviewBotRemediation,
-  formatStaleReviewBotRemediationLine,
   type StaleReviewBotRemediationDto,
 } from "./stale-review-bot-remediation";
+import { formatStaleReviewBotRemediationLine } from "./stale-review-bot-diagnostics-presenter";
 import {
   buildCodexConnectorPolicyBlockDiagnostic,
   formatCodexConnectorPolicyBlockDiagnostic,


### PR DESCRIPTION
## Summary
- Extract stale review-bot remediation line rendering into a shared diagnostics presenter used by status and explain.
- Pass active status the same config and review-thread evidence used by idle status/explain for Codex verified-current-head repair diagnostics.
- Add focused status and explain coverage for verified current-head repair residue remaining distinct from no-source-change residue.

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts
- npm run build
- npm run verify:paths
- node dist/index.js issue-lint 1992 --config <supervisor-config-path>

## Notes
- Full npm test was attempted and currently fails in src/supervisor/supervisor-recovery-reconciliation.test.ts on unrelated existing expectations: handoff-missing vs workstation-local-path-hygiene-failed, and extra codex_connector_review_request_* null fields in a stale failure convergence patch.