### PR TITLE
Fix stale Codex residue review request

### DIFF
--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -6,6 +6,7 @@ import {
   latestReviewThreadCommentFingerprint,
 } from "./review-handling";
 import {
+  codexConnectorStaleReviewCommitThreads,
   codexConnectorMustFixReviewThreads,
   configuredBotReviewFollowUpState,
   latestReviewCommentAuthorIsAllowedBot,
@@ -102,6 +103,9 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
   const staleConfiguredThreadIds = new Set(
     staleConfiguredBotReviewThreads(args.config, args.record, args.pr, args.reviewThreads).map((thread) => thread.id),
   );
+  const staleReviewCommitThreadIds = new Set(
+    codexConnectorStaleReviewCommitThreads(args.pr, args.configuredThreads).map((thread) => thread.id),
+  );
   const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(args.configuredThreads).map((thread) => thread.id));
 
   if (
@@ -110,7 +114,8 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
         codexMustFixThreadIds.has(thread.id) &&
         !staleHeadConfiguredThreadIds.has(thread.id) &&
         !currentHeadConfiguredThreadIds.has(thread.id) &&
-        !staleConfiguredThreadIds.has(thread.id),
+        !staleConfiguredThreadIds.has(thread.id) &&
+        !staleReviewCommitThreadIds.has(thread.id),
     )
   ) {
     return false;
@@ -124,6 +129,7 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
     (thread) =>
       staleHeadConfiguredThreadIds.has(thread.id) ||
       staleConfiguredThreadIds.has(thread.id) ||
+      staleReviewCommitThreadIds.has(thread.id) ||
       (latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
         hasProcessedReviewThread(args.record, args.pr, thread)),
   );

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -159,6 +159,24 @@ test("selectStatusOperatorAction ignores rendered doctor action lines", () => {
   );
 });
 
+test("selectStatusOperatorAction flags elapsed Codex review request fallback instead of continuing", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "codex_connector_review_fallback status=timeout_elapsed provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-19T09:13:41.000Z",
+        "codex_connector_convergence status=stale_review_commit_residue provider=codex current_head_sha=head-1 current_head_observed_at=none latest_signal_head_sha=head-0 highest_severity=none finding_count=0 merge_effect=blocked next_action=request_current_head_review stale_review_commit_threads=1 stale_review_commit_thread_ids=thread-1",
+      ],
+    }),
+    {
+      action: "provider_outage_suspected",
+      source: "codex_connector_review_fallback",
+      priority: 70,
+      summary:
+        "The configured review provider has not reported on the current head after checks turned green; wait, verify provider delivery, or escalate to manual review.",
+    },
+  );
+});
+
 test("buildStatusOperatorCockpitViewModel carries the shared action contract and evidence", () => {
   assert.deepEqual(
     buildStatusOperatorCockpitViewModel({

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -352,6 +352,22 @@ export function selectStatusOperatorAction(args: {
     }
 
     if (
+      /^codex_connector_review_fallback\b/.test(line) &&
+      /\bstatus=timeout_elapsed\b/.test(line) &&
+      /\btimeout_action=request_review_comment\b/.test(line) &&
+      /\brequested_at=none\b/.test(line)
+    ) {
+      actions.push({
+        action: "provider_outage_suspected",
+        source: "codex_connector_review_fallback",
+        priority: 70,
+        summary:
+          "The configured review provider has not reported on the current head after checks turned green; wait, verify provider delivery, or escalate to manual review.",
+      });
+      continue;
+    }
+
+    if (
       /^stale_review_bot_remediation\b/.test(line) &&
       /\bclassification=(?:actionable_current_diff|unknown_needs_operator)\b/.test(line)
     ) {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1824,6 +1824,115 @@ test("handlePostTurnPullRequestTransitionsPhase re-requests Codex Connector revi
   }
 });
 
+test("handlePostTurnPullRequestTransitionsPhase requests Codex review for stale review commit residue after repair-head recovery", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-19T09:14:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 143, title: "HRCore stale Codex residue" });
+    const currentHead = "c1ac7215a12398842152b1daf42311faef297317";
+    const staleReviewHead = "98da2474c530b76dae67b5a6f43e0671b989f65a";
+    const pr = createPullRequest({
+      number: 147,
+      title: "HRCore stale Codex residue",
+      isDraft: false,
+      headRefOid: currentHead,
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotLatestReviewedCommitSha: staleReviewHead,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const staleReviewCommitThread = createReviewThread({
+      id: "PRRT_kwDOSfC_1M6DF5s7",
+      path: "src/local-sqlite.ts",
+      line: 120,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-codex-review-commit",
+            body: "P1: Run new migrations for existing local databases.",
+            createdAt: "2026-05-19T09:01:00Z",
+            url: "https://example.test/pr/147#discussion_r147",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "addressing_review",
+      pr_number: pr.number,
+      last_head_sha: currentHead,
+      review_wait_started_at: null,
+      review_wait_head_sha: null,
+      provider_success_observed_at: "2026-05-19T09:00:00Z",
+      provider_success_head_sha: staleReviewHead,
+      copilot_review_timed_out_at: "2026-05-19T09:13:41.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-143"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [staleReviewCommitThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(comments[0]?.issueNumber, pr.number);
+    assert.equal(
+      comments[0]?.body ?? "",
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
+    );
+    assert.equal(result.record.codex_connector_review_requested_head_sha, currentHead);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blockers when refreshed state is waiting_ci", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -578,29 +578,34 @@ test("status reports Codex Connector P1 policy blocks with thread diagnostics", 
 });
 
 test("status waits for current-head Codex review when non-outdated threads came from a stale review commit", async (t) => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-19T09:14:00Z");
+  t.after(() => {
+    Date.now = originalDateNow;
+  });
   const fixture = await createSupervisorFixture();
   t.after(async () => {
     await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
   });
 
-  const issueNumber = 140;
-  const prNumber = 144;
+  const issueNumber = 143;
+  const prNumber = 147;
   const branch = branchName(fixture.config, issueNumber);
-  const currentHead = "c171be8a7f6e27d18eeef27cf27fd34c33371508";
-  const staleReviewHead = "67e4cf0255342591d1b6410cae5126c4a4a40427";
+  const currentHead = "c1ac7215a12398842152b1daf42311faef297317";
+  const staleReviewHead = "98da2474c530b76dae67b5a6f43e0671b989f65a";
   const state: SupervisorStateFile = {
     activeIssueNumber: issueNumber,
     issues: {
       [String(issueNumber)]: createRecord({
         issue_number: issueNumber,
-        state: "blocked",
+        state: "addressing_review",
         branch,
         pr_number: prNumber,
         workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
         journal_path: null,
         last_head_sha: currentHead,
-        blocked_reason: "manual_review",
-        last_error: "GitHub is blocked by configured-bot review conversations.",
+        blocked_reason: null,
+        last_error: null,
         provider_success_head_sha: staleReviewHead,
         provider_success_observed_at: "2026-05-18T22:30:16Z",
       }),
@@ -615,7 +620,7 @@ test("status waits for current-head Codex review when non-outdated threads came 
     isDraft: false,
     mergeStateStatus: "BLOCKED",
     mergeable: "MERGEABLE",
-    currentHeadCiGreenAt: "2026-05-18T22:40:00Z",
+    currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
     configuredBotCurrentHeadObservedAt: null,
     configuredBotLatestReviewedCommitSha: staleReviewHead,
     configuredBotTopLevelReviewStrength: "blocking",
@@ -628,18 +633,18 @@ test("status waits for current-head Codex review when non-outdated threads came 
   });
   const staleCommitThreads = [
     {
-      id: "PRRT_kwDOSfC_1M6C-80K",
+      id: "PRRT_kwDOSfC_1M6DF5s7",
       isResolved: false,
       isOutdated: false,
-      path: "src/app.ts",
+      path: "src/local-sqlite.ts",
       line: 120,
       comments: {
         nodes: [
           {
             id: "comment-stale-1",
-            body: "P1: Map writeback DB constraint failures to a 4xx response.",
+            body: "P1: Run new migrations for existing local databases.",
             createdAt: "2026-05-18T22:31:00Z",
-            url: "https://example.test/pr/144#discussion_r1",
+            url: "https://example.test/pr/147#discussion_r1",
             author: {
               login: "chatgpt-codex-connector",
               typeName: "Bot",
@@ -649,18 +654,18 @@ test("status waits for current-head Codex review when non-outdated threads came 
       },
     },
     {
-      id: "PRRT_kwDOSfC_1M6C-80N",
+      id: "PRRT_kwDOSfC_1M6DF5s0",
       isResolved: false,
-      isOutdated: false,
-      path: "openapi/hrcore.openapi.json",
+      isOutdated: true,
+      path: "src/writeback-ingest.ts",
       line: 400,
       comments: {
         nodes: [
           {
             id: "comment-stale-2",
-            body: "P2: Declare 400 responses for writeback validation in OpenAPI.",
+            body: "P2: Accept refreshes already reflected in HRCore.",
             createdAt: "2026-05-18T22:32:00Z",
-            url: "https://example.test/pr/144#discussion_r2",
+            url: "https://example.test/pr/147#discussion_r2",
             author: {
               login: "chatgpt-codex-connector",
               typeName: "Bot",
@@ -675,6 +680,7 @@ test("status waits for current-head Codex review when non-outdated threads came 
     ...fixture.config,
     reviewBotLogins: ["chatgpt-codex-connector"],
     configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
   });
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     listCandidateIssues: async () => [],
@@ -688,12 +694,17 @@ test("status waits for current-head Codex review when non-outdated threads came 
   const status = await supervisor.status({ why: true });
   assert.match(
     status,
-    /^codex_connector_convergence status=stale_review_commit_residue provider=codex current_head_sha=c171be8a7f6e27d18eeef27cf27fd34c33371508 current_head_observed_at=none latest_signal_head_sha=67e4cf0255342591d1b6410cae5126c4a4a40427 highest_severity=none finding_count=0 merge_effect=blocked next_action=wait_for_current_head_signal stale_review_commit_threads=2 stale_review_commit_thread_ids=PRRT_kwDOSfC_1M6C-80K,PRRT_kwDOSfC_1M6C-80N$/m,
+    /^codex_connector_review_fallback status=timeout_elapsed provider=codex current_head_sha=c1ac7215a12398842152b1daf42311faef297317 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-05-19T09:13:41\.000Z$/m,
   );
   assert.match(
     status,
-    /^codex_connector_operator_diagnostic interpretation=current_head_review_pending_with_stale_threads current_head_sha=c171be8a7f6e27d18eeef27cf27fd34c33371508 latest_configured_bot_review_sha=67e4cf0255342591d1b6410cae5126c4a4a40427 current_head_review_signal=missing actionable_current_diff_threads=0 stale_review_commit_threads=2 stale_review_commit_thread_ids=PRRT_kwDOSfC_1M6C-80K,PRRT_kwDOSfC_1M6C-80N next_action=wait_for_current_head_signal$/m,
+    /^codex_connector_convergence status=stale_review_commit_residue provider=codex current_head_sha=c1ac7215a12398842152b1daf42311faef297317 current_head_observed_at=none latest_signal_head_sha=98da2474c530b76dae67b5a6f43e0671b989f65a highest_severity=none finding_count=0 merge_effect=blocked next_action=request_current_head_review stale_review_commit_threads=1 stale_review_commit_thread_ids=PRRT_kwDOSfC_1M6DF5s7$/m,
   );
+  assert.match(
+    status,
+    /^codex_connector_operator_diagnostic interpretation=current_head_review_pending_with_stale_threads current_head_sha=c1ac7215a12398842152b1daf42311faef297317 latest_configured_bot_review_sha=98da2474c530b76dae67b5a6f43e0671b989f65a current_head_review_signal=missing actionable_current_diff_threads=0 stale_review_commit_threads=1 stale_review_commit_thread_ids=PRRT_kwDOSfC_1M6DF5s7 next_action=request_current_head_review$/m,
+  );
+  assert.doesNotMatch(status, /^operator_action action=continue /m);
   assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
   assert.doesNotMatch(status, /^codex_connector_policy_block /m);
 });

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -473,6 +473,16 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
       args.pr.codexConnectorReviewRequestedAt &&
       commitShasEqualForComparison(args.pr.codexConnectorReviewRequestedHeadSha, currentHeadSha),
   );
+  const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
+  const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
+  const staleReviewCommitNextAction =
+    requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead
+      ? "wait_for_requested_review"
+      : waitWindow.status === "active"
+        ? "wait_for_current_head_signal"
+        : timeoutAction === "request_review_comment"
+          ? "request_current_head_review"
+          : "wait_for_current_head_signal";
   const hasCurrentHeadProviderSuccess = Boolean(
     args.record.provider_success_observed_at && commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha),
   );
@@ -503,7 +513,7 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   if (staleReviewCommitThreads.length > 0 && policy.outcome === "must_fix_remaining") {
     status = "stale_review_commit_residue";
     mergeEffect = "blocked";
-    nextAction = "wait_for_current_head_signal";
+    nextAction = staleReviewCommitNextAction;
   } else if (hasCurrentHeadProviderSuccess && policy.outcome !== "converged" && policy.outcome !== "nitpick_only") {
     status = "contradictory_evidence";
     nextAction = "fail_closed_inspect_connector_state";
@@ -529,7 +539,6 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     nextAction = policy.nextAction;
   }
 
-  const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
   if (status === "missing_current_head_review" && waitWindow.status === "active") {
     status = "waiting_review";
     nextAction = "wait_for_current_head_signal";
@@ -599,9 +608,16 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
       commitShasEqualForComparison(args.pr.codexConnectorReviewRequestedHeadSha, currentHeadSha),
   );
   const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
+  const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
   const nextAction =
     staleReviewCommitThreads.length > 0
-      ? "wait_for_current_head_signal"
+      ? requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead
+        ? "wait_for_requested_review"
+        : waitWindow.status === "active"
+          ? "wait_for_current_head_signal"
+          : timeoutAction === "request_review_comment"
+            ? "request_current_head_review"
+            : "wait_for_current_head_signal"
       : policy.outcome === "must_fix_remaining"
       ? "repair_must_fix_findings"
       : requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead


### PR DESCRIPTION
## Summary
- allow authoritative stale Codex review-commit residue to trigger a current-head @codex review request after repair-head recovery
- update status diagnostics so expired stale review-commit residue points to request_current_head_review instead of passive waiting
- add HRCore-shaped regressions for post-turn request behavior and status/operator action reporting

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/review-thread-reporting.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/stale-review-bot-recovery.test.ts src/operator-actions.test.ts
- git diff --check
- npm run build
- CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint 2047 --config "$CODEX_SUPERVISOR_CONFIG"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of stale Codex review threads with automatic fallback to request fresh reviews when timeouts occur.
  * Enhanced review request timeout detection and recovery logic for better status reporting.

* **Tests**
  * Added comprehensive test coverage for review request timeout scenarios and stale review recovery processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->