### PR TITLE
Recover handoff-missing tracked PR provider success

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -66,6 +66,7 @@ import { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-commen
 import {
   configuredBotReviewThreads,
   manualReviewThreads,
+  latestReviewComment,
   latestReviewCommentAuthorIsAllowedBot,
 } from "./review-thread-reporting";
 import { hasCodexConnectorFindingReviewComment } from "./codex-connector-review-policy";
@@ -781,8 +782,26 @@ function hasOnlyOutdatedConfiguredBotResidue(
     configuredThreads.every(
       (thread) =>
         thread.isOutdated &&
-        (latestReviewCommentAuthorIsAllowedBot(config, thread) || hasCodexConnectorFindingReviewComment(thread)),
+        (latestReviewCommentAuthorIsAllowedBot(config, thread) || operatorAcknowledgedCodexResidue(thread)),
     )
+  );
+}
+
+function operatorAcknowledgedCodexResidue(thread: ReviewThread): boolean {
+  if (!hasCodexConnectorFindingReviewComment(thread)) {
+    return false;
+  }
+
+  const latestComment = latestReviewComment(thread);
+  if (!latestComment || latestComment.author?.typeName === "Bot") {
+    return false;
+  }
+
+  const normalizedBody = latestComment.body.replace(/\s+/g, " ").trim().toLowerCase();
+  return (
+    /\bresidue acknowledged\b/.test(normalizedBody) ||
+    /\bstale codex connector (?:finding|residue)\b/.test(normalizedBody) ||
+    /\bcovered by the current-head success signal\b/.test(normalizedBody)
   );
 }
 
@@ -1042,7 +1061,9 @@ export async function reconcileRecoverableBlockedIssueStates(
         externalProgressEvidence === null &&
         record.last_head_sha === trackedPullRequest.headRefOid &&
         projection.nextState !== "blocked" &&
-        projection.mergeLatencyVisibilityPatch.provider_success_head_sha === trackedPullRequest.headRefOid;
+        projection.mergeLatencyVisibilityPatch.provider_success_head_sha === trackedPullRequest.headRefOid &&
+        (reviewThreads.filter((thread) => !thread.isResolved).length === 0 ||
+          hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads));
       if (
         !externalProgressEvidence &&
         !sameHeadReviewRequestRecovery &&

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -68,6 +68,7 @@ import {
   manualReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
 } from "./review-thread-reporting";
+import { hasCodexConnectorFindingReviewComment } from "./codex-connector-review-policy";
 
 const OPERATOR_REQUEUEABLE_STATES = new Set<RunState>(["blocked", "failed"]);
 type StaleStabilizingNoPrBranchState = "recoverable" | "already_satisfied_on_main";
@@ -777,7 +778,11 @@ function hasOnlyOutdatedConfiguredBotResidue(
   const configuredThreads = configuredBotReviewThreads(config, unresolvedThreads);
   return (
     configuredThreads.length === unresolvedThreads.length &&
-    configuredThreads.every((thread) => thread.isOutdated && latestReviewCommentAuthorIsAllowedBot(config, thread))
+    configuredThreads.every(
+      (thread) =>
+        thread.isOutdated &&
+        (latestReviewCommentAuthorIsAllowedBot(config, thread) || hasCodexConnectorFindingReviewComment(thread)),
+    )
   );
 }
 
@@ -1033,7 +1038,17 @@ export async function reconcileRecoverableBlockedIssueStates(
         isReviewSignalProjectedState &&
         isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch) &&
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
-      if (!externalProgressEvidence && !sameHeadReviewRequestRecovery && !sameHeadOutdatedConfiguredBotResidueRecovery) {
+      const sameHeadProviderSuccessRecovery =
+        externalProgressEvidence === null &&
+        record.last_head_sha === trackedPullRequest.headRefOid &&
+        projection.nextState !== "blocked" &&
+        projection.mergeLatencyVisibilityPatch.provider_success_head_sha === trackedPullRequest.headRefOid;
+      if (
+        !externalProgressEvidence &&
+        !sameHeadReviewRequestRecovery &&
+        !sameHeadOutdatedConfiguredBotResidueRecovery &&
+        !sameHeadProviderSuccessRecovery
+      ) {
         const failureContext = inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads);
         const updated = await syncTrackedPrPersistentStatusComment({
           github,
@@ -1056,8 +1071,14 @@ export async function reconcileRecoverableBlockedIssueStates(
         continue;
       }
 
-      const nextState = sameHeadOutdatedConfiguredBotResidueRecovery ? "waiting_ci" : projection.nextState;
-      const nextBlockedReason = sameHeadOutdatedConfiguredBotResidueRecovery ? null : projection.nextBlockedReason;
+      const nextState =
+        sameHeadOutdatedConfiguredBotResidueRecovery && !sameHeadProviderSuccessRecovery
+          ? "waiting_ci"
+          : projection.nextState;
+      const nextBlockedReason =
+        sameHeadOutdatedConfiguredBotResidueRecovery && !sameHeadProviderSuccessRecovery
+          ? null
+          : projection.nextBlockedReason;
       const failureContext =
         nextState === "blocked"
           ? inferFailureContextImpl(config, projection.recordForState, trackedPullRequest, checks, reviewThreads)

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -3198,6 +3198,164 @@ test("runOnce blocks an interrupted active turn before selecting the next runnab
   await assert.rejects(fs.access(interruptedTurnMarkerPath(interruptedWorkspace)));
 });
 
+test("runOnce recovers interrupted active tracked PR when Codex success already converged", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
+  fixture.config.configuredBotInitialGraceWaitSeconds = 0;
+  fixture.config.configuredBotSettledWaitSeconds = 0;
+  fixture.config.configuredBotCurrentHeadSignalTimeoutMinutes = 1;
+  fixture.config.configuredBotCurrentHeadSignalTimeoutAction = "request_review_comment";
+  const interruptedIssueNumber = 174;
+  const prNumber = 183;
+  const currentHead = "d5a9957506c697dc13f5431bb460cfe95257bcae";
+  const interruptedBranch = branchName(fixture.config, interruptedIssueNumber);
+  const { workspacePath: interruptedWorkspace, journalPath: interruptedJournalPath } = trackedIssuePaths(
+    fixture.workspaceRoot,
+    interruptedIssueNumber,
+  );
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: interruptedIssueNumber,
+    issues: [
+      createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, interruptedIssueNumber, {
+        state: "addressing_review",
+        branch: interruptedBranch,
+        pr_number: prNumber,
+        last_head_sha: currentHead,
+        review_wait_started_at: "2026-05-23T16:04:34.342Z",
+        review_wait_head_sha: currentHead,
+        copilot_review_timed_out_at: "2026-05-23T16:07:04.342Z",
+        copilot_review_timeout_action: "request_review_comment",
+        copilot_review_timeout_reason: "current_head_signal_wait_timed_out",
+        provider_success_head_sha: null,
+        provider_success_observed_at: null,
+        codex_session_id: "stale-session",
+        blocked_reason: null,
+        last_error: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+        updated_at: "2026-05-25T05:39:34.111Z",
+      }),
+    ],
+  });
+  await writeSupervisorState(fixture.stateFile, state);
+  await fs.mkdir(path.dirname(interruptedJournalPath), { recursive: true });
+  await fs.writeFile(interruptedJournalPath, "# issue journal\n", "utf8");
+  const initialJournalFingerprint = await captureIssueJournalFingerprint(interruptedJournalPath);
+  await fs.writeFile(
+    interruptedTurnMarkerPath(interruptedWorkspace),
+    `${JSON.stringify(
+      {
+        issueNumber: interruptedIssueNumber,
+        state: "addressing_review",
+        startedAt: "2026-05-25T05:39:34.135Z",
+        journalFingerprint: initialJournalFingerprint,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  const issue = createTrackedIssue(interruptedIssueNumber, {
+    title: "HRCore stale Codex Connector residue",
+    body: executionReadyBody("Recover HRCore stale Codex Connector residue without another Codex turn."),
+  });
+  const pr = createTrackedPullRequest(fixture.config, interruptedIssueNumber, {
+    number: prNumber,
+    title: "HRCore stale Codex Connector residue",
+    isDraft: false,
+    reviewDecision: null,
+    headRefOid: currentHead,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-23T16:02:36Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T14:33:41Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: "7327afdab32fb9c7ffb741d6158add4616bb3115",
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
+  });
+  const checks: PullRequestCheck[] = [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads = ["PRRT_hrcore_183_operator", "PRRT_hrcore_183_bot_1", "PRRT_hrcore_183_bot_2"].map(
+    (threadId, index) =>
+      createReviewThread({
+        id: threadId,
+        isOutdated: true,
+        line: null,
+        comments: {
+          nodes: [
+            {
+              id: `comment-codex-${threadId}`,
+              body: "P1: Earlier Codex Connector finding that is obsolete after the current-head no-major signal.",
+              createdAt: "2026-05-23T14:16:47Z",
+              url: `https://example.test/pr/183#discussion_r${index + 1}`,
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+            ...(index === 0
+              ? [
+                  {
+                    id: `comment-operator-${threadId}`,
+                    body: "Supervisor confirmed this stale Codex Connector finding is covered by the current-head success signal.",
+                    createdAt: "2026-05-25T04:16:47Z",
+                    url: `https://example.test/pr/183#discussion_r${index + 1}`,
+                    author: {
+                      login: "TommyKammy",
+                      typeName: "User",
+                    },
+                  },
+                ]
+              : []),
+          ],
+        },
+      }),
+  );
+
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    authStatus: async () => ({ ok: true, message: null }),
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => {
+      throw new Error("unexpected listCandidateIssues call");
+    },
+    getIssue: async () => issue,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => checks,
+    getUnresolvedReviewThreads: async () => reviewThreads,
+    getPullRequestIfExists: async () => pr,
+    getMergedPullRequestsClosingIssue: async () => [],
+    closeIssue: async () => {
+      throw new Error("unexpected closeIssue call");
+    },
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await supervisor.runOnce({ dryRun: true });
+  assert.match(message, /tracked_pr_handoff_missing_same_head_recovered/);
+
+  const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
+  const interruptedRecord = persisted.issues[String(interruptedIssueNumber)]!;
+  assert.equal(persisted.activeIssueNumber, null);
+  assert.equal(interruptedRecord.state, "pr_open");
+  assert.equal(interruptedRecord.blocked_reason, null);
+  assert.equal(interruptedRecord.codex_session_id, null);
+  assert.equal(interruptedRecord.last_failure_context, null);
+  assert.equal(interruptedRecord.last_failure_signature, null);
+  assert.equal(interruptedRecord.provider_success_head_sha, currentHead);
+  assert.ok(interruptedRecord.provider_success_observed_at);
+  await assert.rejects(fs.access(interruptedTurnMarkerPath(interruptedWorkspace)));
+});
+
 test("runOnce clears a stale interrupted-turn marker when the journal changed after the turn began", async () => {
   const fixture = await createSupervisorFixture();
   const interruptedIssueNumber = 91;

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1833,6 +1833,142 @@ test("reconcileRecoverableBlockedIssueStates recovers same-head handoff-missing 
   }
 });
 
+test("reconcileRecoverableBlockedIssueStates records provider success for same-head handoff-missing with operator-replied Codex residue", async () => {
+  const currentHead = "d5a9957506c697dc13f5431bb460cfe95257bcae";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 1,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const original = createTrackedPrStaleReviewRecord({
+    state: "blocked",
+    blocked_reason: "handoff_missing",
+    last_head_sha: currentHead,
+    review_wait_started_at: "2026-05-23T16:04:34.342Z",
+    review_wait_head_sha: currentHead,
+    copilot_review_timed_out_at: "2026-05-23T16:07:04.342Z",
+    copilot_review_timeout_action: "request_review_comment",
+    copilot_review_timeout_reason: "current_head_signal_wait_timed_out",
+    provider_success_head_sha: null,
+    provider_success_observed_at: null,
+    last_failure_signature: "handoff-missing",
+    repeated_failure_signature_count: 1,
+    codex_session_id: "session-366",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createTrackedPrRecoveryIssue({
+    updatedAt: "2026-05-25T06:05:00Z",
+  });
+  const pr = createTrackedPrRecoveryPullRequest({
+    headRefOid: currentHead,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-05-23T16:02:36Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T14:33:41Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: "7327afdab32fb9c7ffb741d6158add4616bb3115",
+    configuredBotTopLevelReviewStrength: null,
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=true"],
+    },
+  });
+  const threadIds = ["PRRT_hrcore_183_operator", "PRRT_hrcore_183_bot_1", "PRRT_hrcore_183_bot_2"];
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () =>
+        threadIds.map((threadId, index) =>
+          createReviewThread({
+            id: threadId,
+            isOutdated: true,
+            line: null,
+            comments: {
+              nodes: [
+                {
+                  id: `comment-codex-${threadId}`,
+                  body: "P1: Earlier Codex Connector finding that is obsolete after the current-head no-major signal.",
+                  createdAt: "2026-05-23T14:16:47Z",
+                  url: `https://example.test/pr/183#discussion_r${index + 1}`,
+                  author: {
+                    login: "chatgpt-codex-connector",
+                    typeName: "Bot",
+                  },
+                },
+                ...(index === 0
+                  ? [
+                      {
+                        id: `comment-operator-${threadId}`,
+                        body: "Supervisor confirmed this stale Codex Connector finding is covered by the current-head success signal.",
+                        createdAt: "2026-05-25T04:16:47Z",
+                        url: `https://example.test/pr/183#discussion_r${index + 1}`,
+                        author: {
+                          login: "TommyKammy",
+                          typeName: "User",
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          }),
+        ),
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-05-25T06:06:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "pr_open");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.codex_session_id, null);
+  assert.equal(updated.provider_success_head_sha, currentHead);
+  assert.ok(updated.provider_success_observed_at);
+  assert.equal(updated.last_tracked_pr_progress_summary, "handoff_missing_recovered=same_head_projected_state=pr_open");
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    `tracked_pr_handoff_missing_same_head_recovered: resumed issue #366 from blocked to pr_open using fresh tracked PR #${TRACKED_PR_NUMBER} facts at head ${currentHead}`,
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates does not force same-head outdated residue recovery from unrelated projected states", async () => {
   const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
   const config = createConfig({

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1969,6 +1969,116 @@ test("reconcileRecoverableBlockedIssueStates records provider success for same-h
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates keeps same-head handoff-missing blocked for unacknowledged human Codex residue replies", async () => {
+  const currentHead = "d5a9957506c697dc13f5431bb460cfe95257bcae";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 1,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const original = createTrackedPrStaleReviewRecord({
+    state: "blocked",
+    blocked_reason: "handoff_missing",
+    last_head_sha: currentHead,
+    review_wait_started_at: "2026-05-23T16:04:34.342Z",
+    review_wait_head_sha: currentHead,
+    provider_success_head_sha: null,
+    provider_success_observed_at: null,
+    last_failure_signature: "handoff-missing",
+    repeated_failure_signature_count: 1,
+    codex_session_id: "session-366",
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createTrackedPrRecoveryIssue({
+    updatedAt: "2026-05-25T06:05:00Z",
+  });
+  const pr = createTrackedPrRecoveryPullRequest({
+    headRefOid: currentHead,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-05-23T16:02:36Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T14:33:41Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: "7327afdab32fb9c7ffb741d6158add4616bb3115",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: "PRRT_hrcore_183_human_followup",
+          isOutdated: true,
+          line: null,
+          comments: {
+            nodes: [
+              {
+                id: "comment-codex-human-followup",
+                body: "P1: Earlier Codex Connector finding.",
+                createdAt: "2026-05-23T14:16:47Z",
+                url: "https://example.test/pr/183#discussion_r1",
+                author: {
+                  login: "chatgpt-codex-connector",
+                  typeName: "Bot",
+                },
+              },
+              {
+                id: "comment-human-followup",
+                body: "This still looks actionable; please inspect the audit correlation path before merging.",
+                createdAt: "2026-05-25T04:16:47Z",
+                url: "https://example.test/pr/183#discussion_r1",
+                author: {
+                  login: "reviewer-user",
+                  typeName: "User",
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-05-25T06:06:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  assert.equal(saveCalls, 0);
+  assert.deepEqual(recoveryEvents, []);
+  assert.deepEqual(state.issues["366"], original);
+});
+
 test("reconcileRecoverableBlockedIssueStates does not force same-head outdated residue recovery from unrelated projected states", async () => {
   const currentHead = "329b8e81ed535a61a2bc59ac3227ad52a58b0756";
   const config = createConfig({


### PR DESCRIPTION
## Summary
- Recover same-head tracked PR `handoff_missing` records when fresh PR facts already show current-head provider success and lifecycle projection is no longer blocked.
- Preserve provider-success merge latency fields during that recovery so `provider_success_head_sha` is recorded instead of leaving the PR stuck behind stale local interrupted-turn state.
- Treat operator-replied outdated Codex Connector finding threads as stale configured-bot residue for the handoff recovery path.

## Verification
- `rtk npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts --test-name-pattern "operator-replied Codex residue|same-head handoff-missing with outdated Codex Connector residue"`
- `rtk npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts --test-name-pattern "interrupted active tracked PR"`
- `rtk npx tsx --test src/recovery-reconciliation.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/run-once-cycle-prelude.test.ts src/tracked-pr-lifecycle-projection.test.ts src/pull-request-state-policy.test.ts`
- `rtk npm run build`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling for tracked pull requests when provider success is confirmed on the same head.
  * Enhanced detection of outdated bot comments in review threads.

* **Tests**
  * Added test coverage for interrupted tracked PR recovery with same-head provider success confirmation.
  * Added test coverage for recovery reconciliation with operator-replied bot residue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->