### PR TITLE
Avoid false negative Codex verification commands

### DIFF
--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -386,6 +386,170 @@ test("executeCodexTurnPhase persists explicit successful Codex verification for 
   ]);
 });
 
+test("executeCodexTurnPhase accepts command-backed Codex verification with failure-adjacent path tokens", async () => {
+  const commands = [
+    "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+    "npm run test:error-reporter",
+    "node ./scripts/failed-fixture-verification.js",
+  ];
+
+  for (const command of commands) {
+    const config = createConfig();
+    const issue: GitHubIssue = createIssue({
+      title: "Persist Codex verification evidence with path tokens",
+    });
+    const pr: GitHubPullRequest = createPullRequest({
+      headRefOid: "head-verified",
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": createRecord({
+          state: "stabilizing",
+          pr_number: 116,
+          last_head_sha: "head-verified",
+        }),
+      },
+    };
+    const context = createCodexTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      checks: [],
+      reviewThreads: [],
+      workspaceStatus: {
+        branch: "codex/issue-102",
+        headSha: "head-verified",
+      },
+    });
+    let journalReads = 0;
+
+    const result = await executeCodexTurnPhase({
+      config,
+      stateStore: {
+        touch: (record, patch) => ({
+          ...record,
+          ...patch,
+          updated_at: record.updated_at,
+        }),
+        save: async () => undefined,
+      },
+      github: {
+        resolvePullRequestForBranch: async () => pr,
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => {
+          throw new Error("unexpected getExternalReviewSurface call");
+        },
+      },
+      context,
+      acquireSessionLock: async () => null,
+      classifyFailure: () => "command_error",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-03-13T06:20:00Z",
+      }),
+      applyFailureSignature: () => ({
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+      }),
+      normalizeBlockerSignature: () => null,
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: (record) => ({
+        recordForState: record,
+        nextState: "pr_open",
+        failureContext: null,
+        reviewWaitPatch: {},
+        copilotRequestObservationPatch: {},
+        mergeLatencyVisibilityPatch: {
+          provider_success_observed_at: null,
+          provider_success_head_sha: null,
+          merge_readiness_last_evaluated_at: null,
+        },
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: null,
+          copilot_review_timeout_action: null,
+          copilot_review_timeout_reason: null,
+        },
+      }),
+      inferStateWithoutPullRequest: () => "stabilizing",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async () => {
+        throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+      },
+      getWorkspaceStatus: async () =>
+        createWorkspaceStatus({
+          branch: "codex/issue-102",
+          headSha: "head-verified",
+        }),
+      agentRunner: createSuccessfulAgentRunner(async () => ({
+        exitCode: 0,
+        sessionId: "session-102",
+        supervisorMessage: [
+          "Summary: Verified the remaining Codex Connector review fixes.",
+          "State hint: pr_open",
+          "Blocked reason: none",
+          `Tests: ${command}`,
+          "Failure signature: none",
+          "Next action: open PR",
+        ].join("\n"),
+        stderr: "",
+        stdout: "",
+        structuredResult: {
+          summary: "Verified the remaining Codex Connector review fixes.",
+          stateHint: "pr_open",
+          blockedReason: null,
+          failureSignature: null,
+          nextAction: "open PR",
+          tests: command,
+        },
+        failureKind: null,
+        failureContext: null,
+      })),
+      readIssueJournal: async () => {
+        journalReads += 1;
+        return journalReads === 1
+          ? [
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: persist successful Codex verification with path tokens.",
+            ].join("\n")
+          : [
+              "## Codex Working Notes",
+              "### Current Handoff",
+              "- Hypothesis: persist successful Codex verification with path tokens.",
+              "- What changed: implemented the path-token verification evidence.",
+              "- Next exact step: inspect the refreshed PR state.",
+            ].join("\n");
+      },
+    });
+
+    assert.equal(result.kind, "completed");
+    assert.deepEqual(result.record.timeline_artifacts, [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command,
+        head_sha: "head-verified",
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Verified the remaining Codex Connector review fixes.",
+        recorded_at: result.record.timeline_artifacts?.[0]?.recorded_at ?? "",
+      },
+    ]);
+  }
+});
+
 test("executeCodexTurnPhase rejects ambiguous Codex verification evidence", async () => {
   const config = createConfig();
   const issue: GitHubIssue = createIssue({

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -159,13 +159,7 @@ function hasExplicitCodexTurnVerificationCommandEvidence(value: string): boolean
     .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
 }
 
-function explicitPassingCodexTurnVerificationCommand(
-  tests: string | null | undefined,
-): string | null {
-  const value = tests?.trim();
-  if (!value) {
-    return null;
-  }
+function hasExplicitNegativeCodexTurnVerificationOutcome(value: string): boolean {
   const normalized = value.toLowerCase();
   if (
     normalized === "not run" ||
@@ -174,17 +168,26 @@ function explicitPassingCodexTurnVerificationCommand(
     normalized === "na" ||
     normalized.includes("not run") ||
     normalized.includes("no tests") ||
-    normalized.includes("failed") ||
-    normalized.includes("failure") ||
-    normalized.includes("error") ||
-    normalized.includes("timeout") ||
-    normalized.includes("blocked") ||
-    normalized.includes("skipped") ||
-    normalized.includes("stale") ||
+    normalized.includes("stale head") ||
     normalized.includes("ambiguous") ||
     normalized.includes("unclear") ||
     normalized.includes("?")
   ) {
+    return true;
+  }
+  return /(?:^|\s)(?:failed|failure|error|timeout|blocked|skipped)(?=$|[\s:.,;])/i.test(
+    value,
+  );
+}
+
+function explicitPassingCodexTurnVerificationCommand(
+  tests: string | null | undefined,
+): string | null {
+  const value = tests?.trim();
+  if (!value) {
+    return null;
+  }
+  if (hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
     return null;
   }
   if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {


### PR DESCRIPTION
## Summary
- refine Codex-turn verification outcome detection so command/path tokens like `stale`, `error`, and `failed` do not suppress successful command-backed evidence
- add focused regression coverage for current-head `codex_turn` verification artifacts with failure-adjacent command/path tokens

## Verification
- `npx tsx --test src/run-once-turn-execution.test.ts`
- `npx tsx --test src/run-once-turn-execution.test.ts src/timeline-artifacts.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2005 --config ../../codex-supervisor-self/supervisor.config.codex.json`

## Notes
- `npm test` was also run for stronger verification, but it failed in unrelated existing areas: architecture placement guard tests and supervisor recovery-reconciliation expectation mismatches.

Closes #2005
