### PR TITLE
Handle active stale Codex residue cleanup

### DIFF
--- a/src/supervisor/stale-review-bot-recovery.test.ts
+++ b/src/supervisor/stale-review-bot-recovery.test.ts
@@ -8,7 +8,10 @@ import {
   createRecord,
   createReviewThread,
 } from "../turn-execution-test-helpers";
-import { recoverStaleConfiguredBotReviewThreads } from "./stale-review-bot-recovery";
+import {
+  recoverStaleConfiguredBotReviewThreads,
+  staleConfiguredBotReviewProgressKey,
+} from "./stale-review-bot-recovery";
 
 function createNoopStateStore() {
   return {
@@ -105,6 +108,119 @@ test("recoverStaleConfiguredBotReviewThreads returns a typed resolved result and
   assert.deepEqual(result.record.stale_review_bot_resolve_progress_keys, [
     "resolve:thread-1@head-116:stalled-bot:thread-1",
   ]);
+});
+
+test("recoverStaleConfiguredBotReviewThreads clears stale residue when resolve progress is partially preexisting", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+  });
+  const pr = createPullRequest({
+    number: 183,
+    headRefOid: "head-183",
+  });
+  const threadIds = ["thread-1", "thread-2"];
+  const signature = threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|");
+  const preexistingReplyKey = staleConfiguredBotReviewProgressKey({
+    headSha: pr.headRefOid,
+    signature,
+    threadId: threadIds[0],
+    phase: "reply",
+  });
+  const preexistingResolveKey = staleConfiguredBotReviewProgressKey({
+    headSha: pr.headRefOid,
+    signature,
+    threadId: threadIds[0],
+    phase: "resolve",
+  });
+  const record = createRecord({
+    issue_number: 102,
+    pr_number: pr.number,
+    state: "addressing_review",
+    blocked_reason: null,
+    last_head_sha: pr.headRefOid,
+    last_failure_context: createFailureContext("stale configured-bot review thread"),
+    last_failure_signature: signature,
+    repeated_failure_signature_count: 4,
+    last_tracked_pr_progress_snapshot: "{\"stale\":true}",
+    last_tracked_pr_progress_summary: "processed_review_thread_fingerprints_changed",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadIds[0]}@${pr.headRefOid}`],
+    processed_review_thread_fingerprints: [`${threadIds[0]}@${pr.headRefOid}#comment-1`],
+    stale_review_bot_reply_progress_keys: [preexistingReplyKey],
+    stale_review_bot_resolve_progress_keys: [preexistingResolveKey],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": record,
+    },
+  };
+  const failureContext = {
+    ...createFailureContext("stale configured-bot review thread"),
+    signature,
+    details: threadIds.map(
+      (threadId) =>
+        `reviewer=chatgpt-codex-connector thread=${threadId} file=src/review.ts line=42 processed_on_current_head=yes`,
+    ),
+    url: "https://example.test/review/183",
+  };
+  const reviewThreads = threadIds.map((threadId) =>
+    createReviewThread({
+      id: threadId,
+      path: "src/review.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "This finding is stale on the current head.",
+            createdAt: "2026-05-24T02:05:00Z",
+            url: `https://example.test/pr/183#discussion_${threadId}`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const replies: string[] = [];
+  const resolutions: string[] = [];
+
+  const result = await recoverStaleConfiguredBotReviewThreads({
+    github: {
+      replyToReviewThread: async (threadId: string) => {
+        replies.push(threadId);
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolutions.push(threadId);
+      },
+    },
+    stateStore: createNoopStateStore(),
+    state,
+    record,
+    pr,
+    reviewThreads,
+    syncJournal: async () => undefined,
+    config,
+    failureContext,
+    resolveAfterReply: true,
+  });
+
+  assert.equal(result.status, "resolved");
+  assert.deepEqual(replies, [threadIds[1]]);
+  assert.deepEqual(resolutions, [threadIds[1]]);
+  assert.equal(result.shouldRefreshPullRequest, true);
+  assert.equal(result.record.last_failure_context, null);
+  assert.equal(result.record.last_failure_signature, null);
+  assert.equal(result.record.repeated_failure_signature_count, 0);
+  assert.equal(result.record.last_tracked_pr_progress_snapshot, null);
+  assert.equal(result.record.last_tracked_pr_progress_summary, null);
+  assert.equal(result.record.last_tracked_pr_repeat_failure_decision, null);
+  assert.deepEqual(result.record.processed_review_thread_ids, []);
+  assert.deepEqual(result.record.processed_review_thread_fingerprints, []);
 });
 
 test("recoverStaleConfiguredBotReviewThreads normalizes raw PRRT thread signatures", async () => {

--- a/src/supervisor/stale-review-bot-recovery.ts
+++ b/src/supervisor/stale-review-bot-recovery.ts
@@ -289,7 +289,21 @@ export async function recoverStaleConfiguredBotReviewThreads(args: {
     });
   }
 
+  const staleResidueClearedPatch =
+    args.resolveAfterReply && resolveCount === replyThreads.length
+      ? {
+          last_failure_context: null,
+          last_failure_signature: null,
+          repeated_failure_signature_count: 0,
+          last_tracked_pr_progress_snapshot: null,
+          last_tracked_pr_progress_summary: null,
+          last_tracked_pr_repeat_failure_decision: null,
+          processed_review_thread_ids: [],
+          processed_review_thread_fingerprints: [],
+        }
+      : {};
   const updatedRecord = args.stateStore.touch(record, {
+    ...staleResidueClearedPatch,
     last_stale_review_bot_reply_head_sha: args.pr.headRefOid,
     last_stale_review_bot_reply_signature: blockerSignature,
   });

--- a/src/supervisor/stale-review-bot-recovery.ts
+++ b/src/supervisor/stale-review-bot-recovery.ts
@@ -290,7 +290,11 @@ export async function recoverStaleConfiguredBotReviewThreads(args: {
   }
 
   const staleResidueClearedPatch =
-    args.resolveAfterReply && resolveCount === replyThreads.length
+    args.resolveAfterReply && hasResolvedAllStaleConfiguredBotThreads({
+      record,
+      headSha: args.pr.headRefOid,
+      signature: blockerSignature,
+    })
       ? {
           last_failure_context: null,
           last_failure_signature: null,

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1750,11 +1750,12 @@ test("runPreparedIssue auto-handles stale Codex Connector conversation residue b
   const branch = branchName(fixture.config, issueNumber);
   const { workspacePath, journalPath } = trackedIssuePaths(fixture.workspaceRoot, issueNumber);
   const threadIds = Array.from({ length: 7 }, (_value, index) => `PRRT_hrcore_183_${index + 1}`);
+  const staleSignature = threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|");
   const staleFailureContext = {
     category: "manual" as const,
     summary:
       "7 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    signature: staleSignature,
     command: null,
     details: threadIds.map(
       (threadId) =>
@@ -1975,11 +1976,19 @@ test("runPreparedIssue marks active stale Codex Connector residue successful bef
   const branch = branchName(fixture.config, issueNumber);
   const { workspacePath, journalPath } = trackedIssuePaths(fixture.workspaceRoot, issueNumber);
   const threadIds = Array.from({ length: 7 }, (_value, index) => `PRRT_hrcore_183_${index + 1}`);
+  const staleSignature = threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|");
+  const preexistingResolvedThreadIds = [threadIds[0]];
+  const preexistingReplyProgressKeys = preexistingResolvedThreadIds.map(
+    (threadId) => `reply:${threadId}@${headSha}:${staleSignature}`,
+  );
+  const preexistingResolveProgressKeys = preexistingResolvedThreadIds.map(
+    (threadId) => `resolve:${threadId}@${headSha}:${staleSignature}`,
+  );
   const staleFailureContext = {
     category: "manual" as const,
     summary:
       "7 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    signature: staleSignature,
     command: null,
     details: threadIds.map(
       (threadId) =>
@@ -2027,6 +2036,8 @@ test("runPreparedIssue marks active stale Codex Connector residue successful bef
     }),
     processed_review_thread_ids: [`${threadIds[0]}@${headSha}`],
     processed_review_thread_fingerprints: [`${threadIds[0]}@${headSha}#comment-${threadIds[0]}`],
+    stale_review_bot_reply_progress_keys: preexistingReplyProgressKeys,
+    stale_review_bot_resolve_progress_keys: preexistingResolveProgressKeys,
     review_follow_up_head_sha: headSha,
     review_follow_up_remaining: 0,
   });
@@ -2099,9 +2110,11 @@ test("runPreparedIssue marks active stale Codex Connector residue successful bef
     getIssue: async () => issue,
     resolvePullRequestForBranch: async () => pr,
     getChecks: async () => checks,
-    getUnresolvedReviewThreads: async () => (resolveCalls.length === threadIds.length ? [] : reviewThreads),
+    getUnresolvedReviewThreads: async () =>
+      resolveCalls.length + preexistingResolvedThreadIds.length === threadIds.length ? [] : reviewThreads,
     getPullRequestIfExists: async () => pr,
-    getPullRequest: async () => (resolveCalls.length === threadIds.length ? resolvedPr : pr),
+    getPullRequest: async () =>
+      resolveCalls.length + preexistingResolvedThreadIds.length === threadIds.length ? resolvedPr : pr,
     getExternalReviewSurface: async () => ({ reviews: [], issueComments: [] }),
     addIssueComment: async (_issueNumberForComment: number, body: string) => {
       addedComments.push(body);
@@ -2190,8 +2203,8 @@ test("runPreparedIssue marks active stale Codex Connector residue successful bef
   });
 
   assert.doesNotMatch(message, /blocked after repeated identical review-related failure signatures/);
-  assert.deepEqual(replyCalls, threadIds);
-  assert.deepEqual(resolveCalls, threadIds);
+  assert.deepEqual(replyCalls, threadIds.slice(1));
+  assert.deepEqual(resolveCalls, threadIds.slice(1));
   assert.equal(addedComments.some((body) => /@codex review/.test(body)), false);
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1955,6 +1955,260 @@ test("runPreparedIssue auto-handles stale Codex Connector conversation residue b
   assert.ok(record.provider_success_observed_at);
 });
 
+test("runPreparedIssue marks active stale Codex Connector residue successful before repeat-stop with partial processed-thread bookkeeping", async () => {
+  const fixture = await createSupervisorFixture({
+    codexScriptLines: [
+      "#!/bin/sh",
+      "echo unexpected Codex dispatch >&2",
+      "exit 97",
+      "",
+    ],
+  });
+  fixture.config.sameFailureSignatureRepeatLimit = 3;
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  fixture.config.verifiedNoSourceChangeReviewThreadAutoResolve = true;
+  fixture.config.configuredBotInitialGraceWaitSeconds = 0;
+  fixture.config.configuredBotSettledWaitSeconds = 0;
+  const issueNumber = 183;
+  const prNumber = 183;
+  const headSha = "d5a9957506c697dc13f5431bb460cfe95257bcae";
+  const branch = branchName(fixture.config, issueNumber);
+  const { workspacePath, journalPath } = trackedIssuePaths(fixture.workspaceRoot, issueNumber);
+  const threadIds = Array.from({ length: 7 }, (_value, index) => `PRRT_hrcore_183_${index + 1}`);
+  const staleFailureContext = {
+    category: "manual" as const,
+    summary:
+      "7 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    command: null,
+    details: threadIds.map(
+      (threadId) =>
+        `reviewer=chatgpt-codex-connector thread=${threadId} file=src/stale-residue.ts line=none processed_on_current_head=yes`,
+    ),
+    url: "https://example.test/pr/183#discussion_r1",
+    updated_at: "2026-05-24T01:00:00Z",
+  };
+  const initialRecord = createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
+    state: "addressing_review",
+    workspace: workspacePath,
+    branch,
+    pr_number: prNumber,
+    journal_path: journalPath,
+    last_head_sha: headSha,
+    provider_success_observed_at: null,
+    provider_success_head_sha: null,
+    last_error: staleFailureContext.summary,
+    last_failure_signature: staleFailureContext.signature,
+    repeated_failure_signature_count: 4,
+    last_failure_context: staleFailureContext,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_tracked_pr_progress_summary: "review_thread_source_anchor_changed | processed_review_thread_fingerprints_changed",
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: headSha,
+      reviewDecision: null,
+      mergeStateStatus: "BLOCKED",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-05-24T00:55:00Z",
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+      currentHeadCiGreenAt: "2026-05-24T00:50:00Z",
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["verify-pre-pr:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: threadIds,
+      unresolvedReviewThreadFingerprints: threadIds.map((threadId) => `${threadId}#comment-${threadId}`),
+      unresolvedReviewThreadSourceAnchors: threadIds.map((threadId) => `${threadId}:src/stale-residue.ts:unknown`),
+      processedReviewThreadIds: [`${threadIds[0]}@${headSha}`],
+      processedReviewThreadFingerprints: [`${threadIds[0]}@${headSha}#comment-${threadIds[0]}`],
+      verificationProbeOutcomes: [],
+    }),
+    processed_review_thread_ids: [`${threadIds[0]}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadIds[0]}@${headSha}#comment-${threadIds[0]}`],
+    review_follow_up_head_sha: headSha,
+    review_follow_up_remaining: 0,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [initialRecord],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+
+  const issue = createTrackedIssue(issueNumber, {
+    title: "Recover active stale Codex Connector residue",
+    body: executionReadyBody("Recover active stale Codex Connector residue without another Codex turn."),
+  });
+  const pr = createTrackedPullRequest(fixture.config, issueNumber, {
+    number: prNumber,
+    title: "HRCore stale Codex Connector residue",
+    isDraft: false,
+    reviewDecision: null,
+    headRefOid: headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-24T00:50:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-24T00:55:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: headSha,
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
+  });
+  const checks: PullRequestCheck[] = [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads = threadIds.map((threadId) =>
+    createReviewThread({
+      id: threadId,
+      isOutdated: true,
+      path: "src/stale-residue.ts",
+      line: null,
+      comments: {
+        nodes: [
+          {
+            id: `comment-${threadId}`,
+            body: "Outdated Codex Connector residue.",
+            createdAt: "2026-05-24T00:40:00Z",
+            url: `https://example.test/pr/183#discussion_${threadId}`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+  const resolvedPr = createTrackedPullRequest(fixture.config, issueNumber, {
+    ...pr,
+    mergeStateStatus: "CLEAN",
+  });
+  const replyCalls: string[] = [];
+  const resolveCalls: string[] = [];
+  const addedComments: string[] = [];
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => checks,
+    getUnresolvedReviewThreads: async () => (resolveCalls.length === threadIds.length ? [] : reviewThreads),
+    getPullRequestIfExists: async () => pr,
+    getPullRequest: async () => (resolveCalls.length === threadIds.length ? resolvedPr : pr),
+    getExternalReviewSurface: async () => ({ reviews: [], issueComments: [] }),
+    addIssueComment: async (_issueNumberForComment: number, body: string) => {
+      addedComments.push(body);
+    },
+    replyToReviewThread: async (threadId: string) => {
+      replyCalls.push(threadId);
+    },
+    resolveReviewThread: async (threadId: string) => {
+      resolveCalls.push(threadId);
+    },
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await (
+    supervisor as unknown as {
+      runPreparedIssue: (context: {
+        state: SupervisorStateFile;
+        record: IssueRunRecord;
+        issue: GitHubIssue;
+        previousCodexSummary: string | null;
+        previousError: string | null;
+        workspacePath: string;
+        journalPath: string;
+        syncJournal: (record: IssueRunRecord) => Promise<void>;
+        memoryArtifacts: {
+          alwaysReadFiles: string[];
+          onDemandFiles: string[];
+          contextIndexPath: string;
+          agentsPath: string;
+        };
+        workspaceStatus: {
+          branch: string;
+          headSha: string;
+          hasUncommittedChanges: boolean;
+          baseAhead: number;
+          baseBehind: number;
+          remoteBranchExists: boolean;
+          remoteAhead: number;
+          remoteBehind: number;
+        };
+        pr: GitHubPullRequest | null;
+        checks: PullRequestCheck[];
+        reviewThreads: ReviewThread[];
+        options: { dryRun: boolean };
+        recoveryLog: string | null;
+        recoveryEvents: [];
+      }) => Promise<string>;
+    }
+  ).runPreparedIssue({
+    state,
+    record: initialRecord,
+    issue,
+    previousCodexSummary: null,
+    previousError: null,
+    workspacePath,
+    journalPath,
+    syncJournal: async () => undefined,
+    memoryArtifacts: {
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+      contextIndexPath: path.join(fixture.workspaceRoot, "context-index.md"),
+      agentsPath: path.join(fixture.workspaceRoot, "AGENTS.generated.md"),
+    },
+    workspaceStatus: {
+      branch,
+      headSha,
+      hasUncommittedChanges: false,
+      baseAhead: 0,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    },
+    pr,
+    checks,
+    reviewThreads,
+    options: { dryRun: false },
+    recoveryLog: null,
+    recoveryEvents: [],
+  });
+
+  assert.doesNotMatch(message, /blocked after repeated identical review-related failure signatures/);
+  assert.deepEqual(replyCalls, threadIds);
+  assert.deepEqual(resolveCalls, threadIds);
+  assert.equal(addedComments.some((body) => /@codex review/.test(body)), false);
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const record = persisted.issues[String(issueNumber)];
+  assert.equal(record.state, "ready_to_merge");
+  assert.equal(record.blocked_reason, null);
+  assert.equal(record.last_failure_context, null);
+  assert.equal(record.last_failure_signature, null);
+  assert.equal(record.repeated_failure_signature_count, 0);
+  assert.equal(record.last_tracked_pr_progress_summary, null);
+  assert.equal(record.last_tracked_pr_progress_snapshot, null);
+  assert.equal(record.last_tracked_pr_repeat_failure_decision, null);
+  assert.deepEqual(record.processed_review_thread_ids, []);
+  assert.deepEqual(record.processed_review_thread_fingerprints, []);
+  assert.equal(record.provider_success_head_sha, headSha);
+  assert.ok(record.provider_success_observed_at);
+});
+
 test("runPreparedIssue recovers blocked stale Codex Connector residue with partial processed-thread bookkeeping", async () => {
   const fixture = await createSupervisorFixture({
     codexScriptLines: [


### PR DESCRIPTION
## Summary
- add an active prepared-issue regression for stale Codex Connector residue with partial processed-thread bookkeeping and over-threshold repeat-stop state
- clear stale failure, repeat-stop, progress snapshot, and processed-thread bookkeeping after every targeted stale configured-bot thread is resolved

## Verification
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern "stale Codex Connector|repeat-stop|processed-thread"
- npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts src/recovery-reconciliation.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/tracked-pr-lifecycle-projection.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-readiness.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-status-selection.test.ts src/supervisor/supervisor-diagnostics-explain.test.ts src/codex/codex-prompt.test.ts
- npm run build

Closes #2143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cleanup of stale review artifacts when reviews are resolved through reply workflows.
  * Enhanced state management to properly clear residual tracking fields during review completion.

* **Tests**
  * Added test coverage for edge case handling in review resolution with partial state tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->