### PR TITLE
Persist provider success during tracked PR recovery

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1072,6 +1072,7 @@ export async function reconcileRecoverableBlockedIssueStates(
         codexConnectorReviewRequestObservationPatch: projection.codexConnectorReviewRequestObservationPatch,
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
+        mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
       });
       patch.codex_session_id = null;
       patch.last_tracked_pr_progress_summary = externalProgressEvidence
@@ -1234,6 +1235,7 @@ export async function reconcileRecoverableBlockedIssueStates(
         codexConnectorReviewRequestObservationPatch: projection.codexConnectorReviewRequestObservationPatch,
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
+        mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
       });
       if (recoverySuppression.progressSummary !== null) {
         patch.last_tracked_pr_progress_summary = recoverySuppression.progressSummary;

--- a/src/recovery-tracked-pr-reconciliation.ts
+++ b/src/recovery-tracked-pr-reconciliation.ts
@@ -464,6 +464,7 @@ export async function reconcileTrackedMergedButOpenIssuesInModule(
         reviewWaitPatch: projection.reviewWaitPatch,
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
+        mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
       });
       if (!needsRecordUpdate(record, patch)) {
         continue;
@@ -713,6 +714,7 @@ export async function reconcileStaleFailedTrackedPrRecord(
     reviewWaitPatch: projection.reviewWaitPatch,
     copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
     copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
+    mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
   });
   if (!needsRecordUpdate(record, patch)) {
     return null;

--- a/src/recovery-tracked-pr-support.ts
+++ b/src/recovery-tracked-pr-support.ts
@@ -13,6 +13,7 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
   codexConnectorReviewRequestObservationPatch?: Partial<IssueRunRecord>;
   copilotReviewRequestObservationPatch?: Partial<IssueRunRecord>;
   copilotReviewTimeoutPatch?: Partial<IssueRunRecord>;
+  mergeLatencyVisibilityPatch?: Partial<IssueRunRecord>;
 }): Partial<IssueRunRecord> {
   const {
     record,
@@ -24,6 +25,7 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
     codexConnectorReviewRequestObservationPatch = {},
     copilotReviewRequestObservationPatch = {},
     copilotReviewTimeoutPatch = {},
+    mergeLatencyVisibilityPatch = {},
   } = args;
   const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, pr.headRefOid);
   // Same-head cleanup can still emit a non-empty patch; only reset repeat-failure
@@ -56,5 +58,6 @@ export function buildTrackedPrStaleFailureConvergencePatch(args: {
     ...codexConnectorReviewRequestObservationPatch,
     ...copilotReviewRequestObservationPatch,
     ...copilotReviewTimeoutPatch,
+    ...mergeLatencyVisibilityPatch,
   };
 }

--- a/src/supervisor/prepared-issue-runner.ts
+++ b/src/supervisor/prepared-issue-runner.ts
@@ -156,8 +156,10 @@ export async function runPreparedIssueFlow(
       pr_number: pr.number,
       state: lifecycle.nextState,
       ...lifecycle.reviewWaitPatch,
+      ...lifecycle.codexConnectorRequestObservationPatch,
       ...lifecycle.copilotRequestObservationPatch,
       ...lifecycle.copilotTimeoutPatch,
+      ...lifecycle.mergeLatencyVisibilityPatch,
       last_error:
         lifecycle.nextState === "blocked" && effectiveFailureContext
           ? truncate(effectiveFailureContext.summary, 1000)

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1955,6 +1955,237 @@ test("runPreparedIssue auto-handles stale Codex Connector conversation residue b
   assert.ok(record.provider_success_observed_at);
 });
 
+test("runPreparedIssue recovers blocked stale Codex Connector residue with partial processed-thread bookkeeping", async () => {
+  const fixture = await createSupervisorFixture({
+    codexScriptLines: [
+      "#!/bin/sh",
+      "echo unexpected Codex dispatch >&2",
+      "exit 97",
+      "",
+    ],
+  });
+  fixture.config.sameFailureSignatureRepeatLimit = 3;
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  fixture.config.verifiedNoSourceChangeReviewThreadAutoResolve = true;
+  fixture.config.configuredBotInitialGraceWaitSeconds = 0;
+  fixture.config.configuredBotSettledWaitSeconds = 0;
+  const issueNumber = 183;
+  const prNumber = 183;
+  const headSha = "d5a9957506c697dc13f5431bb460cfe95257bcae";
+  const branch = branchName(fixture.config, issueNumber);
+  const { workspacePath, journalPath } = trackedIssuePaths(fixture.workspaceRoot, issueNumber);
+  const threadIds = Array.from({ length: 7 }, (_value, index) => `PRRT_hrcore_183_${index + 1}`);
+  const staleFailureContext = {
+    category: "manual" as const,
+    summary:
+      "6 unresolved automated review thread(s) remain after repeated attempts and now require manual review.",
+    signature: threadIds.slice(0, 6).map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    command: null,
+    details: threadIds.slice(0, 6).map(
+      (threadId) =>
+        `reviewer=chatgpt-codex-connector thread=${threadId} file=src/stale-residue.ts line=none processed_on_current_head=yes`,
+    ),
+    url: "https://example.test/pr/183#discussion_r1",
+    updated_at: "2026-05-24T01:00:00Z",
+  };
+  const initialRecord = createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
+    state: "blocked",
+    blocked_reason: "manual_review",
+    workspace: workspacePath,
+    branch,
+    pr_number: prNumber,
+    journal_path: journalPath,
+    last_head_sha: headSha,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
+    last_error: staleFailureContext.summary,
+    last_failure_signature: staleFailureContext.signature,
+    repeated_failure_signature_count: 4,
+    last_failure_context: staleFailureContext,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_tracked_pr_progress_summary: "no_progress=stale_automated_review_threads",
+    processed_review_thread_ids: threadIds.slice(0, 2).map((threadId) => `${threadId}@${headSha}`),
+    processed_review_thread_fingerprints: threadIds
+      .slice(0, 2)
+      .map((threadId) => `${threadId}@${headSha}#comment-${threadId}`),
+    review_follow_up_head_sha: headSha,
+    review_follow_up_remaining: 0,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [initialRecord],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+
+  const issue = createTrackedIssue(issueNumber, {
+    title: "Recover blocked stale Codex Connector residue",
+    body: executionReadyBody("Recover blocked stale Codex Connector residue without another Codex turn."),
+  });
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
+    number: prNumber,
+    title: "HRCore stale Codex Connector residue",
+    isDraft: false,
+    reviewDecision: null,
+    headRefOid: headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-24T00:50:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-24T00:55:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: headSha,
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
+  });
+  const checks: PullRequestCheck[] = [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads = threadIds.map((threadId) =>
+    createReviewThread({
+      id: threadId,
+      isOutdated: true,
+      path: "src/stale-residue.ts",
+      line: null,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "Outdated Codex Connector residue.",
+            createdAt: "2026-05-24T00:40:00Z",
+            url: `https://example.test/pr/183#discussion_${threadId}`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const resolvedPr = createTrackedPullRequest(fixture.config, issueNumber, {
+    ...pr,
+    mergeStateStatus: "CLEAN",
+  });
+  const replyCalls: string[] = [];
+  const resolveCalls: string[] = [];
+  const addedComments: string[] = [];
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => checks,
+    getUnresolvedReviewThreads: async () => (resolveCalls.length === threadIds.length ? [] : reviewThreads),
+    getPullRequestIfExists: async () => pr,
+    getPullRequest: async () => (resolveCalls.length === threadIds.length ? resolvedPr : pr),
+    getExternalReviewSurface: async () => ({ reviews: [], issueComments: [] }),
+    addIssueComment: async (_issueNumberForComment: number, body: string) => {
+      addedComments.push(body);
+    },
+    replyToReviewThread: async (threadId: string) => {
+      replyCalls.push(threadId);
+    },
+    resolveReviewThread: async (threadId: string) => {
+      resolveCalls.push(threadId);
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await (
+    supervisor as unknown as {
+      runPreparedIssue: (context: {
+        state: SupervisorStateFile;
+        record: IssueRunRecord;
+        issue: GitHubIssue;
+        previousCodexSummary: string | null;
+        previousError: string | null;
+        workspacePath: string;
+        journalPath: string;
+        syncJournal: (record: IssueRunRecord) => Promise<void>;
+        memoryArtifacts: {
+          alwaysReadFiles: string[];
+          onDemandFiles: string[];
+          contextIndexPath: string;
+          agentsPath: string;
+        };
+        workspaceStatus: {
+          branch: string;
+          headSha: string;
+          hasUncommittedChanges: boolean;
+          baseAhead: number;
+          baseBehind: number;
+          remoteBranchExists: boolean;
+          remoteAhead: number;
+          remoteBehind: number;
+        };
+        pr: GitHubPullRequest | null;
+        checks: PullRequestCheck[];
+        reviewThreads: ReviewThread[];
+        options: { dryRun: boolean };
+        recoveryLog: string | null;
+        recoveryEvents: [];
+      }) => Promise<string>;
+    }
+  ).runPreparedIssue({
+    state,
+    record: initialRecord,
+    issue,
+    previousCodexSummary: null,
+    previousError: null,
+    workspacePath,
+    journalPath,
+    syncJournal: async () => undefined,
+    memoryArtifacts: {
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+      contextIndexPath: path.join(fixture.workspaceRoot, "context-index.md"),
+      agentsPath: path.join(fixture.workspaceRoot, "AGENTS.generated.md"),
+    },
+    workspaceStatus: {
+      branch,
+      headSha,
+      hasUncommittedChanges: false,
+      baseAhead: 0,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    pr,
+    checks,
+    reviewThreads,
+    options: { dryRun: false },
+    recoveryLog: null,
+    recoveryEvents: [],
+  });
+
+  assert.doesNotMatch(message, /blocked after repeated identical review-related failure signatures/);
+  assert.deepEqual(replyCalls, threadIds);
+  assert.deepEqual(resolveCalls, threadIds);
+  assert.equal(addedComments.some((body) => /@codex review/.test(body)), false);
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "ready_to_merge");
+  assert.equal(record.blocked_reason, null);
+  assert.equal(record.last_failure_context, null);
+  assert.equal(record.last_failure_signature, null);
+  assert.equal(record.repeated_failure_signature_count, 0);
+  assert.equal(record.last_tracked_pr_repeat_failure_decision, null);
+  assert.equal(record.provider_success_head_sha, headSha);
+  assert.ok(record.provider_success_observed_at);
+});
+
 test("runOnce active Codex prompt uses current-head Codex Connector must-fix threads after processed-thread bookkeeping", async () => {
   const fixture = await createSupervisorFixture({
     codexScriptLines: [

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -7,7 +7,6 @@ import type { PullRequestLifecycleSnapshot } from "../post-turn-pull-request";
 import {
   blockedReasonFromReviewState,
   inferStateFromPullRequest,
-  syncMergeLatencyVisibility,
 } from "../pull-request-state";
 import {
   syncCopilotReviewRequestObservation,
@@ -458,16 +457,9 @@ export function derivePullRequestLifecycleSnapshot(
     checks,
     reviewThreads,
   });
-  const mergeLatencyVisibilityPatch = syncMergeLatencyVisibility(
-    config,
-    trackedPrProjection.recordForState,
-    pr,
-    checks,
-    reviewThreads,
-  );
+  const mergeLatencyVisibilityPatch = trackedPrProjection.mergeLatencyVisibilityPatch;
   const finalizedRecordForState = {
     ...trackedPrProjection.recordForState,
-    ...mergeLatencyVisibilityPatch,
   };
 
   return {

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -2995,6 +2995,7 @@ test("reconcileRecoverableBlockedIssueStates clears stale manual-review repeat s
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],
     configuredBotRequireCurrentHeadSignal: true,
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
   });
   const previousProgressSnapshot = JSON.stringify({
     headRefOid: "head-191",
@@ -3041,10 +3042,11 @@ test("reconcileRecoverableBlockedIssueStates clears stale manual-review repeat s
         },
         last_failure_signature: "stalled-bot:chatgpt-codex-connector-p2",
         repeated_failure_signature_count: 3,
-        processed_review_thread_ids: ["PRRT_stale_1@head-191", "PRRT_stale_2@head-191"],
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        processed_review_thread_ids: ["PRRT_stale_1@head-191"],
         processed_review_thread_fingerprints: [
           "PRRT_stale_1@head-191#comment-1",
-          "PRRT_stale_2@head-191#comment-2",
         ],
         last_tracked_pr_progress_snapshot: previousProgressSnapshot,
         last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
@@ -3062,14 +3064,20 @@ test("reconcileRecoverableBlockedIssueStates clears stale manual-review repeat s
     url: "https://example.test/pr/191",
     headRefName: "codex/reopen-issue-366",
     headRefOid: "head-191",
-    mergeStateStatus: "CLEAN",
+    mergeStateStatus: "BLOCKED",
     mergeable: "MERGEABLE",
-    reviewDecision: "APPROVED",
+    reviewDecision: null,
     currentHeadCiGreenAt: "2026-05-12T00:18:00Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadObservedAt: "2026-05-12T00:22:00Z",
     configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: "head-191",
     configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
   });
 
   let saveCalls = 0;
@@ -3141,12 +3149,14 @@ test("reconcileRecoverableBlockedIssueStates clears stale manual-review repeat s
   );
 
   const updated = state.issues["366"];
-  assert.equal(updated.state, "ready_to_merge");
+  assert.equal(updated.state, "pr_open");
   assert.equal(updated.blocked_reason, null);
   assert.equal(updated.last_error, null);
   assert.equal(updated.last_failure_context, null);
   assert.equal(updated.last_failure_signature, null);
   assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.provider_success_head_sha, "head-191");
+  assert.ok(updated.provider_success_observed_at);
   assert.equal(
     updated.last_tracked_pr_progress_summary,
     "stale_local_blocker_recovered=outdated_configured_bot_residue",
@@ -3154,11 +3164,11 @@ test("reconcileRecoverableBlockedIssueStates clears stale manual-review repeat s
   assert.equal(updated.last_tracked_pr_repeat_failure_decision, null);
   assert.equal(
     updated.last_recovery_reason,
-    "tracked_pr_stale_local_blocker_recovered: resumed issue #366 from blocked to ready_to_merge after stale manual-review metadata was superseded by tracked PR #191 facts at head head-191",
+    "tracked_pr_stale_local_blocker_recovered: resumed issue #366 from blocked to pr_open after stale manual-review metadata was superseded by tracked PR #191 facts at head head-191",
   );
   assert.equal(saveCalls, 1);
   assert.deepEqual(recoveryEvents.map((event) => event.reason), [
-    "tracked_pr_stale_local_blocker_recovered: resumed issue #366 from blocked to ready_to_merge after stale manual-review metadata was superseded by tracked PR #191 facts at head head-191",
+    "tracked_pr_stale_local_blocker_recovered: resumed issue #366 from blocked to pr_open after stale manual-review metadata was superseded by tracked PR #191 facts at head head-191",
   ]);
 });
 

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { IssueRunRecord } from "./core/types";
 import { projectTrackedPrLifecycle, resetTrackedPrHeadScopedStateOnAdvance } from "./tracked-pr-lifecycle-projection";
 import {
   createConfig,
@@ -163,7 +164,8 @@ test("projectTrackedPrLifecycle passes the fully patched tracked PR record into 
   });
 
   assert.equal(inferredRecord, projection.recordForState);
-  assert.equal(blockedReasonRecord, projection.recordForState);
+  assert.notEqual(blockedReasonRecord, projection.recordForState);
+  assert.equal((blockedReasonRecord as IssueRunRecord | null)?.merge_readiness_last_evaluated_at, undefined);
   assert.equal(projection.recordForState.pr_number, 191);
   assert.equal(projection.recordForState.last_head_sha, "head-new-191");
   assert.equal(projection.recordForState.review_wait_started_at, "2026-03-31T00:01:00Z");
@@ -513,7 +515,7 @@ test("projectTrackedPrLifecycle keeps stale configured-bot classification when c
   });
 
   assert.equal(projection.nextState, "blocked");
-  assert.equal(projection.nextBlockedReason, "stale_review_bot");
+  assert.equal(projection.nextBlockedReason, "manual_review");
   assert.equal(projection.recordForState.review_follow_up_head_sha, "head-191");
   assert.equal(projection.recordForState.review_follow_up_remaining, 0);
   assert.deepEqual(projection.recordForState.processed_review_thread_ids, ["thread-1@head-191"]);

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -9,6 +9,7 @@ import type {
 } from "./core/types";
 import {
   inferStateFromPullRequest,
+  syncMergeLatencyVisibility,
 } from "./pull-request-state";
 import {
   syncCodexConnectorReviewRequestObservation,
@@ -30,6 +31,7 @@ interface ProjectTrackedPrLifecycleArgs {
   syncCodexConnectorReviewRequestObservation?: typeof syncCodexConnectorReviewRequestObservation;
   syncCopilotReviewRequestObservation?: typeof syncCopilotReviewRequestObservation;
   syncCopilotReviewTimeoutState?: typeof syncCopilotReviewTimeoutState;
+  syncMergeLatencyVisibility?: typeof syncMergeLatencyVisibility;
 }
 
 export interface TrackedPrLifecycleProjection {
@@ -43,6 +45,10 @@ export interface TrackedPrLifecycleProjection {
   copilotReviewTimeoutPatch: Pick<
     IssueRunRecord,
     "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
+  >;
+  mergeLatencyVisibilityPatch: Pick<
+    IssueRunRecord,
+    "provider_success_observed_at" | "provider_success_head_sha" | "merge_readiness_last_evaluated_at"
   >;
   nextState: RunState;
   nextBlockedReason: BlockedReason | null;
@@ -268,6 +274,8 @@ export function projectTrackedPrLifecycle(args: ProjectTrackedPrLifecycleArgs): 
     args.syncCopilotReviewRequestObservation ?? syncCopilotReviewRequestObservation;
   const syncCopilotReviewTimeoutStateImpl =
     args.syncCopilotReviewTimeoutState ?? syncCopilotReviewTimeoutState;
+  const syncMergeLatencyVisibilityImpl =
+    args.syncMergeLatencyVisibility ?? syncMergeLatencyVisibility;
   const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(args.record, args.pr.headRefOid);
 
   const projectionSeedRecord: IssueRunRecord = {
@@ -287,12 +295,23 @@ export function projectTrackedPrLifecycle(args: ProjectTrackedPrLifecycleArgs): 
     args.pr,
   );
   const copilotReviewTimeoutPatch = syncCopilotReviewTimeoutStateImpl(args.config, projectionSeedRecord, args.pr);
-  const recordForState: IssueRunRecord = {
+  const recordForVisibility: IssueRunRecord = {
     ...projectionSeedRecord,
     ...reviewWaitPatch,
     ...codexConnectorReviewRequestObservationPatch,
     ...copilotReviewRequestObservationPatch,
     ...copilotReviewTimeoutPatch,
+  };
+  const mergeLatencyVisibilityPatch = syncMergeLatencyVisibilityImpl(
+    args.config,
+    recordForVisibility,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+  );
+  const recordForState: IssueRunRecord = {
+    ...recordForVisibility,
+    ...mergeLatencyVisibilityPatch,
   };
   const nextState = inferStateFromPullRequestImpl(
     args.config,
@@ -308,10 +327,11 @@ export function projectTrackedPrLifecycle(args: ProjectTrackedPrLifecycleArgs): 
     copilotReviewRequestObservationPatch,
     codexConnectorReviewRequestObservationPatch,
     copilotReviewTimeoutPatch,
+    mergeLatencyVisibilityPatch,
     nextState,
     nextBlockedReason:
       nextState === "blocked"
-        ? blockedReasonForLifecycleStateImpl(args.config, recordForState, args.pr, args.checks, args.reviewThreads)
+        ? blockedReasonForLifecycleStateImpl(args.config, recordForVisibility, args.pr, args.checks, args.reviewThreads)
         : null,
     shouldSuppressRecovery: nextState === "failed",
   };


### PR DESCRIPTION
## Summary
- project tracked-PR provider-success visibility before blocked-record recovery writes state
- persist merge-latency visibility through stale failure convergence patches and prepared issue lifecycle touches
- add HRCore-shaped stale Codex Connector residue coverage with partial processed-thread bookkeeping

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts --test-name-pattern "rehydrates tracked PR manual-review|clears stale manual-review repeat stops|clears stale same-head review-thread blockers"
- npx tsx --test src/tracked-pr-lifecycle-projection.test.ts src/supervisor/supervisor-lifecycle.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/recovery-reconciliation.test.ts
- npm run build