### PR TITLE
Normalize Codex Connector convergence policy result types

### DIFF
--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -535,6 +535,25 @@ test("evaluateCodexConnectorConvergencePolicy separates missing, must-fix, nitpi
   assert.equal(evaluateCodexConnectorConvergencePolicy(config, currentHeadPr, [])?.outcome, "converged");
 });
 
+function assertCodexConnectorConvergencePolicyResultTypes(): void {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const result = evaluateCodexConnectorConvergencePolicy(
+    config,
+    { configuredBotCurrentHeadObservedAt: "2026-03-11T00:04:00Z" },
+    [],
+  );
+  if (result?.outcome === "converged") {
+    assert.equal(result.findingCount, 0);
+    assert.equal(result.mergeEffect, "ready");
+    assert.equal(result.nextAction, "merge_ready");
+    // @ts-expect-error converged results must not expose outcome-specific must-fix counts.
+    void result.mustFixCount;
+    // @ts-expect-error converged results must not expose outcome-specific nitpick counts.
+    void result.nitpickCount;
+  }
+}
+void assertCodexConnectorConvergencePolicyResultTypes;
+
 test("actionableBotReviewThreads treats Codex Connector P2 as actionable by default", () => {
   const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
   const record = createReviewRecord();

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -105,12 +105,59 @@ export type CodexConnectorConvergencePolicyOutcome =
   | "nitpick_only"
   | "converged";
 
-export interface CodexConnectorConvergencePolicyResult {
-  outcome: CodexConnectorConvergencePolicyOutcome;
+export type CodexConnectorConvergenceMergeEffect = "blocked" | "nitpick_only" | "ready";
+
+export type CodexConnectorConvergenceNextAction =
+  | "request_current_head_review"
+  | "repair_must_fix_findings"
+  | "merge_or_follow_up_nitpicks"
+  | "merge_ready";
+
+interface CodexConnectorConvergencePolicyBase {
   currentHeadObservedAt: string | null;
+  findingCount: number;
+  mergeEffect: CodexConnectorConvergenceMergeEffect;
+  highestSeverity: CodexConnectorPSeverity | "nitpick_only" | "none";
+  nextAction: CodexConnectorConvergenceNextAction;
+}
+
+export interface CodexConnectorMissingCurrentHeadReviewPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "missing_current_head_review";
+  currentHeadObservedAt: null;
+  mergeEffect: "blocked";
+  nextAction: "request_current_head_review";
+}
+
+export interface CodexConnectorMustFixRemainingPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "must_fix_remaining";
+  mergeEffect: "blocked";
+  nextAction: "repair_must_fix_findings";
   mustFixCount: number;
+}
+
+export interface CodexConnectorNitpickOnlyPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "nitpick_only";
+  currentHeadObservedAt: string;
+  mergeEffect: "nitpick_only";
+  highestSeverity: "nitpick_only";
+  nextAction: "merge_or_follow_up_nitpicks";
   nitpickCount: number;
 }
+
+export interface CodexConnectorConvergedPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "converged";
+  currentHeadObservedAt: string;
+  findingCount: 0;
+  mergeEffect: "ready";
+  highestSeverity: "none";
+  nextAction: "merge_ready";
+}
+
+export type CodexConnectorConvergencePolicyResult =
+  | CodexConnectorMissingCurrentHeadReviewPolicyResult
+  | CodexConnectorMustFixRemainingPolicyResult
+  | CodexConnectorNitpickOnlyPolicyResult
+  | CodexConnectorConvergedPolicyResult;
 
 function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {
   return { P0: 0, P1: 1, P2: 2, P3: 3 }[severity];
@@ -158,15 +205,20 @@ export function evaluateCodexConnectorConvergencePolicy(
     return null;
   }
 
-  const mustFixCount = codexConnectorMustFixReviewThreads(reviewThreads).length;
+  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
+  const mustFixCount = mustFixThreads.length;
   const nitpickCount = codexConnectorNitpickOnlyReviewThreads(reviewThreads).length;
   const currentHeadObservedAt = validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  const findingCount = mustFixCount + nitpickCount;
   if (mustFixCount > 0) {
     return {
       outcome: "must_fix_remaining",
       currentHeadObservedAt,
+      findingCount,
+      mergeEffect: "blocked",
+      highestSeverity: maxCodexConnectorPSeverity(mustFixThreads),
+      nextAction: "repair_must_fix_findings",
       mustFixCount,
-      nitpickCount,
     };
   }
 
@@ -174,8 +226,10 @@ export function evaluateCodexConnectorConvergencePolicy(
     return {
       outcome: "missing_current_head_review",
       currentHeadObservedAt: null,
-      mustFixCount,
-      nitpickCount,
+      findingCount,
+      mergeEffect: "blocked",
+      highestSeverity: nitpickCount > 0 ? "nitpick_only" : "none",
+      nextAction: "request_current_head_review",
     };
   }
 
@@ -183,7 +237,10 @@ export function evaluateCodexConnectorConvergencePolicy(
     return {
       outcome: "nitpick_only",
       currentHeadObservedAt,
-      mustFixCount,
+      findingCount,
+      mergeEffect: "nitpick_only",
+      highestSeverity: "nitpick_only",
+      nextAction: "merge_or_follow_up_nitpicks",
       nitpickCount,
     };
   }
@@ -191,8 +248,10 @@ export function evaluateCodexConnectorConvergencePolicy(
   return {
     outcome: "converged",
     currentHeadObservedAt,
-    mustFixCount,
-    nitpickCount,
+    findingCount: 0,
+    mergeEffect: "ready",
+    highestSeverity: "none",
+    nextAction: "merge_ready",
   };
 }
 

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -10,10 +10,7 @@ import {
 import { displayLocalCiCommand } from "../core/config-parsing";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
-import {
-  buildCodexConnectorPolicyBlockDiagnostic,
-  evaluateCodexConnectorConvergencePolicy,
-} from "../review-thread-reporting";
+import { evaluateCodexConnectorConvergencePolicy } from "../review-thread-reporting";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
@@ -469,10 +466,8 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   const hasCurrentHeadProviderSuccess = Boolean(
     args.record.provider_success_observed_at && args.record.provider_success_head_sha === currentHeadSha,
   );
-  const findingCount = policy.mustFixCount + policy.nitpickCount;
-  const policyBlock = buildCodexConnectorPolicyBlockDiagnostic(args.config, args.reviewThreads);
-  const highestSeverity =
-    policyBlock?.severity ?? (policy.nitpickCount > 0 ? "nitpick_only" : "none");
+  const findingCount = policy.findingCount;
+  const highestSeverity = policy.highestSeverity;
 
   let status:
     | "contradictory_evidence"
@@ -484,7 +479,7 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     | "missing_current_head_review"
     | "nitpick_only"
     | "converged";
-  let mergeEffect: "blocked" | "nitpick_only" | "ready";
+  let mergeEffect = policy.mergeEffect;
   let nextAction:
     | "fail_closed_inspect_connector_state"
     | "wait_for_current_head_signal"
@@ -496,7 +491,6 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
 
   if (hasCurrentHeadProviderSuccess && policy.outcome !== "converged" && policy.outcome !== "nitpick_only") {
     status = "contradictory_evidence";
-    mergeEffect = "blocked";
     nextAction = "fail_closed_inspect_connector_state";
   } else if (staleSignalHeadSha) {
     status = "stale_head";
@@ -504,24 +498,20 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     nextAction = "wait_for_current_head_signal";
   } else if (policy.outcome === "must_fix_remaining") {
     status = "repairing_must_fix";
-    mergeEffect = "blocked";
-    nextAction = "repair_must_fix_findings";
+    nextAction = policy.nextAction;
   } else if (policy.outcome === "missing_current_head_review") {
     status = requestMatchesCurrentHead
       ? "re_requested_review"
       : hydratedRequestMatchesCurrentHead
         ? "same_head_request_hydrated"
         : "missing_current_head_review";
-    mergeEffect = "blocked";
     nextAction = requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead ? "wait_for_requested_review" : "request_current_head_review";
   } else if (policy.outcome === "nitpick_only") {
     status = "nitpick_only";
-    mergeEffect = "nitpick_only";
-    nextAction = "merge_or_follow_up_nitpicks";
+    nextAction = policy.nextAction;
   } else {
     status = "converged";
-    mergeEffect = "ready";
-    nextAction = "merge_ready";
+    nextAction = policy.nextAction;
   }
 
   const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);


### PR DESCRIPTION
## Summary
- normalize Codex Connector convergence policy results into outcome-specific typed variants
- expose centralized finding count, highest severity, merge effect, and default next action from the policy result
- update convergence diagnostics to consume the normalized result instead of recomputing from counts

## Verification
- npm run build
- npx tsx --test src/review-thread-reporting.test.ts src/pull-request-state-policy.test.ts src/pull-request-state-provider-wait-policy.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts
- npm run verify:paths
- node dist/index.js issue-lint 1997 --config <host-codex-supervisor-config>

Closes #1997