### PR TITLE
Surface conversation-resolution policy evidence

### DIFF
--- a/src/conversation-resolution-policy.ts
+++ b/src/conversation-resolution-policy.ts
@@ -1,0 +1,42 @@
+import type { GitHubPullRequest } from "./core/types";
+
+export type RequiredConversationResolutionState = "enabled" | "disabled" | "unavailable" | "unknown";
+
+export interface RequiredConversationResolutionEvidence {
+  state: RequiredConversationResolutionState;
+  source?: string | null;
+  details?: string[] | null;
+}
+
+export function conversationResolutionEvidence(
+  pr: Pick<GitHubPullRequest, "requiredConversationResolution">,
+): RequiredConversationResolutionEvidence {
+  return pr.requiredConversationResolution ?? {
+    state: "unknown",
+    source: "not_fetched",
+    details: ["required_conversation_resolution=unknown"],
+  };
+}
+
+export function conversationResolutionEvidenceToken(
+  pr: Pick<GitHubPullRequest, "requiredConversationResolution">,
+): string {
+  return `required_conversation_resolution=${conversationResolutionEvidence(pr).state}`;
+}
+
+export function conversationResolutionEvidenceDetails(
+  pr: Pick<GitHubPullRequest, "requiredConversationResolution">,
+): string[] {
+  const evidence = conversationResolutionEvidence(pr);
+  return [
+    conversationResolutionEvidenceToken(pr),
+    ...(evidence.source ? [`required_conversation_resolution_source=${evidence.source}`] : []),
+    ...(evidence.details ?? []).filter((detail) => detail !== conversationResolutionEvidenceToken(pr)),
+  ];
+}
+
+export function conversationResolutionEvidenceContradictsBlocker(
+  pr: Pick<GitHubPullRequest, "requiredConversationResolution">,
+): boolean {
+  return conversationResolutionEvidence(pr).state === "disabled";
+}

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -59,7 +59,7 @@ export class GitHubReviewSurfaceClient {
       "--limit",
       "1",
       "--json",
-      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
+      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,baseRefName,headRefName,headRefOid,mergedAt",
     ]);
     const pullRequests = parseJson<GitHubPullRequest[]>(result.stdout, `gh pr list --head ${branch}`);
     return this.hydratePullRequestForPurpose(pullRequests[0] ?? null, options.purpose ?? "status");
@@ -81,7 +81,7 @@ export class GitHubReviewSurfaceClient {
       "--limit",
       "20",
       "--json",
-      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
+      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,baseRefName,headRefName,headRefOid,mergedAt",
     ]);
     const pullRequests = parseJson<GitHubPullRequest[]>(result.stdout, `gh pr list --all --head ${branch}`);
     const sorted = [...pullRequests].sort((left, right) => {
@@ -100,7 +100,7 @@ export class GitHubReviewSurfaceClient {
       "--repo",
       this.config.repoSlug,
       "--json",
-      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
+      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,baseRefName,headRefName,headRefOid,mergedAt",
     ]);
     const pullRequest = parseJson<GitHubPullRequest>(result.stdout, `gh pr view #${prNumber}`);
     return (await this.hydratePullRequestForAction(pullRequest)) as GitHubPullRequest;
@@ -117,7 +117,7 @@ export class GitHubReviewSurfaceClient {
       "--repo",
       this.config.repoSlug,
       "--json",
-      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,headRefName,headRefOid,mergedAt",
+      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,baseRefName,headRefName,headRefOid,mergedAt",
     ], { allowExitCodes: [0, 1] });
 
     if (result.exitCode === 0) {
@@ -178,6 +178,7 @@ export class GitHubReviewSurfaceClient {
                 reviewDecision
                 mergeStateStatus
                 mergeable
+                baseRefName
                 headRefName
                 headRefOid
                 mergedAt
@@ -710,10 +711,97 @@ export class GitHubReviewSurfaceClient {
   }
 
   private async hydratePullRequestForStatus(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
-    return this.pullRequestHydrator.hydrateForStatus(pr);
+    return this.hydrateConversationResolutionEvidence(await this.pullRequestHydrator.hydrateForStatus(pr));
   }
 
   private async hydratePullRequestForAction(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
-    return this.pullRequestHydrator.hydrateForAction(pr);
+    return this.hydrateConversationResolutionEvidence(await this.pullRequestHydrator.hydrateForAction(pr));
+  }
+
+  private async hydrateConversationResolutionEvidence(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
+    if (!pr) {
+      return null;
+    }
+
+    return {
+      ...pr,
+      requiredConversationResolution: await this.fetchConversationResolutionEvidence(pr.baseRefName ?? this.config.defaultBranch),
+    };
+  }
+
+  private async fetchConversationResolutionEvidence(branchName: string): Promise<NonNullable<GitHubPullRequest["requiredConversationResolution"]>> {
+    const branchProtection = await this.fetchBranchProtectionConversationResolution(branchName);
+    const branchRules = await this.fetchBranchRulesConversationResolution(branchName);
+    const details = [...branchProtection.details, ...branchRules.details];
+
+    if (branchProtection.state === "enabled" || branchRules.state === "enabled") {
+      return { state: "enabled", source: "github_policy", details };
+    }
+    if (branchProtection.state === "disabled" && branchRules.state === "disabled") {
+      return { state: "disabled", source: "github_policy", details };
+    }
+    if (branchProtection.state === "unavailable" || branchRules.state === "unavailable") {
+      return { state: "unavailable", source: "github_policy", details };
+    }
+    return { state: "unknown", source: "github_policy", details };
+  }
+
+  private async fetchBranchProtectionConversationResolution(branchName: string): Promise<{
+    state: "enabled" | "disabled" | "unavailable";
+    details: string[];
+  }> {
+    const { owner, repo } = this.repoOwnerAndName();
+    try {
+      const result = await this.runGhJsonCommand([
+        "api",
+        `repos/${owner}/${repo}/branches/${encodeURIComponent(branchName)}/protection`,
+      ], { allowExitCodes: [0, 1] });
+      if (result.exitCode !== 0) {
+        return { state: "unavailable", details: ["branch_protection=unavailable"] };
+      }
+      const payload = parseJson<{
+        required_conversation_resolution?: { enabled?: boolean | null } | null;
+      }>(result.stdout, `gh api branch protection ${branchName}`);
+      const enabled = payload.required_conversation_resolution?.enabled;
+      if (enabled === true) {
+        return { state: "enabled", details: ["branch_protection=enabled"] };
+      }
+      if (enabled === false) {
+        return { state: "disabled", details: ["branch_protection=disabled"] };
+      }
+      return { state: "unavailable", details: ["branch_protection=unavailable"] };
+    } catch {
+      return { state: "unavailable", details: ["branch_protection=unavailable"] };
+    }
+  }
+
+  private async fetchBranchRulesConversationResolution(branchName: string): Promise<{
+    state: "enabled" | "disabled" | "unavailable";
+    details: string[];
+  }> {
+    const { owner, repo } = this.repoOwnerAndName();
+    try {
+      const result = await this.runGhJsonCommand([
+        "api",
+        `repos/${owner}/${repo}/rules/branches/${encodeURIComponent(branchName)}`,
+      ], { allowExitCodes: [0, 1] });
+      if (result.exitCode !== 0) {
+        return { state: "unavailable", details: ["ruleset=unavailable"] };
+      }
+      const rules = parseJson<Array<{
+        type?: string | null;
+        parameters?: { required_review_thread_resolution?: boolean | null } | null;
+      }>>(result.stdout, `gh api branch rules ${branchName}`);
+      const pullRequestRules = rules.filter((rule) => rule.type === "pull_request");
+      const enabled = pullRequestRules.some(
+        (rule) => rule.parameters?.required_review_thread_resolution === true,
+      );
+      return {
+        state: enabled ? "enabled" : "disabled",
+        details: [enabled ? "ruleset=enabled" : "ruleset=disabled"],
+      };
+    } catch {
+      return { state: "unavailable", details: ["ruleset=unavailable"] };
+    }
   }
 }

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -1832,6 +1832,154 @@ test("GitHubClient getPullRequest does not reuse cached hydration for action rea
   assert.equal(graphqlCalls, 2);
 });
 
+test("GitHubClient hydrates required conversation-resolution evidence from branch protection and rules", async () => {
+  const config = createConfig();
+  const pullRequest = createPullRequest({
+    number: 364,
+    baseRefName: "main",
+    headRefName: "codex/issue-364",
+    headRefOid: "head-364",
+  });
+
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view" && args[2] === "364") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(pullRequest),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "repos/owner/repo/branches/main/protection") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          required_conversation_resolution: {
+            enabled: true,
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "repos/owner/repo/rules/branches/main") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([
+          {
+            type: "pull_request",
+            parameters: {
+              required_review_thread_resolution: false,
+            },
+          },
+        ]),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const hydrated = await client.getPullRequest(364);
+
+  assert.equal(hydrated.requiredConversationResolution?.state, "enabled");
+  assert.equal(hydrated.requiredConversationResolution?.source, "github_policy");
+  assert.deepEqual(hydrated.requiredConversationResolution?.details, [
+    "branch_protection=enabled",
+    "ruleset=disabled",
+  ]);
+});
+
+test("GitHubClient marks conversation-resolution evidence disabled only when branch protection and rules agree", async () => {
+  const config = createConfig();
+  const pullRequest = createPullRequest({
+    number: 365,
+    baseRefName: "main",
+    headRefName: "codex/issue-365",
+    headRefOid: "head-365",
+  });
+
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "pr" && args[1] === "view" && args[2] === "365") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(pullRequest),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "repos/owner/repo/branches/main/protection") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          required_conversation_resolution: {
+            enabled: false,
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    if (args[0] === "api" && args[1] === "repos/owner/repo/rules/branches/main") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([]),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const hydrated = await client.getPullRequest(365);
+
+  assert.equal(hydrated.requiredConversationResolution?.state, "disabled");
+  assert.deepEqual(hydrated.requiredConversationResolution?.details, [
+    "branch_protection=disabled",
+    "ruleset=disabled",
+  ]);
+});
+
 test("GitHubClient resolvePullRequestForBranch reuses cached hydration for informational reads", async () => {
   const config = createConfig();
   const branch = "codex/issue-362";

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -27,6 +27,7 @@ export interface GitHubPullRequest {
   reviewDecision: string | null;
   mergeStateStatus: string | null;
   mergeable?: string | null;
+  baseRefName?: string | null;
   headRefName: string;
   headRefOid: string;
   copilotReviewState?: CopilotReviewState | null;
@@ -45,6 +46,11 @@ export interface GitHubPullRequest {
   configuredBotDraftSkipAt?: string | null;
   configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
   configuredBotTopLevelReviewSubmittedAt?: string | null;
+  requiredConversationResolution?: {
+    state: "enabled" | "disabled" | "unavailable" | "unknown";
+    source?: string | null;
+    details?: string[] | null;
+  } | null;
   hydrationProvenance?: PullRequestHydrationProvenance | null;
   mergedAt?: string | null;
 }

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -6599,8 +6599,211 @@ test("handlePostTurnPullRequestTransitionsPhase diagnoses outdated configured-bo
   assert.equal(result.record.state, "pr_open");
   assert.equal(commentBodies.length, 1);
   assert.match(commentBodies[0] ?? "", /reason code: `conversation_resolution_blocked`/i);
+  assert.match(commentBodies[0] ?? "", /required_conversation_resolution=unknown/i);
   assert.match(commentBodies[0] ?? "", /conversation_threads=thread-outdated-1/i);
   assert.doesNotMatch(commentBodies[0] ?? "", /reason code: `required_check_mismatch`/i);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase names enabled conversation-resolution policy evidence", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const issue = createIssue({ title: "Diagnose confirmed conversation resolution blocker" });
+  const pr = createPullRequest({
+    title: "Tracked PR confirmed conversation resolution blocker",
+    number: 136,
+    isDraft: false,
+    headRefOid: "head-136",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["branch_protection=enabled"],
+    },
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-enabled-1",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-enabled-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/136#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+
+  await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "pr_open", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(pr.headRefOid),
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => reviewThreads,
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `conversation_resolution_blocked`/i);
+  assert.match(commentBodies[0] ?? "", /required_conversation_resolution=enabled/i);
+  assert.match(commentBodies[0] ?? "", /conversation_threads=thread-outdated-enabled-1/i);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase avoids definitive conversation blocker when fresh policy evidence disables it", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const issue = createIssue({ title: "Avoid contradicted conversation resolution blocker" });
+  const pr = createPullRequest({
+    title: "Tracked PR disabled conversation resolution policy",
+    number: 137,
+    isDraft: false,
+    headRefOid: "head-137",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "disabled",
+      source: "branch_protection",
+      details: ["branch_protection=disabled", "ruleset=disabled"],
+    },
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-disabled-1",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-disabled-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/137#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        issue_number: 102,
+        state: "waiting_ci",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const commentBodies: string[] = [];
+
+  await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "pr_open", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(pr.headRefOid),
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => reviewThreads,
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `required_check_mismatch`/i);
+  assert.match(commentBodies[0] ?? "", /required_conversation_resolution=disabled/i);
+  assert.doesNotMatch(commentBodies[0] ?? "", /reason code: `conversation_resolution_blocked`/i);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase auto-resolves eligible outdated configured-bot conversations", async () => {

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -50,6 +50,10 @@ import { truncate } from "../core/utils";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
 import { classifyStaleReviewBotRecoverability } from "./stale-diagnostic-recoverability";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
+import {
+  conversationResolutionEvidenceContradictsBlocker,
+  conversationResolutionEvidenceToken,
+} from "../conversation-resolution-policy";
 
 function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
@@ -92,9 +96,13 @@ function buildConversationResolutionBlockerStatusLine(args: Pick<
   if (codexConnectorPolicy && codexConnectorPolicy.mergeEffect !== "ready") {
     return null;
   }
+  if (conversationResolutionEvidenceContradictsBlocker(args.pr)) {
+    return null;
+  }
 
   return [
     "conversation_resolution_blocker state=blocked",
+    conversationResolutionEvidenceToken(args.pr),
     `outdated_configured_bot_threads=${configuredThreads.length}`,
     `thread_ids=${configuredThreads.map((thread) => thread.id).sort().join(",")}`,
   ].join(" ");

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -848,7 +848,75 @@ test("buildDetailedStatusModel names conversation-resolution blockers from outda
   assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
   assert.ok(
     lines.includes(
-      "conversation_resolution_blocker state=blocked outdated_configured_bot_threads=1 thread_ids=thread-outdated-1",
+      "conversation_resolution_blocker state=blocked required_conversation_resolution=unknown outdated_configured_bot_threads=1 thread_ids=thread-outdated-1",
+    ),
+  );
+});
+
+test("buildDetailedStatusModel includes enabled conversation-resolution policy evidence", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["branch_protection=enabled"],
+    },
+  });
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-outdated-1",
+      isResolved: false,
+      isOutdated: true,
+      path: "src/file.ts",
+      line: 12,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-1",
+            body: "Outdated Codex thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  const lines = buildDetailedStatusModel({
+    config,
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "pr_open",
+      last_error: null,
+      last_failure_context: null,
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    manualReviewThreads,
+    configuredBotReviewThreads,
+    pendingBotReviewThreads: () => [],
+    summarizeChecks: () => ({ allPassing: true, hasPending: false, hasFailing: false }),
+    mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
+  });
+
+  assert.ok(
+    lines.includes(
+      "conversation_resolution_blocker state=blocked required_conversation_resolution=enabled outdated_configured_bot_threads=1 thread_ids=thread-outdated-1",
     ),
   );
 });

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -29,6 +29,11 @@ import {
   STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
 } from "./supervisor/stale-review-bot-recovery";
 import { workspacePreparationRemediationTargetForFailureClass } from "./remediation-targets";
+import {
+  conversationResolutionEvidenceContradictsBlocker,
+  conversationResolutionEvidenceDetails,
+  conversationResolutionEvidenceToken,
+} from "./conversation-resolution-policy";
 
 export type HostLocalTrackedPrBlockerGateType =
   | "workspace_preparation"
@@ -310,7 +315,7 @@ function buildTrackedPrClearedStatusComment(args: {
 }
 
 function buildRequiredCheckMismatchEvidence(args: {
-  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable">;
+  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable" | "requiredConversationResolution">;
   checks: PullRequestCheck[];
 }): string[] {
   const sortedChecks = [...args.checks]
@@ -320,7 +325,9 @@ function buildRequiredCheckMismatchEvidence(args: {
   return [
     `merge_state=${args.pr.mergeStateStatus}`,
     `mergeable=${args.pr.mergeable ?? "unknown"}`,
+    conversationResolutionEvidenceToken(args.pr),
     ...sortedChecks,
+    ...conversationResolutionEvidenceDetails(args.pr).slice(1),
   ];
 }
 
@@ -402,10 +409,14 @@ function buildConversationResolutionBlocker(args: {
     pr: args.pr,
     threads: configuredThreads,
   });
+  if (conversationResolutionEvidenceContradictsBlocker(args.pr)) {
+    return null;
+  }
   const threadIds = configuredThreads.map((thread) => thread.id).sort();
   const evidence = [
     `merge_state=${args.pr.mergeStateStatus}`,
     `mergeable=${args.pr.mergeable}`,
+    ...conversationResolutionEvidenceDetails(args.pr),
     `conversation_threads=${threadIds.join(",")}`,
     ...buildRequiredCheckMismatchEvidence({ pr: args.pr, checks: args.checks }).filter((line) => line.startsWith("check=")),
   ];
@@ -535,7 +546,7 @@ function derivePersistentTrackedPrStatusComment(args: {
       pr: args.pr,
       checks: args.checks,
     });
-    const evidence = fullEvidence.slice(0, 4);
+    const evidence = fullEvidence.slice(0, 5);
     return {
       blockerSignature:
         `merge-state:${args.pr.mergeStateStatus}:${args.pr.mergeable ?? "unknown"}:${fullEvidence.join("|")}`,


### PR DESCRIPTION
## Summary
- hydrate best-effort required conversation-resolution evidence from branch protection and branch rules
- surface `required_conversation_resolution=<state>` in conversation-resolution blockers and generic merge blockers
- avoid definitive `conversation_resolution_blocked` when fresh policy evidence says conversation resolution is disabled

## Verification
- npx tsx --test src/tracked-pr-status-comment.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts
- npm run build
- node dist/index.js issue-lint 2038 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json

Closes #2038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub's required conversation resolution policy detection and tracking. The system now determines and reports the state of this policy (enabled, disabled, unavailable, or unknown) for pull requests, influencing status reporting and blocker logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->