### PR TITLE
Post tracked PR status for handoff-missing blockers

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -62,8 +62,10 @@ import { projectTrackedPrLifecycle } from "./tracked-pr-lifecycle-projection";
 import { hasFreshTrackedPrReadyPromotionBlockerEvidence } from "./tracked-pr-ready-promotion-blocker";
 import { queuedReadyPromotionPathHygieneRepairContext } from "./ready-promotion-path-hygiene-repair";
 import { clearRequirementsBlockerIssueComment } from "./requirements-blocker-issue-comment";
+import { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 import {
   configuredBotReviewThreads,
+  manualReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
 } from "./review-thread-reporting";
 
@@ -81,7 +83,9 @@ type RecoveryGitHubLike = Pick<
   | "getMergedPullRequestsClosingIssue"
   | "getPullRequestIfExists"
   | "getUnresolvedReviewThreads"
-> & Partial<Pick<import("./github").GitHubClient, "getIssueComments" | "updateIssueComment">>;
+> & Partial<
+  Pick<import("./github").GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">
+>;
 
 async function fetchOriginDefaultBranch(
   config: Pick<SupervisorConfig, "repoPath" | "defaultBranch" | "codexExecTimeoutMinutes">,
@@ -779,7 +783,7 @@ function hasOnlyOutdatedConfiguredBotResidue(
 
 export async function reconcileRecoverableBlockedIssueStates(
   github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">
-    & Partial<Pick<RecoveryGitHubLike, "getIssueComments" | "updateIssueComment">>,
+    & Partial<Pick<RecoveryGitHubLike, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">>,
   stateStore: StateStoreLike,
   state: SupervisorStateFile,
   config: SupervisorConfig,
@@ -1030,6 +1034,25 @@ export async function reconcileRecoverableBlockedIssueStates(
         isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch) &&
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
       if (!externalProgressEvidence && !sameHeadReviewRequestRecovery && !sameHeadOutdatedConfiguredBotResidueRecovery) {
+        const failureContext = inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads);
+        const updated = await syncTrackedPrPersistentStatusComment({
+          github,
+          stateStore,
+          state,
+          record,
+          pr: trackedPullRequest,
+          checks,
+          reviewThreads,
+          syncJournal: async () => undefined,
+          config,
+          failureContext,
+          summarizeChecks,
+          manualReviewThreadCount: manualReviewThreads(config, reviewThreads).length,
+          skipAutoHandleStaleConfiguredBotReview: true,
+        });
+        if (updated !== record) {
+          state.issues[String(updated.issue_number)] = updated;
+        }
         continue;
       }
 

--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -236,3 +236,106 @@ test("syncTrackedPrPersistentStatusComment publishes handoff-missing operator re
   assert.equal(repeated, updated);
   assert.equal(saveCalls, 1);
 });
+
+test("syncTrackedPrPersistentStatusComment keeps handoff-missing signature stable without live failure context", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    number: 182,
+    headRefOid: "head-182",
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const blockerSignature = "codex_connector_operator_diagnostic:actionable_current_diff";
+  const record = createRecord({
+    issue_number: 173,
+    state: "blocked",
+    pr_number: pr.number,
+    blocked_reason: "handoff_missing",
+    last_head_sha: pr.headRefOid,
+    last_failure_context: {
+      category: "review",
+      summary:
+        "Code and test evidence appears to cover the current-head finding, but unresolved review-thread metadata still requires explicit operator routing.",
+      signature: blockerSignature,
+      command: null,
+      details: [
+        "interpretation=actionable_current_diff actionable_current_diff_threads=2",
+        "next_action=repair_must_fix_findings",
+      ],
+      url: "https://example.test/pr/182",
+      updated_at: "2026-05-23T00:00:30Z",
+    },
+    last_failure_signature: blockerSignature,
+  });
+  const state = createSupervisorState({
+    issues: [record],
+  });
+  const addBodies: string[] = [];
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-05-23T00:01:00Z",
+      };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      assert.equal(nextState.issues[String(record.issue_number)]?.issue_number, record.issue_number);
+      saveCalls += 1;
+    },
+  };
+
+  const updated = await syncTrackedPrPersistentStatusComment({
+    github: {
+      addIssueComment: async (issueNumber: number, body: string) => {
+        assert.equal(issueNumber, pr.number);
+        addBodies.push(body);
+      },
+    },
+    stateStore,
+    state,
+    record,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+    syncJournal: async () => undefined,
+    config,
+    failureContext: null,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    manualReviewThreadCount: 0,
+  });
+
+  assert.equal(addBodies.length, 1);
+  assert.match(addBodies[0] ?? "", /reason code: `handoff_missing`/);
+  assert.match(addBodies[0] ?? "", /unresolved review-thread metadata still requires explicit operator routing/);
+  assert.match(addBodies[0] ?? "", /actionable_current_diff_threads=2/);
+  assert.equal(updated.last_host_local_pr_blocker_comment_head_sha, pr.headRefOid);
+  assert.equal(updated.last_host_local_pr_blocker_comment_signature, blockerSignature);
+  assert.equal(saveCalls, 1);
+
+  const repeated = await syncTrackedPrPersistentStatusComment({
+    github: {
+      addIssueComment: async () => {
+        throw new Error("unexpected duplicate tracked PR status comment");
+      },
+    },
+    stateStore,
+    state,
+    record: updated,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+    syncJournal: async () => undefined,
+    config,
+    failureContext: null,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    manualReviewThreadCount: 0,
+  });
+
+  assert.equal(repeated, updated);
+  assert.equal(saveCalls, 1);
+});

--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -5,8 +5,11 @@ import {
   buildTrackedPrStatusCommentMarker,
   parseTrackedPrStatusCommentMarker,
   selectOwnedTrackedPrStatusComment,
+  syncTrackedPrPersistentStatusComment,
   workspacePreparationRemediationTarget,
 } from "./tracked-pr-status-comment";
+import { createConfig, createPullRequest, createRecord, createSupervisorState } from "./supervisor/supervisor-test-helpers";
+import { IssueRunRecord, SupervisorStateFile } from "./core/types";
 
 test("buildTrackedPrStatusCommentMarker renders the stable sticky tracked PR marker", () => {
   assert.equal(
@@ -113,4 +116,123 @@ test("workspacePreparationRemediationTarget keeps generic preparation failures o
   assert.equal(workspacePreparationRemediationTarget("workspace_toolchain_missing"), "workspace_environment");
   assert.equal(workspacePreparationRemediationTarget("missing_command"), "config_contract");
   assert.equal(workspacePreparationRemediationTarget("worktree_helper_missing"), "config_contract");
+});
+
+test("syncTrackedPrPersistentStatusComment publishes handoff-missing operator review routing diagnostics once per head and signature", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    number: 182,
+    headRefOid: "head-182",
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const record = createRecord({
+    issue_number: 173,
+    state: "blocked",
+    pr_number: pr.number,
+    blocked_reason: "handoff_missing",
+    last_head_sha: pr.headRefOid,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Codex started a turn but did not write a durable handoff.",
+      signature: "handoff-missing",
+      command: null,
+      details: ["durable_progress_evidence=journal_unchanged"],
+      url: null,
+      updated_at: "2026-05-23T00:00:00Z",
+    },
+    last_failure_signature: "handoff-missing",
+  });
+  const state = createSupervisorState({
+    issues: [record],
+  });
+  const addBodies: string[] = [];
+  let saveCalls = 0;
+  const touched: Partial<IssueRunRecord>[] = [];
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      touched.push(patch);
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-05-23T00:01:00Z",
+      };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      assert.equal(nextState.issues[String(record.issue_number)]?.issue_number, record.issue_number);
+      saveCalls += 1;
+    },
+  };
+  const failureContext = {
+    category: "review" as const,
+    summary:
+      "Code and test evidence appears to cover the current-head finding, but unresolved review-thread metadata still requires explicit operator routing.",
+    signature: "codex_connector_operator_diagnostic:actionable_current_diff",
+    command: null,
+    details: [
+      "interpretation=actionable_current_diff actionable_current_diff_threads=2",
+      "next_action=repair_must_fix_findings",
+    ],
+    url: "https://example.test/pr/182",
+    updated_at: "2026-05-23T00:00:30Z",
+  };
+
+  const updated = await syncTrackedPrPersistentStatusComment({
+    github: {
+      addIssueComment: async (issueNumber: number, body: string) => {
+        assert.equal(issueNumber, pr.number);
+        addBodies.push(body);
+      },
+    },
+    stateStore,
+    state,
+    record,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+    syncJournal: async () => undefined,
+    config,
+    failureContext,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    manualReviewThreadCount: 0,
+  });
+
+  assert.equal(addBodies.length, 1);
+  assert.match(addBodies[0] ?? "", /reason code: `handoff_missing`/);
+  assert.match(addBodies[0] ?? "", /operator review routing/);
+  assert.match(addBodies[0] ?? "", /actionable_current_diff_threads=2/);
+  assert.match(addBodies[0] ?? "", /next_action=repair_must_fix_findings/);
+  assert.match(
+    addBodies[0] ?? "",
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=173 pr=182 kind=status -->/,
+  );
+  assert.equal(updated.last_host_local_pr_blocker_comment_head_sha, pr.headRefOid);
+  assert.equal(updated.last_host_local_pr_blocker_comment_signature, failureContext.signature);
+  assert.equal(saveCalls, 1);
+  assert.equal(touched.length, 1);
+
+  const repeated = await syncTrackedPrPersistentStatusComment({
+    github: {
+      addIssueComment: async () => {
+        throw new Error("unexpected duplicate tracked PR status comment");
+      },
+    },
+    stateStore,
+    state,
+    record: updated,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+    syncJournal: async () => undefined,
+    config,
+    failureContext,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    manualReviewThreadCount: 0,
+  });
+
+  assert.equal(repeated, updated);
+  assert.equal(saveCalls, 1);
 });

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -44,6 +44,7 @@ export type HostLocalTrackedPrBlockerGateType =
 
 const TRACKED_PR_STATUS_COMMENT_MARKER_PREFIX = "codex-supervisor:tracked-pr-status-comment";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED = "draft_review_provider_suppressed";
+const TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING = "handoff_missing";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW = "manual_review";
 export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_STALE_REVIEW_BOT = "stale_review_bot";
 const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "required_check_mismatch";
@@ -467,6 +468,30 @@ function derivePersistentTrackedPrStatusComment(args: {
   const checkSummary = args.summarizeChecks(args.checks);
   if (checkSummary.hasPending || checkSummary.hasFailing) {
     return null;
+  }
+
+  if (args.record.state === "blocked" && args.record.blocked_reason === "handoff_missing") {
+    const evidence = compactEvidenceLines(
+      [
+        ...(args.failureContext?.details ?? []),
+        ...(args.record.last_failure_context?.details ?? []),
+      ],
+      5,
+    );
+    return {
+      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING,
+      body: buildTrackedPrPersistentStatusComment({
+        pr: args.pr,
+        reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING,
+        summary:
+          args.failureContext?.summary ??
+          "Codex exited without a durable handoff, and fresh tracked PR facts still require operator review routing.",
+        evidence,
+        nextAction:
+          "Complete explicit operator review routing for the unresolved review-thread or configured-bot diagnostic, then rerun the supervisor.",
+        automaticRetry: "no",
+      }),
+    };
   }
 
   if (args.record.state === "blocked" && args.record.blocked_reason === "manual_review") {

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -471,6 +471,15 @@ function derivePersistentTrackedPrStatusComment(args: {
   }
 
   if (args.record.state === "blocked" && args.record.blocked_reason === "handoff_missing") {
+    const blockerSignature =
+      args.failureContext?.signature ??
+      args.record.last_failure_context?.signature ??
+      args.record.last_failure_signature ??
+      TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING;
+    const summary =
+      args.failureContext?.summary ??
+      args.record.last_failure_context?.summary ??
+      "Codex exited without a durable handoff, and fresh tracked PR facts still require operator review routing.";
     const evidence = compactEvidenceLines(
       [
         ...(args.failureContext?.details ?? []),
@@ -479,13 +488,11 @@ function derivePersistentTrackedPrStatusComment(args: {
       5,
     );
     return {
-      blockerSignature: args.failureContext?.signature ?? TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING,
+      blockerSignature,
       body: buildTrackedPrPersistentStatusComment({
         pr: args.pr,
         reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING,
-        summary:
-          args.failureContext?.summary ??
-          "Codex exited without a durable handoff, and fresh tracked PR facts still require operator review routing.",
+        summary,
         evidence,
         nextAction:
           "Complete explicit operator review routing for the unresolved review-thread or configured-bot diagnostic, then rerun the supervisor.",


### PR DESCRIPTION
## Summary
- publish sticky tracked-PR status comments for blocked handoff_missing records when fresh PR facts expose operator review-routing diagnostics
- reuse existing tracked-PR status comment dedupe by PR head and blocker signature
- wire blocked tracked-PR recovery reconciliation to publish the explanation without changing merge/runnable/thread-resolution behavior

## Verification
- npm ci
- npm run build
- npx tsx --test src/tracked-pr-status-comment.test.ts
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts

Refs #2116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PR blocker state reconciliation with enhanced handling for missing handoff cases, including detailed diagnostic information and operator review routing guidance displayed in PR status comments.

* **Tests**
  * Added test coverage for missing handoff status comment synchronization, validating diagnostic publication accuracy and preventing duplicate comment creation across PR updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->