### PR TITLE
Extract review bot wait and profile helpers

### DIFF
--- a/src/supervisor/review-bot-profile.ts
+++ b/src/supervisor/review-bot-profile.ts
@@ -1,0 +1,58 @@
+import {
+  configuredReviewProviderKinds,
+  reviewProviderProfileFromConfig,
+} from "../core/review-providers";
+import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
+
+export type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
+
+export type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
+
+export interface ReviewBotProfileSummary {
+  profile: ReviewBotProfileId;
+  provider: string;
+  reviewers: string[];
+  signalSource: string;
+}
+
+export function configuredBotReviewNotExpectedWhileDraft(config: SupervisorConfig, pr: GitHubPullRequest): boolean {
+  return configuredReviewProviderKinds(config).includes("coderabbit") && pr.isDraft && Boolean(pr.configuredBotDraftSkipAt);
+}
+
+export function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummary {
+  return reviewProviderProfileFromConfig(config);
+}
+
+export function summarizeObservedReviewSignal(
+  config: SupervisorConfig,
+  activeRecord: IssueRunRecord,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+  configuredBotReviewThreads: ReviewThreadClassifier,
+): { observedReview: string; hasSignal: boolean } {
+  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
+  if (configuredThreads.length > 0) {
+    return { observedReview: "review_thread", hasSignal: true };
+  }
+
+  if (activeRecord.external_review_head_sha === pr.headRefOid) {
+    return { observedReview: "external_review_record", hasSignal: true };
+  }
+
+  if (pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" && pr.configuredBotCurrentHeadObservedAt) {
+    return { observedReview: "codex_pr_success_comment", hasSignal: true };
+  }
+
+  const lifecycleState = pr.copilotReviewState ?? "not_requested";
+  if (lifecycleState === "arrived") {
+    return { observedReview: "copilot_arrived", hasSignal: true };
+  }
+  if (lifecycleState === "requested") {
+    return { observedReview: "copilot_requested", hasSignal: false };
+  }
+  if (pr.copilotReviewState === null) {
+    return { observedReview: "unknown", hasSignal: false };
+  }
+
+  return { observedReview: "none", hasSignal: false };
+}

--- a/src/supervisor/review-bot-wait-windows.ts
+++ b/src/supervisor/review-bot-wait-windows.ts
@@ -1,0 +1,293 @@
+import { configuredReviewProviderKinds } from "../core/review-providers";
+import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../core/types";
+
+const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
+const DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS = 90_000;
+
+export type CurrentHeadSignalWaitProvider = "none" | "coderabbit" | "codex";
+
+function latestConfiguredBotActionableSignalAt(pr: GitHubPullRequest): string | null {
+  const candidates = [
+    pr.configuredBotCurrentHeadObservedAt,
+    pr.copilotReviewArrivedAt,
+    pr.configuredBotTopLevelReviewSubmittedAt,
+  ]
+    .map((value) => {
+      if (typeof value !== "string" || value.length === 0) {
+        return null;
+      }
+
+      const timestampMs = Date.parse(value);
+      if (Number.isNaN(timestampMs)) {
+        return null;
+      }
+
+      return { value, timestampMs };
+    })
+    .filter((candidate): candidate is { value: string; timestampMs: number } => candidate !== null);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.reduce((latest, candidate) => (candidate.timestampMs > latest.timestampMs ? candidate : latest)).value;
+}
+
+function configuredBotDraftSkipRewaitStartAt(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  record?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
+): string | null {
+  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || !pr.configuredBotDraftSkipAt) {
+    return null;
+  }
+
+  if (!record?.review_wait_started_at || record.review_wait_head_sha !== pr.headRefOid) {
+    return null;
+  }
+
+  const draftSkipAtMs = Date.parse(pr.configuredBotDraftSkipAt);
+  const reviewWaitStartedAtMs = Date.parse(record.review_wait_started_at);
+  if (Number.isNaN(draftSkipAtMs) || Number.isNaN(reviewWaitStartedAtMs) || reviewWaitStartedAtMs <= draftSkipAtMs) {
+    return null;
+  }
+
+  const actionableSignalAt = latestConfiguredBotActionableSignalAt(pr);
+  if (actionableSignalAt) {
+    const actionableSignalAtMs = Date.parse(actionableSignalAt);
+    if (!Number.isNaN(actionableSignalAtMs) && actionableSignalAtMs >= reviewWaitStartedAtMs) {
+      return null;
+    }
+  }
+
+  return record.review_wait_started_at;
+}
+
+function currentHeadSignalWaitProvider(config: SupervisorConfig): Exclude<CurrentHeadSignalWaitProvider, "none"> | null {
+  const providerKinds = configuredReviewProviderKinds(config);
+  if (providerKinds.includes("codex")) {
+    return "codex";
+  }
+  if (providerKinds.includes("coderabbit")) {
+    return "coderabbit";
+  }
+  return null;
+}
+
+function requiresCurrentHeadSignalWait(config: SupervisorConfig): boolean {
+  const provider = currentHeadSignalWaitProvider(config);
+  return provider !== null && (provider === "codex" || config.configuredBotRequireCurrentHeadSignal === true);
+}
+
+export function configuredBotRateLimitWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): { status: "inactive" | "active" | "expired"; observedAt: string | null; waitUntil: string | null } {
+  const waitMinutes = config.configuredBotRateLimitWaitMinutes ?? 0;
+  if (waitMinutes <= 0 || !pr.configuredBotRateLimitedAt) {
+    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt ?? null, waitUntil: null };
+  }
+
+  const observedAtMs = Date.parse(pr.configuredBotRateLimitedAt);
+  if (Number.isNaN(observedAtMs)) {
+    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt, waitUntil: null };
+  }
+
+  const waitUntil = new Date(observedAtMs + waitMinutes * 60_000).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    observedAt: pr.configuredBotRateLimitedAt,
+    waitUntil,
+  };
+}
+
+export function configuredBotSettledWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): {
+  status: "inactive" | "active" | "expired";
+  provider: "none" | "coderabbit";
+  pauseReason: "none" | "recent_current_head_observation";
+  recentObservation: "none" | "current_head_activity";
+  observedAt: string | null;
+  configuredWaitSeconds: number | null;
+  waitUntil: string | null;
+} {
+  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || !pr.configuredBotCurrentHeadObservedAt) {
+    return {
+      status: "inactive",
+      provider: "none",
+      pauseReason: "none",
+      recentObservation: "none",
+      observedAt: pr.configuredBotCurrentHeadObservedAt ?? null,
+      configuredWaitSeconds: null,
+      waitUntil: null,
+    };
+  }
+
+  const observedAtMs = Date.parse(pr.configuredBotCurrentHeadObservedAt);
+  const configuredWaitSeconds = config.configuredBotSettledWaitSeconds ?? DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS / 1_000;
+  if (Number.isNaN(observedAtMs)) {
+    return {
+      status: "inactive",
+      provider: "coderabbit",
+      pauseReason: "recent_current_head_observation",
+      recentObservation: "current_head_activity",
+      observedAt: pr.configuredBotCurrentHeadObservedAt,
+      configuredWaitSeconds,
+      waitUntil: null,
+    };
+  }
+
+  const settledWaitMs = configuredWaitSeconds * 1_000;
+  const waitUntil = new Date(observedAtMs + settledWaitMs).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    provider: "coderabbit",
+    pauseReason: "recent_current_head_observation",
+    recentObservation: "current_head_activity",
+    observedAt: pr.configuredBotCurrentHeadObservedAt,
+    configuredWaitSeconds,
+    waitUntil,
+  };
+}
+
+export function configuredBotCurrentHeadSignalWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+): {
+  status: "inactive" | "active" | "expired";
+  provider: CurrentHeadSignalWaitProvider;
+  pauseReason: "none" | "awaiting_current_head_signal_after_required_checks";
+  recentObservation: "none" | "required_checks_green";
+  observedAt: string | null;
+  configuredWaitMinutes: number | null;
+  waitUntil: string | null;
+} {
+  const provider = currentHeadSignalWaitProvider(config);
+  if (
+    !provider ||
+    !requiresCurrentHeadSignalWait(config) ||
+    pr.isDraft ||
+    pr.configuredBotCurrentHeadObservedAt ||
+    !pr.currentHeadCiGreenAt
+  ) {
+    return {
+      status: "inactive",
+      provider: "none",
+      pauseReason: "none",
+      recentObservation: "none",
+      observedAt: pr.currentHeadCiGreenAt ?? null,
+      configuredWaitMinutes: null,
+      waitUntil: null,
+    };
+  }
+
+  const observedAtMs = Date.parse(pr.currentHeadCiGreenAt);
+  const configuredWaitMinutes = config.configuredBotCurrentHeadSignalTimeoutMinutes ?? null;
+  if (Number.isNaN(observedAtMs) || !configuredWaitMinutes || configuredWaitMinutes <= 0) {
+    return {
+      status: "inactive",
+      provider,
+      pauseReason: "awaiting_current_head_signal_after_required_checks",
+      recentObservation: "required_checks_green",
+      observedAt: pr.currentHeadCiGreenAt,
+      configuredWaitMinutes,
+      waitUntil: null,
+    };
+  }
+
+  const waitUntil = new Date(observedAtMs + configuredWaitMinutes * 60_000).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    provider,
+    pauseReason: "awaiting_current_head_signal_after_required_checks",
+    recentObservation: "required_checks_green",
+    observedAt: pr.currentHeadCiGreenAt,
+    configuredWaitMinutes,
+    waitUntil,
+  };
+}
+
+export function configuredBotInitialGraceWaitWindow(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  record?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
+): {
+  status: "inactive" | "active" | "expired";
+  provider: "none" | "coderabbit";
+  pauseReason: "none" | "awaiting_initial_provider_activity" | "awaiting_fresh_provider_review_after_draft_skip";
+  recentObservation: "none" | "required_checks_green" | "ready_for_review_reopened_wait";
+  observedAt: string | null;
+  configuredWaitSeconds: number | null;
+  waitUntil: string | null;
+} {
+  const draftSkipRewaitStartedAt = configuredBotDraftSkipRewaitStartAt(config, pr, record);
+  if (draftSkipRewaitStartedAt) {
+    const observedAtMs = Date.parse(draftSkipRewaitStartedAt);
+    const configuredWaitSeconds =
+      config.configuredBotInitialGraceWaitSeconds ?? DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS / 1_000;
+    if (Number.isNaN(observedAtMs)) {
+      return {
+        status: "inactive",
+        provider: "coderabbit",
+        pauseReason: "awaiting_fresh_provider_review_after_draft_skip",
+        recentObservation: "ready_for_review_reopened_wait",
+        observedAt: draftSkipRewaitStartedAt,
+        configuredWaitSeconds,
+        waitUntil: null,
+      };
+    }
+
+    const initialGraceWaitMs = configuredWaitSeconds * 1_000;
+    const waitUntil = new Date(observedAtMs + initialGraceWaitMs).toISOString();
+    return {
+      status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+      provider: "coderabbit",
+      pauseReason: "awaiting_fresh_provider_review_after_draft_skip",
+      recentObservation: "ready_for_review_reopened_wait",
+      observedAt: draftSkipRewaitStartedAt,
+      configuredWaitSeconds,
+      waitUntil,
+    };
+  }
+
+  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || pr.configuredBotCurrentHeadObservedAt || !pr.currentHeadCiGreenAt) {
+    return {
+      status: "inactive",
+      provider: "none",
+      pauseReason: "none",
+      recentObservation: "none",
+      observedAt: pr.currentHeadCiGreenAt ?? null,
+      configuredWaitSeconds: null,
+      waitUntil: null,
+    };
+  }
+
+  const observedAtMs = Date.parse(pr.currentHeadCiGreenAt);
+  const configuredWaitSeconds =
+    config.configuredBotInitialGraceWaitSeconds ?? DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS / 1_000;
+  if (Number.isNaN(observedAtMs)) {
+    return {
+      status: "inactive",
+      provider: "coderabbit",
+      pauseReason: "awaiting_initial_provider_activity",
+      recentObservation: "required_checks_green",
+      observedAt: pr.currentHeadCiGreenAt,
+      configuredWaitSeconds,
+      waitUntil: null,
+    };
+  }
+
+  const initialGraceWaitMs = configuredWaitSeconds * 1_000;
+  const waitUntil = new Date(observedAtMs + initialGraceWaitMs).toISOString();
+  return {
+    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
+    provider: "coderabbit",
+    pauseReason: "awaiting_initial_provider_activity",
+    recentObservation: "required_checks_green",
+    observedAt: pr.currentHeadCiGreenAt,
+    configuredWaitSeconds,
+    waitUntil,
+  };
+}

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -4,18 +4,20 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
-  configuredBotInitialGraceWaitWindow,
-  configuredBotCurrentHeadSignalWaitWindow,
-  configuredBotSettledWaitWindow,
-  configuredBotRateLimitWaitWindow,
   configuredBotTopLevelReviewEffect,
   externalSignalReadinessDiagnostics,
   formatCodexConnectorConvergenceDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
   configuredReviewStatusLabel,
-  inferReviewBotProfile,
   reviewBotDiagnostics,
 } from "./supervisor-status-review-bot";
+import {
+  configuredBotInitialGraceWaitWindow,
+  configuredBotCurrentHeadSignalWaitWindow,
+  configuredBotSettledWaitWindow,
+  configuredBotRateLimitWaitWindow,
+} from "./review-bot-wait-windows";
+import { inferReviewBotProfile } from "./review-bot-profile";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -5,7 +5,6 @@ import {
   configuredReviewProviderKinds,
   repoExpectsConfiguredBotReview,
   repoUsesCopilotOnlyReviewBot,
-  reviewProviderProfileFromConfig,
 } from "../core/review-providers";
 import { displayLocalCiCommand } from "../core/config-parsing";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
@@ -26,11 +25,30 @@ import {
   isProvenStaleReviewMetadataClassification,
   type StaleReviewBotRemediationDto,
 } from "./stale-review-bot-remediation";
+import {
+  configuredBotCurrentHeadSignalWaitWindow,
+  configuredBotInitialGraceWaitWindow,
+  configuredBotRateLimitWaitWindow,
+  configuredBotSettledWaitWindow,
+} from "./review-bot-wait-windows";
+import {
+  configuredBotReviewNotExpectedWhileDraft,
+  inferReviewBotProfile,
+  summarizeObservedReviewSignal,
+  type ReviewThreadClassifier,
+} from "./review-bot-profile";
 
-type ReviewThreadClassifier = (config: SupervisorConfig, reviewThreads: ReviewThread[]) => ReviewThread[];
-const DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS = 5_000;
-const DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS = 90_000;
-type CurrentHeadSignalWaitProvider = "none" | "coderabbit" | "codex";
+export {
+  configuredBotCurrentHeadSignalWaitWindow,
+  configuredBotInitialGraceWaitWindow,
+  configuredBotRateLimitWaitWindow,
+  configuredBotSettledWaitWindow,
+} from "./review-bot-wait-windows";
+export {
+  inferReviewBotProfile,
+  summarizeObservedReviewSignal,
+} from "./review-bot-profile";
+export type { ReviewBotProfileId, ReviewBotProfileSummary } from "./review-bot-profile";
 
 function addMinutes(timestamp: string, minutes: number): string | null {
   const parsed = Date.parse(timestamp);
@@ -39,76 +57,6 @@ function addMinutes(timestamp: string, minutes: number): string | null {
   }
 
   return new Date(parsed + minutes * 60_000).toISOString();
-}
-
-function latestConfiguredBotActionableSignalAt(pr: GitHubPullRequest): string | null {
-  const candidates = [
-    pr.configuredBotCurrentHeadObservedAt,
-    pr.copilotReviewArrivedAt,
-    pr.configuredBotTopLevelReviewSubmittedAt,
-  ]
-    .map((value) => {
-      if (typeof value !== "string" || value.length === 0) {
-        return null;
-      }
-
-      const timestampMs = Date.parse(value);
-      if (Number.isNaN(timestampMs)) {
-        return null;
-      }
-
-      return { value, timestampMs };
-    })
-    .filter((candidate): candidate is { value: string; timestampMs: number } => candidate !== null);
-
-  if (candidates.length === 0) {
-    return null;
-  }
-
-  return candidates.reduce((latest, candidate) => (candidate.timestampMs > latest.timestampMs ? candidate : latest)).value;
-}
-
-function configuredBotReviewNotExpectedWhileDraft(config: SupervisorConfig, pr: GitHubPullRequest): boolean {
-  return configuredReviewProviderKinds(config).includes("coderabbit") && pr.isDraft && Boolean(pr.configuredBotDraftSkipAt);
-}
-
-function configuredBotDraftSkipRewaitStartAt(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-  record?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
-): string | null {
-  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || !pr.configuredBotDraftSkipAt) {
-    return null;
-  }
-
-  if (!record?.review_wait_started_at || record.review_wait_head_sha !== pr.headRefOid) {
-    return null;
-  }
-
-  const draftSkipAtMs = Date.parse(pr.configuredBotDraftSkipAt);
-  const reviewWaitStartedAtMs = Date.parse(record.review_wait_started_at);
-  if (Number.isNaN(draftSkipAtMs) || Number.isNaN(reviewWaitStartedAtMs) || reviewWaitStartedAtMs <= draftSkipAtMs) {
-    return null;
-  }
-
-  const actionableSignalAt = latestConfiguredBotActionableSignalAt(pr);
-  if (actionableSignalAt) {
-    const actionableSignalAtMs = Date.parse(actionableSignalAt);
-    if (!Number.isNaN(actionableSignalAtMs) && actionableSignalAtMs >= reviewWaitStartedAtMs) {
-      return null;
-    }
-  }
-
-  return record.review_wait_started_at;
-}
-
-export type ReviewBotProfileId = "none" | "copilot" | "codex" | "coderabbit" | "custom";
-
-export interface ReviewBotProfileSummary {
-  profile: ReviewBotProfileId;
-  provider: string;
-  reviewers: string[];
-  signalSource: string;
 }
 
 export interface ReviewBotDiagnostics {
@@ -156,22 +104,6 @@ export function configuredReviewBots(config: SupervisorConfig): string[] {
   return configuredReviewBotLogins(config);
 }
 
-function currentHeadSignalWaitProvider(config: SupervisorConfig): Exclude<CurrentHeadSignalWaitProvider, "none"> | null {
-  const providerKinds = configuredReviewProviderKinds(config);
-  if (providerKinds.includes("codex")) {
-    return "codex";
-  }
-  if (providerKinds.includes("coderabbit")) {
-    return "coderabbit";
-  }
-  return null;
-}
-
-function requiresCurrentHeadSignalWait(config: SupervisorConfig): boolean {
-  const provider = currentHeadSignalWaitProvider(config);
-  return provider !== null && (provider === "codex" || config.configuredBotRequireCurrentHeadSignal === true);
-}
-
 function repoHasGitHubActionsWorkflows(repoPath: string): boolean | null {
   try {
     const workflowDir = path.join(repoPath, ".github", "workflows");
@@ -183,136 +115,6 @@ function repoHasGitHubActionsWorkflows(repoPath: string): boolean | null {
     }
     return null;
   }
-}
-
-export function configuredBotRateLimitWaitWindow(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-): { status: "inactive" | "active" | "expired"; observedAt: string | null; waitUntil: string | null } {
-  const waitMinutes = config.configuredBotRateLimitWaitMinutes ?? 0;
-  if (waitMinutes <= 0 || !pr.configuredBotRateLimitedAt) {
-    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt ?? null, waitUntil: null };
-  }
-
-  const observedAtMs = Date.parse(pr.configuredBotRateLimitedAt);
-  if (Number.isNaN(observedAtMs)) {
-    return { status: "inactive", observedAt: pr.configuredBotRateLimitedAt, waitUntil: null };
-  }
-
-  const waitUntil = new Date(observedAtMs + waitMinutes * 60_000).toISOString();
-  return {
-    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-    observedAt: pr.configuredBotRateLimitedAt,
-    waitUntil,
-  };
-}
-
-export function configuredBotSettledWaitWindow(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-): {
-  status: "inactive" | "active" | "expired";
-  provider: "none" | "coderabbit";
-  pauseReason: "none" | "recent_current_head_observation";
-  recentObservation: "none" | "current_head_activity";
-  observedAt: string | null;
-  configuredWaitSeconds: number | null;
-  waitUntil: string | null;
-} {
-  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || !pr.configuredBotCurrentHeadObservedAt) {
-    return {
-      status: "inactive",
-      provider: "none",
-      pauseReason: "none",
-      recentObservation: "none",
-      observedAt: pr.configuredBotCurrentHeadObservedAt ?? null,
-      configuredWaitSeconds: null,
-      waitUntil: null,
-    };
-  }
-
-  const observedAtMs = Date.parse(pr.configuredBotCurrentHeadObservedAt);
-  const configuredWaitSeconds = config.configuredBotSettledWaitSeconds ?? DEFAULT_CONFIGURED_BOT_SETTLED_WAIT_MS / 1_000;
-  if (Number.isNaN(observedAtMs)) {
-    return {
-      status: "inactive",
-      provider: "coderabbit",
-      pauseReason: "recent_current_head_observation",
-      recentObservation: "current_head_activity",
-      observedAt: pr.configuredBotCurrentHeadObservedAt,
-      configuredWaitSeconds,
-      waitUntil: null,
-    };
-  }
-
-  const settledWaitMs = configuredWaitSeconds * 1_000;
-  const waitUntil = new Date(observedAtMs + settledWaitMs).toISOString();
-  return {
-    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-    provider: "coderabbit",
-    pauseReason: "recent_current_head_observation",
-    recentObservation: "current_head_activity",
-    observedAt: pr.configuredBotCurrentHeadObservedAt,
-    configuredWaitSeconds,
-    waitUntil,
-  };
-}
-
-export function configuredBotCurrentHeadSignalWaitWindow(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-): {
-  status: "inactive" | "active" | "expired";
-  provider: CurrentHeadSignalWaitProvider;
-  pauseReason: "none" | "awaiting_current_head_signal_after_required_checks";
-  recentObservation: "none" | "required_checks_green";
-  observedAt: string | null;
-  configuredWaitMinutes: number | null;
-  waitUntil: string | null;
-} {
-  const provider = currentHeadSignalWaitProvider(config);
-  if (
-    !provider ||
-    !requiresCurrentHeadSignalWait(config) ||
-    pr.isDraft ||
-    pr.configuredBotCurrentHeadObservedAt ||
-    !pr.currentHeadCiGreenAt
-  ) {
-    return {
-      status: "inactive",
-      provider: "none",
-      pauseReason: "none",
-      recentObservation: "none",
-      observedAt: pr.currentHeadCiGreenAt ?? null,
-      configuredWaitMinutes: null,
-      waitUntil: null,
-    };
-  }
-
-  const observedAtMs = Date.parse(pr.currentHeadCiGreenAt);
-  const configuredWaitMinutes = config.configuredBotCurrentHeadSignalTimeoutMinutes ?? null;
-  if (Number.isNaN(observedAtMs) || !configuredWaitMinutes || configuredWaitMinutes <= 0) {
-    return {
-      status: "inactive",
-      provider,
-      pauseReason: "awaiting_current_head_signal_after_required_checks",
-      recentObservation: "required_checks_green",
-      observedAt: pr.currentHeadCiGreenAt,
-      configuredWaitMinutes,
-      waitUntil: null,
-    };
-  }
-
-  const waitUntil = new Date(observedAtMs + configuredWaitMinutes * 60_000).toISOString();
-  return {
-    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-    provider,
-    pauseReason: "awaiting_current_head_signal_after_required_checks",
-    recentObservation: "required_checks_green",
-    observedAt: pr.currentHeadCiGreenAt,
-    configuredWaitMinutes,
-    waitUntil,
-  };
 }
 
 export function formatCodexConnectorReviewFallbackDiagnostic(args: {
@@ -795,89 +597,6 @@ export function buildCodexConnectorDiagnosticBundle(args: {
   };
 }
 
-export function configuredBotInitialGraceWaitWindow(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-  record?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
-): {
-  status: "inactive" | "active" | "expired";
-  provider: "none" | "coderabbit";
-  pauseReason: "none" | "awaiting_initial_provider_activity" | "awaiting_fresh_provider_review_after_draft_skip";
-  recentObservation: "none" | "required_checks_green" | "ready_for_review_reopened_wait";
-  observedAt: string | null;
-  configuredWaitSeconds: number | null;
-  waitUntil: string | null;
-} {
-  const draftSkipRewaitStartedAt = configuredBotDraftSkipRewaitStartAt(config, pr, record);
-  if (draftSkipRewaitStartedAt) {
-    const observedAtMs = Date.parse(draftSkipRewaitStartedAt);
-    const configuredWaitSeconds =
-      config.configuredBotInitialGraceWaitSeconds ?? DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS / 1_000;
-    if (Number.isNaN(observedAtMs)) {
-      return {
-        status: "inactive",
-        provider: "coderabbit",
-        pauseReason: "awaiting_fresh_provider_review_after_draft_skip",
-        recentObservation: "ready_for_review_reopened_wait",
-        observedAt: draftSkipRewaitStartedAt,
-        configuredWaitSeconds,
-        waitUntil: null,
-      };
-    }
-
-    const initialGraceWaitMs = configuredWaitSeconds * 1_000;
-    const waitUntil = new Date(observedAtMs + initialGraceWaitMs).toISOString();
-    return {
-      status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-      provider: "coderabbit",
-      pauseReason: "awaiting_fresh_provider_review_after_draft_skip",
-      recentObservation: "ready_for_review_reopened_wait",
-      observedAt: draftSkipRewaitStartedAt,
-      configuredWaitSeconds,
-      waitUntil,
-    };
-  }
-
-  if (!configuredReviewProviderKinds(config).includes("coderabbit") || pr.isDraft || pr.configuredBotCurrentHeadObservedAt || !pr.currentHeadCiGreenAt) {
-    return {
-      status: "inactive",
-      provider: "none",
-      pauseReason: "none",
-      recentObservation: "none",
-      observedAt: pr.currentHeadCiGreenAt ?? null,
-      configuredWaitSeconds: null,
-      waitUntil: null,
-    };
-  }
-
-  const observedAtMs = Date.parse(pr.currentHeadCiGreenAt);
-  const configuredWaitSeconds =
-    config.configuredBotInitialGraceWaitSeconds ?? DEFAULT_CONFIGURED_BOT_INITIAL_GRACE_WAIT_MS / 1_000;
-  if (Number.isNaN(observedAtMs)) {
-    return {
-      status: "inactive",
-      provider: "coderabbit",
-      pauseReason: "awaiting_initial_provider_activity",
-      recentObservation: "required_checks_green",
-      observedAt: pr.currentHeadCiGreenAt,
-      configuredWaitSeconds,
-      waitUntil: null,
-    };
-  }
-
-  const initialGraceWaitMs = configuredWaitSeconds * 1_000;
-  const waitUntil = new Date(observedAtMs + initialGraceWaitMs).toISOString();
-  return {
-    status: Date.now() < Date.parse(waitUntil) ? "active" : "expired",
-    provider: "coderabbit",
-    pauseReason: "awaiting_initial_provider_activity",
-    recentObservation: "required_checks_green",
-    observedAt: pr.currentHeadCiGreenAt,
-    configuredWaitSeconds,
-    waitUntil,
-  };
-}
-
 export function configuredReviewStatusLabel(config: SupervisorConfig): string {
   return !repoExpectsConfiguredBotReview(config) || repoUsesCopilotOnlyReviewBot(config)
     ? "copilot_review"
@@ -886,44 +605,6 @@ export function configuredReviewStatusLabel(config: SupervisorConfig): string {
 
 function unresolvedReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-}
-
-export function inferReviewBotProfile(config: SupervisorConfig): ReviewBotProfileSummary {
-  return reviewProviderProfileFromConfig(config);
-}
-
-export function summarizeObservedReviewSignal(
-  config: SupervisorConfig,
-  activeRecord: IssueRunRecord,
-  pr: GitHubPullRequest,
-  reviewThreads: ReviewThread[],
-  configuredBotReviewThreads: ReviewThreadClassifier,
-): { observedReview: string; hasSignal: boolean } {
-  const configuredThreads = configuredBotReviewThreads(config, reviewThreads);
-  if (configuredThreads.length > 0) {
-    return { observedReview: "review_thread", hasSignal: true };
-  }
-
-  if (activeRecord.external_review_head_sha === pr.headRefOid) {
-    return { observedReview: "external_review_record", hasSignal: true };
-  }
-
-  if (pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" && pr.configuredBotCurrentHeadObservedAt) {
-    return { observedReview: "codex_pr_success_comment", hasSignal: true };
-  }
-
-  const lifecycleState = pr.copilotReviewState ?? "not_requested";
-  if (lifecycleState === "arrived") {
-    return { observedReview: "copilot_arrived", hasSignal: true };
-  }
-  if (lifecycleState === "requested") {
-    return { observedReview: "copilot_requested", hasSignal: false };
-  }
-  if (pr.copilotReviewState === null) {
-    return { observedReview: "unknown", hasSignal: false };
-  }
-
-  return { observedReview: "none", hasSignal: false };
 }
 
 function staleProviderSignalObservation(activeRecord: IssueRunRecord, pr: GitHubPullRequest): string | null {
@@ -1077,7 +758,7 @@ export function externalSignalReadinessDiagnostics(
               ? "awaiting_signal"
               : "unknown";
 
-  const reviewSignalSource = reviewProviderProfileFromConfig(config).signalSource;
+  const reviewSignalSource = inferReviewBotProfile(config).signalSource;
   const review =
     !repoExpectsConfiguredBotReview(config)
       ? "disabled"


### PR DESCRIPTION
## Summary
- Extract configured review-bot wait-window helpers into src/supervisor/review-bot-wait-windows.ts
- Extract provider profile and observed review-signal helpers into src/supervisor/review-bot-profile.ts
- Keep compatibility re-exports from supervisor-status-review-bot and point focused helper tests at the new modules

## Verification
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-explain*.test.ts src/supervisor/supervisor-status-selection-diagnostics.test.ts
- npm run build

Part of #2190
Closes #2193