### PR TITLE
Switch repeated review repair prompts to root cause analysis

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -814,6 +814,67 @@ test("buildCodexPrompt suppresses stale handoff next actions during addressing_r
   assert.match(prompt, /Live review guidance should take priority over stale handoff steps\./);
 });
 
+test("buildCodexPrompt switches repeated addressing-review failures to root-cause analysis", () => {
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig(),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 2,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_failure_signature: "1 unresolved automated review thread(s) remain.",
+      last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+      last_tracked_pr_repeat_failure_decision: "retry_on_progress",
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason:
+        "repeated_failure_signature_count=2; signature=1 unresolved automated review thread(s) remain.; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
+    },
+    pr: createPullRequest({
+      number: 144,
+      headRefOid: "head-review-144",
+      reviewDecision: "CHANGES_REQUESTED",
+    }),
+    checks: [],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-repeat",
+        path: "src/review.ts",
+        line: 42,
+        comments: {
+          nodes: [
+            {
+              id: "comment-repeat",
+              body: "The same current-head repair still does not prove the root cause.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/144#discussion_r2",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Addressing-review strategy switch:/);
+  assert.match(prompt, /Triggered: root_cause_analysis/);
+  assert.match(prompt, /tracked_pr_progress=no_meaningful_tracked_pr_progress/);
+  assert.match(prompt, /Do not continue another narrow patch-only pass against the same review comment\./);
+  assert.match(prompt, /First reproduce the blocker or prove the unresolved-thread cluster from current code and tests\./);
+  assert.match(prompt, /Group the repeated comments by root cause/);
+  assert.match(prompt, /do not weaken attempt limits, merge gates, or configured review-bot requirements/);
+});
+
 test("buildCodexPrompt adds structured Codex Connector must-fix guidance only for Codex Connector addressing_review", () => {
   const pr = createPullRequest({
     number: 144,

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -4,6 +4,7 @@ import {
   FailureContext,
   GitHubIssue,
   GitHubPullRequest,
+  IssueRunRecord,
   PullRequestCheck,
   ReviewThread,
   RunState,
@@ -360,6 +361,17 @@ export interface BuildCodexStartPromptInput {
   branch: string;
   workspacePath: string;
   state: RunState;
+  record?: Partial<
+    Pick<
+      IssueRunRecord,
+      | "repeated_failure_signature_count"
+      | "last_failure_signature"
+      | "last_tracked_pr_progress_summary"
+      | "last_tracked_pr_repeat_failure_decision"
+      | "addressing_review_strategy"
+      | "addressing_review_strategy_reason"
+    >
+  > | null;
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
@@ -376,6 +388,40 @@ export interface BuildCodexStartPromptInput {
   localReviewRepairContext?: LocalReviewRepairContext | null;
   externalReviewMissContext?: ExternalReviewMissContext | null;
   reviewProviderProfile?: ReviewProviderProfileSummary;
+}
+
+function buildAddressingReviewStrategySwitch(input: Pick<BuildCodexStartPromptInput, "state" | "record" | "failureContext">): string[] {
+  if (input.state !== "addressing_review") {
+    return [];
+  }
+
+  const record = input.record;
+  const repeatedFailureSignatureCount = record?.repeated_failure_signature_count ?? 0;
+  const strategy =
+    record?.addressing_review_strategy ??
+    (record?.last_failure_signature && repeatedFailureSignatureCount >= 2 ? "root_cause_analysis" : null);
+  if (strategy !== "root_cause_analysis") {
+    return [];
+  }
+
+  const reason =
+    record?.addressing_review_strategy_reason ??
+    [
+      `repeated_failure_signature_count=${record?.repeated_failure_signature_count ?? "unknown"}`,
+      `signature=${record?.last_failure_signature ?? input.failureContext?.signature ?? "unknown"}`,
+      `tracked_pr_progress=${record?.last_tracked_pr_progress_summary ?? "unknown"}`,
+      `repeat_decision=${record?.last_tracked_pr_repeat_failure_decision ?? "pending"}`,
+    ].join("; ");
+
+  return [
+    "Addressing-review strategy switch:",
+    `- Triggered: root_cause_analysis`,
+    `- Reason: ${reason}`,
+    "- Do not continue another narrow patch-only pass against the same review comment.",
+    "- First reproduce the blocker or prove the unresolved-thread cluster from current code and tests.",
+    "- Group the repeated comments by root cause, then make the smallest focused test update that would have caught the repeated failure.",
+    "- Only after that root-cause grouping should you patch code, and do not weaken attempt limits, merge gates, or configured review-bot requirements.",
+  ];
 }
 
 export interface BuildCodexResumePromptInput {
@@ -647,6 +693,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
             : []),
         ]
       : [];
+  const addressingReviewStrategySwitch = buildAddressingReviewStrategySwitch(input);
   const journalOperatorOverrides = useCodexConnectorReviewThreadFastPath
     ? extractJournalOperatorOverrides(input.journalExcerpt)
     : [];
@@ -729,6 +776,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     "",
     "Structured failure context:",
     failureSummary,
+    ...(addressingReviewStrategySwitch.length > 0 ? ["", ...addressingReviewStrategySwitch] : []),
     ...(localReviewRepairSummary.length > 0 ? ["", ...localReviewRepairSummary] : []),
     ...(externalReviewMissSummary.length > 0 ? ["", ...externalReviewMissSummary] : []),
     ...(freshReviewCommentEvidenceExamples.length > 0 ? ["", ...freshReviewCommentEvidenceExamples] : []),
@@ -899,6 +947,7 @@ function toStartPromptInput(input: StartAgentTurnContext): BuildCodexStartPrompt
     branch: input.branch,
     workspacePath: input.workspacePath,
     state: input.state,
+    record: input.record,
     pr: input.pr,
     checks: input.checks,
     reviewThreads: input.reviewThreads,

--- a/src/core/state-store-normalization.test.ts
+++ b/src/core/state-store-normalization.test.ts
@@ -162,3 +162,33 @@ test("normalizeStateForLoad defaults Codex Connector retry bookkeeping", () => {
   assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_node_id, null);
   assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_url, null);
 });
+
+test("normalizeStateForLoad clamps persisted addressing review strategy fields", () => {
+  const loaded = normalizeStateForLoad({
+    activeIssueNumber: null,
+    issues: {
+      "2011": {
+        ...createRecord(2011),
+        addressing_review_strategy: "root_cause_analysis",
+        addressing_review_strategy_reason: "same failure signature repeated",
+      },
+      "2012": {
+        ...createRecord(2012),
+        addressing_review_strategy: "skip_root_cause_switch",
+        addressing_review_strategy_reason: "should not survive without a valid strategy",
+      } as unknown as IssueRunRecord,
+      "2013": {
+        ...createRecord(2013),
+        addressing_review_strategy: "normal_patch",
+        addressing_review_strategy_reason: "   ",
+      },
+    },
+  } satisfies SupervisorStateFile);
+
+  assert.equal(loaded.issues["2011"]?.addressing_review_strategy, "root_cause_analysis");
+  assert.equal(loaded.issues["2011"]?.addressing_review_strategy_reason, "same failure signature repeated");
+  assert.equal(loaded.issues["2012"]?.addressing_review_strategy, null);
+  assert.equal(loaded.issues["2012"]?.addressing_review_strategy_reason, null);
+  assert.equal(loaded.issues["2013"]?.addressing_review_strategy, "normal_patch");
+  assert.equal(loaded.issues["2013"]?.addressing_review_strategy_reason, null);
+});

--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -163,6 +163,8 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     last_tracked_pr_progress_snapshot: value.last_tracked_pr_progress_snapshot ?? null,
     last_tracked_pr_progress_summary: value.last_tracked_pr_progress_summary ?? null,
     last_tracked_pr_repeat_failure_decision: value.last_tracked_pr_repeat_failure_decision ?? null,
+    addressing_review_strategy: value.addressing_review_strategy ?? null,
+    addressing_review_strategy_reason: value.addressing_review_strategy_reason ?? null,
     last_observed_host_local_pr_blocker_signature: value.last_observed_host_local_pr_blocker_signature ?? null,
     last_observed_host_local_pr_blocker_head_sha: value.last_observed_host_local_pr_blocker_head_sha ?? null,
     last_host_local_pr_blocker_comment_signature: value.last_host_local_pr_blocker_comment_signature ?? null,

--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -90,7 +90,20 @@ function normalizeInventoryRefreshDiagnostics(
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function normalizeAddressingReviewStrategy(value: unknown): IssueRunRecord["addressing_review_strategy"] {
+  return value === "normal_patch" || value === "root_cause_analysis" ? value : null;
+}
+
+function normalizeAddressingReviewStrategyReason(
+  value: unknown,
+  strategy: IssueRunRecord["addressing_review_strategy"],
+): string | null {
+  return strategy && typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
 export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
+  const addressingReviewStrategy = normalizeAddressingReviewStrategy(value.addressing_review_strategy);
+
   return {
     ...value,
     journal_path: value.journal_path ?? null,
@@ -163,8 +176,11 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     last_tracked_pr_progress_snapshot: value.last_tracked_pr_progress_snapshot ?? null,
     last_tracked_pr_progress_summary: value.last_tracked_pr_progress_summary ?? null,
     last_tracked_pr_repeat_failure_decision: value.last_tracked_pr_repeat_failure_decision ?? null,
-    addressing_review_strategy: value.addressing_review_strategy ?? null,
-    addressing_review_strategy_reason: value.addressing_review_strategy_reason ?? null,
+    addressing_review_strategy: addressingReviewStrategy,
+    addressing_review_strategy_reason: normalizeAddressingReviewStrategyReason(
+      value.addressing_review_strategy_reason,
+      addressingReviewStrategy,
+    ),
     last_observed_host_local_pr_blocker_signature: value.last_observed_host_local_pr_blocker_signature ?? null,
     last_observed_host_local_pr_blocker_head_sha: value.last_observed_host_local_pr_blocker_head_sha ?? null,
     last_host_local_pr_blocker_comment_signature: value.last_host_local_pr_blocker_comment_signature ?? null,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -291,6 +291,8 @@ export interface IssueRunRecord {
   last_tracked_pr_progress_snapshot?: string | null;
   last_tracked_pr_progress_summary?: string | null;
   last_tracked_pr_repeat_failure_decision?: "retry_on_progress" | "stop_no_progress" | null;
+  addressing_review_strategy?: "normal_patch" | "root_cause_analysis" | null;
+  addressing_review_strategy_reason?: string | null;
   last_observed_host_local_pr_blocker_signature?: string | null;
   last_observed_host_local_pr_blocker_head_sha?: string | null;
   ready_promotion_maintenance_finding_details?: string[];

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -35,8 +35,20 @@ interface AgentRunnerBaseRequest {
   state: RunState;
   record?: Pick<
     IssueRunRecord,
-    "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"
-  > | null;
+    | "repeated_failure_signature_count"
+    | "blocked_verification_retry_count"
+    | "timeout_retry_count"
+  > &
+    Partial<
+      Pick<
+        IssueRunRecord,
+        | "last_failure_signature"
+        | "last_tracked_pr_progress_summary"
+        | "last_tracked_pr_repeat_failure_decision"
+        | "addressing_review_strategy"
+        | "addressing_review_strategy_reason"
+      >
+    > | null;
   repoSlug: string;
   issue: GitHubIssue;
   branch: string;

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -4,6 +4,7 @@ import {
   attemptBudgetForLane,
   attemptLane,
   attemptsUsedForLane,
+  addressingReviewStrategyPatch,
   hasAttemptBudgetRemaining,
   incrementAttemptCounters,
   isEligibleForSelection,
@@ -214,6 +215,46 @@ test("attempt helpers split implementation and repair budgets without using tota
     attempt_count: 9,
     implementation_attempt_count: 2,
     repair_attempt_count: 7,
+  });
+});
+
+test("addressingReviewStrategyPatch switches repeated review failures to root-cause analysis", () => {
+  assert.deepEqual(
+    addressingReviewStrategyPatch(
+      createRecord({
+        state: "addressing_review",
+        last_failure_signature: "review-thread-cluster-a",
+        repeated_failure_signature_count: 2,
+        last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+        last_tracked_pr_repeat_failure_decision: "retry_on_progress",
+      }),
+      "addressing_review",
+    ),
+    {
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason:
+        "repeated_failure_signature_count=2; signature=review-thread-cluster-a; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
+    },
+  );
+
+  assert.deepEqual(
+    addressingReviewStrategyPatch(
+      createRecord({
+        state: "addressing_review",
+        last_failure_signature: "review-thread-cluster-a",
+        repeated_failure_signature_count: 1,
+      }),
+      "addressing_review",
+    ),
+    {
+      addressing_review_strategy: "normal_patch",
+      addressing_review_strategy_reason: null,
+    },
+  );
+
+  assert.deepEqual(addressingReviewStrategyPatch(createRecord(), "repairing_ci"), {
+    addressing_review_strategy: null,
+    addressing_review_strategy_reason: null,
   });
 });
 

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -144,6 +144,38 @@ export function incrementAttemptCounters(
   };
 }
 
+export function addressingReviewStrategyPatch(
+  record: Pick<
+    IssueRunRecord,
+    | "last_failure_signature"
+    | "repeated_failure_signature_count"
+    | "last_tracked_pr_progress_summary"
+    | "last_tracked_pr_repeat_failure_decision"
+  >,
+  nextState: IssueRunRecord["state"],
+): Pick<IssueRunRecord, "addressing_review_strategy" | "addressing_review_strategy_reason"> {
+  if (
+    nextState !== "addressing_review" ||
+    !record.last_failure_signature ||
+    record.repeated_failure_signature_count < 2
+  ) {
+    return {
+      addressing_review_strategy: nextState === "addressing_review" ? "normal_patch" : null,
+      addressing_review_strategy_reason: null,
+    };
+  }
+
+  const progressSummary = record.last_tracked_pr_progress_summary ?? "no progress baseline";
+  const repeatDecision = record.last_tracked_pr_repeat_failure_decision ?? "pending";
+  return {
+    addressing_review_strategy: "root_cause_analysis",
+    addressing_review_strategy_reason:
+      `repeated_failure_signature_count=${record.repeated_failure_signature_count}; ` +
+      `signature=${record.last_failure_signature}; ` +
+      `tracked_pr_progress=${progressSummary}; repeat_decision=${repeatDecision}`,
+  };
+}
+
 export function isEligibleForSelection(record: IssueRunRecord | undefined, config: SupervisorConfig): boolean {
   if (!record) {
     return true;

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -90,6 +90,7 @@ import {
   attemptBudgetForLane,
   attemptLane,
   attemptsUsedForLane,
+  addressingReviewStrategyPatch,
   hasAttemptBudgetRemaining,
   incrementAttemptCounters,
   isVerificationBlockedMessage,
@@ -508,6 +509,7 @@ export class Supervisor {
       record = this.stateStore.touch(record, {
         state: nextState,
         ...incrementAttemptCounters(record, preRunAttemptLane),
+        ...addressingReviewStrategyPatch(record, nextState),
         last_failure_context: inferFailureContext(this.config, record, pr, checks, reviewThreads),
         blocked_reason: null,
       });


### PR DESCRIPTION
## Summary
- persist an addressing-review strategy and reason when repeated review failures recur
- switch repeated addressing-review prompts toward reproduction, root-cause grouping, and focused regression-test updates
- keep non-repeated review failures on the normal patch path

## Verification
- npx tsx --test src/codex/codex-prompt.test.ts src/supervisor/supervisor-execution-policy.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build

Closes #2011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent strategy switching for repeated review failures—when addressing feedback repeatedly fails, the system now switches to root-cause analysis guidance instead of continuing narrow patch attempts.
  * Enhanced prompt generation to provide specific instructions for identifying and resolving underlying blockers causing repeated rejections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->