### PR TITLE
Request Codex review before tracked PR repeat stop

### DIFF
--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1162,12 +1162,13 @@ test("runOnce requests Codex Connector review before repeated stale configured-b
       verificationProbeOutcomes: [],
     });
     const initialRecord = createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
-      state: "addressing_review",
+      state: "blocked",
       workspace: workspacePath,
       branch,
       pr_number: 191,
       journal_path: journalPath,
       last_head_sha: "head-191",
+      blocked_reason: "manual_review",
       review_wait_started_at: "2026-05-22T11:50:00.000Z",
       review_wait_head_sha: "head-191",
       copilot_review_timed_out_at: "2026-05-22T12:00:00.000Z",
@@ -1303,71 +1304,7 @@ test("runOnce requests Codex Connector review before repeated stale configured-b
       },
     };
 
-    const message = await (
-      supervisor as unknown as {
-        runPreparedIssue: (context: {
-          state: SupervisorStateFile;
-          record: IssueRunRecord;
-          issue: GitHubIssue;
-          previousCodexSummary: string | null;
-          previousError: string | null;
-          workspacePath: string;
-          journalPath: string;
-          syncJournal: (record: IssueRunRecord) => Promise<void>;
-          memoryArtifacts: {
-            alwaysReadFiles: string[];
-            onDemandFiles: string[];
-            contextIndexPath: string;
-            agentsPath: string;
-          };
-          workspaceStatus: {
-            branch: string;
-            headSha: string;
-            hasUncommittedChanges: boolean;
-            baseAhead: number;
-            baseBehind: number;
-            remoteBranchExists: boolean;
-            remoteAhead: number;
-            remoteBehind: number;
-          };
-          pr: GitHubPullRequest | null;
-          checks: PullRequestCheck[];
-          reviewThreads: ReviewThread[];
-          options: { dryRun: boolean };
-          recoveryLog: string | null;
-        }) => Promise<string>;
-      }
-    ).runPreparedIssue({
-      state,
-      record: initialRecord,
-      issue,
-      previousCodexSummary: null,
-      previousError: null,
-      workspacePath,
-      journalPath,
-      syncJournal: async () => undefined,
-      memoryArtifacts: {
-        alwaysReadFiles: [],
-        onDemandFiles: [],
-        contextIndexPath: "/tmp/context-index.md",
-        agentsPath: "/tmp/AGENTS.generated.md",
-      },
-      workspaceStatus: {
-        branch,
-        headSha: "head-191",
-        hasUncommittedChanges: false,
-        baseAhead: 0,
-        baseBehind: 0,
-        remoteBranchExists: true,
-        remoteAhead: 0,
-        remoteBehind: 0,
-      },
-      pr,
-      checks,
-      reviewThreads,
-      options: { dryRun: false },
-      recoveryLog: null,
-    });
+    const message = await supervisor.runOnce({ dryRun: false });
     assert.doesNotMatch(message, /blocked after repeated identical review-related failure signatures/);
     assert.equal(comments.length, 1);
     assert.match(comments[0]?.body ?? "", /@codex review/);

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -63,6 +63,7 @@ import {
   PostTurnPullRequestResult,
   syncTrackedPrPersistentStatusComment,
 } from "../post-turn-pull-request";
+import { maybeRequestCodexConnectorReviewComment } from "../codex-connector-review-request-transition";
 import { buildChecksFailureContext, buildConflictFailureContext } from "../pull-request-failure-context";
 import {
   reserveRunnableIssueSelection,
@@ -589,7 +590,7 @@ export class Supervisor {
         lifecycle.nextState === "local_review_fix"
           ? localReviewRepairContinuationSummary(this.config, lifecycle.recordForState, pr)
           : null;
-      const effectiveFailureContext =
+      let effectiveFailureContext =
         lifecycle.failureContext ??
         (lifecycle.nextState === "local_review_fix"
           ? localReviewRepairContinuationFailureContext(this.config, lifecycle.recordForState, pr)
@@ -626,6 +627,35 @@ export class Supervisor {
         last_tracked_pr_repeat_failure_decision: null,
       });
       emitSupervisorEvent(this.onEvent, maybeBuildReviewWaitChangedEvent(context.record, record, pr.number));
+
+      record = await maybeRequestCodexConnectorReviewComment({
+        config: this.config,
+        stateStore: this.stateStore,
+        state,
+        github: this.github,
+        record,
+        pr,
+        checks,
+        reviewThreads,
+        syncJournal,
+        applyFailureSignature,
+        blockedReasonFromReviewState: (phaseRecord, phasePr, phaseChecks, phaseReviewThreads) =>
+          blockedReasonFromReviewState(this.config, phaseRecord, phasePr, phaseChecks, phaseReviewThreads),
+        summarizeChecks,
+        configuredBotReviewThreads,
+        manualReviewThreads,
+        mergeConflictDetected,
+      });
+      if (record.last_failure_context !== effectiveFailureContext) {
+        effectiveFailureContext = record.last_failure_context;
+      }
+      if (
+        record.state === "waiting_ci" &&
+        record.codex_connector_review_requested_head_sha === pr.headRefOid &&
+        record.last_failure_context === null
+      ) {
+        return prependRecoveryLog(formatStatus(record, state), recoveryLog);
+      }
 
       if (effectiveFailureContext && shouldStopForRepeatedFailureSignature(record, this.config)) {
         if (!trackedPrRepeatFailureDisposition.shouldStop) {


### PR DESCRIPTION
## Summary
- request eligible Codex Connector current-head review before tracked PR repeat-stop returns
- keep the successful request transition as the terminal state for that supervisor cycle so repeat failure metadata remains cleared
- tighten the regression to exercise public runOnce from a blocked/manual_review resume shape

Fixes #2078

## Verification
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/post-turn-pull-request.test.ts src/codex-connector-review-request-transition.test.ts src/codex-connector-review-request-decision.test.ts
- npx tsx --test src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npm run build
- node dist/index.js issue-lint 2078 --config <live-codex-supervisor-config>