### PR TITLE
Clear stale Codex residue recovery bookkeeping

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -1237,12 +1237,15 @@ export async function reconcileRecoverableBlockedIssueStates(
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
         mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
       });
-      if (recoverySuppression.progressSummary !== null) {
+      if (!staleLocalManualReviewResidueRecovery && recoverySuppression.progressSummary !== null) {
         patch.last_tracked_pr_progress_summary = recoverySuppression.progressSummary;
       }
       if (staleLocalManualReviewResidueRecovery) {
         patch.last_tracked_pr_progress_snapshot = null;
+        patch.last_tracked_pr_progress_summary = null;
         patch.last_tracked_pr_repeat_failure_decision = null;
+        patch.processed_review_thread_ids = [];
+        patch.processed_review_thread_fingerprints = [];
       }
       const recoveryEvent = staleLocalManualReviewResidueRecovery
         ? buildRecoveryEvent(

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -3157,11 +3157,11 @@ test("reconcileRecoverableBlockedIssueStates clears stale manual-review repeat s
   assert.equal(updated.repeated_failure_signature_count, 0);
   assert.equal(updated.provider_success_head_sha, "head-191");
   assert.ok(updated.provider_success_observed_at);
-  assert.equal(
-    updated.last_tracked_pr_progress_summary,
-    "stale_local_blocker_recovered=outdated_configured_bot_residue",
-  );
+  assert.equal(updated.last_tracked_pr_progress_summary, null);
+  assert.equal(updated.last_tracked_pr_progress_snapshot, null);
   assert.equal(updated.last_tracked_pr_repeat_failure_decision, null);
+  assert.deepEqual(updated.processed_review_thread_ids, []);
+  assert.deepEqual(updated.processed_review_thread_fingerprints, []);
   assert.equal(
     updated.last_recovery_reason,
     "tracked_pr_stale_local_blocker_recovered: resumed issue #366 from blocked to pr_open after stale manual-review metadata was superseded by tracked PR #191 facts at head head-191",


### PR DESCRIPTION
## Summary
- clear stale tracked-PR progress summary/snapshot when safe stale Codex Connector residue recovery is proven
- clear processed review-thread markers so recovered residue cannot re-enter stale addressing_review bookkeeping
- tighten the focused recovery regression around provider success and stale bookkeeping cleanup

Fixes #2141

## Verification
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npx tsx --test src/recovery-reconciliation.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/tracked-pr-lifecycle-projection.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts src/pull-request-state-sync.test.ts src/post-turn-pull-request.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/codex/codex-prompt.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recovery mechanism for stale manual review states. The system now correctly clears all associated stale tracking data, progress information, failure decision histories, and review-related metadata when specific recovery conditions are triggered. This ensures proper state cleanup, maintains data consistency and accuracy, and prevents outdated information from interfering with future processing and operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->