### PR TITLE
Bug: Codex review threads from stale review commits keep PR blocked after newer repair head (#2042)

### DIFF
--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -358,6 +358,7 @@ export function applyConfiguredBotReviewSummary(
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,
+    configuredBotLatestReviewedCommitSha: summary?.latestReviewedCommitSha ?? null,
     currentHeadCiGreenAt: summary?.currentHeadCiGreenAt ?? null,
     configuredBotRateLimitedAt: summary?.rateLimitWarningAt ?? null,
     configuredBotDraftSkipAt: summary?.draftSkipAt ?? null,

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -62,6 +62,7 @@ class ConfiguredBotReviewSummaryCache {
         currentHeadObservedAt: null,
         currentHeadObservationSource: null,
         currentHeadStatusState: null,
+        latestReviewedCommitSha: null,
         currentHeadCiGreenAt: null,
         rateLimitWarningAt: null,
         draftSkipAt: null,

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -722,6 +722,33 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
   });
 });
 
+test("buildConfiguredBotReviewSummary extracts Codex Connector reviewed commit from review body", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        submittedAt: "2026-05-18T22:30:16Z",
+        commitOid: "github-review-commit",
+        state: "CHANGES_REQUESTED",
+        body: "Review complete.\n\nReviewed commit: 67e4cf0255342591d1b6410cae5126c4a4a40427",
+      },
+    ],
+    comments: [],
+    issueComments: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(
+    facts,
+    ["chatgpt-codex-connector"],
+    "c171be8a7f6e27d18eeef27cf27fd34c33371508",
+  );
+
+  assert.equal(summary.latestReviewedCommitSha, "67e4cf0255342591d1b6410cae5126c4a4a40427");
+  assert.equal(summary.currentHeadObservedAt, null);
+});
+
 test("buildConfiguredBotReviewSummary treats summary-only configured-bot reviews on the current head as observations", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -78,6 +78,7 @@ export interface ConfiguredBotReviewSummary {
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
   currentHeadStatusState: string | null;
+  latestReviewedCommitSha: string | null;
   currentHeadCiGreenAt: string | null;
   rateLimitWarningAt: string | null;
   draftSkipAt: string | null;
@@ -493,6 +494,45 @@ function inferConfiguredBotTopLevelReviewSummary(
   return latestConfiguredReview;
 }
 
+function reviewedCommitFromBody(body: string | null | undefined): string | null {
+  const match = body?.match(/\bReviewed commit:\s*([0-9a-f]{7,40})\b/i);
+  return match?.[1] ?? null;
+}
+
+function inferLatestConfiguredBotReviewedCommitSha(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+): string | null {
+  const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
+  if (configuredReviewBots.size === 0) {
+    return null;
+  }
+
+  let latest: { submittedAtMs: number; reviewedCommitSha: string | null } | null = null;
+  for (const review of facts.reviews) {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    if (!authorLogin || !configuredReviewBots.has(authorLogin)) {
+      continue;
+    }
+
+    const submittedAtMs = parseTimestamp(review.submittedAt);
+    if (submittedAtMs === 0) {
+      continue;
+    }
+
+    const reviewedCommitSha = reviewedCommitFromBody(review.body) ?? review.commitOid?.trim() ?? null;
+    if (!reviewedCommitSha) {
+      continue;
+    }
+
+    if (!latest || submittedAtMs >= latest.submittedAtMs) {
+      latest = { submittedAtMs, reviewedCommitSha };
+    }
+  }
+
+  return latest?.reviewedCommitSha ?? null;
+}
+
 function inferConfiguredBotCurrentHeadObservation(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -768,7 +808,7 @@ export function buildConfiguredBotReviewSummary(
   codexConnectorReviewRequestIdentity?: CodexConnectorReviewRequestIdentity | null,
 ): ConfiguredBotReviewSummary {
   const currentHeadObservation = inferConfiguredBotCurrentHeadObservation(facts, reviewBotLogins, currentHeadOid);
-  return {
+  const summary = {
     lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
     topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
     ...(codexConnectorReviewRequestIdentity
@@ -782,5 +822,10 @@ export function buildConfiguredBotReviewSummary(
     currentHeadCiGreenAt: inferCurrentHeadCiGreenAt(facts, currentHeadOid),
     rateLimitWarningAt: inferConfiguredBotRateLimitWarningAt(facts, reviewBotLogins),
     draftSkipAt: inferConfiguredBotDraftSkipAt(facts, reviewBotLogins),
-  };
+  } as ConfiguredBotReviewSummary;
+  Object.defineProperty(summary, "latestReviewedCommitSha", {
+    enumerable: false,
+    value: inferLatestConfiguredBotReviewedCommitSha(facts, reviewBotLogins),
+  });
+  return summary;
 }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -41,6 +41,7 @@ export interface GitHubPullRequest {
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;
+  configuredBotLatestReviewedCommitSha?: string | null;
   currentHeadCiGreenAt?: string | null;
   configuredBotRateLimitedAt?: string | null;
   configuredBotDraftSkipAt?: string | null;

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -8,6 +8,7 @@ import {
   buildStalledBotReviewFailureContext,
   clusterConfiguredBotReviewThreads,
   codexConnectorMustFixReviewThreads,
+  codexConnectorStaleReviewCommitThreads,
   configuredBotReviewFollowUpState,
   evaluateCodexConnectorConvergencePolicy,
   staleConfiguredBotReviewThreads,
@@ -311,6 +312,38 @@ test("codexConnectorMustFixReviewThreads tracks unresolved P1 findings and repor
 
   assert.deepEqual(codexConnectorMustFixReviewThreads([p1Thread]), [p1Thread]);
   assert.match(buildStalledBotReviewFailureContext([p1Thread])?.details[0] ?? "", /p_severity=P1/);
+});
+
+test("codexConnectorStaleReviewCommitThreads compares current-head SHAs case-insensitively", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const currentHeadSha = "c171be8a7f6e27d18eeef27cf27fd34c33371508";
+  const p1Thread = createReviewThread({
+    id: "thread-p1",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p1",
+          body: "P1: Keep the current-head authorization diagnostic active.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const pr: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha"> = {
+    headRefOid: currentHeadSha,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: currentHeadSha.toUpperCase(),
+  };
+
+  assert.deepEqual(codexConnectorStaleReviewCommitThreads(pr, [p1Thread]), []);
+  assert.equal(buildCodexConnectorPolicyBlockDiagnostic(config, [p1Thread], pr)?.count, 1);
 });
 
 test("codexConnectorMustFixReviewThreads treats P2 and escalated P3 findings as must-fix", () => {

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -84,12 +84,35 @@ export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]
   return reviewThreads.filter(isCodexConnectorMustFixReviewThread);
 }
 
+export function normalizeCommitShaForComparison(sha: string | null | undefined): string | null {
+  const normalized = sha?.trim();
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+export function commitShasEqualForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeCommitShaForComparison(left);
+  const normalizedRight = normalizeCommitShaForComparison(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+export function commitShasDifferForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeCommitShaForComparison(left);
+  const normalizedRight = normalizeCommitShaForComparison(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft !== normalizedRight);
+}
+
 export function codexConnectorStaleReviewCommitThreads(
   pr: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
   reviewThreads: ReviewThread[],
 ): ReviewThread[] {
-  const latestReviewedCommitSha = pr.configuredBotLatestReviewedCommitSha?.trim();
-  if (!latestReviewedCommitSha || latestReviewedCommitSha === pr.headRefOid || validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
+  const latestReviewedCommitSha = normalizeCommitShaForComparison(pr.configuredBotLatestReviewedCommitSha);
+  const currentHeadSha = normalizeCommitShaForComparison(pr.headRefOid);
+  if (
+    !latestReviewedCommitSha ||
+    !currentHeadSha ||
+    latestReviewedCommitSha === currentHeadSha ||
+    validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt)
+  ) {
     return [];
   }
 

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -84,6 +84,18 @@ export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]
   return reviewThreads.filter(isCodexConnectorMustFixReviewThread);
 }
 
+export function codexConnectorStaleReviewCommitThreads(
+  pr: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  const latestReviewedCommitSha = pr.configuredBotLatestReviewedCommitSha?.trim();
+  if (!latestReviewedCommitSha || latestReviewedCommitSha === pr.headRefOid || validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
+    return [];
+  }
+
+  return codexConnectorMustFixReviewThreads(reviewThreads);
+}
+
 export interface CodexConnectorPolicyBlockDiagnostic {
   count: number;
   severity: CodexConnectorPSeverity;
@@ -258,8 +270,12 @@ export function evaluateCodexConnectorConvergencePolicy(
 export function buildCodexConnectorPolicyBlockDiagnostic(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
+  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
 ): CodexConnectorPolicyBlockDiagnostic | null {
   if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
     return null;
   }
 
@@ -285,8 +301,12 @@ export function buildCodexConnectorPolicyBlockDiagnostic(
 export function buildCodexConnectorP2P3PolicyDiagnostic(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
+  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
 ): CodexConnectorP2P3PolicyDiagnostic | null {
   if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
     return null;
   }
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -440,11 +440,11 @@ export function buildActiveDetailedStatusLines(
       }
       lines.push(formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation));
     }
-    const codexConnectorPolicyBlock = buildCodexConnectorPolicyBlockDiagnostic(config, reviewThreads);
+    const codexConnectorPolicyBlock = buildCodexConnectorPolicyBlockDiagnostic(config, reviewThreads, pr);
     if (codexConnectorPolicyBlock) {
       lines.push(formatCodexConnectorPolicyBlockDiagnostic(codexConnectorPolicyBlock));
     }
-    const codexConnectorP2P3Policy = buildCodexConnectorP2P3PolicyDiagnostic(config, reviewThreads);
+    const codexConnectorP2P3Policy = buildCodexConnectorP2P3PolicyDiagnostic(config, reviewThreads, pr);
     if (codexConnectorP2P3Policy) {
       lines.push(formatCodexConnectorP2P3PolicyDiagnostic(codexConnectorP2P3Policy));
     }

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -577,6 +577,127 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
   assert.doesNotMatch(status, /^codex_connector_policy_block .*severity=nitpick_only/m);
 });
 
+test("status waits for current-head Codex review when non-outdated threads came from a stale review commit", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 140;
+  const prNumber = 144;
+  const branch = branchName(fixture.config, issueNumber);
+  const currentHead = "c171be8a7f6e27d18eeef27cf27fd34c33371508";
+  const staleReviewHead = "67e4cf0255342591d1b6410cae5126c4a4a40427";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: currentHead,
+        blocked_reason: "manual_review",
+        last_error: "GitHub is blocked by configured-bot review conversations.",
+        provider_success_head_sha: staleReviewHead,
+        provider_success_observed_at: "2026-05-18T22:30:16Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-18T22:40:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: staleReviewHead,
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-05-18T22:30:16Z",
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
+  });
+  const staleCommitThreads = [
+    {
+      id: "PRRT_kwDOSfC_1M6C-80K",
+      isResolved: false,
+      isOutdated: false,
+      path: "src/app.ts",
+      line: 120,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-1",
+            body: "P1: Map writeback DB constraint failures to a 4xx response.",
+            createdAt: "2026-05-18T22:31:00Z",
+            url: "https://example.test/pr/144#discussion_r1",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+    {
+      id: "PRRT_kwDOSfC_1M6C-80N",
+      isResolved: false,
+      isOutdated: false,
+      path: "openapi/hrcore.openapi.json",
+      line: 400,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-2",
+            body: "P2: Declare 400 responses for writeback validation in OpenAPI.",
+            createdAt: "2026-05-18T22:32:00Z",
+            url: "https://example.test/pr/144#discussion_r2",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => staleCommitThreads,
+  };
+
+  const status = await supervisor.status({ why: true });
+  assert.match(
+    status,
+    /^codex_connector_convergence status=stale_review_commit_residue provider=codex current_head_sha=c171be8a7f6e27d18eeef27cf27fd34c33371508 current_head_observed_at=none latest_signal_head_sha=67e4cf0255342591d1b6410cae5126c4a4a40427 highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_current_head_signal stale_review_commit_threads=2 stale_review_commit_thread_ids=PRRT_kwDOSfC_1M6C-80K,PRRT_kwDOSfC_1M6C-80N$/m,
+  );
+  assert.match(
+    status,
+    /^codex_connector_operator_diagnostic interpretation=current_head_review_pending_with_stale_threads current_head_sha=c171be8a7f6e27d18eeef27cf27fd34c33371508 latest_configured_bot_review_sha=67e4cf0255342591d1b6410cae5126c4a4a40427 current_head_review_signal=missing actionable_current_diff_threads=0 stale_review_commit_threads=2 stale_review_commit_thread_ids=PRRT_kwDOSfC_1M6C-80K,PRRT_kwDOSfC_1M6C-80N next_action=wait_for_current_head_signal$/m,
+  );
+  assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
+  assert.doesNotMatch(status, /^codex_connector_policy_block /m);
+});
+
 test("status surfaces host-migration path repair and journal rehydration from the canonical local journal", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -485,7 +485,7 @@ export async function buildIssueExplainDto(
   const codexConnectorPolicyBlockSummary =
     record && pr && !trackedPrHydrationFailed
       ? (() => {
-        const diagnostic = buildCodexConnectorPolicyBlockDiagnostic(config, explainReviewThreads);
+        const diagnostic = buildCodexConnectorPolicyBlockDiagnostic(config, explainReviewThreads, pr);
         return diagnostic ? formatCodexConnectorPolicyBlockDiagnostic(diagnostic) : null;
       })()
       : null;

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -13,6 +13,8 @@ import { localReviewDegradedNeedsBlock } from "../review-handling";
 import {
   codexConnectorMustFixReviewThreads,
   codexConnectorStaleReviewCommitThreads,
+  commitShasDifferForComparison,
+  commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
 } from "../review-thread-reporting";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
@@ -448,31 +450,31 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   const staleReviewCommitThreads = codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads);
   const staleReviewCommitThreadIds = staleReviewCommitThreads.map((thread) => thread.id).join(",");
   const staleSignalHeadSha =
-    args.pr.configuredBotLatestReviewedCommitSha && args.pr.configuredBotLatestReviewedCommitSha !== currentHeadSha
+    args.pr.configuredBotLatestReviewedCommitSha && commitShasDifferForComparison(args.pr.configuredBotLatestReviewedCommitSha, currentHeadSha)
       ? args.pr.configuredBotLatestReviewedCommitSha
-      : args.record.provider_success_head_sha && args.record.provider_success_head_sha !== currentHeadSha
-      ? args.record.provider_success_head_sha
-      : args.record.external_review_head_sha && args.record.external_review_head_sha !== currentHeadSha
-        ? args.record.external_review_head_sha
-        : null;
+      : args.record.provider_success_head_sha && commitShasDifferForComparison(args.record.provider_success_head_sha, currentHeadSha)
+        ? args.record.provider_success_head_sha
+        : args.record.external_review_head_sha && commitShasDifferForComparison(args.record.external_review_head_sha, currentHeadSha)
+          ? args.record.external_review_head_sha
+          : null;
   const latestSignalHeadSha =
     staleSignalHeadSha ??
-    (args.record.provider_success_head_sha === currentHeadSha
+    (commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha)
       ? args.record.provider_success_head_sha
       : policy.currentHeadObservedAt
         ? currentHeadSha
         : "none");
   const requestMatchesCurrentHead = Boolean(
     args.record.codex_connector_review_requested_observed_at &&
-      args.record.codex_connector_review_requested_head_sha === currentHeadSha,
+      commitShasEqualForComparison(args.record.codex_connector_review_requested_head_sha, currentHeadSha),
   );
   const hydratedRequestMatchesCurrentHead = Boolean(
     !requestMatchesCurrentHead &&
       args.pr.codexConnectorReviewRequestedAt &&
-      args.pr.codexConnectorReviewRequestedHeadSha === currentHeadSha,
+      commitShasEqualForComparison(args.pr.codexConnectorReviewRequestedHeadSha, currentHeadSha),
   );
   const hasCurrentHeadProviderSuccess = Boolean(
-    args.record.provider_success_observed_at && args.record.provider_success_head_sha === currentHeadSha,
+    args.record.provider_success_observed_at && commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha),
   );
   const findingCount = staleReviewCommitThreads.length > 0 ? 0 : policy.findingCount;
   const highestSeverity = staleReviewCommitThreads.length > 0 ? "none" : policy.highestSeverity;
@@ -580,19 +582,21 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
   const actionableCurrentDiffThreads =
     staleReviewCommitThreads.length > 0 ? 0 : codexConnectorMustFixReviewThreads(args.reviewThreads).length;
   const currentHeadReviewSignal =
-    policy.currentHeadObservedAt || args.record.provider_success_head_sha === currentHeadSha ? "observed" : "missing";
+    policy.currentHeadObservedAt || commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha)
+      ? "observed"
+      : "missing";
   const latestConfiguredBotReviewSha =
     currentHeadReviewSignal === "observed"
       ? currentHeadSha
       : args.pr.configuredBotLatestReviewedCommitSha ?? args.record.provider_success_head_sha ?? args.record.external_review_head_sha ?? "none";
   const requestMatchesCurrentHead = Boolean(
     args.record.codex_connector_review_requested_observed_at &&
-      args.record.codex_connector_review_requested_head_sha === currentHeadSha,
+      commitShasEqualForComparison(args.record.codex_connector_review_requested_head_sha, currentHeadSha),
   );
   const hydratedRequestMatchesCurrentHead = Boolean(
     !requestMatchesCurrentHead &&
       args.pr.codexConnectorReviewRequestedAt &&
-      args.pr.codexConnectorReviewRequestedHeadSha === currentHeadSha,
+      commitShasEqualForComparison(args.pr.codexConnectorReviewRequestedHeadSha, currentHeadSha),
   );
   const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
   const nextAction =

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -12,6 +12,7 @@ import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, Supe
 import { localReviewDegradedNeedsBlock } from "../review-handling";
 import {
   codexConnectorMustFixReviewThreads,
+  codexConnectorStaleReviewCommitThreads,
   evaluateCodexConnectorConvergencePolicy,
 } from "../review-thread-reporting";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
@@ -444,8 +445,12 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   }
 
   const currentHeadSha = args.pr.headRefOid;
+  const staleReviewCommitThreads = codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads);
+  const staleReviewCommitThreadIds = staleReviewCommitThreads.map((thread) => thread.id).join(",");
   const staleSignalHeadSha =
-    args.record.provider_success_head_sha && args.record.provider_success_head_sha !== currentHeadSha
+    args.pr.configuredBotLatestReviewedCommitSha && args.pr.configuredBotLatestReviewedCommitSha !== currentHeadSha
+      ? args.pr.configuredBotLatestReviewedCommitSha
+      : args.record.provider_success_head_sha && args.record.provider_success_head_sha !== currentHeadSha
       ? args.record.provider_success_head_sha
       : args.record.external_review_head_sha && args.record.external_review_head_sha !== currentHeadSha
         ? args.record.external_review_head_sha
@@ -469,11 +474,12 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   const hasCurrentHeadProviderSuccess = Boolean(
     args.record.provider_success_observed_at && args.record.provider_success_head_sha === currentHeadSha,
   );
-  const findingCount = policy.findingCount;
-  const highestSeverity = policy.highestSeverity;
+  const findingCount = staleReviewCommitThreads.length > 0 ? 0 : policy.findingCount;
+  const highestSeverity = staleReviewCommitThreads.length > 0 ? "none" : policy.highestSeverity;
 
   let status:
     | "contradictory_evidence"
+    | "stale_review_commit_residue"
     | "stale_head"
     | "repairing_must_fix"
     | "re_requested_review"
@@ -492,7 +498,11 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     | "merge_or_follow_up_nitpicks"
     | "merge_ready";
 
-  if (hasCurrentHeadProviderSuccess && policy.outcome !== "converged" && policy.outcome !== "nitpick_only") {
+  if (staleReviewCommitThreads.length > 0 && policy.outcome === "must_fix_remaining") {
+    status = "stale_review_commit_residue";
+    mergeEffect = "blocked";
+    nextAction = "wait_for_current_head_signal";
+  } else if (hasCurrentHeadProviderSuccess && policy.outcome !== "converged" && policy.outcome !== "nitpick_only") {
     status = "contradictory_evidence";
     nextAction = "fail_closed_inspect_connector_state";
   } else if (staleSignalHeadSha) {
@@ -533,6 +543,12 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     `finding_count=${findingCount}`,
     `merge_effect=${mergeEffect}`,
     `next_action=${nextAction}`,
+    ...(staleReviewCommitThreads.length > 0
+      ? [
+          `stale_review_commit_threads=${staleReviewCommitThreads.length}`,
+          `stale_review_commit_thread_ids=${staleReviewCommitThreadIds}`,
+        ]
+      : []),
   ].join(" ");
 }
 
@@ -559,13 +575,16 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
   }
 
   const currentHeadSha = args.pr.headRefOid;
-  const actionableCurrentDiffThreads = codexConnectorMustFixReviewThreads(args.reviewThreads).length;
+  const staleReviewCommitThreads = codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads);
+  const staleReviewCommitThreadIds = staleReviewCommitThreads.map((thread) => thread.id).join(",");
+  const actionableCurrentDiffThreads =
+    staleReviewCommitThreads.length > 0 ? 0 : codexConnectorMustFixReviewThreads(args.reviewThreads).length;
   const currentHeadReviewSignal =
     policy.currentHeadObservedAt || args.record.provider_success_head_sha === currentHeadSha ? "observed" : "missing";
   const latestConfiguredBotReviewSha =
     currentHeadReviewSignal === "observed"
       ? currentHeadSha
-      : args.record.provider_success_head_sha ?? args.record.external_review_head_sha ?? "none";
+      : args.pr.configuredBotLatestReviewedCommitSha ?? args.record.provider_success_head_sha ?? args.record.external_review_head_sha ?? "none";
   const requestMatchesCurrentHead = Boolean(
     args.record.codex_connector_review_requested_observed_at &&
       args.record.codex_connector_review_requested_head_sha === currentHeadSha,
@@ -577,7 +596,9 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
   );
   const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
   const nextAction =
-    policy.outcome === "must_fix_remaining"
+    staleReviewCommitThreads.length > 0
+      ? "wait_for_current_head_signal"
+      : policy.outcome === "must_fix_remaining"
       ? "repair_must_fix_findings"
       : requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead
         ? "wait_for_requested_review"
@@ -585,7 +606,11 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
           ? "wait_for_current_head_signal"
           : "request_current_head_review";
   const interpretation =
-    policy.outcome === "must_fix_remaining" ? "actionable_current_diff" : "review_gate_waiting";
+    staleReviewCommitThreads.length > 0
+      ? "current_head_review_pending_with_stale_threads"
+      : policy.outcome === "must_fix_remaining"
+        ? "actionable_current_diff"
+        : "review_gate_waiting";
 
   return [
     "codex_connector_operator_diagnostic",
@@ -594,6 +619,12 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
     `latest_configured_bot_review_sha=${latestConfiguredBotReviewSha}`,
     `current_head_review_signal=${currentHeadReviewSignal}`,
     `actionable_current_diff_threads=${actionableCurrentDiffThreads}`,
+    ...(staleReviewCommitThreads.length > 0
+      ? [
+          `stale_review_commit_threads=${staleReviewCommitThreads.length}`,
+          `stale_review_commit_thread_ids=${staleReviewCommitThreadIds}`,
+        ]
+      : []),
     `next_action=${nextAction}`,
   ].join(" ");
 }


### PR DESCRIPTION
Closes #2042
This PR was opened by codex-supervisor.
Latest Codex summary:

Summary: Fixed valid CodeRabbit SHA-casing review finding, committed `151c4dc`, pushed PR #2043, CI/CodeRabbit are green, merge state is CLEAN, and unresolved review threads are 0.
State hint: pr_open
Blocked reason: none
Tests: `npx tsx --test ...` full issue-focused set 305 pass; regression/status subset 116 pass; `npm run build`; `git diff --check`; `node dist/index.js issue-lint 2042 --config <codex-supervisor-config-path>`; GitHub CI ubuntu/macos SUCCESS; CodeRabbit SUCCESS
Failure signature: none
Next action: proceed with normal PR merge/readiness handling for PR #2043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track which commit was last reviewed by the configured bot
  * Detect and report stale review threads from outdated commits
  * System now waits for reviews on the current head when stale review threads are identified
  * Enhanced diagnostics displaying stale thread information and status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->