### PR TITLE
Fix Codex Connector review request with outdated residue

### DIFF
--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -133,6 +133,7 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
       staleHeadConfiguredThreadIds.has(thread.id) ||
       staleConfiguredThreadIds.has(thread.id) ||
       staleReviewCommitThreadIds.has(thread.id) ||
+      (thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(args.config, thread)) ||
       (latestReviewCommentAuthorIsAllowedBot(args.config, thread) &&
         hasProcessedReviewThread(args.record, args.pr, thread)),
   );

--- a/src/codex-connector-review-request-transition.test.ts
+++ b/src/codex-connector-review-request-transition.test.ts
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-review-request-transition";
-import type { FailureContext, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "./core/types";
+import type { FailureContext, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, SupervisorStateFile } from "./core/types";
 import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
-import { createConfig, createPullRequest, createRecord } from "./turn-execution-test-helpers";
+import { createConfig, createPullRequest, createRecord, createReviewThread } from "./turn-execution-test-helpers";
 
 function createCodexConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return createConfig({
@@ -60,6 +60,7 @@ async function requestTransition(overrides: {
   config?: Partial<SupervisorConfig>;
   record?: Partial<IssueRunRecord>;
   pr?: Parameters<typeof createPullRequest>[0];
+  reviewThreads?: ReviewThread[];
   addIssueComment?: (issueNumber: number, body: string) => Promise<{
     databaseId: number;
     nodeId: string;
@@ -103,7 +104,7 @@ async function requestTransition(overrides: {
       record,
       pr,
       checks: passingChecks,
-      reviewThreads: [],
+      reviewThreads: overrides.reviewThreads ?? [],
       syncJournal: async (updatedRecord) => {
         journaled.push(updatedRecord);
       },
@@ -121,6 +122,36 @@ async function requestTransition(overrides: {
   } finally {
     Date.now = originalDateNow;
   }
+}
+
+function createCodexConnectorReviewThread(overrides: {
+  id: string;
+  commentId: string;
+  body: string;
+  path: string;
+  line?: number;
+  isOutdated?: boolean;
+}): ReviewThread {
+  return createReviewThread({
+    id: overrides.id,
+    isOutdated: overrides.isOutdated ?? false,
+    path: overrides.path,
+    line: overrides.line,
+    comments: {
+      nodes: [
+        {
+          id: overrides.commentId,
+          body: overrides.body,
+          createdAt: "2026-05-19T09:00:00Z",
+          url: `https://example.test/pr/176#discussion_${overrides.id}`,
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
 }
 
 test("maybeRequestCodexConnectorReviewComment persists initial request comment identity and clears blockers", async () => {
@@ -159,6 +190,110 @@ test("maybeRequestCodexConnectorReviewComment persists initial request comment i
   assert.equal(result.blocked_reason, null);
   assert.equal(result.last_error, null);
   assert.equal(state.issues["2052"], result);
+  assert.deepEqual(journaled, [result]);
+});
+
+test("maybeRequestCodexConnectorReviewComment requests current-head review for mixed verified fixed Codex residue", async () => {
+  const currentHead = "d4178374ff309aa70e5f69a5d2e52ea1cea5c518";
+  const currentThreads = [
+    createCodexConnectorReviewThread({
+      id: "PRRT_current_validation_body",
+      commentId: "comment-current-validation-body",
+      path: "src/app.ts",
+      line: 105,
+      body: "P2: 400 response body should match ValidationErrorResponse.",
+    }),
+    createCodexConnectorReviewThread({
+      id: "PRRT_current_conflict_status",
+      commentId: "comment-current-conflict-status",
+      path: "src/app.ts",
+      line: 105,
+      body: "P2: SQLite/DB write conflicts should return 409 instead of generic 400.",
+    }),
+    createCodexConnectorReviewThread({
+      id: "PRRT_current_openapi_503",
+      commentId: "comment-current-openapi-503",
+      path: "openapi/hrcore.openapi.json",
+      line: 169,
+      body: "P2: Declare 503 response schema for onboarding save endpoint.",
+    }),
+  ];
+  const reviewThreads = [
+    createCodexConnectorReviewThread({
+      id: "PRRT_outdated_draft_update",
+      commentId: "comment-outdated-draft-update",
+      path: "src/onboarding-transaction-request.ts",
+      body: "P2: stale draft update ignored update change count.",
+      isOutdated: true,
+    }),
+    ...currentThreads,
+  ];
+
+  const { result, comments, journaled, pr } = await requestTransition({
+    config: {
+      verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+      verifiedNoSourceChangeReviewThreadAutoResolve: true,
+      localCiCommand: "npm run verify:pre-pr",
+    },
+    record: {
+      issue_number: 168,
+      pr_number: 176,
+      last_head_sha: currentHead,
+      review_wait_head_sha: currentHead,
+      blocked_reason: "manual_review",
+      copilot_review_timed_out_at: "2026-05-19T09:13:41.000Z",
+      processed_review_thread_ids: currentThreads.map((thread) => `${thread.id}@${currentHead}`),
+      processed_review_thread_fingerprints: currentThreads.map(
+        (thread) => `${thread.id}@${currentHead}#${thread.comments.nodes[0]!.id}`,
+      ),
+      timeline_artifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npm run verify:pre-pr",
+          head_sha: currentHead,
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused onboarding/app fixes and verify:pre-pr passed.",
+          recorded_at: "2026-05-19T09:12:00Z",
+        },
+      ],
+    },
+    pr: {
+      number: 176,
+      headRefOid: currentHead,
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "BLOCKED",
+      currentHeadCiGreenAt: "2026-05-19T09:03:41Z",
+      configuredBotLatestReviewedCommitSha: "aa4a6ced39ef776aba2e3d0f15844cdd1dee53f7",
+      configuredBotCurrentHeadObservedAt: null,
+    },
+    reviewThreads,
+    addIssueComment: async () => ({
+      databaseId: 176001,
+      nodeId: "IC_kwDO176_request",
+      url: "https://github.com/owner/repo/issues/176#issuecomment-176001",
+    }),
+  });
+
+  assert.deepEqual(comments, [
+    {
+      issueNumber: pr.number,
+      body: `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=168 pr=${pr.number} head=${currentHead} -->`,
+    },
+  ]);
+  assert.equal(result.state, "waiting_ci");
+  assert.equal(result.blocked_reason, null);
+  assert.equal(result.codex_connector_review_requested_head_sha, currentHead);
+  assert.match(result.codex_connector_review_requested_observed_at ?? "", /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(result.codex_connector_review_request_comment_identity_status, "available");
+  assert.equal(result.codex_connector_review_request_comment_database_id, 176001);
+  assert.equal(result.codex_connector_review_request_comment_node_id, "IC_kwDO176_request");
+  assert.equal(
+    result.codex_connector_review_request_comment_url,
+    "https://github.com/owner/repo/issues/176#issuecomment-176001",
+  );
   assert.deepEqual(journaled, [result]);
 });
 


### PR DESCRIPTION
## Summary
- allow configured-bot outdated residue to pass the Codex Connector current-head request decision
- add an HRCore-shaped regression covering mixed outdated/current configured-bot threads and verified repair evidence

## Verification
- npm run build
- npx tsx --test src/codex-connector-review-request-decision.test.ts src/codex-connector-review-request-transition.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- git diff --check
- node dist/index.js issue-lint 2062 --config <self-supervisor-config-path>

Fixes #2062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of outdated review threads in code review request processing, now correctly evaluating thread eligibility based on bot author status and outdated state.

* **Tests**
  * Enhanced test infrastructure to support explicit review thread configurations and added coverage for mixed review thread scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->