### PR TITLE
Add PR 1323 review repair replay cases

### DIFF
--- a/replay-corpus/cases/clustered-codex-review-repair-convergence/README.md
+++ b/replay-corpus/cases/clustered-codex-review-repair-convergence/README.md
@@ -1,0 +1,5 @@
+# Clustered Codex Review Repair Convergence
+
+This sanitized replay case models a PR #1323-style intervention gap without using the original repository, paths, or review text. It keeps the important shape: multiple same-head Codex Connector findings, several prior repair attempts, focused verifier evidence on the current head, and a current-head configured review signal that still reports must-fix findings.
+
+The expected behavior is to keep the supervisor in `addressing_review` with Codex runnable. This prevents the old narrow repair pattern from treating clustered current-head findings as already handled manual-review residue before a convergence repair pass has consumed the actual current-head evidence.

--- a/replay-corpus/cases/clustered-codex-review-repair-convergence/case.json
+++ b/replay-corpus/cases/clustered-codex-review-repair-convergence/case.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "clustered-codex-review-repair-convergence",
+  "issueNumber": 8132,
+  "title": "Clustered Codex review repair convergence",
+  "capturedAt": "2026-05-17T01:00:00Z"
+}

--- a/replay-corpus/cases/clustered-codex-review-repair-convergence/expected/replay-result.json
+++ b/replay-corpus/cases/clustered-codex-review-repair-convergence/expected/replay-result.json
@@ -1,0 +1,6 @@
+{
+  "nextState": "addressing_review",
+  "shouldRunCodex": true,
+  "blockedReason": "manual_review",
+  "failureSignature": "thread-auth-boundary|thread-verifier-drift|thread-handoff-state"
+}

--- a/replay-corpus/cases/clustered-codex-review-repair-convergence/input/snapshot.json
+++ b/replay-corpus/cases/clustered-codex-review-repair-convergence/input/snapshot.json
@@ -1,0 +1,195 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-05-17T01:00:00Z",
+  "issue": {
+    "number": 8132,
+    "title": "Clustered Codex review repair convergence",
+    "body": "Synthetic replay case for clustered current-head review repair convergence.",
+    "url": "https://example.test/issues/8132",
+    "state": "OPEN",
+    "updatedAt": "2026-05-17T00:58:00Z"
+  },
+  "local": {
+    "record": {
+      "issue_number": 8132,
+      "state": "addressing_review",
+      "branch": "codex/issue-8132",
+      "pr_number": 9132,
+      "workspace": ".",
+      "journal_path": ".codex-supervisor/issues/8132/issue-journal.md",
+      "attempt_count": 7,
+      "implementation_attempt_count": 2,
+      "repair_attempt_count": 5,
+      "timeout_retry_count": 0,
+      "blocked_verification_retry_count": 1,
+      "repeated_blocker_count": 1,
+      "repeated_failure_signature_count": 0,
+      "blocked_reason": null,
+      "last_error": "Clustered current-head Codex review findings still need a convergence repair pass.",
+      "last_failure_kind": null,
+      "last_failure_context": null,
+      "last_failure_signature": "codex-review-cluster:head-pr1323-replay",
+      "last_head_sha": "head-pr1323-replay",
+      "review_wait_started_at": "2026-05-17T00:52:00Z",
+      "review_wait_head_sha": "head-pr1323-replay",
+      "provider_success_observed_at": "2026-05-17T00:57:30Z",
+      "provider_success_head_sha": "head-pr1323-replay",
+      "merge_readiness_last_evaluated_at": "2026-05-17T00:58:30Z",
+      "copilot_review_requested_observed_at": null,
+      "copilot_review_requested_head_sha": null,
+      "copilot_review_timed_out_at": null,
+      "copilot_review_timeout_action": null,
+      "copilot_review_timeout_reason": null,
+      "local_review_head_sha": "head-pr1323-replay",
+      "local_review_blocker_summary": "Focused verifier still reports clustered review-repair residuals.",
+      "local_review_summary_path": ".codex-supervisor/local-review/issue-8132/head-pr1323-replay.md",
+      "local_review_run_at": "2026-05-17T00:56:00Z",
+      "local_review_max_severity": "high",
+      "local_review_findings_count": 3,
+      "local_review_root_cause_count": 2,
+      "local_review_verified_max_severity": "high",
+      "local_review_verified_findings_count": 2,
+      "local_review_recommendation": "changes_requested",
+      "local_review_degraded": false,
+      "last_local_review_signature": "local-review:clustered-current-head",
+      "repeated_local_review_signature_count": 2,
+      "latest_local_ci_result": {
+        "outcome": "passed",
+        "summary": "Focused replay verifier passed on the current head.",
+        "ran_at": "2026-05-17T00:55:30Z",
+        "head_sha": "head-pr1323-replay",
+        "execution_mode": "structured",
+        "command": "npm test -- src/supervisor/replay-corpus-runner.test.ts",
+        "stderr_summary": null,
+        "failure_class": null,
+        "remediation_target": null,
+        "verifier_drift_hint": null
+      },
+      "processed_review_thread_ids": [
+        "thread-auth-boundary@head-pr1323-replay",
+        "thread-verifier-drift@head-pr1323-replay"
+      ],
+      "processed_review_thread_fingerprints": [
+        "thread-auth-boundary@head-pr1323-replay#comment-auth-v1",
+        "thread-verifier-drift@head-pr1323-replay#comment-verifier-v1"
+      ],
+      "updated_at": "2026-05-17T00:58:45Z"
+    },
+    "workspaceStatus": {
+      "branch": "codex/issue-8132",
+      "headSha": "head-pr1323-replay",
+      "hasUncommittedChanges": false,
+      "baseAhead": 3,
+      "baseBehind": 0,
+      "remoteBranchExists": true,
+      "remoteAhead": 0,
+      "remoteBehind": 0
+    }
+  },
+  "github": {
+    "pullRequest": {
+      "number": 9132,
+      "title": "Clustered Codex review repair convergence",
+      "url": "https://example.test/pull/9132",
+      "state": "OPEN",
+      "createdAt": "2026-05-17T00:30:00Z",
+      "updatedAt": "2026-05-17T00:58:30Z",
+      "isDraft": false,
+      "reviewDecision": "CHANGES_REQUESTED",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "headRefName": "codex/issue-8132",
+      "headRefOid": "head-pr1323-replay",
+      "configuredBotCurrentHeadObservedAt": "2026-05-17T00:57:30Z",
+      "currentHeadCiGreenAt": "2026-05-17T00:55:30Z",
+      "configuredBotTopLevelReviewStrength": "blocking",
+      "configuredBotTopLevelReviewSubmittedAt": "2026-05-17T00:57:30Z",
+      "mergedAt": null
+    },
+    "checks": [
+      {
+        "name": "focused replay verifier",
+        "state": "SUCCESS",
+        "bucket": "pass",
+        "workflow": "verification"
+      }
+    ],
+    "reviewThreads": [
+      {
+        "id": "thread-auth-boundary",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "src/review/convergence.ts",
+        "line": 44,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-auth-v2",
+              "body": "P1: The repair path still trusts the old handoff summary instead of the current-head review evidence. Keep this blocked until the convergence pass consumes the current finding cluster.",
+              "createdAt": "2026-05-17T00:57:00Z",
+              "url": "https://example.test/pull/9132#discussion_r1",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "thread-verifier-drift",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "src/review/verifier.ts",
+        "line": 91,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-verifier-v2",
+              "body": "P2: The focused verifier update is present, but the repair loop has not rerun against this current-head cluster, so convergence is not proven.",
+              "createdAt": "2026-05-17T00:57:10Z",
+              "url": "https://example.test/pull/9132#discussion_r2",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "thread-handoff-state",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "src/recovery/current-head.ts",
+        "line": 118,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-handoff-v1",
+              "body": "P2: A stale local handoff_missing marker can still hide the current-head review result from the repair loop.",
+              "createdAt": "2026-05-17T00:57:20Z",
+              "url": "https://example.test/pull/9132#discussion_r3",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "decision": {
+    "nextState": "addressing_review",
+    "shouldRunCodex": true,
+    "blockedReason": null,
+    "failureContext": null
+  },
+  "operatorSummary": {
+    "latestRecoverySummary": null,
+    "retrySummary": "repair_attempts=5 focused_verifier=current_head",
+    "recoveryLoopSummary": null,
+    "activityContext": null
+  }
+}

--- a/replay-corpus/cases/current-head-success-clears-stale-handoff/README.md
+++ b/replay-corpus/cases/current-head-success-clears-stale-handoff/README.md
@@ -1,0 +1,3 @@
+# Current-Head Success Clears Stale Handoff
+
+This companion replay case keeps the current-head review-success path separate from the clustered repair case. It starts from stale local `handoff_missing` state and verifies that fresh PR facts, green checks, no unresolved review threads, and current-head configured review evidence converge to `ready_to_merge`.

--- a/replay-corpus/cases/current-head-success-clears-stale-handoff/case.json
+++ b/replay-corpus/cases/current-head-success-clears-stale-handoff/case.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "current-head-success-clears-stale-handoff",
+  "issueNumber": 8133,
+  "title": "Current-head success clears stale handoff",
+  "capturedAt": "2026-05-17T01:05:00Z"
+}

--- a/replay-corpus/cases/current-head-success-clears-stale-handoff/expected/replay-result.json
+++ b/replay-corpus/cases/current-head-success-clears-stale-handoff/expected/replay-result.json
@@ -1,0 +1,6 @@
+{
+  "nextState": "ready_to_merge",
+  "shouldRunCodex": false,
+  "blockedReason": null,
+  "failureSignature": null
+}

--- a/replay-corpus/cases/current-head-success-clears-stale-handoff/input/snapshot.json
+++ b/replay-corpus/cases/current-head-success-clears-stale-handoff/input/snapshot.json
@@ -1,0 +1,144 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-05-17T01:05:00Z",
+  "issue": {
+    "number": 8133,
+    "title": "Current-head success clears stale handoff",
+    "body": "Synthetic replay case for stale local handoff recovery after current-head review convergence.",
+    "url": "https://example.test/issues/8133",
+    "state": "OPEN",
+    "updatedAt": "2026-05-17T01:04:00Z"
+  },
+  "local": {
+    "record": {
+      "issue_number": 8133,
+      "state": "blocked",
+      "branch": "codex/issue-8133",
+      "pr_number": 9133,
+      "workspace": ".",
+      "journal_path": ".codex-supervisor/issues/8133/issue-journal.md",
+      "attempt_count": 6,
+      "implementation_attempt_count": 2,
+      "repair_attempt_count": 4,
+      "timeout_retry_count": 0,
+      "blocked_verification_retry_count": 0,
+      "repeated_blocker_count": 1,
+      "repeated_failure_signature_count": 1,
+      "blocked_reason": "handoff_missing",
+      "last_error": "A stale local handoff marker remained after the review provider converged.",
+      "last_failure_kind": null,
+      "last_failure_context": {
+        "category": "blocked",
+        "summary": "Stale local handoff marker remained after current-head review convergence.",
+        "signature": "handoff-missing:stale-local",
+        "command": null,
+        "details": [
+          "local_state=stale",
+          "current_head_review=observed"
+        ],
+        "url": null,
+        "updated_at": "2026-05-17T01:01:00Z"
+      },
+      "last_failure_signature": "handoff-missing:stale-local",
+      "last_head_sha": "head-pr1323-replay-final",
+      "review_wait_started_at": "2026-05-17T00:59:00Z",
+      "review_wait_head_sha": "head-pr1323-replay-final",
+      "provider_success_observed_at": "2026-05-17T01:03:00Z",
+      "provider_success_head_sha": "head-pr1323-replay-final",
+      "merge_readiness_last_evaluated_at": "2026-05-17T01:03:30Z",
+      "copilot_review_requested_observed_at": null,
+      "copilot_review_requested_head_sha": null,
+      "copilot_review_timed_out_at": null,
+      "copilot_review_timeout_action": null,
+      "copilot_review_timeout_reason": null,
+      "local_review_head_sha": "head-pr1323-replay-final",
+      "local_review_blocker_summary": null,
+      "local_review_summary_path": ".codex-supervisor/local-review/issue-8133/head-pr1323-replay-final.md",
+      "local_review_run_at": "2026-05-17T01:02:00Z",
+      "local_review_max_severity": "none",
+      "local_review_findings_count": 0,
+      "local_review_root_cause_count": 0,
+      "local_review_verified_max_severity": "none",
+      "local_review_verified_findings_count": 0,
+      "local_review_recommendation": "ready",
+      "local_review_degraded": false,
+      "last_local_review_signature": null,
+      "repeated_local_review_signature_count": 0,
+      "latest_local_ci_result": {
+        "outcome": "passed",
+        "summary": "Focused verifier passed after clustered review repair.",
+        "ran_at": "2026-05-17T01:02:30Z",
+        "head_sha": "head-pr1323-replay-final",
+        "execution_mode": "structured",
+        "command": "npm test -- src/review-thread-reporting.test.ts src/recovery-reconciliation.test.ts",
+        "stderr_summary": null,
+        "failure_class": null,
+        "remediation_target": null,
+        "verifier_drift_hint": null
+      },
+      "processed_review_thread_ids": [
+        "thread-auth-boundary@head-pr1323-replay-final",
+        "thread-verifier-drift@head-pr1323-replay-final",
+        "thread-handoff-state@head-pr1323-replay-final"
+      ],
+      "processed_review_thread_fingerprints": [
+        "thread-auth-boundary@head-pr1323-replay-final#comment-auth-final",
+        "thread-verifier-drift@head-pr1323-replay-final#comment-verifier-final",
+        "thread-handoff-state@head-pr1323-replay-final#comment-handoff-final"
+      ],
+      "updated_at": "2026-05-17T01:04:00Z"
+    },
+    "workspaceStatus": {
+      "branch": "codex/issue-8133",
+      "headSha": "head-pr1323-replay-final",
+      "hasUncommittedChanges": false,
+      "baseAhead": 4,
+      "baseBehind": 0,
+      "remoteBranchExists": true,
+      "remoteAhead": 0,
+      "remoteBehind": 0
+    }
+  },
+  "github": {
+    "pullRequest": {
+      "number": 9133,
+      "title": "Current-head success clears stale handoff",
+      "url": "https://example.test/pull/9133",
+      "state": "OPEN",
+      "createdAt": "2026-05-17T00:30:00Z",
+      "updatedAt": "2026-05-17T01:03:30Z",
+      "isDraft": false,
+      "reviewDecision": "APPROVED",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "headRefName": "codex/issue-8133",
+      "headRefOid": "head-pr1323-replay-final",
+      "configuredBotCurrentHeadObservedAt": "2026-05-17T01:03:00Z",
+      "currentHeadCiGreenAt": "2026-05-17T01:02:30Z",
+      "configuredBotTopLevelReviewStrength": "blocking",
+      "configuredBotTopLevelReviewSubmittedAt": "2026-05-17T01:03:00Z",
+      "mergedAt": null
+    },
+    "checks": [
+      {
+        "name": "focused replay verifier",
+        "state": "SUCCESS",
+        "bucket": "pass",
+        "workflow": "verification"
+      }
+    ],
+    "reviewThreads": []
+  },
+  "decision": {
+    "nextState": "ready_to_merge",
+    "shouldRunCodex": false,
+    "blockedReason": null,
+    "failureContext": null
+  },
+  "operatorSummary": {
+    "latestRecoverySummary": "latest_recovery issue=#8133 reason=current_head_review_convergence detail=stale handoff marker cleared by current-head PR facts",
+    "retrySummary": null,
+    "recoveryLoopSummary": null,
+    "activityContext": null
+  }
+}

--- a/replay-corpus/cases/prompt-injection-combined-github-text-boundary/input/snapshot.json
+++ b/replay-corpus/cases/prompt-injection-combined-github-text-boundary/input/snapshot.json
@@ -80,6 +80,7 @@
       "mergeable": "MERGEABLE",
       "headRefName": "codex/issue-180703",
       "headRefOid": "head-532",
+      "configuredBotCurrentHeadObservedAt": "2026-03-16T10:06:30Z",
       "mergedAt": null,
       "configuredBotTopLevelReviewStrength": "blocking"
     },

--- a/replay-corpus/cases/prompt-injection-issue-body-policy-override/input/snapshot.json
+++ b/replay-corpus/cases/prompt-injection-issue-body-policy-override/input/snapshot.json
@@ -80,6 +80,7 @@
       "mergeable": "MERGEABLE",
       "headRefName": "codex/issue-180701",
       "headRefOid": "head-532",
+      "configuredBotCurrentHeadObservedAt": "2026-03-16T10:06:30Z",
       "mergedAt": null,
       "configuredBotTopLevelReviewStrength": "blocking"
     },

--- a/replay-corpus/cases/prompt-injection-review-thread-policy-override/input/snapshot.json
+++ b/replay-corpus/cases/prompt-injection-review-thread-policy-override/input/snapshot.json
@@ -80,6 +80,7 @@
       "mergeable": "MERGEABLE",
       "headRefName": "codex/issue-180702",
       "headRefOid": "head-532",
+      "configuredBotCurrentHeadObservedAt": "2026-03-16T10:06:30Z",
       "mergedAt": null,
       "configuredBotTopLevelReviewStrength": "blocking"
     },

--- a/replay-corpus/cases/review-blocked/input/snapshot.json
+++ b/replay-corpus/cases/review-blocked/input/snapshot.json
@@ -79,6 +79,7 @@
       "mergeable": "MERGEABLE",
       "headRefName": "codex/issue-532",
       "headRefOid": "head-532",
+      "configuredBotCurrentHeadObservedAt": "2026-03-16T10:06:30Z",
       "mergedAt": null,
       "configuredBotTopLevelReviewStrength": "blocking"
     },

--- a/replay-corpus/manifest.json
+++ b/replay-corpus/manifest.json
@@ -64,6 +64,14 @@
     {
       "id": "prompt-injection-combined-github-text-boundary",
       "path": "cases/prompt-injection-combined-github-text-boundary"
+    },
+    {
+      "id": "clustered-codex-review-repair-convergence",
+      "path": "cases/clustered-codex-review-repair-convergence"
+    },
+    {
+      "id": "current-head-success-clears-stale-handoff",
+      "path": "cases/current-head-success-clears-stale-handoff"
     }
   ]
 }

--- a/src/supervisor/replay-corpus-config.test.ts
+++ b/src/supervisor/replay-corpus-config.test.ts
@@ -16,6 +16,7 @@ test("createCheckedInReplayCorpusConfig derives replay-local paths and provider 
   assert.equal(config.stateFile, path.join(repoRoot, ".codex-supervisor", "replay", "state.json"));
   assert.equal(config.localReviewArtifactDir, path.join(repoRoot, ".codex-supervisor", "replay", "reviews"));
   assert.deepEqual(config.reviewBotLogins, [
+    "chatgpt-codex-connector",
     "copilot-pull-request-reviewer",
     "coderabbitai",
     "coderabbitai[bot]",

--- a/src/supervisor/replay-corpus-config.ts
+++ b/src/supervisor/replay-corpus-config.ts
@@ -4,7 +4,12 @@ import { mapConfiguredReviewProviders } from "../core/review-providers";
 import type { SupervisorConfig } from "../core/types";
 
 export function createCheckedInReplayCorpusConfig(repoRoot: string): SupervisorConfig {
-  const reviewBotLogins = ["copilot-pull-request-reviewer", "coderabbitai", "coderabbitai[bot]"];
+  const reviewBotLogins = [
+    "chatgpt-codex-connector",
+    "copilot-pull-request-reviewer",
+    "coderabbitai",
+    "coderabbitai[bot]",
+  ];
   const replayStateRoot = path.join(repoRoot, ".codex-supervisor", "replay");
 
   return {

--- a/src/supervisor/replay-corpus-runner.test.ts
+++ b/src/supervisor/replay-corpus-runner.test.ts
@@ -388,6 +388,8 @@ test("runReplayCorpus replays the checked-in PR lifecycle safety cases without m
     "prompt-injection-issue-body-policy-override",
     "prompt-injection-review-thread-policy-override",
     "prompt-injection-combined-github-text-boundary",
+    "clustered-codex-review-repair-convergence",
+    "current-head-success-clears-stale-handoff",
   ]);
 });
 


### PR DESCRIPTION
## Summary
- add sanitized replay cases for PR #1323-style clustered Codex Connector repair convergence and stale handoff recovery
- register Codex Connector in the checked-in replay corpus config
- keep older bot-blocked fixtures stable by recording explicit current-head observation timestamps

## Verification
- npx tsx --test src/supervisor/replay-corpus-*.test.ts
- npx tsx --test src/review-thread-reporting.test.ts src/recovery-reconciliation.test.ts
- npm run build
- npm run verify:paths
- git diff --check

Closes #2014