### PR TITLE
Add Codex Connector auto-merge guard (#2126)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1858,28 +1858,44 @@ test("shipped config profiles declare the intended review bot logins", async () 
 
 test("shipped Codex Connector profile opts into aggressive cleanup and auto-merge only for Codex", async () => {
   const rootDir = path.resolve(__dirname, "..");
-  const codex = JSON.parse(await fs.readFile(path.join(rootDir, "supervisor.config.codex.json"), "utf8")) as {
+  type AggressiveProfileFlags = {
     staleConfiguredBotReviewPolicy?: unknown;
     verifiedNoSourceChangeReviewThreadAutoResolve?: unknown;
     verifiedCurrentHeadRepairReviewThreadAutoResolve?: unknown;
     codexConnectorAutoMergeEnabled?: unknown;
   };
-  const coderabbit = JSON.parse(await fs.readFile(path.join(rootDir, "supervisor.config.coderabbit.json"), "utf8")) as {
-    staleConfiguredBotReviewPolicy?: unknown;
-    verifiedNoSourceChangeReviewThreadAutoResolve?: unknown;
-    verifiedCurrentHeadRepairReviewThreadAutoResolve?: unknown;
-    codexConnectorAutoMergeEnabled?: unknown;
-  };
+  const readProfile = async (relativePath: string): Promise<AggressiveProfileFlags> =>
+    JSON.parse(await fs.readFile(path.join(rootDir, relativePath), "utf8")) as AggressiveProfileFlags;
+  const codex = await readProfile("supervisor.config.codex.json");
 
   assert.equal(codex.staleConfiguredBotReviewPolicy, "reply_and_resolve");
   assert.equal(codex.verifiedNoSourceChangeReviewThreadAutoResolve, true);
   assert.equal(codex.verifiedCurrentHeadRepairReviewThreadAutoResolve, true);
   assert.equal(codex.codexConnectorAutoMergeEnabled, true);
 
-  assert.notEqual(coderabbit.staleConfiguredBotReviewPolicy, "reply_and_resolve");
-  assert.notEqual(coderabbit.verifiedNoSourceChangeReviewThreadAutoResolve, true);
-  assert.notEqual(coderabbit.verifiedCurrentHeadRepairReviewThreadAutoResolve, true);
-  assert.notEqual(coderabbit.codexConnectorAutoMergeEnabled, true);
+  const nonCodexProfiles = [
+    "supervisor.config.example.json",
+    "supervisor.config.copilot.json",
+    "supervisor.config.coderabbit.json",
+    "supervisor.config.typescript-node.json",
+    "supervisor.config.nextjs.json",
+    "supervisor.config.python-cli.json",
+  ];
+  for (const relativePath of nonCodexProfiles) {
+    const profile = await readProfile(relativePath);
+    assert.notEqual(profile.staleConfiguredBotReviewPolicy, "reply_and_resolve", `${relativePath} must not auto-resolve stale bot threads`);
+    assert.notEqual(
+      profile.verifiedNoSourceChangeReviewThreadAutoResolve,
+      true,
+      `${relativePath} must not auto-resolve verified no-source-change threads`,
+    );
+    assert.notEqual(
+      profile.verifiedCurrentHeadRepairReviewThreadAutoResolve,
+      true,
+      `${relativePath} must not auto-resolve verified current-head repair threads`,
+    );
+    assert.notEqual(profile.codexConnectorAutoMergeEnabled, true, `${relativePath} must not enable Codex Connector auto-merge`);
+  }
 });
 
 test("shipped CodeRabbit starter profile uses a fail-fast repoSlug placeholder", async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -152,6 +152,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       "staleConfiguredBotReviewPolicy",
       "verifiedNoSourceChangeReviewThreadAutoResolve",
       "verifiedCurrentHeadRepairReviewThreadAutoResolve",
+      "codexConnectorAutoMergeEnabled",
       "approvedTrackedTopLevelEntries",
     ].map((field) => [field, getConfigFieldPostureMetadata(field)?.tier]),
     [
@@ -162,6 +163,7 @@ test("config field posture metadata classifies setup and automation-expanding fi
       ["staleConfiguredBotReviewPolicy", "dangerous_explicit_opt_in"],
       ["verifiedNoSourceChangeReviewThreadAutoResolve", "dangerous_explicit_opt_in"],
       ["verifiedCurrentHeadRepairReviewThreadAutoResolve", "dangerous_explicit_opt_in"],
+      ["codexConnectorAutoMergeEnabled", "dangerous_explicit_opt_in"],
       ["approvedTrackedTopLevelEntries", "dangerous_explicit_opt_in"],
     ],
   );
@@ -356,6 +358,7 @@ test("loadConfig keeps local review disabled by default while using the opiniona
   assert.equal(config.staleConfiguredBotReviewPolicy, "diagnose_only");
   assert.equal(config.verifiedNoSourceChangeReviewThreadAutoResolve, false);
   assert.equal(config.verifiedCurrentHeadRepairReviewThreadAutoResolve, false);
+  assert.equal(config.codexConnectorAutoMergeEnabled, false);
 });
 
 test("loadConfig keeps release readiness advisory by default", async (t) => {
@@ -1851,6 +1854,32 @@ test("shipped config profiles declare the intended review bot logins", async () 
       `${relativePath} should declare the expected reviewBotLogins`,
     );
   }
+});
+
+test("shipped Codex Connector profile opts into aggressive cleanup and auto-merge only for Codex", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const codex = JSON.parse(await fs.readFile(path.join(rootDir, "supervisor.config.codex.json"), "utf8")) as {
+    staleConfiguredBotReviewPolicy?: unknown;
+    verifiedNoSourceChangeReviewThreadAutoResolve?: unknown;
+    verifiedCurrentHeadRepairReviewThreadAutoResolve?: unknown;
+    codexConnectorAutoMergeEnabled?: unknown;
+  };
+  const coderabbit = JSON.parse(await fs.readFile(path.join(rootDir, "supervisor.config.coderabbit.json"), "utf8")) as {
+    staleConfiguredBotReviewPolicy?: unknown;
+    verifiedNoSourceChangeReviewThreadAutoResolve?: unknown;
+    verifiedCurrentHeadRepairReviewThreadAutoResolve?: unknown;
+    codexConnectorAutoMergeEnabled?: unknown;
+  };
+
+  assert.equal(codex.staleConfiguredBotReviewPolicy, "reply_and_resolve");
+  assert.equal(codex.verifiedNoSourceChangeReviewThreadAutoResolve, true);
+  assert.equal(codex.verifiedCurrentHeadRepairReviewThreadAutoResolve, true);
+  assert.equal(codex.codexConnectorAutoMergeEnabled, true);
+
+  assert.notEqual(coderabbit.staleConfiguredBotReviewPolicy, "reply_and_resolve");
+  assert.notEqual(coderabbit.verifiedNoSourceChangeReviewThreadAutoResolve, true);
+  assert.notEqual(coderabbit.verifiedCurrentHeadRepairReviewThreadAutoResolve, true);
+  assert.notEqual(coderabbit.codexConnectorAutoMergeEnabled, true);
 });
 
 test("shipped CodeRabbit starter profile uses a fail-fast repoSlug placeholder", async () => {

--- a/src/core/config-field-posture.ts
+++ b/src/core/config-field-posture.ts
@@ -122,6 +122,7 @@ const CONFIG_FIELD_POSTURE_METADATA_ENTRIES = [
   dangerousExplicitOptIn("staleConfiguredBotReviewPolicy", "Configured-bot stale-thread reply or resolve behavior."),
   dangerousExplicitOptIn("verifiedNoSourceChangeReviewThreadAutoResolve", "Verified no-source-change review-thread auto-resolution opt-in."),
   dangerousExplicitOptIn("verifiedCurrentHeadRepairReviewThreadAutoResolve", "Verified current-head repair review-thread auto-resolution opt-in."),
+  dangerousExplicitOptIn("codexConnectorAutoMergeEnabled", "Codex Connector final auto-merge opt-in."),
   dangerousExplicitOptIn("approvedTrackedTopLevelEntries", "Approved tracked top-level repository skeleton entries."),
 ] as const;
 

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -655,6 +655,10 @@ export function parseSupervisorConfigDocument(raw: Record<string, unknown>, reso
       VALID_CODEX_CONNECTOR_REVIEW_REQUEST_RETRY_MODES.has(raw.codexConnectorReviewRequestRetryMode as CodexConnectorReviewRequestRetryMode)
         ? (raw.codexConnectorReviewRequestRetryMode as CodexConnectorReviewRequestRetryMode)
         : "plain",
+    codexConnectorAutoMergeEnabled:
+      typeof raw.codexConnectorAutoMergeEnabled === "boolean"
+        ? raw.codexConnectorAutoMergeEnabled
+        : false,
     codexExecTimeoutMinutes:
       typeof raw.codexExecTimeoutMinutes === "number" && raw.codexExecTimeoutMinutes > 0
         ? raw.codexExecTimeoutMinutes

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -218,6 +218,7 @@ export interface SupervisorConfig {
   codexConnectorReviewRequestNoResponseMinutes?: number;
   codexConnectorReviewRequestRetryLimit?: number;
   codexConnectorReviewRequestRetryMode?: CodexConnectorReviewRequestRetryMode;
+  codexConnectorAutoMergeEnabled?: boolean;
   codexExecTimeoutMinutes: number;
   maxCodexAttemptsPerIssue: number;
   maxImplementationAttemptsPerIssue: number;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -223,6 +223,7 @@ export interface IssueRunRecord {
   provider_success_observed_at?: string | null;
   provider_success_head_sha?: string | null;
   merge_readiness_last_evaluated_at?: string | null;
+  last_auto_merge_guard_context?: FailureContext | null;
   copilot_review_requested_observed_at: string | null;
   copilot_review_requested_head_sha: string | null;
   codex_connector_review_requested_observed_at?: string | null;

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -731,6 +731,24 @@ function effectiveConfiguredBotReviewThreads(
     : threadsAfterOutdatedClearance;
 }
 
+export function effectiveConfiguredBotReviewThreadsForState(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  return hasProvenCodexConnectorStaleReviewMetadata({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  })
+    ? []
+    : effectiveConfiguredBotReviewThreads(config, record, pr, checks, reviewThreads);
+}
+
 function codexConnectorOutdatedThreadClearanceAllowed(
   config: SupervisorConfig,
   record: IssueRunRecord,
@@ -952,9 +970,7 @@ export function blockedReasonFromReviewState(
     checks,
     reviewThreads,
   });
-  const unresolvedBotThreads = provenCodexStaleReviewMetadata
-    ? []
-    : effectiveConfiguredBotReviewThreads(config, record, pr, checks, reviewThreads);
+  const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
   const staleBotThreads =
     manualThreads.length === 0 && !provenCodexStaleReviewMetadata
       ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads)
@@ -1021,9 +1037,7 @@ export function inferStateFromPullRequest(
     checks,
     reviewThreads,
   });
-  const unresolvedBotThreads = provenCodexStaleReviewMetadata
-    ? []
-    : effectiveConfiguredBotReviewThreads(config, record, pr, checks, reviewThreads);
+  const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);

--- a/src/pull-request-state.ts
+++ b/src/pull-request-state.ts
@@ -2,6 +2,7 @@ export type { GitHubWaitStep } from "./pull-request-state-policy";
 export {
   blockedReasonFromReviewState,
   buildCopilotReviewTimeoutFailureContext,
+  effectiveConfiguredBotReviewThreadsForState,
   inferGitHubWaitStep,
   inferStateFromPullRequest,
   syncMergeLatencyVisibility,

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -411,6 +411,17 @@ export function buildActiveDetailedStatusLines(
     lines.push(`last_error=${truncate(sanitizeStatusValue(activeRecord.last_error), 300)}`);
   }
 
+  if (activeRecord.last_auto_merge_guard_context) {
+    lines.push(
+      `auto_merge_guard summary=${truncate(sanitizeStatusValue(activeRecord.last_auto_merge_guard_context.summary), 200) ?? "none"}`,
+    );
+    if (activeRecord.last_auto_merge_guard_context.details.length > 0) {
+      lines.push(
+        `auto_merge_guard_details=${truncate(sanitizeStatusValue(activeRecord.last_auto_merge_guard_context.details.join(" | ")), 300) ?? "none"}`,
+      );
+    }
+  }
+
   if (activeRecord.last_runtime_error) {
     lines.push(`last_runtime_error=${truncate(sanitizeStatusValue(activeRecord.last_runtime_error), 300)}`);
     lines.push(`last_runtime_failure_kind=${activeRecord.last_runtime_failure_kind ?? "none"}`);

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -3010,6 +3010,73 @@ Explain should stop reporting stale stale_review_bot blockers after fresh tracke
   assert.doesNotMatch(explanation, /^tracked_pr_mismatch /m);
 });
 
+test("explain surfaces final auto-merge guard evidence", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 174;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "merging",
+        branch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        pr_number: 274,
+        last_head_sha: "head-274",
+        last_auto_merge_guard_context: {
+          category: null,
+          summary: "Final auto-merge guard passed for PR #274.",
+          signature: "auto-merge-ready:head-274",
+          command: null,
+          details: ["head_sha=head-274", "checks=green count=1", "configured_bot_blockers=0"],
+          url: "https://example.test/pr/274",
+          updated_at: "2026-03-13T06:30:00Z",
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const trackedIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Explain final auto-merge guard evidence",
+    body: executionReadyBody("Explain final auto-merge guard evidence."),
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const pr = createPullRequest({
+    number: 274,
+    headRefName: branch,
+    headRefOid: "head-274",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    getIssue: async () => trackedIssue,
+    listAllIssues: async () => [trackedIssue],
+    listCandidateIssues: async () => [trackedIssue],
+    resolvePullRequestForBranch: async () => pr,
+    getPullRequest: async () => pr,
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [],
+    getMergedPullRequestsClosingIssue: async () => [],
+  };
+
+  const explanation = await supervisor.explain(issueNumber);
+
+  assert.match(explanation, /^auto_merge_guard=Final auto-merge guard passed for PR #274\.$/m);
+  assert.match(explanation, /^auto_merge_guard_details=head_sha=head-274 \| checks=green count=1 \| configured_bot_blockers=0$/m);
+});
+
 test("explain reuses normalized change-risk policy for risky ambiguity blockers", async () => {
   const fixture = await createSupervisorFixture();
   const state: SupervisorStateFile = {

--- a/src/supervisor/supervisor-diagnostics-explain.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain.test.ts
@@ -3074,7 +3074,12 @@ test("explain surfaces final auto-merge guard evidence", async () => {
   const explanation = await supervisor.explain(issueNumber);
 
   assert.match(explanation, /^auto_merge_guard=Final auto-merge guard passed for PR #274\.$/m);
-  assert.match(explanation, /^auto_merge_guard_details=head_sha=head-274 \| checks=green count=1 \| configured_bot_blockers=0$/m);
+  const detailsLine = explanation.split("\n").find((line) => line.startsWith("auto_merge_guard_details="));
+  assert.ok(detailsLine);
+  const detailTokens = detailsLine.slice("auto_merge_guard_details=".length).split(" | ");
+  assert.ok(detailTokens.includes("head_sha=head-274"));
+  assert.ok(detailTokens.includes("checks=green count=1"));
+  assert.ok(detailTokens.includes("configured_bot_blockers=0"));
 });
 
 test("explain reuses normalized change-risk policy for risky ambiguity blockers", async () => {

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -23,11 +23,29 @@ Execution order: 1 of 1
 Parallelizable: No`;
 }
 
+function passingChecks(name = "build"): PullRequestCheck[] {
+  return [{ name, state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+}
+
+function withCodexConnectorSuccess(pr: GitHubPullRequest, observedAt = "2026-03-13T06:30:00Z"): GitHubPullRequest {
+  return {
+    ...pr,
+    configuredBotCurrentHeadObservedAt: observedAt,
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: pr.configuredBotTopLevelReviewStrength ?? null,
+    currentHeadCiGreenAt: observedAt,
+    copilotReviewState: "arrived",
+    copilotReviewArrivedAt: observedAt,
+  };
+}
+
 test("post-turn PR transitions promote a clean draft PR into merging", async () => {
   const fixture = await createSupervisorFixture();
   const config = createConfig({
     ...fixture.config,
     codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: ["chatgpt-codex-connector"],
   });
   const issueNumber = 92;
   const branch = branchName(config, issueNumber);
@@ -74,19 +92,24 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
     headRefOid: "head-113",
     mergedAt: null,
   };
-  const readyPr: GitHubPullRequest = {
+  let readyPr: GitHubPullRequest = withCodexConnectorSuccess({
     ...draftPr,
     isDraft: false,
-  };
+  });
   await ensureWorkspace(config, issueNumber, branch);
   const localHeadSha = git(["-C", path.join(fixture.workspaceRoot, `issue-${issueNumber}`), "rev-parse", "HEAD"]);
   state.issues[String(issueNumber)] = {
     ...state.issues[String(issueNumber)]!,
     last_head_sha: localHeadSha,
     local_review_head_sha: localHeadSha,
+    review_wait_started_at: "2026-03-13T06:20:00Z",
+    review_wait_head_sha: localHeadSha,
   };
   draftPr.headRefOid = localHeadSha;
-  readyPr.headRefOid = localHeadSha;
+  readyPr = withCodexConnectorSuccess({
+    ...readyPr,
+    headRefOid: localHeadSha,
+  });
   await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
   await fs.mkdir(path.join(fixture.workspaceRoot, `issue-${issueNumber}`, ".codex-supervisor"), { recursive: true });
   await fs.writeFile(
@@ -98,6 +121,7 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
   let readyCalls = 0;
   let snapshotLoads = 0;
   let autoMergeCalls = 0;
+  const comments: Array<{ issueNumber: number; body: string }> = [];
   const supervisor = new Supervisor(config);
   (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
     prNumber: number,
@@ -105,16 +129,19 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
     assert.equal(prNumber, 113);
     snapshotLoads += 1;
     return snapshotLoads === 1
-      ? { pr: draftPr, checks: [], reviewThreads: [] }
-      : { pr: readyPr, checks: [], reviewThreads: [] };
+      ? { pr: draftPr, checks: passingChecks(), reviewThreads: [] }
+      : { pr: readyPr, checks: passingChecks(), reviewThreads: [] };
   };
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     getPullRequest: async (prNumber: number) => {
       assert.equal(prNumber, 113);
       return readyPr;
     },
-    getChecks: async () => [],
+    getChecks: async () => passingChecks(),
     getUnresolvedReviewThreads: async () => [],
+    addIssueComment: async (issueNumber: number, body: string) => {
+      comments.push({ issueNumber, body });
+    },
     markPullRequestReady: async (prNumber: number) => {
       assert.equal(prNumber, 113);
       readyCalls += 1;
@@ -184,6 +211,9 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
   assert.equal(readyCalls, 1);
   assert.equal(autoMergeCalls, 1);
   assert.equal(snapshotLoads, 3);
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0]?.issueNumber, 113);
+  assert.match(comments[0]?.body ?? "", /Final auto-merge guard passed for head/);
 });
 
 test("handlePostTurnPullRequestTransitions waits for Copilot propagation after marking a draft PR ready", async () => {
@@ -717,6 +747,7 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable ev
   const config = createConfig({
     ...fixture.config,
     codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: ["chatgpt-codex-connector"],
   });
   const issueNumber = 121;
   const state: SupervisorStateFile = {
@@ -728,6 +759,8 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable ev
         last_head_sha: "head-121",
         provider_success_observed_at: "2026-03-13T06:30:00Z",
         provider_success_head_sha: "head-121",
+        review_wait_started_at: "2026-03-13T06:20:00Z",
+        review_wait_head_sha: "head-121",
       }),
     },
   };
@@ -740,7 +773,7 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable ev
     url: `https://example.test/issues/${issueNumber}`,
     state: "OPEN",
   };
-  const pr: GitHubPullRequest = {
+  const pr: GitHubPullRequest = withCodexConnectorSuccess({
     number: 121,
     title: "Missing mergeable evidence",
     url: "https://example.test/pr/121",
@@ -753,7 +786,7 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable ev
     headRefName: "codex/issue-121",
     headRefOid: "head-121",
     mergedAt: null,
-  };
+  });
 
   let autoMergeCalls = 0;
   const supervisor = new Supervisor(config);
@@ -764,7 +797,7 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable ev
     },
     getChecks: async (prNumber: number) => {
       assert.equal(prNumber, 121);
-      return [];
+      return passingChecks();
     },
     getUnresolvedReviewThreads: async (prNumber: number) => {
       assert.equal(prNumber, 121);
@@ -790,6 +823,275 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable ev
   assert.equal(result.state, "blocked");
   assert.equal(result.blocked_reason, "verification");
   assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-121:mergeable=UNKNOWN");
+  assert.equal(autoMergeCalls, 0);
+});
+
+test("handlePostTurnMergeAndCompletion blocks auto-merge when required check evidence is missing", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const issueNumber = 122;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-122",
+        provider_success_observed_at: "2026-03-13T06:30:00Z",
+        provider_success_head_sha: "head-122",
+        review_wait_started_at: "2026-03-13T06:20:00Z",
+        review_wait_head_sha: "head-122",
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Require final check surface",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr = withCodexConnectorSuccess({
+    number: 122,
+    title: "Missing required checks",
+    url: "https://example.test/pr/122",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-122",
+    headRefOid: "head-122",
+    mergedAt: null,
+  });
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 122);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 122);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 122);
+      return [];
+    },
+    enableAutoMerge: async () => {
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "verification");
+  assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-122:required_checks_missing");
+  assert.equal(autoMergeCalls, 0);
+});
+
+test("handlePostTurnMergeAndCompletion uses effective Codex thread blockers at the final guard", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const issueNumber = 124;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-124",
+        review_wait_started_at: "2026-03-13T06:20:00Z",
+        review_wait_head_sha: "head-124",
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Honor effective Codex blockers",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr = withCodexConnectorSuccess({
+    number: 124,
+    title: "Nitpick-only Codex thread is non-blocking",
+    url: "https://example.test/pr/124",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-124",
+    headRefOid: "head-124",
+    mergedAt: null,
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+  });
+  const nitpickCodexThread: ReviewThread = {
+    id: "thread-nitpick-codex",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-nitpick-codex",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-13T06:22:00Z",
+          url: "https://example.test/pr/124#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 124);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 124);
+      return passingChecks();
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 124);
+      return [nitpickCodexThread];
+    },
+    enableAutoMerge: async (prNumber: number, headSha: string) => {
+      assert.equal(prNumber, 124);
+      assert.equal(headSha, "head-124");
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "merging");
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("configured_bot_blockers=0"), true);
+  assert.equal(autoMergeCalls, 1);
+});
+
+test("handlePostTurnMergeAndCompletion blocks Codex auto-merge without current-head Codex success", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: [],
+  });
+  const issueNumber = 123;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-123",
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Require current-head Codex success",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 123,
+    title: "Missing Codex success",
+    url: "https://example.test/pr/123",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-123",
+    headRefOid: "head-123",
+    mergedAt: null,
+  };
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 123);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 123);
+      return passingChecks();
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 123);
+      return [];
+    },
+    enableAutoMerge: async () => {
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "verification");
+  assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-123:missing_current_head_codex_no_major");
   assert.equal(autoMergeCalls, 0);
 });
 

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -25,8 +25,12 @@ Parallelizable: No`;
 
 test("post-turn PR transitions promote a clean draft PR into merging", async () => {
   const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+  });
   const issueNumber = 92;
-  const branch = branchName(fixture.config, issueNumber);
+  const branch = branchName(config, issueNumber);
   const state: SupervisorStateFile = {
     activeIssueNumber: issueNumber,
     issues: {
@@ -74,7 +78,7 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
     ...draftPr,
     isDraft: false,
   };
-  await ensureWorkspace(fixture.config, issueNumber, branch);
+  await ensureWorkspace(config, issueNumber, branch);
   const localHeadSha = git(["-C", path.join(fixture.workspaceRoot, `issue-${issueNumber}`), "rev-parse", "HEAD"]);
   state.issues[String(issueNumber)] = {
     ...state.issues[String(issueNumber)]!,
@@ -94,7 +98,7 @@ test("post-turn PR transitions promote a clean draft PR into merging", async () 
   let readyCalls = 0;
   let snapshotLoads = 0;
   let autoMergeCalls = 0;
-  const supervisor = new Supervisor(fixture.config);
+  const supervisor = new Supervisor(config);
   (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
     prNumber: number,
   ) => {
@@ -628,6 +632,164 @@ test("handlePostTurnMergeAndCompletion reverts to stabilizing when the refreshed
   assert.equal(result.state, "stabilizing");
   assert.equal(result.last_head_sha, "head-fresh-117");
   assert.equal(getPullRequestCalls, 1);
+  assert.equal(autoMergeCalls, 0);
+});
+
+test("handlePostTurnMergeAndCompletion leaves ready PRs unmerged without auto-merge opt-in", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 120;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-120",
+        provider_success_observed_at: "2026-03-13T06:30:00Z",
+        provider_success_head_sha: "head-120",
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Require explicit auto-merge opt-in",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 120,
+    title: "Ready but not auto-merge enabled",
+    url: "https://example.test/pr/120",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-120",
+    headRefOid: "head-120",
+    mergedAt: null,
+  };
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 120);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 120);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 120);
+      return [];
+    },
+    enableAutoMerge: async () => {
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "ready_to_merge");
+  assert.equal(result.last_head_sha, "head-120");
+  assert.equal(result.blocked_reason, null);
+  assert.equal(autoMergeCalls, 0);
+});
+
+test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable evidence is missing", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+  });
+  const issueNumber = 121;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-121",
+        provider_success_observed_at: "2026-03-13T06:30:00Z",
+        provider_success_head_sha: "head-121",
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Require final mergeable evidence",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 121,
+    title: "Missing mergeable evidence",
+    url: "https://example.test/pr/121",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "UNKNOWN",
+    headRefName: "codex/issue-121",
+    headRefOid: "head-121",
+    mergedAt: null,
+  };
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 121);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 121);
+      return [];
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 121);
+      return [];
+    },
+    enableAutoMerge: async () => {
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "verification");
+  assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-121:mergeable=UNKNOWN");
   assert.equal(autoMergeCalls, 0);
 });
 

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -1015,6 +1015,90 @@ test("handlePostTurnMergeAndCompletion uses effective Codex thread blockers at t
   assert.equal(autoMergeCalls, 1);
 });
 
+test("handlePostTurnMergeAndCompletion blocks Codex auto-merge on aggregate human review decisions", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const issueNumber = 125;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-125",
+        review_wait_started_at: "2026-03-13T06:20:00Z",
+        review_wait_head_sha: "head-125",
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Do not auto-merge aggregate human review blocks",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr = withCodexConnectorSuccess({
+    number: 125,
+    title: "Aggregate review decision remains blocking",
+    url: "https://example.test/pr/125",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-125",
+    headRefOid: "head-125",
+    mergedAt: null,
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+  });
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 125);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 125);
+      return passingChecks();
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 125);
+      return [];
+    },
+    enableAutoMerge: async () => {
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "verification");
+  assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-125:human_review_decision=CHANGES_REQUESTED");
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("review_decision=CHANGES_REQUESTED"), true);
+  assert.equal(autoMergeCalls, 0);
+});
+
 test("handlePostTurnMergeAndCompletion blocks Codex auto-merge without current-head Codex success", async () => {
   const fixture = await createSupervisorFixture();
   const config = createConfig({

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -135,6 +135,8 @@ export interface SupervisorExplainDto {
   selectionReason: string | null;
   reasons: string[];
   lastError: string | null;
+  autoMergeGuardSummary?: string | null;
+  autoMergeGuardDetails?: string[] | null;
   failureSummary: string | null;
   preservedPartialWorkSummary: string | null;
   runtimeFailureKind?: IssueRunRecord["last_runtime_failure_kind"] | null;
@@ -619,6 +621,8 @@ export async function buildIssueExplainDto(
     selectionReason,
     reasons,
     lastError: record?.last_error ?? null,
+    autoMergeGuardSummary: record?.last_auto_merge_guard_context?.summary ?? null,
+    autoMergeGuardDetails: record?.last_auto_merge_guard_context?.details ?? null,
     failureSummary: record?.last_failure_context?.summary ?? null,
     preservedPartialWorkSummary: summarizePreservedPartialWork(record?.last_failure_context),
     runtimeFailureKind: record?.last_runtime_failure_kind ?? null,
@@ -710,6 +714,12 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
 
   if (dto.lastError) {
     lines.push(`last_error=${dto.lastError}`);
+  }
+  if (dto.autoMergeGuardSummary) {
+    lines.push(`auto_merge_guard=${dto.autoMergeGuardSummary}`);
+  }
+  if (dto.autoMergeGuardDetails && dto.autoMergeGuardDetails.length > 0) {
+    lines.push(`auto_merge_guard_details=${dto.autoMergeGuardDetails.join(" | ")}`);
   }
   if (dto.failureSummary) {
     lines.push(`failure_summary=${dto.failureSummary}`);

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -665,6 +665,37 @@ test("formatDetailedStatus surfaces configured bot review timeout outcome with g
   );
 });
 
+test("formatDetailedStatus surfaces final auto-merge guard evidence", () => {
+  const status = formatDetailedStatus({
+    config: createConfig(),
+    activeRecord: createRecord({
+      pr_number: 44,
+      state: "merging",
+      last_auto_merge_guard_context: {
+        category: null,
+        summary: "Final auto-merge guard passed for PR #44.",
+        signature: "auto-merge-ready:head-44",
+        command: null,
+        details: ["head_sha=head-44", "checks=green count=1", "configured_bot_blockers=0"],
+        url: "https://example.test/pr/44",
+        updated_at: "2026-03-13T06:30:00Z",
+      },
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr: createPullRequest({
+      number: 44,
+      headRefName: "codex/issue-38",
+      headRefOid: "head-44",
+    }),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [],
+  });
+
+  assert.match(status, /auto_merge_guard summary=Final auto-merge guard passed for PR #44\./);
+  assert.match(status, /auto_merge_guard_details=head_sha=head-44 \| checks=green count=1 \| configured_bot_blockers=0/);
+});
+
 test("formatDetailedStatus explains softened nitpick-only configured-bot top-level reviews", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai[bot]"],

--- a/src/supervisor/supervisor-test-helpers.ts
+++ b/src/supervisor/supervisor-test-helpers.ts
@@ -64,6 +64,7 @@ export function createConfig(overrides: Partial<SupervisorConfig> = {}): Supervi
     pollIntervalSeconds: 60,
     copilotReviewWaitMinutes: 10,
     copilotReviewTimeoutAction: "continue",
+    codexConnectorAutoMergeEnabled: false,
     codexExecTimeoutMinutes: 30,
     maxCodexAttemptsPerIssue: 5,
     maxImplementationAttemptsPerIssue: 5,

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -265,6 +265,11 @@ function finalAutoMergeGuard(args: {
     reviewThreads,
   ).length;
   const effectiveHumanBlockers = config.humanReviewBlocksMerge ? manualReviewThreads(config, reviewThreads).length : 0;
+  const aggregateHumanReviewBlocker =
+    config.humanReviewBlocksMerge &&
+    (currentPr.reviewDecision === "CHANGES_REQUESTED" || currentPr.reviewDecision === "REVIEW_REQUIRED")
+      ? currentPr.reviewDecision
+      : null;
   const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr);
   const localCiResult = record.latest_local_ci_result ?? null;
   const localCiMissing =
@@ -278,6 +283,7 @@ function finalAutoMergeGuard(args: {
     `codex_current_head_no_major=${currentHeadCodexNoMajor ? "yes" : "no"}`,
     `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     `human_blockers=${effectiveHumanBlockers}`,
+    `review_decision=${currentPr.reviewDecision ?? "none"}`,
     hasConfiguredLocalCiCommand(config)
       ? `local_ci=${localCiResult?.outcome ?? "missing"} head_sha=${localCiResult?.head_sha ?? "none"}`
       : "local_ci=not_configured",
@@ -291,6 +297,7 @@ function finalAutoMergeGuard(args: {
     currentHeadCodexNoMajor ? null : "missing_current_head_codex_no_major",
     effectiveConfiguredBotBlockers === 0 ? null : `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     effectiveHumanBlockers === 0 ? null : `human_blockers=${effectiveHumanBlockers}`,
+    aggregateHumanReviewBlocker ? `human_review_decision=${aggregateHumanReviewBlocker}` : null,
     localCiMissing ? "missing_current_head_local_ci_success" : null,
   ].filter((detail): detail is string => detail !== null);
 

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -18,6 +18,7 @@ import {
 } from "../recovery-reconciliation";
 import {
   blockedReasonFromReviewState,
+  effectiveConfiguredBotReviewThreadsForState,
   inferStateFromPullRequest,
   inferGitHubWaitStep,
 } from "../pull-request-state";
@@ -201,6 +202,14 @@ function buildAutoMergeRefusalContext(summary: string, details: string[], pr: Gi
   };
 }
 
+function validTimestamp(value: string | null | undefined): string | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  return Number.isNaN(Date.parse(value)) ? null : value;
+}
+
 function hasConfiguredLocalCiCommand(config: Pick<SupervisorConfig, "localCiCommand">): boolean {
   if (typeof config.localCiCommand === "string") {
     return config.localCiCommand.trim() !== "";
@@ -209,46 +218,119 @@ function hasConfiguredLocalCiCommand(config: Pick<SupervisorConfig, "localCiComm
   return config.localCiCommand !== undefined;
 }
 
-function finalAutoMergeRefusal(args: {
+interface FinalAutoMergeGuardResult {
+  evidence: FailureContext;
+  refusal: FailureContext | null;
+}
+
+function buildAutoMergeEvidenceContext(details: string[], pr: GitHubPullRequest): FailureContext {
+  return {
+    category: null,
+    summary: `Final auto-merge guard passed for PR #${pr.number}.`,
+    signature: `auto-merge-ready:${pr.headRefOid}`,
+    command: null,
+    details,
+    url: pr.url,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function hasCurrentHeadCodexNoMajor(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  return Boolean(
+    record.provider_success_head_sha === pr.headRefOid &&
+      validTimestamp(record.provider_success_observed_at) &&
+      pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
+      pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
+      pr.configuredBotTopLevelReviewStrength !== "blocking" &&
+      validTimestamp(pr.configuredBotCurrentHeadObservedAt),
+  );
+}
+
+function finalAutoMergeGuard(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
   originalPr: GitHubPullRequest;
   currentPr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
-}): FailureContext | null {
+}): FinalAutoMergeGuardResult {
   const { config, record, originalPr, currentPr, checks, reviewThreads } = args;
   const checkSummary = summarizeChecks(checks);
-  const effectiveConfiguredBotBlockers = configuredBotReviewThreads(config, reviewThreads).length;
+  const checksGreen = checks.length > 0 && checkSummary.allPassing;
+  const effectiveConfiguredBotBlockers = effectiveConfiguredBotReviewThreadsForState(
+    config,
+    record,
+    currentPr,
+    checks,
+    reviewThreads,
+  ).length;
   const effectiveHumanBlockers = config.humanReviewBlocksMerge ? manualReviewThreads(config, reviewThreads).length : 0;
-  const requiresCodexProviderSuccess = config.reviewBotLogins.includes("chatgpt-codex-connector");
+  const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr);
   const localCiResult = record.latest_local_ci_result ?? null;
   const localCiMissing =
     hasConfiguredLocalCiCommand(config) &&
     (localCiResult?.outcome !== "passed" || localCiResult?.head_sha !== currentPr.headRefOid);
+  const evidenceDetails = [
+    `head_sha=${currentPr.headRefOid}`,
+    `mergeable=${currentPr.mergeable ?? "unknown"}`,
+    `merge_state=${currentPr.mergeStateStatus ?? "unknown"}`,
+    `checks=green count=${checks.length}`,
+    `codex_current_head_no_major=${currentHeadCodexNoMajor ? "yes" : "no"}`,
+    `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
+    `human_blockers=${effectiveHumanBlockers}`,
+    hasConfiguredLocalCiCommand(config)
+      ? `local_ci=${localCiResult?.outcome ?? "missing"} head_sha=${localCiResult?.head_sha ?? "none"}`
+      : "local_ci=not_configured",
+  ];
 
   const details = [
     originalPr.headRefOid === currentPr.headRefOid ? null : `head_mismatch=${originalPr.headRefOid}->${currentPr.headRefOid}`,
     currentPr.mergeable === "MERGEABLE" ? null : `mergeable=${currentPr.mergeable ?? "unknown"}`,
     currentPr.mergeStateStatus === "CLEAN" ? null : `merge_state=${currentPr.mergeStateStatus ?? "unknown"}`,
-    checkSummary.allPassing ? null : "required_checks_not_green",
-    !requiresCodexProviderSuccess ||
-    (record.provider_success_head_sha === currentPr.headRefOid && record.provider_success_observed_at)
-      ? null
-      : "missing_current_head_configured_provider_success",
+    checks.length === 0 ? "required_checks_missing" : checksGreen ? null : "required_checks_not_green",
+    currentHeadCodexNoMajor ? null : "missing_current_head_codex_no_major",
     effectiveConfiguredBotBlockers === 0 ? null : `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     effectiveHumanBlockers === 0 ? null : `human_blockers=${effectiveHumanBlockers}`,
     localCiMissing ? "missing_current_head_local_ci_success" : null,
   ].filter((detail): detail is string => detail !== null);
 
+  const evidence = buildAutoMergeEvidenceContext(evidenceDetails, currentPr);
+
   if (details.length === 0) {
-    return null;
+    return { evidence, refusal: null };
   }
 
-  return buildAutoMergeRefusalContext(
-    `Final auto-merge guard refused PR #${currentPr.number}.`,
-    details,
-    currentPr,
+  return {
+    evidence,
+    refusal: buildAutoMergeRefusalContext(
+      `Final auto-merge guard refused PR #${currentPr.number}.`,
+      details,
+      currentPr,
+    ),
+  };
+}
+
+async function publishFinalAutoMergeGuardComment(args: {
+  github: GitHubClient;
+  pr: GitHubPullRequest;
+  evidence: FailureContext;
+}): Promise<void> {
+  const github = args.github as unknown as {
+    addIssueComment?: (issueNumber: number, body: string) => Promise<unknown>;
+  };
+  if (!github.addIssueComment) {
+    return;
+  }
+
+  await github.addIssueComment(
+    args.pr.number,
+    [
+      `Final auto-merge guard passed for head \`${args.pr.headRefOid}\`.`,
+      "",
+      ...args.evidence.details.map((detail) => `- ${detail}`),
+      "",
+      "<!-- codex-supervisor:final-auto-merge-guard -->",
+    ].join("\n"),
   );
 }
 
@@ -698,35 +780,44 @@ export class Supervisor {
           ...lifecyclePatch,
           state: "ready_to_merge",
           blocked_reason: null,
+          last_auto_merge_guard_context: null,
           last_head_sha: currentPr.headRefOid,
         });
       } else {
-        const autoMergeRefusal = finalAutoMergeRefusal({
+        const autoMergeGuard = finalAutoMergeGuard({
           config: this.config,
-          record: nextRecord,
+          record: lifecycle.recordForState,
           originalPr: pr,
           currentPr,
           checks: refreshed.checks,
           reviewThreads: refreshed.reviewThreads,
         });
-        if (autoMergeRefusal) {
+        if (autoMergeGuard.refusal) {
           nextRecord = this.stateStore.touch(nextRecord, {
             ...lifecyclePatch,
             state: "blocked",
             blocked_reason: "verification",
-            last_error: truncate(autoMergeRefusal.summary, 1000),
-            last_failure_context: autoMergeRefusal,
-            ...applyFailureSignature(nextRecord, autoMergeRefusal),
+            last_error: truncate(autoMergeGuard.refusal.summary, 1000),
+            last_failure_context: autoMergeGuard.refusal,
+            last_auto_merge_guard_context: autoMergeGuard.evidence,
+            ...applyFailureSignature(nextRecord, autoMergeGuard.refusal),
             last_head_sha: currentPr.headRefOid,
           });
         } else {
-        await this.github.enableAutoMerge(currentPr.number, currentPr.headRefOid);
-        nextRecord = this.stateStore.touch(nextRecord, {
-          ...lifecyclePatch,
-          state: "merging",
-          blocked_reason: null,
-          last_head_sha: currentPr.headRefOid,
-        });
+          await publishFinalAutoMergeGuardComment({
+            github: this.github,
+            pr: currentPr,
+            evidence: autoMergeGuard.evidence,
+          });
+          await this.github.enableAutoMerge(currentPr.number, currentPr.headRefOid);
+          nextRecord = this.stateStore.touch(nextRecord, {
+            ...lifecyclePatch,
+            state: "merging",
+            blocked_reason: null,
+            last_failure_context: null,
+            last_auto_merge_guard_context: autoMergeGuard.evidence,
+            last_head_sha: currentPr.headRefOid,
+          });
         }
       }
       state.issues[String(nextRecord.issue_number)] = nextRecord;

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -189,6 +189,69 @@ interface CachedFullIssueInventory {
   fetchedAtMs: number;
 }
 
+function buildAutoMergeRefusalContext(summary: string, details: string[], pr: GitHubPullRequest): FailureContext {
+  return {
+    category: "blocked",
+    summary,
+    signature: `auto-merge-refused:${pr.headRefOid}:${details.join("|")}`,
+    command: null,
+    details,
+    url: pr.url,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function hasConfiguredLocalCiCommand(config: Pick<SupervisorConfig, "localCiCommand">): boolean {
+  if (typeof config.localCiCommand === "string") {
+    return config.localCiCommand.trim() !== "";
+  }
+
+  return config.localCiCommand !== undefined;
+}
+
+function finalAutoMergeRefusal(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  originalPr: GitHubPullRequest;
+  currentPr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): FailureContext | null {
+  const { config, record, originalPr, currentPr, checks, reviewThreads } = args;
+  const checkSummary = summarizeChecks(checks);
+  const effectiveConfiguredBotBlockers = configuredBotReviewThreads(config, reviewThreads).length;
+  const effectiveHumanBlockers = config.humanReviewBlocksMerge ? manualReviewThreads(config, reviewThreads).length : 0;
+  const requiresCodexProviderSuccess = config.reviewBotLogins.includes("chatgpt-codex-connector");
+  const localCiResult = record.latest_local_ci_result ?? null;
+  const localCiMissing =
+    hasConfiguredLocalCiCommand(config) &&
+    (localCiResult?.outcome !== "passed" || localCiResult?.head_sha !== currentPr.headRefOid);
+
+  const details = [
+    originalPr.headRefOid === currentPr.headRefOid ? null : `head_mismatch=${originalPr.headRefOid}->${currentPr.headRefOid}`,
+    currentPr.mergeable === "MERGEABLE" ? null : `mergeable=${currentPr.mergeable ?? "unknown"}`,
+    currentPr.mergeStateStatus === "CLEAN" ? null : `merge_state=${currentPr.mergeStateStatus ?? "unknown"}`,
+    checkSummary.allPassing ? null : "required_checks_not_green",
+    !requiresCodexProviderSuccess ||
+    (record.provider_success_head_sha === currentPr.headRefOid && record.provider_success_observed_at)
+      ? null
+      : "missing_current_head_configured_provider_success",
+    effectiveConfiguredBotBlockers === 0 ? null : `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
+    effectiveHumanBlockers === 0 ? null : `human_blockers=${effectiveHumanBlockers}`,
+    localCiMissing ? "missing_current_head_local_ci_success" : null,
+  ].filter((detail): detail is string => detail !== null);
+
+  if (details.length === 0) {
+    return null;
+  }
+
+  return buildAutoMergeRefusalContext(
+    `Final auto-merge guard refused PR #${currentPr.number}.`,
+    details,
+    currentPr,
+  );
+}
+
 function interruptedTurnRecoveryIssueNumber(events: RecoveryEvent[]): number | null {
   const event = events.find((candidate) => candidate.reason.startsWith("interrupted_turn_recovery:"));
   return event?.issueNumber ?? null;
@@ -630,7 +693,33 @@ export class Supervisor {
               : null,
           last_head_sha: currentPr.headRefOid,
         });
+      } else if (this.config.codexConnectorAutoMergeEnabled !== true) {
+        nextRecord = this.stateStore.touch(nextRecord, {
+          ...lifecyclePatch,
+          state: "ready_to_merge",
+          blocked_reason: null,
+          last_head_sha: currentPr.headRefOid,
+        });
       } else {
+        const autoMergeRefusal = finalAutoMergeRefusal({
+          config: this.config,
+          record: nextRecord,
+          originalPr: pr,
+          currentPr,
+          checks: refreshed.checks,
+          reviewThreads: refreshed.reviewThreads,
+        });
+        if (autoMergeRefusal) {
+          nextRecord = this.stateStore.touch(nextRecord, {
+            ...lifecyclePatch,
+            state: "blocked",
+            blocked_reason: "verification",
+            last_error: truncate(autoMergeRefusal.summary, 1000),
+            last_failure_context: autoMergeRefusal,
+            ...applyFailureSignature(nextRecord, autoMergeRefusal),
+            last_head_sha: currentPr.headRefOid,
+          });
+        } else {
         await this.github.enableAutoMerge(currentPr.number, currentPr.headRefOid);
         nextRecord = this.stateStore.touch(nextRecord, {
           ...lifecyclePatch,
@@ -638,6 +727,7 @@ export class Supervisor {
           blocked_reason: null,
           last_head_sha: currentPr.headRefOid,
         });
+        }
       }
       state.issues[String(nextRecord.issue_number)] = nextRecord;
     }

--- a/supervisor.config.codex.json
+++ b/supervisor.config.codex.json
@@ -69,6 +69,10 @@
   "reviewBotLogins": [
     "chatgpt-codex-connector"
   ],
+  "staleConfiguredBotReviewPolicy": "reply_and_resolve",
+  "verifiedNoSourceChangeReviewThreadAutoResolve": true,
+  "verifiedCurrentHeadRepairReviewThreadAutoResolve": true,
+  "codexConnectorAutoMergeEnabled": true,
   "humanReviewBlocksMerge": true,
   "issueJournalRelativePath": ".codex-supervisor/issues/{issueNumber}/issue-journal.md",
   "issueJournalMaxChars": 6000,


### PR DESCRIPTION
Closes #2126

## Summary
- Add explicit codexConnectorAutoMergeEnabled opt-in with conservative default
- Enable aggressive Codex Connector cleanup and auto-merge only in supervisor.config.codex.json
- Add final auto-merge refusal guard for mergeable state, head match, checks, review blockers, Codex provider success, and local CI evidence

## Verification
- npx tsx --test src/config.test.ts src/supervisor/supervisor-lifecycle.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-status-report.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build
- npm run verify:paths