### PR TITLE
Extract Codex Connector review request transition

### DIFF
--- a/src/codex-connector-review-request-transition.test.ts
+++ b/src/codex-connector-review-request-transition.test.ts
@@ -1,0 +1,262 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-review-request-transition";
+import type { FailureContext, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "./core/types";
+import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
+import { createConfig, createPullRequest, createRecord } from "./turn-execution-test-helpers";
+
+function createCodexConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    codexConnectorReviewRequestNoResponseMinutes: 10,
+    codexConnectorReviewRequestRetryLimit: 1,
+    ...overrides,
+  });
+}
+
+function createNoopStateStore() {
+  return {
+    touch: (record: IssueRunRecord, patch: Partial<IssueRunRecord>) => ({ ...record, ...patch, updated_at: record.updated_at }),
+    save: async () => undefined,
+  };
+}
+
+function summarizeChecks(checks: PullRequestCheck[]) {
+  return {
+    hasPending: checks.some((check) => check.bucket === "pending"),
+    hasFailing: checks.some((check) => check.bucket === "fail"),
+  };
+}
+
+const passingChecks: PullRequestCheck[] = [
+  {
+    name: "build",
+    state: "SUCCESS",
+    bucket: "pass",
+    workflow: "CI",
+  },
+];
+
+function createRequestRecord(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
+  return createRecord({
+    issue_number: 2052,
+    state: "waiting_ci",
+    pr_number: 2052,
+    last_head_sha: "head-2052",
+    review_wait_started_at: "2026-05-08T03:09:36Z",
+    review_wait_head_sha: "head-2052",
+    copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    ...overrides,
+  });
+}
+
+async function requestTransition(overrides: {
+  config?: Partial<SupervisorConfig>;
+  record?: Partial<IssueRunRecord>;
+  pr?: Parameters<typeof createPullRequest>[0];
+  addIssueComment?: (issueNumber: number, body: string) => Promise<{
+    databaseId: number;
+    nodeId: string;
+    url: string;
+  } | void>;
+  now?: string;
+} = {}) {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse(overrides.now ?? "2026-05-08T03:30:00Z");
+  try {
+    const config = createCodexConfig(overrides.config);
+    const record = createRequestRecord(overrides.record);
+    const pr = createPullRequest({
+      number: 2052,
+      title: "Extract Codex Connector review request lifecycle transition",
+      headRefOid: "head-2052",
+      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+      ...overrides.pr,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: record.issue_number,
+      issues: { [String(record.issue_number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+    const journaled: IssueRunRecord[] = [];
+    const result = await maybeRequestCodexConnectorReviewComment({
+      config,
+      stateStore: createNoopStateStore(),
+      state,
+      github: overrides.addIssueComment
+        ? {
+            addIssueComment: async (issueNumber, body) => {
+              comments.push({ issueNumber, body });
+              return overrides.addIssueComment?.(issueNumber, body);
+            },
+          }
+        : {},
+      record,
+      pr,
+      checks: passingChecks,
+      reviewThreads: [],
+      syncJournal: async (updatedRecord) => {
+        journaled.push(updatedRecord);
+      },
+      applyFailureSignature: (_record, failureContext: FailureContext) => ({
+        last_failure_signature: failureContext.signature,
+        repeated_failure_signature_count: 1,
+      }),
+      blockedReasonFromReviewState: () => null,
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+    return { result, state, comments, journaled, pr };
+  } finally {
+    Date.now = originalDateNow;
+  }
+}
+
+test("maybeRequestCodexConnectorReviewComment persists initial request comment identity and clears blockers", async () => {
+  const { result, state, comments, journaled, pr } = await requestTransition({
+    record: {
+      blocked_reason: "review_bot_timeout",
+      last_error: "waiting for review",
+      last_failure_signature: "old-review-timeout",
+      repeated_failure_signature_count: 2,
+    },
+    addIssueComment: async () => ({
+      databaseId: 2052001,
+      nodeId: "IC_kwDOissue2052_request",
+      url: "https://github.com/owner/repo/issues/2052#issuecomment-2052001",
+    }),
+  });
+
+  assert.deepEqual(comments, [
+    {
+      issueNumber: pr.number,
+      body: `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=2052 pr=${pr.number} head=${pr.headRefOid} -->`,
+    },
+  ]);
+  assert.equal(result.state, "waiting_ci");
+  assert.equal(result.codex_connector_review_requested_head_sha, pr.headRefOid);
+  assert.match(result.codex_connector_review_requested_observed_at ?? "", /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(result.codex_connector_review_request_retry_count, 0);
+  assert.equal(result.codex_connector_review_request_retry_head_sha, null);
+  assert.equal(result.codex_connector_review_request_comment_identity_status, "available");
+  assert.equal(result.codex_connector_review_request_comment_database_id, 2052001);
+  assert.equal(result.codex_connector_review_request_comment_node_id, "IC_kwDOissue2052_request");
+  assert.equal(
+    result.codex_connector_review_request_comment_url,
+    "https://github.com/owner/repo/issues/2052#issuecomment-2052001",
+  );
+  assert.equal(result.blocked_reason, null);
+  assert.equal(result.last_error, null);
+  assert.equal(state.issues["2052"], result);
+  assert.deepEqual(journaled, [result]);
+});
+
+test("maybeRequestCodexConnectorReviewComment retries same-head request without resetting original request time", async () => {
+  const { result, comments, pr } = await requestTransition({
+    config: { codexConnectorReviewRequestRetryMode: "plain" },
+    now: "2026-05-08T03:40:00Z",
+    record: {
+      codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+      codex_connector_review_requested_head_sha: "head-2052",
+      codex_connector_review_request_retry_count: 0,
+      codex_connector_review_request_retry_head_sha: null,
+      codex_connector_review_request_last_retried_at: null,
+    },
+    pr: {
+      codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+      codexConnectorReviewRequestedHeadSha: "head-2052",
+    },
+    addIssueComment: async () => ({
+      databaseId: 2052002,
+      nodeId: "IC_kwDOissue2052_retry",
+      url: "https://github.com/owner/repo/issues/2052#issuecomment-2052002",
+    }),
+  });
+
+  assert.deepEqual(comments, [{ issueNumber: pr.number, body: "@codex review" }]);
+  assert.equal(result.codex_connector_review_requested_observed_at, "2026-05-08T03:30:00Z");
+  assert.equal(result.codex_connector_review_requested_head_sha, "head-2052");
+  assert.equal(result.codex_connector_review_request_retry_count, 1);
+  assert.equal(result.codex_connector_review_request_retry_head_sha, "head-2052");
+  assert.match(result.codex_connector_review_request_last_retried_at ?? "", /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(result.codex_connector_review_request_comment_database_id, 2052002);
+});
+
+test("maybeRequestCodexConnectorReviewComment sends a fresh marker request for a stale-head prior request", async () => {
+  const { result, comments, pr } = await requestTransition({
+    record: {
+      codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+      codex_connector_review_requested_head_sha: "head-old",
+      codex_connector_review_request_retry_count: 1,
+      codex_connector_review_request_retry_head_sha: "head-old",
+      codex_connector_review_request_last_retried_at: "2026-05-08T03:40:00Z",
+    },
+    pr: {
+      headRefOid: "head-2052-new",
+      codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+      codexConnectorReviewRequestedHeadSha: "head-old",
+    },
+    addIssueComment: async () => undefined,
+  });
+
+  assert.deepEqual(comments, [
+    {
+      issueNumber: pr.number,
+      body: `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=2052 pr=${pr.number} head=head-2052-new -->`,
+    },
+  ]);
+  assert.match(result.codex_connector_review_requested_observed_at ?? "", /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(result.codex_connector_review_requested_head_sha, "head-2052-new");
+  assert.equal(result.codex_connector_review_request_retry_count, 0);
+  assert.equal(result.codex_connector_review_request_retry_head_sha, null);
+  assert.equal(result.codex_connector_review_request_comment_identity_status, "unavailable");
+});
+
+test("maybeRequestCodexConnectorReviewComment blocks with stable failure context when GitHub transport is missing", async () => {
+  const { result, state, comments, journaled, pr } = await requestTransition();
+
+  assert.deepEqual(comments, []);
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "review_bot_timeout");
+  assert.equal(result.last_error, `Failed to request Codex Connector review for PR #${pr.number}.`);
+  assert.equal(result.last_failure_context?.category, "blocked");
+  assert.equal(result.last_failure_context?.signature, `codex-connector-review-request-failed:${pr.headRefOid}`);
+  assert.deepEqual(result.last_failure_context?.details, [
+    `head=${pr.headRefOid}`,
+    "mutation=add_pr_comment",
+    "error=GitHub comment transport unavailable",
+  ]);
+  assert.equal(result.last_failure_signature, `codex-connector-review-request-failed:${pr.headRefOid}`);
+  assert.equal(result.repeated_failure_signature_count, 1);
+  assert.equal(state.issues["2052"], result);
+  assert.deepEqual(journaled, [result]);
+});
+
+test("maybeRequestCodexConnectorReviewComment blocks with mutation failure details when GitHub comment post fails", async () => {
+  const { result, comments, pr } = await requestTransition({
+    addIssueComment: async () => {
+      throw new Error("GraphQL mutation rejected");
+    },
+  });
+
+  assert.equal(comments.length, 1);
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "review_bot_timeout");
+  assert.equal(result.last_failure_context?.signature, `codex-connector-review-request-failed:${pr.headRefOid}`);
+  assert.deepEqual(result.last_failure_context?.details, [
+    `head=${pr.headRefOid}`,
+    "mutation=add_pr_comment",
+    "error=GraphQL mutation rejected",
+  ]);
+});

--- a/src/codex-connector-review-request-transition.ts
+++ b/src/codex-connector-review-request-transition.ts
@@ -1,0 +1,168 @@
+import type { GitHubClient } from "./github";
+import {
+  codexConnectorReviewRequestAction,
+  type CodexConnectorReviewRequestAction,
+} from "./codex-connector-review-request-decision";
+import type { StateStore } from "./core/state-store";
+import type {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "./core/types";
+import { nowIso, truncate } from "./core/utils";
+import { renderCodexConnectorReviewRequestComment } from "./github/github-review-signals";
+import type { IssueJournalSync } from "./run-once-issue-preparation";
+
+function renderCodexConnectorReviewRequestCommentForAction(args: {
+  action: CodexConnectorReviewRequestAction;
+  config: SupervisorConfig;
+  issueNumber: number;
+  prNumber: number;
+  headSha: string;
+}): string {
+  if (args.action.kind === "retry" && (args.config.codexConnectorReviewRequestRetryMode ?? "plain") === "plain") {
+    return "@codex review";
+  }
+
+  return renderCodexConnectorReviewRequestComment({
+    issueNumber: args.issueNumber,
+    prNumber: args.prNumber,
+    headSha: args.headSha,
+  });
+}
+
+function buildCodexConnectorReviewRequestFailureContext(args: {
+  pr: GitHubPullRequest;
+  error: unknown;
+}): FailureContext {
+  const message = args.error instanceof Error ? args.error.message : String(args.error);
+  return {
+    category: "blocked",
+    summary: `Failed to request Codex Connector review for PR #${args.pr.number}.`,
+    signature: `codex-connector-review-request-failed:${args.pr.headRefOid}`,
+    command: null,
+    details: [
+      `head=${args.pr.headRefOid}`,
+      `mutation=add_pr_comment`,
+      `error=${truncate(message, 500) ?? "unknown error"}`,
+    ],
+    url: args.pr.url,
+    updated_at: nowIso(),
+  };
+}
+
+export async function maybeRequestCodexConnectorReviewComment(args: {
+  config: SupervisorConfig;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  github: Partial<Pick<GitHubClient, "addIssueComment">>;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  syncJournal: IssueJournalSync;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  blockedReasonFromReviewState: (
+    record: IssueRunRecord,
+    pr: GitHubPullRequest,
+    checks: PullRequestCheck[],
+    reviewThreads: ReviewThread[],
+  ) => IssueRunRecord["blocked_reason"] | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  configuredBotReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+  manualReviewThreads: (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+  mergeConflictDetected: (pr: GitHubPullRequest) => boolean;
+}): Promise<IssueRunRecord> {
+  const requestAction = codexConnectorReviewRequestAction({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+    summarizeChecks: args.summarizeChecks,
+    configuredBotReviewThreads: args.configuredBotReviewThreads,
+    manualReviewThreads: args.manualReviewThreads,
+    mergeConflictDetected: args.mergeConflictDetected,
+  });
+  if (requestAction.kind === "none") {
+    return args.record;
+  }
+
+  try {
+    if (!args.github.addIssueComment) {
+      throw new Error("GitHub comment transport unavailable");
+    }
+    const commentIdentity = await args.github.addIssueComment(
+      args.pr.number,
+      renderCodexConnectorReviewRequestCommentForAction({
+        action: requestAction,
+        config: args.config,
+        issueNumber: args.record.issue_number,
+        prNumber: args.pr.number,
+        headSha: args.pr.headRefOid,
+      }),
+    );
+    const commentIdentityPatch: Partial<IssueRunRecord> = commentIdentity
+      ? {
+          codex_connector_review_request_comment_identity_status: "available",
+          codex_connector_review_request_comment_database_id: commentIdentity.databaseId,
+          codex_connector_review_request_comment_node_id: commentIdentity.nodeId,
+          codex_connector_review_request_comment_url: commentIdentity.url,
+        }
+      : {
+          codex_connector_review_request_comment_identity_status: "unavailable",
+          codex_connector_review_request_comment_database_id: null,
+          codex_connector_review_request_comment_node_id: null,
+          codex_connector_review_request_comment_url: null,
+        };
+
+    const requestedAt = nowIso();
+    const updatedRecord = args.stateStore.touch(args.record, {
+      state: "waiting_ci",
+      codex_connector_review_requested_observed_at:
+        requestAction.kind === "initial"
+          ? requestedAt
+          : args.record.codex_connector_review_requested_observed_at ?? args.pr.codexConnectorReviewRequestedAt ?? requestedAt,
+      codex_connector_review_requested_head_sha: args.pr.headRefOid,
+      codex_connector_review_request_retry_count:
+        requestAction.kind === "retry" ? requestAction.retryAttempt : 0,
+      codex_connector_review_request_retry_head_sha:
+        requestAction.kind === "retry" ? args.pr.headRefOid : null,
+      codex_connector_review_request_last_retried_at:
+        requestAction.kind === "retry" ? requestedAt : null,
+      ...commentIdentityPatch,
+      blocked_reason: null,
+      last_error: null,
+      last_failure_kind: null,
+      last_failure_context: null,
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    });
+    args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(updatedRecord);
+    return updatedRecord;
+  } catch (error) {
+    const failureContext = buildCodexConnectorReviewRequestFailureContext({ pr: args.pr, error });
+    const blockedRecord = args.stateStore.touch(args.record, {
+      state: "blocked",
+      last_error: truncate(failureContext.summary, 1000),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      blocked_reason:
+        args.blockedReasonFromReviewState(args.record, args.pr, args.checks, args.reviewThreads) ?? "review_bot_timeout",
+    });
+    args.state.issues[String(blockedRecord.issue_number)] = blockedRecord;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(blockedRecord);
+    return blockedRecord;
+  }
+}

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -29,7 +29,7 @@ import {
   SupervisorConfig,
   SupervisorStateFile,
 } from "./core/types";
-import { nowIso, truncate } from "./core/utils";
+import { truncate } from "./core/utils";
 import { type LocalCiCommandRunner } from "./local-ci";
 import {
   buildWorkstationLocalPathFailureContext,
@@ -52,12 +52,8 @@ import {
 } from "./post-turn-pull-request-policy";
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
-import { renderCodexConnectorReviewRequestComment } from "./github/github-review-signals";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
-import {
-  codexConnectorReviewRequestAction,
-  type CodexConnectorReviewRequestAction,
-} from "./codex-connector-review-request-decision";
+import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-review-request-transition";
 import { hasResolvedAllStaleConfiguredBotThreads } from "./supervisor/stale-review-bot-recovery";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
@@ -315,149 +311,6 @@ async function loadOpenPullRequestSnapshot(
   const checks = await github.getChecks(prNumber);
   const reviewThreads = await github.getUnresolvedReviewThreads(prNumber);
   return { pr, checks, reviewThreads };
-}
-
-function renderCodexConnectorReviewRequestCommentForAction(args: {
-  action: CodexConnectorReviewRequestAction;
-  config: SupervisorConfig;
-  issueNumber: number;
-  prNumber: number;
-  headSha: string;
-}): string {
-  if (args.action.kind === "retry" && (args.config.codexConnectorReviewRequestRetryMode ?? "plain") === "plain") {
-    return "@codex review";
-  }
-
-  return renderCodexConnectorReviewRequestComment({
-    issueNumber: args.issueNumber,
-    prNumber: args.prNumber,
-    headSha: args.headSha,
-  });
-}
-
-function buildCodexConnectorReviewRequestFailureContext(args: {
-  pr: GitHubPullRequest;
-  error: unknown;
-}): FailureContext {
-  const message = args.error instanceof Error ? args.error.message : String(args.error);
-  return {
-    category: "blocked",
-    summary: `Failed to request Codex Connector review for PR #${args.pr.number}.`,
-    signature: `codex-connector-review-request-failed:${args.pr.headRefOid}`,
-    command: null,
-    details: [
-      `head=${args.pr.headRefOid}`,
-      `mutation=add_pr_comment`,
-      `error=${truncate(message, 500) ?? "unknown error"}`,
-    ],
-    url: args.pr.url,
-    updated_at: nowIso(),
-  };
-}
-
-async function maybeRequestCodexConnectorReviewComment(args: {
-  config: SupervisorConfig;
-  stateStore: Pick<StateStore, "touch" | "save">;
-  state: SupervisorStateFile;
-  github: Partial<Pick<GitHubClient, "addIssueComment">>;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  syncJournal: IssueJournalSync;
-  applyFailureSignature: HandlePostTurnPullRequestTransitionsArgs["applyFailureSignature"];
-  blockedReasonFromReviewState: HandlePostTurnPullRequestTransitionsArgs["blockedReasonFromReviewState"];
-  summarizeChecks: HandlePostTurnPullRequestTransitionsArgs["summarizeChecks"];
-  configuredBotReviewThreads: HandlePostTurnPullRequestTransitionsArgs["configuredBotReviewThreads"];
-  manualReviewThreads: HandlePostTurnPullRequestTransitionsArgs["manualReviewThreads"];
-  mergeConflictDetected: HandlePostTurnPullRequestTransitionsArgs["mergeConflictDetected"];
-}): Promise<IssueRunRecord> {
-  const requestAction = codexConnectorReviewRequestAction({
-    config: args.config,
-    record: args.record,
-    pr: args.pr,
-    checks: args.checks,
-    reviewThreads: args.reviewThreads,
-    summarizeChecks: args.summarizeChecks,
-    configuredBotReviewThreads: args.configuredBotReviewThreads,
-    manualReviewThreads: args.manualReviewThreads,
-    mergeConflictDetected: args.mergeConflictDetected,
-  });
-  if (requestAction.kind === "none") {
-    return args.record;
-  }
-
-  try {
-    if (!args.github.addIssueComment) {
-      throw new Error("GitHub comment transport unavailable");
-    }
-    const commentIdentity = await args.github.addIssueComment(
-      args.pr.number,
-      renderCodexConnectorReviewRequestCommentForAction({
-        action: requestAction,
-        config: args.config,
-        issueNumber: args.record.issue_number,
-        prNumber: args.pr.number,
-        headSha: args.pr.headRefOid,
-      }),
-    );
-    const commentIdentityPatch: Partial<IssueRunRecord> = commentIdentity
-      ? {
-          codex_connector_review_request_comment_identity_status: "available",
-          codex_connector_review_request_comment_database_id: commentIdentity.databaseId,
-          codex_connector_review_request_comment_node_id: commentIdentity.nodeId,
-          codex_connector_review_request_comment_url: commentIdentity.url,
-        }
-      : {
-          codex_connector_review_request_comment_identity_status: "unavailable",
-          codex_connector_review_request_comment_database_id: null,
-          codex_connector_review_request_comment_node_id: null,
-          codex_connector_review_request_comment_url: null,
-        };
-
-    const requestedAt = nowIso();
-    const updatedRecord = args.stateStore.touch(args.record, {
-      state: "waiting_ci",
-      codex_connector_review_requested_observed_at:
-        requestAction.kind === "initial"
-          ? requestedAt
-          : args.record.codex_connector_review_requested_observed_at ?? args.pr.codexConnectorReviewRequestedAt ?? requestedAt,
-      codex_connector_review_requested_head_sha: args.pr.headRefOid,
-      codex_connector_review_request_retry_count:
-        requestAction.kind === "retry" ? requestAction.retryAttempt : 0,
-      codex_connector_review_request_retry_head_sha:
-        requestAction.kind === "retry" ? args.pr.headRefOid : null,
-      codex_connector_review_request_last_retried_at:
-        requestAction.kind === "retry" ? requestedAt : null,
-      ...commentIdentityPatch,
-      blocked_reason: null,
-      last_error: null,
-      last_failure_kind: null,
-      last_failure_context: null,
-      last_failure_signature: null,
-      repeated_failure_signature_count: 0,
-    });
-    args.state.issues[String(updatedRecord.issue_number)] = updatedRecord;
-    await args.stateStore.save(args.state);
-    await args.syncJournal(updatedRecord);
-    return updatedRecord;
-  } catch (error) {
-    const failureContext = buildCodexConnectorReviewRequestFailureContext({ pr: args.pr, error });
-    const blockedRecord = args.stateStore.touch(args.record, {
-      state: "blocked",
-      last_error: truncate(failureContext.summary, 1000),
-      last_failure_kind: null,
-      last_failure_context: failureContext,
-      ...args.applyFailureSignature(args.record, failureContext),
-      blocked_reason:
-        args.blockedReasonFromReviewState(args.record, args.pr, args.checks, args.reviewThreads) ?? "review_bot_timeout",
-    });
-    args.state.issues[String(blockedRecord.issue_number)] = blockedRecord;
-    await args.stateStore.save(args.state);
-    await args.syncJournal(blockedRecord);
-    return blockedRecord;
-  }
-
 }
 
 async function applyTrackedPrLifecycleState(args: {


### PR DESCRIPTION
## Summary
- Extract Codex Connector review-request transition handling into a focused module.
- Keep post-turn PR orchestration responsible for sequencing while delegating request rendering, persistence, journal sync, and failure mapping.
- Add focused transition coverage for initial request, retry, stale-head request, missing GitHub transport, and mutation failure.

## Verification
- npx tsx --test src/codex-connector-review-request-transition.test.ts
- npx tsx --test src/codex-connector-review-request-decision.test.ts src/codex-connector-review-request-transition.test.ts src/post-turn-pull-request.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npm run build