### PR TITLE
Fix stale_review_bot Codex review request selection

### DIFF
--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -177,7 +177,7 @@ test("selectStatusOperatorAction flags elapsed Codex review request fallback ins
   );
 });
 
-test("selectStatusOperatorAction prefers selected request-eligible Codex recovery over stale manual-review mismatch", () => {
+test("selectStatusOperatorAction flags request-eligible Codex recovery instead of continuing", () => {
   assert.deepEqual(
     selectStatusOperatorAction({
       detailedStatusLines: [
@@ -187,10 +187,11 @@ test("selectStatusOperatorAction prefers selected request-eligible Codex recover
       contextLines: ["selected_issue=#169"],
     }),
     {
-      action: "continue",
-      source: "status",
-      priority: 0,
-      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+      action: "provider_outage_suspected",
+      source: "codex_connector_review_fallback",
+      priority: 70,
+      summary:
+        "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
     },
   );
 

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -377,6 +377,21 @@ export function selectStatusOperatorAction(args: {
 
     if (
       /^codex_connector_review_fallback\b/.test(line) &&
+      /\bstatus=request_eligible\b/.test(line) &&
+      /\bnext_action=request_current_head_review\b/.test(line)
+    ) {
+      actions.push({
+        action: "provider_outage_suspected",
+        source: "codex_connector_review_fallback",
+        priority: 70,
+        summary:
+          "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
+      });
+      continue;
+    }
+
+    if (
+      /^codex_connector_review_fallback\b/.test(line) &&
       /\bstatus=timeout_elapsed\b/.test(line) &&
       /\btimeout_action=request_review_comment\b/.test(line) &&
       /\brequested_at=none\b/.test(line)

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -434,6 +434,127 @@ test("resolveRunnableIssueContext selects manual-review tracked PR when Codex cu
   }
 });
 
+test("resolveRunnableIssueContext selects stale-review-bot tracked PR when Codex current-head review request is eligible", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2096;
+  const prNumber = 179;
+  const branch = "codex/issue-2096";
+  const headSha = "head-2096-current";
+  const threadId = "thread-stale-review-bot-current-head";
+  const commentId = "comment-stale-review-bot-current-head";
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector request eligible stale review bot recovery",
+    body: executionReadyBody("Request current-head Codex review when stale review bot residue is request eligible."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "stale_review_bot",
+    last_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-2096-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: record,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-2096-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads = [
+    {
+      id: threadId,
+      isResolved: false,
+      isOutdated: true,
+      path: "src/review-policy.ts",
+      line: 12,
+      comments: {
+        nodes: [
+          {
+            id: commentId,
+            body: "P2: metadata-only stale configured-bot finding.",
+            createdAt: "2026-05-21T23:55:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_${threadId}`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => reviewThreads,
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: "/tmp/workspaces/issue-2096/.codex-supervisor/issue-journal.md",
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.notEqual(typeof result, "string");
+  if (typeof result !== "string") {
+    assert.equal(result.kind, "ready");
+    if (result.kind === "ready") {
+      assert.equal(result.record.issue_number, issueNumber);
+      await result.issueLock.release();
+    }
+  }
+});
+
 test("resolveRunnableIssueContext skips manual-review Codex request recovery when GitHub recovery data fails", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -81,7 +81,7 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
   if (
     !record ||
     record.state !== "blocked" ||
-    record.blocked_reason !== "manual_review" ||
+    (record.blocked_reason !== "manual_review" && record.blocked_reason !== "stale_review_bot") ||
     record.pr_number === null ||
     !configuredReviewProviderKinds(config).includes("codex") ||
     config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -724,6 +724,8 @@ test("explain requests Codex current-head review for metadata-only missing revie
 
   const explanation = await supervisor.explain(issueNumber);
 
+  assert.match(explanation, /^runnable=yes$/m);
+  assert.match(explanation, /^selection_reason=ready .*retry_state=resume:blocked$/m);
   assert.match(
     explanation,
     /^stale_review_bot_remediation issue=#144 pr=#148 reason=stale_review_bot code_ci=green current_head_sha=f3addc310b0ff8e4fc53d9f3e0ab783af70a552f processed_on_current_head=unknown classification=metadata_only_missing_current_head_review codex_current_head_review_state=missing review_thread_url=none manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only_pending_current_head_review_request$/m,

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -943,6 +943,114 @@ test("status --why selects manual-review tracked PR when Codex current-head revi
   assert.doesNotMatch(status, /^selected_issue=none$/m);
 });
 
+test("status --why selects stale-review-bot tracked PR when Codex current-head review request is eligible", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  fixture.config.configuredBotInitialGraceWaitSeconds = 0;
+  fixture.config.configuredBotCurrentHeadSignalTimeoutMinutes = 10;
+  fixture.config.configuredBotCurrentHeadSignalTimeoutAction = "request_review_comment";
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 2096;
+  const prNumber = 179;
+  const branch = branchName(fixture.config, issueNumber);
+  const currentHead = "ad2a7f2d9c62f52f190d42884f1844c5b5da2096";
+  const staleReviewHead = "1bd7511632c6db5bf1f1bbe91f0b5c4cebad2096";
+  const staleThread = {
+    id: "thread-stale-review-bot-current-head",
+    isResolved: false,
+    isOutdated: true,
+    path: "src/review-policy.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-stale-review-bot-current-head",
+          body: "P2: metadata-only stale configured-bot finding.",
+          createdAt: "2026-05-22T00:00:00Z",
+          url: "https://example.test/pr/179#discussion_stale_review_bot_current_head",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: currentHead,
+        blocked_reason: "stale_review_bot",
+        provider_success_head_sha: staleReviewHead,
+        provider_success_observed_at: "2026-05-21T23:50:00Z",
+        copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+        copilot_review_timeout_action: "request_review_comment",
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: null,
+        processed_review_thread_ids: [`${staleThread.id}@${currentHead}`],
+        processed_review_thread_fingerprints: [`${staleThread.id}@${currentHead}#${staleThread.comments.nodes[0].id}`],
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Codex Connector request eligible stale review bot recovery",
+    body: executionReadyBody("Request current-head Codex review when stale review bot residue is request eligible."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: staleReviewHead,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [staleThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(status, /^selected_issue=#2096$/m);
+  assert.match(status, /^selection_reason=ready .*retry_state=resume:blocked$/m);
+  assert.match(status, /^runnable_issues=#2096 ready=execution_ready$/m);
+  assert.match(
+    status,
+    /^codex_connector_review_fallback status=request_eligible provider=codex .* next_action=request_current_head_review /m,
+  );
+  assert.doesNotMatch(status, /^operator_action action=continue /m);
+  assert.doesNotMatch(status, /^selected_issue=none$/m);
+});
+
 test("status surfaces host-migration path repair and journal rehydration from the canonical local journal", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -61,7 +61,7 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
   if (
     !record ||
     record.state !== "blocked" ||
-    record.blocked_reason !== "manual_review" ||
+    (record.blocked_reason !== "manual_review" && record.blocked_reason !== "stale_review_bot") ||
     record.pr_number === null ||
     !configuredReviewProviderKinds(config).includes("codex") ||
     config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||


### PR DESCRIPTION
## Summary
- allow request-eligible stale_review_bot tracked PRs through the existing Codex Connector review-request selection gate
- make status --why report the issue as runnable/selected for this state shape
- avoid generic continue operator action when next_action=request_current_head_review

Fixes #2096

## Verification
- npm run build
- npx tsx --test src/codex-connector-review-request-transition.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/run-once-issue-selection.test.ts src/supervisor/supervisor-run-once-runtime.test.ts
- npx tsx --test src/operator-actions.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected a logic error that was preventing proper recovery and selection of issues affected by stale review conditions.

* **Improvements**
  * Enhanced provider outage detection to recognize additional request eligibility scenarios, improving system responsiveness during connectivity issues.
  * Expanded test coverage for stale review recovery paths and issue readiness validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->