### PR TITLE
Fix outdated configured-bot conversation hydration

### DIFF
--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -437,7 +437,7 @@ export class GitHubReviewSurfaceClient {
             : null,
         })),
       },
-    })).filter((thread) => !thread.isResolved && !thread.isOutdated);
+    })).filter((thread) => !thread.isResolved);
   }
 
   private async fetchExternalReviewSurface(prNumber: number): Promise<{

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -236,6 +236,82 @@ test("GitHubClient fetches the newest unresolved review thread comments", async 
   assert.equal(threads[0]?.comments.nodes.at(-1)?.author?.typeName, "Bot");
 });
 
+test("GitHubClient retains unresolved outdated review threads for conversation-resolution diagnostics", async () => {
+  const config = createConfig();
+  const client = new GitHubClient(config, async (_command, args) => {
+    if (args[0] === "api" && args[1] === "graphql") {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: "thread-outdated",
+                      isResolved: false,
+                      isOutdated: true,
+                      path: "src/github/github-review-surface.ts",
+                      line: 440,
+                      comments: {
+                        nodes: [
+                          {
+                            id: "comment-outdated",
+                            body: "Outdated configured-bot thread.",
+                            createdAt: "2026-05-18T00:50:00Z",
+                            url: "https://example.test/comments/outdated",
+                            author: {
+                              login: "chatgpt-codex-connector",
+                              __typename: "Bot",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      id: "thread-resolved",
+                      isResolved: true,
+                      isOutdated: true,
+                      path: "src/github/github-review-surface.ts",
+                      line: 441,
+                      comments: {
+                        nodes: [
+                          {
+                            id: "comment-resolved",
+                            body: "Resolved outdated thread.",
+                            createdAt: "2026-05-18T00:51:00Z",
+                            url: "https://example.test/comments/resolved",
+                            author: {
+                              login: "chatgpt-codex-connector",
+                              __typename: "Bot",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const threads = await client.getUnresolvedReviewThreads(137);
+
+  assert.deepEqual(
+    threads.map((thread) => ({ id: thread.id, isOutdated: thread.isOutdated })),
+    [{ id: "thread-outdated", isOutdated: true }],
+  );
+  assert.equal(threads[0]?.comments.nodes[0]?.author?.typeName, "Bot");
+});
+
 test("GitHubClient resolves a review thread via GraphQL mutation", async () => {
   const config = createConfig();
   let resolveMutation: string | null = null;

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -163,6 +163,31 @@ function createPersistentMergeStagePatch(headSha: string) {
   };
 }
 
+function createOutdatedConfiguredBotThreads(threadIds: string[], prNumber: number): ReviewThread[] {
+  return threadIds.map((threadId, index) =>
+    createReviewThread({
+      id: threadId,
+      isOutdated: true,
+      path: `src/hrcore/reproduction-${index + 1}.ts`,
+      line: 10 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "Outdated Codex Connector thread.",
+            createdAt: "2026-05-18T00:50:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_r${index + 1}`,
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+}
+
 function createInitialMergeStageObservationPatch(headSha: string) {
   return {
     provider_success_observed_at: "2026-04-11T00:00:00.000Z",
@@ -6912,6 +6937,148 @@ test("handlePostTurnPullRequestTransitionsPhase auto-resolves eligible outdated 
   assert.deepEqual(commentBodies, []);
   assert.deepEqual(replyCalls, ["thread-outdated-1"]);
   assert.deepEqual(resolveCalls, ["thread-outdated-1"]);
+  assert.equal(result.record.state, "ready_to_merge");
+});
+
+async function exerciseHrcoreOutdatedConversationResolutionCase(args: {
+  issueNumber: number;
+  prNumber: number;
+  headSha: string;
+  threadIds: string[];
+}) {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({
+    number: args.issueNumber,
+    title: "HRCore outdated configured-bot conversation residue",
+  });
+  const pr = createPullRequest({
+    title: "HRCore tracked PR conversation resolution blocker",
+    number: args.prNumber,
+    isDraft: false,
+    headRefOid: args.headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-18T01:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["branch_protection=enabled"],
+    },
+  });
+  const resolvedPr = createPullRequest({
+    ...pr,
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads = createOutdatedConfiguredBotThreads(args.threadIds, args.prNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: args.issueNumber,
+    issues: {
+      [String(args.issueNumber)]: createRecord({
+        issue_number: args.issueNumber,
+        state: "pr_open",
+        pr_number: pr.number,
+        last_head_sha: pr.headRefOid,
+      }),
+    },
+  };
+  const replyCalls: string[] = [];
+  const resolveCalls: string[] = [];
+  const commentBodies: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+      replyToReviewThread: async (threadId: string) => {
+        replyCalls.push(threadId);
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues[String(args.issueNumber)]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", `issue-${args.issueNumber}`),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, snapshotPr) =>
+      createLifecycleSnapshot(recordForState, snapshotPr.mergeStateStatus === "CLEAN" ? "ready_to_merge" : "pr_open", {
+        failureContext: null,
+        mergeLatencyVisibilityPatch: createPersistentMergeStagePatch(snapshotPr.headRefOid),
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads: () => reviewThreads,
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: resolveCalls.length === args.threadIds.length ? resolvedPr : pr,
+      checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: resolveCalls.length === args.threadIds.length ? [] : reviewThreads,
+    }),
+  });
+
+  return { result, replyCalls, resolveCalls, commentBodies };
+}
+
+test("handlePostTurnPullRequestTransitionsPhase models HRCore PR #136 outdated configured-bot residue", async () => {
+  const threadIds = [
+    "PRRT_kwDOSfC_1M6Cy191",
+    "PRRT_kwDOSfC_1M6Cy193",
+    "PRRT_kwDOSfC_1M6Cy199",
+    "PRRT_kwDOSfC_1M6CzIlF",
+    "PRRT_kwDOSfC_1M6CzIlG",
+    "PRRT_kwDOSfC_1M6CzIlI",
+    "PRRT_kwDOSfC_1M6CzIlL",
+    "PRRT_kwDOSfC_1M6CzgEo",
+    "PRRT_kwDOSfC_1M6CzgEp",
+  ];
+
+  const { result, replyCalls, resolveCalls, commentBodies } = await exerciseHrcoreOutdatedConversationResolutionCase({
+    issueNumber: 132,
+    prNumber: 136,
+    headSha: "37c89d721e787110e651196d16f10d0747fb65a2",
+    threadIds,
+  });
+
+  assert.deepEqual(commentBodies, []);
+  assert.deepEqual(replyCalls, threadIds);
+  assert.deepEqual(resolveCalls, threadIds);
+  assert.equal(result.record.state, "ready_to_merge");
+});
+
+test("handlePostTurnPullRequestTransitionsPhase models HRCore PR #137 outdated configured-bot residue", async () => {
+  const threadIds = ["PRRT_kwDOSfC_1M6C1E02", "PRRT_kwDOSfC_1M6C1E09"];
+
+  const { result, replyCalls, resolveCalls, commentBodies } = await exerciseHrcoreOutdatedConversationResolutionCase({
+    issueNumber: 133,
+    prNumber: 137,
+    headSha: "5791f36781ed5623e8e8d50c643630e3a56e438c",
+    threadIds,
+  });
+
+  assert.deepEqual(commentBodies, []);
+  assert.deepEqual(replyCalls, threadIds);
+  assert.deepEqual(resolveCalls, threadIds);
   assert.equal(result.record.state, "ready_to_merge");
 });
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -546,6 +546,9 @@ export function buildActiveDetailedStatusLines(
       lines.push(`pending_checks=${pendingChecks}`);
     }
     const unresolvedConfiguredBotThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
+    const outdatedUnresolvedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads).filter(
+      (thread) => !thread.isResolved && thread.isOutdated,
+    );
     const reviewFollowUpState = configuredBotReviewFollowUpState(
       config,
       activeRecord,
@@ -553,7 +556,7 @@ export function buildActiveDetailedStatusLines(
       unresolvedConfiguredBotThreads,
     );
     lines.push(
-      `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
+      `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} bot_outdated_unresolved=${outdatedUnresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
     );
     const conversationResolutionBlockerLine = buildConversationResolutionBlockerStatusLine({
       config,

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -786,7 +786,7 @@ test("buildDetailedStatusModel counts only unresolved configured bot threads in 
       "configured_bot_top_level_review strength=nitpick_only submitted_at=2026-03-11T14:06:00Z effect=softened",
     ),
   );
-  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
+  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 bot_outdated_unresolved=0 manual=0"));
 });
 
 test("buildDetailedStatusModel names conversation-resolution blockers from outdated configured-bot threads", () => {
@@ -845,7 +845,7 @@ test("buildDetailedStatusModel names conversation-resolution blockers from outda
     mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
   });
 
-  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
+  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 bot_outdated_unresolved=1 manual=0"));
   assert.ok(
     lines.includes(
       "conversation_resolution_blocker state=blocked required_conversation_resolution=unknown outdated_configured_bot_threads=1 thread_ids=thread-outdated-1",
@@ -987,6 +987,6 @@ test("buildDetailedStatusModel does not name conversation-resolution blocker whe
     mergeConflictDetected: (pr) => pr.mergeStateStatus === "DIRTY",
   });
 
-  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 manual=0"));
+  assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 bot_outdated_unresolved=1 manual=0"));
   assert.equal(lines.some((line) => line.startsWith("conversation_resolution_blocker ")), false);
 });

--- a/src/supervisor/supervisor-status-model.test.ts
+++ b/src/supervisor/supervisor-status-model.test.ts
@@ -370,7 +370,7 @@ test("buildDetailedStatusModel preserves active-line ordering across PR and fail
     "checks=fail=1 pending=1",
     "failing_checks=unit",
     "pending_checks=lint",
-    "review_threads bot_pending=0 bot_unresolved=0 manual=0",
+    "review_threads bot_pending=0 bot_unresolved=0 bot_outdated_unresolved=0 manual=0",
     "failure_context category=checks summary=build failed\\nsee logs",
     "failure_details=step one | step two",
     "runtime_failure_context category=codex summary=Host loop failed while persisting diagnostics.",

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -239,7 +239,7 @@ test("formatDetailedStatus renders core lines before appended summaries", () => 
       "configured_bot_top_level_review strength=none submitted_at=none effect=none",
       "pr_state=OPEN draft=no merge_state=CLEAN review_decision=none head_sha=deadbeef",
       "checks=none",
-      "review_threads bot_pending=0 bot_unresolved=0 manual=0",
+      "review_threads bot_pending=0 bot_unresolved=0 bot_outdated_unresolved=0 manual=0",
       "review_follow_up state=inactive remaining=0 head_sha=none actionable=0",
       "handoff_summary=blocked\\nneeds reproduction",
       "local_review_routing generic=inherit->gpt-5-codex(1) specialists=gpt-5-codex(1) verifier=gpt-5-codex",


### PR DESCRIPTION
## Summary
- retain unresolved outdated review threads from the GitHub review surface so conversation-resolution blockers remain visible
- add HRCore-shaped regression coverage for PR #136 and PR #137 outdated configured-bot residue
- expose outdated unresolved configured-bot counts in detailed status

## Verification
- npx tsx --test src/conversation-resolution-policy.test.ts src/github/github.test.ts src/tracked-pr-status-comment.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/supervisor/supervisor-status-model.test.ts src/supervisor/supervisor-status-rendering.test.ts
- npm run build
- node dist/index.js issue-lint 2040 --config <supervisor-self-codex-config>

Closes #2040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unresolved outdated review threads are now retained for conversation resolution diagnostics and status tracking, improving visibility of pending feedback.
  * Status displays now include a dedicated count of outdated unresolved bot-generated review threads.

* **Tests**
  * Added comprehensive test coverage for handling and reporting of outdated unresolved review threads in PR scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->