### PR TITLE
[codex] Persist Codex provider success for converged residue

### DIFF
--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -638,6 +638,76 @@ test("inferStateFromPullRequest records provider success for converged outdated 
   assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, "head123");
 });
 
+test("inferStateFromPullRequest records provider success when outdated Codex residue is mixed with nitpicks", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T16:07:04Z",
+    review_wait_head_sha: "head123",
+    last_failure_signature: "thread-outdated-codex",
+    repeated_failure_signature_count: 3,
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T14:33:41Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    currentHeadCiGreenAt: "2026-05-23T16:02:36Z",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-codex",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-codex",
+            body: "P1: Earlier Codex Connector finding that is obsolete after the current-head nitpick-only signal.",
+            createdAt: "2026-05-23T14:16:47Z",
+            url: "https://example.test/pr/44#discussion_r2123",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-current-nitpick",
+      isOutdated: false,
+      comments: {
+        nodes: [
+          {
+            id: "comment-current-nitpick",
+            body: "P3: Consider renaming this helper for clarity.",
+            createdAt: "2026-05-23T14:34:00Z",
+            url: "https://example.test/pr/44#discussion_r2124",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "pr_open");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, "head123");
+});
+
 test("inferStateFromPullRequest keeps stale Codex review waits guarded when safe-shape gates are missing", () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -575,6 +575,69 @@ test("inferStateFromPullRequest ignores stale same-head Codex review wait when o
   assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, "head123");
 });
 
+test("inferStateFromPullRequest records provider success for converged outdated Codex residue before another repair turn", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    last_head_sha: "head123",
+    review_wait_started_at: "2026-05-23T16:07:04Z",
+    review_wait_head_sha: "head123",
+    last_failure_context: {
+      category: "review",
+      summary: "7 unresolved automated review thread(s) remain.",
+      signature: "thread-outdated-codex",
+      command: null,
+      details: [
+        "src/mvp-a-onboarding-traceability.ts:? p_severity=P1 summary=stale Codex Connector residue",
+      ],
+      url: "https://example.test/pr/44#discussion_r2123",
+      updated_at: "2026-05-23T16:07:04Z",
+    },
+    last_failure_signature: "thread-outdated-codex",
+    repeated_failure_signature_count: 3,
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T14:33:41Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-05-23T16:02:36Z",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-outdated-codex",
+      isOutdated: true,
+      comments: {
+        nodes: [
+          {
+            id: "comment-outdated-codex",
+            body: "P1: Earlier Codex Connector finding that is obsolete after the current-head no-major signal.",
+            createdAt: "2026-05-23T14:16:47Z",
+            url: "https://example.test/pr/44#discussion_r2123",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "pr_open");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, "head123");
+});
+
 test("inferStateFromPullRequest keeps stale Codex review waits guarded when safe-shape gates are missing", () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -767,15 +767,36 @@ function codexConnectorOutdatedThreadClearanceAllowed(
   checks: PullRequestCheck[],
   reviewThreads: ReviewThread[],
 ): boolean {
+  const providerKinds = configuredReviewProviderKinds(config);
+  const checkSummary = summarizeChecks(checks);
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  const onlyOutdatedCodexConnectorThreads =
+    configuredThreads.length > 0 &&
+    configuredThreads.every((thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread));
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, configuredThreads);
+  const currentHeadCodexSuccess =
+    pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
+    pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
+    pr.configuredBotTopLevelReviewStrength !== "blocking" &&
+    validTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  const convergedOutdatedResidueCanClear =
+    providerKinds.includes("codex") &&
+    providerKinds.every((kind) => kind === "codex") &&
+    currentHeadCodexSuccess &&
+    pullRequestHeadMatchesRecord(record, pr) &&
+    checkSummary.allPassing &&
+    manualReviewThreads(config, reviewThreads).length === 0 &&
+    !mergeConflictDetected(pr) &&
+    onlyOutdatedCodexConnectorThreads &&
+    (codexConnectorPolicy?.outcome === "converged" || codexConnectorPolicy?.outcome === "nitpick_only");
+
   return Boolean(
-    configuredReviewProviderKinds(config).includes("codex") &&
-      pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
-      pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
-      pr.configuredBotTopLevelReviewStrength !== "blocking" &&
-      validTimestamp(pr.configuredBotCurrentHeadObservedAt) &&
+    providerKinds.includes("codex") &&
+      currentHeadCodexSuccess &&
       (currentHeadObservationSatisfiesActiveWait(record, pr) ||
-        staleSameHeadCodexWaitHasOnlyOutdatedResidue(config, record, pr, checks, reviewThreads)) &&
-      summarizeChecks(checks).allPassing,
+        staleSameHeadCodexWaitHasOnlyOutdatedResidue(config, record, pr, checks, reviewThreads) ||
+        convergedOutdatedResidueCanClear) &&
+      checkSummary.allPassing,
   );
 }
 

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -719,8 +719,6 @@ function effectiveConfiguredBotReviewThreads(
   reviewThreads: ReviewThread[],
 ): ReviewThread[] {
   const unresolvedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads);
-  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, unresolvedConfiguredBotThreads);
-  const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(unresolvedConfiguredBotThreads));
   const clearOutdatedCodexConnectorThreads = codexConnectorOutdatedThreadClearanceAllowed(
     config,
     record,
@@ -728,10 +726,7 @@ function effectiveConfiguredBotReviewThreads(
     checks,
     reviewThreads,
   );
-  const effectiveThreads =
-    codexConnectorPolicy?.outcome === "nitpick_only" || codexConnectorPolicy?.outcome === "converged"
-      ? unresolvedConfiguredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread))
-      : unresolvedConfiguredBotThreads;
+  const effectiveThreads = codexConnectorThreadsAfterConvergencePolicy(config, pr, unresolvedConfiguredBotThreads);
   const threadsAfterOutdatedClearance = clearOutdatedCodexConnectorThreads
     ? effectiveThreads.filter(
         (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(config, thread),
@@ -740,6 +735,20 @@ function effectiveConfiguredBotReviewThreads(
   return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, threadsAfterOutdatedClearance)
     ? threadsAfterOutdatedClearance.filter((thread) => !isIssueJournalThreadPath(thread))
     : threadsAfterOutdatedClearance;
+}
+
+function codexConnectorThreadsAfterConvergencePolicy(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  configuredThreads: ReviewThread[],
+): ReviewThread[] {
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, configuredThreads);
+  if (codexConnectorPolicy?.outcome !== "nitpick_only" && codexConnectorPolicy?.outcome !== "converged") {
+    return configuredThreads;
+  }
+
+  const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(configuredThreads));
+  return configuredThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread));
 }
 
 export function effectiveConfiguredBotReviewThreadsForState(
@@ -770,10 +779,13 @@ function codexConnectorOutdatedThreadClearanceAllowed(
   const providerKinds = configuredReviewProviderKinds(config);
   const checkSummary = summarizeChecks(checks);
   const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
-  const onlyOutdatedCodexConnectorThreads =
-    configuredThreads.length > 0 &&
-    configuredThreads.every((thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread));
   const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, configuredThreads);
+  const threadsAfterConvergencePolicy = codexConnectorThreadsAfterConvergencePolicy(config, pr, configuredThreads);
+  const onlyOutdatedCodexConnectorThreads =
+    threadsAfterConvergencePolicy.length > 0 &&
+    threadsAfterConvergencePolicy.every(
+      (thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread),
+    );
   const currentHeadCodexSuccess =
     pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
     pr.configuredBotCurrentHeadStatusState === "SUCCESS" &&
@@ -841,9 +853,12 @@ function staleSameHeadCodexWaitHasOnlyOutdatedResidue(
   }
 
   const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  const threadsAfterConvergencePolicy = codexConnectorThreadsAfterConvergencePolicy(config, pr, configuredThreads);
   return (
-    configuredThreads.length > 0 &&
-    configuredThreads.every((thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread))
+    threadsAfterConvergencePolicy.length > 0 &&
+    threadsAfterConvergencePolicy.every(
+      (thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread),
+    )
   );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced PR state determination to better handle cases where connector data is outdated but has sufficiently converged, including new pathways for clearance decisions.

* **Tests**
  * Added comprehensive test coverage for PR state inference, including validation of provider success head SHA tracking in various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->