### PR TITLE
Use current-head Codex no-major to clear outdated configured-bot blockers

### DIFF
--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -465,6 +465,99 @@ test("inferStateFromPullRequest advances past proven Codex Connector stale metad
   );
 });
 
+test("inferStateFromPullRequest clears outdated Codex Connector blockers after current-head no-major and green checks", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T00:03:00Z",
+    review_wait_head_sha: "head123",
+  });
+  const pr = createPullRequest({
+    configuredBotCurrentHeadObservedAt: "2026-05-23T00:05:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-05-23T00:04:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-codex",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-codex",
+            body: "P1: This stale inline finding should not block after the current-head no-major signal.",
+            createdAt: "2026-05-23T00:00:00Z",
+            url: "https://example.test/pr/44#discussion_r2123",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "ready_to_merge");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), null);
+});
+
+test("inferStateFromPullRequest keeps outdated Codex Connector blockers when required checks are not green", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T00:03:00Z",
+    review_wait_head_sha: "head123",
+  });
+  const pr = createPullRequest({
+    configuredBotCurrentHeadObservedAt: "2026-05-23T00:05:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-codex",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-codex",
+            body: "P1: This stale inline finding still requires green checks before clearance.",
+            createdAt: "2026-05-23T00:00:00Z",
+            url: "https://example.test/pr/44#discussion_r2123",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const pendingChecks = [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }] as const;
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, [...pendingChecks], reviewThreads), "addressing_review");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, [...pendingChecks], reviewThreads), "manual_review");
+});
+
 test("inferStateFromPullRequest still blocks a journal-only configured-bot thread when the PR is not otherwise green", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -708,6 +708,7 @@ function allowJournalOnlyConfiguredBotThreadException(
 
 function effectiveConfiguredBotReviewThreads(
   config: SupervisorConfig,
+  record: IssueRunRecord,
   pr: GitHubPullRequest,
   checks: PullRequestCheck[],
   reviewThreads: ReviewThread[],
@@ -715,13 +716,36 @@ function effectiveConfiguredBotReviewThreads(
   const unresolvedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads);
   const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, unresolvedConfiguredBotThreads);
   const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(unresolvedConfiguredBotThreads));
+  const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(config, record, pr, checks);
   const effectiveThreads =
     codexConnectorPolicy?.outcome === "nitpick_only" || codexConnectorPolicy?.outcome === "converged"
       ? unresolvedConfiguredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread))
       : unresolvedConfiguredBotThreads;
-  return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, effectiveThreads)
-    ? effectiveThreads.filter((thread) => !isIssueJournalThreadPath(thread))
+  const threadsAfterOutdatedClearance = clearOutdatedCodexConnectorThreads
+    ? effectiveThreads.filter(
+        (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(config, thread),
+      )
     : effectiveThreads;
+  return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, threadsAfterOutdatedClearance)
+    ? threadsAfterOutdatedClearance.filter((thread) => !isIssueJournalThreadPath(thread))
+    : threadsAfterOutdatedClearance;
+}
+
+function codexConnectorOutdatedThreadClearanceAllowed(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+): boolean {
+  return Boolean(
+    configuredReviewProviderKinds(config).includes("codex") &&
+      pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
+      pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
+      pr.configuredBotTopLevelReviewStrength !== "blocking" &&
+      validTimestamp(pr.configuredBotCurrentHeadObservedAt) &&
+      currentHeadObservationSatisfiesActiveWait(record, pr) &&
+      summarizeChecks(checks).allPassing,
+  );
 }
 
 function hasProvenCodexConnectorStaleReviewMetadata(args: {
@@ -930,7 +954,7 @@ export function blockedReasonFromReviewState(
   });
   const unresolvedBotThreads = provenCodexStaleReviewMetadata
     ? []
-    : effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
+    : effectiveConfiguredBotReviewThreads(config, record, pr, checks, reviewThreads);
   const staleBotThreads =
     manualThreads.length === 0 && !provenCodexStaleReviewMetadata
       ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads)
@@ -999,7 +1023,7 @@ export function inferStateFromPullRequest(
   });
   const unresolvedBotThreads = provenCodexStaleReviewMetadata
     ? []
-    : effectiveConfiguredBotReviewThreads(config, pr, checks, reviewThreads);
+    : effectiveConfiguredBotReviewThreads(config, record, pr, checks, reviewThreads);
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);


### PR DESCRIPTION
## Summary
- clear outdated Codex Connector configured-bot threads from the effective blocker set only after an active current-head success-comment signal and green required checks
- keep non-green and non-current-head cases conservative
- add regression coverage for the green clearance and pending-check paths

## Verification
- npx tsx --test src/pull-request-state-policy.test.ts
- npx tsx --test src/codex-connector-review-policy.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-lifecycle.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Closes #2123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pull request state evaluation to recognize when review threads are outdated and conditions allow progression to merge-ready status.

* **Tests**
  * Added test coverage for outdated review thread behavior and state determination under various CI conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->