### PR TITLE
Refactor current-head local CI gate orchestration

### DIFF
--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -45,12 +45,12 @@ import {
 } from "./supervisor/supervisor-events";
 import { reviewBotDiagnostics } from "./supervisor/supervisor-status-review-bot";
 import { parseIssueMetadata } from "./issue-metadata";
-import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths, getWorkspaceStatus } from "./core/workspace";
+import { commitAndPushTrackedFiles, filterPresentTrackedFilePaths } from "./core/workspace";
 import {
   derivePostTurnLocalReviewDecision,
   derivePostTurnLocalReviewFailurePatch,
 } from "./post-turn-pull-request-policy";
-import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
+import { runTrackedPrCurrentHeadLocalCiGate } from "./tracked-pr-local-ci-publication-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
 import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-review-request-transition";
@@ -676,86 +676,31 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       };
     }
 
-    const localCiPublicationGate = await runTrackedPrReadyLocalCiPublicationGate({
+    const currentHeadLocalCiGate = await runTrackedPrCurrentHeadLocalCiGate({
       config,
       stateStore,
       state,
       record,
       pr: refreshed.pr,
       workspacePath,
+      gateLabel: `before marking PR #${refreshed.pr.number} ready`,
+      workspaceHeadMismatchDetail: (localHeadSha, prHeadSha) =>
+        `local workspace HEAD ${localHeadSha} does not match PR head ${prHeadSha}; the ready gate is failing closed until the local commit is published.`,
+      publishWorkspaceHeadMismatchComment: true,
       github,
       syncJournal,
       applyFailureSignature: args.applyFailureSignature,
       runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
       runLocalCiCommand: args.runLocalCiCommand,
     });
-    record = localCiPublicationGate.record;
-    if (!localCiPublicationGate.ok) {
+    record = currentHeadLocalCiGate.record;
+    if (!currentHeadLocalCiGate.ok) {
       return {
         record,
         pr: refreshed.pr,
         checks: refreshed.checks,
         reviewThreads: refreshed.reviewThreads,
       };
-    }
-    const localWorkspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, config.defaultBranch);
-    if (localWorkspaceStatus.headSha !== refreshed.pr.headRefOid) {
-      const failureContext = buildWorkstationLocalPathFailureContext({
-        gateLabel: `before marking PR #${refreshed.pr.number} ready`,
-        details: [
-          `local workspace HEAD ${localWorkspaceStatus.headSha} does not match PR head ${refreshed.pr.headRefOid}; the ready gate is failing closed until the local commit is published.`,
-        ],
-      });
-      record = stateStore.touch(record, {
-        state: "blocked",
-        last_error: truncate(failureContext.summary, 1000),
-        last_failure_kind: null,
-        last_failure_context: failureContext,
-        ...args.applyFailureSignature(record, failureContext),
-        blocked_reason: "verification",
-        ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-          pr: refreshed.pr,
-          blockerSignature: failureContext.signature,
-        }),
-      });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
-      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
-        github,
-        stateStore,
-        state,
-        record,
-        pr: refreshed.pr,
-        syncJournal,
-        gateType: "workstation_local_path_hygiene",
-        blockerSignature: failureContext.signature,
-        failureClass: failureContext.signature,
-        remediationTarget: "tracked_publishable_content",
-        summary: failureContext.summary,
-        details: failureContext.details,
-      });
-      return {
-        record,
-        pr: refreshed.pr,
-        checks: refreshed.checks,
-        reviewThreads: refreshed.reviewThreads,
-      };
-    }
-    if (
-      record.latest_local_ci_result !== null &&
-      record.latest_local_ci_result !== undefined &&
-      record.latest_local_ci_result.head_sha !== refreshed.pr.headRefOid
-    ) {
-      record = stateStore.touch(record, {
-        latest_local_ci_result: {
-          ...record.latest_local_ci_result,
-          head_sha: refreshed.pr.headRefOid,
-        },
-      });
-      state.issues[String(record.issue_number)] = record;
-      await stateStore.save(state);
-      await syncJournal(record);
     }
     await github.markPullRequestReady(refreshed.pr.number);
   }
@@ -830,7 +775,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     currentHeadLocalCiMissing(record, postReady.pr) &&
     !options.dryRun
   ) {
-    const localCiPublicationGate = await runTrackedPrReadyLocalCiPublicationGate({
+    const currentHeadLocalCiGate = await runTrackedPrCurrentHeadLocalCiGate({
       config,
       stateStore,
       state,
@@ -838,55 +783,18 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       pr: postReady.pr,
       workspacePath,
       gateLabel: `before auto-merging PR #${postReady.pr.number}`,
+      workspaceHeadMismatchDetail: (localHeadSha, prHeadSha) =>
+        `local workspace HEAD ${localHeadSha} does not match PR head ${prHeadSha}; the auto-merge gate is failing closed until the local commit is published.`,
+      publishWorkspaceHeadMismatchComment: false,
       github,
       syncJournal,
       applyFailureSignature: args.applyFailureSignature,
       runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
       runLocalCiCommand: args.runLocalCiCommand,
     });
-    record = localCiPublicationGate.record;
-    if (!localCiPublicationGate.ok) {
-      effectiveFailureContext = record.last_failure_context;
-    } else {
-      const localWorkspaceStatus = await getWorkspaceStatus(workspacePath, record.branch, config.defaultBranch);
-      if (localWorkspaceStatus.headSha !== postReady.pr.headRefOid) {
-        const failureContext = buildWorkstationLocalPathFailureContext({
-          gateLabel: `before auto-merging PR #${postReady.pr.number}`,
-          details: [
-            `local workspace HEAD ${localWorkspaceStatus.headSha} does not match PR head ${postReady.pr.headRefOid}; the auto-merge gate is failing closed until the local commit is published.`,
-          ],
-        });
-        record = stateStore.touch(record, {
-          state: "blocked",
-          last_error: truncate(failureContext.summary, 1000),
-          last_failure_kind: null,
-          last_failure_context: failureContext,
-          ...args.applyFailureSignature(record, failureContext),
-          blocked_reason: "verification",
-          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-            pr: postReady.pr,
-            blockerSignature: failureContext.signature,
-          }),
-        });
-        state.issues[String(record.issue_number)] = record;
-        await stateStore.save(state);
-        await syncJournal(record);
-        effectiveFailureContext = failureContext;
-      } else if (
-        record.latest_local_ci_result !== null &&
-        record.latest_local_ci_result !== undefined &&
-        record.latest_local_ci_result.head_sha !== postReady.pr.headRefOid
-      ) {
-        record = stateStore.touch(record, {
-          latest_local_ci_result: {
-            ...record.latest_local_ci_result,
-            head_sha: postReady.pr.headRefOid,
-          },
-        });
-        state.issues[String(record.issue_number)] = record;
-        await stateStore.save(state);
-        await syncJournal(record);
-      }
+    record = currentHeadLocalCiGate.record;
+    if (!currentHeadLocalCiGate.ok) {
+      effectiveFailureContext = currentHeadLocalCiGate.failureContext;
     }
   }
   record = await trackedPrStatusComments.maybeCommentOnTrackedPrPersistentStatus({

--- a/src/tracked-pr-local-ci-publication-gate.test.ts
+++ b/src/tracked-pr-local-ci-publication-gate.test.ts
@@ -2,9 +2,85 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { runLocalCiGate } from "./local-ci";
-import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
+import {
+  runTrackedPrCurrentHeadLocalCiGate,
+  runTrackedPrReadyLocalCiPublicationGate,
+} from "./tracked-pr-local-ci-publication-gate";
 import { createConfig, createPullRequest, createRecord } from "./turn-execution-test-helpers";
 import type { SupervisorStateFile } from "./core/types";
+
+test("runTrackedPrCurrentHeadLocalCiGate stamps the local CI result only after workspace HEAD matches the PR", async () => {
+  const pr = createPullRequest({
+    number: 116,
+    isDraft: false,
+    headRefOid: "head-116",
+  });
+  const record = createRecord({
+    state: "ready_to_merge",
+    pr_number: pr.number,
+    branch: "codex/issue-102",
+    latest_local_ci_result: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: record.issue_number,
+    issues: { [String(record.issue_number)]: record },
+  };
+  let localCiCalls = 0;
+  let saveCalls = 0;
+  let syncJournalCalls = 0;
+
+  const result = await runTrackedPrCurrentHeadLocalCiGate({
+    config: createConfig({ localCiCommand: "npm run ci:local" }),
+    stateStore: {
+      touch: (currentRecord, patch) => ({
+        ...currentRecord,
+        ...patch,
+        updated_at: currentRecord.updated_at,
+      }),
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    record,
+    pr,
+    workspacePath: path.join("workspace", "issue-102"),
+    gateLabel: "before auto-merging PR #116",
+    workspaceHeadMismatchDetail: (localHeadSha, prHeadSha) =>
+      `local workspace HEAD ${localHeadSha} does not match PR head ${prHeadSha}; the auto-merge gate is failing closed until the local commit is published.`,
+    publishWorkspaceHeadMismatchComment: false,
+    github: {},
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    applyFailureSignature: (_currentRecord, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runLocalCiCommand: async () => {
+      localCiCalls += 1;
+    },
+    getWorkspaceStatus: async () => ({
+      branch: "codex/issue-102",
+      headSha: "head-116",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.failureContext, null);
+  assert.equal(result.record.latest_local_ci_result?.outcome, "passed");
+  assert.equal(result.record.latest_local_ci_result?.summary, "Configured local CI command passed before auto-merging PR #116.");
+  assert.equal(result.record.latest_local_ci_result?.head_sha, "head-116");
+  assert.equal(localCiCalls, 1);
+  assert.equal(saveCalls, 2);
+  assert.equal(syncJournalCalls, 2);
+});
 
 test("runTrackedPrReadyLocalCiPublicationGate reports workspace failures with the shared remediation target", async () => {
   const pr = createPullRequest({

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -14,6 +14,8 @@ import {
   SupervisorStateFile,
 } from "./core/types";
 import { truncate } from "./core/utils";
+import { getWorkspaceStatus as getWorkspaceStatusImpl } from "./core/workspace";
+import { buildWorkstationLocalPathFailureContext } from "./workstation-local-path-gate";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import {
   appendTimelineArtifact,
@@ -23,6 +25,12 @@ import {
 export interface TrackedPrReadyLocalCiPublicationGateResult {
   ok: boolean;
   record: IssueRunRecord;
+}
+
+export interface TrackedPrCurrentHeadLocalCiGateResult {
+  ok: boolean;
+  record: IssueRunRecord;
+  failureContext: FailureContext | null;
 }
 
 export async function runTrackedPrReadyLocalCiPublicationGate(args: {
@@ -149,4 +157,105 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   await args.stateStore.save(args.state);
   await args.syncJournal(record);
   return { ok: true, record };
+}
+
+export async function runTrackedPrCurrentHeadLocalCiGate(args: {
+  config: Pick<SupervisorConfig, "defaultBranch" | "repoPath" | "workspacePreparationCommand" | "localCiCommand">;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  workspacePath: string;
+  gateLabel: string;
+  workspaceHeadMismatchDetail: (localHeadSha: string, prHeadSha: string) => string;
+  publishWorkspaceHeadMismatchComment: boolean;
+  github: Partial<Pick<GitHubClient, "addIssueComment" | "updateIssueComment">>;
+  syncJournal: IssueJournalSync;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+  runWorkspacePreparationCommand?: LocalCiCommandRunner;
+  runLocalCiCommand?: LocalCiCommandRunner;
+  getWorkspaceStatus?: typeof getWorkspaceStatusImpl;
+}): Promise<TrackedPrCurrentHeadLocalCiGateResult> {
+  const localCiPublicationGate = await runTrackedPrReadyLocalCiPublicationGate({
+    config: args.config,
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    pr: args.pr,
+    workspacePath: args.workspacePath,
+    gateLabel: args.gateLabel,
+    github: args.github,
+    syncJournal: args.syncJournal,
+    applyFailureSignature: args.applyFailureSignature,
+    runWorkspacePreparationCommand: args.runWorkspacePreparationCommand,
+    runLocalCiCommand: args.runLocalCiCommand,
+  });
+  let record = localCiPublicationGate.record;
+  if (!localCiPublicationGate.ok) {
+    return { ok: false, record, failureContext: record.last_failure_context ?? null };
+  }
+
+  const getWorkspaceStatus = args.getWorkspaceStatus ?? getWorkspaceStatusImpl;
+  const localWorkspaceStatus = await getWorkspaceStatus(args.workspacePath, record.branch, args.config.defaultBranch);
+  if (localWorkspaceStatus.headSha !== args.pr.headRefOid) {
+    const failureContext = buildWorkstationLocalPathFailureContext({
+      gateLabel: args.gateLabel,
+      details: [
+        args.workspaceHeadMismatchDetail(localWorkspaceStatus.headSha, args.pr.headRefOid),
+      ],
+    });
+    record = args.stateStore.touch(record, {
+      state: "blocked",
+      last_error: truncate(failureContext.summary, 1000),
+      last_failure_kind: null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(record, failureContext),
+      blocked_reason: "verification",
+      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+        pr: args.pr,
+        blockerSignature: failureContext.signature,
+      }),
+    });
+    args.state.issues[String(record.issue_number)] = record;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(record);
+    if (args.publishWorkspaceHeadMismatchComment) {
+      record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
+        github: args.github,
+        stateStore: args.stateStore,
+        state: args.state,
+        record,
+        pr: args.pr,
+        syncJournal: args.syncJournal,
+        gateType: "workstation_local_path_hygiene",
+        blockerSignature: failureContext.signature,
+        failureClass: failureContext.signature,
+        remediationTarget: "tracked_publishable_content",
+        summary: failureContext.summary,
+        details: failureContext.details,
+      });
+    }
+    return { ok: false, record, failureContext };
+  }
+
+  if (
+    record.latest_local_ci_result !== null &&
+    record.latest_local_ci_result !== undefined &&
+    record.latest_local_ci_result.head_sha !== args.pr.headRefOid
+  ) {
+    record = args.stateStore.touch(record, {
+      latest_local_ci_result: {
+        ...record.latest_local_ci_result,
+        head_sha: args.pr.headRefOid,
+      },
+    });
+    args.state.issues[String(record.issue_number)] = record;
+    await args.stateStore.save(args.state);
+    await args.syncJournal(record);
+  }
+
+  return { ok: true, record, failureContext: null };
 }


### PR DESCRIPTION
## Summary
- Extract current-head tracked-PR local CI orchestration into a shared helper.
- Reuse it for draft ready-promotion and final auto-merge preflight while preserving gate labels and fail-closed handling.
- Add a focused helper test for current-head local CI result stamping.

Closes #2155

## Verification
- npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "current-head local CI before final auto-merge|local CI|workspace preparation|path hygiene"
- npx tsx --test src/tracked-pr-local-ci-publication-gate.test.ts src/local-ci.test.ts
- npm run build