### PR TITLE
Extract Codex Connector review request decision

### DIFF
--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -1,0 +1,165 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { codexConnectorReviewRequestAction } from "./codex-connector-review-request-decision";
+import type { PullRequestCheck, ReviewThread, SupervisorConfig } from "./core/types";
+import { createConfig, createPullRequest, createRecord, createReviewThread } from "./turn-execution-test-helpers";
+
+function createCodexConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    codexConnectorReviewRequestNoResponseMinutes: 10,
+    codexConnectorReviewRequestRetryLimit: 1,
+    ...overrides,
+  });
+}
+
+function summarizeChecks(checks: PullRequestCheck[]) {
+  return {
+    hasPending: checks.some((check) => check.bucket === "pending"),
+    hasFailing: checks.some((check) => check.bucket === "fail"),
+  };
+}
+
+const passingChecks: PullRequestCheck[] = [
+  {
+    name: "build",
+    state: "SUCCESS",
+    bucket: "pass",
+    workflow: "CI",
+  },
+];
+
+function decide(overrides: {
+  config?: Partial<SupervisorConfig>;
+  record?: Parameters<typeof createRecord>[0];
+  pr?: Parameters<typeof createPullRequest>[0];
+  checks?: PullRequestCheck[];
+  reviewThreads?: ReviewThread[];
+  configuredThreads?: ReviewThread[];
+  manualThreads?: ReviewThread[];
+  mergeConflict?: boolean;
+  now?: string;
+} = {}) {
+  const config = createCodexConfig(overrides.config);
+  const reviewThreads = overrides.reviewThreads ?? [];
+  return codexConnectorReviewRequestAction({
+    config,
+    record: createRecord({
+      state: "waiting_ci",
+      pr_number: 1995,
+      last_head_sha: "head-1995",
+      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_head_sha: "head-1995",
+      copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+      ...overrides.record,
+    }),
+    pr: createPullRequest({
+      number: 1995,
+      headRefOid: "head-1995",
+      isDraft: false,
+      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+      ...overrides.pr,
+    }),
+    checks: overrides.checks ?? passingChecks,
+    reviewThreads,
+    summarizeChecks,
+    configuredBotReviewThreads: () => overrides.configuredThreads ?? [],
+    manualReviewThreads: () => overrides.manualThreads ?? [],
+    mergeConflictDetected: () => overrides.mergeConflict ?? false,
+    nowMs: () => Date.parse(overrides.now ?? "2026-05-08T03:30:00Z"),
+  });
+}
+
+test("codexConnectorReviewRequestAction selects an initial request without GitHub mutation inputs", () => {
+  assert.deepEqual(decide(), { kind: "initial" });
+});
+
+test("codexConnectorReviewRequestAction selects retry after the same-head request wait expires", () => {
+  assert.deepEqual(
+    decide({
+      record: {
+        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+        codex_connector_review_requested_head_sha: "head-1995",
+        codex_connector_review_request_retry_count: 0,
+        codex_connector_review_request_retry_head_sha: null,
+        codex_connector_review_request_last_retried_at: null,
+      },
+      now: "2026-05-08T03:40:00.000Z",
+    }),
+    {
+      kind: "retry",
+      retryCount: 0,
+      retryAttempt: 1,
+    },
+  );
+});
+
+test("codexConnectorReviewRequestAction suppresses retry after retry exhaustion", () => {
+  assert.deepEqual(
+    decide({
+      record: {
+        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+        codex_connector_review_requested_head_sha: "head-1995",
+        codex_connector_review_request_retry_count: 1,
+        codex_connector_review_request_retry_head_sha: "head-1995",
+        codex_connector_review_request_last_retried_at: "2026-05-08T03:40:00.000Z",
+      },
+      now: "2026-05-08T04:00:00.000Z",
+    }),
+    { kind: "none" },
+  );
+});
+
+test("codexConnectorReviewRequestAction suppresses requests behind PR and review blockers", () => {
+  const codexMustFixThread = createReviewThread({
+    id: "thread-codex-must-fix",
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-must-fix",
+          body: "P1: fix the boundary before requesting another review.",
+          createdAt: "2026-05-08T03:20:00Z",
+          url: "https://example.test/pr/1995#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const cases: Array<{ name: string; overrides: Parameters<typeof decide>[0] }> = [
+    { name: "draft", overrides: { pr: { isDraft: true } } },
+    { name: "manual review thread", overrides: { manualThreads: [createReviewThread()] } },
+    { name: "unprocessed must-fix Codex thread", overrides: { configuredThreads: [codexMustFixThread] } },
+    { name: "merge conflict", overrides: { mergeConflict: true } },
+    { name: "pending checks", overrides: { checks: [{ ...passingChecks[0]!, bucket: "pending" }] } },
+    { name: "failing checks", overrides: { checks: [{ ...passingChecks[0]!, bucket: "fail" }] } },
+    {
+      name: "missing fallback evidence",
+      overrides: {
+        pr: { currentHeadCiGreenAt: null },
+        checks: [],
+        config: { localCiCommand: "npm test" },
+      },
+    },
+    {
+      name: "current-head review already observed",
+      overrides: { pr: { configuredBotCurrentHeadObservedAt: "2026-05-08T03:24:00Z" } },
+    },
+  ];
+
+  for (const scenario of cases) {
+    assert.deepEqual(decide(scenario.overrides), { kind: "none" }, scenario.name);
+  }
+});

--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -103,6 +103,23 @@ test("codexConnectorReviewRequestAction selects retry after the same-head reques
   );
 });
 
+test("codexConnectorReviewRequestAction falls back to a complete PR request pair when record metadata is partial", () => {
+  assert.deepEqual(
+    decide({
+      record: {
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: "head-old",
+      },
+      pr: {
+        codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+        codexConnectorReviewRequestedHeadSha: "head-1995",
+      },
+      now: "2026-05-08T03:35:00.000Z",
+    }),
+    { kind: "none" },
+  );
+});
+
 test("codexConnectorReviewRequestAction suppresses retry after retry exhaustion", () => {
   assert.deepEqual(
     decide({

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -1,0 +1,242 @@
+import { displayLocalCiCommand } from "./core/config-parsing";
+import { configuredReviewProviderKinds } from "./core/review-providers";
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./core/types";
+import {
+  hasProcessedReviewThread,
+  latestReviewThreadCommentFingerprint,
+} from "./review-handling";
+import {
+  codexConnectorMustFixReviewThreads,
+  configuredBotReviewFollowUpState,
+  latestReviewCommentAuthorIsAllowedBot,
+  staleConfiguredBotReviewThreads,
+} from "./review-thread-reporting";
+import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
+
+export type CodexConnectorReviewRequestAction =
+  | { kind: "none" }
+  | { kind: "initial" }
+  | { kind: "retry"; retryCount: number; retryAttempt: number };
+
+export interface CodexConnectorReviewRequestDecisionArgs {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+  mergeConflictDetected: (pr: GitHubPullRequest) => boolean;
+  nowMs?: () => number;
+}
+
+function isValidTimestamp(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+function addMinutes(timestamp: string, minutes: number): string | null {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return new Date(parsed + minutes * 60_000).toISOString();
+}
+
+function hasProcessedReviewThreadOnNonCurrentHead(
+  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+): boolean {
+  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
+  if (!latestCommentFingerprint) {
+    return false;
+  }
+
+  const processedKeys = new Set(record.processed_review_thread_ids ?? []);
+  const fingerprintPrefix = `${thread.id}@`;
+  const fingerprintSuffix = `#${latestCommentFingerprint}`;
+  return (record.processed_review_thread_fingerprints ?? []).some((key) => {
+    if (!key.startsWith(fingerprintPrefix) || !key.endsWith(fingerprintSuffix)) {
+      return false;
+    }
+
+    const headSha = key.slice(fingerprintPrefix.length, key.length - fingerprintSuffix.length);
+    return Boolean(headSha && headSha !== pr.headRefOid && processedKeys.has(`${thread.id}@${headSha}`));
+  });
+}
+
+function configuredBotThreadsAllowCodexConnectorRequest(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+  configuredThreads: ReviewThread[];
+}): boolean {
+  if (args.configuredThreads.length === 0) {
+    return true;
+  }
+
+  const staleHeadConfiguredThreadIds = new Set(
+    args.configuredThreads
+      .filter(
+        (thread) =>
+          latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
+          hasProcessedReviewThreadOnNonCurrentHead(args.record, args.pr, thread),
+      )
+      .map((thread) => thread.id),
+  );
+  const currentHeadConfiguredThreadIds = new Set(
+    args.configuredThreads
+      .filter((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+      .map((thread) => thread.id),
+  );
+  const staleConfiguredThreadIds = new Set(
+    staleConfiguredBotReviewThreads(args.config, args.record, args.pr, args.reviewThreads).map((thread) => thread.id),
+  );
+  const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(args.configuredThreads).map((thread) => thread.id));
+
+  if (
+    args.configuredThreads.some(
+      (thread) =>
+        codexMustFixThreadIds.has(thread.id) &&
+        !staleHeadConfiguredThreadIds.has(thread.id) &&
+        !currentHeadConfiguredThreadIds.has(thread.id) &&
+        !staleConfiguredThreadIds.has(thread.id),
+    )
+  ) {
+    return false;
+  }
+
+  if (configuredBotReviewFollowUpState(args.config, args.record, args.pr, args.configuredThreads) === "eligible") {
+    return false;
+  }
+
+  return args.configuredThreads.every(
+    (thread) =>
+      staleHeadConfiguredThreadIds.has(thread.id) ||
+      staleConfiguredThreadIds.has(thread.id) ||
+      (latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
+        hasProcessedReviewThread(args.record, args.pr, thread)),
+  );
+}
+
+export function codexConnectorReviewRequestAction(
+  args: CodexConnectorReviewRequestDecisionArgs,
+): CodexConnectorReviewRequestAction {
+  const checkSummary = args.summarizeChecks(args.checks);
+  const configuredThreads = args.configuredBotReviewThreads(args.config, args.reviewThreads);
+  const staleCodexReviewState = configuredReviewProviderKinds(args.config).includes("codex")
+    ? buildStaleReviewBotRemediation({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        checks: args.checks,
+        reviewThreads: args.reviewThreads,
+      })
+    : null;
+  const isCodexMissingCurrentHeadReview =
+    staleCodexReviewState?.classification === "metadata_only_missing_current_head_review";
+  const isCodexConvergedCurrentHeadReview =
+    staleCodexReviewState?.classification === "metadata_only_current_head_converged";
+  const isCodexVerifiedNoSourceChangeThreadResolution =
+    staleCodexReviewState?.classification === "verified_no_source_change_pending_thread_resolution";
+  const isCodexVerifiedCurrentHeadRepairThreadResolution =
+    staleCodexReviewState?.classification === "verified_current_head_repair_pending_thread_resolution";
+  const isCodexMetadataOnly =
+    staleCodexReviewState?.classification === "metadata_only" ||
+    staleCodexReviewState?.classification === "metadata_only_missing_current_head_review" ||
+    staleCodexReviewState?.classification === "metadata_only_current_head_converged" ||
+    isCodexVerifiedNoSourceChangeThreadResolution ||
+    isCodexVerifiedCurrentHeadRepairThreadResolution;
+
+  if (
+    configuredReviewProviderKinds(args.config).includes("codex") &&
+    !isCodexMissingCurrentHeadReview &&
+    (isCodexConvergedCurrentHeadReview ||
+      isCodexVerifiedNoSourceChangeThreadResolution ||
+      isCodexVerifiedCurrentHeadRepairThreadResolution ||
+      isCodexMetadataOnly ||
+      staleCodexReviewState?.classification === "unresolved_work" ||
+      staleCodexReviewState?.classification === "unknown_needs_operator")
+  ) {
+    return { kind: "none" };
+  }
+
+  const configuredThreadsAreSafeForCodexRequest = configuredBotThreadsAllowCodexConnectorRequest({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    reviewThreads: args.reviewThreads,
+    configuredThreads,
+  });
+  const loadedChecksAreGreen =
+    args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
+  const noChecksAndNoLocalCi = args.checks.length === 0 && !displayLocalCiCommand(args.config.localCiCommand);
+  const hasFallbackEligibleSignal =
+    isValidTimestamp(args.pr.currentHeadCiGreenAt) || loadedChecksAreGreen || noChecksAndNoLocalCi;
+
+  if (
+    args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
+    !configuredReviewProviderKinds(args.config).includes("codex") ||
+    args.record.copilot_review_timeout_action !== "request_review_comment" ||
+    !args.record.copilot_review_timed_out_at ||
+    args.pr.isDraft ||
+    args.pr.reviewDecision === "CHANGES_REQUESTED" ||
+    args.mergeConflictDetected(args.pr) ||
+    !configuredThreadsAreSafeForCodexRequest ||
+    args.manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
+    isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) ||
+    !hasFallbackEligibleSignal
+  ) {
+    return { kind: "none" };
+  }
+
+  if (checkSummary.hasPending || checkSummary.hasFailing) {
+    return { kind: "none" };
+  }
+
+  const recordRequestAt = args.record.codex_connector_review_requested_observed_at ?? null;
+  const recordRequestHeadSha = args.record.codex_connector_review_requested_head_sha ?? null;
+  const prRequestAt = args.pr.codexConnectorReviewRequestedAt ?? null;
+  const prRequestHeadSha = args.pr.codexConnectorReviewRequestedHeadSha ?? null;
+  const requestAt = recordRequestAt ?? prRequestAt;
+  const requestHeadSha = recordRequestHeadSha ?? prRequestHeadSha;
+  const requestMatchesCurrentHead = Boolean(requestAt && requestHeadSha === args.pr.headRefOid);
+
+  if (!requestMatchesCurrentHead) {
+    return { kind: "initial" };
+  }
+
+  const retryLimit = args.config.codexConnectorReviewRequestRetryLimit ?? 1;
+  if (retryLimit <= 0) {
+    return { kind: "none" };
+  }
+
+  const retryCount =
+    args.record.codex_connector_review_request_retry_head_sha === args.pr.headRefOid
+      ? args.record.codex_connector_review_request_retry_count ?? 0
+      : 0;
+  if (retryCount >= retryLimit) {
+    return { kind: "none" };
+  }
+
+  const retryAnchorAt =
+    args.record.codex_connector_review_request_retry_head_sha === args.pr.headRefOid &&
+    args.record.codex_connector_review_request_last_retried_at
+      ? args.record.codex_connector_review_request_last_retried_at
+      : requestAt;
+  const waitUntil = retryAnchorAt
+    ? addMinutes(retryAnchorAt, args.config.codexConnectorReviewRequestNoResponseMinutes ?? 10)
+    : null;
+  if (!waitUntil || (args.nowMs ?? Date.now)() < Date.parse(waitUntil)) {
+    return { kind: "none" };
+  }
+
+  return {
+    kind: "retry",
+    retryCount,
+    retryAttempt: retryCount + 1,
+  };
+}

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -44,6 +44,13 @@ function addMinutes(timestamp: string, minutes: number): string | null {
   return new Date(parsed + minutes * 60_000).toISOString();
 }
 
+function completeRequestMetadataPair(
+  requestedAt: string | null,
+  headSha: string | null,
+): { requestedAt: string; headSha: string } | null {
+  return requestedAt && headSha ? { requestedAt, headSha } : null;
+}
+
 function hasProcessedReviewThreadOnNonCurrentHead(
   record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
@@ -201,8 +208,11 @@ export function codexConnectorReviewRequestAction(
   const recordRequestHeadSha = args.record.codex_connector_review_requested_head_sha ?? null;
   const prRequestAt = args.pr.codexConnectorReviewRequestedAt ?? null;
   const prRequestHeadSha = args.pr.codexConnectorReviewRequestedHeadSha ?? null;
-  const requestAt = recordRequestAt ?? prRequestAt;
-  const requestHeadSha = recordRequestHeadSha ?? prRequestHeadSha;
+  const request =
+    completeRequestMetadataPair(recordRequestAt, recordRequestHeadSha) ??
+    completeRequestMetadataPair(prRequestAt, prRequestHeadSha);
+  const requestAt = request?.requestedAt ?? null;
+  const requestHeadSha = request?.headSha ?? null;
   const requestMatchesCurrentHead = Boolean(requestAt && requestHeadSha === args.pr.headRefOid);
 
   if (!requestMatchesCurrentHead) {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -6,8 +6,6 @@ import {
   type PreMergeResidualFinding,
 } from "./local-review";
 import {
-  hasProcessedReviewThread,
-  latestReviewThreadCommentFingerprint,
   localReviewBlocksReady,
   localReviewFailureContext,
   localReviewHighSeverityNeedsBlock,
@@ -46,12 +44,6 @@ import {
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
 import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
-import {
-  codexConnectorMustFixReviewThreads,
-  configuredBotReviewFollowUpState,
-  latestReviewCommentAuthorIsAllowedBot,
-  staleConfiguredBotReviewThreads,
-} from "./review-thread-reporting";
 import { parseIssueMetadata } from "./issue-metadata";
 import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
 import {
@@ -60,10 +52,12 @@ import {
 } from "./post-turn-pull-request-policy";
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
-import { configuredReviewProviderKinds } from "./core/review-providers";
-import { displayLocalCiCommand } from "./core/config-parsing";
 import { renderCodexConnectorReviewRequestComment } from "./github/github-review-signals";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
+import {
+  codexConnectorReviewRequestAction,
+  type CodexConnectorReviewRequestAction,
+} from "./codex-connector-review-request-decision";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -349,229 +343,6 @@ async function loadOpenPullRequestSnapshot(
   const checks = await github.getChecks(prNumber);
   const reviewThreads = await github.getUnresolvedReviewThreads(prNumber);
   return { pr, checks, reviewThreads };
-}
-
-function isValidTimestamp(value: string | null | undefined): boolean {
-  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
-}
-
-function addMinutes(timestamp: string, minutes: number): string | null {
-  const parsed = Date.parse(timestamp);
-  if (Number.isNaN(parsed)) {
-    return null;
-  }
-
-  return new Date(parsed + minutes * 60_000).toISOString();
-}
-
-function hasProcessedReviewThreadOnNonCurrentHead(
-  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-  thread: Pick<ReviewThread, "id" | "comments">,
-): boolean {
-  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
-  if (!latestCommentFingerprint) {
-    return false;
-  }
-
-  const processedKeys = new Set(record.processed_review_thread_ids ?? []);
-  const fingerprintPrefix = `${thread.id}@`;
-  const fingerprintSuffix = `#${latestCommentFingerprint}`;
-  return (record.processed_review_thread_fingerprints ?? []).some((key) => {
-    if (!key.startsWith(fingerprintPrefix) || !key.endsWith(fingerprintSuffix)) {
-      return false;
-    }
-
-    const headSha = key.slice(fingerprintPrefix.length, key.length - fingerprintSuffix.length);
-    return Boolean(headSha && headSha !== pr.headRefOid && processedKeys.has(`${thread.id}@${headSha}`));
-  });
-}
-
-function configuredBotThreadsAllowCodexConnectorRequest(args: {
-  config: SupervisorConfig;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  reviewThreads: ReviewThread[];
-  configuredThreads: ReviewThread[];
-}): boolean {
-  if (args.configuredThreads.length === 0) {
-    return true;
-  }
-
-  const staleHeadConfiguredThreadIds = new Set(
-    args.configuredThreads
-      .filter(
-        (thread) =>
-          latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
-          hasProcessedReviewThreadOnNonCurrentHead(args.record, args.pr, thread),
-      )
-      .map((thread) => thread.id),
-  );
-  const currentHeadConfiguredThreadIds = new Set(
-    args.configuredThreads
-      .filter((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
-      .map((thread) => thread.id),
-  );
-  const staleConfiguredThreadIds = new Set(
-    staleConfiguredBotReviewThreads(args.config, args.record, args.pr, args.reviewThreads).map((thread) => thread.id),
-  );
-  const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(args.configuredThreads).map((thread) => thread.id));
-
-  if (
-    args.configuredThreads.some(
-      (thread) =>
-        codexMustFixThreadIds.has(thread.id) &&
-        !staleHeadConfiguredThreadIds.has(thread.id) &&
-        !currentHeadConfiguredThreadIds.has(thread.id) &&
-        !staleConfiguredThreadIds.has(thread.id),
-    )
-  ) {
-    return false;
-  }
-
-  if (configuredBotReviewFollowUpState(args.config, args.record, args.pr, args.configuredThreads) === "eligible") {
-    return false;
-  }
-
-  return args.configuredThreads.every(
-    (thread) =>
-      staleHeadConfiguredThreadIds.has(thread.id) ||
-      staleConfiguredThreadIds.has(thread.id) ||
-      (latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
-        hasProcessedReviewThread(args.record, args.pr, thread)),
-  );
-}
-
-type CodexConnectorReviewRequestAction =
-  | { kind: "none" }
-  | { kind: "initial" }
-  | { kind: "retry"; retryCount: number; retryAttempt: number };
-
-function codexConnectorReviewRequestAction(args: {
-  config: SupervisorConfig;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  summarizeChecks: HandlePostTurnPullRequestTransitionsArgs["summarizeChecks"];
-  configuredBotReviewThreads: HandlePostTurnPullRequestTransitionsArgs["configuredBotReviewThreads"];
-  manualReviewThreads: HandlePostTurnPullRequestTransitionsArgs["manualReviewThreads"];
-  mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
-}): CodexConnectorReviewRequestAction {
-  const checkSummary = args.summarizeChecks(args.checks);
-  const configuredThreads = args.configuredBotReviewThreads(args.config, args.reviewThreads);
-  const staleCodexReviewState = configuredReviewProviderKinds(args.config).includes("codex")
-    ? buildStaleReviewBotRemediation({
-        config: args.config,
-        record: args.record,
-        pr: args.pr,
-        checks: args.checks,
-        reviewThreads: args.reviewThreads,
-      })
-    : null;
-  const isCodexMissingCurrentHeadReview =
-    staleCodexReviewState?.classification === "metadata_only_missing_current_head_review";
-  const isCodexConvergedCurrentHeadReview =
-    staleCodexReviewState?.classification === "metadata_only_current_head_converged";
-  const isCodexVerifiedNoSourceChangeThreadResolution =
-    staleCodexReviewState?.classification === "verified_no_source_change_pending_thread_resolution";
-  const isCodexVerifiedCurrentHeadRepairThreadResolution =
-    staleCodexReviewState?.classification === "verified_current_head_repair_pending_thread_resolution";
-  const isCodexMetadataOnly =
-    staleCodexReviewState?.classification === "metadata_only" ||
-    staleCodexReviewState?.classification === "metadata_only_missing_current_head_review" ||
-    staleCodexReviewState?.classification === "metadata_only_current_head_converged" ||
-    isCodexVerifiedNoSourceChangeThreadResolution ||
-    isCodexVerifiedCurrentHeadRepairThreadResolution;
-
-  if (
-    configuredReviewProviderKinds(args.config).includes("codex") &&
-    !isCodexMissingCurrentHeadReview &&
-    (isCodexConvergedCurrentHeadReview ||
-      isCodexVerifiedNoSourceChangeThreadResolution ||
-      isCodexVerifiedCurrentHeadRepairThreadResolution ||
-      isCodexMetadataOnly ||
-      staleCodexReviewState?.classification === "unresolved_work" ||
-      staleCodexReviewState?.classification === "unknown_needs_operator")
-  ) {
-    return { kind: "none" };
-  }
-
-  const configuredThreadsAreSafeForCodexRequest = configuredBotThreadsAllowCodexConnectorRequest({
-    config: args.config,
-    record: args.record,
-    pr: args.pr,
-    reviewThreads: args.reviewThreads,
-    configuredThreads,
-  });
-  const loadedChecksAreGreen =
-    args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
-  const noChecksAndNoLocalCi = args.checks.length === 0 && !displayLocalCiCommand(args.config.localCiCommand);
-  const hasFallbackEligibleSignal =
-    isValidTimestamp(args.pr.currentHeadCiGreenAt) || loadedChecksAreGreen || noChecksAndNoLocalCi;
-
-  if (
-    args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
-    !configuredReviewProviderKinds(args.config).includes("codex") ||
-    args.record.copilot_review_timeout_action !== "request_review_comment" ||
-    !args.record.copilot_review_timed_out_at ||
-    args.pr.isDraft ||
-    args.pr.reviewDecision === "CHANGES_REQUESTED" ||
-    args.mergeConflictDetected(args.pr) ||
-    !configuredThreadsAreSafeForCodexRequest ||
-    args.manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
-    isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) ||
-    !hasFallbackEligibleSignal
-  ) {
-    return { kind: "none" };
-  }
-
-  if (checkSummary.hasPending || checkSummary.hasFailing) {
-    return { kind: "none" };
-  }
-
-  const recordRequestAt = args.record.codex_connector_review_requested_observed_at ?? null;
-  const recordRequestHeadSha = args.record.codex_connector_review_requested_head_sha ?? null;
-  const prRequestAt = args.pr.codexConnectorReviewRequestedAt ?? null;
-  const prRequestHeadSha = args.pr.codexConnectorReviewRequestedHeadSha ?? null;
-  const requestAt = recordRequestAt ?? prRequestAt;
-  const requestHeadSha = recordRequestHeadSha ?? prRequestHeadSha;
-  const requestMatchesCurrentHead = Boolean(requestAt && requestHeadSha === args.pr.headRefOid);
-
-  if (!requestMatchesCurrentHead) {
-    return { kind: "initial" };
-  }
-
-  const retryLimit = args.config.codexConnectorReviewRequestRetryLimit ?? 1;
-  if (retryLimit <= 0) {
-    return { kind: "none" };
-  }
-
-  const retryCount =
-    args.record.codex_connector_review_request_retry_head_sha === args.pr.headRefOid
-      ? args.record.codex_connector_review_request_retry_count ?? 0
-      : 0;
-  if (retryCount >= retryLimit) {
-    return { kind: "none" };
-  }
-
-  const retryAnchorAt =
-    args.record.codex_connector_review_request_retry_head_sha === args.pr.headRefOid &&
-    args.record.codex_connector_review_request_last_retried_at
-      ? args.record.codex_connector_review_request_last_retried_at
-      : requestAt;
-  const waitUntil = retryAnchorAt
-    ? addMinutes(retryAnchorAt, args.config.codexConnectorReviewRequestNoResponseMinutes ?? 10)
-    : null;
-  if (!waitUntil || Date.now() < Date.parse(waitUntil)) {
-    return { kind: "none" };
-  }
-
-  return {
-    kind: "retry",
-    retryCount,
-    retryAttempt: retryCount + 1,
-  };
 }
 
 function renderCodexConnectorReviewRequestCommentForAction(args: {


### PR DESCRIPTION
## Summary
- extract Codex Connector review-request eligibility into a focused pure decision module
- keep post-turn PR orchestration responsible for GitHub comments, state patches, sticky comments, and lifecycle transitions
- add focused unit coverage for initial request, retry, retry exhaustion, and blocker suppression decisions

## Verification
- npx tsx --test src/codex-connector-review-request-decision.test.ts src/post-turn-pull-request.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build
- node dist/index.js issue-lint 1995 --config <active-codex-supervisor-config>

Closes #1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated review request decision logic into a dedicated module.

* **Tests**
  * Added comprehensive test suite for review request decision scenarios, including initial requests, retries, and various blocking conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->