### PR TITLE
Fix Codex Connector tracked PR handoff recovery

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -744,6 +744,19 @@ export async function reconcileStaleDoneIssueStates(
   );
 }
 
+function isCurrentHeadReviewSignalRequestTimeout(
+  patch: Pick<
+    IssueRunRecord,
+    "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
+  >,
+): boolean {
+  return (
+    patch.copilot_review_timed_out_at !== null &&
+    patch.copilot_review_timeout_action === "request_review_comment" &&
+    patch.copilot_review_timeout_reason?.includes("current-head review signal") === true
+  );
+}
+
 export async function reconcileRecoverableBlockedIssueStates(
   github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">
     & Partial<Pick<RecoveryGitHubLike, "getIssueComments" | "updateIssueComment">>,
@@ -987,7 +1000,7 @@ export async function reconcileRecoverableBlockedIssueStates(
         externalProgressEvidence === null &&
         record.last_head_sha === trackedPullRequest.headRefOid &&
         projection.nextState === "waiting_ci" &&
-        projection.copilotReviewTimeoutPatch.copilot_review_timeout_action === "request_review_comment";
+        isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch);
       if (!externalProgressEvidence && !sameHeadReviewRequestRecovery) {
         continue;
       }

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -962,15 +962,6 @@ export async function reconcileRecoverableBlockedIssueStates(
 
       const checks = await github.getChecks(trackedPullRequest.number);
       const reviewThreads = await github.getUnresolvedReviewThreads(trackedPullRequest.number);
-      const externalProgressEvidence = trackedHandoffExternalProgressEvidence({
-        record,
-        pr: trackedPullRequest,
-        checks,
-      });
-      if (!externalProgressEvidence) {
-        continue;
-      }
-
       const projection = projectTrackedPrLifecycle({
         config,
         record,
@@ -987,6 +978,20 @@ export async function reconcileRecoverableBlockedIssueStates(
         continue;
       }
 
+      const externalProgressEvidence = trackedHandoffExternalProgressEvidence({
+        record,
+        pr: trackedPullRequest,
+        checks,
+      });
+      const sameHeadReviewRequestRecovery =
+        externalProgressEvidence === null &&
+        record.last_head_sha === trackedPullRequest.headRefOid &&
+        projection.nextState === "waiting_ci" &&
+        projection.copilotReviewTimeoutPatch.copilot_review_timeout_action === "request_review_comment";
+      if (!externalProgressEvidence && !sameHeadReviewRequestRecovery) {
+        continue;
+      }
+
       const nextState = projection.nextState;
       const nextBlockedReason = projection.nextBlockedReason;
       const failureContext =
@@ -1000,16 +1005,19 @@ export async function reconcileRecoverableBlockedIssueStates(
         failureContext,
         blockedReason: nextBlockedReason,
         reviewWaitPatch: projection.reviewWaitPatch,
+        codexConnectorReviewRequestObservationPatch: projection.codexConnectorReviewRequestObservationPatch,
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
       });
       patch.codex_session_id = null;
-      patch.last_tracked_pr_progress_summary = `handoff_missing_recovered=evidence=${externalProgressEvidence}`;
+      patch.last_tracked_pr_progress_summary = externalProgressEvidence
+        ? `handoff_missing_recovered=evidence=${externalProgressEvidence}`
+        : `handoff_missing_recovered=same_head_projected_state=${nextState}`;
 
-      const recoveryEvent = buildRecoveryEvent(
-        record.issue_number,
-        `tracked_pr_handoff_missing_external_progress: resumed issue #${record.issue_number} from blocked to ${nextState} after tracked PR #${trackedPullRequest.number} advanced from ${record.last_head_sha} to ${trackedPullRequest.headRefOid} with evidence=${externalProgressEvidence}`,
-      );
+      const recoveryReason = externalProgressEvidence
+        ? `tracked_pr_handoff_missing_external_progress: resumed issue #${record.issue_number} from blocked to ${nextState} after tracked PR #${trackedPullRequest.number} advanced from ${record.last_head_sha} to ${trackedPullRequest.headRefOid} with evidence=${externalProgressEvidence}`
+        : `tracked_pr_handoff_missing_same_head_recovered: resumed issue #${record.issue_number} from blocked to ${nextState} using fresh tracked PR #${trackedPullRequest.number} facts at head ${trackedPullRequest.headRefOid}`;
+      const recoveryEvent = buildRecoveryEvent(record.issue_number, recoveryReason);
       const updated = stateStore.touch(record, applyRecoveryEvent(patch, recoveryEvent));
       state.issues[String(record.issue_number)] = updated;
       changed = true;
@@ -1152,6 +1160,7 @@ export async function reconcileRecoverableBlockedIssueStates(
         failureContext,
         blockedReason: nextBlockedReason,
         reviewWaitPatch: projection.reviewWaitPatch,
+        codexConnectorReviewRequestObservationPatch: projection.codexConnectorReviewRequestObservationPatch,
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
       });

--- a/src/recovery-tracked-pr-support.ts
+++ b/src/recovery-tracked-pr-support.ts
@@ -10,6 +10,7 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
   failureContext: IssueRunRecord["last_failure_context"];
   blockedReason: IssueRunRecord["blocked_reason"];
   reviewWaitPatch?: Partial<IssueRunRecord>;
+  codexConnectorReviewRequestObservationPatch?: Partial<IssueRunRecord>;
   copilotReviewRequestObservationPatch?: Partial<IssueRunRecord>;
   copilotReviewTimeoutPatch?: Partial<IssueRunRecord>;
 }): Partial<IssueRunRecord> {
@@ -20,6 +21,7 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
     failureContext,
     blockedReason,
     reviewWaitPatch = {},
+    codexConnectorReviewRequestObservationPatch = {},
     copilotReviewRequestObservationPatch = {},
     copilotReviewTimeoutPatch = {},
   } = args;
@@ -51,6 +53,7 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
     last_head_sha: pr.headRefOid,
     ...headAdvanceResetPatch,
     ...reviewWaitPatch,
+    ...codexConnectorReviewRequestObservationPatch,
     ...copilotReviewRequestObservationPatch,
     ...copilotReviewTimeoutPatch,
   };

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1762,6 +1762,84 @@ test("reconcileRecoverableBlockedIssueStates recovers same-head tracked handoff-
   }
 });
 
+test("reconcileRecoverableBlockedIssueStates does not recover same-head handoff-missing for generic review timeouts", async () => {
+  const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const original = createTrackedPrStaleReviewRecord({
+    state: "blocked",
+    blocked_reason: "handoff_missing",
+    last_head_sha: currentHead,
+    review_wait_started_at: "2026-05-19T09:03:41Z",
+    review_wait_head_sha: currentHead,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    last_failure_signature: "handoff-missing",
+    repeated_failure_signature_count: 1,
+    codex_session_id: "session-366",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createTrackedPrRecoveryIssue({
+    updatedAt: "2026-05-19T09:11:00Z",
+  });
+  const pr = createTrackedPrRecoveryPullRequest({
+    headRefOid: currentHead,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-05-19T09:14:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "waiting_ci",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState: () => ({
+        copilot_review_timed_out_at: "2026-05-19T09:13:41.000Z",
+        copilot_review_timeout_action: "request_review_comment",
+        copilot_review_timeout_reason:
+          `Requested chatgpt-codex-connector review never arrived within 10 minute(s) for head ${currentHead}.`,
+      }),
+    },
+  );
+
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+  assert.deepEqual(state.issues["366"], original);
+});
+
 test("reconcileRecoverableBlockedIssueStates reopens configured-bot follow-up when last_head_sha is current but local review state is stale", async () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1650,6 +1650,118 @@ test("reconcileRecoverableBlockedIssueStates keeps tracked handoff-missing block
   assert.deepEqual(state.issues["366"], original);
 });
 
+test("reconcileRecoverableBlockedIssueStates recovers same-head tracked handoff-missing when Codex current-head review request is due", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-19T09:14:00Z");
+  try {
+    const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const original = createTrackedPrStaleReviewRecord({
+      state: "blocked",
+      blocked_reason: "handoff_missing",
+      last_head_sha: currentHead,
+      review_wait_started_at: "2026-05-19T09:03:41Z",
+      review_wait_head_sha: currentHead,
+      copilot_review_timed_out_at: null,
+      copilot_review_timeout_action: null,
+      copilot_review_timeout_reason: null,
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+      last_error: "Codex started a turn but did not write a durable handoff.",
+      last_failure_context: {
+        category: "blocked",
+        summary: "Codex started a turn but did not write a durable handoff.",
+        signature: "handoff-missing",
+        command: null,
+        details: ["Update the issue journal before the turn exits."],
+        url: null,
+        updated_at: "2026-05-19T09:10:00Z",
+      },
+      last_failure_signature: "handoff-missing",
+      repeated_failure_signature_count: 1,
+      codex_session_id: "session-366",
+    });
+    const state: SupervisorStateFile = createSupervisorState({
+      issues: [original],
+    });
+    const issue = createTrackedPrRecoveryIssue({
+      updatedAt: "2026-05-19T09:11:00Z",
+    });
+    const pr = createTrackedPrRecoveryPullRequest({
+      headRefOid: currentHead,
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotLatestReviewedCommitSha: "98da2474c530b76dae67b5a6f43e0671b989f65a",
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    let saveCalls = 0;
+
+    const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+      {
+        getPullRequestIfExists: async () => pr,
+        getIssue: async () => {
+          throw new Error("unexpected getIssue call");
+        },
+        getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        getUnresolvedReviewThreads: async () => [],
+      },
+      {
+        touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+          return {
+            ...current,
+            ...patch,
+            updated_at: "2026-05-19T09:14:00Z",
+          };
+        },
+        async save(): Promise<void> {
+          saveCalls += 1;
+        },
+      },
+      state,
+      config,
+      [issue],
+      {
+        shouldAutoRetryHandoffMissing,
+        inferStateFromPullRequest,
+        inferFailureContext,
+        blockedReasonForLifecycleState,
+        isOpenPullRequest,
+        syncReviewWaitWindow,
+        syncCopilotReviewRequestObservation,
+        syncCopilotReviewTimeoutState,
+      },
+    );
+
+    const updated = state.issues["366"];
+    assert.equal(updated.state, "waiting_ci");
+    assert.equal(updated.blocked_reason, null);
+    assert.equal(updated.last_error, null);
+    assert.equal(updated.last_failure_context, null);
+    assert.equal(updated.last_failure_signature, null);
+    assert.equal(updated.repeated_failure_signature_count, 0);
+    assert.equal(updated.codex_session_id, null);
+    assert.equal(updated.pr_number, TRACKED_PR_NUMBER);
+    assert.equal(updated.last_head_sha, currentHead);
+    assert.equal(updated.copilot_review_timeout_action, "request_review_comment");
+    assert.equal(updated.copilot_review_timeout_reason?.includes("current-head"), true);
+    assert.equal(updated.last_tracked_pr_progress_summary, "handoff_missing_recovered=same_head_projected_state=waiting_ci");
+    assert.equal(saveCalls, 1);
+    assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+      `tracked_pr_handoff_missing_same_head_recovered: resumed issue #366 from blocked to waiting_ci using fresh tracked PR #${TRACKED_PR_NUMBER} facts at head ${currentHead}`,
+    ]);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("reconcileRecoverableBlockedIssueStates reopens configured-bot follow-up when last_head_sha is current but local review state is stale", async () => {
   const config = createConfig({
     localReviewEnabled: true,


### PR DESCRIPTION
## Summary
- recover same-head tracked PR `blocked/handoff_missing` records when fresh PR projection is the Codex Connector current-head review request wait path
- persist Codex Connector review-request observation metadata during tracked PR convergence patches
- add an HRCore-shaped regression for green checks plus missing current-head Codex signal

## Verification
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`
- `npx tsx --test src/supervisor/supervisor-execution-policy.test.ts`
- `npx tsx --test src/post-turn-pull-request.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`
- `npm run build`
- `git diff --check`
- `npm run verify:supervisor-pre-pr`
- `node dist/index.js issue-lint 2058 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`

Notes: `npm test -- src/supervisor/supervisor-recovery-reconciliation.test.ts` currently expands through the repo-wide glob before the requested file and reported unrelated pre-existing family-layout failures; direct focused suites above passed.

Closes #2058


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling for blocked tracked pull requests that remain at the same commit state with pending review actions, expanding recovery support for additional scenarios.

* **Tests**
  * Added comprehensive test coverage for tracked pull request recovery behavior in review timeout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->