### PR TITLE
Refactor Codex Connector current-head policy

### DIFF
--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -147,6 +147,23 @@ test("codexConnectorCurrentHeadReviewReadiness exposes shared wait/request gatin
     }),
     { kind: "none", reason: "missing_fallback_signal" },
   );
+  const pendingChecks: PullRequestCheck[] = [{ ...passingChecks[0]!, bucket: "pending" }];
+
+  assert.deepEqual(
+    codexConnectorCurrentHeadReviewReadiness({
+      config: createCodexConfig({ localCiCommand: "npm test" }),
+      pr: createPullRequest({
+        ...pr,
+        currentHeadCiGreenAt: null,
+      }),
+      checks: pendingChecks,
+      manualThreadCount: 0,
+      configuredThreadsAreSafe: true,
+      checkSummary: summarizeChecks(pendingChecks),
+      mergeConflict: false,
+    }),
+    { kind: "none", reason: "checks_not_green" },
+  );
   assert.deepEqual(
     codexConnectorCurrentHeadReviewReadiness({
       config,

--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { codexConnectorReviewRequestAction } from "./codex-connector-review-request-decision";
+import {
+  codexConnectorCurrentHeadReviewReadiness,
+  codexConnectorReviewRequestAction,
+} from "./codex-connector-review-request-decision";
 import {
   codexConnectorPassingChecks,
   createCodexConnectorRequestRetryScenario,
@@ -93,6 +96,72 @@ function decideScenario(scenario: CodexConnectorReviewRequestScenario) {
 
 test("codexConnectorReviewRequestAction selects an initial request without GitHub mutation inputs", () => {
   assert.deepEqual(decide(), { kind: "initial" });
+});
+
+test("codexConnectorCurrentHeadReviewReadiness exposes shared wait/request gating vocabulary", () => {
+  const config = createCodexConfig();
+  const pr = createPullRequest({
+    number: 1995,
+    headRefOid: "head-1995",
+    isDraft: false,
+    currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+    configuredBotCurrentHeadObservedAt: null,
+  });
+
+  assert.deepEqual(
+    codexConnectorCurrentHeadReviewReadiness({
+      config,
+      pr,
+      checks: passingChecks,
+      manualThreadCount: 0,
+      configuredThreadsAreSafe: true,
+      checkSummary: summarizeChecks(passingChecks),
+      mergeConflict: false,
+    }),
+    { kind: "eligible" },
+  );
+  assert.deepEqual(
+    codexConnectorCurrentHeadReviewReadiness({
+      config,
+      pr,
+      checks: [],
+      manualThreadCount: 0,
+      configuredThreadsAreSafe: true,
+      checkSummary: summarizeChecks([]),
+      mergeConflict: false,
+    }),
+    { kind: "eligible" },
+  );
+  assert.deepEqual(
+    codexConnectorCurrentHeadReviewReadiness({
+      config: createCodexConfig({ localCiCommand: "npm test" }),
+      pr: createPullRequest({
+        ...pr,
+        currentHeadCiGreenAt: null,
+      }),
+      checks: [],
+      manualThreadCount: 0,
+      configuredThreadsAreSafe: true,
+      checkSummary: summarizeChecks([]),
+      mergeConflict: false,
+    }),
+    { kind: "none", reason: "missing_fallback_signal" },
+  );
+  assert.deepEqual(
+    codexConnectorCurrentHeadReviewReadiness({
+      config,
+      pr: createPullRequest({
+        ...pr,
+        configuredBotCurrentHeadObservedAt: "2026-05-08T03:24:00Z",
+      }),
+      checks: passingChecks,
+      manualThreadCount: 0,
+      configuredThreadsAreSafe: true,
+      checkSummary: summarizeChecks(passingChecks),
+      mergeConflict: false,
+    }),
+    { kind: "none", reason: "current_head_already_observed" },
+  );
 });
 
 test("codexConnectorReviewRequestAction requests review for stale-head configured-bot signal after timeout", () => {

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -102,12 +102,12 @@ export function codexConnectorCurrentHeadReviewReadiness(
     return { kind: "none", reason: "current_head_already_observed" };
   }
 
-  if (!hasFallbackEligibleSignal) {
-    return { kind: "none", reason: "missing_fallback_signal" };
-  }
-
   if (args.checkSummary.hasPending || args.checkSummary.hasFailing) {
     return { kind: "none", reason: "checks_not_green" };
+  }
+
+  if (!hasFallbackEligibleSignal) {
+    return { kind: "none", reason: "missing_fallback_signal" };
   }
 
   return { kind: "eligible" };

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -22,6 +22,32 @@ export type CodexConnectorReviewRequestAction =
   | { kind: "initial" }
   | { kind: "retry"; retryCount: number; retryAttempt: number };
 
+export type CodexConnectorCurrentHeadReviewReadiness =
+  | { kind: "eligible" }
+  | {
+      kind: "none";
+      reason:
+        | "non_codex_provider"
+        | "draft_pr"
+        | "changes_requested"
+        | "merge_conflict"
+        | "unsafe_configured_threads"
+        | "manual_review_threads"
+        | "current_head_already_observed"
+        | "missing_fallback_signal"
+        | "checks_not_green";
+    };
+
+export interface CodexConnectorCurrentHeadReviewReadinessArgs {
+  config: SupervisorConfig;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  manualThreadCount: number;
+  configuredThreadsAreSafe: boolean;
+  checkSummary: { hasPending: boolean; hasFailing: boolean };
+  mergeConflict: boolean;
+}
+
 export interface CodexConnectorReviewRequestDecisionArgs {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -37,6 +63,54 @@ export interface CodexConnectorReviewRequestDecisionArgs {
 
 function isValidTimestamp(value: string | null | undefined): boolean {
   return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+export function codexConnectorCurrentHeadReviewReadiness(
+  args: CodexConnectorCurrentHeadReviewReadinessArgs,
+): CodexConnectorCurrentHeadReviewReadiness {
+  const loadedChecksAreGreen =
+    args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
+  const noChecksAndNoLocalCi = args.checks.length === 0 && !displayLocalCiCommand(args.config.localCiCommand);
+  const hasFallbackEligibleSignal =
+    isValidTimestamp(args.pr.currentHeadCiGreenAt) || loadedChecksAreGreen || noChecksAndNoLocalCi;
+
+  if (!configuredReviewProviderKinds(args.config).includes("codex")) {
+    return { kind: "none", reason: "non_codex_provider" };
+  }
+
+  if (args.pr.isDraft) {
+    return { kind: "none", reason: "draft_pr" };
+  }
+
+  if (args.pr.reviewDecision === "CHANGES_REQUESTED") {
+    return { kind: "none", reason: "changes_requested" };
+  }
+
+  if (args.mergeConflict) {
+    return { kind: "none", reason: "merge_conflict" };
+  }
+
+  if (!args.configuredThreadsAreSafe) {
+    return { kind: "none", reason: "unsafe_configured_threads" };
+  }
+
+  if (args.manualThreadCount > 0) {
+    return { kind: "none", reason: "manual_review_threads" };
+  }
+
+  if (isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt)) {
+    return { kind: "none", reason: "current_head_already_observed" };
+  }
+
+  if (!hasFallbackEligibleSignal) {
+    return { kind: "none", reason: "missing_fallback_signal" };
+  }
+
+  if (args.checkSummary.hasPending || args.checkSummary.hasFailing) {
+    return { kind: "none", reason: "checks_not_green" };
+  }
+
+  return { kind: "eligible" };
 }
 
 function addMinutes(timestamp: string, minutes: number): string | null {
@@ -194,29 +268,21 @@ export function codexConnectorReviewRequestAction(
     reviewThreads: args.reviewThreads,
     configuredThreads,
   });
-  const loadedChecksAreGreen =
-    args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
-  const noChecksAndNoLocalCi = args.checks.length === 0 && !displayLocalCiCommand(args.config.localCiCommand);
-  const hasFallbackEligibleSignal =
-    isValidTimestamp(args.pr.currentHeadCiGreenAt) || loadedChecksAreGreen || noChecksAndNoLocalCi;
 
   if (
     args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
-    !configuredReviewProviderKinds(args.config).includes("codex") ||
     args.record.copilot_review_timeout_action !== "request_review_comment" ||
     !args.record.copilot_review_timed_out_at ||
-    args.pr.isDraft ||
-    args.pr.reviewDecision === "CHANGES_REQUESTED" ||
-    args.mergeConflictDetected(args.pr) ||
-    !configuredThreadsAreSafeForCodexRequest ||
-    args.manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
-    isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) ||
-    !hasFallbackEligibleSignal
+    codexConnectorCurrentHeadReviewReadiness({
+      config: args.config,
+      pr: args.pr,
+      checks: args.checks,
+      manualThreadCount: args.manualReviewThreads(args.config, args.reviewThreads).length,
+      configuredThreadsAreSafe: configuredThreadsAreSafeForCodexRequest,
+      checkSummary,
+      mergeConflict: args.mergeConflictDetected(args.pr),
+    }).kind !== "eligible"
   ) {
-    return { kind: "none" };
-  }
-
-  if (checkSummary.hasPending || checkSummary.hasFailing) {
     return { kind: "none" };
   }
 

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -21,6 +21,7 @@ import {
   codexConnectorMustFixReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
 } from "./codex-connector-review-policy";
+import { codexConnectorCurrentHeadReviewReadiness } from "./codex-connector-review-request-decision";
 import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
@@ -760,24 +761,22 @@ function shouldWaitForCodexConnectorCurrentHeadReview(args: {
     return false;
   }
 
-  const checkSummary = summarizeChecks(args.checks);
-  if (checkSummary.hasFailing || checkSummary.hasPending) {
-    return false;
-  }
-
-  const loadedChecksAreGreen = args.checks.length > 0 && args.checks.every((check) => check.bucket === "pass");
-  const noChecksAndNoLocalCi = args.checks.length === 0 && !displayLocalCiCommand(args.config.localCiCommand);
-  if (!validTimestamp(args.pr.currentHeadCiGreenAt) && !loadedChecksAreGreen && !noChecksAndNoLocalCi) {
-    return false;
-  }
-
-  if (
-    !configuredBotThreadsAllowCodexConnectorCurrentHeadWait({
+  const configuredThreadsAreSafe = configuredBotThreadsAllowCodexConnectorCurrentHeadWait({
       config: args.config,
       record: args.record,
       pr: args.pr,
       configuredThreads: args.unresolvedBotThreads,
-    })
+  });
+  if (
+    codexConnectorCurrentHeadReviewReadiness({
+      config: args.config,
+      pr: args.pr,
+      checks: args.checks,
+      manualThreadCount: args.manualThreads.length,
+      configuredThreadsAreSafe,
+      checkSummary: summarizeChecks(args.checks),
+      mergeConflict: mergeConflictDetected(args.pr),
+    }).kind !== "eligible"
   ) {
     return false;
   }


### PR DESCRIPTION
## Summary
- extract shared Codex Connector current-head review readiness vocabulary
- route request-action decisions and PR-state wait inference through the shared helper
- add focused pure coverage for eligible and fail-closed readiness gates

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts src/pull-request-state-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/codex-connector-review-request-decision.test.ts src/codex-connector-review-request-transition.test.ts src/pull-request-state-provider-wait-policy.test.ts
- npm run build
- node dist/index.js issue-lint 2083 --config <self-supervisor-codex-config>

Closes #2083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for review readiness eligibility gating behavior, covering eligible states and various ineligible scenarios.

* **Refactor**
  * Improved code organization by centralizing review eligibility logic into a dedicated reusable function, replacing previous inline checks and enhancing maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->