### PR TITLE
[codex] Recognize supervisor stale residue acknowledgements

### DIFF
--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -801,7 +801,17 @@ function operatorAcknowledgedCodexResidue(thread: ReviewThread): boolean {
   return (
     /\bresidue acknowledged\b/.test(normalizedBody) ||
     /\bstale codex connector (?:finding|residue)\b/.test(normalizedBody) ||
-    /\bcovered by the current-head success signal\b/.test(normalizedBody)
+    /\bcovered by the current-head success signal\b/.test(normalizedBody) ||
+    hasSupervisorVerifiedNoSourceChangeStaleAcknowledgement(normalizedBody)
+  );
+}
+
+function hasSupervisorVerifiedNoSourceChangeStaleAcknowledgement(normalizedBody: string): boolean {
+  return (
+    normalizedBody.includes("the supervisor reprocessed this configured-bot finding") &&
+    normalizedBody.includes("classified it as stale") &&
+    normalizedBody.includes("reason=verified_no_source_change_auto_resolve") &&
+    normalizedBody.includes("processed_on_current_head=yes")
   );
 }
 

--- a/src/supervisor/supervisor-recovery-reconciliation.test.ts
+++ b/src/supervisor/supervisor-recovery-reconciliation.test.ts
@@ -1910,7 +1910,12 @@ test("reconcileRecoverableBlockedIssueStates records provider success for same-h
                   ? [
                       {
                         id: `comment-operator-${threadId}`,
-                        body: "Supervisor confirmed this stale Codex Connector finding is covered by the current-head success signal.",
+                        body: [
+                          `The supervisor reprocessed this configured-bot finding on the current head \`${currentHead}\` and classified it as stale.`,
+                          `Audit: issue=#366 pr=#${TRACKED_PR_NUMBER} head=${currentHead} thread=${threadId} reason=verified_no_source_change_auto_resolve.`,
+                          "Evidence: location=src/mvp-a-onboarding-traceability.ts:? processed_on_current_head=yes. Source: https://example.test/pr/183#discussion_r1",
+                          "Under the configured verified no-source-change auto-resolve opt-in, the supervisor is auto-resolving this thread now.",
+                        ].join("\n\n"),
                         createdAt: "2026-05-25T04:16:47Z",
                         url: `https://example.test/pr/183#discussion_r${index + 1}`,
                         author: {


### PR DESCRIPTION
## Summary
- Recognize the supervisor-generated `verified_no_source_change_auto_resolve` stale-residue reply as an explicit operator acknowledgement for outdated Codex Connector residue.
- Keep the acknowledgement narrow by requiring the supervisor audit wording, the stale classification, the exact reason code, and `processed_on_current_head=yes`.
- Update the handoff-missing recovery test to use the real stale auto-resolve comment shape observed on HRCore #183.

## Root cause
PR #2150 tightened handoff-missing recovery so historical Codex Connector findings are not enough when the latest unresolved comment is from a user. That was correct, but it did not recognize the supervisor's own stale auto-resolve audit reply, which is posted as the operator account rather than as a bot. As a result, HRCore #183 still had effective blockers 0 and Codex convergence ready, but `provider_success_head_sha` remained null.

## Validation
- `npx tsx --test src/supervisor/supervisor-recovery-reconciliation.test.ts --test-name-pattern "operator-replied Codex residue|unacknowledged human Codex residue replies|same-head handoff-missing with outdated Codex Connector residue"`
- `npx tsx --test src/recovery-reconciliation.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/run-once-cycle-prelude.test.ts src/tracked-pr-lifecycle-projection.test.ts src/pull-request-state-policy.test.ts`
- `git diff --check`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved recovery reconciliation detection logic to recognize additional verification patterns and acknowledgement types alongside existing success signal detection.

* **Tests**
  * Updated recovery reconciliation test messages with comprehensive audit-style formatting, now including detailed processing information, status indicators, evidence paths, and resolution status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->