### PR TITLE
Constrain handoff-missing PR status comments

### DIFF
--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1560,6 +1560,7 @@ test("reconcileRecoverableBlockedIssueStates keeps tracked handoff-missing block
     mergeable: "MERGEABLE",
   });
   let saveCalls = 0;
+  const addBodies: string[] = [];
 
   const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
     {
@@ -1569,6 +1570,9 @@ test("reconcileRecoverableBlockedIssueStates keeps tracked handoff-missing block
       },
       getChecks: async () => [],
       getUnresolvedReviewThreads: async () => [],
+      addIssueComment: async (_issueNumber: number, body: string) => {
+        addBodies.push(body);
+      },
     },
     {
       touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
@@ -1597,6 +1601,7 @@ test("reconcileRecoverableBlockedIssueStates keeps tracked handoff-missing block
     },
   );
 
+  assert.deepEqual(addBodies, []);
   assert.equal(saveCalls, 0);
   assert.deepEqual(recoveryEvents, []);
   assert.deepEqual(state.issues["366"], original);

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -452,6 +452,16 @@ function hasPersistentTrackedPrMergeStageSignal(args: {
   );
 }
 
+function hasConcreteHandoffMissingStatusEvidence(context: FailureContext | null | undefined): context is FailureContext {
+  if (!context) {
+    return false;
+  }
+
+  const genericHandoffMissingSignature =
+    context.signature === TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING || context.signature === "handoff-missing";
+  return context.category !== "blocked" || !genericHandoffMissingSignature;
+}
+
 function derivePersistentTrackedPrStatusComment(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -471,20 +481,19 @@ function derivePersistentTrackedPrStatusComment(args: {
   }
 
   if (args.record.state === "blocked" && args.record.blocked_reason === "handoff_missing") {
-    const blockerSignature =
-      args.failureContext?.signature ??
-      args.record.last_failure_context?.signature ??
-      args.record.last_failure_signature ??
-      TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING;
-    const summary =
-      args.failureContext?.summary ??
-      args.record.last_failure_context?.summary ??
-      "Codex exited without a durable handoff, and fresh tracked PR facts still require operator review routing.";
+    const handoffContext = hasConcreteHandoffMissingStatusEvidence(args.failureContext)
+      ? args.failureContext
+      : hasConcreteHandoffMissingStatusEvidence(args.record.last_failure_context)
+      ? args.record.last_failure_context
+      : null;
+    if (!handoffContext) {
+      return null;
+    }
+
+    const summary = handoffContext.summary;
+    const blockerSignature = handoffContext.signature ?? `${TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING}:${summary}`;
     const evidence = compactEvidenceLines(
-      [
-        ...(args.failureContext?.details ?? []),
-        ...(args.record.last_failure_context?.details ?? []),
-      ],
+      handoffContext.details,
       5,
     );
     return {


### PR DESCRIPTION
## Summary
- suppress generic handoff-missing tracked-PR status comments when fresh PR facts expose no concrete operator-facing blocker
- keep handoff-missing comments for fresh or persisted concrete diagnostics
- add reconciliation-boundary regression coverage for the no-evidence path

## Verification
- npm run build
- npx tsx --test src/tracked-pr-status-comment.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts

Fixes #2118