### PR TITLE
Fail closed on unverified Codex thread residue

### DIFF
--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -351,6 +351,20 @@ export function selectStatusOperatorAction(args: {
       continue;
     }
 
+    if (
+      /^stale_review_bot_remediation\b/.test(line) &&
+      /\bclassification=(?:actionable_current_diff|unknown_needs_operator)\b/.test(line)
+    ) {
+      actions.push({
+        action: "manual_review",
+        source: "stale_review_bot_remediation",
+        priority: 73,
+        summary:
+          "A Codex Connector must-fix thread still lacks trusted current-head verification evidence; inspect the thread or run a focused verifier before resolving it.",
+      });
+      continue;
+    }
+
     if (/^stale_review_bot_remediation\b/.test(line)) {
       actions.push({
         action: "resolve_stale_review_bot",

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4398,7 +4398,7 @@ test("handlePostTurnPullRequestTransitionsPhase replies and resolves stale confi
   assert.equal(resolveCalls.length, 2);
 });
 
-test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-change Codex threads and requests current-head review when enabled", async () => {
+test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-change Codex threads after current-head success", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
@@ -4416,11 +4416,26 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
     commentBody: "P1: This finding was verified as no source change needed.",
     discussionUrl: "https://example.test/pr/1985#discussion_r1985",
   });
-  const pr = createPullRequest(scenario.pullRequestPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-05-15T00:17:00Z",
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
-      "102": createRecord(scenario.recordPatch),
+      "102": createRecord({
+        ...scenario.recordPatch,
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Focused verifier proved the current head no longer reproduces the finding.",
+          ran_at: "2026-05-15T00:18:00Z",
+          head_sha: "head-1985",
+          execution_mode: "shell",
+          command: "npm test -- src/post-turn-pull-request.test.ts",
+          failure_class: null,
+          remediation_target: null,
+        },
+      }),
     },
   };
   const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
@@ -4494,9 +4509,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
   assert.deepEqual(resolveCalls, ["thread-codex"]);
   assert.match(replyCalls[0]?.body ?? "", /reason=verified_no_source_change_auto_resolve/);
   assert.match(replyCalls[0]?.body ?? "", /issue=#102 pr=#1985 head=head-1985 thread=thread-codex/);
-  assert.equal(requestComments.length, 1);
-  assert.match(requestComments[0] ?? "", /@codex review/);
-  assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1985 head=head-1985/);
+  assert.equal(requestComments.length, 0);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads only with the repair opt-in", async () => {

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -27,5 +27,8 @@ export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotR
       `verification_evidence=${formatStaleReviewBotTokenValue(remediation.verificationEvidenceSummary).replace(/\s+/gu, "_")}`,
     );
   }
+  if (remediation.missingProbeReason) {
+    tokens.splice(tokens.length - 1, 0, `missing_probe_reason=${remediation.missingProbeReason}`);
+  }
   return tokens.join(" ");
 }

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -18,6 +18,7 @@ export interface StaleReviewBotRemediationDto {
   processedOnCurrentHead: "yes" | "no" | "unknown";
   codeCiState: "green" | "not_green" | "unknown";
   classification:
+    | "actionable_current_diff"
     | "metadata_only"
     | "metadata_only_missing_current_head_review"
     | "metadata_only_current_head_converged"
@@ -28,6 +29,7 @@ export interface StaleReviewBotRemediationDto {
   codexCurrentHeadReviewState: "observed" | "requested" | "missing" | "not_applicable";
   reviewThreadUrl: string | null;
   verificationEvidenceSummary: string | null;
+  missingProbeReason: string | null;
   manualNextStep: string;
   summary: string;
 }
@@ -53,6 +55,7 @@ interface StaleReviewBotClassification {
   classification: StaleReviewBotRemediationDto["classification"];
   summary: string;
   verificationEvidenceSummary?: string | null;
+  missingProbeReason?: string | null;
 }
 
 export function formatStaleReviewBotTokenValue(value: string): string {
@@ -207,22 +210,28 @@ function classifyCodexMetadataOnly(args: {
       (thread) => !hasProcessedReviewThread(args.record, args.pr, thread),
     );
     if (hasUnprocessedMustFix) {
-      return unresolvedWork;
+      return {
+        classification: "actionable_current_diff",
+        summary: STALE_REVIEW_BOT_SUMMARY,
+      };
     }
     const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(args.record, args.pr);
     if (verificationEvidenceSummary) {
       return {
-        classification: "verified_current_head_repair_pending_thread_resolution",
-        summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
+        classification: policy.currentHeadObservedAt
+          ? "verified_no_source_change_pending_thread_resolution"
+          : "verified_current_head_repair_pending_thread_resolution",
+        summary: policy.currentHeadObservedAt
+          ? VERIFIED_NO_SOURCE_CHANGE_SUMMARY
+          : VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
         verificationEvidenceSummary,
       };
     }
-    if (!policy.currentHeadObservedAt) {
-      return {
-        classification: "verified_no_source_change_pending_thread_resolution",
-        summary: VERIFIED_NO_SOURCE_CHANGE_SUMMARY,
-      };
-    }
+    return {
+      classification: "unknown_needs_operator",
+      summary: STALE_REVIEW_BOT_SUMMARY,
+      missingProbeReason: "current_head_verification_evidence_missing",
+    };
   }
 
   if (policy.outcome === "converged" || policy.outcome === "nitpick_only") {
@@ -327,6 +336,7 @@ export function buildStaleReviewBotRemediation(args: {
     codexCurrentHeadReviewState,
     reviewThreadUrl: args.record.last_failure_context?.url ?? null,
     verificationEvidenceSummary: classification.verificationEvidenceSummary ?? null,
+    missingProbeReason: classification.missingProbeReason ?? null,
     manualNextStep:
       classification.classification === "verified_current_head_repair_pending_thread_resolution"
         ? VERIFIED_CURRENT_HEAD_REPAIR_MANUAL_NEXT_STEP

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1103,6 +1103,7 @@ test("explain surfaces stale configured-bot remediation with the exact review th
     codexCurrentHeadReviewState: "not_applicable",
     reviewThreadUrl: "https://example.test/pr/295#discussion_r295",
     verificationEvidenceSummary: null,
+    missingProbeReason: null,
     manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
     summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
   });
@@ -1317,7 +1318,7 @@ test("explain keeps configured-bot success without current-head observation as u
   assert.doesNotMatch(explanation, /classification=metadata_only/m);
 });
 
-test("explain classifies processed Codex must-fix residue as missing-current-head review metadata", async () => {
+test("explain fails closed for processed Codex must-fix residue without verification evidence", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
   const issueNumber = 198;
@@ -1357,7 +1358,7 @@ test("explain classifies processed Codex must-fix residue as missing-current-hea
   const trackedIssue: GitHubIssue = {
     number: issueNumber,
     title: "Explain Codex processed metadata residue",
-    body: executionReadyBody("Explain should classify Codex must-fix residue as metadata-only pending review."),
+    body: executionReadyBody("Explain should keep Codex must-fix residue blocked without verification evidence."),
     createdAt: "2026-05-13T00:00:00Z",
     updatedAt: "2026-05-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,
@@ -1410,11 +1411,11 @@ test("explain classifies processed Codex must-fix residue as missing-current-hea
 
   assert.match(
     explanation,
-    /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#198 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-198 processed_on_current_head=yes classification=unknown_needs_operator codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/398#discussion_r398 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note missing_probe_reason=current_head_verification_evidence_missing summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
   );
   assert.match(
     explanation,
-    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=head-198 latest_configured_bot_review_sha=head-198 current_head_review_signal=missing actionable_current_diff_threads=0 next_action=resolve_verified_configured_bot_threads_then_rerun_supervisor$/m,
+    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=head-198 latest_configured_bot_review_sha=head-198 current_head_review_signal=missing actionable_current_diff_threads=unknown next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -932,7 +932,7 @@ test("status --why classifies current-head processed configured-bot success as s
   assert.doesNotMatch(status, /stale_review_bot_provider_signal_missing/);
 });
 
-test("status --why includes codex processed-residue missing-current-head review state", async (t) => {
+test("status --why fails closed for codex processed residue without current-head verification evidence", async (t) => {
   const fixture = await createSupervisorFixture();
   fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
   const issueNumber = 398;
@@ -964,7 +964,7 @@ test("status --why includes codex processed-residue missing-current-head review 
   const trackedIssue: GitHubIssue = {
     number: issueNumber,
     title: "Status why classifies codex processed residue",
-    body: executionReadyBody("Classify Codex processed residue as missing current-head review metadata."),
+    body: executionReadyBody("Keep Codex processed residue blocked until current-head verification evidence exists."),
     createdAt: "2026-05-13T00:00:00Z",
     updatedAt: "2026-05-13T00:00:00Z",
     url: `https://example.test/issues/${issueNumber}`,
@@ -987,13 +987,14 @@ test("status --why includes codex processed-residue missing-current-head review 
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#398 pr=#498 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=verified_no_source_change_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/498#discussion_r398 manual_next_step=resolve_verified_configured_bot_threads_then_rerun_supervisor summary=verified_no_source_change_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#398 pr=#498 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=unknown_needs_operator codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/498#discussion_r398 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note missing_probe_reason=current_head_verification_evidence_missing summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
   );
   assert.match(
     status,
-    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a latest_configured_bot_review_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a current_head_review_signal=missing actionable_current_diff_threads=0 next_action=resolve_verified_configured_bot_threads_then_rerun_supervisor$/m,
+    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a latest_configured_bot_review_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a current_head_review_signal=missing actionable_current_diff_threads=unknown next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m,
   );
-  assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
+  assert.doesNotMatch(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
+  assert.match(status, /^operator_action action=manual_review source=stale_review_bot_remediation /m);
 });
 
 test("status --why distinguishes codex verified current-head repair residue from no-source-change residue", async (t) => {


### PR DESCRIPTION
## Summary
- require trusted current-head verification evidence before classifying processed Codex Connector P1/P2 residue as verified stale residue
- surface missing probe reasons in stale-review diagnostics and route unknown/actionable residue to manual review instead of stale-thread resolution guidance
- update status, explain, and post-turn coverage for unverified residue and verified no-source-change handling

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/post-turn-pull-request.test.ts
- npm run build
- node dist/index.js issue-lint 2026 --config <usable-self-codex-config>

Note: repo-local supervisor.config.codex.json is a starter profile in this worktree and fails before lint with unresolved placeholder config.