### PR TITLE
Handle outdated Codex threads in residue diagnostics

### DIFF
--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -140,6 +140,116 @@ test("buildStaleReviewBotRemediation fails closed when current-head no-major has
   assert.equal(remediation?.missingProbeReason, null);
 });
 
+test("buildStaleReviewBotRemediation ignores unprocessed outdated Codex threads when probing missing verification", () => {
+  const issueNumber = 1701;
+  const prNumber = 1801;
+  const headSha = "12b099926c39c8b7502176339ea34750e6a807a4";
+  const currentThreadIds = [
+    "PRRT_current_head_residue_one",
+    "PRRT_current_head_residue_two",
+    "PRRT_current_head_residue_three",
+  ];
+  const outdatedThreadIds = [
+    "PRRT_kwDOSfC_1M6EPhQ2",
+    "PRRT_kwDOSfC_1M6EPhQ3",
+    "PRRT_kwDOSfC_1M6EPhQ5",
+  ];
+  const currentThreads = currentThreadIds.map((threadId, index) =>
+    createReviewThread({
+      id: threadId,
+      isOutdated: false,
+      path: "src/review-policy.ts",
+      line: 40 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "P1: current-head Codex residue already processed by the supervisor.",
+            createdAt: "2026-05-22T10:00:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_${threadId}`,
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const outdatedThreads = outdatedThreadIds.map((threadId, index) =>
+    createReviewThread({
+      id: threadId,
+      isOutdated: true,
+      path: "src/review-policy.ts",
+      line: 80 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "P1: earlier-head Codex residue that remains unresolved on GitHub.",
+            createdAt: "2026-05-21T10:00:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_${threadId}`,
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: issueNumber,
+    state: "blocked",
+    pr_number: prNumber,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: currentThreads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: currentThreads.map((thread) => `${thread.id}@${headSha}#comment-${thread.id}`),
+    last_failure_context: {
+      category: "manual",
+      summary: "Current-head Codex residue has no verification artifact.",
+      signature: currentThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
+      command: null,
+      details: currentThreads.map(
+        (thread) =>
+          `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} p_severity=P1 processed_on_current_head=yes`,
+      ),
+      url: `https://example.test/pr/${prNumber}#discussion_current_head_residue`,
+      updated_at: "2026-05-22T10:20:00Z",
+    },
+    codex_connector_review_requested_observed_at: "2026-05-22T10:05:00Z",
+    codex_connector_review_requested_head_sha: headSha,
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-22T10:25:00Z",
+    codexConnectorReviewRequestedAt: "2026-05-22T10:05:00Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-05-22T10:15:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [...currentThreads, ...outdatedThreads],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
 test("buildStaleReviewBotThreadDiagnostics does not report repeat-stop suppression when Codex current-head request is pending", () => {
   const issueNumber = 168;
   const prNumber = 176;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -365,14 +365,15 @@ function classifyCodexMetadataOnly(args: {
     return unresolvedWork;
   }
 
+  const currentConfiguredThreads = configuredThreads.filter((thread) => !thread.isOutdated);
   if (
     manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
     args.record.last_head_sha !== args.pr.headRefOid ||
     !allChecksPassing(args.checks) ||
     hasMergeConflictState(args.pr) ||
-    pendingBotReviewThreads(args.config, args.record, args.pr, configuredThreads).length > 0 ||
-    configuredBotReviewFollowUpState(args.config, args.record, args.pr, configuredThreads) === "eligible" ||
-    !configuredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+    pendingBotReviewThreads(args.config, args.record, args.pr, currentConfiguredThreads).length > 0 ||
+    configuredBotReviewFollowUpState(args.config, args.record, args.pr, currentConfiguredThreads) === "eligible" ||
+    !currentConfiguredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
   ) {
     return unresolvedWork;
   }

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -1869,6 +1869,27 @@ test("explain names missing verification for manual-review Codex no-major residu
     state: "OPEN",
   };
   const pr = createPullRequest(scenario.pullRequestPatch);
+  const outdatedThreads = [
+    "PRRT_kwDOSfC_1M6EPhQ2",
+    "PRRT_kwDOSfC_1M6EPhQ3",
+    "PRRT_kwDOSfC_1M6EPhQ5",
+  ].map((threadId, index) => ({
+    ...scenario.reviewThread,
+    id: threadId,
+    isOutdated: true,
+    path: `src/earlier-review-state-${index}.ts`,
+    line: 80 + index,
+    comments: {
+      nodes: [
+        {
+          ...scenario.reviewThread.comments.nodes[0],
+          id: `comment-outdated-residue-${index}`,
+          body: "P1: Earlier-head Codex residue remains unresolved on GitHub.",
+          url: `https://example.test/pr/1802#discussion_${threadId}`,
+        },
+      ],
+    },
+  }));
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
@@ -1877,7 +1898,7 @@ test("explain names missing verification for manual-review Codex no-major residu
     listCandidateIssues: async () => [trackedIssue],
     resolvePullRequestForBranch: async () => pr,
     getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread, ...outdatedThreads],
   };
 
   const explanation = await supervisor.explain(issueNumber);

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1753,6 +1753,27 @@ test("status --why names missing verification for manual-review Codex no-major r
     state: "OPEN",
   };
   const pr = createPullRequest(scenario.pullRequestPatch);
+  const outdatedThreads = [
+    "PRRT_kwDOSfC_1M6EPhQ2",
+    "PRRT_kwDOSfC_1M6EPhQ3",
+    "PRRT_kwDOSfC_1M6EPhQ5",
+  ].map((threadId, index) => ({
+    ...scenario.reviewThread,
+    id: threadId,
+    isOutdated: true,
+    path: `src/earlier-review-state-${index}.ts`,
+    line: 80 + index,
+    comments: {
+      nodes: [
+        {
+          ...scenario.reviewThread.comments.nodes[0],
+          id: `comment-outdated-residue-${index}`,
+          body: "P1: Earlier-head Codex residue remains unresolved on GitHub.",
+          url: `https://example.test/pr/1801#discussion_${threadId}`,
+        },
+      ],
+    },
+  }));
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
@@ -1760,7 +1781,7 @@ test("status --why names missing verification for manual-review Codex no-major r
     listAllIssues: async () => [trackedIssue],
     getPullRequestIfExists: async () => pr,
     getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread, ...outdatedThreads],
   };
 
   const status = await supervisor.status({ why: true });


### PR DESCRIPTION
## Summary
- exclude outdated configured-bot Codex threads from the current-head residue processed/pending proof gate
- add mixed current-head-plus-outdated regression coverage for stale remediation, status --why, and explain

## Verification
- npm ci
- npm run build
- npm run verify:paths
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts
- npx tsx --test src/review-thread-reporting.test.ts

Closes #2105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remediation classification to properly exclude outdated code review threads, ensuring verification probe reasons are correctly identified when outdated and current-head threads coexist.

* **Tests**
  * Added test coverage verifying correct remediation classification and probe reason identification when outdated threads are present alongside current threads.
  * Enhanced existing tests to exercise diagnostic behavior with mixed current and outdated review threads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->