### PR TITLE
Recover request-eligible Codex manual review stalls

### DIFF
--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -7,7 +7,7 @@ import {
   formatNoRunnableIssueFoundMessage,
   resolveRunnableIssueContext,
 } from "./run-once-issue-selection";
-import { GitHubIssue, IssueRunRecord, SupervisorConfig, SupervisorStateFile } from "./core/types";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "./core/types";
 import {
   buildRequirementsBlockerIssueComment,
   syncRequirementsBlockerIssueComment,
@@ -336,6 +336,102 @@ Add execution-ready gating.`,
   assert.match(addedComments[0]?.body ?? "", /Parallelizable: No/);
   assert.match(addedComments[0]?.body ?? "", /## Execution order[\s\S]*1 of 1/);
   assert.doesNotMatch(addedComments[0]?.body ?? "", /Part of: none/i);
+});
+
+test("resolveRunnableIssueContext selects manual-review tracked PR when Codex current-head review request is eligible", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2072;
+  const prNumber = 177;
+  const branch = "codex/issue-2072";
+  const headSha = "head-2072-current";
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector request eligible manual review recovery",
+    body: executionReadyBody("Request current-head Codex review when stale manual review residue is request eligible."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-2072-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: record,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-2072-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: "/tmp/workspaces/issue-2072/.codex-supervisor/issue-journal.md",
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.notEqual(typeof result, "string");
+  if (typeof result !== "string") {
+    assert.equal(result.kind, "ready");
+    if (result.kind === "ready") {
+      assert.equal(result.record.issue_number, issueNumber);
+      await result.issueLock.release();
+    }
+  }
 });
 
 test("buildRequirementsBlockerIssueComment uses sequenced-child guidance without inventing a parent dependency", () => {

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -434,6 +434,73 @@ test("resolveRunnableIssueContext selects manual-review tracked PR when Codex cu
   }
 });
 
+test("resolveRunnableIssueContext skips manual-review Codex request recovery when GitHub recovery data fails", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2072;
+  const prNumber = 177;
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector request eligible manual review recovery",
+    body: executionReadyBody("Request current-head Codex review when stale manual review residue is request eligible."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch: "codex/issue-2072",
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: "head-2072-current",
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: "head-2072-current",
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-2072-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: record,
+    },
+  };
+  const savedStates: SupervisorStateFile[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+      getPullRequestIfExists: async () => {
+        throw new Error("GitHub PR fetch failed");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+    },
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: null,
+  });
+
+  assert.equal(result, "No matching open issue found.");
+  assert.equal(savedStates.length, 1);
+  assert.equal(state.activeIssueNumber, null);
+});
+
 test("buildRequirementsBlockerIssueComment uses sequenced-child guidance without inventing a parent dependency", () => {
   const issue: GitHubIssue = {
     number: 193,

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -45,6 +45,9 @@ import {
   type SupervisorEventSink,
 } from "./supervisor/supervisor-events";
 import { findLatestBlockedPreservedPartialWorkIncident } from "./supervisor/supervisor-preserved-partial-work";
+import { codexConnectorReviewRequestAction } from "./codex-connector-review-request-decision";
+import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
+import { mergeConflictDetected, summarizeChecks } from "./supervisor/supervisor-reporting";
 
 export interface ReadyIssueContext {
   kind: "ready";
@@ -59,7 +62,8 @@ export interface RestartRunOnce {
 
 type IssueSelectionResult = ReadyIssueContext | RestartRunOnce | string;
 
-type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues">;
+type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues"> &
+  Partial<Pick<GitHubClient, "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
 type IssueSelectionGitHub = IssueSelectionCandidateGitHub
   & Pick<GitHubClient, "getIssue">
   & Partial<Pick<GitHubClient, "addIssueComment" | "getIssueComments" | "updateIssueComment">>;
@@ -67,6 +71,45 @@ type IssueSelectionSaveStateStore = Pick<StateStore, "save">;
 type IssueSelectionStateStore = IssueSelectionSaveStateStore & Pick<StateStore, "touch">;
 
 type IssueJournalContext = Pick<IssueRunRecord, "workspace" | "journal_path">;
+
+async function shouldSelectCodexConnectorReviewRequestRecovery(
+  github: IssueSelectionCandidateGitHub,
+  config: SupervisorConfig,
+  record: IssueRunRecord | undefined,
+): Promise<boolean> {
+  if (
+    !record ||
+    record.state !== "blocked" ||
+    record.blocked_reason !== "manual_review" ||
+    record.pr_number === null ||
+    !github.getPullRequestIfExists ||
+    !github.getChecks ||
+    !github.getUnresolvedReviewThreads
+  ) {
+    return false;
+  }
+
+  const pr = await github.getPullRequestIfExists(record.pr_number, { purpose: "status" });
+  if (!pr || pr.headRefName !== record.branch) {
+    return false;
+  }
+
+  const [checks, reviewThreads] = await Promise.all([
+    github.getChecks(pr.number),
+    github.getUnresolvedReviewThreads(pr.number),
+  ]);
+  return codexConnectorReviewRequestAction({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected,
+  }).kind !== "none";
+}
 
 interface SelectedIssueRecord {
   record: IssueRunRecord;
@@ -386,6 +429,7 @@ async function selectIssueRecord(
       const trustDecision = evaluateAutonomousExecutionTrust(config, issue);
       if (
         !isEligibleForSelection(existing, config) &&
+        !(await shouldSelectCodexConnectorReviewRequestRecovery(github, config, existing)) &&
         !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
       ) {
         continue;

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -29,6 +29,7 @@ import {
 } from "./supervisor/supervisor-trust-gate";
 import { syncRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
 import { StateStore } from "./core/state-store";
+import { configuredReviewProviderKinds } from "./core/review-providers";
 import {
   FailureContext,
   GitHubIssue,
@@ -82,6 +83,10 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
     record.state !== "blocked" ||
     record.blocked_reason !== "manual_review" ||
     record.pr_number === null ||
+    !configuredReviewProviderKinds(config).includes("codex") ||
+    config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
+    record.copilot_review_timeout_action !== "request_review_comment" ||
+    !record.copilot_review_timed_out_at ||
     !github.getPullRequestIfExists ||
     !github.getChecks ||
     !github.getUnresolvedReviewThreads
@@ -89,26 +94,30 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
     return false;
   }
 
-  const pr = await github.getPullRequestIfExists(record.pr_number, { purpose: "status" });
-  if (!pr || pr.headRefName !== record.branch) {
+  try {
+    const pr = await github.getPullRequestIfExists(record.pr_number, { purpose: "status" });
+    if (!pr || pr.headRefName !== record.branch) {
+      return false;
+    }
+
+    const [checks, reviewThreads] = await Promise.all([
+      github.getChecks(pr.number),
+      github.getUnresolvedReviewThreads(pr.number),
+    ]);
+    return codexConnectorReviewRequestAction({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected,
+    }).kind !== "none";
+  } catch {
     return false;
   }
-
-  const [checks, reviewThreads] = await Promise.all([
-    github.getChecks(pr.number),
-    github.getUnresolvedReviewThreads(pr.number),
-  ]);
-  return codexConnectorReviewRequestAction({
-    config,
-    record,
-    pr,
-    checks,
-    reviewThreads,
-    summarizeChecks,
-    configuredBotReviewThreads,
-    manualReviewThreads,
-    mergeConflictDetected,
-  }).kind !== "none";
 }
 
 interface SelectedIssueRecord {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -831,6 +831,87 @@ test("status --why requests Codex current-head review for metadata-only missing 
   assert.doesNotMatch(status, /^codex_connector_operator_diagnostic .*next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m);
 });
 
+test("status --why selects manual-review tracked PR when Codex current-head review request is eligible", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  fixture.config.configuredBotInitialGraceWaitSeconds = 0;
+  fixture.config.configuredBotCurrentHeadSignalTimeoutMinutes = 10;
+  fixture.config.configuredBotCurrentHeadSignalTimeoutAction = "request_review_comment";
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 2072;
+  const prNumber = 177;
+  const branch = branchName(fixture.config, issueNumber);
+  const currentHead = "ad2a7f2d9c62f52f190d42884f1844c5b5da2072";
+  const staleReviewHead = "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: currentHead,
+        blocked_reason: "manual_review",
+        review_wait_started_at: "2026-05-22T00:00:00Z",
+        review_wait_head_sha: currentHead,
+        provider_success_head_sha: staleReviewHead,
+        provider_success_observed_at: "2026-05-21T23:50:00Z",
+        copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+        copilot_review_timeout_action: "request_review_comment",
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector request eligible manual review recovery",
+    body: executionReadyBody("Request current-head Codex review when stale manual review residue is request eligible."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: staleReviewHead,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(status, /^selected_issue=#2072$/m);
+  assert.match(status, /^selection_reason=ready .*retry_state=resume:blocked$/m);
+  assert.doesNotMatch(status, /^selected_issue=none$/m);
+});
+
 test("status surfaces host-migration path repair and journal rehydration from the canonical local journal", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -8,7 +8,7 @@ import {
   buildReadinessSummary,
   buildSelectionWhySummary,
 } from "./supervisor-selection-readiness-summary";
-import { createConfig, createRecord } from "./supervisor-test-helpers";
+import { createConfig, createPullRequest, createRecord } from "./supervisor-test-helpers";
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -330,6 +330,176 @@ Execution order: 3 of 3`,
   assert.deepEqual(lines, [
     "selected_issue=#96",
     "selection_reason=ready execution_ready=yes depends_on=91|92:done execution_order=150/3 predecessors=91|92:done retry_state=fresh",
+  ]);
+});
+
+test("buildReadinessSummary shares the Codex Connector request recovery override with selection", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2072;
+  const prNumber = 177;
+  const branch = "codex/issue-2072";
+  const currentHead = "ad2a7f2d9c62f52f190d42884f1844c5b5da2072";
+  const staleReviewHead = "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770";
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Codex Connector request eligible manual review recovery",
+    body: `## Summary
+Request current-head Codex review when stale manual review residue is request eligible.
+
+## Scope
+- keep readiness and selection diagnostics consistent
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+
+## Acceptance criteria
+- the issue is not reported as both selected and blocked
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        blocked_reason: "manual_review",
+        last_head_sha: currentHead,
+        review_wait_started_at: "2026-05-22T00:00:00Z",
+        review_wait_head_sha: currentHead,
+        provider_success_head_sha: staleReviewHead,
+        provider_success_observed_at: "2026-05-21T23:50:00Z",
+        copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+        copilot_review_timeout_action: "request_review_comment",
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: null,
+      }),
+    },
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: staleReviewHead,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+  const github = {
+    listCandidateIssues: async () => [issue],
+    listAllIssues: async () => [issue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const readinessSummary = await buildReadinessSummary(github, config, state);
+
+  assert.deepEqual(readinessSummary.blockedIssues, []);
+  assert.deepEqual(readinessSummary.runnableIssues, [
+    {
+      issueNumber,
+      title: "Codex Connector request eligible manual review recovery",
+      readiness: "execution_ready",
+    },
+  ]);
+  assert.deepEqual(readinessSummary.readinessLines, [
+    "runnable_issues=#2072 ready=execution_ready",
+    "blocked_issues=none",
+  ]);
+
+  const whyLines = await buildSelectionWhySummary(github, config, state);
+
+  assert.match(whyLines.join("\n"), /^selected_issue=#2072$/m);
+  assert.doesNotMatch(readinessSummary.readinessLines.join("\n"), /^blocked_issues=#2072 blocked_by=local_state:blocked$/m);
+});
+
+test("buildReadinessSummary keeps manual-review recovery blocked when GitHub recovery data fails", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2072;
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Codex Connector request fetch failure",
+    body: `## Summary
+Keep recovery fail-closed when GitHub status data cannot be loaded.
+
+## Scope
+- avoid selecting uncertain recovery states
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+
+## Acceptance criteria
+- the issue remains locally blocked
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: "codex/issue-2072",
+        pr_number: 177,
+        blocked_reason: "manual_review",
+        copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+        copilot_review_timeout_action: "request_review_comment",
+      }),
+    },
+  };
+  const github = {
+    listCandidateIssues: async () => [issue],
+    listAllIssues: async () => [issue],
+    getPullRequestIfExists: async () => {
+      throw new Error("GitHub PR fetch failed");
+    },
+    getChecks: async () => {
+      throw new Error("unexpected getChecks call");
+    },
+    getUnresolvedReviewThreads: async () => {
+      throw new Error("unexpected getUnresolvedReviewThreads call");
+    },
+  };
+
+  const readinessSummary = await buildReadinessSummary(github, config, state);
+  const whyLines = await buildSelectionWhySummary(github, config, state);
+
+  assert.deepEqual(readinessSummary.runnableIssues, []);
+  assert.deepEqual(readinessSummary.blockedIssues, [
+    {
+      issueNumber,
+      title: "Codex Connector request fetch failure",
+      blockedBy: "local_state:blocked",
+    },
+  ]);
+  assert.deepEqual(whyLines, [
+    "selected_issue=none",
+    "selection_reason=no_runnable_issue",
   ]);
 });
 

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -1,5 +1,6 @@
 import { GitHubClient } from "../github";
 import { DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW } from "../core/config";
+import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
   findBlockingIssue,
   findHighRiskBlockingAmbiguity,
@@ -43,7 +44,7 @@ import { mergeConflictDetected, summarizeChecks } from "./supervisor-reporting";
 
 type ReadinessSummaryGitHub =
   Pick<GitHubClient, "listAllIssues" | "listCandidateIssues">
-  & Partial<Pick<GitHubClient, "getCandidateDiscoveryDiagnostics">>;
+  & Partial<Pick<GitHubClient, "getCandidateDiscoveryDiagnostics" | "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
 type SelectionWhyGitHub = Pick<GitHubClient, "listAllIssues" | "listCandidateIssues"> &
   Partial<Pick<GitHubClient, "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
 
@@ -62,6 +63,10 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
     record.state !== "blocked" ||
     record.blocked_reason !== "manual_review" ||
     record.pr_number === null ||
+    !configuredReviewProviderKinds(config).includes("codex") ||
+    config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
+    record.copilot_review_timeout_action !== "request_review_comment" ||
+    !record.copilot_review_timed_out_at ||
     !github.getPullRequestIfExists ||
     !github.getChecks ||
     !github.getUnresolvedReviewThreads
@@ -69,26 +74,46 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
     return false;
   }
 
-  const pr = await github.getPullRequestIfExists(record.pr_number, { purpose: "status" });
-  if (!pr || pr.headRefName !== record.branch) {
+  try {
+    const pr = await github.getPullRequestIfExists(record.pr_number, { purpose: "status" });
+    if (!pr || pr.headRefName !== record.branch) {
+      return false;
+    }
+
+    const [checks, reviewThreads] = await Promise.all([
+      github.getChecks(pr.number),
+      github.getUnresolvedReviewThreads(pr.number),
+    ]);
+    return codexConnectorReviewRequestAction({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected,
+    }).kind !== "none";
+  } catch {
     return false;
   }
+}
 
-  const [checks, reviewThreads] = await Promise.all([
-    github.getChecks(pr.number),
-    github.getUnresolvedReviewThreads(pr.number),
-  ]);
-  return codexConnectorReviewRequestAction({
-    config,
-    record,
-    pr,
-    checks,
-    reviewThreads,
-    summarizeChecks,
-    configuredBotReviewThreads,
-    manualReviewThreads,
-    mergeConflictDetected,
-  }).kind !== "none";
+async function findCodexConnectorReviewRequestRecoveryIssueNumbers(
+  github: SelectionWhyGitHub,
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+  candidateIssues: GitHubIssue[],
+): Promise<ReadonlySet<number>> {
+  const recoveryIssueNumbers = new Set<number>();
+  for (const issue of candidateIssues) {
+    if (await shouldSelectCodexConnectorReviewRequestRecovery(github, config, state.issues[String(issue.number)])) {
+      recoveryIssueNumbers.add(issue.number);
+    }
+  }
+
+  return recoveryIssueNumbers;
 }
 
 export interface SupervisorCandidateDiscoveryDto {
@@ -195,7 +220,16 @@ export async function buildReadinessSummary(
   const candidateDiscoveryWarningLine = formatCandidateDiscoveryStatusLine(diagnostics);
   const candidateIssues = await github.listCandidateIssues();
   const issues = await github.listAllIssues();
-  return buildReadinessSummaryFromIssues(config, state, candidateIssues, issues, candidateDiscoveryWarningLine);
+  const recoveryIssueNumbers = await findCodexConnectorReviewRequestRecoveryIssueNumbers(github, config, state, candidateIssues);
+  return buildReadinessSummaryFromIssues(
+    config,
+    state,
+    candidateIssues,
+    issues,
+    candidateDiscoveryWarningLine,
+    [],
+    recoveryIssueNumbers,
+  );
 }
 
 export function buildLastKnownGoodSnapshotReadinessSummary(
@@ -225,6 +259,7 @@ function buildReadinessSummaryFromIssues(
   issues: GitHubIssue[],
   candidateDiscoveryWarningLine: string | null,
   prefixedReadinessLines: string[] = [],
+  codexConnectorReviewRequestRecoveryIssueNumbers: ReadonlySet<number> = new Set(),
 ): SupervisorReadinessSummaryDto {
   const runnableIssues: SupervisorRunnableIssueDto[] = [];
   const blockedIssues: SupervisorBlockedIssueDto[] = [];
@@ -286,6 +321,7 @@ function buildReadinessSummaryFromIssues(
 
     if (
       !isEligibleForSelection(existing, config) &&
+      !codexConnectorReviewRequestRecoveryIssueNumbers.has(issue.number) &&
       !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
     ) {
       blockedIssues.push({

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -37,15 +37,58 @@ import {
   findLatestMergedPrConvergenceRecord,
   formatMergedPrConvergenceOperatorEventLine,
 } from "./supervisor-operator-events";
+import { codexConnectorReviewRequestAction } from "../codex-connector-review-request-decision";
+import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
+import { mergeConflictDetected, summarizeChecks } from "./supervisor-reporting";
 
 type ReadinessSummaryGitHub =
   Pick<GitHubClient, "listAllIssues" | "listCandidateIssues">
   & Partial<Pick<GitHubClient, "getCandidateDiscoveryDiagnostics">>;
-type SelectionWhyGitHub = Pick<GitHubClient, "listAllIssues" | "listCandidateIssues">;
+type SelectionWhyGitHub = Pick<GitHubClient, "listAllIssues" | "listCandidateIssues"> &
+  Partial<Pick<GitHubClient, "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
 
 export interface SupervisorSelectionSummaryDto {
   selectedIssueNumber: number | null;
   selectionReason: string | null;
+}
+
+async function shouldSelectCodexConnectorReviewRequestRecovery(
+  github: SelectionWhyGitHub,
+  config: SupervisorConfig,
+  record: SupervisorStateFile["issues"][string] | undefined,
+): Promise<boolean> {
+  if (
+    !record ||
+    record.state !== "blocked" ||
+    record.blocked_reason !== "manual_review" ||
+    record.pr_number === null ||
+    !github.getPullRequestIfExists ||
+    !github.getChecks ||
+    !github.getUnresolvedReviewThreads
+  ) {
+    return false;
+  }
+
+  const pr = await github.getPullRequestIfExists(record.pr_number, { purpose: "status" });
+  if (!pr || pr.headRefName !== record.branch) {
+    return false;
+  }
+
+  const [checks, reviewThreads] = await Promise.all([
+    github.getChecks(pr.number),
+    github.getUnresolvedReviewThreads(pr.number),
+  ]);
+  return codexConnectorReviewRequestAction({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected,
+  }).kind !== "none";
 }
 
 export interface SupervisorCandidateDiscoveryDto {
@@ -367,6 +410,7 @@ export async function buildSelectionSummary(
 
     if (
       !isEligibleForSelection(existing, config) &&
+      !(await shouldSelectCodexConnectorReviewRequestRecovery(github, config, existing)) &&
       !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
     ) {
       if (blockedPartialWorkIncident?.record.issue_number === issue.number) {


### PR DESCRIPTION
## Summary
- make blocked manual-review tracked PRs selectable when the existing Codex Connector review-request decision is eligible
- reuse the existing fail-closed request decision before selection hydrates a stale manual-review record
- add run-once and status regressions for the HRCore PR #177 style request-eligible/manual-review stall

## Verification
- npx tsx --test src/run-once-issue-selection.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build
- npx tsx --test src/run-once-issue-selection.test.ts src/codex-connector-review-request-decision.test.ts src/codex-connector-review-request-transition.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/tracked-pr-lifecycle-projection.test.ts
- node dist/index.js issue-lint 2072 --config <supervisor-config-path>

Notes: attempted npm test -- --runInBand src/run-once-issue-selection.test.ts, but this package script runs the full src/**/*.test.ts glob before extra args; the broad run surfaced unrelated existing family-layout failures and earlier patch compile errors that were fixed before the focused green runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test verifying issue selection when specific PR and review conditions are met
  * Added diagnostic status test validating issue selection under manual review scenarios

* **Refactor**
  * Extended issue selection logic with additional eligibility evaluation pathways
  * Enhanced GitHub API surface area to support more comprehensive selection decision-making

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->