### PR TITLE
Fix ready-promotion path hygiene repair context

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -1329,6 +1329,7 @@ test("buildCodexPrompt includes current structured path hygiene repair context d
   assert.match(prompt, /Structured failure context:/);
   assert.match(prompt, /Command\/source: npm run verify:paths/);
   assert.match(prompt, /backend\/app\/features\/auth\/bridge\.py/);
+  assert.doesNotMatch(prompt, /Treat the failing CI signal as the primary task/);
   assert.doesNotMatch(prompt, /Leave the draft PR alone and wait\./);
 });
 

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -23,6 +23,7 @@ import type {
 } from "../supervisor/agent-runner";
 import { reviewProviderProfileFromConfig, type ReviewProviderProfileSummary } from "../core/review-providers";
 import { buildCodexConnectorMustFixFindingDetails } from "../codex-connector-review-policy";
+import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 
 export interface LocalReviewRepairContext {
   repairIntent?: "same_pr_fix_blocked" | "same_pr_follow_up" | "same_pr_manual_review" | "high_severity_retry" | "unspecified";
@@ -51,7 +52,7 @@ export function shouldUseCompactResumePrompt(state: RunState): boolean {
   return COMPACT_RESUME_PROMPT_STATES.has(state);
 }
 
-function phaseGuidance(state: RunState): string[] {
+function phaseGuidance(state: RunState, failureContext?: FailureContext | null): string[] {
   if (state === "planning" || state === "reproducing") {
     return [
       "- First make the failure reproducible in a focused way before broad implementation changes.",
@@ -91,6 +92,16 @@ function phaseGuidance(state: RunState): string[] {
     return [
       "- A local advisory review is running for the current draft PR.",
       "- Do not change code in this phase unless a later implementation turn is explicitly triggered.",
+    ];
+  }
+
+  if (
+    state === "repairing_ci" &&
+    isWorkstationLocalPathHygieneFailureSignature(failureContext?.signature)
+  ) {
+    return [
+      "- Treat the workstation-local path hygiene blocker as the primary repair task.",
+      "- Use the structured failure context command/source and actionable file details before checking unrelated CI state.",
     ];
   }
 
@@ -740,7 +751,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     `Supervisor state: ${input.state}`,
     "",
     "Current phase guidance:",
-    ...phaseGuidance(input.state),
+    ...phaseGuidance(input.state, input.failureContext),
     ...(verificationPolicy
       ? [
           "",

--- a/src/supervisor/supervisor-failure-context.test.ts
+++ b/src/supervisor/supervisor-failure-context.test.ts
@@ -196,6 +196,42 @@ test("inferFailureContext prefers failing checks over later blockers", () => {
   assert.equal(context?.summary, "PR #44 has failing checks.");
 });
 
+test("inferFailureContext preserves queued ready-promotion path hygiene repair context when checks are green", () => {
+  const config = createConfig();
+  const pr = createPullRequest({ isDraft: true });
+  const record = createRecord({
+    state: "repairing_ci",
+    pr_number: pr.number,
+    last_head_sha: pr.headRefOid,
+    last_failure_signature: "workstation-local-path-hygiene-failed",
+    last_host_local_pr_blocker_comment_head_sha: pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: "workstation-local-path-hygiene-failed",
+    timeline_artifacts: [
+      {
+        type: "path_hygiene_result",
+        gate: "workstation_local_path_hygiene",
+        command: "npm run verify:paths",
+        head_sha: pr.headRefOid,
+        outcome: "repair_queued",
+        remediation_target: "repair_already_queued",
+        next_action: "wait_for_repair_turn",
+        summary:
+          "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: docs/guide.md.",
+        recorded_at: "2026-05-23T12:00:00Z",
+        repair_targets: ["docs/guide.md"],
+      },
+    ],
+  });
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  const context = inferFailureContext(config, record, pr, checks, []);
+
+  assert.equal(context?.signature, "workstation-local-path-hygiene-failed");
+  assert.equal(context?.command, "npm run verify:paths");
+  assert.deepEqual(context?.details, ["Actionable file: docs/guide.md"]);
+  assert.match(context?.summary ?? "", /Ready-promotion path hygiene/);
+});
+
 test("inferFailureContext returns timeout context before review blockers", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/supervisor/supervisor-failure-context.ts
+++ b/src/supervisor/supervisor-failure-context.ts
@@ -27,6 +27,7 @@ import {
   localReviewStallFailureContext,
 } from "../review-handling";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor-reporting";
+import { queuedReadyPromotionPathHygieneRepairContext } from "../ready-promotion-path-hygiene-repair";
 import {
   FailureContext,
   GitHubPullRequest,
@@ -47,6 +48,11 @@ export function inferFailureContext(
     const checksContext = buildChecksFailureContext(pr, checks);
     if (checksContext) {
       return checksContext;
+    }
+
+    const queuedReadyPromotionPathHygieneRepair = queuedReadyPromotionPathHygieneRepairContext(record, pr);
+    if (queuedReadyPromotionPathHygieneRepair) {
+      return queuedReadyPromotionPathHygieneRepair;
     }
 
     const copilotTimeoutContext = buildCopilotReviewTimeoutFailureContext(config, record, pr);

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -215,6 +215,41 @@ test("derivePullRequestLifecycleSnapshot applies review-bot lifecycle patches be
   });
 });
 
+test("derivePullRequestLifecycleSnapshot keeps queued ready-promotion path hygiene context through green-check refresh", () => {
+  const config = createConfig();
+  const pr = createPullRequest({ isDraft: true });
+  const record = createRecord({
+    state: "draft_pr",
+    pr_number: pr.number,
+    last_failure_signature: "workstation-local-path-hygiene-failed",
+    last_host_local_pr_blocker_comment_head_sha: pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: "workstation-local-path-hygiene-failed",
+    timeline_artifacts: [
+      {
+        type: "path_hygiene_result",
+        gate: "workstation_local_path_hygiene",
+        command: "npm run verify:paths",
+        head_sha: pr.headRefOid,
+        outcome: "repair_queued",
+        remediation_target: "repair_already_queued",
+        next_action: "wait_for_repair_turn",
+        summary:
+          "Ready-promotion path hygiene found actionable publishable tracked content; supervisor will retry a repair turn before marking the draft PR ready. Actionable files: docs/guide.md.",
+        recorded_at: "2026-05-23T12:00:00Z",
+        repair_targets: ["docs/guide.md"],
+      },
+    ],
+  });
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  const snapshot = derivePullRequestLifecycleSnapshot(config, record, pr, checks, []);
+
+  assert.equal(snapshot.nextState, "repairing_ci");
+  assert.equal(snapshot.failureContext?.signature, "workstation-local-path-hygiene-failed");
+  assert.equal(snapshot.failureContext?.command, "npm run verify:paths");
+  assert.deepEqual(snapshot.failureContext?.details, ["Actionable file: docs/guide.md"]);
+});
+
 test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci during the short current-head quiet period", () => {
   withStubbedDateNow("2026-03-13T02:04:03Z", () => {
     const config = createConfig({


### PR DESCRIPTION
## Summary
- Preserve queued ready-promotion path hygiene repair context during lifecycle failure-context refresh.
- Switch repairing_ci prompt guidance to path-hygiene repair wording when the active signature is workstation-local path hygiene.
- Add regression coverage for green-CI draft PR path-hygiene repair routing and prompt wording.

Fixes #2115

## Verification
- npx tsx --test src/supervisor/supervisor-failure-context.test.ts src/supervisor/supervisor-lifecycle.test.ts src/codex/codex-prompt.test.ts
- npx tsx --test src/codex/codex-prompt.test.ts src/supervisor/supervisor-failure-context.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/prepared-issue-runner.test.ts src/turn-execution-orchestration.test.ts src/ready-promotion-gate.test.ts src/run-once-turn-execution.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run verify:paths
- npm run build

Note: npm test -- <files> expands the package script's src/**/*.test.ts glob first in this repo, so exact file-scoped verification used npx tsx --test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CI repair workflow with improved path hygiene detection and contextual guidance during repairs
  * Better failure context preservation when transitioning between repair states

* **Tests**
  * Added test coverage for ready-promotion path hygiene repair queuing scenarios
  * Added test validation for failure context persistence across CI repair state transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->