### PR TITLE
Extract stale review bot recovery service

### DIFF
--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -58,6 +58,7 @@ import {
   codexConnectorReviewRequestAction,
   type CodexConnectorReviewRequestAction,
 } from "./codex-connector-review-request-decision";
+import { hasResolvedAllStaleConfiguredBotThreads } from "./supervisor/stale-review-bot-recovery";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -102,35 +103,6 @@ export interface PullRequestLifecycleSnapshot {
 }
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
-
-function staleConfiguredBotThreadIdsFromSignature(signature: string | null | undefined): string[] {
-  if (!signature) {
-    return [];
-  }
-
-  return signature
-    .split("|")
-    .map((part) => part.trim())
-    .filter((part) => part.startsWith("stalled-bot:"))
-    .map((part) => part.slice("stalled-bot:".length).trim())
-    .filter((threadId) => threadId.length > 0);
-}
-
-function hasResolvedAllStaleConfiguredBotThreads(args: {
-  record: Pick<IssueRunRecord, "stale_review_bot_resolve_progress_keys">;
-  headSha: string;
-  signature: string;
-}): boolean {
-  const threadIds = staleConfiguredBotThreadIdsFromSignature(args.signature);
-  if (threadIds.length === 0) {
-    return false;
-  }
-
-  const progressKeys = new Set(args.record.stale_review_bot_resolve_progress_keys ?? []);
-  return threadIds.every((threadId) =>
-    progressKeys.has(`resolve:${threadId}@${args.headSha}:${args.signature}`),
-  );
-}
 
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/supervisor/stale-review-bot-recovery.test.ts
+++ b/src/supervisor/stale-review-bot-recovery.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { IssueRunRecord, SupervisorStateFile } from "../core/types";
+import {
+  createConfig,
+  createFailureContext,
+  createPullRequest,
+  createRecord,
+  createReviewThread,
+} from "../turn-execution-test-helpers";
+import { recoverStaleConfiguredBotReviewThreads } from "./stale-review-bot-recovery";
+
+function createNoopStateStore() {
+  return {
+    touch: (record: IssueRunRecord, patch: Partial<IssueRunRecord>) => ({
+      ...record,
+      ...patch,
+      updated_at: record.updated_at,
+    }),
+    save: async () => undefined,
+  };
+}
+
+test("recoverStaleConfiguredBotReviewThreads returns a typed resolved result and preserves progress keys", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+  });
+  const pr = createPullRequest({
+    number: 116,
+    headRefOid: "head-116",
+  });
+  const record = createRecord({
+    issue_number: 102,
+    pr_number: pr.number,
+    state: "blocked",
+    blocked_reason: "stale_review_bot",
+    last_head_sha: pr.headRefOid,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": record,
+    },
+  };
+  const failureContext = {
+    ...createFailureContext("stale configured-bot review thread"),
+    signature: "stalled-bot:thread-1",
+    details: ["reviewer=copilot-pull-request-reviewer file=src/review.ts line=42 processed_on_current_head=yes"],
+    url: "https://example.test/review/1",
+  };
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      path: "src/review.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "This finding is stale on the current head.",
+            createdAt: "2026-03-13T02:05:00Z",
+            url: "https://example.test/pr/116#discussion_r1",
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const replies: string[] = [];
+  const resolutions: string[] = [];
+
+  const result = await recoverStaleConfiguredBotReviewThreads({
+    github: {
+      replyToReviewThread: async (threadId: string) => {
+        replies.push(threadId);
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolutions.push(threadId);
+      },
+    },
+    stateStore: createNoopStateStore(),
+    state,
+    record,
+    pr,
+    reviewThreads,
+    syncJournal: async () => undefined,
+    config,
+    failureContext,
+    resolveAfterReply: true,
+  });
+
+  assert.equal(result.status, "resolved");
+  assert.equal(result.replyCount, 1);
+  assert.equal(result.resolveCount, 1);
+  assert.equal(result.shouldRefreshPullRequest, true);
+  assert.deepEqual(replies, ["thread-1"]);
+  assert.deepEqual(resolutions, ["thread-1"]);
+  assert.deepEqual(result.record.stale_review_bot_reply_progress_keys, [
+    "reply:thread-1@head-116:stalled-bot:thread-1",
+  ]);
+  assert.deepEqual(result.record.stale_review_bot_resolve_progress_keys, [
+    "resolve:thread-1@head-116:stalled-bot:thread-1",
+  ]);
+});

--- a/src/supervisor/stale-review-bot-recovery.ts
+++ b/src/supervisor/stale-review-bot-recovery.ts
@@ -1,0 +1,298 @@
+import type { GitHubClient } from "../github";
+import type { IssueJournalSync } from "../run-once-issue-preparation";
+import type { StateStore } from "../core/state-store";
+import type {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "../core/types";
+import { truncate } from "../core/utils";
+import { configuredBotReviewThreads, latestReviewComment } from "../review-thread-reporting";
+
+export const STALE_CONFIGURED_BOT_REVIEW_REASON_CODE = "stale_review_bot";
+
+export type StaleConfiguredBotReviewRecoveryStatus =
+  | "no_op"
+  | "replied"
+  | "resolved"
+  | "skipped"
+  | "failed";
+
+export interface StaleConfiguredBotReviewRecoveryResult {
+  status: StaleConfiguredBotReviewRecoveryStatus;
+  record: IssueRunRecord;
+  replyCount: number;
+  resolveCount: number;
+  skippedReason?: string;
+  failureMessage?: string;
+  shouldRefreshPullRequest: boolean;
+}
+
+function buildResult(args: {
+  status: StaleConfiguredBotReviewRecoveryStatus;
+  record: IssueRunRecord;
+  replyCount?: number;
+  resolveCount?: number;
+  skippedReason?: string;
+  failureMessage?: string;
+  shouldRefreshPullRequest?: boolean;
+}): StaleConfiguredBotReviewRecoveryResult {
+  return {
+    status: args.status,
+    record: args.record,
+    replyCount: args.replyCount ?? 0,
+    resolveCount: args.resolveCount ?? 0,
+    skippedReason: args.skippedReason,
+    failureMessage: args.failureMessage,
+    shouldRefreshPullRequest: args.shouldRefreshPullRequest ?? false,
+  };
+}
+
+function buildStaleConfiguredBotReplyBody(args: {
+  issueNumber: number;
+  pr: GitHubPullRequest;
+  thread: ReviewThread;
+  failureContext: FailureContext | null;
+  resolveAfterReply: boolean;
+  reasonCode?: string;
+}): string {
+  const latestComment = latestReviewComment(args.thread);
+  const location = `${args.thread.path ?? "unknown"}:${args.thread.line ?? "?"}`;
+  const evidenceLine =
+    args.failureContext?.details?.find((detail) => {
+      const fileMatch = detail.match(/\bfile=([^\s]+)/);
+      const lineMatch = detail.match(/\bline=(\d+)/);
+      return fileMatch?.[1] === (args.thread.path ?? "unknown") && lineMatch?.[1] === String(args.thread.line ?? "?");
+    }) ?? `location=${location} processed_on_current_head=yes`;
+  const sourceLink = latestComment?.url ?? args.failureContext?.url;
+  const sourceLine = sourceLink ? ` Source: ${sourceLink}` : "";
+  return [
+    `The supervisor reprocessed this configured-bot finding on the current head \`${args.pr.headRefOid}\` and classified it as stale.`,
+    `Audit: issue=#${args.issueNumber} pr=#${args.pr.number} head=${args.pr.headRefOid} thread=${args.thread.id} reason=${args.reasonCode ?? STALE_CONFIGURED_BOT_REVIEW_REASON_CODE}.`,
+    `Evidence: ${evidenceLine}.${sourceLine}`,
+    args.resolveAfterReply
+      ? args.reasonCode === "verified_no_source_change_auto_resolve"
+        ? "Under the configured verified no-source-change auto-resolve opt-in, the supervisor is auto-resolving this thread now."
+        : args.reasonCode === "verified_current_head_repair_auto_resolve"
+          ? "Under the configured verified current-head repair auto-resolve opt-in, the supervisor is auto-resolving this thread now."
+        : "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
+      : "Leaving thread resolution to a human operator.",
+  ].join("\n\n");
+}
+
+export function staleConfiguredBotReplyThreadIds(signature: string | null | undefined): string[] {
+  if (!signature) {
+    return [];
+  }
+
+  return signature
+    .split("|")
+    .map((part) => part.trim())
+    .filter((part) => part.startsWith("stalled-bot:"))
+    .map((part) => part.slice("stalled-bot:".length).trim())
+    .filter((threadId) => threadId.length > 0);
+}
+
+export function staleConfiguredBotReviewProgressKey(args: {
+  headSha: string;
+  signature: string;
+  threadId: string;
+  phase: "reply" | "resolve";
+}): string {
+  return `${args.phase}:${args.threadId}@${args.headSha}:${args.signature}`;
+}
+
+function appendBoundedUniqueStringEntry(existing: string[] | undefined, value: string): string[] {
+  return Array.from(new Set([...(existing ?? []).filter((entry) => entry !== value), value])).slice(-200);
+}
+
+async function persistStaleConfiguredBotReviewProgress(args: {
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  syncJournal: IssueJournalSync;
+  patch: Pick<IssueRunRecord, "stale_review_bot_reply_progress_keys" | "stale_review_bot_resolve_progress_keys">;
+}): Promise<IssueRunRecord> {
+  const updatedRecord = args.stateStore.touch(args.record, args.patch);
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+  return updatedRecord;
+}
+
+export function hasResolvedAllStaleConfiguredBotThreads(args: {
+  record: Pick<IssueRunRecord, "stale_review_bot_resolve_progress_keys">;
+  headSha: string;
+  signature: string;
+}): boolean {
+  const threadIds = staleConfiguredBotReplyThreadIds(args.signature);
+  if (threadIds.length === 0) {
+    return false;
+  }
+
+  const progressKeys = new Set(args.record.stale_review_bot_resolve_progress_keys ?? []);
+  return threadIds.every((threadId) =>
+    progressKeys.has(staleConfiguredBotReviewProgressKey({
+      headSha: args.headSha,
+      signature: args.signature,
+      threadId,
+      phase: "resolve",
+    })),
+  );
+}
+
+export async function recoverStaleConfiguredBotReviewThreads(args: {
+  github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+  syncJournal: IssueJournalSync;
+  config: SupervisorConfig;
+  failureContext: FailureContext | null;
+  resolveAfterReply: boolean;
+  reasonCode?: string;
+}): Promise<StaleConfiguredBotReviewRecoveryResult> {
+  if (!args.github.replyToReviewThread) {
+    return buildResult({ status: "skipped", record: args.record, skippedReason: "missing_reply_api" });
+  }
+  if (args.resolveAfterReply && !args.github.resolveReviewThread) {
+    return buildResult({ status: "skipped", record: args.record, skippedReason: "missing_resolve_api" });
+  }
+
+  const blockerSignature = args.failureContext?.signature ?? STALE_CONFIGURED_BOT_REVIEW_REASON_CODE;
+  if (
+    args.record.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
+    args.record.last_stale_review_bot_reply_signature === blockerSignature
+  ) {
+    return buildResult({
+      status: "no_op",
+      record: args.record,
+      shouldRefreshPullRequest: args.resolveAfterReply && hasResolvedAllStaleConfiguredBotThreads({
+        record: args.record,
+        headSha: args.pr.headRefOid,
+        signature: blockerSignature,
+      }),
+    });
+  }
+
+  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
+  const replyThreadIds = staleConfiguredBotReplyThreadIds(blockerSignature);
+  if (replyThreadIds.length === 0) {
+    return buildResult({ status: "skipped", record: args.record, skippedReason: "missing_thread_signature" });
+  }
+
+  const replyThreads = replyThreadIds
+    .map((threadId) => configuredThreads.find((thread) => thread.id === threadId) ?? null)
+    .filter((thread): thread is ReviewThread => thread !== null);
+  if (replyThreads.length !== replyThreadIds.length) {
+    return buildResult({ status: "skipped", record: args.record, skippedReason: "missing_configured_thread" });
+  }
+
+  let record = args.record;
+  let replyCount = 0;
+  let resolveCount = 0;
+  const replyProgressKeys = new Set(record.stale_review_bot_reply_progress_keys ?? []);
+  const resolveProgressKeys = new Set(record.stale_review_bot_resolve_progress_keys ?? []);
+
+  try {
+    for (const replyThread of replyThreads) {
+      const replyKey = staleConfiguredBotReviewProgressKey({
+        headSha: args.pr.headRefOid,
+        signature: blockerSignature,
+        threadId: replyThread.id,
+        phase: "reply",
+      });
+      if (!replyProgressKeys.has(replyKey)) {
+        const replyBody = buildStaleConfiguredBotReplyBody({
+          issueNumber: record.issue_number,
+          pr: args.pr,
+          thread: replyThread,
+          failureContext: args.failureContext,
+          resolveAfterReply: args.resolveAfterReply,
+          reasonCode: args.reasonCode,
+        });
+        await args.github.replyToReviewThread(replyThread.id, replyBody);
+        replyCount += 1;
+        record = await persistStaleConfiguredBotReviewProgress({
+          stateStore: args.stateStore,
+          state: args.state,
+          record,
+          syncJournal: args.syncJournal,
+          patch: {
+            stale_review_bot_reply_progress_keys: appendBoundedUniqueStringEntry(
+              record.stale_review_bot_reply_progress_keys,
+              replyKey,
+            ),
+            stale_review_bot_resolve_progress_keys: record.stale_review_bot_resolve_progress_keys ?? [],
+          },
+        });
+        replyProgressKeys.add(replyKey);
+      }
+
+      if (args.resolveAfterReply) {
+        const resolveKey = staleConfiguredBotReviewProgressKey({
+          headSha: args.pr.headRefOid,
+          signature: blockerSignature,
+          threadId: replyThread.id,
+          phase: "resolve",
+        });
+        if (!resolveProgressKeys.has(resolveKey)) {
+          await args.github.resolveReviewThread?.(replyThread.id);
+          resolveCount += 1;
+          record = await persistStaleConfiguredBotReviewProgress({
+            stateStore: args.stateStore,
+            state: args.state,
+            record,
+            syncJournal: args.syncJournal,
+            patch: {
+              stale_review_bot_reply_progress_keys: record.stale_review_bot_reply_progress_keys ?? [],
+              stale_review_bot_resolve_progress_keys: appendBoundedUniqueStringEntry(
+                record.stale_review_bot_resolve_progress_keys,
+                resolveKey,
+              ),
+            },
+          });
+          resolveProgressKeys.add(resolveKey);
+        }
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `Failed to ${args.resolveAfterReply ? "reply-and-resolve" : "publish"} stale configured-bot reply for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
+    );
+    return buildResult({
+      status: "failed",
+      record,
+      replyCount,
+      resolveCount,
+      failureMessage: message,
+    });
+  }
+
+  const updatedRecord = args.stateStore.touch(record, {
+    last_stale_review_bot_reply_head_sha: args.pr.headRefOid,
+    last_stale_review_bot_reply_signature: blockerSignature,
+  });
+  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(updatedRecord);
+
+  const status = resolveCount > 0 ? "resolved" : replyCount > 0 ? "replied" : "no_op";
+  return buildResult({
+    status,
+    record: updatedRecord,
+    replyCount,
+    resolveCount,
+    shouldRefreshPullRequest: args.resolveAfterReply && hasResolvedAllStaleConfiguredBotThreads({
+      record: updatedRecord,
+      headSha: args.pr.headRefOid,
+      signature: blockerSignature,
+    }),
+  });
+}

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -17,7 +17,10 @@ import {
 import { truncate } from "./core/utils";
 import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
-import { configuredBotReviewThreads, latestReviewComment } from "./review-thread-reporting";
+import {
+  recoverStaleConfiguredBotReviewThreads,
+  STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
+} from "./supervisor/stale-review-bot-recovery";
 import { workspacePreparationRemediationTargetForFailureClass } from "./remediation-targets";
 
 export type HostLocalTrackedPrBlockerGateType =
@@ -537,201 +540,6 @@ async function publishTrackedPrStatusComment(args: {
   await args.github.addIssueComment(args.pr.number, bodyWithMarker);
 }
 
-function buildStaleConfiguredBotReplyBody(args: {
-  issueNumber: number;
-  pr: GitHubPullRequest;
-  thread: ReviewThread;
-  failureContext: FailureContext | null;
-  resolveAfterReply: boolean;
-  reasonCode?: string;
-}): string {
-  const latestComment = latestReviewComment(args.thread);
-  const location = `${args.thread.path ?? "unknown"}:${args.thread.line ?? "?"}`;
-  const evidenceLine =
-    args.failureContext?.details?.find((detail) => {
-      const fileMatch = detail.match(/\bfile=([^\s]+)/);
-      const lineMatch = detail.match(/\bline=(\d+)/);
-      return fileMatch?.[1] === (args.thread.path ?? "unknown") && lineMatch?.[1] === String(args.thread.line ?? "?");
-    }) ?? `location=${location} processed_on_current_head=yes`;
-  const sourceLink = latestComment?.url ?? args.failureContext?.url;
-  const sourceLine = sourceLink ? ` Source: ${sourceLink}` : "";
-  return [
-    `The supervisor reprocessed this configured-bot finding on the current head \`${args.pr.headRefOid}\` and classified it as stale.`,
-    `Audit: issue=#${args.issueNumber} pr=#${args.pr.number} head=${args.pr.headRefOid} thread=${args.thread.id} reason=${args.reasonCode ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT}.`,
-    `Evidence: ${evidenceLine}.${sourceLine}`,
-    args.resolveAfterReply
-      ? args.reasonCode === "verified_no_source_change_auto_resolve"
-        ? "Under the configured verified no-source-change auto-resolve opt-in, the supervisor is auto-resolving this thread now."
-        : args.reasonCode === "verified_current_head_repair_auto_resolve"
-          ? "Under the configured verified current-head repair auto-resolve opt-in, the supervisor is auto-resolving this thread now."
-        : "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now."
-      : "Leaving thread resolution to a human operator.",
-  ].join("\n\n");
-}
-
-function staleConfiguredBotReplyThreadIds(signature: string | null | undefined): string[] {
-  if (!signature) {
-    return [];
-  }
-
-  return signature
-    .split("|")
-    .map((part) => part.trim())
-    .filter((part) => part.startsWith("stalled-bot:"))
-    .map((part) => part.slice("stalled-bot:".length).trim())
-    .filter((threadId) => threadId.length > 0);
-}
-
-function staleConfiguredBotReviewProgressKey(args: {
-  headSha: string;
-  signature: string;
-  threadId: string;
-  phase: "reply" | "resolve";
-}): string {
-  return `${args.phase}:${args.threadId}@${args.headSha}:${args.signature}`;
-}
-
-function appendBoundedUniqueStringEntry(existing: string[] | undefined, value: string): string[] {
-  return Array.from(new Set([...(existing ?? []).filter((entry) => entry !== value), value])).slice(-200);
-}
-
-async function persistStaleConfiguredBotReviewProgress(args: {
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  syncJournal: IssueJournalSync;
-  patch: Pick<IssueRunRecord, "stale_review_bot_reply_progress_keys" | "stale_review_bot_resolve_progress_keys">;
-}): Promise<IssueRunRecord> {
-  const updatedRecord = args.stateStore.touch(args.record, args.patch);
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
-async function maybeHandleTrackedPrStaleConfiguredBotReview(args: {
-  github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  reviewThreads: ReviewThread[];
-  syncJournal: IssueJournalSync;
-  config: SupervisorConfig;
-  failureContext: FailureContext | null;
-  resolveAfterReply: boolean;
-  reasonCode?: string;
-}): Promise<IssueRunRecord> {
-  if (!args.github.replyToReviewThread) {
-    return args.record;
-  }
-  if (args.resolveAfterReply && !args.github.resolveReviewThread) {
-    return args.record;
-  }
-
-  const blockerSignature = args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
-  if (
-    args.record.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
-    args.record.last_stale_review_bot_reply_signature === blockerSignature
-  ) {
-    return args.record;
-  }
-
-  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
-  const replyThreadIds = staleConfiguredBotReplyThreadIds(blockerSignature);
-  if (replyThreadIds.length === 0) {
-    return args.record;
-  }
-
-  const replyThreads = replyThreadIds
-    .map((threadId) => configuredThreads.find((thread) => thread.id === threadId) ?? null)
-    .filter((thread): thread is ReviewThread => thread !== null);
-  if (replyThreads.length !== replyThreadIds.length) {
-    return args.record;
-  }
-
-  let record = args.record;
-  const replyProgressKeys = new Set(record.stale_review_bot_reply_progress_keys ?? []);
-  const resolveProgressKeys = new Set(record.stale_review_bot_resolve_progress_keys ?? []);
-
-  try {
-    for (const replyThread of replyThreads) {
-      const replyKey = staleConfiguredBotReviewProgressKey({
-        headSha: args.pr.headRefOid,
-        signature: blockerSignature,
-        threadId: replyThread.id,
-        phase: "reply",
-      });
-      if (!replyProgressKeys.has(replyKey)) {
-        const replyBody = buildStaleConfiguredBotReplyBody({
-          issueNumber: record.issue_number,
-          pr: args.pr,
-          thread: replyThread,
-          failureContext: args.failureContext,
-          resolveAfterReply: args.resolveAfterReply,
-          reasonCode: args.reasonCode,
-        });
-        await args.github.replyToReviewThread(replyThread.id, replyBody);
-        record = await persistStaleConfiguredBotReviewProgress({
-          stateStore: args.stateStore,
-          state: args.state,
-          record,
-          syncJournal: args.syncJournal,
-          patch: {
-            stale_review_bot_reply_progress_keys: appendBoundedUniqueStringEntry(
-              record.stale_review_bot_reply_progress_keys,
-              replyKey,
-            ),
-            stale_review_bot_resolve_progress_keys: record.stale_review_bot_resolve_progress_keys ?? [],
-          },
-        });
-        replyProgressKeys.add(replyKey);
-      }
-
-      if (args.resolveAfterReply) {
-        const resolveKey = staleConfiguredBotReviewProgressKey({
-          headSha: args.pr.headRefOid,
-          signature: blockerSignature,
-          threadId: replyThread.id,
-          phase: "resolve",
-        });
-        if (!resolveProgressKeys.has(resolveKey)) {
-          await args.github.resolveReviewThread?.(replyThread.id);
-          record = await persistStaleConfiguredBotReviewProgress({
-            stateStore: args.stateStore,
-            state: args.state,
-            record,
-            syncJournal: args.syncJournal,
-            patch: {
-              stale_review_bot_reply_progress_keys: record.stale_review_bot_reply_progress_keys ?? [],
-              stale_review_bot_resolve_progress_keys: appendBoundedUniqueStringEntry(
-                record.stale_review_bot_resolve_progress_keys,
-                resolveKey,
-              ),
-            },
-          });
-          resolveProgressKeys.add(resolveKey);
-        }
-      }
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(
-      `Failed to ${args.resolveAfterReply ? "reply-and-resolve" : "publish"} stale configured-bot reply for PR #${args.pr.number}: ${truncate(message, 500) ?? "unknown error"}`,
-    );
-    return record;
-  }
-
-  const updatedRecord = args.stateStore.touch(record, {
-    last_stale_review_bot_reply_head_sha: args.pr.headRefOid,
-    last_stale_review_bot_reply_signature: blockerSignature,
-  });
-  args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-  await args.stateStore.save(args.state);
-  await args.syncJournal(updatedRecord);
-  return updatedRecord;
-}
-
 export async function maybeCommentOnTrackedPrHostLocalBlocker(args: {
   github: Partial<Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">>;
   stateStore: Pick<StateStore, "touch" | "save">;
@@ -918,7 +726,7 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
 
   let currentRecord = args.record;
   if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
-    const repliedRecord = await maybeHandleTrackedPrStaleConfiguredBotReview({
+    const recoveryResult = await recoverStaleConfiguredBotReviewThreads({
       github: args.github,
       stateStore: args.stateStore,
       state: args.state,
@@ -936,14 +744,15 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
         ? "verified_current_head_repair_auto_resolve"
         : canResolveVerifiedNoSourceChangeThreadResolution
         ? "verified_no_source_change_auto_resolve"
-        : TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT,
+        : STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
     });
-    currentRecord = repliedRecord;
+    const repliedRecord = recoveryResult.record;
+    currentRecord = recoveryResult.record;
     const replyHandled =
       repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
       repliedRecord.last_stale_review_bot_reply_signature ===
-        (args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT);
-    if (replyHandled) {
+        (args.failureContext?.signature ?? STALE_CONFIGURED_BOT_REVIEW_REASON_CODE);
+    if (replyHandled || recoveryResult.status === "replied" || recoveryResult.status === "resolved") {
       return repliedRecord;
     }
   }


### PR DESCRIPTION
## Summary
- extract stale configured-bot reply and resolve orchestration into `stale-review-bot-recovery`
- return typed recovery results for no-op, replied, resolved, skipped, and failed paths
- keep post-turn refresh detection on shared resolve progress keys

## Verification
- `npx tsx --test src/supervisor/stale-review-bot-recovery.test.ts src/tracked-pr-status-comment.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 1996 --config <supervisor-config-path>`

Fixes #1996