### PR TITLE
Isolate stale configured-bot auto handling

### DIFF
--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -1,0 +1,130 @@
+import type { GitHubClient } from "./github";
+import type { IssueJournalSync } from "./run-once-issue-preparation";
+import type { StateStore } from "./core/state-store";
+import type {
+  FailureContext,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "./core/types";
+import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
+import {
+  recoverStaleConfiguredBotReviewThreads,
+  STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
+} from "./supervisor/stale-review-bot-recovery";
+
+export interface StaleConfiguredBotConversationResolutionBlocker {
+  failureContext: FailureContext;
+}
+
+export interface StaleConfiguredBotReviewRemediationResult {
+  handled: boolean;
+  record: IssueRunRecord;
+}
+
+export async function handleStaleConfiguredBotReviewRemediation(args: {
+  github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
+  stateStore: Pick<StateStore, "touch" | "save">;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  manualReviewThreadCount: number;
+  syncJournal: IssueJournalSync;
+  config: SupervisorConfig;
+  failureContext: FailureContext | null;
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+  statusCommentAvailable: boolean;
+  conversationResolutionBlocker: StaleConfiguredBotConversationResolutionBlocker | null;
+  skipAutoHandleStaleConfiguredBotReview?: boolean;
+}): Promise<StaleConfiguredBotReviewRemediationResult> {
+  const remediationRecord =
+    args.record.state === "blocked" &&
+    (args.record.blocked_reason === "stale_review_bot" || args.record.blocked_reason === "manual_review") &&
+    args.manualReviewThreadCount === 0
+      ? { ...args.record, blocked_reason: "stale_review_bot" as const }
+      : args.record;
+  const staleReviewBotRemediation =
+    remediationRecord.state === "blocked" && remediationRecord.blocked_reason === "stale_review_bot"
+      ? buildStaleReviewBotRemediation({
+          config: args.config,
+          record: remediationRecord,
+          pr: args.pr,
+          checks: args.checks,
+          reviewThreads: args.reviewThreads,
+        })
+      : null;
+  const canResolveStaleConfiguredBotReview =
+    args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
+    (staleReviewBotRemediation?.classification === "metadata_only" ||
+      staleReviewBotRemediation?.classification === "metadata_only_current_head_converged");
+  const canResolveVerifiedNoSourceChangeThreadResolution =
+    args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
+    staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution";
+  const canResolveVerifiedCurrentHeadRepairThreadResolution =
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution";
+  const canResolveConversationResolutionBlocker =
+    args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
+    args.conversationResolutionBlocker !== null;
+  const checkSummary = args.summarizeChecks(args.checks);
+
+  const canAutoHandleStaleConfiguredBotReview =
+    !args.skipAutoHandleStaleConfiguredBotReview &&
+    (args.record.state === "blocked" || canResolveConversationResolutionBlocker) &&
+    (args.record.blocked_reason === "stale_review_bot" ||
+      canResolveConversationResolutionBlocker ||
+      ((canResolveVerifiedNoSourceChangeThreadResolution || canResolveVerifiedCurrentHeadRepairThreadResolution) &&
+        args.record.blocked_reason === "manual_review")) &&
+    (args.statusCommentAvailable || canResolveConversationResolutionBlocker) &&
+    args.manualReviewThreadCount === 0 &&
+    !checkSummary.hasPending &&
+    !checkSummary.hasFailing &&
+    (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
+      args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
+      canResolveVerifiedNoSourceChangeThreadResolution ||
+      canResolveVerifiedCurrentHeadRepairThreadResolution ||
+      canResolveConversationResolutionBlocker);
+
+  if (!canAutoHandleStaleConfiguredBotReview || !args.github.replyToReviewThread) {
+    return { handled: false, record: args.record };
+  }
+
+  const recoveryResult = await recoverStaleConfiguredBotReviewThreads({
+    github: args.github,
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    pr: args.pr,
+    reviewThreads: args.reviewThreads,
+    syncJournal: args.syncJournal,
+    config: args.config,
+    failureContext: args.conversationResolutionBlocker?.failureContext ?? args.failureContext,
+    resolveAfterReply:
+      canResolveConversationResolutionBlocker ||
+      canResolveStaleConfiguredBotReview ||
+      canResolveVerifiedNoSourceChangeThreadResolution ||
+      canResolveVerifiedCurrentHeadRepairThreadResolution,
+    reasonCode: canResolveVerifiedCurrentHeadRepairThreadResolution
+      ? "verified_current_head_repair_auto_resolve"
+      : canResolveVerifiedNoSourceChangeThreadResolution || canResolveConversationResolutionBlocker
+        ? "verified_no_source_change_auto_resolve"
+        : STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
+  });
+  const repliedRecord = recoveryResult.record;
+  const replyHandled =
+    repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
+    repliedRecord.last_stale_review_bot_reply_signature ===
+      (args.conversationResolutionBlocker?.failureContext.signature ??
+        args.failureContext?.signature ??
+        STALE_CONFIGURED_BOT_REVIEW_REASON_CODE);
+
+  return {
+    handled: replyHandled || recoveryResult.status === "replied" || recoveryResult.status === "resolved",
+    record: repliedRecord,
+  };
+}

--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -10,7 +10,14 @@ import {
 } from "./tracked-pr-status-comment";
 import { publishTrackedPrStatusComment } from "./tracked-pr-status-comment-publisher";
 import { buildTrackedPrHostLocalBlockerComment } from "./tracked-pr-status-comment-rendering";
-import { createConfig, createPullRequest, createRecord, createSupervisorState } from "./supervisor/supervisor-test-helpers";
+import { handleStaleConfiguredBotReviewRemediation } from "./stale-configured-bot-auto-handle";
+import {
+  createConfig,
+  createPullRequest,
+  createRecord,
+  createReviewThread,
+  createSupervisorState,
+} from "./supervisor/supervisor-test-helpers";
 import { IssueRunRecord, SupervisorStateFile } from "./core/types";
 
 test("buildTrackedPrStatusCommentMarker renders the stable sticky tracked PR marker", () => {
@@ -154,6 +161,103 @@ test("buildTrackedPrHostLocalBlockerComment renders status text without marker t
     ].join("\n"),
   );
   assert.doesNotMatch(body, /codex-supervisor:tracked-pr-status-comment/);
+});
+
+test("handleStaleConfiguredBotReviewRemediation owns reply_only recovery decisions outside status publishing", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    staleConfiguredBotReviewPolicy: "reply_only",
+  });
+  const pr = createPullRequest({
+    number: 116,
+    headRefOid: "head-116",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Configured bot thread is stale.",
+    signature: "stalled-bot:thread-1",
+    command: null,
+    details: ["file=src/file.ts line=12 processed_on_current_head=yes"],
+    url: "https://example.test/pr/116#discussion_r1",
+    updated_at: "2026-05-26T00:00:00Z",
+  };
+  const record = createRecord({
+    issue_number: 102,
+    pr_number: pr.number,
+    state: "blocked",
+    blocked_reason: "stale_review_bot",
+    last_head_sha: pr.headRefOid,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+  });
+  const state = createSupervisorState({ issues: [record] });
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  let saveCalls = 0;
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-05-26T00:01:00Z",
+      };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      assert.equal(nextState.issues[String(record.issue_number)]?.issue_number, record.issue_number);
+      saveCalls += 1;
+    },
+  };
+
+  const result = await handleStaleConfiguredBotReviewRemediation({
+    github: {
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+    },
+    stateStore,
+    state,
+    record,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        isOutdated: true,
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "This finding is stale on the current head.",
+              createdAt: "2026-05-26T00:00:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    syncJournal: async () => undefined,
+    config,
+    failureContext,
+    manualReviewThreadCount: 0,
+    statusCommentAvailable: true,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    skipAutoHandleStaleConfiguredBotReview: false,
+    conversationResolutionBlocker: null,
+  });
+
+  assert.equal(result.handled, true);
+  assert.equal(result.record.last_stale_review_bot_reply_head_sha, pr.headRefOid);
+  assert.equal(result.record.last_stale_review_bot_reply_signature, failureContext.signature);
+  assert.equal(replyCalls.length, 1);
+  assert.equal(replyCalls[0]?.threadId, "thread-1");
+  assert.match(replyCalls[0]?.body ?? "", /Leaving thread resolution to a human operator/);
+  assert.equal(saveCalls, 2);
 });
 
 test("publishTrackedPrStatusComment updates the newest owned editable marker before adding", async () => {

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -23,11 +23,7 @@ import {
 } from "./core/types";
 import { truncate } from "./core/utils";
 import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
-import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
-import {
-  recoverStaleConfiguredBotReviewThreads,
-  STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
-} from "./supervisor/stale-review-bot-recovery";
+import { handleStaleConfiguredBotReviewRemediation } from "./stale-configured-bot-auto-handle";
 import {
   conversationResolutionEvidenceContradictsBlocker,
   conversationResolutionEvidenceDetails,
@@ -602,87 +598,27 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     reviewThreads: args.reviewThreads,
     summarizeChecks: args.summarizeChecks,
   });
-  const remediationRecord =
-    args.record.state === "blocked" &&
-    (args.record.blocked_reason === "stale_review_bot" || args.record.blocked_reason === "manual_review") &&
-    args.manualReviewThreadCount === 0
-      ? { ...args.record, blocked_reason: "stale_review_bot" as const }
-      : args.record;
-  const staleReviewBotRemediation =
-    remediationRecord.state === "blocked" && remediationRecord.blocked_reason === "stale_review_bot"
-      ? buildStaleReviewBotRemediation({
-          config: args.config,
-          record: remediationRecord,
-          pr: args.pr,
-          checks: args.checks,
-          reviewThreads: args.reviewThreads,
-        })
-      : null;
-  const canResolveStaleConfiguredBotReview =
-    args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" &&
-    (staleReviewBotRemediation?.classification === "metadata_only" ||
-      staleReviewBotRemediation?.classification === "metadata_only_current_head_converged");
-  const canResolveVerifiedNoSourceChangeThreadResolution =
-    args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
-    staleReviewBotRemediation?.classification === "verified_no_source_change_pending_thread_resolution";
-  const canResolveVerifiedCurrentHeadRepairThreadResolution =
-    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
-    staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution";
-  const canResolveConversationResolutionBlocker =
-    args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true &&
-    conversationResolutionBlocker !== null;
-
-  const canAutoHandleStaleConfiguredBotReview =
-    !args.skipAutoHandleStaleConfiguredBotReview &&
-    (args.record.state === "blocked" || canResolveConversationResolutionBlocker) &&
-    (args.record.blocked_reason === "stale_review_bot" ||
-      canResolveConversationResolutionBlocker ||
-      ((canResolveVerifiedNoSourceChangeThreadResolution || canResolveVerifiedCurrentHeadRepairThreadResolution) &&
-        args.record.blocked_reason === "manual_review")) &&
-    (comment || canResolveConversationResolutionBlocker) &&
-    args.manualReviewThreadCount === 0 &&
-    !args.summarizeChecks(args.checks).hasPending &&
-    !args.summarizeChecks(args.checks).hasFailing &&
-    (args.config.staleConfiguredBotReviewPolicy === "reply_only" ||
-      args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve" ||
-      canResolveVerifiedNoSourceChangeThreadResolution ||
-      canResolveVerifiedCurrentHeadRepairThreadResolution ||
-      canResolveConversationResolutionBlocker);
-
   let currentRecord = args.record;
-  if (canAutoHandleStaleConfiguredBotReview && args.github.replyToReviewThread) {
-    const recoveryResult = await recoverStaleConfiguredBotReviewThreads({
+  const staleReviewBotRemediationResult = await handleStaleConfiguredBotReviewRemediation({
       github: args.github,
       stateStore: args.stateStore,
       state: args.state,
       record: args.record,
       pr: args.pr,
+      checks: args.checks,
       reviewThreads: args.reviewThreads,
+      manualReviewThreadCount: args.manualReviewThreadCount,
       syncJournal: args.syncJournal,
       config: args.config,
-      failureContext: conversationResolutionBlocker?.failureContext ?? args.failureContext,
-      resolveAfterReply:
-        canResolveConversationResolutionBlocker ||
-        canResolveStaleConfiguredBotReview ||
-        canResolveVerifiedNoSourceChangeThreadResolution ||
-        canResolveVerifiedCurrentHeadRepairThreadResolution,
-      reasonCode: canResolveVerifiedCurrentHeadRepairThreadResolution
-        ? "verified_current_head_repair_auto_resolve"
-        : canResolveVerifiedNoSourceChangeThreadResolution || canResolveConversationResolutionBlocker
-        ? "verified_no_source_change_auto_resolve"
-        : STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
+      failureContext: args.failureContext,
+      summarizeChecks: args.summarizeChecks,
+      statusCommentAvailable: comment !== null,
+      conversationResolutionBlocker,
+      skipAutoHandleStaleConfiguredBotReview: args.skipAutoHandleStaleConfiguredBotReview,
     });
-    const repliedRecord = recoveryResult.record;
-    currentRecord = recoveryResult.record;
-    const replyHandled =
-      repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
-      repliedRecord.last_stale_review_bot_reply_signature ===
-        (conversationResolutionBlocker?.failureContext.signature ??
-          args.failureContext?.signature ??
-          STALE_CONFIGURED_BOT_REVIEW_REASON_CODE);
-    if (replyHandled || recoveryResult.status === "replied" || recoveryResult.status === "resolved") {
-      return repliedRecord;
-    }
+  currentRecord = staleReviewBotRemediationResult.record;
+  if (staleReviewBotRemediationResult.handled) {
+    return currentRecord;
   }
 
   if (!args.github.addIssueComment) {


### PR DESCRIPTION
## Summary
- Extract stale configured-bot reply/resolve orchestration from tracked PR status-comment publishing into a focused helper
- Keep persistent status comment publication as status UX plus delegated remediation
- Add a narrow helper-boundary regression test for reply_only recovery

## Verification
- npx tsx --test src/tracked-pr-status-comment.test.ts src/post-turn-pull-request.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts
- npm run build

Closes #2176