### PR TITLE
[codex] Introduce supervisor regression scenario builders

### DIFF
--- a/src/backend/webui-dashboard-test-fixtures.ts
+++ b/src/backend/webui-dashboard-test-fixtures.ts
@@ -314,6 +314,41 @@ export function textResponse(body: string, statusCode = 200, contentType = "text
   };
 }
 
+type DashboardStatusFixtureArgs = Parameters<typeof createDashboardStatusFixture>[0];
+type DashboardLoopRuntimeFixture = NonNullable<NonNullable<DashboardStatusFixtureArgs>["loopRuntime"]>;
+type DashboardTrackedIssueFixture = NonNullable<NonNullable<DashboardStatusFixtureArgs>["trackedIssues"]>[number];
+
+export function createDashboardLoopRuntimeFixture(
+  overrides: Partial<DashboardLoopRuntimeFixture> = {},
+): DashboardLoopRuntimeFixture {
+  return {
+    state: "off",
+    hostMode: "unknown",
+    markerPath: "none",
+    configPath: null,
+    stateFile: "none",
+    pid: null,
+    startedAt: null,
+    ownershipConfidence: "none",
+    detail: null,
+    ...overrides,
+  };
+}
+
+export function createDashboardTrackedIssueFixture(
+  overrides: Partial<DashboardTrackedIssueFixture> = {},
+): DashboardTrackedIssueFixture {
+  const issueNumber = overrides.issueNumber ?? 58;
+  return {
+    issueNumber,
+    state: "queued",
+    branch: `codex/issue-${issueNumber}`,
+    prNumber: issueNumber,
+    blockedReason: null,
+    ...overrides,
+  };
+}
+
 function createManualTimerController(): ManualTimerController {
   let now = 0;
   let nextId = 1;

--- a/src/backend/webui-dashboard.test.ts
+++ b/src/backend/webui-dashboard.test.ts
@@ -24,8 +24,10 @@ import {
   createDashboardExplainFixture as createExplain,
   createDashboardHarness,
   createDashboardIssueLintFixture as createIssueLint,
+  createDashboardLoopRuntimeFixture as createLoopRuntime,
   createDashboardServerFixture,
   createDashboardStatusFixture as createStatus,
+  createDashboardTrackedIssueFixture as createTrackedIssue,
   createDeferred,
   type FakeElement,
   FakeStorage,
@@ -489,13 +491,13 @@ test("dashboard does not claim loop mode is off while typed runtime status repor
     ...dashboardServer.page({
       status: createStatus({
         selectedIssueNumber: 42,
-        loopRuntime: {
+        loopRuntime: createLoopRuntime({
           state: "running",
           hostMode: "tmux",
           pid: 4242,
           startedAt: "2026-03-25T00:00:00.000Z",
           detail: "pid 4242",
-        },
+        }),
       }),
     }),
   ]);
@@ -517,13 +519,13 @@ test("dashboard warns when a macOS loop is reported as running directly instead 
   const harness = createDashboardHarness([
     ...dashboardServer.page({
       status: createStatus({
-        loopRuntime: {
+        loopRuntime: createLoopRuntime({
           state: "running",
           hostMode: "direct",
           pid: 4242,
           startedAt: "2026-03-25T00:00:00.000Z",
           detail: "pid 4242",
-        },
+        }),
         warning: {
           message:
             "macOS loop runtime is active outside tmux. Restart it with ./scripts/start-loop-tmux.sh and stop unsupported direct hosts before relying on steady-state automation.",
@@ -547,13 +549,13 @@ test("dashboard renders the loop-off presentation only when typed runtime status
   const harness = createDashboardHarness([
     ...dashboardServer.page({
       status: createStatus({
-        loopRuntime: {
+        loopRuntime: createLoopRuntime({
           state: "off",
           hostMode: "unknown",
           pid: null,
           startedAt: null,
           detail: null,
-        },
+        }),
       }),
     }),
   ]);
@@ -573,7 +575,7 @@ test("dashboard renders duplicate loop ownership as ambiguous instead of loop of
   const harness = createDashboardHarness([
     ...dashboardServer.page({
       status: createStatus({
-        loopRuntime: {
+        loopRuntime: createLoopRuntime({
           state: "off",
           hostMode: "unknown",
           pid: null,
@@ -592,7 +594,7 @@ test("dashboard renders duplicate loop ownership as ambiguous instead of loop of
             recoveryGuidance:
               "Safe recovery: for config /tmp/supervisor.config.json, stop the tmux-managed loop with ./scripts/stop-loop-tmux.sh, inspect the listed direct loop PIDs before stopping any process, then restart with ./scripts/start-loop-tmux.sh using the same config.",
           },
-        },
+        }),
       }),
     }),
   ]);
@@ -616,21 +618,21 @@ test("dashboard treats loop-off tracked work as an active blocker instead of idl
     ...dashboardServer.page({
       status: createStatus({
         trackedIssues: [
-          {
+          createTrackedIssue({
             issueNumber: 58,
             state: "queued",
             branch: "codex/issue-58",
             prNumber: 58,
             blockedReason: null,
-          },
+          }),
         ],
-        loopRuntime: {
+        loopRuntime: createLoopRuntime({
           state: "off",
           hostMode: "unknown",
           pid: null,
           startedAt: null,
           detail: null,
-        },
+        }),
         warning: {
           message:
             "Tracked work is active for issue #58, but the supervisor loop is off. Restart the supported loop host; expect loop_runtime state=running before issue #58 advances.",
@@ -661,21 +663,21 @@ test("dashboard does not tell the operator to restart the loop for blocked-only 
     ...dashboardServer.page({
       status: createStatus({
         trackedIssues: [
-          {
+          createTrackedIssue({
             issueNumber: 58,
             state: "blocked",
             branch: "codex/issue-58",
             prNumber: 58,
             blockedReason: "manual_review",
-          },
+          }),
         ],
-        loopRuntime: {
+        loopRuntime: createLoopRuntime({
           state: "off",
           hostMode: "unknown",
           pid: null,
           startedAt: null,
           detail: null,
-        },
+        }),
         warning: null,
       }),
     }),

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -372,6 +372,66 @@ function createLocalReviewResult({
   };
 }
 
+function createCodexConnectorReviewRequestScenario({
+  issueNumber = 1924,
+  issueTitle = "Request Codex Connector review after timeout",
+  headSha = `head-${issueNumber}`,
+  dryRun = false,
+  configOverrides = {},
+  recordOverrides = {},
+}: {
+  issueNumber?: number;
+  issueTitle?: string;
+  headSha?: string;
+  dryRun?: boolean;
+  configOverrides?: Partial<ReturnType<typeof createConfig>>;
+  recordOverrides?: Partial<IssueRunRecord>;
+} = {}) {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    ...configOverrides,
+  });
+  const issue = createIssue({ number: issueNumber, title: issueTitle });
+  const pr = createPullRequest({
+    number: issueNumber,
+    title: issueTitle,
+    isDraft: false,
+    headRefOid: headSha,
+    currentHeadCiGreenAt: null,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+  const record = createRecord({
+    issue_number: issue.number,
+    state: "waiting_ci",
+    pr_number: pr.number,
+    last_head_sha: pr.headRefOid,
+    review_wait_started_at: "2026-05-08T03:09:36Z",
+    review_wait_head_sha: pr.headRefOid,
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    ...recordOverrides,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issue.number,
+    issues: { [String(issue.number)]: record },
+  };
+  const context = createPostTurnContext({
+    issue,
+    pr,
+    workspacePath: path.join("/tmp/workspaces", `issue-${issueNumber}`),
+    state,
+    record,
+    dryRun,
+  });
+
+  return { config, context, issue, pr, record, state };
+}
+
 test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking ready", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {
@@ -514,37 +574,7 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
   const originalDateNow = Date.now;
   Date.now = () => Date.parse("2026-05-08T03:30:00Z");
   try {
-    const config = createConfig({
-      reviewBotLogins: ["chatgpt-codex-connector"],
-      configuredBotInitialGraceWaitSeconds: 0,
-      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
-      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
-    });
-    const issue = createIssue({ title: "Request Codex Connector review after timeout" });
-    const pr = createPullRequest({
-      number: 1924,
-      title: "Request Codex Connector review after timeout",
-      isDraft: false,
-      headRefOid: "head-1924",
-      currentHeadCiGreenAt: null,
-      configuredBotCurrentHeadObservedAt: null,
-      codexConnectorReviewRequestedAt: null,
-      codexConnectorReviewRequestedHeadSha: null,
-    });
-    const record = createRecord({
-      issue_number: issue.number,
-      state: "waiting_ci",
-      pr_number: pr.number,
-      last_head_sha: pr.headRefOid,
-      review_wait_started_at: "2026-05-08T03:09:36Z",
-      review_wait_head_sha: pr.headRefOid,
-      codex_connector_review_requested_observed_at: null,
-      codex_connector_review_requested_head_sha: null,
-    });
-    const state: SupervisorStateFile = {
-      activeIssueNumber: issue.number,
-      issues: { [String(issue.number)]: record },
-    };
+    const { config, context, issue, pr, record, state } = createCodexConnectorReviewRequestScenario();
     const comments: Array<{ issueNumber: number; body: string }> = [];
 
     const result = await handlePostTurnPullRequestTransitionsPhase({
@@ -560,13 +590,7 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex Connector review 
           };
         },
       }),
-      context: createPostTurnContext({
-        issue,
-        pr,
-        workspacePath: "/tmp/workspaces/issue-1924",
-        state,
-        record,
-      }),
+      context,
       loadOpenPullRequestSnapshot: async () => ({
         pr,
         checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
@@ -668,37 +692,10 @@ test("handlePostTurnPullRequestTransitionsPhase does not request Codex Connector
   const originalDateNow = Date.now;
   Date.now = () => Date.parse("2026-05-08T03:30:00Z");
   try {
-    const config = createConfig({
-      reviewBotLogins: ["chatgpt-codex-connector"],
-      configuredBotInitialGraceWaitSeconds: 0,
-      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
-      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    const { config, context, pr } = createCodexConnectorReviewRequestScenario({
+      issueTitle: "Dry-run Codex Connector review request",
+      dryRun: true,
     });
-    const issue = createIssue({ title: "Dry-run Codex Connector review request" });
-    const pr = createPullRequest({
-      number: 1924,
-      title: "Dry-run Codex Connector review request",
-      isDraft: false,
-      headRefOid: "head-1924",
-      currentHeadCiGreenAt: null,
-      configuredBotCurrentHeadObservedAt: null,
-      codexConnectorReviewRequestedAt: null,
-      codexConnectorReviewRequestedHeadSha: null,
-    });
-    const record = createRecord({
-      issue_number: issue.number,
-      state: "waiting_ci",
-      pr_number: pr.number,
-      last_head_sha: pr.headRefOid,
-      review_wait_started_at: "2026-05-08T03:09:36Z",
-      review_wait_head_sha: pr.headRefOid,
-      codex_connector_review_requested_observed_at: null,
-      codex_connector_review_requested_head_sha: null,
-    });
-    const state: SupervisorStateFile = {
-      activeIssueNumber: issue.number,
-      issues: { [String(issue.number)]: record },
-    };
     let addIssueCommentCalls = 0;
 
     const result = await handlePostTurnPullRequestTransitionsPhase({
@@ -710,14 +707,7 @@ test("handlePostTurnPullRequestTransitionsPhase does not request Codex Connector
           throw new Error("dry-run must not post Codex Connector review requests");
         },
       }),
-      context: createPostTurnContext({
-        issue,
-        pr,
-        workspacePath: "/tmp/workspaces/issue-1924",
-        state,
-        record,
-        dryRun: true,
-      }),
+      context,
       loadOpenPullRequestSnapshot: async () => ({
         pr,
         checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import test, { mock } from "node:test";
 import { StateStore } from "../core/state-store";
-import { GitHubIssue, SupervisorStateFile } from "../core/types";
+import { GitHubIssue, IssueRunRecord, SupervisorStateFile } from "../core/types";
 import { renderSupervisorStatusDto } from "./supervisor-status-report";
 import { Supervisor } from "./supervisor";
 import {
@@ -22,6 +22,47 @@ import {
   clearCurrentReconciliationPhase,
   writeCurrentReconciliationPhase,
 } from "./supervisor-reconciliation-phase";
+
+function createTrackedPullRequestStatusScenario(
+  fixture: Awaited<ReturnType<typeof createSupervisorFixture>>,
+  args: {
+    issueNumber: number;
+    prNumber: number;
+    state?: IssueRunRecord["state"];
+    headSha?: string;
+    recordOverrides?: Partial<IssueRunRecord>;
+  },
+) {
+  const headSha = args.headSha ?? `head-${args.issueNumber}`;
+  const branch = branchName(fixture.config, args.issueNumber);
+  const record = createRecord({
+    issue_number: args.issueNumber,
+    state: args.state ?? "waiting_ci",
+    branch,
+    pr_number: args.prNumber,
+    workspace: path.join(fixture.workspaceRoot, `issue-${args.issueNumber}`),
+    journal_path: null,
+    last_head_sha: headSha,
+    ...args.recordOverrides,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: args.issueNumber,
+    issues: {
+      [String(args.issueNumber)]: record,
+    },
+  };
+  const pr = createPullRequest({
+    number: args.prNumber,
+    headRefName: branch,
+    headRefOid: headSha,
+  });
+
+  return { branch, headSha, pr, record, state };
+}
+
+async function writeSupervisorState(fixture: Awaited<ReturnType<typeof createSupervisorFixture>>, state: SupervisorStateFile) {
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
 
 test("doctor uses the diagnostic-only state loader instead of StateStore.load", async (t) => {
   const fixture = await createSupervisorFixture();
@@ -186,24 +227,15 @@ test("status surfaces Codex Connector review-request fallback lifecycle for the 
 
   const issueNumber = 1925;
   const prNumber = 2925;
-  const branch = branchName(fixture.config, issueNumber);
-  const state: SupervisorStateFile = {
-    activeIssueNumber: issueNumber,
-    issues: {
-      [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "waiting_ci",
-        branch,
-        pr_number: prNumber,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
-        journal_path: null,
-        last_head_sha: "head-1925",
-        codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
-        codex_connector_review_requested_head_sha: "head-1925",
-      }),
+  const scenario = createTrackedPullRequestStatusScenario(fixture, {
+    issueNumber,
+    prNumber,
+    recordOverrides: {
+      codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+      codex_connector_review_requested_head_sha: "head-1925",
     },
-  };
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  });
+  await writeSupervisorState(fixture, scenario.state);
 
   const supervisor = new Supervisor({
     ...fixture.config,
@@ -217,7 +249,7 @@ test("status surfaces Codex Connector review-request fallback lifecycle for the 
     resolvePullRequestForBranch: async () =>
       createPullRequest({
         number: prNumber,
-        headRefName: branch,
+        headRefName: scenario.branch,
         headRefOid: "head-1925",
         currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
         configuredBotCurrentHeadObservedAt: null,
@@ -248,22 +280,11 @@ test("status --why distinguishes hydrated same-head Codex Connector review reque
 
   const issueNumber = 1958;
   const prNumber = 2958;
-  const branch = branchName(fixture.config, issueNumber);
-  const state: SupervisorStateFile = {
-    activeIssueNumber: issueNumber,
-    issues: {
-      [String(issueNumber)]: createRecord({
-        issue_number: issueNumber,
-        state: "waiting_ci",
-        branch,
-        pr_number: prNumber,
-        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
-        journal_path: null,
-        last_head_sha: "head-1958",
-      }),
-    },
-  };
-  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  const scenario = createTrackedPullRequestStatusScenario(fixture, {
+    issueNumber,
+    prNumber,
+  });
+  await writeSupervisorState(fixture, scenario.state);
 
   const supervisor = new Supervisor({
     ...fixture.config,
@@ -277,7 +298,7 @@ test("status --why distinguishes hydrated same-head Codex Connector review reque
     resolvePullRequestForBranch: async () =>
       createPullRequest({
         number: prNumber,
-        headRefName: branch,
+        headRefName: scenario.branch,
         headRefOid: "head-1958",
         currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
         configuredBotCurrentHeadObservedAt: null,

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { runCommand } from "../core/command";
-import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorStateFile } from "../core/types";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorStateFile } from "../core/types";
 import { buildIssueDefinitionFingerprint } from "../issue-definition-freshness";
 import {
   buildTrackedPrStaleFailureConvergencePatch,
@@ -473,17 +473,22 @@ function createCodexConnectorRecoveryConfig() {
   });
 }
 
-test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tracked PR after same-head Codex Connector success", async () => {
-  const record = createReviewBotTimeoutTrackedPrRecord();
+async function runReviewBotTimeoutRecoveryScenario({
+  recordOverrides = {},
+  pullRequestOverrides = {},
+  checks = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+}: {
+  recordOverrides?: Partial<IssueRunRecord>;
+  pullRequestOverrides?: Partial<GitHubPullRequest>;
+  checks?: PullRequestCheck[];
+} = {}) {
+  const record = createReviewBotTimeoutTrackedPrRecord(recordOverrides);
   const state: SupervisorStateFile = createSupervisorState({ issues: [record] });
   let saveCalls = 0;
 
   const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
     {
-      getPullRequestIfExists: async () => createTrackedPrRecoveryPullRequest({
-        configuredBotCurrentHeadObservedAt: "2026-03-13T00:13:00Z",
-        configuredBotCurrentHeadStatusState: "SUCCESS",
-      }),
+      getPullRequestIfExists: async () => createTrackedPrRecoveryPullRequest(pullRequestOverrides),
       getIssue: async () => {
         throw new Error("unexpected getIssue call");
       },
@@ -493,7 +498,7 @@ test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tr
       closePullRequest: async () => {
         throw new Error("unexpected closePullRequest call");
       },
-      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getChecks: async () => checks,
       getMergedPullRequestsClosingIssue: async () => [],
       getUnresolvedReviewThreads: async () => [],
     },
@@ -513,6 +518,17 @@ test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tr
     createCodexConnectorRecoveryConfig(),
     [],
   );
+
+  return { recoveryEvents, saveCalls, state };
+}
+
+test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tracked PR after same-head Codex Connector success", async () => {
+  const { recoveryEvents, saveCalls, state } = await runReviewBotTimeoutRecoveryScenario({
+    pullRequestOverrides: {
+      configuredBotCurrentHeadObservedAt: "2026-03-13T00:13:00Z",
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+    },
+  });
 
   assert.equal(saveCalls, 1);
   assert.equal(state.issues["366"]?.state, "ready_to_merge");
@@ -524,45 +540,13 @@ test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tr
 });
 
 test("reconcileTrackedMergedButOpenIssues recovers review_bot_timeout blocked tracked PR after late Codex Connector PR comment success", async () => {
-  const record = createReviewBotTimeoutTrackedPrRecord();
-  const state: SupervisorStateFile = createSupervisorState({ issues: [record] });
-  let saveCalls = 0;
-
-  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
-    {
-      getPullRequestIfExists: async () => createTrackedPrRecoveryPullRequest({
-        configuredBotCurrentHeadObservedAt: "2026-03-13T00:13:00Z",
-        configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
-      }),
-      getIssue: async () => {
-        throw new Error("unexpected getIssue call");
-      },
-      closeIssue: async () => {
-        throw new Error("unexpected closeIssue call");
-      },
-      closePullRequest: async () => {
-        throw new Error("unexpected closePullRequest call");
-      },
-      getChecks: async () => [],
-      getMergedPullRequestsClosingIssue: async () => [],
-      getUnresolvedReviewThreads: async () => [],
+  const { recoveryEvents, saveCalls, state } = await runReviewBotTimeoutRecoveryScenario({
+    pullRequestOverrides: {
+      configuredBotCurrentHeadObservedAt: "2026-03-13T00:13:00Z",
+      configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     },
-    {
-      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
-        return {
-          ...current,
-          ...patch,
-          updated_at: "2026-03-13T00:14:00Z",
-        };
-      },
-      save: async () => {
-        saveCalls += 1;
-      },
-    },
-    state,
-    createCodexConnectorRecoveryConfig(),
-    [],
-  );
+    checks: [],
+  });
 
   assert.equal(saveCalls, 1);
   assert.equal(state.issues["366"]?.state, "ready_to_merge");
@@ -638,45 +622,13 @@ test("reconcileTrackedMergedButOpenIssues does not recover Codex Connector succe
 });
 
 test("reconcileTrackedMergedButOpenIssues leaves review_bot_timeout blocked for stale Codex Connector PR comment success", async () => {
-  const record = createReviewBotTimeoutTrackedPrRecord();
-  const state: SupervisorStateFile = createSupervisorState({ issues: [record] });
-  let saveCalls = 0;
-
-  const recoveryEvents = await reconcileTrackedMergedButOpenIssues(
-    {
-      getPullRequestIfExists: async () => createTrackedPrRecoveryPullRequest({
-        configuredBotCurrentHeadObservedAt: "2026-03-12T23:59:00Z",
-        configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
-      }),
-      getIssue: async () => {
-        throw new Error("unexpected getIssue call");
-      },
-      closeIssue: async () => {
-        throw new Error("unexpected closeIssue call");
-      },
-      closePullRequest: async () => {
-        throw new Error("unexpected closePullRequest call");
-      },
-      getChecks: async () => [],
-      getMergedPullRequestsClosingIssue: async () => [],
-      getUnresolvedReviewThreads: async () => [],
+  const { recoveryEvents, saveCalls, state } = await runReviewBotTimeoutRecoveryScenario({
+    pullRequestOverrides: {
+      configuredBotCurrentHeadObservedAt: "2026-03-12T23:59:00Z",
+      configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     },
-    {
-      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
-        return {
-          ...current,
-          ...patch,
-          updated_at: "2026-03-13T00:14:00Z",
-        };
-      },
-      save: async () => {
-        saveCalls += 1;
-      },
-    },
-    state,
-    createCodexConnectorRecoveryConfig(),
-    [],
-  );
+    checks: [],
+  });
 
   assert.equal(saveCalls, 0);
   assert.deepEqual(recoveryEvents, []);


### PR DESCRIPTION
## Summary
- Extract named scenario builders for repeated supervisor regression fixtures.
- Cover recovery reconciliation, post-turn PR transitions, diagnostics status selection, and dashboard status DTO setup.
- Keep changes test-only with production behavior unchanged.

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/backend/webui-dashboard.test.ts
- npm run build
- node dist/index.js issue-lint 2088 --config <active-host-supervisor-config>

Note: the repo-local supervisor.config.codex.json is a starter placeholder profile, so issue-lint was run with the active host config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixture factories and scenario helpers to improve consistency and reduce duplication across test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->