### PR TITLE
Recover handoff_missing with outdated Codex residue

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1021,9 +1021,12 @@ export async function reconcileRecoverableBlockedIssueStates(
         record.last_head_sha === trackedPullRequest.headRefOid &&
         projection.nextState === "waiting_ci" &&
         isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch);
+      const isReviewSignalProjectedState =
+        projection.nextState === "addressing_review" || projection.nextState === "waiting_ci";
       const sameHeadOutdatedConfiguredBotResidueRecovery =
         externalProgressEvidence === null &&
         record.last_head_sha === trackedPullRequest.headRefOid &&
+        isReviewSignalProjectedState &&
         isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch) &&
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
       if (!externalProgressEvidence && !sameHeadReviewRequestRecovery && !sameHeadOutdatedConfiguredBotResidueRecovery) {

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -62,6 +62,10 @@ import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "./tracked-pr-ready-promotion-blocker";
 import { queuedReadyPromotionPathHygieneRepairContext } from "./ready-promotion-path-hygiene-repair";
 import { clearRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
+import {
+  configuredBotReviewThreads,
+  latestReviewCommentAuthorIsAllowedBot,
+} from "./review-thread-reporting";
 
 const OPERATOR_REQUEUEABLE_STATES = new Set<RunState>(["blocked", "failed"]);
 type StaleStabilizingNoPrBranchState = "recoverable" | "already_satisfied_on_main";
@@ -757,6 +761,22 @@ function isCurrentHeadReviewSignalRequestTimeout(
   );
 }
 
+function hasOnlyOutdatedConfiguredBotResidue(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): boolean {
+  const unresolvedThreads = reviewThreads.filter((thread) => !thread.isResolved);
+  if (unresolvedThreads.length === 0) {
+    return false;
+  }
+
+  const configuredThreads = configuredBotReviewThreads(config, unresolvedThreads);
+  return (
+    configuredThreads.length === unresolvedThreads.length &&
+    configuredThreads.every((thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread))
+  );
+}
+
 export async function reconcileRecoverableBlockedIssueStates(
   github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">
     & Partial<Pick<RecoveryGitHubLike, "getIssueComments" | "updateIssueComment">>,
@@ -1001,12 +1021,17 @@ export async function reconcileRecoverableBlockedIssueStates(
         record.last_head_sha === trackedPullRequest.headRefOid &&
         projection.nextState === "waiting_ci" &&
         isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch);
-      if (!externalProgressEvidence && !sameHeadReviewRequestRecovery) {
+      const sameHeadOutdatedConfiguredBotResidueRecovery =
+        externalProgressEvidence === null &&
+        record.last_head_sha === trackedPullRequest.headRefOid &&
+        isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch) &&
+        hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
+      if (!externalProgressEvidence && !sameHeadReviewRequestRecovery && !sameHeadOutdatedConfiguredBotResidueRecovery) {
         continue;
       }
 
-      const nextState = projection.nextState;
-      const nextBlockedReason = projection.nextBlockedReason;
+      const nextState = sameHeadOutdatedConfiguredBotResidueRecovery ? "waiting_ci" : projection.nextState;
+      const nextBlockedReason = sameHeadOutdatedConfiguredBotResidueRecovery ? null : projection.nextBlockedReason;
       const failureContext =
         nextState === "blocked"
           ? inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads)

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1876,6 +1876,103 @@ test("reconcileRecoverableBlockedIssueStates recovers same-head handoff-missing 
   }
 });
 
+test("reconcileRecoverableBlockedIssueStates does not force same-head outdated residue recovery from unrelated projected states", async () => {
+  const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const original = createTrackedPrStaleReviewRecord({
+    state: "blocked",
+    blocked_reason: "handoff_missing",
+    last_head_sha: currentHead,
+    review_wait_started_at: "2026-05-19T09:03:41Z",
+    review_wait_head_sha: currentHead,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    last_failure_signature: "handoff-missing",
+    repeated_failure_signature_count: 1,
+    codex_session_id: "session-366",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createTrackedPrRecoveryIssue({
+    updatedAt: "2026-05-19T09:11:00Z",
+  });
+  const pr = createTrackedPrRecoveryPullRequest({
+    headRefOid: currentHead,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: "thread-outdated-codex-1",
+          isOutdated: true,
+          comments: {
+            nodes: [
+              {
+                id: "comment-outdated-codex-1",
+                body: "P2: Stale residue that should not override an unrelated block.",
+                createdAt: "2026-05-19T09:00:00Z",
+                url: "https://example.test/pr/191#discussion_r5",
+                author: {
+                  login: "chatgpt-codex-connector",
+                  typeName: "Bot",
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-05-19T09:14:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "blocked",
+      inferFailureContext,
+      blockedReasonForLifecycleState: () => "verification",
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState: () => ({
+        copilot_review_timed_out_at: "2026-05-19T09:13:41.000Z",
+        copilot_review_timeout_action: "request_review_comment",
+        copilot_review_timeout_reason:
+          `Requested chatgpt-codex-connector review never arrived within 10 minute(s) for head ${currentHead}.`,
+      }),
+    },
+  );
+
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+  assert.deepEqual(state.issues["366"], original);
+});
+
 test("reconcileRecoverableBlockedIssueStates keeps same-head handoff-missing blocked for actionable or non-configured residue", async () => {
   const originalDateNow = Date.now;
   Date.now = () => Date.parse("2026-05-19T09:14:00Z");

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1762,6 +1762,273 @@ test("reconcileRecoverableBlockedIssueStates recovers same-head tracked handoff-
   }
 });
 
+test("reconcileRecoverableBlockedIssueStates recovers same-head handoff-missing with outdated Codex Connector residue", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-19T09:14:00Z");
+  try {
+    const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const original = createTrackedPrStaleReviewRecord({
+      state: "blocked",
+      blocked_reason: "handoff_missing",
+      last_head_sha: currentHead,
+      review_wait_started_at: "2026-05-19T09:03:41Z",
+      review_wait_head_sha: currentHead,
+      copilot_review_timed_out_at: null,
+      copilot_review_timeout_action: null,
+      copilot_review_timeout_reason: null,
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+      last_failure_signature: "handoff-missing",
+      repeated_failure_signature_count: 1,
+      codex_session_id: "session-366",
+    });
+    const state: SupervisorStateFile = createSupervisorState({
+      issues: [original],
+    });
+    const issue = createTrackedPrRecoveryIssue({
+      updatedAt: "2026-05-19T09:11:00Z",
+    });
+    const pr = createTrackedPrRecoveryPullRequest({
+      headRefOid: currentHead,
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotLatestReviewedCommitSha: "98da2474c530b76dae67b5a6f43e0671b989f65a",
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    let saveCalls = 0;
+
+    const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+      {
+        getPullRequestIfExists: async () => pr,
+        getIssue: async () => {
+          throw new Error("unexpected getIssue call");
+        },
+        getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        getUnresolvedReviewThreads: async () => [
+          createReviewThread({
+            id: "thread-outdated-codex-1",
+            isOutdated: true,
+            comments: {
+              nodes: [
+                {
+                  id: "comment-outdated-codex-1",
+                  body: "P2: This stale current-head finding was already addressed.",
+                  createdAt: "2026-05-19T09:00:00Z",
+                  url: "https://example.test/pr/191#discussion_r1",
+                  author: {
+                    login: "chatgpt-codex-connector",
+                    typeName: "Bot",
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+      {
+        touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+          return {
+            ...current,
+            ...patch,
+            updated_at: "2026-05-19T09:14:00Z",
+          };
+        },
+        async save(): Promise<void> {
+          saveCalls += 1;
+        },
+      },
+      state,
+      config,
+      [issue],
+      {
+        shouldAutoRetryHandoffMissing,
+        inferStateFromPullRequest,
+        inferFailureContext,
+        blockedReasonForLifecycleState,
+        isOpenPullRequest,
+        syncReviewWaitWindow,
+        syncCopilotReviewRequestObservation,
+        syncCopilotReviewTimeoutState,
+      },
+    );
+
+    const updated = state.issues["366"];
+    assert.equal(updated.state, "waiting_ci");
+    assert.equal(updated.blocked_reason, null);
+    assert.equal(updated.last_failure_signature, null);
+    assert.equal(updated.codex_session_id, null);
+    assert.equal(updated.copilot_review_timeout_action, "request_review_comment");
+    assert.equal(saveCalls, 1);
+    assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+      `tracked_pr_handoff_missing_same_head_recovered: resumed issue #366 from blocked to waiting_ci using fresh tracked PR #${TRACKED_PR_NUMBER} facts at head ${currentHead}`,
+    ]);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
+test("reconcileRecoverableBlockedIssueStates keeps same-head handoff-missing blocked for actionable or non-configured residue", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-19T09:14:00Z");
+  try {
+    const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
+    const config = createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    });
+    const pr = createTrackedPrRecoveryPullRequest({
+      headRefOid: currentHead,
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotLatestReviewedCommitSha: "98da2474c530b76dae67b5a6f43e0671b989f65a",
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const scenarios: Array<{ name: string; thread: ReturnType<typeof createReviewThread> }> = [
+      {
+        name: "human-authored outdated thread",
+        thread: createReviewThread({
+          id: "thread-human-outdated",
+          isOutdated: true,
+          comments: {
+            nodes: [
+              {
+                id: "comment-human-outdated",
+                body: "Please keep this blocked for a human reviewer.",
+                createdAt: "2026-05-19T09:00:00Z",
+                url: "https://example.test/pr/191#discussion_r2",
+                author: {
+                  login: "reviewer",
+                  typeName: "User",
+                },
+              },
+            ],
+          },
+        }),
+      },
+      {
+        name: "current Codex Connector must-fix thread",
+        thread: createReviewThread({
+          id: "thread-current-codex",
+          isOutdated: false,
+          comments: {
+            nodes: [
+              {
+                id: "comment-current-codex",
+                body: "P2: Keep this current-head finding blocked.",
+                createdAt: "2026-05-19T09:00:00Z",
+                url: "https://example.test/pr/191#discussion_r3",
+                author: {
+                  login: "chatgpt-codex-connector",
+                  typeName: "Bot",
+                },
+              },
+            ],
+          },
+        }),
+      },
+      {
+        name: "non-configured bot outdated thread",
+        thread: createReviewThread({
+          id: "thread-other-bot-outdated",
+          isOutdated: true,
+          comments: {
+            nodes: [
+              {
+                id: "comment-other-bot-outdated",
+                body: "Please keep this blocked for another reviewer.",
+                createdAt: "2026-05-19T09:00:00Z",
+                url: "https://example.test/pr/191#discussion_r4",
+                author: {
+                  login: "other-review-bot",
+                  typeName: "Bot",
+                },
+              },
+            ],
+          },
+        }),
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const original = createTrackedPrStaleReviewRecord({
+        state: "blocked",
+        blocked_reason: "handoff_missing",
+        last_head_sha: currentHead,
+        review_wait_started_at: "2026-05-19T09:03:41Z",
+        review_wait_head_sha: currentHead,
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: null,
+        last_failure_signature: "handoff-missing",
+        repeated_failure_signature_count: 1,
+        codex_session_id: "session-366",
+      });
+      const state: SupervisorStateFile = createSupervisorState({
+        issues: [original],
+      });
+      let saveCalls = 0;
+
+      const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+        {
+          getPullRequestIfExists: async () => pr,
+          getIssue: async () => {
+            throw new Error("unexpected getIssue call");
+          },
+          getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+          getUnresolvedReviewThreads: async () => [scenario.thread],
+        },
+        {
+          touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+            return {
+              ...current,
+              ...patch,
+              updated_at: "2026-05-19T09:14:00Z",
+            };
+          },
+          async save(): Promise<void> {
+            saveCalls += 1;
+          },
+        },
+        state,
+        config,
+        [createTrackedPrRecoveryIssue({ updatedAt: "2026-05-19T09:11:00Z" })],
+        {
+          shouldAutoRetryHandoffMissing,
+          inferStateFromPullRequest,
+          inferFailureContext,
+          blockedReasonForLifecycleState,
+          isOpenPullRequest,
+          syncReviewWaitWindow,
+          syncCopilotReviewRequestObservation,
+          syncCopilotReviewTimeoutState,
+        },
+      );
+
+      assert.equal(saveCalls, 0, scenario.name);
+      assert.deepEqual(recoveryEvents, [], scenario.name);
+      assert.deepEqual(state.issues["366"], original, scenario.name);
+    }
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("reconcileRecoverableBlockedIssueStates does not recover same-head handoff-missing for generic review timeouts", async () => {
   const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
   const config = createConfig({


### PR DESCRIPTION
## Summary
- recover same-head `blocked/handoff_missing` tracked PRs when the only unresolved review residue is outdated configured-bot Codex Connector threads
- keep recovery fail-closed for human/non-configured residue and current actionable Codex Connector must-fix threads
- add focused regression coverage for the HRCore-shaped outdated residue gap

## Verification
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts`
- `npx tsx --test src/post-turn-pull-request.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`
- `npm run build`
- `npm run verify:supervisor-pre-pr`
- `git diff --check`
- `node dist/index.js issue-lint 2060 --config <codex-supervisor-self codex config>`

Notes:
- `npm test -- src/supervisor/supervisor-recovery-reconciliation.test.ts` currently expands the repo-wide `src/**/*.test.ts` glob first and exposed unrelated existing family-layout snapshot failures; the focused `npx tsx --test ...` recovery suite passed.

Closes #2060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced recovery logic to correctly handle cases where only outdated bot-generated review threads remain unresolved, allowing progress to continue.

* **Tests**
  * Added comprehensive test coverage for recovery scenarios involving outdated bot-generated review threads and edge cases with actionable reviews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->