### PR TITLE
Persist Codex turn verification timeline evidence

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -98,6 +98,7 @@ export type TimelineArtifactOutcome =
 
 export type TimelineArtifactGate =
   | "local_ci"
+  | "codex_turn"
   | "workspace_preparation"
   | "workstation_local_path_hygiene";
 

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -230,6 +230,163 @@ test("executeCodexTurnPhase does not mark review threads processed for a refresh
   assert.deepEqual(resolvePurposes, ["action"]);
 });
 
+test("executeCodexTurnPhase persists explicit successful Codex verification for the current PR head", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = createIssue({
+    title: "Persist Codex verification evidence",
+  });
+  const pr: GitHubPullRequest = createPullRequest({
+    headRefOid: "head-verified",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: 116,
+        last_head_sha: "head-verified",
+      }),
+    },
+  };
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    pr,
+    checks: [],
+    reviewThreads: [],
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-verified",
+    },
+  });
+  let journalReads = 0;
+
+  const result = await executeCodexTurnPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => pr,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context,
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-13T06:20:00Z",
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "pr_open",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({
+        branch: "codex/issue-102",
+        headSha: "head-verified",
+      }),
+    agentRunner: createSuccessfulAgentRunner(async () => ({
+      exitCode: 0,
+      sessionId: "session-102",
+      supervisorMessage: [
+        "Summary: Verified the remaining Codex Connector review fixes.",
+        "State hint: pr_open",
+        "Blocked reason: none",
+        "Tests: npx tsx --test src/run-once-turn-execution.test.ts",
+        "Failure signature: none",
+        "Next action: open PR",
+      ].join("\n"),
+      stderr: "",
+      stdout: "",
+      structuredResult: {
+        summary: "Verified the remaining Codex Connector review fixes.",
+        stateHint: "pr_open",
+        blockedReason: null,
+        failureSignature: null,
+        nextAction: "open PR",
+        tests: "npx tsx --test src/run-once-turn-execution.test.ts",
+      },
+      failureKind: null,
+      failureContext: null,
+    })),
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: persist successful Codex verification.",
+          ].join("\n")
+        : [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: persist successful Codex verification.",
+            "- What changed: implemented the current-head verification evidence.",
+            "- Next exact step: inspect the refreshed PR state.",
+          ].join("\n");
+    },
+  });
+
+  assert.equal(result.kind, "completed");
+  assert.deepEqual(result.record.timeline_artifacts, [
+    {
+      type: "verification_result",
+      gate: "codex_turn",
+      command: "npx tsx --test src/run-once-turn-execution.test.ts",
+      head_sha: "head-verified",
+      outcome: "passed",
+      remediation_target: null,
+      next_action: "continue",
+      summary: "Verified the remaining Codex Connector review fixes.",
+      recorded_at: result.record.timeline_artifacts?.[0]?.recorded_at ?? "",
+    },
+  ]);
+});
+
+
 test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned journal normalization commits", async (t) => {
   const workspacePath = await createTrackedRepo();
   t.after(async () => {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -386,6 +386,150 @@ test("executeCodexTurnPhase persists explicit successful Codex verification for 
   ]);
 });
 
+test("executeCodexTurnPhase rejects ambiguous Codex verification evidence", async () => {
+  const config = createConfig();
+  const issue: GitHubIssue = createIssue({
+    title: "Reject ambiguous Codex verification evidence",
+  });
+  const pr: GitHubPullRequest = createPullRequest({
+    headRefOid: "head-verified",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "stabilizing",
+        pr_number: 116,
+        last_head_sha: "head-verified",
+      }),
+    },
+  };
+  const context = createCodexTurnContext({
+    state,
+    record: state.issues["102"]!,
+    issue,
+    pr,
+    checks: [],
+    reviewThreads: [],
+    workspaceStatus: {
+      branch: "codex/issue-102",
+      headSha: "head-verified",
+    },
+  });
+  let journalReads = 0;
+
+  const result = await executeCodexTurnPhase({
+    config,
+    stateStore: {
+      touch: (record, patch) => ({
+        ...record,
+        ...patch,
+        updated_at: record.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => pr,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context,
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-03-13T06:20:00Z",
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "pr_open",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async () => {
+      throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+    },
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({
+        branch: "codex/issue-102",
+        headSha: "head-verified",
+      }),
+    agentRunner: createSuccessfulAgentRunner(async () => ({
+      exitCode: 0,
+      sessionId: "session-102",
+      supervisorMessage: [
+        "Summary: Reviewed the remaining Codex Connector findings.",
+        "State hint: pr_open",
+        "Blocked reason: none",
+        "Tests: remaining review findings look addressed",
+        "Failure signature: none",
+        "Next action: open PR",
+      ].join("\n"),
+      stderr: "",
+      stdout: "",
+      structuredResult: {
+        summary: "Reviewed the remaining Codex Connector findings.",
+        stateHint: "pr_open",
+        blockedReason: null,
+        failureSignature: null,
+        nextAction: "open PR",
+        tests: "remaining review findings look addressed",
+      },
+      failureKind: null,
+      failureContext: null,
+    })),
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: persist only explicit command-backed verification.",
+          ].join("\n")
+        : [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: persist only explicit command-backed verification.",
+            "- What changed: reviewed ambiguous evidence handling.",
+            "- Next exact step: inspect the refreshed PR state.",
+          ].join("\n");
+    },
+  });
+
+  assert.equal(result.kind, "completed");
+  assert.equal(result.record.timeline_artifacts, undefined);
+});
+
 
 test("executeCodexTurnPhase refreshes review bookkeeping after supervisor-owned journal normalization commits", async (t) => {
   const workspacePath = await createTrackedRepo();

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -69,6 +69,7 @@ import {
 } from "./interrupted-turn-marker";
 import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate";
+import { upsertTimelineArtifact } from "./timeline-artifacts";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -106,6 +107,35 @@ export interface CodexTurnResult {
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
   "Normalize trusted durable artifacts for path hygiene";
+
+function explicitPassingCodexTurnVerificationCommand(
+  tests: string | null | undefined,
+): string | null {
+  const value = tests?.trim();
+  if (!value) {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  if (
+    normalized === "not run" ||
+    normalized === "none" ||
+    normalized.includes("not run") ||
+    normalized.includes("no tests") ||
+    normalized.includes("failed") ||
+    normalized.includes("failure") ||
+    normalized.includes("blocked") ||
+    normalized.includes("skipped")
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function conciseCodexVerificationSummary(summary: string | null | undefined): string {
+  const value = summary?.trim();
+  return truncate(value && value.length > 0 ? value : "Codex turn verification passed.", 500) ??
+    "Codex turn verification passed.";
+}
 
 export interface CodexTurnShortCircuit {
   kind: "returned";
@@ -1070,6 +1100,43 @@ export async function executeCodexTurnPhase(
           ? postRunSnapshot.nextState
           : (hintedState ??
             args.inferStateWithoutPullRequest(record, workspaceStatus));
+        const codexVerificationCommand =
+          explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
+        const codexTurnVerificationHeadSha =
+          pr &&
+          codexVerificationCommand &&
+          workspaceStatus.headSha === pr.headRefOid &&
+          postRunState !== "blocked" &&
+          postRunState !== "failed"
+            ? pr.headRefOid
+            : null;
+        const codexTurnVerificationTimelineArtifacts =
+          pr &&
+          codexVerificationCommand &&
+          codexTurnVerificationHeadSha
+            ? upsertTimelineArtifact(
+                record,
+                {
+                  type: "verification_result",
+                  gate: "codex_turn",
+                  command: codexVerificationCommand,
+                  head_sha: codexTurnVerificationHeadSha,
+                  outcome: "passed",
+                  remediation_target: null,
+                  next_action: "continue",
+                  summary: conciseCodexVerificationSummary(
+                    structuredResult?.summary,
+                  ),
+                  recorded_at: new Date().toISOString(),
+                },
+                (candidate) =>
+                  candidate.type === "verification_result" &&
+                  candidate.gate === "codex_turn" &&
+                  candidate.outcome === "passed" &&
+                  candidate.head_sha === codexTurnVerificationHeadSha &&
+                  candidate.command === codexVerificationCommand,
+              )
+            : null;
         const preserveStaleNoPrRecoveryTracking =
           pr === null &&
           postRunSnapshot === null &&
@@ -1120,6 +1187,9 @@ export async function executeCodexTurnPhase(
                   reviewThreads,
                 )
               : null,
+          ...(codexTurnVerificationTimelineArtifacts
+            ? { timeline_artifacts: codexTurnVerificationTimelineArtifacts }
+            : {}),
           state: postRunState,
           ...(pr === null &&
           (postRunState === "blocked" || postRunState === "failed")

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -108,6 +108,57 @@ export interface CodexTurnResult {
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
   "Normalize trusted durable artifacts for path hygiene";
 
+const CODEX_TURN_VERIFICATION_COMMAND_NAMES = [
+  "npm",
+  "npx",
+  "pnpm",
+  "yarn",
+  "bun",
+  "node",
+  "deno",
+  "tsx",
+  "tsc",
+  "ts-node",
+  "jest",
+  "vitest",
+  "mocha",
+  "playwright",
+  "pytest",
+  "python",
+  "python3",
+  "uv",
+  "go",
+  "cargo",
+  "make",
+  "cmake",
+  "mvn",
+  "gradle",
+  "bash",
+  "sh",
+  "zsh",
+  "ruby",
+  "bundle",
+  "rspec",
+  "eslint",
+  "prettier",
+  "ruff",
+  "mypy",
+  "gh",
+  "git",
+].join("|");
+const CODEX_TURN_VERIFICATION_COMMAND_PATTERN = new RegExp(
+  `^(?:[\\\`$]\\s*)?(?:(?:${CODEX_TURN_VERIFICATION_COMMAND_NAMES})\\b|(?:\\.{0,2}/))`,
+  "i",
+);
+
+function hasExplicitCodexTurnVerificationCommandEvidence(value: string): boolean {
+  return value
+    .split(/[\n;]+/)
+    .map((candidate) => candidate.trim().replace(/^`+|`+$/g, "").trim())
+    .filter((candidate) => candidate.length > 0)
+    .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
+}
+
 function explicitPassingCodexTurnVerificationCommand(
   tests: string | null | undefined,
 ): string | null {
@@ -119,13 +170,24 @@ function explicitPassingCodexTurnVerificationCommand(
   if (
     normalized === "not run" ||
     normalized === "none" ||
+    normalized === "n/a" ||
+    normalized === "na" ||
     normalized.includes("not run") ||
     normalized.includes("no tests") ||
     normalized.includes("failed") ||
     normalized.includes("failure") ||
+    normalized.includes("error") ||
+    normalized.includes("timeout") ||
     normalized.includes("blocked") ||
-    normalized.includes("skipped")
+    normalized.includes("skipped") ||
+    normalized.includes("stale") ||
+    normalized.includes("ambiguous") ||
+    normalized.includes("unclear") ||
+    normalized.includes("?")
   ) {
+    return null;
+  }
+  if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {
     return null;
   }
   return value;

--- a/src/supervisor/replay-corpus-validation.ts
+++ b/src/supervisor/replay-corpus-validation.ts
@@ -64,6 +64,7 @@ const LOCAL_CI_REMEDIATION_TARGETS = [
 const TIMELINE_ARTIFACT_TYPES = ["verification_result", "path_hygiene_result"] as const;
 const TIMELINE_ARTIFACT_GATES = [
   "local_ci",
+  "codex_turn",
   "workspace_preparation",
   "workstation_local_path_hygiene",
 ] as const;

--- a/src/timeline-artifacts.ts
+++ b/src/timeline-artifacts.ts
@@ -89,6 +89,16 @@ export function appendTimelineArtifact(
   return [...(record.timeline_artifacts ?? []), artifact].slice(-MAX_TIMELINE_ARTIFACTS);
 }
 
+export function upsertTimelineArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  artifact: TimelineArtifact,
+  matches: (candidate: TimelineArtifact) => boolean,
+): TimelineArtifact[] {
+  const existingArtifacts = record.timeline_artifacts ?? [];
+  const retainedArtifacts = existingArtifacts.filter((candidate) => !matches(candidate));
+  return [...retainedArtifacts, artifact].slice(-MAX_TIMELINE_ARTIFACTS);
+}
+
 export function nextActionForRemediationTarget(
   remediationTarget: LocalCiRemediationTarget | null,
 ): string {
@@ -210,6 +220,8 @@ function timelineEventFromArtifact(record: IssueRunRecord, artifact: TimelineArt
   const eventType: IssueRunTimelineEventType =
     artifact.gate === "workstation_local_path_hygiene"
       ? "path_hygiene"
+      : artifact.gate === "codex_turn"
+        ? "codex_turn"
       : artifact.gate === "workspace_preparation"
         ? "publication_gate"
         : "local_ci";


### PR DESCRIPTION
## Summary
- persist structured successful Codex turn verification as `verification_result` timeline artifacts on the current tracked PR head
- add `codex_turn` timeline gate support across artifact export and replay validation
- cover the current-head happy path with a focused `executeCodexTurnPhase` regression test

## Verification
- `npx tsx --test src/run-once-turn-execution.test.ts src/timeline-artifacts.test.ts src/supervisor/supervisor-status-report.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 1998 --config <supervisor-config-path>`
- `npm run verify:paths`

Closes #1998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Codex turn verification and result persistence in the execution pipeline
  * Codex turn phases now automatically record verification outcomes and success status
  * Added support for validating and tracking Codex turn artifacts throughout the execution lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->