### PR TITLE
Clear operator-replied Codex stale residue

### DIFF
--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -34,6 +34,10 @@ export function latestCodexConnectorPSeverity(thread: ReviewThread): CodexConnec
   return latestCodexConnectorReviewComment(thread)?.severity ?? null;
 }
 
+export function hasCodexConnectorFindingReviewComment(thread: ReviewThread): boolean {
+  return latestCodexConnectorReviewComment(thread) !== null;
+}
+
 function isCodexConnectorMustFixReviewThread(thread: ReviewThread): boolean {
   const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
   if (!latestCodexConnectorReview || thread.isResolved || thread.isOutdated) {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -628,6 +628,16 @@ test("inferStateFromPullRequest records provider success for converged outdated 
               typeName: "Bot",
             },
           },
+          {
+            id: "comment-operator-replied",
+            body: "Supervisor confirmed this stale Codex Connector finding is covered by the current-head success signal.",
+            createdAt: "2026-05-25T04:16:47Z",
+            url: "https://example.test/pr/44#discussion_r2123",
+            author: {
+              login: "TommyKammy",
+              typeName: "User",
+            },
+          },
         ],
       },
     }),

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -20,6 +20,7 @@ import {
   codexConnectorNitpickOnlyReviewThreads,
   codexConnectorMustFixReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
+  hasCodexConnectorFindingReviewComment,
   hasCodexConnectorPrSuccessCurrentHeadObservation,
 } from "./codex-connector-review-policy";
 import { codexConnectorCurrentHeadReviewReadiness } from "./codex-connector-review-request-decision";
@@ -729,9 +730,7 @@ function effectiveConfiguredBotReviewThreads(
   );
   const effectiveThreads = codexConnectorThreadsAfterConvergencePolicy(config, pr, unresolvedConfiguredBotThreads);
   const threadsAfterOutdatedClearance = clearOutdatedCodexConnectorThreads
-    ? effectiveThreads.filter(
-        (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(config, thread),
-      )
+    ? effectiveThreads.filter((thread) => !isClearableOutdatedCodexConnectorResidueThread(config, thread))
     : effectiveThreads;
   return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, threadsAfterOutdatedClearance)
     ? threadsAfterOutdatedClearance.filter((thread) => !isIssueJournalThreadPath(thread))
@@ -750,6 +749,13 @@ function codexConnectorThreadsAfterConvergencePolicy(
 
   const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(configuredThreads));
   return configuredThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread));
+}
+
+function isClearableOutdatedCodexConnectorResidueThread(config: SupervisorConfig, thread: ReviewThread): boolean {
+  return (
+    thread.isOutdated &&
+    (latestReviewCommentAuthorIsAllowedBot(config, thread) || hasCodexConnectorFindingReviewComment(thread))
+  );
 }
 
 export function effectiveConfiguredBotReviewThreadsForState(
@@ -784,9 +790,7 @@ function codexConnectorOutdatedThreadClearanceAllowed(
   const threadsAfterConvergencePolicy = codexConnectorThreadsAfterConvergencePolicy(config, pr, configuredThreads);
   const onlyOutdatedCodexConnectorThreads =
     threadsAfterConvergencePolicy.length > 0 &&
-    threadsAfterConvergencePolicy.every(
-      (thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread),
-    );
+    threadsAfterConvergencePolicy.every((thread) => isClearableOutdatedCodexConnectorResidueThread(config, thread));
   const currentHeadCodexSuccess = hasCodexConnectorPrSuccessCurrentHeadObservation(pr);
   const convergedOutdatedResidueCanClear =
     providerKinds.includes("codex") &&
@@ -851,9 +855,7 @@ function staleSameHeadCodexWaitHasOnlyOutdatedResidue(
   const threadsAfterConvergencePolicy = codexConnectorThreadsAfterConvergencePolicy(config, pr, configuredThreads);
   return (
     threadsAfterConvergencePolicy.length > 0 &&
-    threadsAfterConvergencePolicy.every(
-      (thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread),
-    )
+    threadsAfterConvergencePolicy.every((thread) => isClearableOutdatedCodexConnectorResidueThread(config, thread))
   );
 }
 
@@ -1005,8 +1007,7 @@ function hasConfiguredProviderSuccess(
   const configuredBotThreads = configuredBotReviewThreads(config, reviewThreads).filter(
     (thread) =>
       !clearOutdatedCodexConnectorThreads ||
-      !thread.isOutdated ||
-      !latestReviewCommentAuthorIsAllowedBot(config, thread),
+      !isClearableOutdatedCodexConnectorResidueThread(config, thread),
   );
   const codexConnectorNitpickThreads = new Set(codexConnectorNitpickOnlyReviewThreads(configuredBotThreads));
   if (configuredBotThreads.filter((thread) => !codexConnectorNitpickThreads.has(thread)).length > 0) {

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -2558,6 +2558,16 @@ test("runPreparedIssue records provider success for HRCore stale residue before 
               typeName: "Bot",
             },
           },
+          {
+            id: `comment-operator-${threadId}`,
+            body: "Supervisor confirmed this stale Codex Connector finding is covered by the current-head success signal.",
+            createdAt: "2026-05-25T04:16:47Z",
+            url: `https://example.test/pr/183#discussion_${threadId}`,
+            author: {
+              login: "TommyKammy",
+              typeName: "User",
+            },
+          },
         ],
       },
     }),

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -6960,6 +6960,16 @@ test("reconcileTrackedMergedButOpenIssues records provider success from Codex su
               typeName: "Bot",
             },
           },
+          {
+            id: `comment-operator-hrcore-${index + 1}`,
+            body: "Supervisor confirmed this stale Codex Connector finding is covered by the current-head success signal.",
+            createdAt: "2026-05-25T04:16:47Z",
+            url: `https://example.test/pr/183#discussion_r${index + 1}`,
+            author: {
+              login: "TommyKammy",
+              typeName: "User",
+            },
+          },
         ],
       },
     }),

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -3,6 +3,7 @@ import { IssueJournalSync } from "./run-once-issue-preparation";
 import { StateStore } from "./core/state-store";
 import {
   evaluateCodexConnectorConvergencePolicy,
+  hasCodexConnectorFindingReviewComment,
   hasCodexConnectorPrSuccessCurrentHeadObservation,
 } from "./codex-connector-review-policy";
 import {
@@ -465,9 +466,7 @@ function buildConversationResolutionBlocker(args: {
   const configuredThreads = configuredBotReviewThreads(args.config, unresolvedThreads);
   if (
     configuredThreads.length !== unresolvedThreads.length ||
-    configuredThreads.some(
-      (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(args.config, thread),
-    )
+    configuredThreads.some((thread) => !isClearableConversationResolutionResidueThread(args.config, args.pr, thread))
   ) {
     return null;
   }
@@ -507,6 +506,22 @@ function buildConversationResolutionBlocker(args: {
       automaticRetry: "no",
     }),
   };
+}
+
+function isClearableConversationResolutionResidueThread(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  thread: ReviewThread,
+): boolean {
+  if (!thread.isOutdated) {
+    return false;
+  }
+
+  if (latestReviewCommentAuthorIsAllowedBot(config, thread)) {
+    return true;
+  }
+
+  return hasCodexConnectorPrSuccessCurrentHeadObservation(pr) && hasCodexConnectorFindingReviewComment(thread);
 }
 
 function hasPersistentTrackedPrMergeStageSignal(args: {


### PR DESCRIPTION
## Summary
- Treat outdated Codex Connector residue as clearable when a later supervisor/operator reply becomes the latest review-thread comment, as long as the thread still contains a Codex Connector finding comment.
- Apply the same clearance shape to tracked PR conversation-resolution cleanup so reply/resolve can proceed after provider success.
- Extend HRCore stale-residue regression tests with operator-replied review threads.

## Verification
- `rtk npx tsx --test src/pull-request-state-policy.test.ts`
- `rtk npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts --test-name-pattern "records provider success from Codex success comments"`
- `rtk npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern "HRCore stale residue"`
- `rtk npx tsx --test src/tracked-pr-status-comment.test.ts`
- `rtk npx tsx --test src/supervisor/supervisor-failure-context.test.ts src/supervisor/supervisor-lifecycle.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/tracked-pr-status-comment.test.ts`
- `rtk npm run build`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced detection and handling of outdated code review findings, allowing the system to more intelligently determine when review threads can be resolved or cleared based on current pull request status.

* **Tests**
  * Updated test scenarios to verify improved review thread handling behavior across multiple workflow paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->