### PR TITLE
Fix conversation-resolution blocker diagnosis

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -6506,6 +6506,212 @@ test("handlePostTurnPullRequestTransitionsPhase comments when merge readiness st
   assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase diagnoses outdated configured-bot conversations before check mismatch", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const issue = createIssue({ title: "Diagnose conversation resolution blocker" });
+  const pr = createPullRequest({
+    title: "Tracked PR conversation resolution blocker",
+    number: 135,
+    isDraft: false,
+    headRefOid: "head-135",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-1",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/135#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "pr_open", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(pr.headRefOid),
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => reviewThreads,
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(result.record.state, "pr_open");
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `conversation_resolution_blocked`/i);
+  assert.match(commentBodies[0] ?? "", /conversation_threads=thread-outdated-1/i);
+  assert.doesNotMatch(commentBodies[0] ?? "", /reason code: `required_check_mismatch`/i);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase auto-resolves eligible outdated configured-bot conversations", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Auto-resolve conversation resolution blocker" });
+  const pr = createPullRequest({
+    title: "Tracked PR conversation resolution blocker",
+    number: 135,
+    isDraft: false,
+    headRefOid: "head-135",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const resolvedPr = createPullRequest({
+    ...pr,
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-1",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/135#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "pr_open",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const replyCalls: string[] = [];
+  const resolveCalls: string[] = [];
+  const commentBodies: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+      replyToReviewThread: async (threadId: string) => {
+        replyCalls.push(threadId);
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, snapshotPr) =>
+      createLifecycleSnapshot(recordForState, snapshotPr.mergeStateStatus === "CLEAN" ? "ready_to_merge" : "pr_open", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(snapshotPr.headRefOid),
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => reviewThreads,
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: replyCalls.length > 0 && resolveCalls.length > 0 ? resolvedPr : pr,
+      checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: replyCalls.length > 0 && resolveCalls.length > 0 ? [] : reviewThreads,
+    }),
+  });
+
+  assert.deepEqual(commentBodies, []);
+  assert.deepEqual(replyCalls, ["thread-outdated-1"]);
+  assert.deepEqual(resolveCalls, ["thread-outdated-1"]);
+  assert.equal(result.record.state, "ready_to_merge");
+});
+
 test("handlePostTurnPullRequestTransitionsPhase skips merge-stage sticky comments on the first clean-check observation", async () => {
   const config = createConfig();
   const issue = createIssue({ title: "Suppress first-observation merge-stage blocker comment" });

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -975,13 +975,17 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     summarizeChecks: args.summarizeChecks,
   });
   const staleReviewBotReplySignature =
-    effectiveFailureContext?.signature ?? trackedPrStatusComments.TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
+    record.last_stale_review_bot_reply_signature ??
+    effectiveFailureContext?.signature ??
+    trackedPrStatusComments.TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT;
   const shouldRefreshAfterReplyAndResolve =
     (config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
       config.verifiedNoSourceChangeReviewThreadAutoResolve === true ||
       config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true) &&
-    record.state === "blocked" &&
-    (record.blocked_reason === "stale_review_bot" || record.blocked_reason === "manual_review") &&
+    (record.state === "blocked" || record.state === "pr_open") &&
+    (record.blocked_reason === "stale_review_bot" ||
+      record.blocked_reason === "manual_review" ||
+      record.state === "pr_open") &&
     record.last_stale_review_bot_reply_head_sha === postReady.pr.headRefOid &&
     record.last_stale_review_bot_reply_signature === staleReviewBotReplySignature &&
     hasResolvedAllStaleConfiguredBotThreads({

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -500,6 +500,21 @@ export function buildActiveDetailedStatusLines(
     lines.push(
       `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
     );
+    const unresolvedOutdatedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads)
+      .filter((thread) => !thread.isResolved && thread.isOutdated);
+    const checkSummary = summarizeChecks(checks);
+    if (
+      pr.mergeStateStatus === "BLOCKED" &&
+      pr.mergeable === "MERGEABLE" &&
+      !checkSummary.hasPending &&
+      !checkSummary.hasFailing &&
+      manualReviewThreads(config, reviewThreads).length === 0 &&
+      unresolvedOutdatedConfiguredBotThreads.length > 0
+    ) {
+      lines.push(
+        `conversation_resolution_blocker state=blocked outdated_configured_bot_threads=${unresolvedOutdatedConfiguredBotThreads.length} thread_ids=${unresolvedOutdatedConfiguredBotThreads.map((thread) => thread.id).sort().join(",")}`,
+      );
+    }
     lines.push(
       `review_follow_up state=${reviewFollowUpState} remaining=${activeRecord.review_follow_up_remaining ?? 0} head_sha=${activeRecord.review_follow_up_head_sha ?? "none"} actionable=${actionableBotReviewThreads(config, activeRecord, pr, reviewThreads).length}`,
     );

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -7,8 +7,10 @@ import {
   buildCodexConnectorP2P3PolicyDiagnostic,
   buildCodexConnectorPolicyBlockDiagnostic,
   configuredBotReviewFollowUpState,
+  evaluateCodexConnectorConvergencePolicy,
   formatCodexConnectorP2P3PolicyDiagnostic,
   formatCodexConnectorPolicyBlockDiagnostic,
+  latestReviewCommentAuthorIsAllowedBot,
 } from "../review-thread-reporting";
 import { formatWorkspaceRestoreStatusLine } from "../core/workspace";
 import {
@@ -51,6 +53,51 @@ import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-lo
 
 function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+}
+
+function buildConversationResolutionBlockerStatusLine(args: Pick<
+  BuildDetailedStatusModelArgs,
+  "config" | "checks" | "reviewThreads" | "manualReviewThreads" | "configuredBotReviewThreads" | "summarizeChecks"
+> & {
+  pr: NonNullable<BuildDetailedStatusModelArgs["pr"]>;
+}): string | null {
+  const checkSummary = args.summarizeChecks(args.checks);
+  if (
+    args.pr.mergeStateStatus !== "BLOCKED" ||
+    args.pr.mergeable !== "MERGEABLE" ||
+    !args.pr.configuredBotCurrentHeadObservedAt ||
+    args.pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
+    checkSummary.hasPending ||
+    checkSummary.hasFailing
+  ) {
+    return null;
+  }
+
+  const unresolvedThreads = args.reviewThreads.filter((thread) => !thread.isResolved);
+  if (unresolvedThreads.length === 0 || args.manualReviewThreads(args.config, unresolvedThreads).length > 0) {
+    return null;
+  }
+
+  const configuredThreads = args.configuredBotReviewThreads(args.config, unresolvedThreads);
+  if (
+    configuredThreads.length !== unresolvedThreads.length ||
+    configuredThreads.some(
+      (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(args.config, thread),
+    )
+  ) {
+    return null;
+  }
+
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, configuredThreads);
+  if (codexConnectorPolicy && codexConnectorPolicy.mergeEffect !== "ready") {
+    return null;
+  }
+
+  return [
+    "conversation_resolution_blocker state=blocked",
+    `outdated_configured_bot_threads=${configuredThreads.length}`,
+    `thread_ids=${configuredThreads.map((thread) => thread.id).sort().join(",")}`,
+  ].join(" ");
 }
 
 export function formatStaleReviewResidueOperatorDiagnostic(
@@ -500,20 +547,17 @@ export function buildActiveDetailedStatusLines(
     lines.push(
       `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
     );
-    const unresolvedOutdatedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads)
-      .filter((thread) => !thread.isResolved && thread.isOutdated);
-    const checkSummary = summarizeChecks(checks);
-    if (
-      pr.mergeStateStatus === "BLOCKED" &&
-      pr.mergeable === "MERGEABLE" &&
-      !checkSummary.hasPending &&
-      !checkSummary.hasFailing &&
-      manualReviewThreads(config, reviewThreads).length === 0 &&
-      unresolvedOutdatedConfiguredBotThreads.length > 0
-    ) {
-      lines.push(
-        `conversation_resolution_blocker state=blocked outdated_configured_bot_threads=${unresolvedOutdatedConfiguredBotThreads.length} thread_ids=${unresolvedOutdatedConfiguredBotThreads.map((thread) => thread.id).sort().join(",")}`,
-      );
+    const conversationResolutionBlockerLine = buildConversationResolutionBlockerStatusLine({
+      config,
+      pr,
+      checks,
+      reviewThreads,
+      manualReviewThreads,
+      configuredBotReviewThreads,
+      summarizeChecks,
+    });
+    if (conversationResolutionBlockerLine) {
+      lines.push(conversationResolutionBlockerLine);
     }
     lines.push(
       `review_follow_up state=${reviewFollowUpState} remaining=${activeRecord.review_follow_up_remaining ?? 0} head_sha=${activeRecord.review_follow_up_head_sha ?? "none"} actionable=${actionableBotReviewThreads(config, activeRecord, pr, reviewThreads).length}`,

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -852,3 +852,73 @@ test("buildDetailedStatusModel names conversation-resolution blockers from outda
     ),
   );
 });
+
+test("buildDetailedStatusModel does not name conversation-resolution blocker when latest thread author is not configured bot", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-human-latest",
+      isResolved: false,
+      isOutdated: true,
+      path: "src/file.ts",
+      line: 12,
+      comments: {
+        nodes: [
+          {
+            id: "comment-bot-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+          {
+            id: "comment-human-1",
+            body: "This still needs a human decision.",
+            createdAt: "2026-05-18T00:55:00Z",
+            url: "https://example.test/pr/44#discussion_r2",
+            author: {
+              login: "octocat",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  const lines = buildDetailedStatusModel({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "pr_open",
+      last_error: null,
+      last_failure_context: null,
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    manualReviewThreads,
+    configuredBotReviewThreads,
+    pendingBotReviewThreads: () => [],
+    summarizeChecks: () => ({ allPassing: true, hasPending: false, hasFailing: false }),
+    mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
+  });
+
+  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
+  assert.equal(lines.some((line) => line.startsWith("conversation_resolution_blocker ")), false);
+});

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -788,3 +788,67 @@ test("buildDetailedStatusModel counts only unresolved configured bot threads in 
   );
   assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
 });
+
+test("buildDetailedStatusModel names conversation-resolution blockers from outdated configured-bot threads", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-outdated-1",
+      isResolved: false,
+      isOutdated: true,
+      path: "src/file.ts",
+      line: 12,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  const lines = buildDetailedStatusModel({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "pr_open",
+      last_error: null,
+      last_failure_context: null,
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    manualReviewThreads,
+    configuredBotReviewThreads,
+    pendingBotReviewThreads: () => [],
+    summarizeChecks: () => ({ allPassing: true, hasPending: false, hasFailing: false }),
+    mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
+  });
+
+  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
+  assert.ok(
+    lines.includes(
+      "conversation_resolution_blocker state=blocked outdated_configured_bot_threads=1 thread_ids=thread-outdated-1",
+    ),
+  );
+});

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -2,6 +2,13 @@ import { GitHubClient } from "./github";
 import { IssueJournalSync } from "./run-once-issue-preparation";
 import { StateStore } from "./core/state-store";
 import {
+  configuredBotReviewThreads,
+  evaluateCodexConnectorConvergencePolicy,
+  latestReviewComment,
+  manualReviewThreads,
+  latestReviewCommentAuthorIsAllowedBot,
+} from "./review-thread-reporting";
+import {
   FailureContext,
   GitHubPullRequest,
   IssueComment,
@@ -33,6 +40,7 @@ const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
 export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT = "stale_review_bot";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CONVERSATION_RESOLUTION_BLOCKED = "conversation_resolution_blocked";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
 
@@ -316,6 +324,108 @@ function buildRequiredCheckMismatchEvidence(args: {
   ];
 }
 
+interface ConversationResolutionBlocker {
+  blockerSignature: string;
+  body: string;
+  failureContext: FailureContext;
+}
+
+function buildConversationResolutionFailureContext(args: {
+  pr: GitHubPullRequest;
+  threads: ReviewThread[];
+}): FailureContext {
+  const threadIds = args.threads.map((thread) => thread.id).sort();
+  return {
+    category: "blocked",
+    summary:
+      `GitHub reports PR #${args.pr.number} as blocked after green checks; unresolved outdated configured-bot conversations remain.`,
+    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    command: null,
+    details: args.threads
+      .map((thread) => {
+        const latestComment = latestReviewComment(thread);
+        return [
+          `thread=${thread.id}`,
+          `reviewer=${latestComment?.author?.login ?? "unknown"}`,
+          `file=${thread.path ?? "unknown"}`,
+          `line=${thread.line ?? "unknown"}`,
+          "is_outdated=yes",
+          "processed_on_current_head=yes",
+        ].join(" ");
+      })
+      .sort(),
+    url: latestReviewComment(args.threads[0])?.url ?? args.pr.url,
+    updated_at: new Date(0).toISOString(),
+  };
+}
+
+function buildConversationResolutionBlocker(args: {
+  config: SupervisorConfig;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+}): ConversationResolutionBlocker | null {
+  const checkSummary = args.summarizeChecks(args.checks);
+  if (
+    args.pr.mergeStateStatus !== "BLOCKED" ||
+    args.pr.mergeable !== "MERGEABLE" ||
+    !args.pr.configuredBotCurrentHeadObservedAt ||
+    args.pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
+    checkSummary.hasPending ||
+    checkSummary.hasFailing
+  ) {
+    return null;
+  }
+
+  const unresolvedThreads = args.reviewThreads.filter((thread) => !thread.isResolved);
+  if (unresolvedThreads.length === 0 || manualReviewThreads(args.config, unresolvedThreads).length > 0) {
+    return null;
+  }
+
+  const configuredThreads = configuredBotReviewThreads(args.config, unresolvedThreads);
+  if (
+    configuredThreads.length !== unresolvedThreads.length ||
+    configuredThreads.some(
+      (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(args.config, thread),
+    )
+  ) {
+    return null;
+  }
+
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, configuredThreads);
+  if (codexConnectorPolicy && codexConnectorPolicy.mergeEffect !== "ready") {
+    return null;
+  }
+
+  const failureContext = buildConversationResolutionFailureContext({
+    pr: args.pr,
+    threads: configuredThreads,
+  });
+  const threadIds = configuredThreads.map((thread) => thread.id).sort();
+  const evidence = [
+    `merge_state=${args.pr.mergeStateStatus}`,
+    `mergeable=${args.pr.mergeable}`,
+    `conversation_threads=${threadIds.join(",")}`,
+    ...buildRequiredCheckMismatchEvidence({ pr: args.pr, checks: args.checks }).filter((line) => line.startsWith("check=")),
+  ];
+
+  return {
+    blockerSignature: `conversation-resolution:${args.pr.headRefOid}:${threadIds.join(",")}`,
+    failureContext,
+    body: buildTrackedPrPersistentStatusComment({
+      pr: args.pr,
+      reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_CONVERSATION_RESOLUTION_BLOCKED,
+      summary:
+        "GitHub is not merge-ready because unresolved outdated configured-bot review conversations still require resolution.",
+      evidence,
+      nextAction:
+        "Resolve the listed configured-bot review conversations, or rerun with the verified configured-bot auto-resolve opt-in enabled.",
+      automaticRetry: "no",
+    }),
+  };
+}
+
 function hasPersistentTrackedPrMergeStageSignal(args: {
   record: Pick<IssueRunRecord, "merge_readiness_last_evaluated_at" | "provider_success_head_sha" | "provider_success_observed_at">;
   pr: Pick<GitHubPullRequest, "headRefOid">;
@@ -403,6 +513,20 @@ function derivePersistentTrackedPrStatusComment(args: {
         nextAction: mismatch.guidanceLine.replace(/^recovery_guidance=/, ""),
         automaticRetry: "no",
       }),
+    };
+  }
+
+  const conversationResolutionBlocker = buildConversationResolutionBlocker({
+    config: args.config,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+    summarizeChecks: args.summarizeChecks,
+  });
+  if (conversationResolutionBlocker) {
+    return {
+      blockerSignature: conversationResolutionBlocker.blockerSignature,
+      body: conversationResolutionBlocker.body,
     };
   }
 
@@ -690,6 +814,13 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     failureContext: args.failureContext,
     summarizeChecks: args.summarizeChecks,
   });
+  const conversationResolutionBlocker = buildConversationResolutionBlocker({
+    config: args.config,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+    summarizeChecks: args.summarizeChecks,
+  });
   const remediationRecord =
     args.record.state === "blocked" &&
     (args.record.blocked_reason === "stale_review_bot" || args.record.blocked_reason === "manual_review") &&
@@ -716,21 +847,26 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
   const canResolveVerifiedCurrentHeadRepairThreadResolution =
     args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
     staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution";
+  const canResolveConversationResolutionBlocker =
+    args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
+    conversationResolutionBlocker !== null;
 
   const canAutoHandleStaleConfiguredBotReview =
     !args.skipAutoHandleStaleConfiguredBotReview &&
-    args.record.state === "blocked" &&
+    (args.record.state === "blocked" || canResolveConversationResolutionBlocker) &&
     (args.record.blocked_reason === "stale_review_bot" ||
+      canResolveConversationResolutionBlocker ||
       ((canResolveVerifiedNoSourceChangeThreadResolution || canResolveVerifiedCurrentHeadRepairThreadResolution) &&
         args.record.blocked_reason === "manual_review")) &&
-    comment &&
+    (comment || canResolveConversationResolutionBlocker) &&
     args.manualReviewThreadCount === 0 &&
     !args.summarizeChecks(args.checks).hasPending &&
     !args.summarizeChecks(args.checks).hasFailing &&
     (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
       args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
       canResolveVerifiedNoSourceChangeThreadResolution ||
-      canResolveVerifiedCurrentHeadRepairThreadResolution);
+      canResolveVerifiedCurrentHeadRepairThreadResolution ||
+      canResolveConversationResolutionBlocker);
 
   let currentRecord = args.record;
   if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
@@ -743,14 +879,15 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
       reviewThreads: args.reviewThreads,
       syncJournal: args.syncJournal,
       config: args.config,
-      failureContext: args.failureContext,
+      failureContext: conversationResolutionBlocker?.failureContext ?? args.failureContext,
       resolveAfterReply:
+        canResolveConversationResolutionBlocker ||
         canResolveStaleConfiguredBotReview ||
         canResolveVerifiedNoSourceChangeThreadResolution ||
         canResolveVerifiedCurrentHeadRepairThreadResolution,
       reasonCode: canResolveVerifiedCurrentHeadRepairThreadResolution
         ? "verified_current_head_repair_auto_resolve"
-        : canResolveVerifiedNoSourceChangeThreadResolution
+        : canResolveVerifiedNoSourceChangeThreadResolution || canResolveConversationResolutionBlocker
         ? "verified_no_source_change_auto_resolve"
         : STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
     });
@@ -759,7 +896,9 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     const replyHandled =
       repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
       repliedRecord.last_stale_review_bot_reply_signature ===
-        (args.failureContext?.signature ?? STALE_CONFIGURED_BOT_REVIEW_REASON_CODE);
+        (conversationResolutionBlocker?.failureContext.signature ??
+          args.failureContext?.signature ??
+          STALE_CONFIGURED_BOT_REVIEW_REASON_CODE);
     if (replyHandled || recoveryResult.status === "replied" || recoveryResult.status === "resolved") {
       return repliedRecord;
     }


### PR DESCRIPTION
## Summary
- classify green-check GitHub BLOCKED PRs with unresolved outdated configured-bot threads as conversation_resolution_blocked instead of required_check_mismatch
- reuse the audited stale configured-bot reply/resolve path for verified no-source-change auto-resolution and refresh PR state afterward
- surface conversation-resolution blockers in status/explain detailed lines

## Verification
- npx tsx --test src/tracked-pr-status-comment.test.ts src/post-turn-pull-request.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts
- npm run build
- node dist/index.js issue-lint 2036 --config <active-codex-supervisor-config>

Closes #2036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and reporting of conversation resolution blockers when outdated review threads prevent merge despite passing checks.
  * Enabled auto-resolution of eligible outdated review threads in specific scenarios.

* **Tests**
  * Added test coverage for conversation resolution blocker detection and auto-resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->