### PR TITLE
Recover stale Codex Connector residue

### DIFF
--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -294,6 +294,7 @@ function shouldWaitForCopilotReviewPropagation(
     !policy.shouldWaitForRequestPropagation ||
     config.copilotReviewWaitMinutes <= 0 ||
     pr.isDraft ||
+    pr.configuredBotCurrentHeadObservedAt ||
     pr.headRefOid !== record.review_wait_head_sha
   ) {
     return false;
@@ -354,8 +355,12 @@ function currentHeadObservationSatisfiesActiveWait(
 
   const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
   const waitStartedAt = validTimestamp(record.review_wait_started_at);
-  if (!observedAt || !waitStartedAt || record.review_wait_head_sha !== pr.headRefOid) {
+  if (!observedAt) {
     return false;
+  }
+
+  if (!waitStartedAt || record.review_wait_head_sha !== pr.headRefOid) {
+    return true;
   }
 
   return Date.parse(observedAt) >= Date.parse(waitStartedAt);
@@ -890,7 +895,9 @@ function isMergeCriticalPullRequest(pr: GitHubPullRequest): boolean {
 
 function hasConfiguredProviderSuccess(
   config: SupervisorConfig,
+  record: IssueRunRecord,
   pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
   reviewThreads: ReviewThread[],
 ): boolean {
   if (!repoExpectsConfiguredBotReview(config) || !isMergeCriticalPullRequest(pr)) {
@@ -902,7 +909,13 @@ function hasConfiguredProviderSuccess(
     return false;
   }
 
-  const configuredBotThreads = configuredBotReviewThreads(config, reviewThreads);
+  const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(config, record, pr, checks);
+  const configuredBotThreads = configuredBotReviewThreads(config, reviewThreads).filter(
+    (thread) =>
+      !clearOutdatedCodexConnectorThreads ||
+      !thread.isOutdated ||
+      !latestReviewCommentAuthorIsAllowedBot(config, thread),
+  );
   const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(configuredBotThreads));
   if (configuredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread)).length > 0) {
     return false;
@@ -923,6 +936,7 @@ export function syncMergeLatencyVisibility(
   config: SupervisorConfig,
   record: IssueRunRecord,
   pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
   reviewThreads: ReviewThread[],
 ): Pick<
   IssueRunRecord,
@@ -931,7 +945,7 @@ export function syncMergeLatencyVisibility(
   const observedNow = nowIso();
   const mergeReadinessLastEvaluatedAt = isMergeCriticalPullRequest(pr) ? observedNow : null;
 
-  if (!hasConfiguredProviderSuccess(config, pr, reviewThreads)) {
+  if (!hasConfiguredProviderSuccess(config, record, pr, checks, reviewThreads)) {
     return {
       provider_success_observed_at: null,
       provider_success_head_sha: null,

--- a/src/pull-request-state-sync.ts
+++ b/src/pull-request-state-sync.ts
@@ -11,6 +11,13 @@ export function syncReviewWaitWindow(record: IssueRunRecord, pr: GitHubPullReque
     };
   }
 
+  if (pr.configuredBotCurrentHeadObservedAt && !record.review_wait_started_at) {
+    return {
+      review_wait_started_at: null,
+      review_wait_head_sha: null,
+    };
+  }
+
   if (!record.review_wait_started_at || record.review_wait_head_sha !== pr.headRefOid) {
     return {
       review_wait_started_at: nowIso(),

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1737,6 +1737,224 @@ test("runPreparedIssue only refreshes the sticky tracked PR status comment when 
   assert.equal(record.last_host_local_pr_blocker_comment_signature, "stalled-bot:thread-1");
 });
 
+test("runPreparedIssue auto-handles stale Codex Connector conversation residue before repeat-stop suppression", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.sameFailureSignatureRepeatLimit = 3;
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  fixture.config.verifiedNoSourceChangeReviewThreadAutoResolve = true;
+  fixture.config.configuredBotInitialGraceWaitSeconds = 0;
+  fixture.config.configuredBotSettledWaitSeconds = 0;
+  const issueNumber = 183;
+  const prNumber = 183;
+  const headSha = "head-183";
+  const branch = branchName(fixture.config, issueNumber);
+  const { workspacePath, journalPath } = trackedIssuePaths(fixture.workspaceRoot, issueNumber);
+  const threadIds = Array.from({ length: 7 }, (_value, index) => `PRRT_hrcore_183_${index + 1}`);
+  const staleFailureContext = {
+    category: "manual" as const,
+    summary:
+      "7 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    command: null,
+    details: threadIds.map(
+      (threadId) =>
+        `reviewer=chatgpt-codex-connector thread=${threadId} file=src/stale-residue.ts line=none processed_on_current_head=yes`,
+    ),
+    url: "https://example.test/pr/183#discussion_r1",
+    updated_at: "2026-05-24T01:00:00Z",
+  };
+  const initialRecord = createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
+    state: "addressing_review",
+    workspace: workspacePath,
+    branch,
+    pr_number: prNumber,
+    journal_path: journalPath,
+    last_head_sha: headSha,
+    last_failure_signature: staleFailureContext.signature,
+    repeated_failure_signature_count: 3,
+    last_failure_context: staleFailureContext,
+    processed_review_thread_ids: threadIds.map((threadId) => `${threadId}@${headSha}`),
+    processed_review_thread_fingerprints: threadIds.map((threadId) => `${threadId}@${headSha}#comment-${threadId}`),
+    review_follow_up_head_sha: headSha,
+    review_follow_up_remaining: 0,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [initialRecord],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+
+  const issue = createTrackedIssue(issueNumber, {
+    title: "Recover stale Codex Connector residue",
+    body: executionReadyBody("Recover stale Codex Connector residue without another Codex turn."),
+  });
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
+    number: prNumber,
+    title: "HRCore stale Codex Connector residue",
+    isDraft: false,
+    reviewDecision: null,
+    headRefOid: headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-24T00:50:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-24T00:55:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: headSha,
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
+  });
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads = threadIds.map((threadId) =>
+    createReviewThread({
+      id: threadId,
+      isOutdated: true,
+      path: "src/stale-residue.ts",
+      line: null,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "Outdated Codex Connector residue.",
+            createdAt: "2026-05-24T00:40:00Z",
+            url: `https://example.test/pr/183#discussion_${threadId}`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const resolvedPr = createTrackedPullRequest(fixture.config, issueNumber, {
+    ...pr,
+    mergeStateStatus: "CLEAN",
+  });
+  const replyCalls: string[] = [];
+  const resolveCalls: string[] = [];
+  let snapshotLoads = 0;
+  const addedComments: string[] = [];
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => checks,
+    getUnresolvedReviewThreads: async () => (resolveCalls.length === threadIds.length ? [] : reviewThreads),
+    getPullRequestIfExists: async () => pr,
+    getPullRequest: async () => {
+      snapshotLoads += 1;
+      return resolveCalls.length === threadIds.length ? resolvedPr : pr;
+    },
+    getExternalReviewSurface: async () => ({ reviews: [], issueComments: [] }),
+    addIssueComment: async (_issueNumberForComment: number, body: string) => {
+      addedComments.push(body);
+    },
+    replyToReviewThread: async (threadId: string) => {
+      replyCalls.push(threadId);
+    },
+    resolveReviewThread: async (threadId: string) => {
+      resolveCalls.push(threadId);
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await (
+    supervisor as unknown as {
+      runPreparedIssue: (context: {
+        state: SupervisorStateFile;
+        record: IssueRunRecord;
+        issue: GitHubIssue;
+        previousCodexSummary: string | null;
+        previousError: string | null;
+        workspacePath: string;
+        journalPath: string;
+        syncJournal: (record: IssueRunRecord) => Promise<void>;
+        memoryArtifacts: {
+          alwaysReadFiles: string[];
+          onDemandFiles: string[];
+          contextIndexPath: string;
+          agentsPath: string;
+        };
+        workspaceStatus: {
+          branch: string;
+          headSha: string;
+          hasUncommittedChanges: boolean;
+          baseAhead: number;
+          baseBehind: number;
+          remoteBranchExists: boolean;
+          remoteAhead: number;
+          remoteBehind: number;
+        };
+        pr: GitHubPullRequest | null;
+        checks: PullRequestCheck[];
+        reviewThreads: ReviewThread[];
+        options: { dryRun: boolean };
+        recoveryLog: string | null;
+        recoveryEvents: [];
+      }) => Promise<string>;
+    }
+  ).runPreparedIssue({
+    state,
+    record: initialRecord,
+    issue,
+    previousCodexSummary: null,
+    previousError: null,
+    workspacePath,
+    journalPath,
+    syncJournal: async () => undefined,
+    memoryArtifacts: {
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+      contextIndexPath: path.join(fixture.workspaceRoot, "context-index.md"),
+      agentsPath: path.join(fixture.workspaceRoot, "AGENTS.generated.md"),
+    },
+    workspaceStatus: {
+      branch,
+      headSha,
+      hasUncommittedChanges: false,
+      baseAhead: 0,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    pr,
+    checks,
+    reviewThreads,
+    options: { dryRun: false },
+    recoveryLog: null,
+    recoveryEvents: [],
+  });
+
+  assert.doesNotMatch(message, /blocked after repeated identical review-related failure signatures/);
+  assert.deepEqual(replyCalls, threadIds);
+  assert.deepEqual(resolveCalls, threadIds);
+  assert.equal(addedComments.some((body) => /@codex review/.test(body)), false);
+  assert.ok(snapshotLoads > 0);
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "ready_to_merge");
+  assert.equal(record.last_failure_context, null);
+  assert.equal(record.repeated_failure_signature_count, 0);
+  assert.equal(record.provider_success_head_sha, headSha);
+  assert.ok(record.provider_success_observed_at);
+});
+
 test("runOnce active Codex prompt uses current-head Codex Connector must-fix threads after processed-thread bookkeeping", async () => {
   const fixture = await createSupervisorFixture({
     codexScriptLines: [

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -462,6 +462,7 @@ export function derivePullRequestLifecycleSnapshot(
     config,
     trackedPrProjection.recordForState,
     pr,
+    checks,
     reviewThreads,
   );
   const finalizedRecordForState = {


### PR DESCRIPTION
## Summary
- recover HRCore #183-shaped stale Codex Connector residue without launching another Codex turn
- preserve stale-observation fail-closed behavior while allowing current-head Codex success to satisfy an absent active wait
- record provider success through safe outdated Codex residue so merge-readiness and final guards can proceed

## Verification
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts src/tracked-pr-status-comment.test.ts src/supervisor/supervisor-pr-readiness.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npm run build

Closes #2133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and cleanup of stale review thread data during issue processing
  * Enhanced review state synchronization when bot observations are present
  * More reliable review wait window tracking for pending reviews

* **Tests**
  * Added test coverage for stale review thread resolution during repeat-issue processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->