### PR TITLE
Exercise codex_turn verified repair auto-resolve

### DIFF
--- a/src/codex-connector-tracked-pr-test-helpers.ts
+++ b/src/codex-connector-tracked-pr-test-helpers.ts
@@ -21,6 +21,7 @@ type CodexConnectorTrackedReviewScenarioOptions = {
     summary: string;
     ranAt: string;
     command: string;
+    evidenceSource?: "latest_local_ci_result" | "codex_turn_timeline_artifact";
   };
 };
 
@@ -67,7 +68,7 @@ export function createCodexConnectorTrackedReviewResidueScenario({
       updated_at: "2026-05-15T00:20:00Z",
     },
   };
-  if (verifiedRepair) {
+  if (verifiedRepair?.evidenceSource !== "codex_turn_timeline_artifact" && verifiedRepair) {
     recordPatch.latest_local_ci_result = {
       outcome: "passed",
       summary: verifiedRepair.summary,
@@ -78,6 +79,21 @@ export function createCodexConnectorTrackedReviewResidueScenario({
       failure_class: null,
       remediation_target: null,
     };
+  } else if (verifiedRepair) {
+    recordPatch.latest_local_ci_result = null;
+    recordPatch.timeline_artifacts = [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: verifiedRepair.command,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: verifiedRepair.summary,
+        recorded_at: verifiedRepair.ranAt,
+      },
+    ];
   }
 
   return {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4520,6 +4520,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
       summary: "Focused verifier passed after the repair commit.",
       ranAt: "2026-05-15T00:18:00Z",
       command: "npm test -- src/post-turn-pull-request.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
     },
   });
   const pr = createPullRequest(scenario.pullRequestPatch);
@@ -4603,6 +4604,229 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
   assert.equal(requestComments.length, 1);
   assert.match(requestComments[0] ?? "", /@codex review/);
   assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1988 head=head-1988/);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase keeps verified repair thread resolution fail-closed without opt-in or current codex_turn evidence", async () => {
+  const cases: Array<{
+    name: string;
+    autoResolve?: boolean;
+    reviewThreadAuthor?: { login: string; typeName: "Bot" | "User" };
+    timelineArtifacts: IssueRunRecord["timeline_artifacts"];
+  }> = [
+    {
+      name: "repair opt-in disabled",
+      autoResolve: false,
+      timelineArtifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npx tsx --test src/post-turn-pull-request.test.ts",
+          head_sha: "head-2000",
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed after the repair commit.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+    {
+      name: "missing codex_turn artifact",
+      timelineArtifacts: [],
+    },
+    {
+      name: "failed codex_turn artifact",
+      timelineArtifacts: [
+        {
+          type: "verification_result" as const,
+          gate: "codex_turn" as const,
+          command: "npx tsx --test src/post-turn-pull-request.test.ts",
+          head_sha: "head-2000",
+          outcome: "failed" as const,
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier failed after the repair commit.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+    {
+      name: "stale-head codex_turn artifact",
+      timelineArtifacts: [
+        {
+          type: "verification_result" as const,
+          gate: "codex_turn" as const,
+          command: "npx tsx --test src/post-turn-pull-request.test.ts",
+          head_sha: "stale-head-2000",
+          outcome: "passed" as const,
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed before the repair commit.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+    {
+      name: "different-head codex_turn artifact",
+      timelineArtifacts: [
+        {
+          type: "verification_result" as const,
+          gate: "codex_turn" as const,
+          command: "npx tsx --test src/post-turn-pull-request.test.ts",
+          head_sha: "head-elsewhere",
+          outcome: "passed" as const,
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed on another PR head.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+    {
+      name: "current-head non-codex verification artifact",
+      timelineArtifacts: [
+        {
+          type: "verification_result" as const,
+          gate: "workspace_preparation" as const,
+          command: "node dist/index.js issue-lint 2000 --config <supervisor-config-path>",
+          head_sha: "head-2000",
+          outcome: "passed" as const,
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Workspace preparation passed but is not repair verification.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+    {
+      name: "manual review thread",
+      reviewThreadAuthor: { login: "human-reviewer", typeName: "User" },
+      timelineArtifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npx tsx --test src/post-turn-pull-request.test.ts",
+          head_sha: "head-2000",
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed after the repair commit.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+    {
+      name: "unconfigured bot review thread",
+      reviewThreadAuthor: { login: "unconfigured-review-bot", typeName: "Bot" },
+      timelineArtifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npx tsx --test src/post-turn-pull-request.test.ts",
+          head_sha: "head-2000",
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed after the repair commit.",
+          recorded_at: "2026-05-15T00:18:00Z",
+        },
+      ],
+    },
+  ];
+
+  for (const testCase of cases) {
+    const config = createConfig({
+      reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+      verifiedCurrentHeadRepairReviewThreadAutoResolve: testCase.autoResolve ?? true,
+    });
+    const issue = createIssue({ title: `Keep ${testCase.name} blocked` });
+    const scenario = createCodexConnectorTrackedReviewResidueScenario({
+      issueNumber: issue.number,
+      prNumber: 2000,
+      headSha: "head-2000",
+      threadId: `thread-${testCase.name.replace(/[^a-z0-9]+/giu, "-")}`,
+      commentId: `comment-${testCase.name.replace(/[^a-z0-9]+/giu, "-")}`,
+      path: "src/review.ts",
+      line: 7,
+      commentBody: "P1: Verify the repair covers this finding before merge.",
+      discussionUrl: "https://example.test/pr/2000#discussion_r2000",
+    });
+    const pr = createPullRequest(scenario.pullRequestPatch);
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": createRecord({
+          ...scenario.recordPatch,
+          latest_local_ci_result: null,
+          timeline_artifacts: testCase.timelineArtifacts,
+        }),
+      },
+    };
+    const reviewThread = testCase.reviewThreadAuthor
+      ? {
+          ...scenario.reviewThread,
+          comments: {
+            nodes: scenario.reviewThread.comments.nodes.map((comment) => ({
+              ...comment,
+              author: testCase.reviewThreadAuthor!,
+            })),
+          },
+        }
+      : scenario.reviewThread;
+    const replyCalls: Array<{ threadId: string; body: string }> = [];
+    const resolveCalls: string[] = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async () => {
+          throw new Error("unexpected addIssueComment call");
+        },
+        replyToReviewThread: async (threadId: string, body: string) => {
+          replyCalls.push({ threadId, body });
+        },
+        resolveReviewThread: async (threadId: string) => {
+          resolveCalls.push(threadId);
+        },
+      }),
+      context: createPostTurnContext({
+        state,
+        record: state.issues["102"]!,
+        issue,
+        pr,
+        workspacePath: path.join("/tmp/workspaces", "issue-102"),
+      }),
+      derivePullRequestLifecycleSnapshot: (recordForState) =>
+        createLifecycleSnapshot(recordForState, "blocked", {
+          failureContext: scenario.staleReviewFailureContext,
+        }),
+      applyFailureSignature: (_record, failureContext) => ({
+        last_failure_signature: failureContext?.signature ?? null,
+        repeated_failure_signature_count: failureContext ? 1 : 0,
+      }),
+      blockedReasonFromReviewState: () => "stale_review_bot",
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+      runLocalCiCommand: async () => undefined,
+      runWorkstationLocalPathGate: async () => ({
+        ok: true,
+        failureContext: null,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: scenario.passingChecks,
+        reviewThreads: [reviewThread],
+      }),
+    });
+
+    assert.equal(result.record.state, "blocked", testCase.name);
+    assert.deepEqual(replyCalls, [], testCase.name);
+    assert.deepEqual(resolveCalls, [], testCase.name);
+  }
 });
 
 test("handlePostTurnPullRequestTransitionsPhase does not resolve stale configured-bot review threads until metadata-only evidence is satisfied", async () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -147,6 +147,7 @@ function currentHeadVerificationEvidenceSummary(
   const timelineEvidence = (record.timeline_artifacts ?? []).find(
     (artifact) =>
       artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid,
   );

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1430,6 +1430,7 @@ test("explain distinguishes Codex verified current-head repair residue from no-s
       summary: "Focused verifier passed after the repair commit.",
       ranAt: "2026-05-15T00:18:00Z",
       command: "npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
     },
   });
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1005,6 +1005,7 @@ test("status --why distinguishes codex verified current-head repair residue from
       summary: "Focused verifier passed after the repair commit.",
       ranAt: "2026-05-13T00:18:00Z",
       command: "npm test -- src/supervisor/supervisor-diagnostics-status-selection.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
     },
   });
   const state: SupervisorStateFile = {
@@ -1070,6 +1071,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
       summary: "Focused verifier passed after the repair commit.",
       ranAt: "2026-05-15T00:18:00Z",
       command: "npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
     },
   });
   const state: SupervisorStateFile = {


### PR DESCRIPTION
## Summary
- require timeline verified-repair evidence to come from passed current-head codex_turn artifacts
- add codex_turn fixtures for verified repair stale review-bot remediation diagnostics
- cover post-turn reply/resolve/refresh success plus opt-in disabled, invalid evidence, manual-thread, and unconfigured-bot fail-closed cases

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build
- node dist/index.js issue-lint 2000 --config <supervisor-config-path>

Closes #2000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for verified repair thread resolution, including comprehensive edge cases with missing, failed, stale, or incompatible verification evidence scenarios.
  * Updated test fixtures with configuration options for verification evidence source.

* **Chores**
  * Enhanced verification evidence filtering logic to support multiple storage location types for verification results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->