### PR TITLE
Diagnose missing Codex residue verification

### DIFF
--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -517,7 +517,11 @@ export function buildStaleReviewBotRemediation(args: {
       checks: args.checks,
       reviewThreads: args.reviewThreads ?? [],
     });
-  if (args.record.blocked_reason === "manual_review" && !isVerifiedStaleResidueClassification(classification.classification)) {
+  if (
+    args.record.blocked_reason === "manual_review" &&
+    !isVerifiedStaleResidueClassification(classification.classification) &&
+    !classification.missingProbeReason
+  ) {
     return null;
   }
   const codexCurrentHeadReviewState = args.pr

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1823,6 +1823,81 @@ test("explain fails closed for processed Codex must-fix residue without verifica
   );
 });
 
+test("explain names missing verification for manual-review Codex no-major residue", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  const issueNumber = 1702;
+  const prNumber = 1802;
+  const headSha = "12b099926c39c8b7502176339ea34750e6a807a4";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-residue",
+    commentId: "comment-current-head-residue",
+    path: "src/review-state.ts",
+    line: 42,
+    commentBody: "P2: Preserve current-head review metadata convergence.",
+    discussionUrl: "https://example.test/pr/1802#discussion_current_head_residue",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-23T01:09:53Z",
+      observedAt: "2026-05-23T01:14:50Z",
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain HRCore shaped missing verification Codex residue",
+    body: executionReadyBody("Explain the missing verification predicate for current-head Codex residue."),
+    createdAt: "2026-05-23T00:00:00Z",
+    updatedAt: "2026-05-23T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(
+    explanation,
+    /^stale_review_bot_remediation issue=#1702 pr=#1802 reason=stale_review_bot code_ci=green current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 processed_on_current_head=yes classification=unknown_needs_operator codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/1802#discussion_current_head_residue manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note missing_probe_reason=current_head_verification_evidence_missing summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+  );
+  assert.match(
+    explanation,
+    /^stale_review_bot_thread_diagnostics issue=#1702 pr=#1802 current_head_success=yes unresolved_current_threads=1 actionable_must_fix_threads=1 verified_stale_residue_threads=0 missing_verification_evidence_threads=1 repeat_stop_exhausted=no auto_repair_suppressed_reason=missing_verification_probe$/m,
+  );
+  assert.match(
+    explanation,
+    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 latest_configured_bot_review_sha=12b099926c39c8b7502176339ea34750e6a807a4 current_head_review_signal=observed actionable_current_diff_threads=unknown next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m,
+  );
+  assert.doesNotMatch(explanation, /^codex_connector_convergence status=repairing_must_fix /m);
+  assert.doesNotMatch(explanation, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
+});
+
 test("explain distinguishes Codex verified current-head repair residue from no-source-change residue", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1778,7 +1778,7 @@ test("status --why names missing verification for manual-review Codex no-major r
     status,
     /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 latest_configured_bot_review_sha=12b099926c39c8b7502176339ea34750e6a807a4 current_head_review_signal=observed actionable_current_diff_threads=unknown next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m,
   );
-  assert.doesNotMatch(status, /^codex_connector_convergence status=repairing_must_fix /m);
+  assert.doesNotMatch(status, /^codex_connector_convergence\b/m);
   assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
 });
 

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1704,6 +1704,84 @@ test("status --why uses the shared stale review-bot presenter for active verifie
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });
 
+test("status --why names missing verification for manual-review Codex no-major residue", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  const issueNumber = 1701;
+  const prNumber = 1801;
+  const headSha = "12b099926c39c8b7502176339ea34750e6a807a4";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-residue",
+    commentId: "comment-current-head-residue",
+    path: "src/review-state.ts",
+    line: 42,
+    commentBody: "P1: Preserve current-head review metadata convergence.",
+    discussionUrl: "https://example.test/pr/1801#discussion_current_head_residue",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-23T01:09:53Z",
+      observedAt: "2026-05-23T01:14:50Z",
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "HRCore shaped missing verification Codex residue",
+    body: executionReadyBody("Surface the missing verification predicate for current-head Codex residue."),
+    createdAt: "2026-05-23T00:00:00Z",
+    updatedAt: "2026-05-23T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(status, /^no_active_tracked_record issue=#1701 classification=stale_review_bot_remediation state=blocked reason=unknown_needs_operator$/m);
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#1701 pr=#1801 reason=stale_review_bot code_ci=green current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 processed_on_current_head=yes classification=unknown_needs_operator codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/1801#discussion_current_head_residue manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note missing_probe_reason=current_head_verification_evidence_missing summary=code_or_ci_green_but_review_thread_metadata_unresolved$/m,
+  );
+  assert.match(
+    status,
+    /^stale_review_bot_thread_diagnostics issue=#1701 pr=#1801 current_head_success=yes unresolved_current_threads=1 actionable_must_fix_threads=1 verified_stale_residue_threads=0 missing_verification_evidence_threads=1 repeat_stop_exhausted=no auto_repair_suppressed_reason=missing_verification_probe$/m,
+  );
+  assert.match(
+    status,
+    /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 latest_configured_bot_review_sha=12b099926c39c8b7502176339ea34750e6a807a4 current_head_review_signal=observed actionable_current_diff_threads=unknown next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m,
+  );
+  assert.doesNotMatch(status, /^codex_connector_convergence status=repairing_must_fix /m);
+  assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
+});
+
 test("status --why converges processed current-head Codex no-major review threads from stale manual review", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -725,6 +725,13 @@ function shouldUseStaleReviewRemediationDiagnostic(remediation: StaleReviewBotRe
   );
 }
 
+function shouldSuppressActionableCodexDiagnostics(remediation: StaleReviewBotRemediationDto): boolean {
+  return Boolean(
+    isProvenStaleReviewMetadataClassification(remediation.classification) ||
+      remediation.missingProbeReason,
+  );
+}
+
 export function buildCodexConnectorDiagnosticBundle(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -739,7 +746,7 @@ export function buildCodexConnectorDiagnosticBundle(args: {
     : null;
   const suppressActionableReviewPolicy = Boolean(
     staleReviewBotRemediation &&
-      isProvenStaleReviewMetadataClassification(staleReviewBotRemediation.classification),
+      shouldSuppressActionableCodexDiagnostics(staleReviewBotRemediation),
   );
   const policyBlock = suppressActionableReviewPolicy
     ? null
@@ -763,12 +770,14 @@ export function buildCodexConnectorDiagnosticBundle(args: {
           remediation: staleReviewBotRemediation,
           pr: args.pr,
         }) ??
-          formatCodexConnectorConvergenceDiagnostic({
-            config: args.config,
-            record: args.record,
-            pr: args.pr,
-            reviewThreads: args.reviewThreads,
-          })
+          (staleReviewBotRemediation.missingProbeReason
+            ? null
+            : formatCodexConnectorConvergenceDiagnostic({
+              config: args.config,
+              record: args.record,
+              pr: args.pr,
+              reviewThreads: args.reviewThreads,
+            }))
         : formatCodexConnectorConvergenceDiagnostic({
           config: args.config,
           record: args.record,


### PR DESCRIPTION
## Summary
- surface missing current-head verification evidence for manual-review Codex residue instead of falling back to actionable current diff
- add HRCore-shaped status/explain regressions with processed current-head fingerprints, current-head Codex no-major signal, and green GitHub checks but no local/codex-turn verification artifact
- keep the behavior fail-closed while naming `current_head_verification_evidence_missing`

Refs #2103

## Verification
- `npm ci`
- `npm run build`
- `npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts`
- `npx tsx --test src/post-turn-pull-request.test.ts`
- `npx tsx --test src/review-thread-reporting.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of manual review verification scenarios to better assess missing evidence.

* **Tests**
  * Added test coverage for verification in manual review scenarios.
  * Added test coverage for status diagnostics in review classification.

* **Refactor**
  * Enhanced diagnostic suppression logic for improved review handling accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->