### PR TITLE
[codex] Clear stale Codex timeouts after provider success

### DIFF
--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -4,6 +4,7 @@ import {
   blockedReasonFromReviewState,
   inferGitHubWaitStep,
   inferStateFromPullRequest,
+  syncCopilotReviewTimeoutState,
   syncMergeLatencyVisibility,
 } from "./pull-request-state";
 import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "./core/types";
@@ -192,6 +193,50 @@ test("inferStateFromPullRequest keeps waiting for a required current-head signal
   withStubbedDateNow("2026-03-16T00:02:00Z", () => {
     assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), []), "waiting_ci");
     assert.equal(inferGitHubWaitStep(config, record, pr, passingChecks()), "configured_bot_current_head_signal_wait");
+  });
+});
+
+test("inferStateFromPullRequest clears stale Codex request-comment timeout after provider success", () => {
+  const headSha = "d5a9957506c697dc13f5431bb460cfe95257bcae";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotRequireCurrentHeadSignal: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 1,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const record = createRecord({
+    state: "waiting_ci",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-23T16:04:34.342Z",
+    review_wait_head_sha: headSha,
+    provider_success_observed_at: "2026-05-25T10:04:37.026Z",
+    provider_success_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-23T16:07:04.342Z",
+    copilot_review_timeout_action: "request_review_comment",
+    copilot_review_timeout_reason: "current_head_signal_wait_timed_out",
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-23T16:02:36Z",
+    configuredBotCurrentHeadObservedAt: "2026-05-23T14:33:41Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: "7327afdab32fb9c7ffb741d6158add4616bb3115",
+    configuredBotTopLevelReviewStrength: null,
+  });
+
+  withStubbedDateNow("2026-05-25T10:10:02.845Z", () => {
+    assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), []), "ready_to_merge");
+    assert.equal(inferGitHubWaitStep(config, record, pr, passingChecks(), []), null);
+    assert.deepEqual(syncCopilotReviewTimeoutState(config, record, pr), {
+      copilot_review_timed_out_at: null,
+      copilot_review_timeout_action: null,
+      copilot_review_timeout_reason: null,
+    });
   });
 });
 

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -347,6 +347,16 @@ function validTimestamp(value: string | null | undefined): string | null {
   return Number.isNaN(Date.parse(value)) ? null : value;
 }
 
+function hasCurrentHeadProviderSuccess(
+  record: Pick<IssueRunRecord, "provider_success_head_sha" | "provider_success_observed_at">,
+  pr: GitHubPullRequest,
+): boolean {
+  return (
+    record.provider_success_head_sha === pr.headRefOid &&
+    validTimestamp(record.provider_success_observed_at) !== null
+  );
+}
+
 function currentHeadObservationSatisfiesActiveWait(
   record: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">,
   pr: GitHubPullRequest,
@@ -552,6 +562,7 @@ function configuredBotCurrentHeadSignalWaitStartAt(
   if (
     !requiresConfiguredBotCurrentHeadSignal(config) ||
     pr.isDraft ||
+    hasCurrentHeadProviderSuccess(record, pr) ||
     (validTimestamp(pr.configuredBotCurrentHeadObservedAt) && currentHeadObservationSatisfiesActiveWait(record, pr))
   ) {
     return null;


### PR DESCRIPTION
## Summary
- Treat a recorded current-head provider success as sufficient evidence to retire the active configured-bot current-head wait.
- Clear stale `request_review_comment` timeout state when the PR is otherwise clean, green, and already has current-head provider success.
- Add an HRCore #183-shaped regression test where the Codex success observation predates the later wait window, but `provider_success_head_sha` is current.

## Context
HRCore #183 recovered its stale Codex connector residue and recorded `provider_success_head_sha`, but the old `review_wait_started_at` / `copilot_review_timed_out_at` pair kept `inferStateFromPullRequest` in `waiting_ci`. After the stale residue was resolved, the previous stale-residue bypass no longer applied, so the stale timeout resurfaced and prevented merge readiness.

## Verification
- `rtk npx tsx --test src/pull-request-state-policy.test.ts --test-name-pattern "stale Codex request-comment timeout after provider success|current-head signal"`
- `rtk npx tsx --test src/pull-request-state-policy.test.ts src/pull-request-state-sync.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `rtk git diff --check`
- `rtk npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pull request state management to properly recognize provider success signals, allowing pull requests to transition to ready-to-merge status more accurately and reducing unnecessary wait states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->