### PR TITLE
[codex] Run local CI before final auto-merge

### DIFF
--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -2275,6 +2275,108 @@ test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blo
   assert.equal(snapshotLoads, 2);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase runs current-head local CI before final auto-merge", async (t) => {
+  const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
+  t.after(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+  const config = createConfig({ localCiCommand: "npm run ci:local" });
+  const issue = createIssue({ title: "Run local CI before auto-merge" });
+  const pr = createPullRequest({
+    title: "Run local CI before auto-merge",
+    headRefName: "codex/issue-102",
+    headRefOid: headSha,
+  });
+  const passingChecks = [{ name: "verify", state: "SUCCESS", bucket: "pass", workflow: "CI" }] satisfies PullRequestCheck[];
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "ready_to_merge",
+        pr_number: pr.number,
+        branch: "codex/issue-102",
+        last_head_sha: headSha,
+        latest_local_ci_result: null,
+      }),
+    },
+  };
+
+  let localCiCalls = 0;
+  let readyCalls = 0;
+  let snapshotLoads = 0;
+  let syncJournalCalls = 0;
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      markPullRequestReady: async () => {
+        readyCalls += 1;
+      },
+    }),
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath,
+      syncJournal: async () => {
+        syncJournalCalls += 1;
+      },
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => ({
+      recordForState: record,
+      nextState: "ready_to_merge",
+      failureContext: null,
+      reviewWaitPatch: {},
+      copilotRequestObservationPatch: {},
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: "2026-05-25T10:04:37.026Z",
+        provider_success_head_sha: headSha,
+        merge_readiness_last_evaluated_at: "2026-05-25T11:44:09.822Z",
+      },
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+    }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks: (checks) => ({
+      hasPending: checks.some((check) => check.bucket === "pending"),
+      hasFailing: checks.some((check) => check.bucket === "fail"),
+    }),
+    configuredBotReviewThreads: () => [],
+    manualReviewThreads: () => [],
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async (command, cwd) => {
+      assert.equal(command.displayCommand, "npm run ci:local");
+      assert.equal(cwd, workspacePath);
+      localCiCalls += 1;
+    },
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return { pr, checks: passingChecks, reviewThreads: [] satisfies ReviewThread[] };
+    },
+  });
+
+  assert.equal(result.record.state, "ready_to_merge");
+  assert.equal(result.record.blocked_reason, null);
+  assert.equal(result.record.latest_local_ci_result?.outcome, "passed");
+  assert.equal(result.record.latest_local_ci_result?.summary, "Configured local CI command passed before auto-merging PR #116.");
+  assert.equal(result.record.latest_local_ci_result?.head_sha, headSha);
+  assert.equal(result.record.latest_local_ci_result?.command, "npm run ci:local");
+  assert.equal(localCiCalls, 1);
+  assert.equal(readyCalls, 0);
+  assert.equal(snapshotLoads, 2);
+  assert.equal(syncJournalCalls, 3);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase blocks draft-to-ready promotion when configured local CI fails", async () => {
   const config = createConfig({ localCiCommand: "npm run ci:local" });
   const issue = createIssue({ title: "Gate draft promotion on local CI" });

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -100,6 +100,15 @@ export interface PullRequestLifecycleSnapshot {
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
 
+function hasConfiguredLocalCiCommand(config: Pick<SupervisorConfig, "localCiCommand">): boolean {
+  return config.localCiCommand !== null && config.localCiCommand !== undefined;
+}
+
+function currentHeadLocalCiMissing(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  const latestLocalCi = record.latest_local_ci_result ?? null;
+  return latestLocalCi?.outcome !== "passed" || latestLocalCi.head_sha !== pr.headRefOid;
+}
+
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -813,6 +822,72 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   });
   if (record.state === "blocked" && record.last_failure_context?.signature?.startsWith("codex-connector-review-request-failed:")) {
     effectiveFailureContext = record.last_failure_context;
+  }
+  if (
+    record.state === "ready_to_merge" &&
+    !postReady.pr.isDraft &&
+    hasConfiguredLocalCiCommand(config) &&
+    currentHeadLocalCiMissing(record, postReady.pr) &&
+    !options.dryRun
+  ) {
+    const localCiPublicationGate = await runTrackedPrReadyLocalCiPublicationGate({
+      config,
+      stateStore,
+      state,
+      record,
+      pr: postReady.pr,
+      workspacePath,
+      gateLabel: `before auto-merging PR #${postReady.pr.number}`,
+      github,
+      syncJournal,
+      applyFailureSignature: args.applyFailureSignature,
+      runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
+      runLocalCiCommand: args.runLocalCiCommand,
+    });
+    record = localCiPublicationGate.record;
+    if (!localCiPublicationGate.ok) {
+      effectiveFailureContext = record.last_failure_context;
+    } else {
+      const localWorkspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, config.defaultBranch);
+      if (localWorkspaceStatus.headSha !== postReady.pr.headRefOid) {
+        const failureContext = buildWorkstationLocalPathFailureContext({
+          gateLabel: `before auto-merging PR #${postReady.pr.number}`,
+          details: [
+            `local workspace HEAD ${localWorkspaceStatus.headSha} does not match PR head ${postReady.pr.headRefOid}; the auto-merge gate is failing closed until the local commit is published.`,
+          ],
+        });
+        record = stateStore.touch(record, {
+          state: "blocked",
+          last_error: truncate(failureContext.summary, 1000),
+          last_failure_kind: null,
+          last_failure_context: failureContext,
+          ...args.applyFailureSignature(record, failureContext),
+          blocked_reason: "verification",
+          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+            pr: postReady.pr,
+            blockerSignature: failureContext.signature,
+          }),
+        });
+        state.issues[String(record.issue_number)] = record;
+        await stateStore.save(state);
+        await syncJournal(record);
+        effectiveFailureContext = failureContext;
+      } else if (
+        record.latest_local_ci_result !== null &&
+        record.latest_local_ci_result !== undefined &&
+        record.latest_local_ci_result.head_sha !== postReady.pr.headRefOid
+      ) {
+        record = stateStore.touch(record, {
+          latest_local_ci_result: {
+            ...record.latest_local_ci_result,
+            head_sha: postReady.pr.headRefOid,
+          },
+        });
+        state.issues[String(record.issue_number)] = record;
+        await stateStore.save(state);
+        await syncJournal(record);
+      }
+    }
   }
   record = await trackedPrStatusComments.maybeCommentOnTrackedPrPersistentStatus({
     github,

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -32,6 +32,7 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   record: IssueRunRecord;
   pr: GitHubPullRequest;
   workspacePath: string;
+  gateLabel?: string;
   github: Partial<Pick<GitHubClient, "addIssueComment" | "updateIssueComment">>;
   syncJournal: IssueJournalSync;
   applyFailureSignature: (
@@ -41,10 +42,11 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   runWorkspacePreparationCommand?: LocalCiCommandRunner;
   runLocalCiCommand?: LocalCiCommandRunner;
 }): Promise<TrackedPrReadyLocalCiPublicationGateResult> {
+  const gateLabel = args.gateLabel ?? `before marking PR #${args.pr.number} ready`;
   const workspacePreparationGate = await runWorkspacePreparationGate({
     config: args.config,
     workspacePath: args.workspacePath,
-    gateLabel: `before marking PR #${args.pr.number} ready`,
+    gateLabel,
     runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
   });
   if (!workspacePreparationGate.ok) {
@@ -86,7 +88,7 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   const localCiGate = await runLocalCiGate({
     config: args.config,
     workspacePath: args.workspacePath,
-    gateLabel: `before marking PR #${args.pr.number} ready`,
+    gateLabel,
     runLocalCiCommand: args.runLocalCiCommand,
   });
   if (!localCiGate.ok) {


### PR DESCRIPTION
## Summary
- Run the configured workspace preparation and local CI gates when a tracked PR reaches `ready_to_merge` but has no current-head `latest_local_ci_result`.
- Stamp the successful local CI result with the PR head SHA before the final auto-merge guard evaluates it.
- Keep the existing fail-closed behavior when local CI fails or the local workspace HEAD does not match the PR head.

## Context
After #2152, HRCore #183 / issue #174 moved from stale `waiting_ci` to `ready_to_merge`, but final auto-merge still refused the PR with `missing_current_head_local_ci_success`. The PR was otherwise `CLEAN`, `MERGEABLE`, CI green, current-head Codex no-major, and had no effective review blockers.

The missing piece was that ready non-draft PRs could reach the final auto-merge guard without first populating a current-head local CI result. Draft-to-ready promotion already ran this gate, but already-ready tracked PRs did not.

## Verification
- `rtk npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "current-head local CI before final auto-merge|local CI"`
- `rtk npx tsx --test src/post-turn-pull-request.test.ts src/tracked-pr-local-ci-publication-gate.test.ts src/local-ci.test.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `rtk git diff --check`
- `rtk npm run build`
