### PR TITLE
Fix stale Codex review repeat-stop diagnostics

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -4692,6 +4692,135 @@ test("handlePostTurnPullRequestTransitionsPhase replies and resolves stale confi
   assert.equal(resolveCalls.length, 2);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase requests current-head Codex review despite repeat-stop on outdated metadata-only residue", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issue = createIssue({ number: 168, title: "Fix stale Codex metadata-only residue" });
+  const headSha = "f3addc310b0ff8e4fc53d9f3e0ab783af70a552f";
+  const staleReviewedSha = "d0800e414f305e8ce4f4f9785fc4ee6ad2ba0c90";
+  const pr = createPullRequest({
+    number: 176,
+    title: "Tracked PR with stale metadata-only Codex residue",
+    isDraft: false,
+    headRefOid: headSha,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "BLOCKED",
+    currentHeadCiGreenAt: "2026-05-21T20:32:06Z",
+    configuredBotLatestReviewedCommitSha: staleReviewedSha,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+  const reviewThreads = createOutdatedConfiguredBotThreads(
+    ["thread-date-fields", "thread-correlation-id", "thread-email-expectation", "thread-onboarding-strings"],
+    pr.number,
+  );
+  const staleBotFailureContext = {
+    ...createFailureContext("Outdated configured-bot metadata-only residue is blocking the tracked PR."),
+    signature: reviewThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
+    details: reviewThreads.map(
+      (thread) =>
+        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} processed_on_current_head=yes`,
+    ),
+    url: "https://example.test/pr/176#discussion_rmetadata",
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issue.number,
+    issues: {
+      [String(issue.number)]: createRecord({
+        issue_number: issue.number,
+        state: "blocked",
+        pr_number: pr.number,
+        last_head_sha: headSha,
+        blocked_reason: "stale_review_bot",
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+        last_tracked_pr_progress_summary: "recovery_blocked=stale_review_bot_no_auto_retry",
+        repeated_failure_signature_count: 5,
+        last_failure_signature: staleBotFailureContext.signature,
+        last_failure_context: staleBotFailureContext,
+        processed_review_thread_ids: reviewThreads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: reviewThreads.map(
+          (thread) => `${thread.id}@${headSha}#comment-${thread.id}`,
+        ),
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: null,
+      }),
+    },
+  };
+  const requestComments: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 176001,
+          nodeId: "IC_kwDO176",
+          url: "https://example.test/pr/176#issuecomment-176001",
+        };
+      },
+      replyToReviewThread: async () => {
+        throw new Error("unexpected replyToReviewThread call");
+      },
+      resolveReviewThread: async () => {
+        throw new Error("unexpected resolveReviewThread call");
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues[String(issue.number)]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-168"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "blocked", {
+        failureContext: staleBotFailureContext,
+        copilotTimeoutPatch: {
+          copilot_review_timed_out_at: "2026-05-21T20:42:06Z",
+          copilot_review_timeout_action: "request_review_comment",
+          copilot_review_timeout_reason: "current_head_signal_timeout",
+        },
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 5 : 0,
+    }),
+    blockedReasonFromReviewState: () => "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(requestComments.length, 1);
+  assert.match(requestComments[0] ?? "", /^@codex review\b/);
+  assert.match(requestComments[0] ?? "", /codex-supervisor:codex-connector-review-request/);
+  assert.equal(result.record.state, "waiting_ci");
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(result.record.codex_connector_review_requested_head_sha, headSha);
+  assert.ok(result.record.codex_connector_review_requested_observed_at);
+  assert.equal(result.record.last_failure_context, null);
+  assert.equal(result.record.repeated_failure_signature_count, 0);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resolves verified no-source-change Codex threads after current-head success", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -1,11 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createConfig, createPullRequest, createRecord } from "../turn-execution-test-helpers";
+import { createConfig, createPullRequest, createRecord, createReviewThread } from "../turn-execution-test-helpers";
 import {
   CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
   createCodexConnectorTrackedReviewResidueScenario,
 } from "../codex-connector-tracked-pr-test-helpers";
-import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
+import { buildStaleReviewBotRemediation, buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-remediation";
 
 test("buildStaleReviewBotRemediation classifies same-head Codex no-major with covered evidence as stale metadata", () => {
   const issueNumber = 110;
@@ -138,4 +138,100 @@ test("buildStaleReviewBotRemediation fails closed when current-head no-major has
   assert.equal(remediation?.classification, "unresolved_work");
   assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
   assert.equal(remediation?.missingProbeReason, null);
+});
+
+test("buildStaleReviewBotThreadDiagnostics does not report repeat-stop suppression when Codex current-head request is pending", () => {
+  const issueNumber = 168;
+  const prNumber = 176;
+  const headSha = "f3addc310b0ff8e4fc53d9f3e0ab783af70a552f";
+  const staleReviewedSha = "d0800e414f305e8ce4f4f9785fc4ee6ad2ba0c90";
+  const reviewThreads = ["thread-date-fields", "thread-correlation-id", "thread-email-expectation", "thread-onboarding-strings"].map(
+    (threadId, index) =>
+      createReviewThread({
+        id: threadId,
+        isOutdated: true,
+        path: "openapi/hrcore.openapi.json",
+        line: 40 + index,
+        comments: {
+          nodes: [
+            {
+              id: `comment-${threadId}`,
+              body: "P2: stale metadata-only schema finding.",
+              createdAt: "2026-05-21T20:00:00Z",
+              url: `https://example.test/pr/${prNumber}#discussion_${threadId}`,
+              author: {
+                login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+  );
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const record = createRecord({
+    issue_number: issueNumber,
+    state: "blocked",
+    pr_number: prNumber,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    copilot_review_timed_out_at: "2026-05-21T20:42:06Z",
+    copilot_review_timeout_action: "request_review_comment",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: reviewThreads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: reviewThreads.map(
+      (thread) => `${thread.id}@${headSha}#comment-${thread.id}`,
+    ),
+    last_failure_context: {
+      category: "manual",
+      summary: "Outdated configured-bot metadata-only residue is blocking the tracked PR.",
+      signature: reviewThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
+      command: null,
+      details: reviewThreads.map(
+        (thread) =>
+          `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} processed_on_current_head=yes`,
+      ),
+      url: "https://example.test/pr/176#discussion_rmetadata",
+      updated_at: "2026-05-21T20:42:06Z",
+    },
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefOid: headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-21T20:32:06Z",
+    configuredBotLatestReviewedCommitSha: staleReviewedSha,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "metadata_only_missing_current_head_review");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
+  assert.equal(diagnostics?.unresolvedCurrentThreads, 0);
+  assert.equal(diagnostics?.repeatStopExhausted, "no");
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "not_verified_stale_residue");
 });

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -569,11 +569,16 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
     : config && args.pr
       ? pendingBotReviewThreads(config, args.record, args.pr, configuredThreads)
       : [];
+  const currentHeadReviewRequestPending =
+    remediation.classification === "metadata_only_missing_current_head_review" &&
+    remediation.codexCurrentHeadReviewState === "missing";
   const repeatStopExhausted =
-    args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
-    (config && args.pr
-      ? configuredBotReviewFollowUpState(config, args.record, args.pr, configuredThreads) === "exhausted"
-      : false);
+    currentHeadReviewRequestPending
+      ? false
+      : args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
+        (config && args.pr
+          ? configuredBotReviewFollowUpState(config, args.record, args.pr, configuredThreads) === "exhausted"
+          : false);
   const verifiedStaleResidueThreads = isVerifiedStaleResidueClassification(remediation.classification)
     ? unresolvedConfiguredThreads.length
     : 0;


### PR DESCRIPTION
## Summary
- keep stale review-bot diagnostics from treating repeat-stop exhaustion as terminal while a metadata-only Codex current-head review request is still missing
- add focused regressions for the HRCore-style outdated metadata-only residue shape and the post-turn @codex review request path

## Verification
- npm run build
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- node dist/index.js issue-lint 2066 --config <self-supervisor-config>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of review request state management to ensure proper behavior when processing stale metadata.

* **Tests**
  * Added test coverage for edge cases in pull request transition handling and review state diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->