### PR TITLE
Split Codex Connector review policy

### DIFF
--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCodexConnectorP2P3PolicyDiagnostic,
+  buildCodexConnectorPolicyBlockDiagnostic,
+  clusterConfiguredBotReviewThreads,
+  codexConnectorMustFixReviewThreads,
+  codexConnectorStaleReviewCommitThreads,
+  evaluateCodexConnectorConvergencePolicy,
+} from "./codex-connector-review-policy";
+import type { GitHubPullRequest, ReviewThread } from "./core/types";
+import { createConfig, createReviewThread } from "./turn-execution-test-helpers";
+
+function codexThread(overrides: Partial<ReviewThread> & { body: string }): ReviewThread {
+  return createReviewThread({
+    ...overrides,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: overrides.body,
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+}
+
+test("Codex Connector policy classifies must-fix, nitpick, and stale review commit findings", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const p2Thread = codexThread({
+    id: "thread-p2",
+    body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+  });
+  const p3NitpickThread = codexThread({
+    id: "thread-p3-softened",
+    body: "P3: Nitpick: prefer a shorter helper name for readability.",
+  });
+  const p3RiskThread = codexThread({
+    id: "thread-p3-escalated",
+    body: "P3: This cleanup can cause a regression in the restore failure path.",
+  });
+  const pr: Pick<
+    GitHubPullRequest,
+    "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha"
+  > = {
+    headRefOid: "head-new",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: "head-old",
+  };
+
+  assert.deepEqual(codexConnectorMustFixReviewThreads([p2Thread, p3NitpickThread, p3RiskThread]), [
+    p2Thread,
+    p3RiskThread,
+  ]);
+  assert.deepEqual(codexConnectorStaleReviewCommitThreads(pr, [p2Thread]), [p2Thread]);
+  assert.deepEqual(buildCodexConnectorP2P3PolicyDiagnostic(config, [p2Thread, p3NitpickThread, p3RiskThread]), {
+    p2Actionable: 1,
+    p3Softened: 1,
+    p3Escalated: 1,
+  });
+});
+
+test("Codex Connector policy diagnostics and convergence stay focused in the policy module", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const p1Thread = codexThread({
+    id: "thread-p1",
+    path: "src/policy.ts",
+    line: 12,
+    body: "P1: Tighten the diagnostic wording before merge.",
+  });
+  const p0Thread = codexThread({
+    id: "thread-p0",
+    path: "src/auth.ts",
+    line: 24,
+    body: "P0: Keep the authorization bypass blocked.",
+  });
+
+  assert.deepEqual(buildCodexConnectorPolicyBlockDiagnostic(config, [p1Thread, p0Thread]), {
+    count: 2,
+    severity: "P0",
+    file: "src/auth.ts",
+    line: "24",
+    threadUrl: "https://example.test/pr/44#discussion_r1",
+    nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+  });
+  assert.equal(
+    evaluateCodexConnectorConvergencePolicy(config, { configuredBotCurrentHeadObservedAt: "2026-03-11T00:04:00Z" }, [
+      p0Thread,
+    ])?.outcome,
+    "must_fix_remaining",
+  );
+});
+
+test("Codex Connector policy clusters repeated configured-bot findings", () => {
+  const body =
+    "P1: Missing verifier coverage lets failed restore writes leave a half-restored durable state. Add a regression.";
+  const firstThread = codexThread({
+    id: "thread-restore",
+    path: "src/restore.ts",
+    line: 42,
+    body,
+  });
+  const secondThread = codexThread({
+    id: "thread-restore-test",
+    path: "src/restore.test.ts",
+    line: 88,
+    body,
+  });
+  const unrelatedThread = codexThread({
+    id: "thread-export",
+    path: "src/export.ts",
+    line: 12,
+    body: "P2: Export readiness must reject mixed-snapshot rows instead of stitching partial results together.",
+  });
+
+  const clusters = clusterConfiguredBotReviewThreads([firstThread, secondThread, unrelatedThread]);
+
+  assert.equal(clusters.length, 2);
+  assert.deepEqual(clusters[0]?.threads.map((thread) => thread.id), ["thread-restore", "thread-restore-test"]);
+  assert.deepEqual(clusters[1]?.threads.map((thread) => thread.id), ["thread-export"]);
+});

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -1,0 +1,544 @@
+import { configuredReviewProviderKinds } from "./core/review-providers";
+import type { GitHubPullRequest, ReviewThread, SupervisorConfig } from "./core/types";
+import {
+  type CodexConnectorPSeverity,
+  extractCodexConnectorPSeverity,
+  hasCodexConnectorStrongRiskWording,
+  isCodexConnectorReviewer,
+} from "./external-review/external-review-normalization";
+
+export function latestCodexConnectorReviewComment(thread: ReviewThread): {
+  severity: CodexConnectorPSeverity;
+  body: string;
+} | null {
+  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
+    const comment = thread.comments.nodes[index];
+    const login = comment.author?.login;
+    if (!login || !isCodexConnectorReviewer(login)) {
+      continue;
+    }
+
+    const pSeverity = extractCodexConnectorPSeverity(comment.body);
+    if (pSeverity) {
+      return {
+        severity: pSeverity,
+        body: comment.body,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function latestCodexConnectorPSeverity(thread: ReviewThread): CodexConnectorPSeverity | null {
+  return latestCodexConnectorReviewComment(thread)?.severity ?? null;
+}
+
+function isCodexConnectorMustFixReviewThread(thread: ReviewThread): boolean {
+  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+  if (!latestCodexConnectorReview || thread.isResolved || thread.isOutdated) {
+    return false;
+  }
+
+  if (
+    latestCodexConnectorReview.severity === "P0" ||
+    latestCodexConnectorReview.severity === "P1" ||
+    latestCodexConnectorReview.severity === "P2"
+  ) {
+    return true;
+  }
+
+  return latestCodexConnectorReview.severity === "P3" && hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body);
+}
+
+export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter(isCodexConnectorMustFixReviewThread);
+}
+
+export function normalizeCommitShaForComparison(sha: string | null | undefined): string | null {
+  const normalized = sha?.trim();
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+export function commitShasEqualForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeCommitShaForComparison(left);
+  const normalizedRight = normalizeCommitShaForComparison(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+export function commitShasDifferForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeCommitShaForComparison(left);
+  const normalizedRight = normalizeCommitShaForComparison(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft !== normalizedRight);
+}
+
+export function codexConnectorStaleReviewCommitThreads(
+  pr: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  const latestReviewedCommitSha = normalizeCommitShaForComparison(pr.configuredBotLatestReviewedCommitSha);
+  const currentHeadSha = normalizeCommitShaForComparison(pr.headRefOid);
+  if (
+    !latestReviewedCommitSha ||
+    !currentHeadSha ||
+    latestReviewedCommitSha === currentHeadSha ||
+    validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt)
+  ) {
+    return [];
+  }
+
+  return codexConnectorMustFixReviewThreads(reviewThreads);
+}
+
+export interface CodexConnectorPolicyBlockDiagnostic {
+  count: number;
+  severity: CodexConnectorPSeverity;
+  file: string;
+  line: string;
+  threadUrl: string;
+  nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path";
+}
+
+export interface CodexConnectorP2P3PolicyDiagnostic {
+  p2Actionable: number;
+  p3Softened: number;
+  p3Escalated: number;
+}
+
+export type CodexConnectorConvergencePolicyOutcome =
+  | "missing_current_head_review"
+  | "must_fix_remaining"
+  | "nitpick_only"
+  | "converged";
+
+export type CodexConnectorConvergenceMergeEffect = "blocked" | "nitpick_only" | "ready";
+
+export type CodexConnectorConvergenceNextAction =
+  | "request_current_head_review"
+  | "repair_must_fix_findings"
+  | "merge_or_follow_up_nitpicks"
+  | "merge_ready";
+
+interface CodexConnectorConvergencePolicyBase {
+  currentHeadObservedAt: string | null;
+  findingCount: number;
+  mergeEffect: CodexConnectorConvergenceMergeEffect;
+  highestSeverity: CodexConnectorPSeverity | "nitpick_only" | "none";
+  nextAction: CodexConnectorConvergenceNextAction;
+}
+
+export interface CodexConnectorMissingCurrentHeadReviewPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "missing_current_head_review";
+  currentHeadObservedAt: null;
+  mergeEffect: "blocked";
+  nextAction: "request_current_head_review";
+}
+
+export interface CodexConnectorMustFixRemainingPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "must_fix_remaining";
+  mergeEffect: "blocked";
+  nextAction: "repair_must_fix_findings";
+  mustFixCount: number;
+}
+
+export interface CodexConnectorNitpickOnlyPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "nitpick_only";
+  currentHeadObservedAt: string;
+  mergeEffect: "nitpick_only";
+  highestSeverity: "nitpick_only";
+  nextAction: "merge_or_follow_up_nitpicks";
+  nitpickCount: number;
+}
+
+export interface CodexConnectorConvergedPolicyResult extends CodexConnectorConvergencePolicyBase {
+  outcome: "converged";
+  currentHeadObservedAt: string;
+  findingCount: 0;
+  mergeEffect: "ready";
+  highestSeverity: "none";
+  nextAction: "merge_ready";
+}
+
+export type CodexConnectorConvergencePolicyResult =
+  | CodexConnectorMissingCurrentHeadReviewPolicyResult
+  | CodexConnectorMustFixRemainingPolicyResult
+  | CodexConnectorNitpickOnlyPolicyResult
+  | CodexConnectorConvergedPolicyResult;
+
+function latestReviewComment(thread: ReviewThread) {
+  return thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
+}
+
+function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {
+  return { P0: 0, P1: 1, P2: 2, P3: 3 }[severity];
+}
+
+function maxCodexConnectorPSeverity(threads: ReviewThread[]): CodexConnectorPSeverity {
+  return threads
+    .map((thread) => latestCodexConnectorPSeverity(thread))
+    .filter((severity): severity is CodexConnectorPSeverity => severity !== null)
+    .sort((left, right) => codexConnectorPSeverityRank(left) - codexConnectorPSeverityRank(right))[0] ?? "P3";
+}
+
+export function isSoftenedCodexConnectorP3Thread(thread: ReviewThread): boolean {
+  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+  return (
+    latestCodexConnectorReview?.severity === "P3" &&
+    !hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)
+  );
+}
+
+export function codexConnectorNitpickOnlyReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter(
+    (thread) => !thread.isResolved && !thread.isOutdated && isSoftenedCodexConnectorP3Thread(thread),
+  );
+}
+
+function formatDiagnosticToken(value: string): string {
+  return value.replace(/\s+/g, "_");
+}
+
+function validPolicyTimestamp(value: string | null | undefined): string | null {
+  if (!value || Number.isNaN(Date.parse(value))) {
+    return null;
+  }
+
+  return value;
+}
+
+export function evaluateCodexConnectorConvergencePolicy(
+  config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "configuredBotCurrentHeadObservedAt">,
+  reviewThreads: ReviewThread[],
+): CodexConnectorConvergencePolicyResult | null {
+  if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+
+  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
+  const mustFixCount = mustFixThreads.length;
+  const nitpickCount = codexConnectorNitpickOnlyReviewThreads(reviewThreads).length;
+  const currentHeadObservedAt = validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  const findingCount = mustFixCount + nitpickCount;
+  if (mustFixCount > 0) {
+    return {
+      outcome: "must_fix_remaining",
+      currentHeadObservedAt,
+      findingCount,
+      mergeEffect: "blocked",
+      highestSeverity: maxCodexConnectorPSeverity(mustFixThreads),
+      nextAction: "repair_must_fix_findings",
+      mustFixCount,
+    };
+  }
+
+  if (!currentHeadObservedAt) {
+    return {
+      outcome: "missing_current_head_review",
+      currentHeadObservedAt: null,
+      findingCount,
+      mergeEffect: "blocked",
+      highestSeverity: nitpickCount > 0 ? "nitpick_only" : "none",
+      nextAction: "request_current_head_review",
+    };
+  }
+
+  if (nitpickCount > 0) {
+    return {
+      outcome: "nitpick_only",
+      currentHeadObservedAt,
+      findingCount,
+      mergeEffect: "nitpick_only",
+      highestSeverity: "nitpick_only",
+      nextAction: "merge_or_follow_up_nitpicks",
+      nitpickCount,
+    };
+  }
+
+  return {
+    outcome: "converged",
+    currentHeadObservedAt,
+    findingCount: 0,
+    mergeEffect: "ready",
+    highestSeverity: "none",
+    nextAction: "merge_ready",
+  };
+}
+
+export function buildCodexConnectorPolicyBlockDiagnostic(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+): CodexConnectorPolicyBlockDiagnostic | null {
+  if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
+    return null;
+  }
+
+  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
+  if (mustFixThreads.length === 0) {
+    return null;
+  }
+
+  const severity = maxCodexConnectorPSeverity(mustFixThreads);
+  const representativeThread =
+    mustFixThreads.find((thread) => latestCodexConnectorPSeverity(thread) === severity) ?? mustFixThreads[0];
+  const latestComment = latestReviewComment(representativeThread);
+  return {
+    count: mustFixThreads.length,
+    severity,
+    file: formatDiagnosticToken(representativeThread.path ?? "unknown"),
+    line: representativeThread.line == null ? "unknown" : String(representativeThread.line),
+    threadUrl: formatDiagnosticToken(latestComment?.url ?? "none"),
+    nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+  };
+}
+
+export function buildCodexConnectorP2P3PolicyDiagnostic(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+): CodexConnectorP2P3PolicyDiagnostic | null {
+  if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
+    return null;
+  }
+
+  const diagnostic: CodexConnectorP2P3PolicyDiagnostic = {
+    p2Actionable: 0,
+    p3Softened: 0,
+    p3Escalated: 0,
+  };
+
+  for (const thread of reviewThreads) {
+    if (thread.isResolved || thread.isOutdated) {
+      continue;
+    }
+
+    const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+    if (latestCodexConnectorReview?.severity === "P2") {
+      diagnostic.p2Actionable += 1;
+    } else if (latestCodexConnectorReview?.severity === "P3") {
+      if (hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)) {
+        diagnostic.p3Escalated += 1;
+      } else {
+        diagnostic.p3Softened += 1;
+      }
+    }
+  }
+
+  return diagnostic.p2Actionable > 0 || diagnostic.p3Softened > 0 || diagnostic.p3Escalated > 0 ? diagnostic : null;
+}
+
+export function formatCodexConnectorPolicyBlockDiagnostic(
+  diagnostic: CodexConnectorPolicyBlockDiagnostic,
+): string {
+  return [
+    "codex_connector_policy_block",
+    `count=${diagnostic.count}`,
+    `severity=${diagnostic.severity}`,
+    `file=${diagnostic.file}`,
+    `line=${diagnostic.line}`,
+    `thread_url=${diagnostic.threadUrl}`,
+    `next_action=${diagnostic.nextAction}`,
+  ].join(" ");
+}
+
+export function formatCodexConnectorP2P3PolicyDiagnostic(diagnostic: CodexConnectorP2P3PolicyDiagnostic): string {
+  return [
+    "codex_connector_policy_review",
+    `p2_actionable=${diagnostic.p2Actionable}`,
+    `p3_softened=${diagnostic.p3Softened}`,
+    `p3_escalated=${diagnostic.p3Escalated}`,
+  ].join(" ");
+}
+
+function normalizeReviewCommentWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function extractReviewCommentSummary(body: string): string {
+  const normalized = normalizeReviewCommentWhitespace(
+    body
+      .replace(/```[\s\S]*?```/g, " ")
+      .replace(/<[^>]+>/g, " "),
+  );
+  if (normalized.length === 0) {
+    return "review details available at source link";
+  }
+
+  const sentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/)?.[1] ?? normalized;
+  const summary = sentence.trim();
+  return summary.length > 180 ? `${summary.slice(0, 177)}...` : summary;
+}
+
+export function buildCodexConnectorMustFixFindingDetails(args: {
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+  reviewThreads: ReviewThread[];
+}): string[] {
+  return clusterConfiguredBotReviewThreads(codexConnectorMustFixReviewThreads(args.reviewThreads)).map((cluster, index) => {
+    const representativeThread = cluster.threads[0];
+    const latestComment = latestReviewComment(representativeThread);
+    const lineRange = representativeThread.line == null ? "unknown" : String(representativeThread.line);
+    return [
+      `- Root-cause repair group ${index + 1}`,
+      `  Policy: Codex Connector must_fix_remaining`,
+      `  Severity: ${cluster.severity}`,
+      `  PR: ${args.pr ? `#${args.pr.number}` : "unknown"}`,
+      `  Head SHA: ${args.pr?.headRefOid ?? "unknown"}`,
+      `  Thread IDs: ${cluster.threads.map((thread) => thread.id).join(", ")}`,
+      `  Affected files: ${cluster.files.join(", ")}`,
+      `  Representative source URLs: ${cluster.sourceUrls.join(", ") || "n/a"}`,
+      `  Source URL: ${latestComment?.url ?? "n/a"}`,
+      `  File: ${representativeThread.path ?? "unknown"}`,
+      `  Line range: ${lineRange}`,
+      `  Summary: ${cluster.summary}`,
+      ...(cluster.threads.length === 1
+        ? [`  Latest relevant comment: ${extractReviewCommentSummary(latestComment?.body ?? "")}`]
+        : []),
+      `  Evidence: ${cluster.threads
+        .map((thread) => {
+          const comment = latestReviewComment(thread);
+          return `${thread.id} ${thread.path ?? "unknown"}:${thread.line ?? "?"} ${comment?.url ?? "n/a"}`;
+        })
+        .join("; ")}`,
+    ].join("\n");
+  });
+}
+
+export interface ConfiguredBotReviewThreadCluster {
+  severity: CodexConnectorPSeverity | "unknown";
+  summary: string;
+  signature: string;
+  threads: ReviewThread[];
+  files: string[];
+  sourceUrls: string[];
+}
+
+function normalizeReviewThreadSignature(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/`[^`]+`/g, " ")
+    .replace(/\b\d+\b/g, "#")
+    .replace(/[^a-z0-9#]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const REVIEW_THREAD_THEME_STOP_WORDS = new Set([
+  "add",
+  "after",
+  "again",
+  "before",
+  "being",
+  "because",
+  "cannot",
+  "comment",
+  "coverage",
+  "does",
+  "from",
+  "here",
+  "into",
+  "keep",
+  "lets",
+  "merge",
+  "must",
+  "needs",
+  "only",
+  "path",
+  "please",
+  "prefer",
+  "proving",
+  "repair",
+  "review",
+  "should",
+  "still",
+  "than",
+  "that",
+  "this",
+  "thread",
+  "until",
+  "when",
+  "with",
+  "without",
+]);
+
+function normalizeFailureThemeTokens(summary: string): string[] {
+  return uniqueInOrder(
+    normalizeReviewThreadSignature(summary)
+      .split(" ")
+      .filter((token) => {
+        return token.length >= 4 && !REVIEW_THREAD_THEME_STOP_WORDS.has(token) && !/^#+$/.test(token);
+      }),
+  ).sort();
+}
+
+function hasSimilarFailureTheme(left: string[], right: string[]): boolean {
+  if (left.length < 3 || right.length < 3) {
+    return false;
+  }
+
+  const rightTokens = new Set(right);
+  const sharedCount = left.filter((token) => rightTokens.has(token)).length;
+  return sharedCount >= 4 || sharedCount / Math.min(left.length, right.length) >= 0.5;
+}
+
+function uniqueInOrder(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function clusterConfiguredBotReviewThreads(reviewThreads: ReviewThread[]): ConfiguredBotReviewThreadCluster[] {
+  const clusters = new Map<string, ConfiguredBotReviewThreadCluster>();
+  const clusterThemeTokens = new Map<string, string[]>();
+
+  for (const thread of reviewThreads) {
+    const latestComment = latestReviewComment(thread);
+    const severity = latestCodexConnectorPSeverity(thread) ?? "unknown";
+    const summary = extractReviewCommentSummary(latestComment?.body ?? "");
+    const signature = `${severity}:${normalizeReviewThreadSignature(summary) || thread.id}`;
+    const themeTokens = normalizeFailureThemeTokens(summary);
+    const normalizedPath = thread.path?.replace(/\\/g, "/");
+    const existingSignature = clusters.has(signature)
+      ? signature
+      : [...clusters.entries()].find(([candidateSignature, candidate]) => {
+          return (
+            normalizedPath !== undefined &&
+            candidate.severity === severity &&
+            candidate.files.map((filePath) => filePath.replace(/\\/g, "/")).includes(normalizedPath) &&
+            hasSimilarFailureTheme(themeTokens, clusterThemeTokens.get(candidateSignature) ?? [])
+          );
+        })?.[0];
+    const existing = existingSignature ? clusters.get(existingSignature) : undefined;
+    if (existing) {
+      existing.threads.push(thread);
+      existing.files = uniqueInOrder([...existing.files, thread.path ?? "unknown"]);
+      if (latestComment?.url) {
+        existing.sourceUrls = uniqueInOrder([...existing.sourceUrls, latestComment.url]);
+      }
+      if (existingSignature) {
+        clusterThemeTokens.set(
+          existingSignature,
+          uniqueInOrder([...(clusterThemeTokens.get(existingSignature) ?? []), ...themeTokens]).sort(),
+        );
+      }
+      continue;
+    }
+
+    clusters.set(signature, {
+      severity,
+      summary,
+      signature,
+      threads: [thread],
+      files: [thread.path ?? "unknown"],
+      sourceUrls: latestComment?.url ? [latestComment.url] : [],
+    });
+    clusterThemeTokens.set(signature, themeTokens);
+  }
+
+  return [...clusters.values()];
+}

--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -1,6 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { codexConnectorReviewRequestAction } from "./codex-connector-review-request-decision";
+import {
+  codexConnectorPassingChecks,
+  createCodexConnectorRequestRetryScenario,
+  createCodexConnectorSameHeadRequestScenario,
+  createCodexConnectorStaleHeadRequestScenario,
+  createCodexConnectorStaleReviewCommitRequestScenario,
+  type CodexConnectorReviewRequestScenario,
+} from "./codex-connector-tracked-pr-test-helpers";
 import type { PullRequestCheck, ReviewThread, SupervisorConfig } from "./core/types";
 import { createConfig, createPullRequest, createRecord, createReviewThread } from "./turn-execution-test-helpers";
 
@@ -23,14 +31,7 @@ function summarizeChecks(checks: PullRequestCheck[]) {
   };
 }
 
-const passingChecks: PullRequestCheck[] = [
-  {
-    name: "build",
-    state: "SUCCESS",
-    bucket: "pass",
-    workflow: "CI",
-  },
-];
+const passingChecks: PullRequestCheck[] = codexConnectorPassingChecks;
 
 function decide(overrides: {
   config?: Partial<SupervisorConfig>;
@@ -79,50 +80,46 @@ function decide(overrides: {
   });
 }
 
+function decideScenario(scenario: CodexConnectorReviewRequestScenario) {
+  return decide({
+    record: scenario.recordPatch,
+    pr: scenario.pullRequestPatch,
+    checks: scenario.checks,
+    reviewThreads: scenario.reviewThreads,
+    configuredThreads: scenario.configuredThreads,
+    now: scenario.now,
+  });
+}
+
 test("codexConnectorReviewRequestAction selects an initial request without GitHub mutation inputs", () => {
   assert.deepEqual(decide(), { kind: "initial" });
 });
 
 test("codexConnectorReviewRequestAction requests review for stale-head configured-bot signal after timeout", () => {
-  assert.deepEqual(
-    decide({
-      record: {
-        state: "blocked",
-        blocked_reason: "stale_review_bot",
-        provider_success_head_sha: "head-old",
-        provider_success_observed_at: "2026-05-08T03:00:00Z",
-        external_review_head_sha: "head-old",
-      },
-      pr: {
-        headRefOid: "head-1995",
-        configuredBotLatestReviewedCommitSha: "head-old",
-        configuredBotCurrentHeadObservedAt: null,
-      },
-      reviewThreads: [],
-      configuredThreads: [],
-      manualThreads: [],
-    }),
-    { kind: "initial" },
-  );
+  assert.deepEqual(decideScenario(createCodexConnectorStaleHeadRequestScenario()), { kind: "initial" });
+});
+
+test("codexConnectorReviewRequestAction requests review for stale review commit residue after timeout", () => {
+  assert.deepEqual(decideScenario(createCodexConnectorStaleReviewCommitRequestScenario()), { kind: "initial" });
 });
 
 test("codexConnectorReviewRequestAction selects retry after the same-head request wait expires", () => {
+  assert.deepEqual(decideScenario(createCodexConnectorRequestRetryScenario()), {
+    kind: "retry",
+    retryCount: 0,
+    retryAttempt: 1,
+  });
+});
+
+test("codexConnectorReviewRequestAction suppresses request while same-head request wait is active", () => {
   assert.deepEqual(
-    decide({
-      record: {
-        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
-        codex_connector_review_requested_head_sha: "head-1995",
-        codex_connector_review_request_retry_count: 0,
-        codex_connector_review_request_retry_head_sha: null,
-        codex_connector_review_request_last_retried_at: null,
-      },
-      now: "2026-05-08T03:40:00.000Z",
-    }),
-    {
-      kind: "retry",
-      retryCount: 0,
-      retryAttempt: 1,
-    },
+    decideScenario(
+      createCodexConnectorSameHeadRequestScenario({
+        requestedAt: "2026-05-08T03:30:00Z",
+        now: "2026-05-08T03:35:00.000Z",
+      }),
+    ),
+    { kind: "none" },
   );
 });
 

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -6,9 +6,11 @@ import {
   latestReviewThreadCommentFingerprint,
 } from "./review-handling";
 import {
-  codexConnectorStaleReviewCommitThreads,
   codexConnectorMustFixReviewThreads,
+  codexConnectorStaleReviewCommitThreads,
   commitShasDifferForComparison,
+} from "./codex-connector-review-policy";
+import {
   configuredBotReviewFollowUpState,
   latestReviewCommentAuthorIsAllowedBot,
   staleConfiguredBotReviewThreads,

--- a/src/codex-connector-tracked-pr-test-helpers.ts
+++ b/src/codex-connector-tracked-pr-test-helpers.ts
@@ -1,9 +1,179 @@
 import type { FailureContext, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread } from "./core/types";
 
 export const CODEX_CONNECTOR_REVIEW_BOT_LOGIN = "chatgpt-codex-connector";
+export const CODEX_CONNECTOR_DEFAULT_HEAD_SHA = "head-1995";
+export const CODEX_CONNECTOR_STALE_HEAD_SHA = "head-old";
 
 const STALE_REVIEW_BOT_SUMMARY =
   "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.";
+
+export const codexConnectorPassingChecks: PullRequestCheck[] = [
+  {
+    name: "build",
+    state: "SUCCESS",
+    bucket: "pass",
+    workflow: "CI",
+  },
+];
+
+type CodexConnectorRequestScenarioOptions = {
+  issueNumber?: number;
+  prNumber?: number;
+  headSha?: string;
+  staleHeadSha?: string;
+  requestedAt?: string;
+  retryCount?: number;
+  now?: string;
+};
+
+export type CodexConnectorReviewRequestScenario = {
+  recordPatch: Partial<IssueRunRecord>;
+  pullRequestPatch: Partial<GitHubPullRequest>;
+  reviewThreads: ReviewThread[];
+  configuredThreads: ReviewThread[];
+  checks: PullRequestCheck[];
+  now?: string;
+};
+
+function createCodexConnectorThread({
+  threadId,
+  commentId,
+  headSha,
+  body,
+}: {
+  threadId: string;
+  commentId: string;
+  headSha: string;
+  body: string;
+}): ReviewThread {
+  return {
+    id: threadId,
+    isResolved: false,
+    isOutdated: false,
+    path: "src/review-policy.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: commentId,
+          body,
+          createdAt: "2026-05-08T03:20:00Z",
+          url: `https://example.test/pr/1995#discussion_${threadId}_${headSha}`,
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+}
+
+export function createCodexConnectorStaleHeadRequestScenario({
+  issueNumber = 1995,
+  prNumber = 1995,
+  headSha = CODEX_CONNECTOR_DEFAULT_HEAD_SHA,
+  staleHeadSha = CODEX_CONNECTOR_STALE_HEAD_SHA,
+}: CodexConnectorRequestScenarioOptions = {}): CodexConnectorReviewRequestScenario {
+  return {
+    recordPatch: {
+      issue_number: issueNumber,
+      state: "blocked",
+      pr_number: prNumber,
+      last_head_sha: headSha,
+      blocked_reason: "stale_review_bot",
+      provider_success_head_sha: staleHeadSha,
+      external_review_head_sha: staleHeadSha,
+    },
+    pullRequestPatch: {
+      number: prNumber,
+      headRefOid: headSha,
+      configuredBotLatestReviewedCommitSha: staleHeadSha,
+      configuredBotCurrentHeadObservedAt: null,
+    },
+    reviewThreads: [],
+    configuredThreads: [],
+    checks: codexConnectorPassingChecks,
+  };
+}
+
+export function createCodexConnectorStaleReviewCommitRequestScenario({
+  issueNumber = 1995,
+  prNumber = 1995,
+  headSha = CODEX_CONNECTOR_DEFAULT_HEAD_SHA,
+  staleHeadSha = CODEX_CONNECTOR_STALE_HEAD_SHA,
+}: CodexConnectorRequestScenarioOptions = {}): CodexConnectorReviewRequestScenario {
+  const reviewThread = createCodexConnectorThread({
+    threadId: "thread-stale-review-commit",
+    commentId: "comment-stale-review-commit",
+    headSha: staleHeadSha,
+    body: "P1: Re-run the current-head review before treating this stale review commit as merge-ready.",
+  });
+
+  return {
+    recordPatch: {
+      issue_number: issueNumber,
+      state: "blocked",
+      pr_number: prNumber,
+      last_head_sha: headSha,
+      blocked_reason: "stale_review_bot",
+    },
+    pullRequestPatch: {
+      number: prNumber,
+      headRefOid: headSha,
+      configuredBotLatestReviewedCommitSha: staleHeadSha,
+      configuredBotCurrentHeadObservedAt: null,
+    },
+    reviewThreads: [reviewThread],
+    configuredThreads: [reviewThread],
+    checks: codexConnectorPassingChecks,
+  };
+}
+
+export function createCodexConnectorSameHeadRequestScenario({
+  issueNumber = 1995,
+  prNumber = 1995,
+  headSha = CODEX_CONNECTOR_DEFAULT_HEAD_SHA,
+  requestedAt = "2026-05-08T03:30:00Z",
+  now,
+}: CodexConnectorRequestScenarioOptions = {}): CodexConnectorReviewRequestScenario {
+  return {
+    recordPatch: {
+      issue_number: issueNumber,
+      pr_number: prNumber,
+      codex_connector_review_requested_observed_at: requestedAt,
+      codex_connector_review_requested_head_sha: headSha,
+    },
+    pullRequestPatch: {
+      number: prNumber,
+      headRefOid: headSha,
+      codexConnectorReviewRequestedAt: requestedAt,
+      codexConnectorReviewRequestedHeadSha: headSha,
+    },
+    reviewThreads: [],
+    configuredThreads: [],
+    checks: codexConnectorPassingChecks,
+    now,
+  };
+}
+
+export function createCodexConnectorRequestRetryScenario({
+  retryCount = 0,
+  now = "2026-05-08T03:40:00.000Z",
+  ...options
+}: CodexConnectorRequestScenarioOptions = {}): CodexConnectorReviewRequestScenario {
+  const scenario = createCodexConnectorSameHeadRequestScenario(options);
+  return {
+    ...scenario,
+    recordPatch: {
+      ...scenario.recordPatch,
+      codex_connector_review_request_retry_count: retryCount,
+      codex_connector_review_request_retry_head_sha: null,
+      codex_connector_review_request_last_retried_at: null,
+    },
+    now,
+  };
+}
 
 type CodexConnectorTrackedReviewScenarioOptions = {
   issueNumber: number;

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -22,7 +22,7 @@ import type {
   StartAgentTurnContext,
 } from "../supervisor/agent-runner";
 import { reviewProviderProfileFromConfig, type ReviewProviderProfileSummary } from "../core/review-providers";
-import { buildCodexConnectorMustFixFindingDetails } from "../review-thread-reporting";
+import { buildCodexConnectorMustFixFindingDetails } from "../codex-connector-review-policy";
 
 export interface LocalReviewRepairContext {
   repairIntent?: "same_pr_fix_blocked" | "same_pr_follow_up" | "same_pr_manual_review" | "high_severity_retry" | "unspecified";

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -19,9 +19,11 @@ import {
 import {
   codexConnectorNitpickOnlyReviewThreads,
   codexConnectorMustFixReviewThreads,
+  evaluateCodexConnectorConvergencePolicy,
+} from "./codex-connector-review-policy";
+import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
-  evaluateCodexConnectorConvergencePolicy,
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
   pendingBotReviewThreads,

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -1,17 +1,40 @@
 import { hasProcessedReviewThread } from "./review-handling";
-import {
-  configuredReviewBotLogins,
-  configuredReviewProviderKinds,
-  normalizeReviewProviderLogin,
-} from "./core/review-providers";
+import { configuredReviewBotLogins, normalizeReviewProviderLogin } from "./core/review-providers";
 import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
 import {
-  type CodexConnectorPSeverity,
-  extractCodexConnectorPSeverity,
-  hasCodexConnectorStrongRiskWording,
-  isCodexConnectorReviewer,
-} from "./external-review/external-review-normalization";
+  codexConnectorMustFixReviewThreads,
+  isSoftenedCodexConnectorP3Thread,
+  latestCodexConnectorPSeverity,
+} from "./codex-connector-review-policy";
+
+export {
+  buildCodexConnectorMustFixFindingDetails,
+  buildCodexConnectorP2P3PolicyDiagnostic,
+  buildCodexConnectorPolicyBlockDiagnostic,
+  clusterConfiguredBotReviewThreads,
+  codexConnectorMustFixReviewThreads,
+  codexConnectorNitpickOnlyReviewThreads,
+  codexConnectorStaleReviewCommitThreads,
+  commitShasDifferForComparison,
+  commitShasEqualForComparison,
+  evaluateCodexConnectorConvergencePolicy,
+  formatCodexConnectorP2P3PolicyDiagnostic,
+  formatCodexConnectorPolicyBlockDiagnostic,
+  latestCodexConnectorReviewComment,
+  normalizeCommitShaForComparison,
+  type CodexConnectorConvergenceMergeEffect,
+  type CodexConnectorConvergenceNextAction,
+  type CodexConnectorConvergencePolicyOutcome,
+  type CodexConnectorConvergencePolicyResult,
+  type CodexConnectorConvergedPolicyResult,
+  type CodexConnectorMissingCurrentHeadReviewPolicyResult,
+  type CodexConnectorMustFixRemainingPolicyResult,
+  type CodexConnectorNitpickOnlyPolicyResult,
+  type CodexConnectorP2P3PolicyDiagnostic,
+  type CodexConnectorPolicyBlockDiagnostic,
+  type ConfiguredBotReviewThreadCluster,
+} from "./codex-connector-review-policy";
 
 function isAllowedReviewBotThread(config: SupervisorConfig, thread: ReviewThread): boolean {
   const configuredLogins = new Set(configuredReviewBotLogins(config));
@@ -34,352 +57,6 @@ export function latestReviewCommentAuthorIsAllowedBot(config: SupervisorConfig, 
 
   const configuredLogins = new Set(configuredReviewBotLogins(config));
   return configuredLogins.has(latestLogin);
-}
-
-export function latestCodexConnectorReviewComment(thread: ReviewThread): {
-  severity: CodexConnectorPSeverity;
-  body: string;
-} | null {
-  for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
-    const comment = thread.comments.nodes[index];
-    const login = comment.author?.login;
-    if (!login || !isCodexConnectorReviewer(login)) {
-      continue;
-    }
-
-    const pSeverity = extractCodexConnectorPSeverity(comment.body);
-    if (pSeverity) {
-      return {
-        severity: pSeverity,
-        body: comment.body,
-      };
-    }
-  }
-
-  return null;
-}
-
-function latestCodexConnectorPSeverity(thread: ReviewThread): CodexConnectorPSeverity | null {
-  return latestCodexConnectorReviewComment(thread)?.severity ?? null;
-}
-
-function isCodexConnectorMustFixReviewThread(thread: ReviewThread): boolean {
-  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
-  if (!latestCodexConnectorReview || thread.isResolved || thread.isOutdated) {
-    return false;
-  }
-
-  if (
-    latestCodexConnectorReview.severity === "P0" ||
-    latestCodexConnectorReview.severity === "P1" ||
-    latestCodexConnectorReview.severity === "P2"
-  ) {
-    return true;
-  }
-
-  return latestCodexConnectorReview.severity === "P3" && hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body);
-}
-
-export function codexConnectorMustFixReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
-  return reviewThreads.filter(isCodexConnectorMustFixReviewThread);
-}
-
-export function normalizeCommitShaForComparison(sha: string | null | undefined): string | null {
-  const normalized = sha?.trim();
-  return normalized ? normalized.toLowerCase() : null;
-}
-
-export function commitShasEqualForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
-  const normalizedLeft = normalizeCommitShaForComparison(left);
-  const normalizedRight = normalizeCommitShaForComparison(right);
-  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
-}
-
-export function commitShasDifferForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
-  const normalizedLeft = normalizeCommitShaForComparison(left);
-  const normalizedRight = normalizeCommitShaForComparison(right);
-  return Boolean(normalizedLeft && normalizedRight && normalizedLeft !== normalizedRight);
-}
-
-export function codexConnectorStaleReviewCommitThreads(
-  pr: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
-  reviewThreads: ReviewThread[],
-): ReviewThread[] {
-  const latestReviewedCommitSha = normalizeCommitShaForComparison(pr.configuredBotLatestReviewedCommitSha);
-  const currentHeadSha = normalizeCommitShaForComparison(pr.headRefOid);
-  if (
-    !latestReviewedCommitSha ||
-    !currentHeadSha ||
-    latestReviewedCommitSha === currentHeadSha ||
-    validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt)
-  ) {
-    return [];
-  }
-
-  return codexConnectorMustFixReviewThreads(reviewThreads);
-}
-
-export interface CodexConnectorPolicyBlockDiagnostic {
-  count: number;
-  severity: CodexConnectorPSeverity;
-  file: string;
-  line: string;
-  threadUrl: string;
-  nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path";
-}
-
-export interface CodexConnectorP2P3PolicyDiagnostic {
-  p2Actionable: number;
-  p3Softened: number;
-  p3Escalated: number;
-}
-
-export type CodexConnectorConvergencePolicyOutcome =
-  | "missing_current_head_review"
-  | "must_fix_remaining"
-  | "nitpick_only"
-  | "converged";
-
-export type CodexConnectorConvergenceMergeEffect = "blocked" | "nitpick_only" | "ready";
-
-export type CodexConnectorConvergenceNextAction =
-  | "request_current_head_review"
-  | "repair_must_fix_findings"
-  | "merge_or_follow_up_nitpicks"
-  | "merge_ready";
-
-interface CodexConnectorConvergencePolicyBase {
-  currentHeadObservedAt: string | null;
-  findingCount: number;
-  mergeEffect: CodexConnectorConvergenceMergeEffect;
-  highestSeverity: CodexConnectorPSeverity | "nitpick_only" | "none";
-  nextAction: CodexConnectorConvergenceNextAction;
-}
-
-export interface CodexConnectorMissingCurrentHeadReviewPolicyResult extends CodexConnectorConvergencePolicyBase {
-  outcome: "missing_current_head_review";
-  currentHeadObservedAt: null;
-  mergeEffect: "blocked";
-  nextAction: "request_current_head_review";
-}
-
-export interface CodexConnectorMustFixRemainingPolicyResult extends CodexConnectorConvergencePolicyBase {
-  outcome: "must_fix_remaining";
-  mergeEffect: "blocked";
-  nextAction: "repair_must_fix_findings";
-  mustFixCount: number;
-}
-
-export interface CodexConnectorNitpickOnlyPolicyResult extends CodexConnectorConvergencePolicyBase {
-  outcome: "nitpick_only";
-  currentHeadObservedAt: string;
-  mergeEffect: "nitpick_only";
-  highestSeverity: "nitpick_only";
-  nextAction: "merge_or_follow_up_nitpicks";
-  nitpickCount: number;
-}
-
-export interface CodexConnectorConvergedPolicyResult extends CodexConnectorConvergencePolicyBase {
-  outcome: "converged";
-  currentHeadObservedAt: string;
-  findingCount: 0;
-  mergeEffect: "ready";
-  highestSeverity: "none";
-  nextAction: "merge_ready";
-}
-
-export type CodexConnectorConvergencePolicyResult =
-  | CodexConnectorMissingCurrentHeadReviewPolicyResult
-  | CodexConnectorMustFixRemainingPolicyResult
-  | CodexConnectorNitpickOnlyPolicyResult
-  | CodexConnectorConvergedPolicyResult;
-
-function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {
-  return { P0: 0, P1: 1, P2: 2, P3: 3 }[severity];
-}
-
-function maxCodexConnectorPSeverity(threads: ReviewThread[]): CodexConnectorPSeverity {
-  return threads
-    .map((thread) => latestCodexConnectorPSeverity(thread))
-    .filter((severity): severity is CodexConnectorPSeverity => severity !== null)
-    .sort((left, right) => codexConnectorPSeverityRank(left) - codexConnectorPSeverityRank(right))[0] ?? "P3";
-}
-
-function isSoftenedCodexConnectorP3Thread(thread: ReviewThread): boolean {
-  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
-  return (
-    latestCodexConnectorReview?.severity === "P3" &&
-    !hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)
-  );
-}
-
-export function codexConnectorNitpickOnlyReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
-  return reviewThreads.filter(
-    (thread) => !thread.isResolved && !thread.isOutdated && isSoftenedCodexConnectorP3Thread(thread),
-  );
-}
-
-function formatDiagnosticToken(value: string): string {
-  return value.replace(/\s+/g, "_");
-}
-
-function validPolicyTimestamp(value: string | null | undefined): string | null {
-  if (!value || Number.isNaN(Date.parse(value))) {
-    return null;
-  }
-
-  return value;
-}
-
-export function evaluateCodexConnectorConvergencePolicy(
-  config: SupervisorConfig,
-  pr: Pick<GitHubPullRequest, "configuredBotCurrentHeadObservedAt">,
-  reviewThreads: ReviewThread[],
-): CodexConnectorConvergencePolicyResult | null {
-  if (!configuredReviewProviderKinds(config).includes("codex")) {
-    return null;
-  }
-
-  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
-  const mustFixCount = mustFixThreads.length;
-  const nitpickCount = codexConnectorNitpickOnlyReviewThreads(reviewThreads).length;
-  const currentHeadObservedAt = validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt);
-  const findingCount = mustFixCount + nitpickCount;
-  if (mustFixCount > 0) {
-    return {
-      outcome: "must_fix_remaining",
-      currentHeadObservedAt,
-      findingCount,
-      mergeEffect: "blocked",
-      highestSeverity: maxCodexConnectorPSeverity(mustFixThreads),
-      nextAction: "repair_must_fix_findings",
-      mustFixCount,
-    };
-  }
-
-  if (!currentHeadObservedAt) {
-    return {
-      outcome: "missing_current_head_review",
-      currentHeadObservedAt: null,
-      findingCount,
-      mergeEffect: "blocked",
-      highestSeverity: nitpickCount > 0 ? "nitpick_only" : "none",
-      nextAction: "request_current_head_review",
-    };
-  }
-
-  if (nitpickCount > 0) {
-    return {
-      outcome: "nitpick_only",
-      currentHeadObservedAt,
-      findingCount,
-      mergeEffect: "nitpick_only",
-      highestSeverity: "nitpick_only",
-      nextAction: "merge_or_follow_up_nitpicks",
-      nitpickCount,
-    };
-  }
-
-  return {
-    outcome: "converged",
-    currentHeadObservedAt,
-    findingCount: 0,
-    mergeEffect: "ready",
-    highestSeverity: "none",
-    nextAction: "merge_ready",
-  };
-}
-
-export function buildCodexConnectorPolicyBlockDiagnostic(
-  config: SupervisorConfig,
-  reviewThreads: ReviewThread[],
-  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
-): CodexConnectorPolicyBlockDiagnostic | null {
-  if (!configuredReviewProviderKinds(config).includes("codex")) {
-    return null;
-  }
-  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
-    return null;
-  }
-
-  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
-  if (mustFixThreads.length === 0) {
-    return null;
-  }
-
-  const severity = maxCodexConnectorPSeverity(mustFixThreads);
-  const representativeThread =
-    mustFixThreads.find((thread) => latestCodexConnectorPSeverity(thread) === severity) ?? mustFixThreads[0];
-  const latestComment = latestReviewComment(representativeThread);
-  return {
-    count: mustFixThreads.length,
-    severity,
-    file: formatDiagnosticToken(representativeThread.path ?? "unknown"),
-    line: representativeThread.line == null ? "unknown" : String(representativeThread.line),
-    threadUrl: formatDiagnosticToken(latestComment?.url ?? "none"),
-    nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
-  };
-}
-
-export function buildCodexConnectorP2P3PolicyDiagnostic(
-  config: SupervisorConfig,
-  reviewThreads: ReviewThread[],
-  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
-): CodexConnectorP2P3PolicyDiagnostic | null {
-  if (!configuredReviewProviderKinds(config).includes("codex")) {
-    return null;
-  }
-  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
-    return null;
-  }
-
-  const diagnostic: CodexConnectorP2P3PolicyDiagnostic = {
-    p2Actionable: 0,
-    p3Softened: 0,
-    p3Escalated: 0,
-  };
-
-  for (const thread of reviewThreads) {
-    if (thread.isResolved || thread.isOutdated) {
-      continue;
-    }
-
-    const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
-    if (latestCodexConnectorReview?.severity === "P2") {
-      diagnostic.p2Actionable += 1;
-    } else if (latestCodexConnectorReview?.severity === "P3") {
-      if (hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)) {
-        diagnostic.p3Escalated += 1;
-      } else {
-        diagnostic.p3Softened += 1;
-      }
-    }
-  }
-
-  return diagnostic.p2Actionable > 0 || diagnostic.p3Softened > 0 || diagnostic.p3Escalated > 0 ? diagnostic : null;
-}
-
-export function formatCodexConnectorPolicyBlockDiagnostic(
-  diagnostic: CodexConnectorPolicyBlockDiagnostic,
-): string {
-  return [
-    "codex_connector_policy_block",
-    `count=${diagnostic.count}`,
-    `severity=${diagnostic.severity}`,
-    `file=${diagnostic.file}`,
-    `line=${diagnostic.line}`,
-    `thread_url=${diagnostic.threadUrl}`,
-    `next_action=${diagnostic.nextAction}`,
-  ].join(" ");
-}
-
-export function formatCodexConnectorP2P3PolicyDiagnostic(diagnostic: CodexConnectorP2P3PolicyDiagnostic): string {
-  return [
-    "codex_connector_policy_review",
-    `p2_actionable=${diagnostic.p2Actionable}`,
-    `p3_softened=${diagnostic.p3Softened}`,
-    `p3_escalated=${diagnostic.p3Escalated}`,
-  ].join(" ");
 }
 
 function normalizeReviewCommentWhitespace(value: string): string {
@@ -410,173 +87,6 @@ function renderReviewThreadDetail(thread: ReviewThread, includeAuthor = false): 
   const summary = ` summary=${extractReviewCommentSummary(latestComment?.body ?? "")}`;
   const url = latestComment?.url ? ` url=${latestComment.url}` : "";
   return `${location}${author}${severity}${summary}${url}`;
-}
-
-export function buildCodexConnectorMustFixFindingDetails(args: {
-  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
-  reviewThreads: ReviewThread[];
-}): string[] {
-  return clusterConfiguredBotReviewThreads(codexConnectorMustFixReviewThreads(args.reviewThreads)).map((cluster, index) => {
-    const representativeThread = cluster.threads[0];
-    const latestComment = latestReviewComment(representativeThread);
-    const lineRange = representativeThread.line == null ? "unknown" : String(representativeThread.line);
-    return [
-      `- Root-cause repair group ${index + 1}`,
-      `  Policy: Codex Connector must_fix_remaining`,
-      `  Severity: ${cluster.severity}`,
-      `  PR: ${args.pr ? `#${args.pr.number}` : "unknown"}`,
-      `  Head SHA: ${args.pr?.headRefOid ?? "unknown"}`,
-      `  Thread IDs: ${cluster.threads.map((thread) => thread.id).join(", ")}`,
-      `  Affected files: ${cluster.files.join(", ")}`,
-      `  Representative source URLs: ${cluster.sourceUrls.join(", ") || "n/a"}`,
-      `  Source URL: ${latestComment?.url ?? "n/a"}`,
-      `  File: ${representativeThread.path ?? "unknown"}`,
-      `  Line range: ${lineRange}`,
-      `  Summary: ${cluster.summary}`,
-      ...(cluster.threads.length === 1
-        ? [`  Latest relevant comment: ${extractReviewCommentSummary(latestComment?.body ?? "")}`]
-        : []),
-      `  Evidence: ${cluster.threads
-        .map((thread) => {
-          const comment = latestReviewComment(thread);
-          return `${thread.id} ${thread.path ?? "unknown"}:${thread.line ?? "?"} ${comment?.url ?? "n/a"}`;
-        })
-        .join("; ")}`,
-    ].join("\n");
-  });
-}
-
-export interface ConfiguredBotReviewThreadCluster {
-  severity: CodexConnectorPSeverity | "unknown";
-  summary: string;
-  signature: string;
-  threads: ReviewThread[];
-  files: string[];
-  sourceUrls: string[];
-}
-
-function normalizeReviewThreadSignature(summary: string): string {
-  return summary
-    .toLowerCase()
-    .replace(/https?:\/\/\S+/g, " ")
-    .replace(/`[^`]+`/g, " ")
-    .replace(/\b\d+\b/g, "#")
-    .replace(/[^a-z0-9#]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-const REVIEW_THREAD_THEME_STOP_WORDS = new Set([
-  "add",
-  "after",
-  "again",
-  "before",
-  "being",
-  "because",
-  "cannot",
-  "comment",
-  "coverage",
-  "does",
-  "from",
-  "here",
-  "into",
-  "keep",
-  "lets",
-  "merge",
-  "must",
-  "needs",
-  "only",
-  "path",
-  "please",
-  "prefer",
-  "proving",
-  "repair",
-  "review",
-  "should",
-  "still",
-  "than",
-  "that",
-  "this",
-  "thread",
-  "until",
-  "when",
-  "with",
-  "without",
-]);
-
-function normalizeFailureThemeTokens(summary: string): string[] {
-  return uniqueInOrder(
-    normalizeReviewThreadSignature(summary)
-      .split(" ")
-      .filter((token) => {
-        return token.length >= 4 && !REVIEW_THREAD_THEME_STOP_WORDS.has(token) && !/^#+$/.test(token);
-      }),
-  ).sort();
-}
-
-function hasSimilarFailureTheme(left: string[], right: string[]): boolean {
-  if (left.length < 3 || right.length < 3) {
-    return false;
-  }
-
-  const rightTokens = new Set(right);
-  const sharedCount = left.filter((token) => rightTokens.has(token)).length;
-  return sharedCount >= 4 || sharedCount / Math.min(left.length, right.length) >= 0.5;
-}
-
-function uniqueInOrder(values: string[]): string[] {
-  return [...new Set(values)];
-}
-
-export function clusterConfiguredBotReviewThreads(reviewThreads: ReviewThread[]): ConfiguredBotReviewThreadCluster[] {
-  const clusters = new Map<string, ConfiguredBotReviewThreadCluster>();
-  const clusterThemeTokens = new Map<string, string[]>();
-
-  for (const thread of reviewThreads) {
-    const latestComment = latestReviewComment(thread);
-    const severity = latestCodexConnectorPSeverity(thread) ?? "unknown";
-    const summary = extractReviewCommentSummary(latestComment?.body ?? "");
-    const signature = `${severity}:${normalizeReviewThreadSignature(summary) || thread.id}`;
-    const themeTokens = normalizeFailureThemeTokens(summary);
-    const normalizedPath = thread.path?.replace(/\\/g, "/");
-    const existingSignature = clusters.has(signature)
-      ? signature
-      : [...clusters.entries()].find(([candidateSignature, candidate]) => {
-          return (
-            normalizedPath !== undefined &&
-            candidate.severity === severity &&
-            candidate.files.map((filePath) => filePath.replace(/\\/g, "/")).includes(normalizedPath) &&
-            hasSimilarFailureTheme(themeTokens, clusterThemeTokens.get(candidateSignature) ?? [])
-          );
-        })?.[0];
-    const existing = existingSignature ? clusters.get(existingSignature) : undefined;
-    if (existing) {
-      existing.threads.push(thread);
-      existing.files = uniqueInOrder([...existing.files, thread.path ?? "unknown"]);
-      if (latestComment?.url) {
-        existing.sourceUrls = uniqueInOrder([...existing.sourceUrls, latestComment.url]);
-      }
-      if (existingSignature) {
-        clusterThemeTokens.set(
-          existingSignature,
-          uniqueInOrder([...(clusterThemeTokens.get(existingSignature) ?? []), ...themeTokens]).sort(),
-        );
-      }
-      continue;
-    }
-
-    clusters.set(signature, {
-      severity,
-      summary,
-      signature,
-      threads: [thread],
-      files: [thread.path ?? "unknown"],
-      sourceUrls: latestComment?.url ? [latestComment.url] : [],
-    });
-    clusterThemeTokens.set(signature, themeTokens);
-  }
-
-  return [...clusters.values()];
 }
 
 export function manualReviewThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
@@ -688,8 +198,8 @@ export function staleConfiguredBotReviewThreads(
     | "processed_review_thread_ids"
     | "processed_review_thread_fingerprints"
     | "last_head_sha"
-      | "review_follow_up_head_sha"
-      | "review_follow_up_remaining"
+    | "review_follow_up_head_sha"
+    | "review_follow_up_remaining"
   >,
   pr: Pick<
     GitHubPullRequest,

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -2,10 +2,12 @@ import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread,
 import { hasProcessedReviewThread } from "../review-handling";
 import {
   clusterConfiguredBotReviewThreads,
-  configuredBotReviewFollowUpState,
-  configuredBotReviewThreads,
   codexConnectorMustFixReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
+} from "../codex-connector-review-policy";
+import {
+  configuredBotReviewFollowUpState,
+  configuredBotReviewThreads,
   manualReviewThreads,
   nonActionableConfiguredBotReviewThreads,
   pendingBotReviewThreads,

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -3,9 +3,11 @@ import {
 } from "../review-handling";
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
+  evaluateCodexConnectorConvergencePolicy,
+} from "../codex-connector-review-policy";
+import {
   actionableBotReviewThreads,
   configuredBotReviewFollowUpState,
-  evaluateCodexConnectorConvergencePolicy,
   latestReviewCommentAuthorIsAllowedBot,
 } from "../review-thread-reporting";
 import { formatWorkspaceRestoreStatusLine } from "../core/workspace";

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -22,7 +22,8 @@ import {
 import { latestReviewThreadCommentFingerprint } from "../review-handling";
 import { inferFailureContext } from "./supervisor-failure-context";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor-status-rendering";
-import { clusterConfiguredBotReviewThreads, configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
+import { clusterConfiguredBotReviewThreads } from "../codex-connector-review-policy";
+import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
 import {
   FailureContext,
   GitHubPullRequest,

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -20,7 +20,7 @@ import {
   evaluateCodexConnectorConvergencePolicy,
   formatCodexConnectorP2P3PolicyDiagnostic,
   formatCodexConnectorPolicyBlockDiagnostic,
-} from "../review-thread-reporting";
+} from "../codex-connector-review-policy";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 import type { StaleReviewBotRemediationDto } from "./stale-review-bot-remediation";
 

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -2,8 +2,10 @@ import { GitHubClient } from "./github";
 import { IssueJournalSync } from "./run-once-issue-preparation";
 import { StateStore } from "./core/state-store";
 import {
-  configuredBotReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
+} from "./codex-connector-review-policy";
+import {
+  configuredBotReviewThreads,
   latestReviewComment,
   manualReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -17,8 +17,10 @@ import {
   processedReviewThreadKey,
 } from "./review-handling";
 import {
-  actionableConfiguredBotReviewThreads,
   codexConnectorMustFixReviewThreads,
+} from "./codex-connector-review-policy";
+import {
+  actionableConfiguredBotReviewThreads,
   configuredBotReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
 } from "./review-thread-reporting";


### PR DESCRIPTION
## Summary
- move Codex Connector P-severity policy, convergence, stale-review-commit, diagnostics, and clustering helpers into `codex-connector-review-policy`
- keep `review-thread-reporting` compatibility re-exports while slimming it to generic review-thread reporting behavior
- consolidate Codex Connector tracked-PR fixture builders for stale-head, stale-review-commit, same-head request, retry, and verified residue scenarios

## Verification
- `npx tsx --test src/codex-connector-review-policy.test.ts src/review-thread-reporting.test.ts src/codex-connector-review-request-decision.test.ts src/post-turn-pull-request.test.ts`
- `npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts`
- `npm run verify:paths`
- `npm run build`

Closes #2054