### PR TITLE
Clarify Codex Connector review diagnostics

### DIFF
--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -28,6 +28,7 @@ import {
   configuredReviewStatusLabel,
   externalSignalReadinessDiagnostics,
   formatCodexConnectorConvergenceDiagnostic,
+  formatCodexConnectorOperatorDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
   inferReviewBotProfile,
   reviewBotDiagnostics,
@@ -46,6 +47,26 @@ import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-lo
 
 function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+}
+
+export function formatStaleReviewResidueOperatorDiagnostic(
+  remediation: NonNullable<ReturnType<typeof buildStaleReviewBotRemediation>>,
+): string {
+  const latestConfiguredBotReviewSha =
+    remediation.processedOnCurrentHead === "yes" ? remediation.currentHeadSha : "none";
+  const actionableCurrentDiffThreads =
+    remediation.classification === "unresolved_work" || remediation.classification === "unknown_needs_operator"
+      ? "unknown"
+      : "0";
+  return [
+    "codex_connector_operator_diagnostic",
+    "interpretation=stale_review_residue",
+    `current_head_sha=${sanitizeStatusValue(remediation.currentHeadSha)}`,
+    `latest_configured_bot_review_sha=${sanitizeStatusValue(latestConfiguredBotReviewSha)}`,
+    `current_head_review_signal=${remediation.codexCurrentHeadReviewState}`,
+    `actionable_current_diff_threads=${actionableCurrentDiffThreads}`,
+    `next_action=${remediation.manualNextStep}`,
+  ].join(" ");
 }
 
 export function sanitizeStatusValue(value: string | null | undefined): string | null {
@@ -232,6 +253,7 @@ export function buildInactiveDetailedStatusLines(
   }
   if (staleReviewBotRemediation) {
     lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));
+    lines.push(formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation));
   }
 
   if (latestRecoveryRecord?.last_recovery_reason && latestRecoveryRecord.last_recovery_at) {
@@ -335,6 +357,7 @@ export function buildActiveDetailedStatusLines(
     });
     if (staleReviewBotRemediation) {
       lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));
+      lines.push(formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation));
     }
     const codexConnectorPolicyBlock = buildCodexConnectorPolicyBlockDiagnostic(config, reviewThreads);
     if (codexConnectorPolicyBlock) {
@@ -388,6 +411,15 @@ export function buildActiveDetailedStatusLines(
     });
     if (codexConnectorConvergence) {
       lines.push(codexConnectorConvergence);
+    }
+    const codexConnectorOperatorDiagnostic = formatCodexConnectorOperatorDiagnostic({
+      config,
+      record: activeRecord,
+      pr,
+      reviewThreads,
+    });
+    if (codexConnectorOperatorDiagnostic) {
+      lines.push(codexConnectorOperatorDiagnostic);
     }
     lines.push(`pr_hydration provenance=${pr.hydrationProvenance ?? "unknown"} head_sha=${pr.headRefOid}`);
     lines.push(

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -425,6 +425,10 @@ test("explain distinguishes hydrated same-head Codex Connector review requests",
     explanation,
     /^codex_connector_convergence status=same_head_request_hydrated provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review$/m,
   );
+  assert.match(
+    explanation,
+    /^codex_connector_operator_diagnostic interpretation=review_gate_waiting current_head_sha=head-1958 latest_configured_bot_review_sha=none current_head_review_signal=missing actionable_current_diff_threads=0 next_action=wait_for_requested_review$/m,
+  );
 });
 
 test("explain surfaces loop-off as an operator blocker for active tracked work", async () => {
@@ -1407,6 +1411,10 @@ test("explain classifies processed Codex must-fix residue as missing-current-hea
   assert.match(
     explanation,
     /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.match(
+    explanation,
+    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=head-198 latest_configured_bot_review_sha=head-198 current_head_review_signal=missing actionable_current_diff_threads=0 next_action=resolve_verified_configured_bot_threads_then_rerun_supervisor$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -298,6 +298,10 @@ test("status --why distinguishes hydrated same-head Codex Connector review reque
     report.detailedStatusLines.join("\n"),
     /^codex_connector_convergence status=same_head_request_hydrated provider=codex current_head_sha=head-1958 current_head_observed_at=none latest_signal_head_sha=none highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_requested_review$/m,
   );
+  assert.match(
+    report.detailedStatusLines.join("\n"),
+    /^codex_connector_operator_diagnostic interpretation=review_gate_waiting current_head_sha=head-1958 latest_configured_bot_review_sha=none current_head_review_signal=missing actionable_current_diff_threads=0 next_action=wait_for_requested_review$/m,
+  );
 });
 
 test("status reports effective Codex routing for inherited defaults and explicit overrides", async (t) => {
@@ -564,6 +568,10 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
   assert.match(
     status,
     /^codex_connector_policy_block count=3 severity=P1 file=src\/supervisor\/policy\.ts line=42 thread_url=https:\/\/example\.test\/pr\/246#discussion_r1 next_action=fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path$/m,
+  );
+  assert.match(
+    status,
+    /^codex_connector_operator_diagnostic interpretation=actionable_current_diff current_head_sha=head-246 latest_configured_bot_review_sha=head-246 current_head_review_signal=observed actionable_current_diff_threads=3 next_action=repair_must_fix_findings$/m,
   );
   assert.match(status, /^codex_connector_policy_review p2_actionable=1 p3_softened=1 p3_escalated=1$/m);
   assert.doesNotMatch(status, /^codex_connector_policy_block .*severity=nitpick_only/m);
@@ -980,6 +988,10 @@ test("status --why includes codex processed-residue missing-current-head review 
   assert.match(
     status,
     /^stale_review_bot_remediation issue=#398 pr=#498 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/498#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.match(
+    status,
+    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a latest_configured_bot_review_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a current_head_review_signal=missing actionable_current_diff_threads=0 next_action=resolve_verified_configured_bot_threads_then_rerun_supervisor$/m,
   );
   assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
 });

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -32,12 +32,14 @@ import {
   loadStatusChangedFiles,
 } from "./supervisor-status-rendering";
 import {
+  formatStaleReviewResidueOperatorDiagnostic,
   formatLatestRecoveryStatusLine,
   formatNoActiveTrackedRecordClassificationLine,
 } from "./supervisor-detailed-status-assembly";
 import {
   externalSignalReadinessDiagnostics,
   formatCodexConnectorConvergenceDiagnostic,
+  formatCodexConnectorOperatorDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
 } from "./supervisor-status-review-bot";
 import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
@@ -114,6 +116,7 @@ export interface SupervisorExplainDto {
   activityContext: SupervisorIssueActivityContextDto | null;
   staleDiagnosticSummary?: string | null;
   staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
+  codexConnectorOperatorDiagnosticSummary?: string | null;
   codexConnectorPolicyBlockSummary?: string | null;
   codexConnectorReviewFallbackSummary?: string | null;
   codexConnectorConvergenceSummary?: string | null;
@@ -487,6 +490,17 @@ export async function buildIssueExplainDto(
         reviewThreads: explainReviewThreads,
       })
       : null;
+  const codexConnectorOperatorDiagnosticSummary =
+    staleReviewBotRemediation
+      ? formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation)
+      : record && pr && !trackedPrHydrationFailed
+        ? formatCodexConnectorOperatorDiagnostic({
+          config,
+          record,
+          pr,
+          reviewThreads: explainReviewThreads,
+        })
+        : null;
   const noActiveTrackedRecordSummary =
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
@@ -581,6 +595,7 @@ export async function buildIssueExplainDto(
       : null,
     staleDiagnosticSummary,
     staleReviewBotRemediation,
+    codexConnectorOperatorDiagnosticSummary,
     codexConnectorPolicyBlockSummary,
     codexConnectorReviewFallbackSummary,
     codexConnectorConvergenceSummary,
@@ -659,6 +674,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(localCiStatusLine ? [localCiStatusLine] : []),
     ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
+    ...(dto.codexConnectorOperatorDiagnosticSummary ? [dto.codexConnectorOperatorDiagnosticSummary] : []),
     ...(dto.codexConnectorPolicyBlockSummary ? [dto.codexConnectorPolicyBlockSummary] : []),
     ...(dto.codexConnectorReviewFallbackSummary ? [dto.codexConnectorReviewFallbackSummary] : []),
     ...(dto.codexConnectorConvergenceSummary ? [dto.codexConnectorConvergenceSummary] : []),

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -10,7 +10,10 @@ import {
 import { displayLocalCiCommand } from "../core/config-parsing";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
-import { evaluateCodexConnectorConvergencePolicy } from "../review-thread-reporting";
+import {
+  codexConnectorMustFixReviewThreads,
+  evaluateCodexConnectorConvergencePolicy,
+} from "../review-thread-reporting";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
@@ -529,6 +532,68 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     `highest_severity=${highestSeverity}`,
     `finding_count=${findingCount}`,
     `merge_effect=${mergeEffect}`,
+    `next_action=${nextAction}`,
+  ].join(" ");
+}
+
+export function formatCodexConnectorOperatorDiagnostic(args: {
+  config: SupervisorConfig;
+  record: Pick<
+    IssueRunRecord,
+    | "provider_success_head_sha"
+    | "provider_success_observed_at"
+    | "external_review_head_sha"
+    | "codex_connector_review_requested_observed_at"
+    | "codex_connector_review_requested_head_sha"
+  >;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+}): string | null {
+  if (!configuredReviewProviderKinds(args.config).includes("codex")) {
+    return null;
+  }
+
+  const policy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, args.reviewThreads);
+  if (!policy || (policy.outcome !== "missing_current_head_review" && policy.outcome !== "must_fix_remaining")) {
+    return null;
+  }
+
+  const currentHeadSha = args.pr.headRefOid;
+  const actionableCurrentDiffThreads = codexConnectorMustFixReviewThreads(args.reviewThreads).length;
+  const currentHeadReviewSignal =
+    policy.currentHeadObservedAt || args.record.provider_success_head_sha === currentHeadSha ? "observed" : "missing";
+  const latestConfiguredBotReviewSha =
+    currentHeadReviewSignal === "observed"
+      ? currentHeadSha
+      : args.record.provider_success_head_sha ?? args.record.external_review_head_sha ?? "none";
+  const requestMatchesCurrentHead = Boolean(
+    args.record.codex_connector_review_requested_observed_at &&
+      args.record.codex_connector_review_requested_head_sha === currentHeadSha,
+  );
+  const hydratedRequestMatchesCurrentHead = Boolean(
+    !requestMatchesCurrentHead &&
+      args.pr.codexConnectorReviewRequestedAt &&
+      args.pr.codexConnectorReviewRequestedHeadSha === currentHeadSha,
+  );
+  const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
+  const nextAction =
+    policy.outcome === "must_fix_remaining"
+      ? "repair_must_fix_findings"
+      : requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead
+        ? "wait_for_requested_review"
+        : waitWindow.status === "active"
+          ? "wait_for_current_head_signal"
+          : "request_current_head_review";
+  const interpretation =
+    policy.outcome === "must_fix_remaining" ? "actionable_current_diff" : "review_gate_waiting";
+
+  return [
+    "codex_connector_operator_diagnostic",
+    `interpretation=${interpretation}`,
+    `current_head_sha=${currentHeadSha}`,
+    `latest_configured_bot_review_sha=${latestConfiguredBotReviewSha}`,
+    `current_head_review_signal=${currentHeadReviewSignal}`,
+    `actionable_current_diff_threads=${actionableCurrentDiffThreads}`,
     `next_action=${nextAction}`,
   ].join(" ");
 }


### PR DESCRIPTION
## Summary
- add a Codex Connector operator diagnostic line for review-gate waiting, actionable current-diff blockers, and stale review residue
- surface PR head SHA, latest configured-bot review SHA when known, current-head review signal state, actionable thread count, and next action in status/explain
- tighten focused diagnostics coverage for status --why and explain

Closes #2012

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts
- npm run build