### PR TITLE
Fix verified Codex thread auto-resolve manual-review fallthrough

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4619,6 +4619,105 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
   assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1988 head=head-1988/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads even when review state falls through to manual_review", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Resolve verified repair thread after manual_review fallthrough" });
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 2034,
+    headSha: "head-2034",
+    threadId: "thread-codex-manual-fallthrough",
+    commentId: "comment-codex-manual-fallthrough",
+    path: "src/review.ts",
+    line: 300,
+    commentBody: "P2: Validate group keys before encoding projection metadata.",
+    discussionUrl: "https://example.test/pr/2034#discussion_r2034",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-18T07:18:00Z",
+      command: "npm test -- --test-name-pattern \"malformed projection key|group projection\"",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord(scenario.recordPatch),
+    },
+  };
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  let snapshotLoads = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => ({
+        databaseId: 2034001,
+        nodeId: "IC_kwDO2034",
+        url: "https://example.test/pr/2034#issuecomment-2034001",
+      }),
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "manual_review",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr,
+        checks: scenario.passingChecks,
+        reviewThreads: snapshotLoads <= 2 ? reviewThreads : [],
+      };
+    },
+  });
+
+  assert.equal(result.record.state, "waiting_ci");
+  assert.equal(result.record.blocked_reason, null);
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-manual-fallthrough"]);
+  assert.deepEqual(resolveCalls, ["thread-codex-manual-fallthrough"]);
+  assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase keeps verified repair thread resolution fail-closed without opt-in or current codex_turn evidence", async () => {
   const cases: Array<{
     name: string;

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -981,7 +981,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       config.verifiedNoSourceChangeReviewThreadAutoResolve === true ||
       config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true) &&
     record.state === "blocked" &&
-    record.blocked_reason === "stale_review_bot" &&
+    (record.blocked_reason === "stale_review_bot" || record.blocked_reason === "manual_review") &&
     record.last_stale_review_bot_reply_head_sha === postReady.pr.headRefOid &&
     record.last_stale_review_bot_reply_signature === staleReviewBotReplySignature &&
     hasResolvedAllStaleConfiguredBotThreads({

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -690,11 +690,17 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     failureContext: args.failureContext,
     summarizeChecks: args.summarizeChecks,
   });
+  const remediationRecord =
+    args.record.state === "blocked" &&
+    (args.record.blocked_reason === "stale_review_bot" || args.record.blocked_reason === "manual_review") &&
+    args.manualReviewThreadCount === 0
+      ? { ...args.record, blocked_reason: "stale_review_bot" as const }
+      : args.record;
   const staleReviewBotRemediation =
-    args.record.state === "blocked" && args.record.blocked_reason === "stale_review_bot"
+    remediationRecord.state === "blocked" && remediationRecord.blocked_reason === "stale_review_bot"
       ? buildStaleReviewBotRemediation({
           config: args.config,
-          record: args.record,
+          record: remediationRecord,
           pr: args.pr,
           checks: args.checks,
           reviewThreads: args.reviewThreads,
@@ -714,7 +720,9 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
   const canAutoHandleStaleConfiguredBotReview =
     !args.skipAutoHandleStaleConfiguredBotReview &&
     args.record.state === "blocked" &&
-    args.record.blocked_reason === "stale_review_bot" &&
+    (args.record.blocked_reason === "stale_review_bot" ||
+      ((canResolveVerifiedNoSourceChangeThreadResolution || canResolveVerifiedCurrentHeadRepairThreadResolution) &&
+        args.record.blocked_reason === "manual_review")) &&
     comment &&
     args.manualReviewThreadCount === 0 &&
     !args.summarizeChecks(args.checks).hasPending &&


### PR DESCRIPTION
## Summary
- Reproduces the HRCore-style case where verified Codex Connector residue is blocked as `manual_review` instead of entering verified auto-resolve.
- Allows the tracked PR status path to evaluate verified stale-review remediation for `manual_review` fallthroughs only when manual thread count is zero.
- Keeps auto-resolution behind configured-bot scope, green checks, existing verification evidence, and explicit verified auto-resolve opt-ins.

## Verification
- `npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "manual_review fallthrough"`
- `npx tsx --test src/post-turn-pull-request.test.ts src/tracked-pr-status-comment.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/codex-connector-review-request-decision.test.ts src/pull-request-state-policy.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2034 --config <codex-supervisor-self-config>`

Closes #2034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended automatic review thread resolution to handle additional pull request block scenarios, reducing manual intervention required for certain review states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->