### PR TITLE
Update tracked PR comment for manual local review

### DIFF
--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -339,3 +339,109 @@ test("syncTrackedPrPersistentStatusComment keeps handoff-missing signature stabl
   assert.equal(repeated, updated);
   assert.equal(saveCalls, 1);
 });
+
+test("syncTrackedPrPersistentStatusComment supersedes draft suppression when current-head local review blocks manually", async () => {
+  const artifactRoot = "runtime-artifacts/local-review";
+  const summaryPath = `${artifactRoot}/owner-repo/issue-173/head-182.md`;
+  const config = createConfig({
+    localReviewArtifactDir: artifactRoot,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    number: 182,
+    headRefOid: "head-182",
+    isDraft: true,
+    mergeStateStatus: "UNKNOWN",
+    mergeable: "UNKNOWN",
+  });
+  const record = createRecord({
+    issue_number: 173,
+    state: "blocked",
+    pr_number: pr.number,
+    blocked_reason: "manual_review",
+    last_head_sha: pr.headRefOid,
+    local_review_head_sha: pr.headRefOid,
+    local_review_summary_path: summaryPath,
+    pre_merge_evaluation_outcome: "manual_review_blocked",
+    pre_merge_manual_review_count: 1,
+    last_host_local_pr_blocker_comment_head_sha: pr.headRefOid,
+    last_host_local_pr_blocker_comment_signature: "draft_review_provider_suppressed",
+  });
+  const state = createSupervisorState({
+    issues: [record],
+  });
+  const updateCalls: Array<{ commentId: number; body: string }> = [];
+  let addCalls = 0;
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-05-24T00:01:00Z",
+      };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      assert.equal(nextState.issues[String(record.issue_number)]?.issue_number, record.issue_number);
+      saveCalls += 1;
+    },
+  };
+
+  const updated = await syncTrackedPrPersistentStatusComment({
+    github: {
+      addIssueComment: async () => {
+        addCalls += 1;
+      },
+      getExternalReviewSurface: async () => ({
+        reviews: [],
+        issueComments: [
+          {
+            id: "comment-42",
+            databaseId: 42,
+            body: [
+              "Tracked PR head `head-182` is still draft because provider review is intentionally suppressed.",
+              "",
+              "- reason code: `draft_review_provider_suppressed`",
+              "- automatic retry: yes",
+              "",
+              "<!-- codex-supervisor:tracked-pr-status-comment issue=173 pr=182 kind=status -->",
+            ].join("\n"),
+            createdAt: "2026-05-24T00:00:00Z",
+            url: "https://example.test/comments/42",
+            viewerDidAuthor: true,
+            author: null,
+          },
+        ],
+      }),
+      updateIssueComment: async (commentId: number, body: string) => {
+        updateCalls.push({ commentId, body });
+      },
+    },
+    stateStore,
+    state,
+    record,
+    pr,
+    checks: [],
+    reviewThreads: [],
+    syncJournal: async () => undefined,
+    config,
+    failureContext: null,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    manualReviewThreadCount: 0,
+  });
+
+  assert.equal(addCalls, 0);
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0]?.commentId, 42);
+  assert.match(updateCalls[0]?.body ?? "", /reason code: `manual_review`/);
+  assert.match(updateCalls[0]?.body ?? "", /local-review outcome: `manual_review_blocked`/);
+  assert.match(updateCalls[0]?.body ?? "", /local-review summary path: `owner-repo\/issue-173\/head-182\.md`/);
+  assert.match(updateCalls[0]?.body ?? "", /automatic retry: no/);
+  assert.doesNotMatch(updateCalls[0]?.body ?? "", /automatic retry: yes/);
+  assert.equal(updated.last_host_local_pr_blocker_comment_head_sha, pr.headRefOid);
+  assert.equal(
+    updated.last_host_local_pr_blocker_comment_signature,
+    "manual_review:head-182:manual_review_blocked:1:owner-repo/issue-173/head-182.md",
+  );
+  assert.equal(saveCalls, 1);
+});

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -36,6 +36,7 @@ import {
   conversationResolutionEvidenceDetails,
   conversationResolutionEvidenceToken,
 } from "./conversation-resolution-policy";
+import { displayRelativeArtifactPath } from "./supervisor/supervisor-status-summary-helpers";
 
 export type HostLocalTrackedPrBlockerGateType =
   | "workspace_preparation"
@@ -286,6 +287,71 @@ function buildTrackedPrPersistentStatusComment(args: {
   ].join("\n");
 }
 
+function buildTrackedPrManualReviewStatusComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  summary: string;
+  evidence: string[];
+  localReviewOutcome: string | null;
+  localReviewSummaryPath: string | null;
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` is blocked by terminal local review and now requires operator manual review.`,
+    "",
+    `- current head SHA: \`${args.pr.headRefOid}\``,
+    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW}\``,
+    `- local-review outcome: \`${args.localReviewOutcome ?? "unknown"}\``,
+    `- blocker summary: ${args.summary}`,
+    ...(args.localReviewSummaryPath ? [`- local-review summary path: \`${args.localReviewSummaryPath}\``] : []),
+    ...args.evidence.map((detail) => `- evidence: ${detail}`),
+    "- automatic retry: no",
+    "- next action: complete the required operator/manual review, then rerun the supervisor so progress can resume.",
+  ].join("\n");
+}
+
+function currentHeadManualReviewStatusComment(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  failureContext: FailureContext | null;
+}): { blockerSignature: string; body: string } | null {
+  if (args.record.state !== "blocked" || args.record.blocked_reason !== "manual_review") {
+    return null;
+  }
+  if (
+    args.record.pre_merge_evaluation_outcome !== "manual_review_blocked" ||
+    args.record.local_review_head_sha !== args.pr.headRefOid
+  ) {
+    return null;
+  }
+
+  const summary =
+    args.failureContext?.summary ?? "Current-head local review reported manual-review residuals requiring human judgment.";
+  const displayedSummaryPath = args.record.local_review_summary_path
+    ? displayRelativeArtifactPath(args.config, args.record.local_review_summary_path)
+    : null;
+  const localReviewOutcome = args.record.pre_merge_evaluation_outcome;
+  const manualReviewCount = args.record.pre_merge_manual_review_count ?? "unknown";
+  const blockerIdentity = args.failureContext?.signature ?? String(manualReviewCount);
+  const blockerSignature = [
+    TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
+    args.pr.headRefOid,
+    localReviewOutcome,
+    blockerIdentity,
+    displayedSummaryPath ?? "summary=none",
+  ].join(":");
+
+  return {
+    blockerSignature,
+    body: buildTrackedPrManualReviewStatusComment({
+      pr: args.pr,
+      summary,
+      evidence: compactEvidenceLines(args.failureContext?.details),
+      localReviewOutcome,
+      localReviewSummaryPath: displayedSummaryPath,
+    }),
+  };
+}
+
 function isTrackedPrActiveStatusState(state: RunState): boolean {
   switch (state) {
     case "local_review":
@@ -471,6 +537,16 @@ function derivePersistentTrackedPrStatusComment(args: {
   failureContext: FailureContext | null;
   summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
 }): { blockerSignature: string; body: string } | null {
+  const currentHeadManualReviewComment = currentHeadManualReviewStatusComment({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    failureContext: args.failureContext,
+  });
+  if (currentHeadManualReviewComment) {
+    return currentHeadManualReviewComment;
+  }
+
   if (args.pr.isDraft) {
     return null;
   }


### PR DESCRIPTION
## Summary
- publish terminal manual-review tracked PR status before draft-suppression early return
- update the owned sticky comment with current head, local-review outcome, blocker summary, relative summary path, and automatic retry disabled
- add a focused regression for a draft-suppressed sticky comment superseded by current-head manual-review local review

## Verification
- npx tsx --test src/tracked-pr-status-comment.test.ts
- npx tsx --test src/tracked-pr-status-comment.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts
- npx tsx --test src/run-once-turn-execution.test.ts src/recovery-reconciliation.test.ts
- npm run build

Closes #2131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR status comments now properly display manual review blockers with supporting evidence, even when the current PR is in draft status. Manual review requirements are correctly prioritized in comment updates.

* **Tests**
  * Added test coverage for manual review blocking behavior and persistent PR status comment handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->