### PR TITLE
Fix verified Codex residue remediation

### DIFF
--- a/src/supervisor/stale-review-bot-recovery.test.ts
+++ b/src/supervisor/stale-review-bot-recovery.test.ts
@@ -106,3 +106,88 @@ test("recoverStaleConfiguredBotReviewThreads returns a typed resolved result and
     "resolve:thread-1@head-116:stalled-bot:thread-1",
   ]);
 });
+
+test("recoverStaleConfiguredBotReviewThreads normalizes raw PRRT thread signatures", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+  });
+  const pr = createPullRequest({
+    number: 147,
+    headRefOid: "68401b26947918f0ce2280a9526ab68298b1a25c",
+  });
+  const record = createRecord({
+    issue_number: 143,
+    pr_number: pr.number,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    last_head_sha: pr.headRefOid,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 143,
+    issues: {
+      "143": record,
+    },
+  };
+  const failureContext = {
+    ...createFailureContext("stale Codex review commit residue"),
+    signature: "PRRT_kwDOSfC_1M6DBYp8",
+    details: ["reviewer=chatgpt-codex-connector file=src/writeback-ingest.ts line=42 processed_on_current_head=yes"],
+    url: "https://example.test/pr/147#discussion_r147",
+  };
+  const reviewThreads = [
+    createReviewThread({
+      id: "PRRT_kwDOSfC_1M6DBYp8",
+      path: "src/writeback-ingest.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Update the published writeback response schema.",
+            createdAt: "2026-05-18T02:05:00Z",
+            url: "https://example.test/pr/147#discussion_r147",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const replies: string[] = [];
+  const resolutions: string[] = [];
+
+  const result = await recoverStaleConfiguredBotReviewThreads({
+    github: {
+      replyToReviewThread: async (threadId: string) => {
+        replies.push(threadId);
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolutions.push(threadId);
+      },
+    },
+    stateStore: createNoopStateStore(),
+    state,
+    record,
+    pr,
+    reviewThreads,
+    syncJournal: async () => undefined,
+    config,
+    failureContext,
+    resolveAfterReply: true,
+    reasonCode: "verified_current_head_repair_auto_resolve",
+  });
+
+  assert.equal(result.status, "resolved");
+  assert.equal(result.shouldRefreshPullRequest, true);
+  assert.deepEqual(replies, ["PRRT_kwDOSfC_1M6DBYp8"]);
+  assert.deepEqual(resolutions, ["PRRT_kwDOSfC_1M6DBYp8"]);
+  assert.deepEqual(result.record.stale_review_bot_reply_progress_keys, [
+    "reply:PRRT_kwDOSfC_1M6DBYp8@68401b26947918f0ce2280a9526ab68298b1a25c:stalled-bot:PRRT_kwDOSfC_1M6DBYp8",
+  ]);
+  assert.deepEqual(result.record.stale_review_bot_resolve_progress_keys, [
+    "resolve:PRRT_kwDOSfC_1M6DBYp8@68401b26947918f0ce2280a9526ab68298b1a25c:stalled-bot:PRRT_kwDOSfC_1M6DBYp8",
+  ]);
+});

--- a/src/supervisor/stale-review-bot-recovery.ts
+++ b/src/supervisor/stale-review-bot-recovery.ts
@@ -91,9 +91,21 @@ export function staleConfiguredBotReplyThreadIds(signature: string | null | unde
   return signature
     .split("|")
     .map((part) => part.trim())
-    .filter((part) => part.startsWith("stalled-bot:"))
-    .map((part) => part.slice("stalled-bot:".length).trim())
+    .map((part) => {
+      if (part.startsWith("stalled-bot:")) {
+        return part.slice("stalled-bot:".length).trim();
+      }
+      return part.startsWith("PRRT_") ? part : "";
+    })
     .filter((threadId) => threadId.length > 0);
+}
+
+function normalizeStaleConfiguredBotReviewSignature(signature: string): string {
+  const threadIds = staleConfiguredBotReplyThreadIds(signature);
+  if (threadIds.length === 0) {
+    return signature;
+  }
+  return threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|");
 }
 
 export function staleConfiguredBotReviewProgressKey(args: {
@@ -164,7 +176,9 @@ export async function recoverStaleConfiguredBotReviewThreads(args: {
     return buildResult({ status: "skipped", record: args.record, skippedReason: "missing_resolve_api" });
   }
 
-  const blockerSignature = args.failureContext?.signature ?? STALE_CONFIGURED_BOT_REVIEW_REASON_CODE;
+  const blockerSignature = normalizeStaleConfiguredBotReviewSignature(
+    args.failureContext?.signature ?? STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
+  );
   if (
     args.record.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
     args.record.last_stale_review_bot_reply_signature === blockerSignature

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -144,6 +144,10 @@ function hasCleanMergeState(pr: GitHubPullRequest): boolean {
   return pr.state === "OPEN" && !pr.isDraft && pr.mergeStateStatus === "CLEAN" && pr.mergeable === "MERGEABLE";
 }
 
+function hasMergeConflictState(pr: GitHubPullRequest): boolean {
+  return pr.state !== "OPEN" || pr.isDraft || pr.mergeStateStatus === "DIRTY" || pr.mergeable === "CONFLICTING";
+}
+
 function currentHeadSuccess(pr: GitHubPullRequest | null): StaleReviewBotThreadDiagnosticsDto["currentHeadSuccess"] {
   if (!pr) {
     return "unknown";
@@ -191,7 +195,7 @@ function classifyAutoRepairSuppression(args: {
   if (manualReviewThreads(config, args.reviewThreads).length > 0 || nonActionableConfiguredBotReviewThreads(config, args.reviewThreads).length > 0) {
     return "manual_or_unconfigured_review_threads";
   }
-  if (pr.mergeStateStatus === "DIRTY" || pr.mergeable === "CONFLICTING" || !hasCleanMergeState(pr)) {
+  if (hasMergeConflictState(pr)) {
     return "merge_conflict";
   }
   if (hasFailingChecks(checks)) {
@@ -288,7 +292,7 @@ function classifyCodexMetadataOnly(args: {
     manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
     args.record.last_head_sha !== args.pr.headRefOid ||
     !allChecksPassing(args.checks) ||
-    !hasCleanMergeState(args.pr) ||
+    hasMergeConflictState(args.pr) ||
     pendingBotReviewThreads(args.config, args.record, args.pr, configuredThreads).length > 0 ||
     configuredBotReviewFollowUpState(args.config, args.record, args.pr, configuredThreads) === "eligible" ||
     !configuredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
@@ -408,7 +412,7 @@ export function buildStaleReviewBotRemediation(args: {
   checks: PullRequestCheck[];
   reviewThreads?: ReviewThread[];
 }): StaleReviewBotRemediationDto | null {
-  if (args.record.blocked_reason !== "stale_review_bot") {
+  if (args.record.blocked_reason !== "stale_review_bot" && args.record.blocked_reason !== "manual_review") {
     return null;
   }
 
@@ -417,12 +421,15 @@ export function buildStaleReviewBotRemediation(args: {
     return null;
   }
   const classification = classifyRemediation({
-    config: args.config ?? null,
-    record: args.record,
-    pr: args.pr,
-    checks: args.checks,
-    reviewThreads: args.reviewThreads ?? [],
-  });
+      config: args.config ?? null,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads ?? [],
+    });
+  if (args.record.blocked_reason === "manual_review" && !isVerifiedStaleResidueClassification(classification.classification)) {
+    return null;
+  }
   const codexCurrentHeadReviewState = args.pr
     ? codexConnectorCurrentHeadReviewState({
       config: args.config ?? null,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1189,6 +1189,81 @@ test("status --why distinguishes codex verified current-head repair residue from
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });
 
+test("status --why surfaces verified Codex residue remediation for manual_review fallthrough", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  fixture.config.verifiedCurrentHeadRepairReviewThreadAutoResolve = true;
+  const issueNumber = 143;
+  const prNumber = 147;
+  const headSha = "68401b26947918f0ce2280a9526ab68298b1a25c";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_kwDOSfC_1M6DBYp8",
+    commentId: "comment-PRRT_kwDOSfC_1M6DBYp8",
+    path: "src/writeback-ingest.ts",
+    line: 42,
+    commentBody: "P2: Update the published writeback response schema.",
+    discussionUrl: "https://example.test/pr/147#discussion_r147",
+    severity: "P2",
+    verifiedRepair: {
+      summary: "verify-pre-pr passed with 96 tests.",
+      ranAt: "2026-05-18T07:18:00Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        last_failure_signature: "PRRT_kwDOSfC_1M6DBYp8",
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Tracked PR manual_review bypasses verified Codex residue remediation",
+    body: executionReadyBody("Resolve verified stale Codex review residue after manual review fallthrough."),
+    createdAt: "2026-05-18T00:00:00Z",
+    updatedAt: "2026-05-18T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => scenario.passingChecks,
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#143 pr=#147 reason=stale_review_bot code_ci=green current_head_sha=68401b26947918f0ce2280a9526ab68298b1a25c processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/147#discussion_r147 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=verify-pre-pr_passed_with_96_tests\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
+  assert.doesNotMatch(status, /run-once --config \.\.\. --dry-run/);
+});
+
 test("status --why uses the shared stale review-bot presenter for active verified repair residue", async (t) => {
   const fixture = await createSupervisorFixture();
   fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];

--- a/src/supervisor/tracked-pr-mismatch.ts
+++ b/src/supervisor/tracked-pr-mismatch.ts
@@ -32,6 +32,7 @@ import {
   type StaleDiagnosticRecoverability,
 } from "./stale-diagnostic-recoverability";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
+import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
 
 export interface TrackedPrMismatch {
   issueNumber: number;
@@ -454,6 +455,20 @@ export function buildTrackedPrMismatch(
   const staleLocalBlocker =
     record.blocked_reason !== null &&
     (githubState !== "blocked" || githubBlockedReason !== record.blocked_reason);
+
+  if (
+    record.state === "blocked" &&
+    record.blocked_reason === "manual_review" &&
+    buildStaleReviewBotRemediation({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    })
+  ) {
+    return null;
+  }
 
   if (record.state === "blocked" && record.blocked_reason === "verification" && githubState === "draft_pr" && pr.isDraft) {
     const readyPromotionGate = readyPromotionGateSummary(config, record, pr, checks);


### PR DESCRIPTION
## Summary
- surface verified Codex stale-residue remediation when tracked PR state fell through to manual_review
- normalize raw PRRT review-thread signatures for stale configured-bot reply/resolve progress
- suppress stale tracked-PR dry-run mismatch guidance when verified remediation is the authoritative next action

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/review-thread-reporting.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/stale-review-bot-recovery.test.ts
- npm run build
- node dist/index.js issue-lint 2045 --config <supervisor-config-path>

Closes #2045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge conflict detection for stale review bot remediation.
  * Enhanced handling of manual review items with verified remediation classifications.

* **Tests**
  * Added test coverage for stale review thread normalization and recovery.
  * Added test verification for Codex residue remediation in manual review scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->