### PR TITLE
Share Codex Connector diagnostic bundle

### DIFF
--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -4,12 +4,8 @@ import {
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
   actionableBotReviewThreads,
-  buildCodexConnectorP2P3PolicyDiagnostic,
-  buildCodexConnectorPolicyBlockDiagnostic,
   configuredBotReviewFollowUpState,
   evaluateCodexConnectorConvergencePolicy,
-  formatCodexConnectorP2P3PolicyDiagnostic,
-  formatCodexConnectorPolicyBlockDiagnostic,
   latestReviewCommentAuthorIsAllowedBot,
 } from "../review-thread-reporting";
 import { formatWorkspaceRestoreStatusLine } from "../core/workspace";
@@ -21,6 +17,7 @@ import {
   summarizeCheckBuckets,
 } from "./supervisor-status-summary-helpers";
 import {
+  buildCodexConnectorDiagnosticBundle,
   configuredBotCurrentHeadSignalWaitWindow,
   configuredBotInitialGraceWaitWindow,
   configuredBotSettledWaitWindow,
@@ -29,9 +26,7 @@ import {
   configuredReviewBots,
   configuredReviewStatusLabel,
   externalSignalReadinessDiagnostics,
-  formatCodexConnectorConvergenceDiagnostic,
-  formatCodexConnectorOperatorDiagnostic,
-  formatCodexConnectorReviewFallbackDiagnostic,
+  formatStaleReviewResidueOperatorDiagnostic,
   inferReviewBotProfile,
   reviewBotDiagnostics,
 } from "./supervisor-status-review-bot";
@@ -105,26 +100,6 @@ function buildConversationResolutionBlockerStatusLine(args: Pick<
     conversationResolutionEvidenceToken(args.pr),
     `outdated_configured_bot_threads=${configuredThreads.length}`,
     `thread_ids=${configuredThreads.map((thread) => thread.id).sort().join(",")}`,
-  ].join(" ");
-}
-
-export function formatStaleReviewResidueOperatorDiagnostic(
-  remediation: NonNullable<ReturnType<typeof buildStaleReviewBotRemediation>>,
-): string {
-  const latestConfiguredBotReviewSha =
-    remediation.processedOnCurrentHead === "yes" ? remediation.currentHeadSha : "none";
-  const actionableCurrentDiffThreads =
-    remediation.classification === "unresolved_work" || remediation.classification === "unknown_needs_operator"
-      ? "unknown"
-      : "0";
-  return [
-    "codex_connector_operator_diagnostic",
-    "interpretation=stale_review_residue",
-    `current_head_sha=${sanitizeStatusValue(remediation.currentHeadSha)}`,
-    `latest_configured_bot_review_sha=${sanitizeStatusValue(latestConfiguredBotReviewSha)}`,
-    `current_head_review_signal=${remediation.codexCurrentHeadReviewState}`,
-    `actionable_current_diff_threads=${actionableCurrentDiffThreads}`,
-    `next_action=${remediation.manualNextStep}`,
   ].join(" ");
 }
 
@@ -440,13 +415,19 @@ export function buildActiveDetailedStatusLines(
       }
       lines.push(formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation));
     }
-    const codexConnectorPolicyBlock = buildCodexConnectorPolicyBlockDiagnostic(config, reviewThreads, pr);
-    if (codexConnectorPolicyBlock) {
-      lines.push(formatCodexConnectorPolicyBlockDiagnostic(codexConnectorPolicyBlock));
+    const codexConnectorDiagnostics = buildCodexConnectorDiagnosticBundle({
+      config,
+      record: activeRecord,
+      pr,
+      checks,
+      reviewThreads,
+      includeP2P3Policy: true,
+    });
+    if (codexConnectorDiagnostics.policyBlockSummary) {
+      lines.push(codexConnectorDiagnostics.policyBlockSummary);
     }
-    const codexConnectorP2P3Policy = buildCodexConnectorP2P3PolicyDiagnostic(config, reviewThreads, pr);
-    if (codexConnectorP2P3Policy) {
-      lines.push(formatCodexConnectorP2P3PolicyDiagnostic(codexConnectorP2P3Policy));
+    if (codexConnectorDiagnostics.p2p3PolicySummary) {
+      lines.push(codexConnectorDiagnostics.p2p3PolicySummary);
     }
     const reviewBotProfile = inferReviewBotProfile(config);
     const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
@@ -475,32 +456,14 @@ export function buildActiveDetailedStatusLines(
     lines.push(
       `${reviewStatusLabel} state=${copilotReviewState}${reviewersSuffix} requested_at=${pr.copilotReviewRequestedAt ?? "none"} arrived_at=${pr.copilotReviewArrivedAt ?? "none"} timed_out_at=${activeRecord.copilot_review_timed_out_at ?? "none"} timeout_action=${activeRecord.copilot_review_timeout_action ?? "none"}`,
     );
-    const codexConnectorReviewFallback = formatCodexConnectorReviewFallbackDiagnostic({
-      config,
-      record: activeRecord,
-      pr,
-      checks,
-    });
-    if (codexConnectorReviewFallback) {
-      lines.push(codexConnectorReviewFallback);
+    if (codexConnectorDiagnostics.reviewFallbackSummary) {
+      lines.push(codexConnectorDiagnostics.reviewFallbackSummary);
     }
-    const codexConnectorConvergence = formatCodexConnectorConvergenceDiagnostic({
-      config,
-      record: activeRecord,
-      pr,
-      reviewThreads,
-    });
-    if (codexConnectorConvergence) {
-      lines.push(codexConnectorConvergence);
+    if (codexConnectorDiagnostics.convergenceSummary) {
+      lines.push(codexConnectorDiagnostics.convergenceSummary);
     }
-    const codexConnectorOperatorDiagnostic = formatCodexConnectorOperatorDiagnostic({
-      config,
-      record: activeRecord,
-      pr,
-      reviewThreads,
-    });
-    if (codexConnectorOperatorDiagnostic) {
-      lines.push(codexConnectorOperatorDiagnostic);
+    if (codexConnectorDiagnostics.operatorDiagnosticSummary) {
+      lines.push(codexConnectorDiagnostics.operatorDiagnosticSummary);
     }
     lines.push(`pr_hydration provenance=${pr.hydrationProvenance ?? "unknown"} head_sha=${pr.headRefOid}`);
     lines.push(

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -51,6 +51,17 @@ async function writeExternalReviewDigest(args: {
   );
 }
 
+function codexConnectorDiagnosticLines(text: string): string[] {
+  return text
+    .split("\n")
+    .filter((line) =>
+      line.startsWith("codex_connector_policy_block ") ||
+      line.startsWith("codex_connector_review_fallback ") ||
+      line.startsWith("codex_connector_convergence ") ||
+      line.startsWith("codex_connector_operator_diagnostic ")
+    );
+}
+
 test("explain reports dependency blockers for a non-runnable issue", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {
@@ -123,6 +134,76 @@ Depends on: #91`,
   assert.match(explanation, /^state=untracked$/m);
   assert.match(explanation, /^runnable=no$/m);
   assert.match(explanation, /^reason_1=dependency depends on #91$/m);
+});
+
+test("status and explain share Codex Connector diagnostics for the same tracked PR", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 1961;
+  const prNumber = 2961;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "waiting_ci",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: prNumber,
+        last_head_sha: "head-1961",
+        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+        codex_connector_review_requested_head_sha: "head-1961",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector diagnostic parity",
+    body: executionReadyBody("Status and explain should report the same Codex Connector diagnostics."),
+    createdAt: "2026-05-08T03:00:00Z",
+    updatedAt: "2026-05-08T03:30:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pullRequest = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-1961",
+    currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
+    codexConnectorReviewRequestedHeadSha: "head-1961",
+  });
+  const checks = [{ name: "build", state: "SUCCESS" as const, bucket: "pass" as const, workflow: "CI" }];
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pullRequest,
+    getChecks: async () => checks,
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const [status, explanation] = await Promise.all([
+    supervisor.statusReport({ why: true }),
+    supervisor.explain(issueNumber),
+  ]);
+
+  assert.deepEqual(
+    codexConnectorDiagnosticLines(status.detailedStatusLines.join("\n")).sort(),
+    codexConnectorDiagnosticLines(explanation).sort(),
+  );
 });
 
 test("explain reports candidate filtering for a non-candidate issue", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -32,15 +32,12 @@ import {
   loadStatusChangedFiles,
 } from "./supervisor-status-rendering";
 import {
-  formatStaleReviewResidueOperatorDiagnostic,
   formatLatestRecoveryStatusLine,
   formatNoActiveTrackedRecordClassificationLine,
 } from "./supervisor-detailed-status-assembly";
 import {
+  buildCodexConnectorDiagnosticBundle,
   externalSignalReadinessDiagnostics,
-  formatCodexConnectorConvergenceDiagnostic,
-  formatCodexConnectorOperatorDiagnostic,
-  formatCodexConnectorReviewFallbackDiagnostic,
 } from "./supervisor-status-review-bot";
 import { inspectTrackedIssueHostDiagnostics, summarizeIssueJournalHandoff } from "../core/journal";
 import { formatInventoryRefreshDiagnosticLines, formatInventoryRefreshStatusLine } from "../inventory-refresh-state";
@@ -80,10 +77,6 @@ import {
   formatStaleReviewBotRemediationLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
-import {
-  buildCodexConnectorPolicyBlockDiagnostic,
-  formatCodexConnectorPolicyBlockDiagnostic,
-} from "../review-thread-reporting";
 import { formatMergedPrConvergenceOperatorEventLine } from "./supervisor-operator-events";
 import { appendRestartRecommendationLine } from "../operator-actions";
 import {
@@ -482,42 +475,17 @@ export async function buildIssueExplainDto(
         remediation: staleReviewBotRemediation,
       })
       : null;
-  const codexConnectorPolicyBlockSummary =
+  const codexConnectorDiagnostics =
     record && pr && !trackedPrHydrationFailed
-      ? (() => {
-        const diagnostic = buildCodexConnectorPolicyBlockDiagnostic(config, explainReviewThreads, pr);
-        return diagnostic ? formatCodexConnectorPolicyBlockDiagnostic(diagnostic) : null;
-      })()
-      : null;
-  const codexConnectorReviewFallbackSummary =
-    record && pr && !trackedPrHydrationFailed
-      ? formatCodexConnectorReviewFallbackDiagnostic({
+      ? buildCodexConnectorDiagnosticBundle({
         config,
         record,
         pr,
         checks: explainChecks,
-      })
-      : null;
-  const codexConnectorConvergenceSummary =
-    record && pr && !trackedPrHydrationFailed
-      ? formatCodexConnectorConvergenceDiagnostic({
-        config,
-        record,
-        pr,
         reviewThreads: explainReviewThreads,
+        staleReviewBotRemediation,
       })
       : null;
-  const codexConnectorOperatorDiagnosticSummary =
-    staleReviewBotRemediation
-      ? formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation)
-      : record && pr && !trackedPrHydrationFailed
-        ? formatCodexConnectorOperatorDiagnostic({
-          config,
-          record,
-          pr,
-          reviewThreads: explainReviewThreads,
-        })
-        : null;
   const noActiveTrackedRecordSummary =
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
@@ -613,10 +581,10 @@ export async function buildIssueExplainDto(
     staleDiagnosticSummary,
     staleReviewBotRemediation,
     staleReviewBotThreadDiagnostics,
-    codexConnectorOperatorDiagnosticSummary,
-    codexConnectorPolicyBlockSummary,
-    codexConnectorReviewFallbackSummary,
-    codexConnectorConvergenceSummary,
+    codexConnectorOperatorDiagnosticSummary: codexConnectorDiagnostics?.operatorDiagnosticSummary ?? null,
+    codexConnectorPolicyBlockSummary: codexConnectorDiagnostics?.policyBlockSummary ?? null,
+    codexConnectorReviewFallbackSummary: codexConnectorDiagnostics?.reviewFallbackSummary ?? null,
+    codexConnectorConvergenceSummary: codexConnectorDiagnostics?.convergenceSummary ?? null,
     noActiveTrackedRecordSummary,
     trackedPrRetryabilitySummary:
       record?.last_tracked_pr_repeat_failure_decision && record.last_tracked_pr_progress_summary

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -11,13 +11,18 @@ import { displayLocalCiCommand } from "../core/config-parsing";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
 import {
+  buildCodexConnectorP2P3PolicyDiagnostic,
+  buildCodexConnectorPolicyBlockDiagnostic,
   codexConnectorMustFixReviewThreads,
   codexConnectorStaleReviewCommitThreads,
   commitShasDifferForComparison,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
+  formatCodexConnectorP2P3PolicyDiagnostic,
+  formatCodexConnectorPolicyBlockDiagnostic,
 } from "../review-thread-reporting";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
+import type { StaleReviewBotRemediationDto } from "./stale-review-bot-remediation";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
@@ -115,6 +120,14 @@ export interface ExternalSignalReadinessDiagnostics {
   ci: string;
   review: string;
   workflows: string;
+}
+
+export interface CodexConnectorDiagnosticBundle {
+  policyBlockSummary: string | null;
+  p2p3PolicySummary: string | null;
+  reviewFallbackSummary: string | null;
+  convergenceSummary: string | null;
+  operatorDiagnosticSummary: string | null;
 }
 
 function hasCurrentHeadProviderSuccess(activeRecord: IssueRunRecord, pr: GitHubPullRequest): boolean {
@@ -647,6 +660,63 @@ export function formatCodexConnectorOperatorDiagnostic(args: {
       : []),
     `next_action=${nextAction}`,
   ].join(" ");
+}
+
+export function formatStaleReviewResidueOperatorDiagnostic(remediation: StaleReviewBotRemediationDto): string {
+  const latestConfiguredBotReviewSha =
+    remediation.processedOnCurrentHead === "yes" ? remediation.currentHeadSha : "none";
+  const actionableCurrentDiffThreads =
+    remediation.classification === "unresolved_work" || remediation.classification === "unknown_needs_operator"
+      ? "unknown"
+      : "0";
+  return [
+    "codex_connector_operator_diagnostic",
+    "interpretation=stale_review_residue",
+    `current_head_sha=${remediation.currentHeadSha.replace(/\r?\n/g, "\\n")}`,
+    `latest_configured_bot_review_sha=${latestConfiguredBotReviewSha.replace(/\r?\n/g, "\\n")}`,
+    `current_head_review_signal=${remediation.codexCurrentHeadReviewState}`,
+    `actionable_current_diff_threads=${actionableCurrentDiffThreads}`,
+    `next_action=${remediation.manualNextStep}`,
+  ].join(" ");
+}
+
+export function buildCodexConnectorDiagnosticBundle(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
+  includeP2P3Policy?: boolean;
+}): CodexConnectorDiagnosticBundle {
+  const policyBlock = buildCodexConnectorPolicyBlockDiagnostic(args.config, args.reviewThreads, args.pr);
+  const p2p3Policy = args.includeP2P3Policy
+    ? buildCodexConnectorP2P3PolicyDiagnostic(args.config, args.reviewThreads, args.pr)
+    : null;
+  return {
+    policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
+    p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
+    reviewFallbackSummary: formatCodexConnectorReviewFallbackDiagnostic({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+    }),
+    convergenceSummary: formatCodexConnectorConvergenceDiagnostic({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+    }),
+    operatorDiagnosticSummary: args.staleReviewBotRemediation
+      ? formatStaleReviewResidueOperatorDiagnostic(args.staleReviewBotRemediation)
+      : formatCodexConnectorOperatorDiagnostic({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        reviewThreads: args.reviewThreads,
+      }),
+  };
 }
 
 export function configuredBotInitialGraceWaitWindow(


### PR DESCRIPTION
## Summary
- Add a typed Codex Connector diagnostic bundle shared by status and explain paths.
- Reuse the bundle for fallback, convergence, operator, and policy-block diagnostics while preserving status-only P2/P3 policy review output.
- Add a status/explain parity regression for the same tracked Codex Connector PR.

Closes #2053

## Verification
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/codex-connector-review-request-decision.test.ts src/post-turn-pull-request.test.ts
- npm run build
- git diff --check
- node dist/index.js issue-lint 2053 --config <self-supervisor-config-path>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored diagnostic reporting to ensure consistent Codex Connector diagnostics across status and explain outputs for pull request analysis.

* **Tests**
  * Added test coverage verifying diagnostic parity between status and explain commands for tracked pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->