### PR TITLE
Centralize local CI policy predicates

### DIFF
--- a/src/local-ci-policy.ts
+++ b/src/local-ci-policy.ts
@@ -1,0 +1,19 @@
+import { displayLocalCiCommand } from "./core/config";
+import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "./core/types";
+
+export type LocalCiConfiguredState = Pick<SupervisorConfig, "localCiCommand"> & {
+  localCiCommand?: SupervisorConfig["localCiCommand"] | null;
+};
+
+export function hasConfiguredLocalCiCommand(config: LocalCiConfiguredState): boolean {
+  return displayLocalCiCommand(config.localCiCommand ?? undefined) !== null;
+}
+
+export function hasCurrentHeadLocalCiSuccess(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  const latestLocalCi = record.latest_local_ci_result ?? null;
+  return latestLocalCi?.outcome === "passed" && latestLocalCi.head_sha === pr.headRefOid;
+}
+
+export function currentHeadLocalCiMissing(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
+  return !hasCurrentHeadLocalCiSuccess(record, pr);
+}

--- a/src/local-ci.test.ts
+++ b/src/local-ci.test.ts
@@ -5,6 +5,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { executeLocalCiCommand, runLocalCiGate, runWorkspacePreparationGate } from "./local-ci";
+import {
+  currentHeadLocalCiMissing,
+  hasConfiguredLocalCiCommand,
+  hasCurrentHeadLocalCiSuccess,
+} from "./local-ci-policy";
 import { runTrackedPrReadyLocalCiPublicationGate } from "./tracked-pr-local-ci-publication-gate";
 import { REPO_OWNED_SUBPROCESS_TIMEOUT_MS, resolveExecutablePath } from "./subprocess-test-helpers";
 import {
@@ -23,6 +28,41 @@ function git(cwd: string, ...args: string[]): string {
     timeout: REPO_OWNED_SUBPROCESS_TIMEOUT_MS,
   });
 }
+
+test("shared local CI policy matches configured command and current-head success semantics", () => {
+  const pr = createPullRequest({ headRefOid: "head-116" });
+  const currentRecord = createRecord({
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #116.",
+      ran_at: "2026-03-13T06:32:00Z",
+      head_sha: "head-116",
+      execution_mode: "shell",
+      command: "npm run ci:local",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const staleRecord = createRecord({
+    latest_local_ci_result: {
+      ...currentRecord.latest_local_ci_result!,
+      head_sha: "old-head-116",
+    },
+  });
+
+  assert.equal(hasConfiguredLocalCiCommand(createConfig({ localCiCommand: " npm run ci:local " })), true);
+  assert.equal(
+    hasConfiguredLocalCiCommand(createConfig({ localCiCommand: { mode: "structured", executable: "npm", args: ["test"] } })),
+    true,
+  );
+  assert.equal(hasConfiguredLocalCiCommand(createConfig({ localCiCommand: "" })), false);
+  assert.equal(hasConfiguredLocalCiCommand(createConfig({ localCiCommand: null as unknown as undefined })), false);
+  assert.equal(hasConfiguredLocalCiCommand(createConfig({ localCiCommand: undefined })), false);
+  assert.equal(hasCurrentHeadLocalCiSuccess(currentRecord, pr), true);
+  assert.equal(currentHeadLocalCiMissing(currentRecord, pr), false);
+  assert.equal(hasCurrentHeadLocalCiSuccess(staleRecord, pr), false);
+  assert.equal(currentHeadLocalCiMissing(staleRecord, pr), true);
+});
 
 test("runTrackedPrReadyLocalCiPublicationGate blocks ready promotion on local CI failure", async () => {
   const pr = createPullRequest({

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -51,6 +51,7 @@ import {
   derivePostTurnLocalReviewFailurePatch,
 } from "./post-turn-pull-request-policy";
 import { runTrackedPrCurrentHeadLocalCiGate } from "./tracked-pr-local-ci-publication-gate";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "./local-ci-policy";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
 import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-review-request-transition";
@@ -99,15 +100,6 @@ export interface PullRequestLifecycleSnapshot {
 }
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE = "Normalize trusted durable artifacts for path hygiene";
-
-function hasConfiguredLocalCiCommand(config: Pick<SupervisorConfig, "localCiCommand">): boolean {
-  return config.localCiCommand !== null && config.localCiCommand !== undefined;
-}
-
-function currentHeadLocalCiMissing(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
-  const latestLocalCi = record.latest_local_ci_result ?? null;
-  return latestLocalCi?.outcome !== "passed" || latestLocalCi.head_sha !== pr.headRefOid;
-}
 
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -847,6 +847,95 @@ test("handlePostTurnMergeAndCompletion auto-merges CodeRabbit nitpick-only PRs w
   assert.equal(comments.length, 1);
 });
 
+test("handlePostTurnMergeAndCompletion treats null local CI config as unconfigured before auto-merge", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    reviewBotLogins: ["coderabbitai"],
+    localCiCommand: null as unknown as undefined,
+  });
+  const issueNumber = 128;
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: "head-128",
+        latest_local_ci_result: null,
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Auto-merge without configured local CI",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 128,
+    title: "CodeRabbit ready PR without local CI",
+    url: "https://example.test/pr/128",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-128",
+    headRefOid: "head-128",
+    mergedAt: null,
+    configuredBotCurrentHeadObservedAt: "2026-03-13T06:30:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-13T06:30:00Z",
+    currentHeadCiGreenAt: "2026-03-13T06:31:00Z",
+  };
+
+  let autoMergeCalls = 0;
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 128);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 128);
+      return passingChecks();
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 128);
+      return [];
+    },
+    addIssueComment: async () => {},
+    enableAutoMerge: async (prNumber: number, headSha: string) => {
+      assert.equal(prNumber, 128);
+      assert.equal(headSha, "head-128");
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "merging");
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("local_ci=not_configured"), true);
+  assert.equal(result.last_failure_context, null);
+  assert.equal(autoMergeCalls, 1);
+});
+
 test("handlePostTurnMergeAndCompletion blocks CodeRabbit auto-merge on stale local CI without Codex no-major refusal", async () => {
   const fixture = await createSupervisorFixture();
   const config = createConfig({

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { runCommand } from "../core/command";
 import { loadConfig } from "../core/config";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
 import { GitHubClient } from "../github";
 import { issueJournalPath, resolveTrackedIssueHostPaths } from "../core/journal";
 import { acquireFileLock, LockHandle } from "../core/lock";
@@ -212,14 +213,6 @@ function validTimestamp(value: string | null | undefined): string | null {
   return Number.isNaN(Date.parse(value)) ? null : value;
 }
 
-function hasConfiguredLocalCiCommand(config: Pick<SupervisorConfig, "localCiCommand">): boolean {
-  if (typeof config.localCiCommand === "string") {
-    return config.localCiCommand.trim() !== "";
-  }
-
-  return config.localCiCommand !== undefined;
-}
-
 interface FinalAutoMergeGuardResult {
   evidence: FailureContext;
   refusal: FailureContext | null;
@@ -284,9 +277,8 @@ function finalAutoMergeGuard(args: {
       ? currentPr.reviewDecision
       : null;
   const localCiResult = record.latest_local_ci_result ?? null;
-  const localCiMissing =
-    hasConfiguredLocalCiCommand(config) &&
-    (localCiResult?.outcome !== "passed" || localCiResult?.head_sha !== currentPr.headRefOid);
+  const localCiConfigured = hasConfiguredLocalCiCommand(config);
+  const localCiMissing = localCiConfigured && currentHeadLocalCiMissing(record, currentPr);
   const evidenceDetails = [
     `auto_merge_path=${autoMergePath}`,
     `head_sha=${currentPr.headRefOid}`,
@@ -299,7 +291,7 @@ function finalAutoMergeGuard(args: {
     `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     `human_blockers=${effectiveHumanBlockers}`,
     `review_decision=${currentPr.reviewDecision ?? "none"}`,
-    hasConfiguredLocalCiCommand(config)
+    localCiConfigured
       ? `local_ci=${localCiResult?.outcome ?? "missing"} head_sha=${localCiResult?.head_sha ?? "none"}`
       : "local_ci=not_configured",
   ];


### PR DESCRIPTION
## Summary
- Add shared local CI policy helpers for configured-state and current-head success/missing checks.
- Use the shared policy in post-turn preflight and final auto-merge guard logic.
- Add regression coverage for null local CI config and direct policy semantics.

## Verification
- npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts --test-name-pattern "local CI|auto-merge"
- npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "current-head local CI before final auto-merge|local CI"
- npx tsx --test src/local-ci.test.ts
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced local CI state management with improved configuration detection and PR head validation logic.

* **Tests**
  * Added comprehensive unit tests for local CI policy behaviors and auto-merge scenarios with unconfigured local CI.

* **Refactor**
  * Consolidated duplicate local CI helper functions into a shared module for improved maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->