### PR TITLE
Deduplicate local CI timeline artifact patching

### DIFF
--- a/src/tracked-pr-local-ci-publication-gate.test.ts
+++ b/src/tracked-pr-local-ci-publication-gate.test.ts
@@ -77,6 +77,19 @@ test("runTrackedPrCurrentHeadLocalCiGate stamps the local CI result only after w
   assert.equal(result.record.latest_local_ci_result?.outcome, "passed");
   assert.equal(result.record.latest_local_ci_result?.summary, "Configured local CI command passed before auto-merging PR #116.");
   assert.equal(result.record.latest_local_ci_result?.head_sha, "head-116");
+  assert.deepEqual(result.record.timeline_artifacts, [
+    {
+      type: "verification_result",
+      gate: "local_ci",
+      command: "npm run ci:local",
+      head_sha: "head-116",
+      outcome: "passed",
+      remediation_target: null,
+      next_action: "continue",
+      summary: "Configured local CI command passed before auto-merging PR #116.",
+      recorded_at: result.record.timeline_artifacts?.[0]?.recorded_at ?? "",
+    },
+  ]);
   assert.equal(localCiCalls, 1);
   assert.equal(saveCalls, 2);
   assert.equal(syncJournalCalls, 2);

--- a/src/tracked-pr-local-ci-publication-gate.ts
+++ b/src/tracked-pr-local-ci-publication-gate.ts
@@ -10,6 +10,7 @@ import {
   FailureContext,
   GitHubPullRequest,
   IssueRunRecord,
+  LatestLocalCiResult,
   SupervisorConfig,
   SupervisorStateFile,
 } from "./core/types";
@@ -21,6 +22,23 @@ import {
   appendTimelineArtifact,
   buildLocalCiTimelineArtifact,
 } from "./timeline-artifacts";
+
+function buildLocalCiResultRecordPatch(args: {
+  record: Pick<IssueRunRecord, "timeline_artifacts">;
+  latestResult: LatestLocalCiResult | null | undefined;
+  headSha: string | null;
+}): Pick<IssueRunRecord, "latest_local_ci_result" | "timeline_artifacts"> {
+  return {
+    latest_local_ci_result: args.latestResult ?? null,
+    timeline_artifacts: args.latestResult
+      ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
+        gate: "local_ci",
+        result: args.latestResult,
+        headSha: args.headSha,
+      }))
+      : args.record.timeline_artifacts,
+  };
+}
 
 export interface TrackedPrReadyLocalCiPublicationGateResult {
   ok: boolean;
@@ -136,14 +154,11 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
       pr: args.pr,
       failureContext,
       recordPatch: {
-        latest_local_ci_result: localCiGate.latestResult ?? null,
-        timeline_artifacts: localCiGate.latestResult
-          ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
-            gate: "local_ci",
-            result: localCiGate.latestResult,
-            headSha: args.pr.headRefOid ?? null,
-          }))
-          : args.record.timeline_artifacts,
+        ...buildLocalCiResultRecordPatch({
+          record: args.record,
+          latestResult: localCiGate.latestResult,
+          headSha: args.pr.headRefOid ?? null,
+        }),
       },
       syncJournal: args.syncJournal,
       applyFailureSignature: args.applyFailureSignature,
@@ -166,14 +181,11 @@ export async function runTrackedPrReadyLocalCiPublicationGate(args: {
   }
 
   const record = args.stateStore.touch(args.record, {
-    latest_local_ci_result: localCiGate.latestResult ?? null,
-    timeline_artifacts: localCiGate.latestResult
-      ? appendTimelineArtifact(args.record, buildLocalCiTimelineArtifact({
-        gate: "local_ci",
-        result: localCiGate.latestResult,
-        headSha: args.pr.headRefOid ?? null,
-      }))
-      : args.record.timeline_artifacts,
+    ...buildLocalCiResultRecordPatch({
+      record: args.record,
+      latestResult: localCiGate.latestResult,
+      headSha: args.pr.headRefOid ?? null,
+    }),
     last_observed_host_local_pr_blocker_signature: null,
     last_observed_host_local_pr_blocker_head_sha: null,
   });


### PR DESCRIPTION
## Summary
- add a shared local CI result record patch helper for latest result and timeline artifact updates
- use the helper for both failed and passed tracked PR local CI publication outcomes
- tighten success-path coverage for the emitted local CI timeline artifact shape

## Verification
- npx tsx --test src/tracked-pr-local-ci-publication-gate.test.ts src/local-ci.test.ts src/timeline-artifacts.test.ts
- npm run build

Closes #2158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage to verify timeline artifacts, CI command details, execution outcomes, and next actions are correctly recorded.

* **Refactor**
  * Consolidated local CI gate result recording logic into a shared helper function.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TommyKammy/codex-supervisor/pull/2162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->