### PR TITLE
Recover stale Codex review commit residue

### DIFF
--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -189,6 +189,40 @@ test("codexConnectorReviewRequestAction requests review for stale review commit 
   assert.deepEqual(decideScenario(createCodexConnectorStaleReviewCommitRequestScenario()), { kind: "initial" });
 });
 
+test("codexConnectorReviewRequestAction waits for scheduler timeout before recovering stale review commit residue without timeout metadata", () => {
+  const scenario = createCodexConnectorStaleReviewCommitRequestScenario();
+  const record = {
+    ...scenario.recordPatch,
+    review_wait_started_at: "2026-05-08T03:09:36Z",
+    review_wait_head_sha: "head-1995",
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+  };
+
+  assert.deepEqual(
+    decide({
+      record,
+      pr: scenario.pullRequestPatch,
+      checks: scenario.checks,
+      reviewThreads: scenario.reviewThreads,
+      configuredThreads: scenario.configuredThreads,
+      now: "2026-05-08T03:19:35.999Z",
+    }),
+    { kind: "none" },
+  );
+  assert.deepEqual(
+    decide({
+      record,
+      pr: scenario.pullRequestPatch,
+      checks: scenario.checks,
+      reviewThreads: scenario.reviewThreads,
+      configuredThreads: scenario.configuredThreads,
+      now: "2026-05-08T03:19:36.000Z",
+    }),
+    { kind: "initial" },
+  );
+});
+
 test("codexConnectorReviewRequestAction selects retry after the same-head request wait expires", () => {
   assert.deepEqual(decideScenario(createCodexConnectorRequestRetryScenario()), {
     kind: "retry",

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -16,6 +16,7 @@ import {
   staleConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
+import { determineCopilotReviewTimeout } from "./pull-request-state-current-head-policy";
 
 export type CodexConnectorReviewRequestAction =
   | { kind: "none" }
@@ -216,6 +217,7 @@ function configuredBotThreadsAllowCodexConnectorRequest(args: {
 export function codexConnectorReviewRequestAction(
   args: CodexConnectorReviewRequestDecisionArgs,
 ): CodexConnectorReviewRequestAction {
+  const nowMs = args.nowMs?.() ?? Date.now();
   const checkSummary = args.summarizeChecks(args.checks);
   const configuredThreads = args.configuredBotReviewThreads(args.config, args.reviewThreads);
   const staleCodexReviewState = configuredReviewProviderKinds(args.config).includes("codex")
@@ -274,10 +276,16 @@ export function codexConnectorReviewRequestAction(
   const hasCurrentHeadRequestTrigger =
     args.record.copilot_review_timeout_action === "request_review_comment" &&
     Boolean(args.record.copilot_review_timed_out_at);
+  const currentHeadReviewTimeout = determineCopilotReviewTimeout(args.config, args.record, args.pr, nowMs);
+  const currentHeadReviewRequestTimedOut =
+    currentHeadReviewTimeout.kind === "current_head_signal" &&
+    currentHeadReviewTimeout.timedOut &&
+    currentHeadReviewTimeout.action === "request_review_comment";
   const hasRecoverableStaleReviewCommitResidue =
     configuredReviewProviderKinds(args.config).includes("codex") &&
     staleReviewCommitThreadIds.size > 0 &&
-    isStaleHeadMissingCurrentHeadReview;
+    isStaleHeadMissingCurrentHeadReview &&
+    currentHeadReviewRequestTimedOut;
 
   if (
     args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
@@ -331,7 +339,7 @@ export function codexConnectorReviewRequestAction(
   const waitUntil = retryAnchorAt
     ? addMinutes(retryAnchorAt, args.config.codexConnectorReviewRequestNoResponseMinutes ?? 10)
     : null;
-  if (!waitUntil || (args.nowMs ?? Date.now)() < Date.parse(waitUntil)) {
+  if (!waitUntil || nowMs < Date.parse(waitUntil)) {
     return { kind: "none" };
   }
 

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -235,6 +235,9 @@ export function codexConnectorReviewRequestAction(
     staleCodexReviewState?.classification === "verified_no_source_change_pending_thread_resolution";
   const isCodexVerifiedCurrentHeadRepairThreadResolution =
     staleCodexReviewState?.classification === "verified_current_head_repair_pending_thread_resolution";
+  const staleReviewCommitThreadIds = new Set(
+    codexConnectorStaleReviewCommitThreads(args.pr, configuredThreads).map((thread) => thread.id),
+  );
   const isStaleHeadMissingCurrentHeadReview =
     !isValidTimestamp(args.pr.configuredBotCurrentHeadObservedAt) &&
     (commitShasDifferForComparison(args.pr.configuredBotLatestReviewedCommitSha, args.pr.headRefOid) ||
@@ -268,11 +271,17 @@ export function codexConnectorReviewRequestAction(
     reviewThreads: args.reviewThreads,
     configuredThreads,
   });
+  const hasCurrentHeadRequestTrigger =
+    args.record.copilot_review_timeout_action === "request_review_comment" &&
+    Boolean(args.record.copilot_review_timed_out_at);
+  const hasRecoverableStaleReviewCommitResidue =
+    configuredReviewProviderKinds(args.config).includes("codex") &&
+    staleReviewCommitThreadIds.size > 0 &&
+    isStaleHeadMissingCurrentHeadReview;
 
   if (
     args.config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
-    args.record.copilot_review_timeout_action !== "request_review_comment" ||
-    !args.record.copilot_review_timed_out_at ||
+    (!hasCurrentHeadRequestTrigger && !hasRecoverableStaleReviewCommitResidue) ||
     codexConnectorCurrentHeadReviewReadiness({
       config: args.config,
       pr: args.pr,

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -1452,6 +1452,120 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex review for stale 
   }
 });
 
+test("handlePostTurnPullRequestTransitionsPhase requests current-head Codex review for stale review-commit residue before manual review stop", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-05-26T04:00:00Z");
+  try {
+    const config = createConfig({
+      reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+      configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+      verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+    });
+    const issue = createIssue({
+      number: 2199,
+      title: "Recover stale Codex review-commit residue before manual-review stop",
+    });
+    const staleReviewedHead = "stale-reviewed-head-2199";
+    const currentRepairHead = "current-repair-head-2199";
+    const pr = createPullRequest({
+      number: 2198,
+      title: "Repair stale Codex residue",
+      isDraft: false,
+      headRefOid: currentRepairHead,
+      currentHeadCiGreenAt: "2026-05-26T03:55:00Z",
+      configuredBotLatestReviewedCommitSha: staleReviewedHead,
+      configuredBotCurrentHeadObservedAt: null,
+      codexConnectorReviewRequestedAt: null,
+      codexConnectorReviewRequestedHeadSha: null,
+    });
+    const staleReviewCommitThread = createReviewThread({
+      id: "thread-stale-review-commit-residue",
+      path: "src/supervisor/supervisor-status-review-bot.ts",
+      line: 42,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-review-commit-residue",
+            body: "P1: Keep the stale review residue diagnostic formatter exported from the facade.",
+            createdAt: "2026-05-26T03:30:00Z",
+            url: "https://example.test/pr/2198#discussion_r2199",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    });
+    const record = createRecord({
+      issue_number: issue.number,
+      state: "blocked",
+      pr_number: pr.number,
+      last_head_sha: currentRepairHead,
+      blocked_reason: "manual_review",
+      last_failure_context: createFailureContext("1 unresolved automated review thread(s) remain."),
+      last_failure_signature: "stale-review-commit-residue",
+      processed_review_thread_ids: [`${staleReviewCommitThread.id}@${staleReviewedHead}`],
+      processed_review_thread_fingerprints: [
+        `${staleReviewCommitThread.id}@${staleReviewedHead}#comment-stale-review-commit-residue`,
+      ],
+      codex_connector_review_requested_observed_at: null,
+      codex_connector_review_requested_head_sha: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issue.number,
+      issues: { [String(issue.number)]: record },
+    };
+    const comments: Array<{ issueNumber: number; body: string }> = [];
+
+    const result = await handlePostTurnPullRequestTransitionsPhase({
+      config,
+      stateStore: createNoopStateStore(),
+      github: createDefaultGithub({
+        addIssueComment: async (issueNumber, body) => {
+          comments.push({ issueNumber, body });
+        },
+      }),
+      context: createPostTurnContext({
+        issue,
+        pr,
+        workspacePath: path.join(os.tmpdir(), "workspaces", "issue-2199"),
+        state,
+        record,
+      }),
+      loadOpenPullRequestSnapshot: async () => ({
+        pr,
+        checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        reviewThreads: [staleReviewCommitThread],
+      }),
+      derivePullRequestLifecycleSnapshot: (currentRecord, currentPr, checks, reviewThreads, recordPatch) =>
+        deriveSupervisorPullRequestLifecycleSnapshot(config, currentRecord, currentPr, checks, reviewThreads, recordPatch),
+      applyFailureSignature: () => ({ last_failure_signature: null, repeated_failure_signature_count: 0 }),
+      blockedReasonFromReviewState: (currentRecord, currentPr, checks, reviewThreads) =>
+        resolveBlockedReasonFromReviewState(config, currentRecord, currentPr, checks, reviewThreads),
+      summarizeChecks,
+      configuredBotReviewThreads,
+      manualReviewThreads,
+      mergeConflictDetected: () => false,
+    });
+
+    assert.equal(comments.length, 1);
+    assert.equal(comments[0]?.issueNumber, pr.number);
+    assert.equal(
+      comments[0]?.body ?? "",
+      `@codex review\n\n<!-- codex-supervisor:codex-connector-review-request issue=${issue.number} pr=${pr.number} head=${currentRepairHead} -->`,
+    );
+    assert.equal(result.record.state, "waiting_ci");
+    assert.equal(result.record.blocked_reason, null);
+    assert.equal(result.record.codex_connector_review_requested_head_sha, currentRepairHead);
+    assert.ok(result.record.codex_connector_review_requested_observed_at);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase requests Codex review for blocked stale-head configured-bot signal", async () => {
   const originalDateNow = Date.now;
   Date.now = () => Date.parse("2026-05-19T09:14:00Z");

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -1454,7 +1454,7 @@ test("handlePostTurnPullRequestTransitionsPhase requests Codex review for stale 
 
 test("handlePostTurnPullRequestTransitionsPhase requests current-head Codex review for stale review-commit residue before manual review stop", async () => {
   const originalDateNow = Date.now;
-  Date.now = () => Date.parse("2026-05-26T04:00:00Z");
+  Date.now = () => Date.parse("2026-05-26T04:06:00Z");
   try {
     const config = createConfig({
       reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -7,7 +7,15 @@ import {
   formatNoRunnableIssueFoundMessage,
   resolveRunnableIssueContext,
 } from "./run-once-issue-selection";
-import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "./core/types";
+import {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "./core/types";
 import {
   buildRequirementsBlockerIssueComment,
   syncRequirementsBlockerIssueComment,
@@ -541,6 +549,122 @@ test("resolveRunnableIssueContext selects stale-review-bot tracked PR when Codex
     ensureRecordJournalContext: async (selectedRecord) => ({
       workspace: selectedRecord.workspace,
       journal_path: "/tmp/workspaces/issue-2096/.codex-supervisor/issue-journal.md",
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.notEqual(typeof result, "string");
+  if (typeof result !== "string") {
+    assert.equal(result.kind, "ready");
+    if (result.kind === "ready") {
+      assert.equal(result.record.issue_number, issueNumber);
+      await result.issueLock.release();
+    }
+  }
+});
+
+test("resolveRunnableIssueContext selects stale review-commit residue without timeout metadata", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2199;
+  const prNumber = 2200;
+  const branch = "codex/issue-2199";
+  const headSha = "7d2a6e42f0a28a176463bda1c2cff4001e6aeb5a";
+  const staleReviewHead = "707f0eb2b95722c1c60bc3773a17a272957d775c";
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Recover stale Codex review residue",
+    body: executionReadyBody("Request current-head Codex review for stale review-commit residue."),
+    createdAt: "2026-05-26T22:00:00Z",
+    updatedAt: "2026-05-26T22:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-26T22:00:00Z",
+    review_wait_head_sha: headSha,
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: record,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-26T22:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-26T22:00:00Z",
+    configuredBotLatestReviewedCommitSha: staleReviewHead,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-stale-review-commit",
+      isResolved: false,
+      isOutdated: false,
+      path: "src/codex-connector-review-request-decision.ts",
+      line: 284,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-review-commit",
+            body: "P1: Verify the repair on the current head.",
+            createdAt: "2026-05-26T21:55:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_r2199`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [issue],
+      getIssue: async () => issue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => reviewThreads,
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: "/tmp/workspaces/issue-2199/.codex-supervisor/issue-journal.md",
     }),
     syncIssueJournal: async () => {},
   });

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -85,8 +85,6 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
     record.pr_number === null ||
     !configuredReviewProviderKinds(config).includes("codex") ||
     config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
-    record.copilot_review_timeout_action !== "request_review_comment" ||
-    !record.copilot_review_timed_out_at ||
     !github.getPullRequestIfExists ||
     !github.getChecks ||
     !github.getUnresolvedReviewThreads

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   GitHubIssue,
+  ReviewThread,
   SupervisorStateFile,
 } from "../core/types";
 import {
@@ -427,6 +428,114 @@ Parallelizable: No
 
   assert.match(whyLines.join("\n"), /^selected_issue=#2072$/m);
   assert.doesNotMatch(readinessSummary.readinessLines.join("\n"), /^blocked_issues=#2072 blocked_by=local_state:blocked$/m);
+});
+
+test("buildReadinessSummary selects stale review-commit residue recovery without timeout metadata", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 2199;
+  const prNumber = 2200;
+  const branch = "codex/issue-2199";
+  const currentHead = "7d2a6e42f0a28a176463bda1c2cff4001e6aeb5a";
+  const staleReviewHead = "707f0eb2b95722c1c60bc3773a17a272957d775c";
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Recover stale Codex review residue",
+    body: `## Summary
+Request current-head Codex review for stale review-commit residue.
+
+## Scope
+- keep recovery selectable before timeout metadata is recorded
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+
+## Acceptance criteria
+- stale review residue can re-enter the request lane
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        blocked_reason: "manual_review",
+        last_head_sha: currentHead,
+        review_wait_started_at: "2026-05-26T22:00:00Z",
+        review_wait_head_sha: currentHead,
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: null,
+      }),
+    },
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-05-26T22:00:00Z",
+    configuredBotLatestReviewedCommitSha: staleReviewHead,
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  });
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-stale-review-commit",
+      isResolved: false,
+      isOutdated: false,
+      path: "src/codex-connector-review-request-decision.ts",
+      line: 284,
+      comments: {
+        nodes: [
+          {
+            id: "comment-stale-review-commit",
+            body: "P1: Verify the repair on the current head.",
+            createdAt: "2026-05-26T21:55:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_r2199`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+  const github = {
+    listCandidateIssues: async () => [issue],
+    listAllIssues: async () => [issue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => reviewThreads,
+  };
+
+  const readinessSummary = await buildReadinessSummary(github, config, state);
+  const whyLines = await buildSelectionWhySummary(github, config, state);
+
+  assert.deepEqual(readinessSummary.blockedIssues, []);
+  assert.deepEqual(readinessSummary.runnableIssues, [
+    {
+      issueNumber,
+      title: "Recover stale Codex review residue",
+      readiness: "execution_ready",
+    },
+  ]);
+  assert.match(whyLines.join("\n"), /^selected_issue=#2199$/m);
 });
 
 test("buildReadinessSummary keeps manual-review recovery blocked when GitHub recovery data fails", async () => {

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -65,8 +65,6 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
     record.pr_number === null ||
     !configuredReviewProviderKinds(config).includes("codex") ||
     config.configuredBotCurrentHeadSignalTimeoutAction !== "request_review_comment" ||
-    record.copilot_review_timeout_action !== "request_review_comment" ||
-    !record.copilot_review_timed_out_at ||
     !github.getPullRequestIfExists ||
     !github.getChecks ||
     !github.getUnresolvedReviewThreads


### PR DESCRIPTION
## Summary
- Treat stale Codex Connector review-commit residue as eligible to request a current-head Codex review before staying stopped on manual_review.
- Add a PR #2198-shaped regression covering stale reviewed commit, later repair head, aggressive request opt-in, and missing current-head Codex signal.

## Verification
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-explain*.test.ts src/post-turn-pull-request-codex-connector.test.ts src/post-turn-pull-request-tracked-status.test.ts
- npm run build
