### PR TITLE
Ignore stale Codex review wait residue

### DIFF
--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -570,6 +570,7 @@ test("inferStateFromPullRequest ignores stale same-head Codex review wait when o
   const checks = passingChecks();
 
   assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(inferGitHubWaitStep(config, record, pr, checks, reviewThreads), null);
   assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
   assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, "head123");
 });
@@ -731,6 +732,60 @@ test("inferStateFromPullRequest does not apply Codex stale-residue bypass to Cod
 
   assert.notEqual(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "ready_to_merge");
   assert.equal(syncMergeLatencyVisibility(config, record, pr, passingChecks(), reviewThreads).provider_success_head_sha, null);
+});
+
+test("inferStateFromPullRequest keeps stale Codex residue guarded while another provider wait is active", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T00:10:00Z",
+    review_wait_head_sha: "head123",
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T00:05:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    copilotReviewState: "requested",
+    copilotReviewRequestedAt: "2026-05-23T00:09:00Z",
+    currentHeadCiGreenAt: "2026-05-23T00:04:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-codex",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-codex",
+            body: "P1: This stale inline finding should not bypass another provider wait.",
+            createdAt: "2026-05-23T00:00:00Z",
+            url: "https://example.test/pr/44#discussion_r2126",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(
+    inferGitHubWaitStep(config, record, pr, checks, reviewThreads, Date.parse("2026-05-23T00:10:30Z")),
+    "configured_bot_current_head_signal_wait",
+  );
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, null);
 });
 
 test("inferStateFromPullRequest keeps outdated Codex Connector blockers when required checks are not green", () => {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { blockedReasonFromReviewState, inferGitHubWaitStep, inferStateFromPullRequest } from "./pull-request-state";
+import {
+  blockedReasonFromReviewState,
+  inferGitHubWaitStep,
+  inferStateFromPullRequest,
+  syncMergeLatencyVisibility,
+} from "./pull-request-state";
 import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "./core/types";
 import {
   createConfig,
@@ -509,6 +514,223 @@ test("inferStateFromPullRequest clears outdated Codex Connector blockers after c
 
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "ready_to_merge");
   assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), null);
+});
+
+test("inferStateFromPullRequest ignores stale same-head Codex review wait when only outdated connector residue remains", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T00:10:00Z",
+    review_wait_head_sha: "head123",
+    last_failure_context: {
+      category: "review",
+      summary: "1 unresolved automated review thread(s) remain.",
+      signature: "manual-review:head123:configured-bot:1",
+      command: null,
+      details: ["configured_bot_thread id=thread-outdated-codex outdated=true"],
+      url: "https://example.test/pr/44",
+      updated_at: "2026-05-23T00:11:00Z",
+    },
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T00:05:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-05-23T00:04:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-codex",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-codex",
+            body: "P1: This stale inline finding should not block after the current-head no-major signal.",
+            createdAt: "2026-05-23T00:00:00Z",
+            url: "https://example.test/pr/44#discussion_r2123",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, "head123");
+});
+
+test("inferStateFromPullRequest keeps stale Codex review waits guarded when safe-shape gates are missing", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T00:10:00Z",
+    review_wait_head_sha: "head123",
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T00:05:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-05-23T00:04:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const outdatedCodexThread = createReviewThread({
+    id: "thread-outdated-codex",
+    isOutdated: true,
+    comments: {
+      nodes: [
+        {
+          id: "comment-outdated-codex",
+          body: "P1: This stale inline finding should not block after the current-head no-major signal.",
+          createdAt: "2026-05-23T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_r2123",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const pendingChecks = [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }] as const;
+  const cases = [
+    {
+      name: "missing current-head Codex success",
+      pr: createPullRequest({ ...pr, configuredBotCurrentHeadObservedAt: null }),
+      checks: passingChecks(),
+      reviewThreads: [outdatedCodexThread],
+    },
+    {
+      name: "non-green checks",
+      pr,
+      checks: [...pendingChecks],
+      reviewThreads: [outdatedCodexThread],
+    },
+    {
+      name: "human review thread",
+      pr,
+      checks: passingChecks(),
+      reviewThreads: [
+        outdatedCodexThread,
+        createReviewThread({
+          id: "thread-human",
+          comments: {
+            nodes: [
+              {
+                id: "comment-human",
+                body: "Please address this before merge.",
+                createdAt: "2026-05-23T00:01:00Z",
+                url: "https://example.test/pr/44#discussion_r2124",
+                author: { login: "reviewer", typeName: "User" },
+              },
+            ],
+          },
+        }),
+      ],
+    },
+    {
+      name: "current configured-bot thread",
+      pr,
+      checks: passingChecks(),
+      reviewThreads: [createReviewThread({ ...outdatedCodexThread, isOutdated: false })],
+    },
+    {
+      name: "tracked head mismatch",
+      record: createRecord({ ...record, last_head_sha: "head-old" }),
+      pr,
+      checks: passingChecks(),
+      reviewThreads: [outdatedCodexThread],
+    },
+    {
+      name: "merge conflict",
+      pr: createPullRequest({ ...pr, mergeStateStatus: "DIRTY" }),
+      checks: passingChecks(),
+      reviewThreads: [outdatedCodexThread],
+    },
+  ];
+
+  for (const scenario of cases) {
+    const scenarioRecord = scenario.record ?? record;
+    assert.notEqual(
+      inferStateFromPullRequest(config, scenarioRecord, scenario.pr, scenario.checks, scenario.reviewThreads),
+      "ready_to_merge",
+      scenario.name,
+    );
+    assert.equal(
+      syncMergeLatencyVisibility(config, scenarioRecord, scenario.pr, scenario.checks, scenario.reviewThreads)
+        .provider_success_head_sha,
+      null,
+      scenario.name,
+    );
+  }
+});
+
+test("inferStateFromPullRequest does not apply Codex stale-residue bypass to CodeRabbit waits", () => {
+  const config = createConfig({
+    reviewBotLogins: ["coderabbitai[bot]"],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T00:10:00Z",
+    review_wait_head_sha: "head123",
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T00:05:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-05-23T00:04:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-coderabbit",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-coderabbit",
+            body: "This stale CodeRabbit finding still follows CodeRabbit wait semantics.",
+            createdAt: "2026-05-23T00:00:00Z",
+            url: "https://example.test/pr/44#discussion_r2125",
+            author: {
+              login: "coderabbitai[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "ready_to_merge");
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, passingChecks(), reviewThreads).provider_success_head_sha, null);
 });
 
 test("inferStateFromPullRequest keeps outdated Codex Connector blockers when required checks are not green", () => {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -721,7 +721,13 @@ function effectiveConfiguredBotReviewThreads(
   const unresolvedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads);
   const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, unresolvedConfiguredBotThreads);
   const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(unresolvedConfiguredBotThreads));
-  const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(config, record, pr, checks);
+  const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  );
   const effectiveThreads =
     codexConnectorPolicy?.outcome === "nitpick_only" || codexConnectorPolicy?.outcome === "converged"
       ? unresolvedConfiguredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread))
@@ -759,6 +765,7 @@ function codexConnectorOutdatedThreadClearanceAllowed(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
   checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
 ): boolean {
   return Boolean(
     configuredReviewProviderKinds(config).includes("codex") &&
@@ -766,8 +773,50 @@ function codexConnectorOutdatedThreadClearanceAllowed(
       pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
       pr.configuredBotTopLevelReviewStrength !== "blocking" &&
       validTimestamp(pr.configuredBotCurrentHeadObservedAt) &&
-      currentHeadObservationSatisfiesActiveWait(record, pr) &&
+      (currentHeadObservationSatisfiesActiveWait(record, pr) ||
+        staleSameHeadCodexWaitHasOnlyOutdatedResidue(config, record, pr, checks, reviewThreads)) &&
       summarizeChecks(checks).allPassing,
+  );
+}
+
+function staleSameHeadCodexWaitHasOnlyOutdatedResidue(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewThreads: ReviewThread[],
+): boolean {
+  if (
+    !configuredReviewProviderKinds(config).includes("codex") ||
+    pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment" ||
+    pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
+    pr.configuredBotTopLevelReviewStrength === "blocking"
+  ) {
+    return false;
+  }
+
+  const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  const waitStartedAt = validTimestamp(record.review_wait_started_at);
+  if (!observedAt || !waitStartedAt || record.review_wait_head_sha !== pr.headRefOid) {
+    return false;
+  }
+
+  if (Date.parse(observedAt) >= Date.parse(waitStartedAt)) {
+    return false;
+  }
+
+  if (!pullRequestHeadMatchesRecord(record, pr) || mergeConflictDetected(pr) || !summarizeChecks(checks).allPassing) {
+    return false;
+  }
+
+  if (manualReviewThreads(config, reviewThreads).length > 0) {
+    return false;
+  }
+
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  return (
+    configuredThreads.length > 0 &&
+    configuredThreads.every((thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread))
   );
 }
 
@@ -909,7 +958,13 @@ function hasConfiguredProviderSuccess(
     return false;
   }
 
-  const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(config, record, pr, checks);
+  const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  );
   const configuredBotThreads = configuredBotReviewThreads(config, reviewThreads).filter(
     (thread) =>
       !clearOutdatedCodexConnectorThreads ||
@@ -990,8 +1045,20 @@ export function blockedReasonFromReviewState(
       ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads)
       : [];
   const checkSummary = summarizeChecks(checks);
+  const staleCodexWaitHasOnlyOutdatedResidue = staleSameHeadCodexWaitHasOnlyOutdatedResidue(
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  );
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
-  if (copilotTimeout.timedOut && copilotTimeout.action === "block" && !provenCodexStaleReviewMetadata) {
+  if (
+    copilotTimeout.timedOut &&
+    copilotTimeout.action === "block" &&
+    !provenCodexStaleReviewMetadata &&
+    !staleCodexWaitHasOnlyOutdatedResidue
+  ) {
     return "review_bot_timeout";
   }
 
@@ -1056,6 +1123,13 @@ export function inferStateFromPullRequest(
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
   const checkSummary = summarizeChecks(checks);
+  const staleCodexWaitHasOnlyOutdatedResidue = staleSameHeadCodexWaitHasOnlyOutdatedResidue(
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  );
 
   if (pr.mergedAt || pr.state === "MERGED") {
     return "done";
@@ -1259,14 +1333,20 @@ export function inferStateFromPullRequest(
   }
 
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
-  if (copilotTimeout.timedOut && copilotTimeout.action === "block" && !provenCodexStaleReviewMetadata) {
+  if (
+    copilotTimeout.timedOut &&
+    copilotTimeout.action === "block" &&
+    !provenCodexStaleReviewMetadata &&
+    !staleCodexWaitHasOnlyOutdatedResidue
+  ) {
     return "blocked";
   }
 
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "request_review_comment" &&
-    !provenCodexStaleReviewMetadata
+    !provenCodexStaleReviewMetadata &&
+    !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "waiting_ci";
   }
@@ -1289,6 +1369,7 @@ export function inferStateFromPullRequest(
 
   if (
     !provenCodexStaleReviewMetadata &&
+    !staleCodexWaitHasOnlyOutdatedResidue &&
     configuredBotCurrentHeadSignalPending(config, record, pr) &&
     !copilotTimeout.timedOut
   ) {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -786,12 +786,18 @@ function staleSameHeadCodexWaitHasOnlyOutdatedResidue(
   checks: PullRequestCheck[],
   reviewThreads: ReviewThread[],
 ): boolean {
+  const providerKinds = configuredReviewProviderKinds(config);
   if (
-    !configuredReviewProviderKinds(config).includes("codex") ||
+    !providerKinds.includes("codex") ||
+    providerKinds.some((kind) => kind !== "codex") ||
     pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment" ||
     pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
     pr.configuredBotTopLevelReviewStrength === "blocking"
   ) {
+    return false;
+  }
+
+  if (copilotReviewPending(config, record, pr)) {
     return false;
   }
 
@@ -1404,8 +1410,14 @@ export function inferGitHubWaitStep(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
   checks: PullRequestCheck[],
-  nowMs = pullRequestStateInferenceNowMs(),
+  reviewThreadsOrNowMs: ReviewThread[] | number = pullRequestStateInferenceNowMs(),
+  maybeNowMs?: number,
 ): GitHubWaitStep | null {
+  const reviewThreads = Array.isArray(reviewThreadsOrNowMs) ? reviewThreadsOrNowMs : [];
+  const nowMs =
+    typeof reviewThreadsOrNowMs === "number"
+      ? reviewThreadsOrNowMs
+      : maybeNowMs ?? pullRequestStateInferenceNowMs();
   const configuredBotRateLimitWait = determineConfiguredBotRateLimitWait(config, pr, nowMs);
   if (configuredBotRateLimitWait.active) {
     return "configured_bot_rate_limit_wait";
@@ -1428,7 +1440,13 @@ export function inferGitHubWaitStep(
   }
 
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
-  if (configuredBotCurrentHeadSignalPending(config, record, pr) && !copilotTimeout.timedOut) {
+  const staleCodexWaitHasOnlyOutdatedResidue =
+    reviewThreads.length > 0 && staleSameHeadCodexWaitHasOnlyOutdatedResidue(config, record, pr, checks, reviewThreads);
+  if (
+    !staleCodexWaitHasOnlyOutdatedResidue &&
+    configuredBotCurrentHeadSignalPending(config, record, pr) &&
+    !copilotTimeout.timedOut
+  ) {
     return "configured_bot_current_head_signal_wait";
   }
 


### PR DESCRIPTION
## Summary
- ignore stale same-head Codex Connector review waits only when current-head success plus green checks prove only outdated connector residue remains
- keep provider-success visibility and ready/merge routing unblocked for that safe shape
- add guarded regressions for missing success, non-green checks, human threads, current bot threads, head mismatch, merge conflict, and CodeRabbit waits

## Verification
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts src/tracked-pr-status-comment.test.ts src/supervisor/supervisor-pr-readiness.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts src/pull-request-state-sync.test.ts src/codex-connector-review-request-transition.test.ts
- npm run build

Fixes #2135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale Codex review waits with only outdated residue; pull requests are now correctly marked as ready to merge when all blocking signals are resolved and prerequisite checks pass.
  * This optimization does not apply to CodeRabbit reviews, which maintain existing blocking behavior.

* **Tests**
  * Expanded test coverage for Codex stale residue scenarios and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->