### PR TITLE
Cluster configured bot review findings

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -985,6 +985,100 @@ This stale handoff history should not be replayed into a targeted thread repair 
   assert.doesNotMatch(prompt, /On-demand durable memory files:/);
 });
 
+test("buildCodexPrompt groups repeated Codex Connector findings into root-cause repair groups", () => {
+  const pr = createPullRequest({
+    number: 144,
+    headRefOid: "head-connector-144",
+  });
+  const missingVerifierBody =
+    "P1: Missing verifier coverage lets failed restore writes leave a half-restored durable state. Add a regression that proves the restore failure rolls back every persisted record.";
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "addressing_review" satisfies RunState,
+    pr,
+    checks: [],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-restore-service",
+        path: "src/restore.ts",
+        line: 42,
+        comments: {
+          nodes: [
+            {
+              id: "comment-restore-service",
+              body: missingVerifierBody,
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/144#discussion_r2",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-restore-test",
+        path: "src/restore.test.ts",
+        line: 88,
+        comments: {
+          nodes: [
+            {
+              id: "comment-restore-test",
+              body: missingVerifierBody,
+              createdAt: "2026-03-11T00:06:00Z",
+              url: "https://example.test/pr/144#discussion_r3",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-unrelated",
+        path: "src/export.ts",
+        line: 12,
+        comments: {
+          nodes: [
+            {
+              id: "comment-unrelated",
+              body: "P2: Export readiness must reject mixed-snapshot rows instead of stitching partial results together.",
+              createdAt: "2026-03-11T00:07:00Z",
+              url: "https://example.test/pr/144#discussion_r4",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Root-cause repair group 1/);
+  assert.match(prompt, /Thread IDs: thread-restore-service, thread-restore-test/);
+  assert.match(prompt, /Representative source URLs:/);
+  assert.match(prompt, /https:\/\/example\.test\/pr\/144#discussion_r2/);
+  assert.match(prompt, /https:\/\/example\.test\/pr\/144#discussion_r3/);
+  assert.match(prompt, /Affected files: src\/restore\.ts, src\/restore\.test\.ts/);
+  assert.match(prompt, /Root-cause repair group 2/);
+  assert.match(prompt, /Thread IDs: thread-unrelated/);
+  assert.equal((prompt.match(/Missing verifier coverage/g) ?? []).length, 1);
+});
+
 test("buildCodexPrompt keeps explicit operator overrides during addressing_review", () => {
   const prompt = buildCodexPrompt({
     repoSlug: "owner/repo",

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -6,6 +6,7 @@ import {
   buildCodexConnectorP2P3PolicyDiagnostic,
   actionableBotReviewThreads,
   buildStalledBotReviewFailureContext,
+  clusterConfiguredBotReviewThreads,
   codexConnectorMustFixReviewThreads,
   configuredBotReviewFollowUpState,
   evaluateCodexConnectorConvergencePolicy,
@@ -483,6 +484,79 @@ test("buildCodexConnectorP2P3PolicyDiagnostic distinguishes actionable, softened
     p3Softened: 1,
     p3Escalated: 1,
   });
+});
+
+test("clusterConfiguredBotReviewThreads groups repeated signatures while preserving audit evidence", () => {
+  const repeatedBody =
+    "P1: Missing verifier coverage lets failed restore writes leave a half-restored durable state. Add a regression.";
+  const firstThread = createReviewThread({
+    id: "thread-restore",
+    path: "src/restore.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-restore",
+          body: repeatedBody,
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const secondThread = createReviewThread({
+    id: "thread-restore-test",
+    path: "src/restore.test.ts",
+    line: 88,
+    comments: {
+      nodes: [
+        {
+          id: "comment-restore-test",
+          body: repeatedBody,
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const unrelatedThread = createReviewThread({
+    id: "thread-export",
+    path: "src/export.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-export",
+          body: "P2: Export readiness must reject mixed-snapshot rows instead of stitching partial results together.",
+          createdAt: "2026-03-11T00:02:00Z",
+          url: "https://example.test/pr/44#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const clusters = clusterConfiguredBotReviewThreads([firstThread, secondThread, unrelatedThread]);
+
+  assert.equal(clusters.length, 2);
+  assert.deepEqual(clusters[0]?.threads.map((thread) => thread.id), ["thread-restore", "thread-restore-test"]);
+  assert.deepEqual(clusters[0]?.files, ["src/restore.ts", "src/restore.test.ts"]);
+  assert.deepEqual(clusters[0]?.sourceUrls, [
+    "https://example.test/pr/44#discussion_r1",
+    "https://example.test/pr/44#discussion_r2",
+  ]);
+  assert.deepEqual(clusters[1]?.threads.map((thread) => thread.id), ["thread-export"]);
 });
 
 test("evaluateCodexConnectorConvergencePolicy separates missing, must-fix, nitpick-only, and converged outcomes", () => {

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -527,6 +527,25 @@ test("clusterConfiguredBotReviewThreads groups repeated signatures while preserv
       ],
     },
   });
+  const malformedUrlThread = createReviewThread({
+    id: "thread-restore-worker",
+    path: "src/restore-worker.ts",
+    line: 120,
+    comments: {
+      nodes: [
+        {
+          id: "comment-restore-worker",
+          body: repeatedBody,
+          createdAt: "2026-03-11T00:01:30Z",
+          url: undefined as unknown as string,
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
   const unrelatedThread = createReviewThread({
     id: "thread-export",
     path: "src/export.ts",
@@ -547,11 +566,15 @@ test("clusterConfiguredBotReviewThreads groups repeated signatures while preserv
     },
   });
 
-  const clusters = clusterConfiguredBotReviewThreads([firstThread, secondThread, unrelatedThread]);
+  const clusters = clusterConfiguredBotReviewThreads([firstThread, secondThread, malformedUrlThread, unrelatedThread]);
 
   assert.equal(clusters.length, 2);
-  assert.deepEqual(clusters[0]?.threads.map((thread) => thread.id), ["thread-restore", "thread-restore-test"]);
-  assert.deepEqual(clusters[0]?.files, ["src/restore.ts", "src/restore.test.ts"]);
+  assert.deepEqual(clusters[0]?.threads.map((thread) => thread.id), [
+    "thread-restore",
+    "thread-restore-test",
+    "thread-restore-worker",
+  ]);
+  assert.deepEqual(clusters[0]?.files, ["src/restore.ts", "src/restore.test.ts", "src/restore-worker.ts"]);
   assert.deepEqual(clusters[0]?.sourceUrls, [
     "https://example.test/pr/44#discussion_r1",
     "https://example.test/pr/44#discussion_r2",

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -439,7 +439,9 @@ export function clusterConfiguredBotReviewThreads(reviewThreads: ReviewThread[])
     if (existing) {
       existing.threads.push(thread);
       existing.files = uniqueInOrder([...existing.files, thread.path ?? "unknown"]);
-      existing.sourceUrls = uniqueInOrder([...existing.sourceUrls, latestComment?.url ?? "n/a"]);
+      if (latestComment?.url) {
+        existing.sourceUrls = uniqueInOrder([...existing.sourceUrls, latestComment.url]);
+      }
       continue;
     }
 

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -373,23 +373,87 @@ export function buildCodexConnectorMustFixFindingDetails(args: {
   pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
   reviewThreads: ReviewThread[];
 }): string[] {
-  return codexConnectorMustFixReviewThreads(args.reviewThreads).map((thread, index) => {
-    const latestComment = latestReviewComment(thread);
-    const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
-    const lineRange = thread.line == null ? "unknown" : String(thread.line);
+  return clusterConfiguredBotReviewThreads(codexConnectorMustFixReviewThreads(args.reviewThreads)).map((cluster, index) => {
+    const representativeThread = cluster.threads[0];
+    const latestComment = latestReviewComment(representativeThread);
+    const lineRange = representativeThread.line == null ? "unknown" : String(representativeThread.line);
     return [
-      `- Finding ${index + 1}`,
+      `- Root-cause repair group ${index + 1}`,
       `  Policy: Codex Connector must_fix_remaining`,
-      `  Severity: ${latestCodexConnectorReview?.severity ?? "unknown"}`,
+      `  Severity: ${cluster.severity}`,
       `  PR: ${args.pr ? `#${args.pr.number}` : "unknown"}`,
       `  Head SHA: ${args.pr?.headRefOid ?? "unknown"}`,
+      `  Thread IDs: ${cluster.threads.map((thread) => thread.id).join(", ")}`,
+      `  Affected files: ${cluster.files.join(", ")}`,
+      `  Representative source URLs: ${cluster.sourceUrls.join(", ") || "n/a"}`,
       `  Source URL: ${latestComment?.url ?? "n/a"}`,
-      `  File: ${thread.path ?? "unknown"}`,
+      `  File: ${representativeThread.path ?? "unknown"}`,
       `  Line range: ${lineRange}`,
-      `  Summary: ${extractReviewCommentSummary(latestComment?.body ?? "")}`,
-      `  Latest relevant comment: ${extractReviewCommentSummary(latestComment?.body ?? "")}`,
+      `  Summary: ${cluster.summary}`,
+      ...(cluster.threads.length === 1
+        ? [`  Latest relevant comment: ${extractReviewCommentSummary(latestComment?.body ?? "")}`]
+        : []),
+      `  Evidence: ${cluster.threads
+        .map((thread) => {
+          const comment = latestReviewComment(thread);
+          return `${thread.id} ${thread.path ?? "unknown"}:${thread.line ?? "?"} ${comment?.url ?? "n/a"}`;
+        })
+        .join("; ")}`,
     ].join("\n");
   });
+}
+
+export interface ConfiguredBotReviewThreadCluster {
+  severity: CodexConnectorPSeverity | "unknown";
+  summary: string;
+  signature: string;
+  threads: ReviewThread[];
+  files: string[];
+  sourceUrls: string[];
+}
+
+function normalizeReviewThreadSignature(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/`[^`]+`/g, " ")
+    .replace(/\b\d+\b/g, "#")
+    .replace(/[^a-z0-9#]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function uniqueInOrder(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function clusterConfiguredBotReviewThreads(reviewThreads: ReviewThread[]): ConfiguredBotReviewThreadCluster[] {
+  const clusters = new Map<string, ConfiguredBotReviewThreadCluster>();
+
+  for (const thread of reviewThreads) {
+    const latestComment = latestReviewComment(thread);
+    const severity = latestCodexConnectorPSeverity(thread) ?? "unknown";
+    const summary = extractReviewCommentSummary(latestComment?.body ?? "");
+    const signature = `${severity}:${normalizeReviewThreadSignature(summary) || thread.id}`;
+    const existing = clusters.get(signature);
+    if (existing) {
+      existing.threads.push(thread);
+      existing.files = uniqueInOrder([...existing.files, thread.path ?? "unknown"]);
+      existing.sourceUrls = uniqueInOrder([...existing.sourceUrls, latestComment?.url ?? "n/a"]);
+      continue;
+    }
+
+    clusters.set(signature, {
+      severity,
+      summary,
+      signature,
+      threads: [thread],
+      files: [thread.path ?? "unknown"],
+      sourceUrls: latestComment?.url ? [latestComment.url] : [],
+    });
+  }
+
+  return [...clusters.values()];
 }
 
 export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {


### PR DESCRIPTION
## Summary
- cluster Codex Connector must-fix review threads into root-cause repair groups
- preserve thread IDs, source URLs, affected files, and per-thread evidence in the addressing-review prompt
- add focused regression coverage for grouped and standalone findings

## Verification
- npx tsx --test src/review-thread-reporting.test.ts src/codex/codex-prompt.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts
- npm run build

Part of #2009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex Connector findings are now grouped into "root-cause repair groups" when multiple findings share identical patterns, consolidating affected files and source references.

* **Tests**
  * Added test coverage for review thread clustering and grouping logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->