### PR TITLE
Centralize issue metadata contract helpers

### DIFF
--- a/src/issue-metadata/issue-metadata-contract.ts
+++ b/src/issue-metadata/issue-metadata-contract.ts
@@ -1,0 +1,66 @@
+export const ISSUE_METADATA_FIELDS = {
+  partOf: "Part of",
+  dependsOn: "Depends on",
+  parallelizable: "Parallelizable",
+  executionOrder: "Execution order",
+  parallelGroup: "Parallel group",
+  touches: "Touches",
+} as const;
+
+export const ISSUE_METADATA_KEYS = {
+  partOf: "part of",
+  dependsOn: "depends on",
+  parallelizable: "parallelizable",
+  executionOrder: "execution order",
+} as const;
+
+export const ISSUE_METADATA_VALUES = {
+  dependsOnNone: "none",
+  defaultParallelizable: "No",
+  defaultExecutionOrder: "1 of 1",
+} as const;
+
+export const ISSUE_METADATA_PATTERNS = {
+  partOfParseLine: /^\s*(?:-\s+)?Part of:?\s+#(\d+)\s*$/im,
+  partOfSyntaxLine: /^\s*(?:-\s+)?Part of\b.*$/im,
+  validPartOfSyntaxLine: /^\s*(?:-\s+)?Part of:?\s+#([1-9]\d*)\s*$/i,
+  canonicalPartOfReadinessLine: /^\s*(?:-\s+)?Part of:\s+#\d+\s*$/im,
+  executionOrderLineDeclaration: /^\s*Execution order:[^\r\n]*$/gim,
+  executionOrderHeadingDeclaration: /^\s*##\s*Execution order\s*$[\r\n]+^[^\r\n]*$/gim,
+  executionOrderHeadingValue: /^\s*##\s*Execution order\s*$[\r\n]+^\s*(\d+)\s+of\s+(\d+)\s*$/im,
+  executionOrderLineValue: /^\s*Execution order:\s*(\d+)\s+of\s+(\d+)\s*$/im,
+  validDependsOnValue: /^(?:none|#(?:[1-9]\d*)(?:\s*,\s*#(?:[1-9]\d*))*)$/i,
+  validParallelizableValue: /^(?:yes|no)$/i,
+} as const;
+
+export function escapeMetadataRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function createMetadataLineDeclarationPattern(fieldName: string): RegExp {
+  return new RegExp(`^\\s*${escapeMetadataRegExp(fieldName)}:[^\\r\\n]*$`, "gim");
+}
+
+export function createMetadataLineValuePattern(fieldName: string): RegExp {
+  return new RegExp(`^\\s*${escapeMetadataRegExp(fieldName)}:[^\\S\\r\\n]*(.*)$`, "gim");
+}
+
+export function countMetadataLineDeclarations(body: string, fieldName: string): number {
+  return [...body.matchAll(createMetadataLineDeclarationPattern(fieldName))].length;
+}
+
+export function getSingleMetadataLineValue(body: string, fieldName: string): string | null {
+  const matches = [...body.matchAll(createMetadataLineValuePattern(fieldName))];
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  return matches[0][1].trim();
+}
+
+export function countExecutionOrderDeclarations(body: string): number {
+  return [
+    ...body.matchAll(new RegExp(ISSUE_METADATA_PATTERNS.executionOrderLineDeclaration)),
+    ...body.matchAll(new RegExp(ISSUE_METADATA_PATTERNS.executionOrderHeadingDeclaration)),
+  ].length;
+}

--- a/src/issue-metadata/issue-metadata-gates.ts
+++ b/src/issue-metadata/issue-metadata-gates.ts
@@ -1,9 +1,13 @@
 import type { GitHubIssue } from "../core/types";
 import {
   countExecutionOrderDeclarations,
+  countMetadataLineDeclarations,
   getSingleMetadataLineValue,
-  parseExecutionOrder,
-} from "./issue-metadata-parser";
+  ISSUE_METADATA_FIELDS,
+  ISSUE_METADATA_KEYS,
+  ISSUE_METADATA_PATTERNS,
+} from "./issue-metadata-contract";
+import { parseExecutionOrder } from "./issue-metadata-parser";
 import {
   detectRiskyChangeClasses,
   parseRiskyChangeApprovalList,
@@ -145,21 +149,21 @@ function hasLabel(issue: Pick<GitHubIssue, "labels">, labelName: string): boolea
 }
 
 function hasValidDependsOnMetadata(body: string): boolean {
-  const dependsOnValue = getSingleMetadataLineValue(body, "Depends on");
+  const dependsOnValue = getSingleMetadataLineValue(body, ISSUE_METADATA_FIELDS.dependsOn);
   if (dependsOnValue === null) {
     return false;
   }
 
-  return /^(?:none|#(?:[1-9]\d*)(?:\s*,\s*#(?:[1-9]\d*))*)$/i.test(dependsOnValue);
+  return ISSUE_METADATA_PATTERNS.validDependsOnValue.test(dependsOnValue);
 }
 
 function hasValidParallelizableMetadata(body: string): boolean {
-  const parallelizableValue = getSingleMetadataLineValue(body, "Parallelizable");
-  return parallelizableValue !== null && /^(?:yes|no)$/i.test(parallelizableValue);
+  const parallelizableValue = getSingleMetadataLineValue(body, ISSUE_METADATA_FIELDS.parallelizable);
+  return parallelizableValue !== null && ISSUE_METADATA_PATTERNS.validParallelizableValue.test(parallelizableValue);
 }
 
 function hasCanonicalPartOfMetadata(body: string): boolean {
-  return /^\s*(?:-\s+)?Part of:\s+#\d+\s*$/im.test(body);
+  return ISSUE_METADATA_PATTERNS.canonicalPartOfReadinessLine.test(body);
 }
 
 function parseSingleExecutionOrder(
@@ -213,21 +217,21 @@ export function lintExecutionReadyIssueBody(
     ...(isCodexLabeled
       ? [
         {
-          key: "depends on",
+          key: ISSUE_METADATA_KEYS.dependsOn,
           present: hasValidDependsOnMetadata(issue.body),
         },
         {
-          key: "parallelizable",
+          key: ISSUE_METADATA_KEYS.parallelizable,
           present: hasValidParallelizableMetadata(issue.body),
         },
         {
-          key: "execution order",
+          key: ISSUE_METADATA_KEYS.executionOrder,
           present: hasValidExecutionOrderMetadata(executionOrder),
         },
         ...(requiresPartOf
           ? [
             {
-              key: "part of",
+              key: ISSUE_METADATA_KEYS.partOf,
               present: hasCanonicalPartOfMetadata(issue.body),
             },
           ]
@@ -239,11 +243,11 @@ export function lintExecutionReadyIssueBody(
     ...(!isCodexLabeled
       ? [
         {
-          key: "depends on",
-          present: /^\s*Depends on:\s*.+$/im.test(issue.body),
+          key: ISSUE_METADATA_KEYS.dependsOn,
+          present: countMetadataLineDeclarations(issue.body, ISSUE_METADATA_FIELDS.dependsOn) > 0,
         },
         {
-          key: "execution order",
+          key: ISSUE_METADATA_KEYS.executionOrder,
           present: executionOrder !== null,
         },
       ]

--- a/src/issue-metadata/issue-metadata-parser.test.ts
+++ b/src/issue-metadata/issue-metadata-parser.test.ts
@@ -2,6 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { parseIssueMetadata } from "./issue-metadata-parser";
 import { GitHubIssue } from "../core/types";
+import {
+  countExecutionOrderDeclarations,
+  countMetadataLineDeclarations,
+  getSingleMetadataLineValue,
+  ISSUE_METADATA_FIELDS,
+} from "./issue-metadata-contract";
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -64,4 +70,16 @@ Parallel group: parser-refactor`,
     parallelGroup: "parser-refactor",
     touches: [],
   });
+});
+
+test("issue metadata contract helpers define shared scheduling line parsing", () => {
+  const body = `Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1`;
+
+  assert.equal(countMetadataLineDeclarations(body, ISSUE_METADATA_FIELDS.dependsOn), 1);
+  assert.equal(getSingleMetadataLineValue(body, ISSUE_METADATA_FIELDS.parallelizable), "No");
+  assert.equal(countExecutionOrderDeclarations(body), 1);
 });

--- a/src/issue-metadata/issue-metadata-parser.ts
+++ b/src/issue-metadata/issue-metadata-parser.ts
@@ -1,13 +1,14 @@
 import type { GitHubIssue } from "../core/types";
 import type { IssueMetadata } from "./issue-metadata";
 import type { RiskyChangeClass } from "./issue-metadata-risky-policy";
+import {
+  countExecutionOrderDeclarations,
+  getSingleMetadataLineValue,
+  ISSUE_METADATA_FIELDS,
+  ISSUE_METADATA_PATTERNS,
+} from "./issue-metadata-contract";
 
-const PART_OF_LINE_PATTERN = /^\s*(?:-\s+)?Part of:?\s+#(\d+)\s*$/im;
 const CHILD_ISSUE_BULLET_PATTERN = /^\s*-\s+#(\d+)\s*$/;
-
-function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function parseIssueNumberList(input: string): number[] {
   return Array.from(
@@ -27,32 +28,8 @@ function parseList(input: string): string[] {
 }
 
 export function parseTouchesList(body: string): string[] {
-  const touchesMatch = body.match(/^\s*Touches:\s*(.+)\s*$/im);
-  return touchesMatch ? parseList(touchesMatch[1]) : [];
-}
-
-export function countMetadataLineDeclarations(body: string, fieldName: string): number {
-  return [
-    ...body.matchAll(new RegExp(`^\\s*${escapeRegExp(fieldName)}:[^\\r\\n]*$`, "gim")),
-  ].length;
-}
-
-export function getSingleMetadataLineValue(body: string, fieldName: string): string | null {
-  const matches = [
-    ...body.matchAll(new RegExp(`^\\s*${escapeRegExp(fieldName)}:[^\\S\\r\\n]*(.*)$`, "gim")),
-  ];
-  if (matches.length !== 1) {
-    return null;
-  }
-
-  return matches[0][1].trim();
-}
-
-export function countExecutionOrderDeclarations(body: string): number {
-  return [
-    ...body.matchAll(/^\s*Execution order:[^\r\n]*$/gim),
-    ...body.matchAll(/^\s*##\s*Execution order\s*$[\r\n]+^[^\r\n]*$/gim),
-  ].length;
+  const touchesValue = getSingleMetadataLineValue(body, ISSUE_METADATA_FIELDS.touches);
+  return touchesValue ? parseList(touchesValue) : [];
 }
 
 export function parseExecutionOrder(
@@ -62,9 +39,7 @@ export function parseExecutionOrder(
     return null;
   }
 
-  const headingMatch = body.match(
-    /^\s*##\s*Execution order\s*$[\r\n]+^\s*(\d+)\s+of\s+(\d+)\s*$/im,
-  );
+  const headingMatch = body.match(ISSUE_METADATA_PATTERNS.executionOrderHeadingValue);
   if (headingMatch) {
     return {
       executionOrderIndex: Number(headingMatch[1]),
@@ -72,7 +47,7 @@ export function parseExecutionOrder(
     };
   }
 
-  const singleLineMatch = body.match(/^\s*Execution order:\s*(\d+)\s+of\s+(\d+)\s*$/im);
+  const singleLineMatch = body.match(ISSUE_METADATA_PATTERNS.executionOrderLineValue);
   if (!singleLineMatch) {
     return null;
   }
@@ -84,9 +59,9 @@ export function parseExecutionOrder(
 }
 
 export function parseIssueMetadata(issue: GitHubIssue): IssueMetadata {
-  const parentMatch = issue.body.match(PART_OF_LINE_PATTERN);
-  const dependsOnValue = getSingleMetadataLineValue(issue.body, "Depends on");
-  const parallelGroupValue = getSingleMetadataLineValue(issue.body, "Parallel group");
+  const parentMatch = issue.body.match(ISSUE_METADATA_PATTERNS.partOfParseLine);
+  const dependsOnValue = getSingleMetadataLineValue(issue.body, ISSUE_METADATA_FIELDS.dependsOn);
+  const parallelGroupValue = getSingleMetadataLineValue(issue.body, ISSUE_METADATA_FIELDS.parallelGroup);
   const executionOrder = parseExecutionOrder(issue.body);
 
   return {

--- a/src/issue-metadata/issue-metadata-validation.ts
+++ b/src/issue-metadata/issue-metadata-validation.ts
@@ -3,12 +3,13 @@ import {
   countExecutionOrderDeclarations,
   countMetadataLineDeclarations,
   getSingleMetadataLineValue,
+  ISSUE_METADATA_FIELDS,
+  ISSUE_METADATA_PATTERNS,
+} from "./issue-metadata-contract";
+import {
   parseExecutionOrder,
   parseIssueMetadata,
 } from "./issue-metadata-parser";
-
-const PART_OF_LINE_PATTERN = /^\s*(?:-\s+)?Part of\b.*$/im;
-const VALID_PART_OF_LINE_PATTERN = /^\s*(?:-\s+)?Part of:?\s+#([1-9]\d*)\s*$/i;
 
 function uniqueNumbers(values: number[]): number[] {
   return Array.from(new Set(values)).sort((left, right) => left - right);
@@ -28,9 +29,9 @@ export function validateIssueMetadataSyntax(issue: Pick<GitHubIssue, "number" | 
   const errors: string[] = [];
   const metadata = parseIssueMetadata(issue as GitHubIssue);
 
-  const partOfLine = issue.body.match(PART_OF_LINE_PATTERN)?.[0] ?? null;
+  const partOfLine = issue.body.match(ISSUE_METADATA_PATTERNS.partOfSyntaxLine)?.[0] ?? null;
   if (partOfLine) {
-    const validPartOf = VALID_PART_OF_LINE_PATTERN.test(partOfLine);
+    const validPartOf = ISSUE_METADATA_PATTERNS.validPartOfSyntaxLine.test(partOfLine);
     if (!validPartOf) {
       errors.push("part of must reference a single issue as #<number>");
     } else if (metadata.parentIssueNumber === issue.number) {
@@ -38,8 +39,8 @@ export function validateIssueMetadataSyntax(issue: Pick<GitHubIssue, "number" | 
     }
   }
 
-  const dependsOnDeclarationCount = countMetadataLineDeclarations(issue.body, "Depends on");
-  const dependsOnLine = getSingleMetadataLineValue(issue.body, "Depends on");
+  const dependsOnDeclarationCount = countMetadataLineDeclarations(issue.body, ISSUE_METADATA_FIELDS.dependsOn);
+  const dependsOnLine = getSingleMetadataLineValue(issue.body, ISSUE_METADATA_FIELDS.dependsOn);
   if (dependsOnDeclarationCount > 1) {
     errors.push("depends on must appear exactly once");
   } else if (dependsOnLine !== null) {
@@ -102,11 +103,14 @@ export function validateIssueMetadataSyntax(issue: Pick<GitHubIssue, "number" | 
     }
   }
 
-  const parallelizableDeclarationCount = countMetadataLineDeclarations(issue.body, "Parallelizable");
-  const parallelizableValue = getSingleMetadataLineValue(issue.body, "Parallelizable");
+  const parallelizableDeclarationCount = countMetadataLineDeclarations(issue.body, ISSUE_METADATA_FIELDS.parallelizable);
+  const parallelizableValue = getSingleMetadataLineValue(issue.body, ISSUE_METADATA_FIELDS.parallelizable);
   if (parallelizableDeclarationCount > 1) {
     errors.push("parallelizable must appear exactly once");
-  } else if (parallelizableValue !== null && !/^(?:yes|no)$/i.test(parallelizableValue)) {
+  } else if (
+    parallelizableValue !== null &&
+    !ISSUE_METADATA_PATTERNS.validParallelizableValue.test(parallelizableValue)
+  ) {
     errors.push("parallelizable must be Yes or No");
   }
 

--- a/src/issue-metadata/issue-metadata.ts
+++ b/src/issue-metadata/issue-metadata.ts
@@ -2,6 +2,15 @@ import { GitHubIssue, IssueRunRecord, SupervisorStateFile } from "../core/types"
 import { parseCanonicalEpicChildIssueNumbers, parseIssueMetadata } from "./issue-metadata-parser";
 
 export { parseCanonicalEpicChildIssueNumbers, parseIssueMetadata } from "./issue-metadata-parser";
+export {
+  countExecutionOrderDeclarations,
+  countMetadataLineDeclarations,
+  getSingleMetadataLineValue,
+  ISSUE_METADATA_FIELDS,
+  ISSUE_METADATA_KEYS,
+  ISSUE_METADATA_PATTERNS,
+  ISSUE_METADATA_VALUES,
+} from "./issue-metadata-contract";
 export { validateIssueMetadataSyntax } from "./issue-metadata-validation";
 export {
   classifyChangedFile,

--- a/src/supervisor/supervisor-selection-issue-lint.ts
+++ b/src/supervisor/supervisor-selection-issue-lint.ts
@@ -3,6 +3,9 @@ import { GitHubIssue } from "../core/types";
 import {
   findHighRiskBlockingAmbiguity,
   hasAvailableIssueLabels,
+  ISSUE_METADATA_FIELDS,
+  ISSUE_METADATA_KEYS,
+  ISSUE_METADATA_VALUES,
   LABEL_GATED_POLICY_MISSING_LABELS_MESSAGE,
   LABEL_GATED_POLICY_MISSING_LABELS_REPAIR_GUIDANCE,
   lintExecutionReadyIssueBody,
@@ -101,17 +104,17 @@ function buildIssueLintSuggestionLines(dto: SupervisorIssueLintDto): string[] {
     ];
   }
 
-  if (dto.missingRequired.includes("part of")) {
+  if (dto.missingRequired.includes(ISSUE_METADATA_KEYS.partOf)) {
     return [
       "suggestion_mode=suggest",
       "suggestion_status=needs_explicit_sequence_input",
       "suggestion_note=Sequenced-child metadata is incomplete; provide the parent issue number and confirmed order before copying a child skeleton.",
       "suggested_repair_skeleton:",
-      "Part of: #<parent-issue-number>",
-      "Depends on: none",
-      "Parallelizable: No",
+      `${ISSUE_METADATA_FIELDS.partOf}: #<parent-issue-number>`,
+      `${ISSUE_METADATA_FIELDS.dependsOn}: ${ISSUE_METADATA_VALUES.dependsOnNone}`,
+      `${ISSUE_METADATA_FIELDS.parallelizable}: ${ISSUE_METADATA_VALUES.defaultParallelizable}`,
       "",
-      "## Execution order",
+      `## ${ISSUE_METADATA_FIELDS.executionOrder}`,
       "<N> of <M>",
     ];
   }
@@ -139,11 +142,11 @@ export function buildStandaloneIssueBodyLines(): string[] {
     "## Verification",
     "- <exact command, test file, or manual check>",
     "",
-    "Depends on: none",
-    "Parallelizable: No",
+    `${ISSUE_METADATA_FIELDS.dependsOn}: ${ISSUE_METADATA_VALUES.dependsOnNone}`,
+    `${ISSUE_METADATA_FIELDS.parallelizable}: ${ISSUE_METADATA_VALUES.defaultParallelizable}`,
     "",
-    "## Execution order",
-    "1 of 1",
+    `## ${ISSUE_METADATA_FIELDS.executionOrder}`,
+    ISSUE_METADATA_VALUES.defaultExecutionOrder,
   ];
 }
 
@@ -172,18 +175,18 @@ function buildIssueLintRepairGuidance(
       case "verification":
         guidance.push("Add a `## Verification` section with the exact command, test file, or manual check to run.");
         break;
-      case "depends on":
+      case ISSUE_METADATA_KEYS.dependsOn:
         guidance.push("Add `Depends on: none` if nothing blocks this issue, or list blocking issues as `Depends on: #123, #456`.");
         break;
-      case "parallelizable":
+      case ISSUE_METADATA_KEYS.parallelizable:
         guidance.push("Add `Parallelizable: No` unless this issue is explicitly safe to run alongside related work.");
         break;
-      case "execution order":
+      case ISSUE_METADATA_KEYS.executionOrder:
         guidance.push(
           "Add a `## Execution order` section with `1 of 1` for standalone work, or `N of M` for a sequenced series.",
         );
         break;
-      case "part of":
+      case ISSUE_METADATA_KEYS.partOf:
         guidance.push("Add `Part of: #<number>` when this sequenced codex issue belongs to a parent epic or tracking issue.");
         break;
       default:
@@ -225,10 +228,10 @@ function buildIssueLintRepairGuidance(
 
   for (const missingField of readiness.missingRecommended) {
     switch (missingField) {
-      case "depends on":
+      case ISSUE_METADATA_KEYS.dependsOn:
         guidance.push("Add `Depends on: none` if nothing blocks this issue, or list blocking issues as `Depends on: #123, #456`.");
         break;
-      case "execution order":
+      case ISSUE_METADATA_KEYS.executionOrder:
         guidance.push(
           "Add a `## Execution order` section with `1 of 1` for standalone work, or `N of M` for a sequenced series.",
         );


### PR DESCRIPTION
## Summary
- Add a shared issue metadata contract module for canonical scheduling fields, values, regexes, and line parsing helpers.
- Update parser, syntax validation, readiness gates, and issue-lint skeleton/guidance code to consume the shared contract.
- Add a focused regression test for the shared scheduling line helper behavior.

## Verification
- npx tsx --test src/issue-metadata/issue-metadata-parser.test.ts src/issue-metadata/issue-metadata.test.ts src/issue-metadata/issue-metadata-gates.test.ts src/supervisor/supervisor-selection-issue-lint.test.ts
- npm run build

## Verification gap
- node dist/index.js issue-lint 2084 --config supervisor.config.codex.json currently fails because the checked-in config is still a starter profile with placeholders.