### PR TITLE
Gate Codex stale metadata on no-major proof

### DIFF
--- a/src/codex-connector-tracked-pr-test-helpers.ts
+++ b/src/codex-connector-tracked-pr-test-helpers.ts
@@ -193,6 +193,10 @@ type CodexConnectorTrackedReviewScenarioOptions = {
     command: string;
     evidenceSource?: "latest_local_ci_result" | "codex_turn_timeline_artifact";
   };
+  currentHeadNoMajorReview?: {
+    requestedAt?: string;
+    observedAt?: string;
+  };
 };
 
 export function createCodexConnectorTrackedReviewResidueScenario({
@@ -208,6 +212,7 @@ export function createCodexConnectorTrackedReviewResidueScenario({
   discussionUrl,
   severity = "P1",
   verifiedRepair,
+  currentHeadNoMajorReview,
 }: CodexConnectorTrackedReviewScenarioOptions): {
   recordPatch: Partial<IssueRunRecord>;
   pullRequestPatch: Partial<GitHubPullRequest>;
@@ -238,6 +243,11 @@ export function createCodexConnectorTrackedReviewResidueScenario({
       updated_at: "2026-05-15T00:20:00Z",
     },
   };
+  if (currentHeadNoMajorReview) {
+    recordPatch.codex_connector_review_requested_observed_at =
+      currentHeadNoMajorReview.requestedAt ?? "2026-05-15T00:12:00Z";
+    recordPatch.codex_connector_review_requested_head_sha = headSha;
+  }
   if (verifiedRepair?.evidenceSource !== "codex_turn_timeline_artifact" && verifiedRepair) {
     recordPatch.latest_local_ci_result = {
       outcome: "passed",
@@ -280,8 +290,19 @@ export function createCodexConnectorTrackedReviewResidueScenario({
       mergeable: "MERGEABLE",
       currentHeadCiGreenAt: verifiedRepair ? "2026-05-15T00:19:00Z" : "2026-05-15T00:10:00Z",
       configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadObservationSource: null,
       configuredBotCurrentHeadStatusState: "SUCCESS",
       configuredBotTopLevelReviewStrength: null,
+      ...(currentHeadNoMajorReview
+        ? {
+            codexConnectorReviewRequestedAt:
+              currentHeadNoMajorReview.requestedAt ?? "2026-05-15T00:12:00Z",
+            codexConnectorReviewRequestedHeadSha: headSha,
+            configuredBotCurrentHeadObservedAt:
+              currentHeadNoMajorReview.observedAt ?? "2026-05-15T00:16:00Z",
+            configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+          }
+        : {}),
     },
     reviewThread: {
       id: threadId,

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4709,6 +4709,10 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-chan
     line: 7,
     commentBody: "P1: This finding was verified as no source change needed.",
     discussionUrl: "https://example.test/pr/1985#discussion_r1985",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
+    },
   });
   const pr = createPullRequest({
     ...scenario.pullRequestPatch,
@@ -4829,6 +4833,10 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
       command: "npm test -- src/post-turn-pull-request.test.ts",
       evidenceSource: "codex_turn_timeline_artifact",
     },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
+    },
   });
   const pr = createPullRequest(scenario.pullRequestPatch);
   const state: SupervisorStateFile = {
@@ -4908,9 +4916,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
   assert.deepEqual(resolveCalls, ["thread-codex-repair"]);
   assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
   assert.doesNotMatch(replyCalls[0]?.body ?? "", /verified_no_source_change_auto_resolve/);
-  assert.equal(requestComments.length, 1);
-  assert.match(requestComments[0] ?? "", /@codex review/);
-  assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request issue=102 pr=1988 head=head-1988/);
+  assert.equal(requestComments.length, 0);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads even when review state falls through to manual_review", async () => {
@@ -4935,6 +4941,10 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
       ranAt: "2026-05-18T07:18:00Z",
       command: "npm test -- --test-name-pattern \"malformed projection key|group projection\"",
       evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-18T07:12:00Z",
+      observedAt: "2026-05-18T07:17:00Z",
     },
   });
   const pr = createPullRequest({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createConfig, createPullRequest, createRecord } from "../turn-execution-test-helpers";
+import {
+  CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+  createCodexConnectorTrackedReviewResidueScenario,
+} from "../codex-connector-tracked-pr-test-helpers";
+import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
+
+test("buildStaleReviewBotRemediation classifies same-head Codex no-major with covered evidence as stale metadata", () => {
+  const issueNumber = 110;
+  const prNumber = 115;
+  const headSha = "c184c41883b831ab6b85bf3467a66a5c01fd49fa";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-mutation-lock-stale-recovery",
+    commentId: "comment-mutation-lock-stale-recovery",
+    path: "src/mutation-lock.ts",
+    line: 42,
+    commentBody: "P1: Verify stale mutation lock recovery only releases the acquired lock instance.",
+    discussionUrl: "https://example.test/pr/115#discussion_r115",
+    verifiedRepair: {
+      summary: "Focused mutation lock verifier passed on the current head.",
+      ranAt: "2026-05-21T11:10:00Z",
+      command: "npm test -- src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-21T11:05:00Z",
+      observedAt: "2026-05-21T11:09:00Z",
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(
+    remediation?.missingProbeReason,
+    null,
+  );
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /Focused mutation lock verifier passed on the current head.;codex_pr_success_comment_after_current_head_request/,
+  );
+});
+
+test("buildStaleReviewBotRemediation fails closed when covered evidence lacks current-head Codex no-major signal", () => {
+  const issueNumber = 110;
+  const prNumber = 115;
+  const headSha = "c184c41883b831ab6b85bf3467a66a5c01fd49fa";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-mutation-lock-stale-recovery",
+    commentId: "comment-mutation-lock-stale-recovery",
+    path: "src/mutation-lock.ts",
+    line: 42,
+    commentBody: "P1: Verify stale mutation lock recovery only releases the acquired lock instance.",
+    discussionUrl: "https://example.test/pr/115#discussion_r115",
+    verifiedRepair: {
+      summary: "Focused mutation lock verifier passed on the current head.",
+      ranAt: "2026-05-21T11:10:00Z",
+      command: "npm test -- src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+});
+
+test("buildStaleReviewBotRemediation fails closed when current-head no-major has unprocessed must-fix threads", () => {
+  const issueNumber = 110;
+  const prNumber = 115;
+  const headSha = "c184c41883b831ab6b85bf3467a66a5c01fd49fa";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-mutation-lock-stale-recovery",
+    commentId: "comment-mutation-lock-stale-recovery",
+    path: "src/mutation-lock.ts",
+    line: 42,
+    commentBody: "P1: Verify stale mutation lock recovery only releases the acquired lock instance.",
+    discussionUrl: "https://example.test/pr/115#discussion_r115",
+    verifiedRepair: {
+      summary: "Focused mutation lock verifier passed on the current head.",
+      ranAt: "2026-05-21T11:10:00Z",
+      command: "npm test -- src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-21T11:05:00Z",
+      observedAt: "2026-05-21T11:09:00Z",
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    processed_review_thread_ids: [],
+    processed_review_thread_fingerprints: [],
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "unresolved_work");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(remediation?.missingProbeReason, null);
+});

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -3,6 +3,7 @@ import { hasProcessedReviewThread } from "../review-handling";
 import {
   clusterConfiguredBotReviewThreads,
   codexConnectorMustFixReviewThreads,
+  commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
 } from "../codex-connector-review-policy";
 import {
@@ -273,6 +274,69 @@ function currentHeadVerificationEvidenceSummary(
   return null;
 }
 
+function hasCurrentHeadCodexTurnVerification(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  return (record.timeline_artifacts ?? []).some(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid,
+  );
+}
+
+function validTimestamp(value: string | null | undefined): string | null {
+  if (!value || Number.isNaN(Date.parse(value))) {
+    return null;
+  }
+  return value;
+}
+
+function currentHeadCodexNoMajorSignalEvidence(args: {
+  record: Pick<
+    IssueRunRecord,
+    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+  >;
+  pr: Pick<
+    GitHubPullRequest,
+    | "headRefOid"
+    | "codexConnectorReviewRequestedAt"
+    | "codexConnectorReviewRequestedHeadSha"
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotCurrentHeadObservationSource"
+    | "configuredBotCurrentHeadStatusState"
+  >;
+}): string | null {
+  if (
+    args.pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment" ||
+    args.pr.configuredBotCurrentHeadStatusState !== "SUCCESS"
+  ) {
+    return null;
+  }
+
+  const observedAt = validTimestamp(args.pr.configuredBotCurrentHeadObservedAt);
+  if (!observedAt) {
+    return null;
+  }
+
+  const requestedAt =
+    validTimestamp(args.record.codex_connector_review_requested_observed_at) ??
+    validTimestamp(args.pr.codexConnectorReviewRequestedAt);
+  const requestedHeadSha =
+    args.record.codex_connector_review_requested_head_sha ?? args.pr.codexConnectorReviewRequestedHeadSha;
+  if (!requestedAt || !commitShasEqualForComparison(requestedHeadSha, args.pr.headRefOid)) {
+    return null;
+  }
+
+  if (Date.parse(observedAt) < Date.parse(requestedAt)) {
+    return null;
+  }
+
+  return "codex_pr_success_comment_after_current_head_request";
+}
+
 function classifyCodexMetadataOnly(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -329,14 +393,27 @@ function classifyCodexMetadataOnly(args: {
     }
     const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(args.record, args.pr);
     if (verificationEvidenceSummary) {
+      const noMajorSignalEvidence = currentHeadCodexNoMajorSignalEvidence({
+        record: args.record,
+        pr: args.pr,
+      });
+      if (!noMajorSignalEvidence) {
+        return {
+          classification: "unknown_needs_operator",
+          summary: STALE_REVIEW_BOT_SUMMARY,
+          verificationEvidenceSummary,
+          missingProbeReason: "current_head_codex_no_major_signal_missing",
+        };
+      }
+      const verifiedCurrentHeadRepair = hasCurrentHeadCodexTurnVerification(args.record, args.pr);
       return {
-        classification: policy.currentHeadObservedAt
-          ? "verified_no_source_change_pending_thread_resolution"
-          : "verified_current_head_repair_pending_thread_resolution",
-        summary: policy.currentHeadObservedAt
-          ? VERIFIED_NO_SOURCE_CHANGE_SUMMARY
-          : VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
-        verificationEvidenceSummary,
+        classification: verifiedCurrentHeadRepair
+          ? "verified_current_head_repair_pending_thread_resolution"
+          : "verified_no_source_change_pending_thread_resolution",
+        summary: verifiedCurrentHeadRepair
+          ? VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY
+          : VERIFIED_NO_SOURCE_CHANGE_SUMMARY,
+        verificationEvidenceSummary: `${verificationEvidenceSummary};${noMajorSignalEvidence}`,
       };
     }
     return {

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1526,6 +1526,10 @@ test("explain distinguishes Codex verified current-head repair residue from no-s
       command: "npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts",
       evidenceSource: "codex_turn_timeline_artifact",
     },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
+    },
   });
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
@@ -1565,7 +1569,7 @@ test("explain distinguishes Codex verified current-head repair residue from no-s
 
   assert.match(
     explanation,
-    /^stale_review_bot_remediation issue=#199 pr=#399 reason=stale_review_bot code_ci=green current_head_sha=head-199 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/399#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#199 pr=#399 reason=stale_review_bot code_ci=green current_head_sha=head-199 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/399#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.doesNotMatch(explanation, /classification=verified_no_source_change_pending_thread_resolution/);
 });

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1156,6 +1156,10 @@ test("status --why distinguishes codex verified current-head repair residue from
       command: "npm test -- src/supervisor/supervisor-diagnostics-status-selection.test.ts",
       evidenceSource: "codex_turn_timeline_artifact",
     },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-13T00:12:00Z",
+      observedAt: "2026-05-13T00:17:00Z",
+    },
   });
   const state: SupervisorStateFile = {
     activeIssueNumber: null,
@@ -1195,7 +1199,7 @@ test("status --why distinguishes codex verified current-head repair residue from
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#399 pr=#499 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f3 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/499#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#399 pr=#499 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f3 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/499#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });
@@ -1223,6 +1227,10 @@ test("status --why surfaces verified Codex residue remediation for manual_review
       ranAt: "2026-05-18T07:18:00Z",
       command: "npm run verify:pre-pr",
       evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-18T07:12:00Z",
+      observedAt: "2026-05-18T07:17:00Z",
     },
   });
   const state: SupervisorStateFile = {
@@ -1269,7 +1277,7 @@ test("status --why surfaces verified Codex residue remediation for manual_review
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#143 pr=#147 reason=stale_review_bot code_ci=green current_head_sha=68401b26947918f0ce2280a9526ab68298b1a25c processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/147#discussion_r147 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=verify-pre-pr_passed_with_96_tests\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#143 pr=#147 reason=stale_review_bot code_ci=green current_head_sha=68401b26947918f0ce2280a9526ab68298b1a25c processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/147#discussion_r147 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=verify-pre-pr_passed_with_96_tests\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
   assert.doesNotMatch(status, /run-once --config \.\.\. --dry-run/);
@@ -1296,6 +1304,10 @@ test("status --why uses the shared stale review-bot presenter for active verifie
       ranAt: "2026-05-15T00:18:00Z",
       command: "npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts",
       evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
     },
   });
   const state: SupervisorStateFile = {
@@ -1336,7 +1348,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });


### PR DESCRIPTION
## Summary
- require same-head Codex Connector no-major evidence before classifying processed must-fix residue as stale metadata
- add a focused Ensen-loop-shaped remediation regression for eligible, missing-signal, and unprocessed-thread cases
- update status and post-turn fixtures to model the explicit proof source

## Verification
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npx tsx --test src/codex-connector-review-policy.test.ts src/review-thread-reporting.test.ts src/supervisor/stale-review-bot-recovery.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/post-turn-pull-request.test.ts
- npm run build
- node dist/index.js issue-lint 2063 --config <self-supervisor-config-path>

Closes #2063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for review state detection and remediation classification scenarios
  * Added comprehensive test cases for stale review bot remediation behavior across multiple outcomes
  
* **Internal Improvements**
  * Enhanced validation logic for review evidence detection and state verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->