### PR TITLE
Cluster Codex Connector must-fix threads by theme

### DIFF
--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -582,6 +582,86 @@ test("clusterConfiguredBotReviewThreads groups repeated signatures while preserv
   assert.deepEqual(clusters[1]?.threads.map((thread) => thread.id), ["thread-export"]);
 });
 
+test("clusterConfiguredBotReviewThreads groups same-path Codex Connector findings by normalized failure theme", () => {
+  const simulatorAuthorityThread = createReviewThread({
+    id: "thread-simulator-authority",
+    path: "src/simulator/validation.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-simulator-authority",
+          body:
+            "P1: The simulator validation path still accepts a production authority flag without proving the signed fixture. Add regression coverage before merge.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const simulatorFixtureThread = createReviewThread({
+    id: "thread-simulator-fixture",
+    path: "src/simulator/validation.ts",
+    line: 88,
+    comments: {
+      nodes: [
+        {
+          id: "comment-simulator-fixture",
+          body:
+            "P1: Simulator validation can still pass when the signed fixture proof is missing, so production authority is inferred from an unsafe fallback.",
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const unrelatedThread = createReviewThread({
+    id: "thread-export-snapshot",
+    path: "src/export/readiness.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-export-snapshot",
+          body:
+            "P1: Export readiness still stitches rows from mixed snapshots instead of rejecting the inconsistent read set.",
+          createdAt: "2026-03-11T00:02:00Z",
+          url: "https://example.test/pr/44#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const clusters = clusterConfiguredBotReviewThreads([
+    simulatorAuthorityThread,
+    simulatorFixtureThread,
+    unrelatedThread,
+  ]);
+
+  assert.equal(clusters.length, 2);
+  assert.deepEqual(clusters[0]?.threads.map((thread) => thread.id), [
+    "thread-simulator-authority",
+    "thread-simulator-fixture",
+  ]);
+  assert.deepEqual(clusters[0]?.sourceUrls, [
+    "https://example.test/pr/44#discussion_r1",
+    "https://example.test/pr/44#discussion_r2",
+  ]);
+  assert.deepEqual(clusters[1]?.threads.map((thread) => thread.id), ["thread-export-snapshot"]);
+});
+
 test("evaluateCodexConnectorConvergencePolicy separates missing, must-fix, nitpick-only, and converged outcomes", () => {
   const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
   const currentHeadPr = {

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -423,24 +423,101 @@ function normalizeReviewThreadSignature(summary: string): string {
     .trim();
 }
 
+const REVIEW_THREAD_THEME_STOP_WORDS = new Set([
+  "add",
+  "after",
+  "again",
+  "before",
+  "being",
+  "because",
+  "cannot",
+  "comment",
+  "coverage",
+  "does",
+  "from",
+  "here",
+  "into",
+  "keep",
+  "lets",
+  "merge",
+  "must",
+  "needs",
+  "only",
+  "path",
+  "please",
+  "prefer",
+  "proving",
+  "repair",
+  "review",
+  "should",
+  "still",
+  "than",
+  "that",
+  "this",
+  "thread",
+  "until",
+  "when",
+  "with",
+  "without",
+]);
+
+function normalizeFailureThemeTokens(summary: string): string[] {
+  return uniqueInOrder(
+    normalizeReviewThreadSignature(summary)
+      .split(" ")
+      .filter((token) => {
+        return token.length >= 4 && !REVIEW_THREAD_THEME_STOP_WORDS.has(token) && !/^#+$/.test(token);
+      }),
+  ).sort();
+}
+
+function hasSimilarFailureTheme(left: string[], right: string[]): boolean {
+  if (left.length < 3 || right.length < 3) {
+    return false;
+  }
+
+  const rightTokens = new Set(right);
+  const sharedCount = left.filter((token) => rightTokens.has(token)).length;
+  return sharedCount >= 4 || sharedCount / Math.min(left.length, right.length) >= 0.5;
+}
+
 function uniqueInOrder(values: string[]): string[] {
   return [...new Set(values)];
 }
 
 export function clusterConfiguredBotReviewThreads(reviewThreads: ReviewThread[]): ConfiguredBotReviewThreadCluster[] {
   const clusters = new Map<string, ConfiguredBotReviewThreadCluster>();
+  const clusterThemeTokens = new Map<string, string[]>();
 
   for (const thread of reviewThreads) {
     const latestComment = latestReviewComment(thread);
     const severity = latestCodexConnectorPSeverity(thread) ?? "unknown";
     const summary = extractReviewCommentSummary(latestComment?.body ?? "");
     const signature = `${severity}:${normalizeReviewThreadSignature(summary) || thread.id}`;
-    const existing = clusters.get(signature);
+    const themeTokens = normalizeFailureThemeTokens(summary);
+    const normalizedPath = thread.path?.replace(/\\/g, "/");
+    const existingSignature = clusters.has(signature)
+      ? signature
+      : [...clusters.entries()].find(([candidateSignature, candidate]) => {
+          return (
+            normalizedPath !== undefined &&
+            candidate.severity === severity &&
+            candidate.files.map((filePath) => filePath.replace(/\\/g, "/")).includes(normalizedPath) &&
+            hasSimilarFailureTheme(themeTokens, clusterThemeTokens.get(candidateSignature) ?? [])
+          );
+        })?.[0];
+    const existing = existingSignature ? clusters.get(existingSignature) : undefined;
     if (existing) {
       existing.threads.push(thread);
       existing.files = uniqueInOrder([...existing.files, thread.path ?? "unknown"]);
       if (latestComment?.url) {
         existing.sourceUrls = uniqueInOrder([...existing.sourceUrls, latestComment.url]);
+      }
+      if (existingSignature) {
+        clusterThemeTokens.set(
+          existingSignature,
+          uniqueInOrder([...(clusterThemeTokens.get(existingSignature) ?? []), ...themeTokens]).sort(),
+        );
       }
       continue;
     }
@@ -453,6 +530,7 @@ export function clusterConfiguredBotReviewThreads(reviewThreads: ReviewThread[])
       files: [thread.path ?? "unknown"],
       sourceUrls: latestComment?.url ? [latestComment.url] : [],
     });
+    clusterThemeTokens.set(signature, themeTokens);
   }
 
   return [...clusters.values()];

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -459,6 +459,86 @@ test("summarizeTrackedPrProgress treats updated same-thread guidance as tracked 
   assert.match(result.summary ?? "", /same_review_thread_guidance_changed/);
 });
 
+test("summarizeTrackedPrProgress treats changed review-thread cluster membership as tracked PR progress", () => {
+  const record = createRecord({
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head123",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: null,
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-simulator-authority", "thread-simulator-fixture"],
+      unresolvedReviewThreadFingerprints: [
+        "thread-simulator-authority#comment-simulator-authority",
+        "thread-simulator-fixture#comment-simulator-fixture",
+      ],
+      unresolvedReviewThreadClusterSignatures: [
+        "P1:old-authority-only:thread-simulator-authority",
+        "P1:old-fixture-only:thread-simulator-fixture",
+      ],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads: ReviewThread[] = [
+    createReviewThread({
+      id: "thread-simulator-authority",
+      path: "src/simulator/validation.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-simulator-authority",
+            body:
+              "P1: The simulator validation path still accepts a production authority flag without proving the signed fixture.",
+            createdAt: "2026-03-13T06:20:00Z",
+            url: "https://example.test/pr/42#discussion_r1",
+            author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-simulator-fixture",
+      path: "src/simulator/validation.ts",
+      line: 88,
+      comments: {
+        nodes: [
+          {
+            id: "comment-simulator-fixture",
+            body:
+              "P1: Simulator validation can still pass when the signed fixture proof is missing, so production authority is inferred.",
+            createdAt: "2026-03-13T06:25:00Z",
+            url: "https://example.test/pr/42#discussion_r2",
+            author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const result = summarizeTrackedPrProgress(
+    record,
+    pr,
+    [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  );
+
+  assert.match(result.summary ?? "", /review_thread_cluster_membership_changed/);
+});
+
 test("derivePullRequestLifecycleSnapshot re-arms CodeRabbit waiting after ready-for-review when draft skip was the latest prior signal", () => {
   withStubbedDateNow("2026-03-13T02:30:10Z", () => {
     const config = createConfig({

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -22,7 +22,7 @@ import {
 import { latestReviewThreadCommentFingerprint } from "../review-handling";
 import { inferFailureContext } from "./supervisor-failure-context";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor-status-rendering";
-import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
+import { clusterConfiguredBotReviewThreads, configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
 import {
   FailureContext,
   GitHubPullRequest,
@@ -119,6 +119,7 @@ interface TrackedPrProgressSnapshot {
   checks: string[];
   unresolvedReviewThreadIds: string[];
   unresolvedReviewThreadFingerprints?: string[];
+  unresolvedReviewThreadClusterSignatures?: string[];
 }
 
 export interface TrackedPrRepeatFailureDisposition {
@@ -133,6 +134,10 @@ function buildTrackedPrProgressSnapshot(
   checks: PullRequestCheck[],
   reviewThreads: ReviewThread[],
 ): TrackedPrProgressSnapshot {
+  const unresolvedReviewThreads = reviewThreads.filter((thread) => !thread.isResolved);
+  const unresolvedReviewThreadClusterSignatures = clusterConfiguredBotReviewThreads(unresolvedReviewThreads)
+    .map((cluster) => `${cluster.signature}:${cluster.threads.map((thread) => thread.id).sort().join(",")}`)
+    .sort();
   return {
     headRefOid: pr.headRefOid,
     reviewDecision: pr.reviewDecision,
@@ -150,14 +155,13 @@ function buildTrackedPrProgressSnapshot(
     checks: checks
       .map((check) => `${check.name}:${check.bucket}:${check.state}:${check.workflow ?? "none"}`)
       .sort(),
-    unresolvedReviewThreadIds: reviewThreads
-      .filter((thread) => !thread.isResolved)
-      .map((thread) => thread.id)
-      .sort(),
-    unresolvedReviewThreadFingerprints: reviewThreads
-      .filter((thread) => !thread.isResolved)
+    unresolvedReviewThreadIds: unresolvedReviewThreads.map((thread) => thread.id).sort(),
+    unresolvedReviewThreadFingerprints: unresolvedReviewThreads
       .map((thread) => `${thread.id}#${latestReviewThreadCommentFingerprint(thread) ?? "no-comment"}`)
       .sort(),
+    ...(unresolvedReviewThreadClusterSignatures.length > 0
+      ? { unresolvedReviewThreadClusterSignatures }
+      : {}),
   };
 }
 
@@ -208,6 +212,8 @@ function listChangedSignals(previous: TrackedPrProgressSnapshot | null, current:
     (previous?.unresolvedReviewThreadIds.join("|") ?? null) !== current.unresolvedReviewThreadIds.join("|");
   const previousThreadFingerprints = previous?.unresolvedReviewThreadFingerprints?.join("|") ?? null;
   const currentThreadFingerprints = current.unresolvedReviewThreadFingerprints?.join("|") ?? null;
+  const previousClusterSignatures = previous?.unresolvedReviewThreadClusterSignatures?.join("|") ?? null;
+  const currentClusterSignatures = current.unresolvedReviewThreadClusterSignatures?.join("|") ?? null;
   const sameThreadIds =
     previous !== null &&
     previous.unresolvedReviewThreadIds.join("|") === current.unresolvedReviewThreadIds.join("|");
@@ -219,6 +225,14 @@ function listChangedSignals(previous: TrackedPrProgressSnapshot | null, current:
     previousThreadFingerprints !== currentThreadFingerprints;
   if (sameThreadGuidanceChanged) {
     signals.push("same_review_thread_guidance_changed");
+  }
+  if (
+    previous !== null &&
+    previousClusterSignatures !== null &&
+    currentClusterSignatures !== null &&
+    previousClusterSignatures !== currentClusterSignatures
+  ) {
+    signals.push("review_thread_cluster_membership_changed");
   }
   if (previous !== null && reviewSignalChanged) {
     signals.push("review_state_changed");


### PR DESCRIPTION
## Summary
- cluster Codex Connector same-path same-severity findings by normalized failure theme while preserving exact-summary grouping across files
- include cluster signatures in tracked-PR progress snapshots so membership changes count as meaningful same-PR repair progress
- add focused regression coverage for theme clustering and cluster-membership progress

## Verification
- npx tsx --test src/review-thread-reporting.test.ts src/turn-execution-orchestration.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npx tsx --test src/supervisor/supervisor-lifecycle.test.ts
- npm run build
- npm run verify:paths
- node dist/index.js issue-lint 2025 --config <host self supervisor config>

Closes #2025