### PR TITLE
Extract tracked PR host-local blocker persistence

### DIFF
--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -50,7 +50,10 @@ import {
   derivePostTurnLocalReviewDecision,
   derivePostTurnLocalReviewFailurePatch,
 } from "./post-turn-pull-request-policy";
-import { runTrackedPrCurrentHeadLocalCiGate } from "./tracked-pr-local-ci-publication-gate";
+import {
+  persistTrackedPrHostLocalBlocker,
+  runTrackedPrCurrentHeadLocalCiGate,
+} from "./tracked-pr-local-ci-publication-gate";
 import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "./local-ci-policy";
 import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
@@ -593,21 +596,15 @@ export async function handlePostTurnPullRequestTransitionsPhase(
             `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
           ],
         });
-        record = stateStore.touch(record, {
-          state: "blocked",
-          last_error: truncate(failureContext.summary, 1000),
-          last_failure_kind: null,
-          last_failure_context: failureContext,
-          ...args.applyFailureSignature(record, failureContext),
-          blocked_reason: "verification",
-          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-            pr: refreshed.pr,
-            blockerSignature: failureContext.signature,
-          }),
+        record = await persistTrackedPrHostLocalBlocker({
+          stateStore,
+          state,
+          record,
+          pr: refreshed.pr,
+          failureContext,
+          syncJournal,
+          applyFailureSignature: args.applyFailureSignature,
         });
-        state.issues[String(record.issue_number)] = record;
-        await stateStore.save(state);
-        await syncJournal(record);
         return {
           record,
           pr: refreshed.pr,
@@ -622,21 +619,15 @@ export async function handlePostTurnPullRequestTransitionsPhase(
             `durable artifact normalization reported rewritten paths for ${presentRewrittenTrackedPaths.join(", ")} but did not create a commit to publish.`,
           ],
         });
-        record = stateStore.touch(record, {
-          state: "blocked",
-          last_error: truncate(failureContext.summary, 1000),
-          last_failure_kind: null,
-          last_failure_context: failureContext,
-          ...args.applyFailureSignature(record, failureContext),
-          blocked_reason: "verification",
-          ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-            pr: refreshed.pr,
-            blockerSignature: failureContext.signature,
-          }),
+        record = await persistTrackedPrHostLocalBlocker({
+          stateStore,
+          state,
+          record,
+          pr: refreshed.pr,
+          failureContext,
+          syncJournal,
+          applyFailureSignature: args.applyFailureSignature,
         });
-        state.issues[String(record.issue_number)] = record;
-        await stateStore.save(state);
-        await syncJournal(record);
         return {
           record,
           pr: refreshed.pr,

--- a/src/tracked-pr-local-ci-publication-gate.test.ts
+++ b/src/tracked-pr-local-ci-publication-gate.test.ts
@@ -82,6 +82,90 @@ test("runTrackedPrCurrentHeadLocalCiGate stamps the local CI result only after w
   assert.equal(syncJournalCalls, 2);
 });
 
+test("runTrackedPrCurrentHeadLocalCiGate persists auto-merge workspace HEAD mismatch without commenting", async () => {
+  const pr = createPullRequest({
+    number: 116,
+    isDraft: false,
+    headRefOid: "remote-head-116",
+  });
+  const record = createRecord({
+    state: "ready_to_merge",
+    pr_number: pr.number,
+    branch: "codex/issue-102",
+    latest_local_ci_result: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: record.issue_number,
+    issues: { [String(record.issue_number)]: record },
+  };
+  let localCiCalls = 0;
+  let commentCalls = 0;
+  let saveCalls = 0;
+  let syncJournalCalls = 0;
+
+  const result = await runTrackedPrCurrentHeadLocalCiGate({
+    config: createConfig({ localCiCommand: "npm run ci:local" }),
+    stateStore: {
+      touch: (currentRecord, patch) => ({
+        ...currentRecord,
+        ...patch,
+        updated_at: currentRecord.updated_at,
+      }),
+      save: async () => {
+        saveCalls += 1;
+      },
+    },
+    state,
+    record,
+    pr,
+    workspacePath: path.join("workspace", "issue-102"),
+    gateLabel: "before auto-merging PR #116",
+    workspaceHeadMismatchDetail: (localHeadSha, prHeadSha) =>
+      `local workspace HEAD ${localHeadSha} does not match PR head ${prHeadSha}; the auto-merge gate is failing closed until the local commit is published.`,
+    publishWorkspaceHeadMismatchComment: false,
+    github: {
+      addIssueComment: async () => {
+        commentCalls += 1;
+      },
+    },
+    syncJournal: async () => {
+      syncJournalCalls += 1;
+    },
+    applyFailureSignature: (_currentRecord, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    runLocalCiCommand: async () => {
+      localCiCalls += 1;
+    },
+    getWorkspaceStatus: async () => ({
+      branch: "codex/issue-102",
+      headSha: "local-head-116",
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 1,
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.record.state, "blocked");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(result.record.last_observed_host_local_pr_blocker_head_sha, "remote-head-116");
+  assert.equal(result.record.last_observed_host_local_pr_blocker_signature, "workstation-local-path-hygiene-failed");
+  assert.match(result.failureContext?.details[0] ?? "", /local workspace HEAD local-head-116 does not match PR head remote-head-116/);
+  assert.equal(result.record.latest_local_ci_result?.outcome, "passed");
+  assert.equal(result.record.latest_local_ci_result?.head_sha, null);
+  assert.equal(localCiCalls, 1);
+  assert.equal(commentCalls, 0);
+  assert.equal(saveCalls, 2);
+  assert.equal(syncJournalCalls, 2);
+  assert.equal(state.issues[String(record.issue_number)], result.record);
+});
+
 test("runTrackedPrReadyLocalCiPublicationGate reports workspace failures with the shared remediation target", async () => {
   const pr = createPullRequest({
     number: 116,

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -33,6 +33,40 @@ export interface TrackedPrCurrentHeadLocalCiGateResult {
   failureContext: FailureContext | null;
 }
 
+export async function persistTrackedPrHostLocalBlocker(args: {
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  failureContext: FailureContext | null;
+  recordPatch?: Partial<IssueRunRecord>;
+  blockedReason?: IssueRunRecord["blocked_reason"];
+  syncJournal: IssueJournalSync;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
+}): Promise<IssueRunRecord> {
+  const recordPatch = args.recordPatch ?? {};
+  const record = args.stateStore.touch(args.record, {
+    ...recordPatch,
+    state: recordPatch.state ?? "blocked",
+    last_error: recordPatch.last_error ?? truncate(args.failureContext?.summary, 1000),
+    last_failure_kind: null,
+    last_failure_context: args.failureContext,
+    ...args.applyFailureSignature(args.record, args.failureContext),
+    blocked_reason: recordPatch.blocked_reason ?? args.blockedReason ?? "verification",
+    ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
+      pr: args.pr,
+      blockerSignature: args.failureContext?.signature ?? null,
+    }),
+  });
+  args.state.issues[String(record.issue_number)] = record;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(record);
+  return record;
+}
+
 export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   config: Pick<SupervisorConfig, "repoPath" | "workspacePreparationCommand" | "localCiCommand">;
   stateStore: Pick<StateStore, "touch" | "save">;
@@ -59,21 +93,15 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   });
   if (!workspacePreparationGate.ok) {
     const failureContext = workspacePreparationGate.failureContext;
-    let record = args.stateStore.touch(args.record, {
-      state: "blocked",
-      last_error: truncate(failureContext?.summary, 1000),
-      last_failure_kind: null,
-      last_failure_context: failureContext,
-      ...args.applyFailureSignature(args.record, failureContext),
-      blocked_reason: "verification",
-      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-        pr: args.pr,
-        blockerSignature: failureContext?.signature ?? null,
-      }),
+    let record = await persistTrackedPrHostLocalBlocker({
+      stateStore: args.stateStore,
+      state: args.state,
+      record: args.record,
+      pr: args.pr,
+      failureContext,
+      syncJournal: args.syncJournal,
+      applyFailureSignature: args.applyFailureSignature,
     });
-    args.state.issues[String(record.issue_number)] = record;
-    await args.stateStore.save(args.state);
-    await args.syncJournal(record);
     record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
       github: args.github,
       stateStore: args.stateStore,
@@ -101,29 +129,25 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   });
   if (!localCiGate.ok) {
     const failureContext = localCiGate.failureContext;
-    let record = args.stateStore.touch(args.record, {
-      state: "blocked",
-      latest_local_ci_result: localCiGate.latestResult ?? null,
-      timeline_artifacts: localCiGate.latestResult
-        ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
-          gate: "local_ci",
-          result: localCiGate.latestResult,
-          headSha: args.pr.headRefOid ?? null,
-        }))
-        : args.record.timeline_artifacts,
-      last_error: truncate(failureContext?.summary, 1000),
-      last_failure_kind: null,
-      last_failure_context: failureContext,
-      ...args.applyFailureSignature(args.record, failureContext),
-      blocked_reason: "verification",
-      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-        pr: args.pr,
-        blockerSignature: failureContext?.signature ?? null,
-      }),
+    let record = await persistTrackedPrHostLocalBlocker({
+      stateStore: args.stateStore,
+      state: args.state,
+      record: args.record,
+      pr: args.pr,
+      failureContext,
+      recordPatch: {
+        latest_local_ci_result: localCiGate.latestResult ?? null,
+        timeline_artifacts: localCiGate.latestResult
+          ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
+            gate: "local_ci",
+            result: localCiGate.latestResult,
+            headSha: args.pr.headRefOid ?? null,
+          }))
+          : args.record.timeline_artifacts,
+      },
+      syncJournal: args.syncJournal,
+      applyFailureSignature: args.applyFailureSignature,
     });
-    args.state.issues[String(record.issue_number)] = record;
-    await args.stateStore.save(args.state);
-    await args.syncJournal(record);
     record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
       github: args.github,
       stateStore: args.stateStore,
@@ -207,21 +231,15 @@ export async function runTrackedPrCurrentHeadLocalCiGate(args: {
         args.workspaceHeadMismatchDetail(localWorkspaceStatus.headSha, args.pr.headRefOid),
       ],
     });
-    record = args.stateStore.touch(record, {
-      state: "blocked",
-      last_error: truncate(failureContext.summary, 1000),
-      last_failure_kind: null,
-      last_failure_context: failureContext,
-      ...args.applyFailureSignature(record, failureContext),
-      blocked_reason: "verification",
-      ...trackedPrStatusComments.observedTrackedPrHostLocalBlockerPatch({
-        pr: args.pr,
-        blockerSignature: failureContext.signature,
-      }),
+    record = await persistTrackedPrHostLocalBlocker({
+      stateStore: args.stateStore,
+      state: args.state,
+      record,
+      pr: args.pr,
+      failureContext,
+      syncJournal: args.syncJournal,
+      applyFailureSignature: args.applyFailureSignature,
     });
-    args.state.issues[String(record.issue_number)] = record;
-    await args.stateStore.save(args.state);
-    await args.syncJournal(record);
     if (args.publishWorkspaceHeadMismatchComment) {
       record = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
         github: args.github,


### PR DESCRIPTION
## Summary
- add a shared helper for tracked PR host-local blocker state persistence, failure signatures, save, and journal sync
- route ready-promotion local blockers, current-head workspace mismatch blockers, and ready normalization mismatch failures through the helper
- preserve ready-promotion blocker comments while keeping auto-merge preflight mismatch comment-free

## Verification
- npx tsx --test src/tracked-pr-local-ci-publication-gate.test.ts
- npx tsx --test src/post-turn-pull-request.test.ts --test-name-pattern "workstation-local path|local workspace HEAD|host-local blocker|current-head local CI before final auto-merge"
- npm run build

Part of #2157