### PR TITLE
Restore CodeRabbit nitpick-only auto-merge

### DIFF
--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -742,6 +742,209 @@ test("handlePostTurnMergeAndCompletion leaves ready PRs unmerged without auto-me
   assert.equal(autoMergeCalls, 0);
 });
 
+test("handlePostTurnMergeAndCompletion auto-merges CodeRabbit nitpick-only PRs without Codex auto-merge opt-in", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],
+    localCiCommand: "npm run verify:pre-pr",
+  });
+  const issueNumber = 126;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-126",
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Configured local CI command passed before marking PR #126 ready.",
+          ran_at: "2026-03-13T06:32:00Z",
+          head_sha: "head-126",
+          execution_mode: "shell",
+          command: "npm run verify:pre-pr",
+          failure_class: null,
+          remediation_target: null,
+        },
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Auto-merge CodeRabbit nitpick-only review",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 126,
+    title: "CodeRabbit nitpick-only ready PR",
+    url: "https://example.test/pr/126",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-126",
+    headRefOid: "head-126",
+    mergedAt: null,
+    configuredBotCurrentHeadObservedAt: "2026-03-13T06:30:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-13T06:30:00Z",
+    currentHeadCiGreenAt: "2026-03-13T06:31:00Z",
+  };
+
+  let autoMergeCalls = 0;
+  const comments: Array<{ issueNumber: number; body: string }> = [];
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 126);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 126);
+      return passingChecks();
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 126);
+      return [];
+    },
+    addIssueComment: async (issueNumber: number, body: string) => {
+      comments.push({ issueNumber, body });
+    },
+    enableAutoMerge: async (prNumber: number, headSha: string) => {
+      assert.equal(prNumber, 126);
+      assert.equal(headSha, "head-126");
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "merging");
+  assert.equal(result.blocked_reason, null);
+  assert.equal(result.last_failure_context, null);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("auto_merge_path=configured_bot_provider"), true);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("codex_current_head_no_major=not_required"), true);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("local_ci=passed head_sha=head-126"), true);
+  assert.equal(autoMergeCalls, 1);
+  assert.equal(comments.length, 1);
+});
+
+test("handlePostTurnMergeAndCompletion blocks CodeRabbit auto-merge on stale local CI without Codex no-major refusal", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    reviewBotLogins: ["coderabbitai"],
+    localCiCommand: "npm run verify:pre-pr",
+  });
+  const issueNumber = 127;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-127",
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Configured local CI command passed before marking PR #127 ready.",
+          ran_at: "2026-03-13T06:32:00Z",
+          head_sha: "old-head-127",
+          execution_mode: "shell",
+          command: "npm run verify:pre-pr",
+          failure_class: null,
+          remediation_target: null,
+        },
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Block CodeRabbit auto-merge on stale local CI",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 127,
+    title: "CodeRabbit ready PR with stale local CI",
+    url: "https://example.test/pr/127",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-127",
+    headRefOid: "head-127",
+    mergedAt: null,
+    configuredBotCurrentHeadObservedAt: "2026-03-13T06:30:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-13T06:30:00Z",
+    currentHeadCiGreenAt: "2026-03-13T06:31:00Z",
+  };
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 127);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 127);
+      return passingChecks();
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 127);
+      return [];
+    },
+    enableAutoMerge: async () => {
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "blocked");
+  assert.equal(result.blocked_reason, "verification");
+  assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-127:missing_current_head_local_ci_success");
+  assert.equal(result.last_failure_context?.details.includes("missing_current_head_codex_no_major"), false);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("auto_merge_path=configured_bot_provider"), true);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("codex_current_head_no_major=not_required"), true);
+  assert.equal(autoMergeCalls, 0);
+});
+
 test("handlePostTurnMergeAndCompletion blocks auto-merge when final mergeable evidence is missing", async () => {
   const fixture = await createSupervisorFixture();
   const config = createConfig({

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -95,6 +95,7 @@ import {
   isIgnoredSupervisorArtifactPath,
   parseGitStatusPorcelainV1Paths,
 } from "../core/git-workspace-helpers";
+import { configuredReviewProviderKinds } from "../core/review-providers";
 import { StateStore } from "../core/state-store";
 import { renderDoctorReport } from "../doctor";
 import { buildSetupConfigPreview, type SetupConfigPreviewSelectableReviewProviderProfile } from "../setup-config-preview";
@@ -246,6 +247,15 @@ function hasCurrentHeadCodexNoMajor(record: IssueRunRecord, pr: GitHubPullReques
   );
 }
 
+function autoMergePathForConfig(config: SupervisorConfig): "codex_connector_no_major" | "configured_bot_provider" | null {
+  const providerKinds = configuredReviewProviderKinds(config);
+  if (providerKinds.length > 0 && !providerKinds.includes("codex")) {
+    return "configured_bot_provider";
+  }
+
+  return config.codexConnectorAutoMergeEnabled === true ? "codex_connector_no_major" : null;
+}
+
 function finalAutoMergeGuard(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -253,8 +263,9 @@ function finalAutoMergeGuard(args: {
   currentPr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  autoMergePath: "codex_connector_no_major" | "configured_bot_provider";
 }): FinalAutoMergeGuardResult {
-  const { config, record, originalPr, currentPr, checks, reviewThreads } = args;
+  const { config, record, originalPr, currentPr, checks, reviewThreads, autoMergePath } = args;
   const checkSummary = summarizeChecks(checks);
   const checksGreen = checks.length > 0 && checkSummary.allPassing;
   const effectiveConfiguredBotBlockers = effectiveConfiguredBotReviewThreadsForState(
@@ -265,22 +276,28 @@ function finalAutoMergeGuard(args: {
     reviewThreads,
   ).length;
   const effectiveHumanBlockers = config.humanReviewBlocksMerge ? manualReviewThreads(config, reviewThreads).length : 0;
+  const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr);
+  const requiresCodexNoMajor = autoMergePath === "codex_connector_no_major";
   const aggregateHumanReviewBlocker =
     config.humanReviewBlocksMerge &&
-    (currentPr.reviewDecision === "CHANGES_REQUESTED" || currentPr.reviewDecision === "REVIEW_REQUIRED")
+    (currentPr.reviewDecision === "REVIEW_REQUIRED" ||
+      (currentPr.reviewDecision === "CHANGES_REQUESTED" &&
+        (requiresCodexNoMajor || currentPr.configuredBotTopLevelReviewStrength !== "nitpick_only")))
       ? currentPr.reviewDecision
       : null;
-  const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr);
   const localCiResult = record.latest_local_ci_result ?? null;
   const localCiMissing =
     hasConfiguredLocalCiCommand(config) &&
     (localCiResult?.outcome !== "passed" || localCiResult?.head_sha !== currentPr.headRefOid);
   const evidenceDetails = [
+    `auto_merge_path=${autoMergePath}`,
     `head_sha=${currentPr.headRefOid}`,
     `mergeable=${currentPr.mergeable ?? "unknown"}`,
     `merge_state=${currentPr.mergeStateStatus ?? "unknown"}`,
     `checks=green count=${checks.length}`,
-    `codex_current_head_no_major=${currentHeadCodexNoMajor ? "yes" : "no"}`,
+    requiresCodexNoMajor
+      ? `codex_current_head_no_major=${currentHeadCodexNoMajor ? "yes" : "no"}`
+      : "codex_current_head_no_major=not_required",
     `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     `human_blockers=${effectiveHumanBlockers}`,
     `review_decision=${currentPr.reviewDecision ?? "none"}`,
@@ -294,7 +311,7 @@ function finalAutoMergeGuard(args: {
     currentPr.mergeable === "MERGEABLE" ? null : `mergeable=${currentPr.mergeable ?? "unknown"}`,
     currentPr.mergeStateStatus === "CLEAN" ? null : `merge_state=${currentPr.mergeStateStatus ?? "unknown"}`,
     checks.length === 0 ? "required_checks_missing" : checksGreen ? null : "required_checks_not_green",
-    currentHeadCodexNoMajor ? null : "missing_current_head_codex_no_major",
+    requiresCodexNoMajor && !currentHeadCodexNoMajor ? "missing_current_head_codex_no_major" : null,
     effectiveConfiguredBotBlockers === 0 ? null : `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     effectiveHumanBlockers === 0 ? null : `human_blockers=${effectiveHumanBlockers}`,
     aggregateHumanReviewBlocker ? `human_review_decision=${aggregateHumanReviewBlocker}` : null,
@@ -782,49 +799,53 @@ export class Supervisor {
               : null,
           last_head_sha: currentPr.headRefOid,
         });
-      } else if (this.config.codexConnectorAutoMergeEnabled !== true) {
-        nextRecord = this.stateStore.touch(nextRecord, {
-          ...lifecyclePatch,
-          state: "ready_to_merge",
-          blocked_reason: null,
-          last_auto_merge_guard_context: null,
-          last_head_sha: currentPr.headRefOid,
-        });
       } else {
-        const autoMergeGuard = finalAutoMergeGuard({
-          config: this.config,
-          record: lifecycle.recordForState,
-          originalPr: pr,
-          currentPr,
-          checks: refreshed.checks,
-          reviewThreads: refreshed.reviewThreads,
-        });
-        if (autoMergeGuard.refusal) {
+        const autoMergePath = autoMergePathForConfig(this.config);
+        if (autoMergePath === null) {
           nextRecord = this.stateStore.touch(nextRecord, {
             ...lifecyclePatch,
-            state: "blocked",
-            blocked_reason: "verification",
-            last_error: truncate(autoMergeGuard.refusal.summary, 1000),
-            last_failure_context: autoMergeGuard.refusal,
-            last_auto_merge_guard_context: autoMergeGuard.evidence,
-            ...applyFailureSignature(nextRecord, autoMergeGuard.refusal),
+            state: "ready_to_merge",
+            blocked_reason: null,
+            last_auto_merge_guard_context: null,
             last_head_sha: currentPr.headRefOid,
           });
         } else {
-          await publishFinalAutoMergeGuardComment({
-            github: this.github,
-            pr: currentPr,
-            evidence: autoMergeGuard.evidence,
+          const autoMergeGuard = finalAutoMergeGuard({
+            config: this.config,
+            record: lifecycle.recordForState,
+            originalPr: pr,
+            currentPr,
+            checks: refreshed.checks,
+            reviewThreads: refreshed.reviewThreads,
+            autoMergePath,
           });
-          await this.github.enableAutoMerge(currentPr.number, currentPr.headRefOid);
-          nextRecord = this.stateStore.touch(nextRecord, {
-            ...lifecyclePatch,
-            state: "merging",
-            blocked_reason: null,
-            last_failure_context: null,
-            last_auto_merge_guard_context: autoMergeGuard.evidence,
-            last_head_sha: currentPr.headRefOid,
-          });
+          if (autoMergeGuard.refusal) {
+            nextRecord = this.stateStore.touch(nextRecord, {
+              ...lifecyclePatch,
+              state: "blocked",
+              blocked_reason: "verification",
+              last_error: truncate(autoMergeGuard.refusal.summary, 1000),
+              last_failure_context: autoMergeGuard.refusal,
+              last_auto_merge_guard_context: autoMergeGuard.evidence,
+              ...applyFailureSignature(nextRecord, autoMergeGuard.refusal),
+              last_head_sha: currentPr.headRefOid,
+            });
+          } else {
+            await publishFinalAutoMergeGuardComment({
+              github: this.github,
+              pr: currentPr,
+              evidence: autoMergeGuard.evidence,
+            });
+            await this.github.enableAutoMerge(currentPr.number, currentPr.headRefOid);
+            nextRecord = this.stateStore.touch(nextRecord, {
+              ...lifecyclePatch,
+              state: "merging",
+              blocked_reason: null,
+              last_failure_context: null,
+              last_auto_merge_guard_context: autoMergeGuard.evidence,
+              last_head_sha: currentPr.headRefOid,
+            });
+          }
         }
       }
       state.issues[String(nextRecord.issue_number)] = nextRecord;


### PR DESCRIPTION
## Summary
- add a provider-aware auto-merge path for non-Codex configured review providers
- keep Codex Connector auto-merge on the existing current-head no-major guard
- cover CodeRabbit nitpick-only success and stale local-CI refusal in readiness tests

## Verification
- npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts src/config.test.ts
- npm run build
- node dist/index.js issue-lint 2145 --config <temporary CodeRabbit config with repoSlug substituted>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced auto-merge decision logic to support configuration-based guard paths and improved handling of stale CI results.

* **Tests**
  * Added comprehensive test coverage for auto-merge behavior across different review configurations and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->