### PR TITLE
Classify proven Codex stale metadata residue

### DIFF
--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -10,6 +10,10 @@ import {
   passingChecks,
   withStubbedDateNow,
 } from "./pull-request-state-test-helpers";
+import {
+  CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+  createCodexConnectorTrackedReviewResidueScenario,
+} from "./codex-connector-tracked-pr-test-helpers";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
   const config = createConfig({
@@ -410,6 +414,55 @@ test("blockedReasonFromReviewState classifies same-head configured-bot threads a
 
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
   assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), "stale_review_bot");
+});
+
+test("inferStateFromPullRequest advances past proven Codex Connector stale metadata residue", () => {
+  const issueNumber = 2097;
+  const prNumber = 117;
+  const headSha = "76060523f803ebe25832cb2c355aaaa9530502f4";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-no-major",
+    commentId: "comment-current-head-no-major",
+    path: "src/current-head-proof.ts",
+    line: 42,
+    commentBody: "P1: This older inline finding should not outvote current-head no-major evidence.",
+    discussionUrl: "https://example.test/pr/117#discussion_r117",
+    verifiedRepair: {
+      summary: "Focused current-head verifier passed.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npx tsx --test src/pull-request-state-policy.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotLatestReviewedCommitSha: "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770",
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    "ready_to_merge",
+  );
+  assert.equal(
+    blockedReasonFromReviewState(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    null,
+  );
 });
 
 test("inferStateFromPullRequest still blocks a journal-only configured-bot thread when the PR is not otherwise green", () => {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -48,6 +48,10 @@ import {
 import { displayLocalCiCommand } from "./core/config-parsing";
 import { nowIso } from "./core/utils";
 import { hasQueuedReadyPromotionPathHygieneRepair } from "./ready-promotion-path-hygiene-repair";
+import {
+  buildStaleReviewBotRemediation,
+  isProvenStaleReviewMetadataClassification,
+} from "./supervisor/stale-review-bot-remediation";
 
 const COPILOT_REVIEW_PROPAGATION_GRACE_MS = 5_000;
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
@@ -720,6 +724,23 @@ function effectiveConfiguredBotReviewThreads(
     : effectiveThreads;
 }
 
+function hasProvenCodexConnectorStaleReviewMetadata(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  const remediation = buildStaleReviewBotRemediation({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+  });
+  return remediation ? isProvenStaleReviewMetadataClassification(remediation.classification) : false;
+}
+
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -900,12 +921,23 @@ export function blockedReasonFromReviewState(
   nowMs = pullRequestStateInferenceNowMs(),
 ): Exclude<BlockedReason, null> | null {
   const manualThreads = manualReviewThreads(config, reviewThreads);
-  const unresolvedBotThreads = effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
+  const provenCodexStaleReviewMetadata = hasProvenCodexConnectorStaleReviewMetadata({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
+  const unresolvedBotThreads = provenCodexStaleReviewMetadata
+    ? []
+    : effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
   const staleBotThreads =
-    manualThreads.length === 0 ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads) : [];
+    manualThreads.length === 0 && !provenCodexStaleReviewMetadata
+      ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads)
+      : [];
   const checkSummary = summarizeChecks(checks);
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
-  if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
+  if (copilotTimeout.timedOut && copilotTimeout.action === "block" && !provenCodexStaleReviewMetadata) {
     return "review_bot_timeout";
   }
 
@@ -958,7 +990,16 @@ export function inferStateFromPullRequest(
   nowMs = pullRequestStateInferenceNowMs(),
 ): RunState {
   const manualThreads = manualReviewThreads(config, reviewThreads);
-  const unresolvedBotThreads = effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
+  const provenCodexStaleReviewMetadata = hasProvenCodexConnectorStaleReviewMetadata({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
+  const unresolvedBotThreads = provenCodexStaleReviewMetadata
+    ? []
+    : effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
@@ -969,6 +1010,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
+    !provenCodexStaleReviewMetadata &&
     shouldWaitForCodexConnectorCurrentHeadReview({
       config,
       record,
@@ -1165,11 +1207,15 @@ export function inferStateFromPullRequest(
   }
 
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
-  if (copilotTimeout.timedOut && copilotTimeout.action === "block") {
+  if (copilotTimeout.timedOut && copilotTimeout.action === "block" && !provenCodexStaleReviewMetadata) {
     return "blocked";
   }
 
-  if (copilotTimeout.timedOut && copilotTimeout.action === "request_review_comment") {
+  if (
+    copilotTimeout.timedOut &&
+    copilotTimeout.action === "request_review_comment" &&
+    !provenCodexStaleReviewMetadata
+  ) {
     return "waiting_ci";
   }
 
@@ -1189,7 +1235,11 @@ export function inferStateFromPullRequest(
     return "waiting_ci";
   }
 
-  if (configuredBotCurrentHeadSignalPending(config, record, pr) && !copilotTimeout.timedOut) {
+  if (
+    !provenCodexStaleReviewMetadata &&
+    configuredBotCurrentHeadSignalPending(config, record, pr) &&
+    !copilotTimeout.timedOut
+  ) {
     return "waiting_ci";
   }
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -158,6 +158,17 @@ function currentHeadSuccess(pr: GitHubPullRequest | null): StaleReviewBotThreadD
   return pr.configuredBotCurrentHeadObservedAt && pr.configuredBotCurrentHeadStatusState === "SUCCESS" ? "yes" : "no";
 }
 
+export function isProvenStaleReviewMetadataClassification(
+  classification: StaleReviewBotRemediationDto["classification"],
+): boolean {
+  return (
+    classification === "metadata_only" ||
+    classification === "metadata_only_current_head_converged" ||
+    classification === "verified_no_source_change_pending_thread_resolution" ||
+    classification === "verified_current_head_repair_pending_thread_resolution"
+  );
+}
+
 function isVerifiedStaleResidueClassification(classification: StaleReviewBotRemediationDto["classification"]): boolean {
   return (
     classification === "verified_no_source_change_pending_thread_resolution" ||

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -445,6 +445,7 @@ export function buildActiveDetailedStatusLines(
       pr,
       checks,
       reviewThreads,
+      staleReviewBotRemediation,
       includeP2P3Policy: true,
     });
     if (codexConnectorDiagnostics.policyBlockSummary) {

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1525,7 +1525,10 @@ test("status --why distinguishes codex verified current-head repair residue from
     labels: [],
     state: "OPEN",
   };
-  const pr = createPullRequest(scenario.pullRequestPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotLatestReviewedCommitSha: "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770",
+  });
   const staleMetadataThread = scenario.reviewThread;
 
   const supervisor = new Supervisor(fixture.config);
@@ -1692,6 +1695,12 @@ test("status --why uses the shared stale review-bot presenter for active verifie
     status,
     /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
+  assert.match(
+    status,
+    /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution$/m,
+  );
+  assert.doesNotMatch(status, /^codex_connector_convergence status=stale_head /m);
+  assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });
 

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -22,7 +22,10 @@ import {
   formatCodexConnectorPolicyBlockDiagnostic,
 } from "../codex-connector-review-policy";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
-import type { StaleReviewBotRemediationDto } from "./stale-review-bot-remediation";
+import {
+  isProvenStaleReviewMetadataClassification,
+  type StaleReviewBotRemediationDto,
+} from "./stale-review-bot-remediation";
 
 type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
 const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
@@ -466,12 +469,18 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   const currentHeadSha = args.pr.headRefOid;
   const staleReviewCommitThreads = codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads);
   const staleReviewCommitThreadIds = staleReviewCommitThreads.map((thread) => thread.id).join(",");
+  const hasCurrentHeadProviderSuccess = Boolean(
+    args.record.provider_success_observed_at && commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha),
+  );
+  const currentHeadSignalObserved = Boolean(
+    policy.currentHeadObservedAt || hasCurrentHeadProviderSuccess,
+  );
   const staleSignalHeadSha =
-    args.pr.configuredBotLatestReviewedCommitSha && commitShasDifferForComparison(args.pr.configuredBotLatestReviewedCommitSha, currentHeadSha)
+    !currentHeadSignalObserved && args.pr.configuredBotLatestReviewedCommitSha && commitShasDifferForComparison(args.pr.configuredBotLatestReviewedCommitSha, currentHeadSha)
       ? args.pr.configuredBotLatestReviewedCommitSha
-      : args.record.provider_success_head_sha && commitShasDifferForComparison(args.record.provider_success_head_sha, currentHeadSha)
+      : !currentHeadSignalObserved && args.record.provider_success_head_sha && commitShasDifferForComparison(args.record.provider_success_head_sha, currentHeadSha)
         ? args.record.provider_success_head_sha
-        : args.record.external_review_head_sha && commitShasDifferForComparison(args.record.external_review_head_sha, currentHeadSha)
+        : !currentHeadSignalObserved && args.record.external_review_head_sha && commitShasDifferForComparison(args.record.external_review_head_sha, currentHeadSha)
           ? args.record.external_review_head_sha
           : null;
   const latestSignalHeadSha =
@@ -500,9 +509,6 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
         : timeoutAction === "request_review_comment"
           ? "request_current_head_review"
           : "wait_for_current_head_signal";
-  const hasCurrentHeadProviderSuccess = Boolean(
-    args.record.provider_success_observed_at && commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha),
-  );
   const findingCount = staleReviewCommitThreads.length > 0 ? 0 : policy.findingCount;
   const highestSeverity = staleReviewCommitThreads.length > 0 ? "none" : policy.highestSeverity;
 
@@ -689,6 +695,36 @@ export function formatStaleReviewResidueOperatorDiagnostic(remediation: StaleRev
   ].join(" ");
 }
 
+function formatStaleReviewMetadataConvergenceDiagnostic(args: {
+  remediation: StaleReviewBotRemediationDto;
+  pr: GitHubPullRequest;
+}): string | null {
+  if (!isProvenStaleReviewMetadataClassification(args.remediation.classification)) {
+    return null;
+  }
+
+  return [
+    "codex_connector_convergence status=stale_review_metadata",
+    "provider=codex",
+    `current_head_sha=${args.remediation.currentHeadSha.replace(/\r?\n/g, "\\n")}`,
+    `current_head_observed_at=${args.pr.configuredBotCurrentHeadObservedAt ?? "none"}`,
+    `latest_signal_head_sha=${args.remediation.currentHeadSha.replace(/\r?\n/g, "\\n")}`,
+    "highest_severity=none",
+    "finding_count=0",
+    "merge_effect=ready",
+    "next_action=merge_ready",
+    `stale_review_metadata_classification=${args.remediation.classification}`,
+  ].join(" ");
+}
+
+function shouldUseStaleReviewRemediationDiagnostic(remediation: StaleReviewBotRemediationDto | null | undefined): remediation is StaleReviewBotRemediationDto {
+  return Boolean(
+    remediation &&
+      remediation.classification !== "unresolved_work" &&
+      remediation.classification !== "actionable_current_diff",
+  );
+}
+
 export function buildCodexConnectorDiagnosticBundle(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -702,6 +738,9 @@ export function buildCodexConnectorDiagnosticBundle(args: {
   const p2p3Policy = args.includeP2P3Policy
     ? buildCodexConnectorP2P3PolicyDiagnostic(args.config, args.reviewThreads, args.pr)
     : null;
+  const staleReviewBotRemediation = shouldUseStaleReviewRemediationDiagnostic(args.staleReviewBotRemediation)
+    ? args.staleReviewBotRemediation
+    : null;
   return {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
     p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
@@ -711,14 +750,26 @@ export function buildCodexConnectorDiagnosticBundle(args: {
       pr: args.pr,
       checks: args.checks,
     }),
-    convergenceSummary: formatCodexConnectorConvergenceDiagnostic({
-      config: args.config,
-      record: args.record,
-      pr: args.pr,
-      reviewThreads: args.reviewThreads,
-    }),
-    operatorDiagnosticSummary: args.staleReviewBotRemediation
-      ? formatStaleReviewResidueOperatorDiagnostic(args.staleReviewBotRemediation)
+    convergenceSummary:
+      staleReviewBotRemediation
+        ? formatStaleReviewMetadataConvergenceDiagnostic({
+          remediation: staleReviewBotRemediation,
+          pr: args.pr,
+        }) ??
+          formatCodexConnectorConvergenceDiagnostic({
+            config: args.config,
+            record: args.record,
+            pr: args.pr,
+            reviewThreads: args.reviewThreads,
+          })
+        : formatCodexConnectorConvergenceDiagnostic({
+          config: args.config,
+          record: args.record,
+          pr: args.pr,
+          reviewThreads: args.reviewThreads,
+        }),
+    operatorDiagnosticSummary: staleReviewBotRemediation
+      ? formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation)
       : formatCodexConnectorOperatorDiagnostic({
         config: args.config,
         record: args.record,


### PR DESCRIPTION
## Summary
- classify proven current-head Codex no-major residue as stale review metadata in status diagnostics
- prevent older configured-bot inline metadata from overriding current-head no-major convergence
- let PR state inference advance when only proven configured-bot residue remains

## Verification
- npm run build
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts src/github/github-review-signals.test.ts src/pull-request-state-policy.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts

Closes #2097