### PR TITLE
Do not rerun Codex for merge-ready stale Connector residue

### DIFF
--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -36,6 +36,7 @@ import {
 import {
   buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
+  isProvenStaleReviewMetadataClassification,
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
@@ -427,14 +428,18 @@ export function buildActiveDetailedStatusLines(
     lines.push(`last_runtime_failure_kind=${activeRecord.last_runtime_failure_kind ?? "none"}`);
   }
 
-  if (pr) {
-    const staleReviewBotRemediation = buildStaleReviewBotRemediation({
+  const activeStaleReviewBotRemediation = pr
+    ? buildStaleReviewBotRemediation({
       config,
       record: activeRecord,
       pr,
       checks,
       reviewThreads,
-    });
+    })
+    : null;
+
+  if (pr) {
+    const staleReviewBotRemediation = activeStaleReviewBotRemediation;
     if (staleReviewBotRemediation) {
       lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));
       const diagnostics = buildStaleReviewBotThreadDiagnostics({
@@ -574,7 +579,13 @@ export function buildActiveDetailedStatusLines(
     );
   }
 
-  if (activeRecord.last_failure_context) {
+  const suppressStaleReviewFailureContext = Boolean(
+    activeRecord.last_failure_context &&
+      activeStaleReviewBotRemediation &&
+      isProvenStaleReviewMetadataClassification(activeStaleReviewBotRemediation.classification),
+  );
+
+  if (activeRecord.last_failure_context && !suppressStaleReviewFailureContext) {
     lines.push(
       `failure_context category=${activeRecord.last_failure_context.category ?? "none"} summary=${truncate(sanitizeStatusValue(activeRecord.last_failure_context.summary), 200) ?? "none"}`,
     );

--- a/src/supervisor/supervisor-diagnostics-status-selection.test.ts
+++ b/src/supervisor/supervisor-diagnostics-status-selection.test.ts
@@ -1782,6 +1782,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
     listCandidateIssues: async () => [trackedIssue],
     listAllIssues: async () => [trackedIssue],
     getPullRequestIfExists: async () => pr,
@@ -1791,6 +1792,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
   };
 
   const status = await supervisor.status({ why: true });
+  const explanation = await supervisor.explain(issueNumber);
 
   assert.match(
     status,
@@ -1802,6 +1804,8 @@ test("status --why uses the shared stale review-bot presenter for active verifie
   );
   assert.doesNotMatch(status, /^codex_connector_convergence status=stale_head /m);
   assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
+  assert.doesNotMatch(status, /^failure_context category=manual summary=1 configured bot review thread\(s\) remain/m);
+  assert.doesNotMatch(explanation, /^failure_summary=1 configured bot review thread\(s\) remain/m);
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });
 

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -70,6 +70,7 @@ import {
 import {
   buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
+  isProvenStaleReviewMetadataClassification,
   type StaleReviewBotRemediationDto,
   type StaleReviewBotThreadDiagnosticsDto,
 } from "./stale-review-bot-remediation";
@@ -522,6 +523,11 @@ export async function buildIssueExplainDto(
         : ["stale_diagnostic", "kind=stale_review_bot", recoverabilityStatusToken(recoverability)].join(" ");
     })()
     : null;
+  const suppressStaleReviewFailureContext = Boolean(
+    record?.last_failure_context &&
+      staleReviewBotRemediation &&
+      isProvenStaleReviewMetadataClassification(staleReviewBotRemediation.classification),
+  );
 
   if (matchingSkipPrefix) {
     reasons.push(`skip_title_prefix ${matchingSkipPrefix}`);
@@ -623,8 +629,10 @@ export async function buildIssueExplainDto(
     lastError: record?.last_error ?? null,
     autoMergeGuardSummary: record?.last_auto_merge_guard_context?.summary ?? null,
     autoMergeGuardDetails: record?.last_auto_merge_guard_context?.details ?? null,
-    failureSummary: record?.last_failure_context?.summary ?? null,
-    preservedPartialWorkSummary: summarizePreservedPartialWork(record?.last_failure_context),
+    failureSummary: suppressStaleReviewFailureContext ? null : record?.last_failure_context?.summary ?? null,
+    preservedPartialWorkSummary: suppressStaleReviewFailureContext
+      ? null
+      : summarizePreservedPartialWork(record?.last_failure_context),
     runtimeFailureKind: record?.last_runtime_failure_kind ?? null,
     runtimeFailureSummary: record?.last_runtime_failure_context?.summary ?? null,
     timeline: record ? buildIssueRunTimelineExport({ issue, record, pr, checks: explainChecks }) : null,


### PR DESCRIPTION
## Summary
- suppress stale automated-review failure context in status/explain when live Codex Connector stale-residue diagnostics are already merge-ready
- add regression coverage for active verified Codex residue status/explain output

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-model.test.ts
- npm run build

Closes #2137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure context information is now correctly suppressed from status displays and explanations when stale review bot remediation is classified as proven, reducing unnecessary diagnostic output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->