### PR TITLE
Fix stale-head Codex review request fallback

### DIFF
--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -83,6 +83,29 @@ test("codexConnectorReviewRequestAction selects an initial request without GitHu
   assert.deepEqual(decide(), { kind: "initial" });
 });
 
+test("codexConnectorReviewRequestAction requests review for stale-head configured-bot signal after timeout", () => {
+  assert.deepEqual(
+    decide({
+      record: {
+        state: "blocked",
+        blocked_reason: "stale_review_bot",
+        provider_success_head_sha: "head-old",
+        provider_success_observed_at: "2026-05-08T03:00:00Z",
+        external_review_head_sha: "head-old",
+      },
+      pr: {
+        headRefOid: "head-1995",
+        configuredBotLatestReviewedCommitSha: "head-old",
+        configuredBotCurrentHeadObservedAt: null,
+      },
+      reviewThreads: [],
+      configuredThreads: [],
+      manualThreads: [],
+    }),
+    { kind: "initial" },
+  );
+});
+
 test("codexConnectorReviewRequestAction selects retry after the same-head request wait expires", () => {
   assert.deepEqual(
     decide({

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -8,6 +8,7 @@ import {
 import {
   codexConnectorStaleReviewCommitThreads,
   codexConnectorMustFixReviewThreads,
+  commitShasDifferForComparison,
   configuredBotReviewFollowUpState,
   latestReviewCommentAuthorIsAllowedBot,
   staleConfiguredBotReviewThreads,
@@ -157,6 +158,11 @@ export function codexConnectorReviewRequestAction(
     staleCodexReviewState?.classification === "verified_no_source_change_pending_thread_resolution";
   const isCodexVerifiedCurrentHeadRepairThreadResolution =
     staleCodexReviewState?.classification === "verified_current_head_repair_pending_thread_resolution";
+  const isStaleHeadMissingCurrentHeadReview =
+    !isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) &&
+    (commitShasDifferForComparison(args.pr.configuredBotLatestReviewedCommitSha, args.pr.headRefOid) ||
+      commitShasDifferForComparison(args.record.provider_success_head_sha, args.pr.headRefOid) ||
+      commitShasDifferForComparison(args.record.external_review_head_sha, args.pr.headRefOid));
   const isCodexMetadataOnly =
     staleCodexReviewState?.classification === "metadata_only" ||
     staleCodexReviewState?.classification === "metadata_only_missing_current_head_review" ||
@@ -167,6 +173,7 @@ export function codexConnectorReviewRequestAction(
   if (
     configuredReviewProviderKinds(args.config).includes("codex") &&
     !isCodexMissingCurrentHeadReview &&
+    !isStaleHeadMissingCurrentHeadReview &&
     (isCodexConvergedCurrentHeadReview ||
       isCodexVerifiedNoSourceChangeThreadResolution ||
       isCodexVerifiedCurrentHeadRepairThreadResolution ||

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -1933,6 +1933,166 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex review for stale 
   }
 });
 
+test("handlePostTurnPullRequestTransitionsPhase requests Codex review for blocked stale-head configured-bot signal", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-19T09:14:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const issue = createIssue({ number: 150, title: "HRCore stale-head Codex request" });
+    const currentHead = "48263f7ab1e54762bf467b6a74ca97df3096b178";
+    const staleReviewHead = "f26360ae56dea3deaadddb958ad1ef01567aaefb";
+    const pr = createPullRequest({
+      number: 154,
+      title: "HRCore stale-head Codex request",
+      isDraft: false,
+      headRefOid: currentHead,
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotLatestReviewedCommitSha: staleReviewHead,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "blocked",
+      blocked_reason: "stale_review_bot",
+      pr_number: pr.number,
+      last_head_sha: currentHead,
+      review_wait_started_at: "2026-05-19T09:03:41Z",
+      review_wait_head_sha: currentHead,
+      provider_success_observed_at: "2026-05-19T09:00:00Z",
+      provider_success_head_sha: staleReviewHead,
+      external_review_head_sha: staleReviewHead,
+      copilot_review_timed_out_at: "2026-05-19T09:13:41.000Z",
+      copilot_review_timeout_action: "request_review_comment",
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+          return {
+            databaseId: 154001,
+            nodeId: "IC_kwDO154",
+            url: "https://example.test/pr/154#issuecomment-154001",
+          };
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-150"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (recordForState) =>
+        createLifecycleSnapshot(recordForState, "blocked", {
+          copilotTimeoutPatch: {
+            copilot_review_timed_out_at: "2026-05-19T09:13:41.000Z",
+            copilot_review_timeout_action: "request_review_comment",
+            copilot_review_timeout_reason: "current_head_signal_timeout",
+          },
+        }),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: () => "stale_review_bot",
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.deepEqual(comments, [
+      {
+        issueNumber: pr.number,
+        body: `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${pr.headRefOid} -->`,
+      },
+    ]);
+    assert.equal(result.record.codex_connector_review_requested_head_sha, currentHead);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+    assert.equal(result.record.codex_connector_review_request_comment_identity_status, "available");
+    assert.equal(result.record.codex_connector_review_request_comment_database_id, 154001);
+
+    const duplicateState: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: result.record },
+    };
+    const duplicateResult = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr: {
+          ...pr,
+          codexConnectorReviewRequestedAt: result.record.codex_connector_review_requested_observed_at,
+          codexConnectorReviewRequestedHeadSha: result.record.codex_connector_review_requested_head_sha,
+        },
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-150"),
+        state: duplicateState,
+        record: result.record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr: {
+          ...pr,
+          codexConnectorReviewRequestedAt: result.record.codex_connector_review_requested_observed_at,
+          codexConnectorReviewRequestedHeadSha: result.record.codex_connector_review_requested_head_sha,
+        },
+        checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [],
+      }),
+      derivePullRequestLifecycleSnapshot: (recordForState) =>
+        createLifecycleSnapshot(recordForState, "blocked", {
+          codexConnectorRequestObservationPatch: {},
+          copilotTimeoutPatch: {
+            copilot_review_timed_out_at: result.record.copilot_review_timed_out_at,
+            copilot_review_timeout_action: result.record.copilot_review_timeout_action,
+            copilot_review_timeout_reason: result.record.copilot_review_timeout_reason,
+          },
+        }),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: () => "stale_review_bot",
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(
+      comments.filter((comment) => comment.body.includes("codex-supervisor:codex-connector-review-request")).length,
+      1,
+      JSON.stringify(comments),
+    );
+    assert.equal(duplicateResult.record.codex_connector_review_requested_head_sha, currentHead);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blockers when refreshed state is waiting_ci", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -1119,6 +1119,43 @@ test("formatCodexConnectorConvergenceDiagnostic distinguishes Codex Connector re
   );
 });
 
+test("formatCodexConnectorConvergenceDiagnostic requests review for stale-head signal after timeout", () => {
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-05-08T03:30:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const pr = createPr({
+      headRefOid: "head-new",
+      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotLatestReviewedCommitSha: "head-old",
+    });
+
+    assert.equal(
+      formatCodexConnectorConvergenceDiagnostic({
+        config,
+        record: createRecord({
+          state: "blocked",
+          pr_number: pr.number,
+          provider_success_head_sha: "head-old",
+          provider_success_observed_at: "2026-05-08T03:00:00Z",
+          codex_connector_review_requested_observed_at: null,
+          codex_connector_review_requested_head_sha: null,
+        }),
+        pr,
+        reviewThreads: [],
+      }),
+      "codex_connector_convergence status=stale_head provider=codex current_head_sha=head-new current_head_observed_at=none latest_signal_head_sha=head-old highest_severity=none finding_count=0 merge_effect=blocked next_action=request_current_head_review",
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("configuredBotInitialGraceWaitWindow reports the active CodeRabbit re-wait after a draft skip when the PR becomes ready", () => {
   const originalNow = Date.now;
   Date.now = () => Date.parse("2026-03-16T00:00:45.000Z");

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -520,7 +520,7 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   } else if (staleSignalHeadSha) {
     status = "stale_head";
     mergeEffect = "blocked";
-    nextAction = "wait_for_current_head_signal";
+    nextAction = staleReviewCommitNextAction;
   } else if (policy.outcome === "must_fix_remaining") {
     status = "repairing_must_fix";
     nextAction = policy.nextAction;


### PR DESCRIPTION
## Summary
- allow stale-head Codex Connector records to request a current-head review after the request-comment timeout
- align stale-head convergence diagnostics with the same request-current-head-review fallback
- add focused decision, post-turn, and diagnostic regressions for issue #2049

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/codex-connector-review-request-decision.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npm run build
- node dist/index.js issue-lint 2049 --config <temporary-resolved-supervisor-config>

Closes #2049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of stale review signals when a pull request's code has changed since the last review
  * Improved handling of blocked pull requests by requesting fresh reviews when the configured head SHA diverges from the current PR state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->