### PR TITLE
Extract conversation-resolution blocker diagnostics

### DIFF
--- a/src/conversation-resolution-blocker-diagnostics.test.ts
+++ b/src/conversation-resolution-blocker-diagnostics.test.ts
@@ -1,0 +1,172 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildConversationResolutionBlockerDiagnostic } from "./conversation-resolution-blocker-diagnostics";
+import {
+  createConfig,
+  createPullRequest,
+  createReviewThread,
+} from "./supervisor/supervisor-test-helpers";
+import type { GitHubPullRequest, PullRequestCheck, ReviewThread } from "./core/types";
+
+const checks: PullRequestCheck[] = [
+  { name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+];
+const summarizeChecks = () => ({ hasPending: false, hasFailing: false });
+
+function blockedPr(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return createPullRequest({
+    number: 116,
+    headRefOid: "head-116",
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-26T00:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=enabled"],
+    },
+    ...overrides,
+  });
+}
+
+function outdatedBotThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return createReviewThread({
+    id: "thread-1",
+    isOutdated: true,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Finding is stale on the current head.",
+          createdAt: "2026-05-26T00:00:00Z",
+          url: "https://example.test/pr/116#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+test("conversation-resolution diagnostic builds stable status, signature, evidence, and failure context", () => {
+  const diagnostic = buildConversationResolutionBlockerDiagnostic({
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+    pr: blockedPr(),
+    checks,
+    reviewThreads: [outdatedBotThread()],
+    summarizeChecks,
+  });
+
+  assert.equal(
+    diagnostic?.statusLine,
+    "conversation_resolution_blocker state=blocked required_conversation_resolution=enabled outdated_configured_bot_threads=1 thread_ids=thread-1",
+  );
+  assert.equal(diagnostic?.blockerSignature, "conversation-resolution:head-116:thread-1");
+  assert.deepEqual(diagnostic?.persistentCommentEvidence, [
+    "merge_state=BLOCKED",
+    "mergeable=MERGEABLE",
+    "required_conversation_resolution=enabled",
+    "required_conversation_resolution_source=branch_protection",
+    "conversation_threads=thread-1",
+    "check=verify-pre-pr:pass:SUCCESS",
+  ]);
+  assert.equal(
+    diagnostic?.failureContext.summary,
+    "GitHub reports PR #116 as blocked after green checks; unresolved outdated configured-bot conversations remain.",
+  );
+  assert.deepEqual(diagnostic?.failureContext.details, [
+    "thread=thread-1 reviewer=chatgpt-codex-connector file=src/file.ts line=12 is_outdated=yes processed_on_current_head=yes",
+  ]);
+});
+
+test("conversation-resolution diagnostic returns null when the PR is merge-ready", () => {
+  assert.equal(
+    buildConversationResolutionBlockerDiagnostic({
+      config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+      pr: blockedPr({ mergeStateStatus: "CLEAN" }),
+      checks,
+      reviewThreads: [outdatedBotThread()],
+      summarizeChecks,
+    }),
+    null,
+  );
+});
+
+test("conversation-resolution diagnostic returns null for manual review threads", () => {
+  assert.equal(
+    buildConversationResolutionBlockerDiagnostic({
+      config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+      pr: blockedPr(),
+      checks,
+      reviewThreads: [
+        outdatedBotThread({
+          comments: {
+            nodes: [
+              {
+                id: "comment-1",
+                body: "Please address this.",
+                createdAt: "2026-05-26T00:00:00Z",
+                url: "https://example.test/pr/116#discussion_r1",
+                author: {
+                  login: "alice",
+                  typeName: "User",
+                },
+              },
+            ],
+          },
+        }),
+      ],
+      summarizeChecks,
+    }),
+    null,
+  );
+});
+
+test("conversation-resolution diagnostic returns null for non-outdated configured-bot threads", () => {
+  assert.equal(
+    buildConversationResolutionBlockerDiagnostic({
+      config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+      pr: blockedPr(),
+      checks,
+      reviewThreads: [outdatedBotThread({ isOutdated: false })],
+      summarizeChecks,
+    }),
+    null,
+  );
+});
+
+test("conversation-resolution diagnostic returns null when Codex Connector policy is not ready", () => {
+  assert.equal(
+    buildConversationResolutionBlockerDiagnostic({
+      config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+      pr: blockedPr({ configuredBotCurrentHeadObservedAt: null }),
+      checks,
+      reviewThreads: [outdatedBotThread()],
+      summarizeChecks,
+    }),
+    null,
+  );
+});
+
+test("conversation-resolution diagnostic returns null when branch-protection evidence contradicts the blocker", () => {
+  assert.equal(
+    buildConversationResolutionBlockerDiagnostic({
+      config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+      pr: blockedPr({
+        requiredConversationResolution: {
+          state: "disabled",
+          source: "branch_protection",
+          details: ["required_conversation_resolution=disabled"],
+        },
+      }),
+      checks,
+      reviewThreads: [outdatedBotThread()],
+      summarizeChecks,
+    }),
+    null,
+  );
+});

--- a/src/conversation-resolution-blocker-diagnostics.ts
+++ b/src/conversation-resolution-blocker-diagnostics.ts
@@ -1,0 +1,164 @@
+import {
+  evaluateCodexConnectorConvergencePolicy,
+  hasCodexConnectorFindingReviewComment,
+  hasCodexConnectorPrSuccessCurrentHeadObservation,
+} from "./codex-connector-review-policy";
+import {
+  configuredBotReviewThreads,
+  latestReviewComment,
+  latestReviewCommentAuthorIsAllowedBot,
+  manualReviewThreads,
+} from "./review-thread-reporting";
+import {
+  conversationResolutionEvidenceContradictsBlocker,
+  conversationResolutionEvidenceDetails,
+  conversationResolutionEvidenceToken,
+} from "./conversation-resolution-policy";
+import type {
+  FailureContext,
+  GitHubPullRequest,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+} from "./core/types";
+
+export interface ConversationResolutionBlockerDiagnostic {
+  blockerSignature: string;
+  statusLine: string;
+  failureContext: FailureContext;
+  persistentCommentEvidence: string[];
+  threadIds: string[];
+  threads: ReviewThread[];
+}
+
+export function buildConversationResolutionFailureContext(args: {
+  pr: GitHubPullRequest;
+  threads: ReviewThread[];
+}): FailureContext {
+  const threadIds = args.threads.map((thread) => thread.id).sort();
+  return {
+    category: "blocked",
+    summary:
+      `GitHub reports PR #${args.pr.number} as blocked after green checks; unresolved outdated configured-bot conversations remain.`,
+    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
+    command: null,
+    details: args.threads
+      .map((thread) => {
+        const latestComment = latestReviewComment(thread);
+        return [
+          `thread=${thread.id}`,
+          `reviewer=${latestComment?.author?.login ?? "unknown"}`,
+          `file=${thread.path ?? "unknown"}`,
+          `line=${thread.line ?? "unknown"}`,
+          "is_outdated=yes",
+          "processed_on_current_head=yes",
+        ].join(" ");
+      })
+      .sort(),
+    url: latestReviewComment(args.threads[0])?.url ?? args.pr.url,
+    updated_at: new Date(0).toISOString(),
+  };
+}
+
+export function buildRequiredCheckMismatchEvidence(args: {
+  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable" | "requiredConversationResolution">;
+  checks: PullRequestCheck[];
+}): string[] {
+  const sortedChecks = [...args.checks]
+    .map((check) => `check=${check.name}:${check.bucket}:${check.state}`)
+    .sort();
+
+  return [
+    `merge_state=${args.pr.mergeStateStatus}`,
+    `mergeable=${args.pr.mergeable ?? "unknown"}`,
+    conversationResolutionEvidenceToken(args.pr),
+    ...sortedChecks,
+    ...conversationResolutionEvidenceDetails(args.pr).slice(1),
+  ];
+}
+
+function isClearableConversationResolutionResidueThread(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  thread: ReviewThread,
+): boolean {
+  if (!thread.isOutdated) {
+    return false;
+  }
+
+  if (latestReviewCommentAuthorIsAllowedBot(config, thread)) {
+    return true;
+  }
+
+  return hasCodexConnectorPrSuccessCurrentHeadObservation(pr) && hasCodexConnectorFindingReviewComment(thread);
+}
+
+export function buildConversationResolutionBlockerDiagnostic(args: {
+  config: SupervisorConfig;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
+}): ConversationResolutionBlockerDiagnostic | null {
+  const checkSummary = args.summarizeChecks(args.checks);
+  if (
+    args.pr.mergeStateStatus !== "BLOCKED" ||
+    args.pr.mergeable !== "MERGEABLE" ||
+    !(
+      args.pr.configuredBotCurrentHeadStatusState === "SUCCESS" ||
+      hasCodexConnectorPrSuccessCurrentHeadObservation(args.pr)
+    ) ||
+    checkSummary.hasPending ||
+    checkSummary.hasFailing
+  ) {
+    return null;
+  }
+
+  const unresolvedThreads = args.reviewThreads.filter((thread) => !thread.isResolved);
+  if (unresolvedThreads.length === 0 || manualReviewThreads(args.config, unresolvedThreads).length > 0) {
+    return null;
+  }
+
+  const configuredThreads = configuredBotReviewThreads(args.config, unresolvedThreads);
+  if (
+    configuredThreads.length !== unresolvedThreads.length ||
+    configuredThreads.some((thread) => !isClearableConversationResolutionResidueThread(args.config, args.pr, thread))
+  ) {
+    return null;
+  }
+
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, configuredThreads);
+  if (codexConnectorPolicy && codexConnectorPolicy.mergeEffect !== "ready") {
+    return null;
+  }
+  if (conversationResolutionEvidenceContradictsBlocker(args.pr)) {
+    return null;
+  }
+
+  const threadIds = configuredThreads.map((thread) => thread.id).sort();
+  const failureContext = buildConversationResolutionFailureContext({
+    pr: args.pr,
+    threads: configuredThreads,
+  });
+  const persistentCommentEvidence = [
+    `merge_state=${args.pr.mergeStateStatus}`,
+    `mergeable=${args.pr.mergeable}`,
+    ...conversationResolutionEvidenceDetails(args.pr),
+    `conversation_threads=${threadIds.join(",")}`,
+    ...buildRequiredCheckMismatchEvidence({ pr: args.pr, checks: args.checks }).filter((line) => line.startsWith("check=")),
+  ];
+
+  return {
+    blockerSignature: `conversation-resolution:${args.pr.headRefOid}:${threadIds.join(",")}`,
+    statusLine: [
+      "conversation_resolution_blocker state=blocked",
+      conversationResolutionEvidenceToken(args.pr),
+      `outdated_configured_bot_threads=${configuredThreads.length}`,
+      `thread_ids=${threadIds.join(",")}`,
+    ].join(" "),
+    failureContext,
+    persistentCommentEvidence,
+    threadIds,
+    threads: configuredThreads,
+  };
+}

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -3,14 +3,10 @@ import {
 } from "../review-handling";
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
-  evaluateCodexConnectorConvergencePolicy,
-} from "../codex-connector-review-policy";
-import {
   actionableBotReviewThreads,
   configuredBotReviewFollowUpState,
   effectiveReviewThreadDiagnostics,
   formatEffectiveReviewThreadDiagnosticsLine,
-  latestReviewCommentAuthorIsAllowedBot,
 } from "../review-thread-reporting";
 import { formatWorkspaceRestoreStatusLine } from "../core/workspace";
 import {
@@ -49,62 +45,10 @@ import { truncate } from "../core/utils";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
 import { classifyStaleReviewBotRecoverability } from "./stale-diagnostic-recoverability";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
-import {
-  conversationResolutionEvidenceContradictsBlocker,
-  conversationResolutionEvidenceToken,
-} from "../conversation-resolution-policy";
+import { buildConversationResolutionBlockerDiagnostic } from "../conversation-resolution-blocker-diagnostics";
 
 function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["reviewThreads"]) {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-}
-
-function buildConversationResolutionBlockerStatusLine(args: Pick<
-  BuildDetailedStatusModelArgs,
-  "config" | "checks" | "reviewThreads" | "manualReviewThreads" | "configuredBotReviewThreads" | "summarizeChecks"
-> & {
-  pr: NonNullable<BuildDetailedStatusModelArgs["pr"]>;
-}): string | null {
-  const checkSummary = args.summarizeChecks(args.checks);
-  if (
-    args.pr.mergeStateStatus !== "BLOCKED" ||
-    args.pr.mergeable !== "MERGEABLE" ||
-    !args.pr.configuredBotCurrentHeadObservedAt ||
-    args.pr.configuredBotCurrentHeadStatusState !== "SUCCESS" ||
-    checkSummary.hasPending ||
-    checkSummary.hasFailing
-  ) {
-    return null;
-  }
-
-  const unresolvedThreads = args.reviewThreads.filter((thread) => !thread.isResolved);
-  if (unresolvedThreads.length === 0 || args.manualReviewThreads(args.config, unresolvedThreads).length > 0) {
-    return null;
-  }
-
-  const configuredThreads = args.configuredBotReviewThreads(args.config, unresolvedThreads);
-  if (
-    configuredThreads.length !== unresolvedThreads.length ||
-    configuredThreads.some(
-      (thread) => !thread.isOutdated || !latestReviewCommentAuthorIsAllowedBot(args.config, thread),
-    )
-  ) {
-    return null;
-  }
-
-  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, configuredThreads);
-  if (codexConnectorPolicy && codexConnectorPolicy.mergeEffect !== "ready") {
-    return null;
-  }
-  if (conversationResolutionEvidenceContradictsBlocker(args.pr)) {
-    return null;
-  }
-
-  return [
-    "conversation_resolution_blocker state=blocked",
-    conversationResolutionEvidenceToken(args.pr),
-    `outdated_configured_bot_threads=${configuredThreads.length}`,
-    `thread_ids=${configuredThreads.map((thread) => thread.id).sort().join(",")}`,
-  ].join(" ");
 }
 
 export function sanitizeStatusValue(value: string | null | undefined): string | null {
@@ -562,15 +506,13 @@ export function buildActiveDetailedStatusLines(
       `review_threads bot_pending=${pendingBotReviewThreads(config, activeRecord, pr, reviewThreads).length} bot_unresolved=${unresolvedConfiguredBotThreads.length} bot_effective_unresolved=${effectiveReviewThreadDiagnostics(config, reviewThreads).effectiveUnresolvedConfiguredBotThreadCount} bot_outdated_unresolved=${outdatedUnresolvedConfiguredBotThreads.length} manual=${manualReviewThreads(config, reviewThreads).length}`,
     );
     lines.push(formatEffectiveReviewThreadDiagnosticsLine(effectiveReviewThreadDiagnostics(config, reviewThreads)));
-    const conversationResolutionBlockerLine = buildConversationResolutionBlockerStatusLine({
+    const conversationResolutionBlockerLine = buildConversationResolutionBlockerDiagnostic({
       config,
       pr,
       checks,
       reviewThreads,
-      manualReviewThreads,
-      configuredBotReviewThreads,
       summarizeChecks,
-    });
+    })?.statusLine;
     if (conversationResolutionBlockerLine) {
       lines.push(conversationResolutionBlockerLine);
     }

--- a/src/supervisor/supervisor-status-rendering-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor.test.ts
@@ -6,7 +6,15 @@ import test from "node:test";
 import { formatDetailedStatus, summarizeChecks } from "./supervisor-status-rendering";
 import { buildDetailedStatusSummaryLines } from "./supervisor-status-model";
 import { buildReadinessSummary } from "./supervisor-selection-readiness-summary";
-import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig, SupervisorStateFile } from "../core/types";
+import {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  SupervisorStateFile,
+} from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -256,6 +264,31 @@ function createPullRequest(overrides: Partial<GitHubPullRequest> = {}): GitHubPu
   };
 }
 
+function createReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "Please address this.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/42#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
 function withStubbedDateNow<T>(nowIso: string, run: () => T): T {
   const realDateNow = Date.now;
   Date.now = () => Date.parse(nowIso);
@@ -272,6 +305,47 @@ test("summarizeChecks treats cancelled runs as waiting, not failing", () => {
   assert.equal(summary.allPassing, false);
   assert.equal(summary.hasPending, true);
   assert.equal(summary.hasFailing, false);
+});
+
+test("formatDetailedStatus preserves conversation-resolution blocker status line tokens", () => {
+  const status = formatDetailedStatus({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    }),
+    activeRecord: createRecord({
+      pr_number: 42,
+      state: "pr_open",
+    }),
+    latestRecord: null,
+    trackedIssueCount: 1,
+    pr: createPullRequest({
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      configuredBotCurrentHeadObservedAt: "2026-05-26T00:00:00Z",
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+      requiredConversationResolution: {
+        state: "enabled",
+        source: "branch_protection",
+        details: ["required_conversation_resolution=enabled"],
+      },
+    }),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-2",
+        isOutdated: true,
+      }),
+      createReviewThread({
+        id: "thread-1",
+        isOutdated: true,
+      }),
+    ],
+  });
+
+  assert.match(
+    status,
+    /^conversation_resolution_blocker state=blocked required_conversation_resolution=enabled outdated_configured_bot_threads=2 thread_ids=thread-1,thread-2$/m,
+  );
 });
 
 test("formatDetailedStatus shows blocking local review status for current PR head", () => {

--- a/src/tracked-pr-status-comment.test.ts
+++ b/src/tracked-pr-status-comment.test.ts
@@ -260,6 +260,109 @@ test("handleStaleConfiguredBotReviewRemediation owns reply_only recovery decisio
   assert.equal(saveCalls, 2);
 });
 
+test("syncTrackedPrPersistentStatusComment preserves conversation-resolution blocker comment body", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPullRequest({
+    number: 116,
+    headRefOid: "head-116",
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-05-26T00:00:00Z",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    requiredConversationResolution: {
+      state: "enabled",
+      source: "branch_protection",
+      details: ["required_conversation_resolution=enabled"],
+    },
+  });
+  const record = createRecord({
+    issue_number: 102,
+    pr_number: pr.number,
+    state: "pr_open",
+    last_head_sha: pr.headRefOid,
+    provider_success_head_sha: pr.headRefOid,
+    provider_success_observed_at: "2026-05-26T00:00:00Z",
+    merge_readiness_last_evaluated_at: "2026-05-26T00:01:00Z",
+  });
+  const state = createSupervisorState({ issues: [record] });
+  const addBodies: string[] = [];
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return {
+        ...current,
+        ...patch,
+        updated_at: "2026-05-26T00:02:00Z",
+      };
+    },
+    async save(nextState: SupervisorStateFile): Promise<void> {
+      assert.equal(nextState.issues[String(record.issue_number)]?.issue_number, record.issue_number);
+    },
+  };
+
+  const updated = await syncTrackedPrPersistentStatusComment({
+    github: {
+      addIssueComment: async (issueNumber: number, body: string) => {
+        assert.equal(issueNumber, pr.number);
+        addBodies.push(body);
+      },
+    },
+    stateStore,
+    state,
+    record,
+    pr,
+    checks: [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        isOutdated: true,
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "Finding is stale on the current head.",
+              createdAt: "2026-05-26T00:00:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    syncJournal: async () => undefined,
+    config,
+    failureContext: null,
+    summarizeChecks: () => ({ hasPending: false, hasFailing: false }),
+    manualReviewThreadCount: 0,
+  });
+
+  assert.deepEqual(addBodies, [
+    [
+      "Tracked PR head `head-116` remains stopped near merge.",
+      "",
+      "- reason code: `conversation_resolution_blocked`",
+      "- summary: GitHub is not merge-ready because unresolved outdated configured-bot review conversations still require resolution.",
+      "- evidence: merge_state=BLOCKED",
+      "- evidence: mergeable=MERGEABLE",
+      "- evidence: required_conversation_resolution=enabled",
+      "- evidence: required_conversation_resolution_source=branch_protection",
+      "- evidence: conversation_threads=thread-1",
+      "- evidence: check=verify-pre-pr:pass:SUCCESS",
+      "- automatic retry: no",
+      "- next action: Resolve the listed configured-bot review conversations, or rerun with the verified configured-bot auto-resolve opt-in enabled.",
+      "",
+      "<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->",
+    ].join("\n"),
+  ]);
+  assert.equal(updated.last_host_local_pr_blocker_comment_head_sha, pr.headRefOid);
+  assert.equal(updated.last_host_local_pr_blocker_comment_signature, "conversation-resolution:head-116:thread-1");
+});
+
 test("publishTrackedPrStatusComment updates the newest owned editable marker before adding", async () => {
   const pr = createPullRequest({
     number: 116,

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -2,17 +2,6 @@ import { GitHubClient } from "./github";
 import { IssueJournalSync } from "./run-once-issue-preparation";
 import { StateStore } from "./core/state-store";
 import {
-  evaluateCodexConnectorConvergencePolicy,
-  hasCodexConnectorFindingReviewComment,
-  hasCodexConnectorPrSuccessCurrentHeadObservation,
-} from "./codex-connector-review-policy";
-import {
-  configuredBotReviewThreads,
-  latestReviewComment,
-  manualReviewThreads,
-  latestReviewCommentAuthorIsAllowedBot,
-} from "./review-thread-reporting";
-import {
   FailureContext,
   GitHubPullRequest,
   IssueRunRecord,
@@ -25,10 +14,9 @@ import { truncate } from "./core/utils";
 import { buildTrackedPrMismatch } from "./supervisor/tracked-pr-mismatch";
 import { handleStaleConfiguredBotReviewRemediation } from "./stale-configured-bot-auto-handle";
 import {
-  conversationResolutionEvidenceContradictsBlocker,
-  conversationResolutionEvidenceDetails,
-  conversationResolutionEvidenceToken,
-} from "./conversation-resolution-policy";
+  buildConversationResolutionBlockerDiagnostic,
+  buildRequiredCheckMismatchEvidence,
+} from "./conversation-resolution-blocker-diagnostics";
 import { displayRelativeArtifactPath } from "./supervisor/supervisor-status-summary-helpers";
 import { publishTrackedPrStatusComment } from "./tracked-pr-status-comment-publisher";
 import {
@@ -123,56 +111,10 @@ function currentHeadManualReviewStatusComment(args: {
   };
 }
 
-function buildRequiredCheckMismatchEvidence(args: {
-  pr: Pick<GitHubPullRequest, "mergeStateStatus" | "mergeable" | "requiredConversationResolution">;
-  checks: PullRequestCheck[];
-}): string[] {
-  const sortedChecks = [...args.checks]
-    .map((check) => `check=${check.name}:${check.bucket}:${check.state}`)
-    .sort();
-
-  return [
-    `merge_state=${args.pr.mergeStateStatus}`,
-    `mergeable=${args.pr.mergeable ?? "unknown"}`,
-    conversationResolutionEvidenceToken(args.pr),
-    ...sortedChecks,
-    ...conversationResolutionEvidenceDetails(args.pr).slice(1),
-  ];
-}
-
 interface ConversationResolutionBlocker {
   blockerSignature: string;
   body: string;
   failureContext: FailureContext;
-}
-
-function buildConversationResolutionFailureContext(args: {
-  pr: GitHubPullRequest;
-  threads: ReviewThread[];
-}): FailureContext {
-  const threadIds = args.threads.map((thread) => thread.id).sort();
-  return {
-    category: "blocked",
-    summary:
-      `GitHub reports PR #${args.pr.number} as blocked after green checks; unresolved outdated configured-bot conversations remain.`,
-    signature: threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|"),
-    command: null,
-    details: args.threads
-      .map((thread) => {
-        const latestComment = latestReviewComment(thread);
-        return [
-          `thread=${thread.id}`,
-          `reviewer=${latestComment?.author?.login ?? "unknown"}`,
-          `file=${thread.path ?? "unknown"}`,
-          `line=${thread.line ?? "unknown"}`,
-          "is_outdated=yes",
-          "processed_on_current_head=yes",
-        ].join(" ");
-      })
-      .sort(),
-    url: latestReviewComment(args.threads[0])?.url ?? args.pr.url,
-    updated_at: new Date(0).toISOString(),
-  };
 }
 
 function buildConversationResolutionBlocker(args: {
@@ -182,84 +124,25 @@ function buildConversationResolutionBlocker(args: {
   reviewThreads: ReviewThread[];
   summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
 }): ConversationResolutionBlocker | null {
-  const checkSummary = args.summarizeChecks(args.checks);
-  if (
-    args.pr.mergeStateStatus !== "BLOCKED" ||
-    args.pr.mergeable !== "MERGEABLE" ||
-    !(
-      args.pr.configuredBotCurrentHeadStatusState === "SUCCESS" ||
-      hasCodexConnectorPrSuccessCurrentHeadObservation(args.pr)
-    ) ||
-    checkSummary.hasPending ||
-    checkSummary.hasFailing
-  ) {
+  const diagnostic = buildConversationResolutionBlockerDiagnostic(args);
+  if (!diagnostic) {
     return null;
   }
-
-  const unresolvedThreads = args.reviewThreads.filter((thread) => !thread.isResolved);
-  if (unresolvedThreads.length === 0 || manualReviewThreads(args.config, unresolvedThreads).length > 0) {
-    return null;
-  }
-
-  const configuredThreads = configuredBotReviewThreads(args.config, unresolvedThreads);
-  if (
-    configuredThreads.length !== unresolvedThreads.length ||
-    configuredThreads.some((thread) => !isClearableConversationResolutionResidueThread(args.config, args.pr, thread))
-  ) {
-    return null;
-  }
-
-  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, configuredThreads);
-  if (codexConnectorPolicy && codexConnectorPolicy.mergeEffect !== "ready") {
-    return null;
-  }
-
-  const failureContext = buildConversationResolutionFailureContext({
-    pr: args.pr,
-    threads: configuredThreads,
-  });
-  if (conversationResolutionEvidenceContradictsBlocker(args.pr)) {
-    return null;
-  }
-  const threadIds = configuredThreads.map((thread) => thread.id).sort();
-  const evidence = [
-    `merge_state=${args.pr.mergeStateStatus}`,
-    `mergeable=${args.pr.mergeable}`,
-    ...conversationResolutionEvidenceDetails(args.pr),
-    `conversation_threads=${threadIds.join(",")}`,
-    ...buildRequiredCheckMismatchEvidence({ pr: args.pr, checks: args.checks }).filter((line) => line.startsWith("check=")),
-  ];
 
   return {
-    blockerSignature: `conversation-resolution:${args.pr.headRefOid}:${threadIds.join(",")}`,
-    failureContext,
+    blockerSignature: diagnostic.blockerSignature,
+    failureContext: diagnostic.failureContext,
     body: buildTrackedPrPersistentStatusComment({
       pr: args.pr,
       reasonCode: TRACKED_PR_STATUS_COMMENT_REASON_CODE_CONVERSATION_RESOLUTION_BLOCKED,
       summary:
         "GitHub is not merge-ready because unresolved outdated configured-bot review conversations still require resolution.",
-      evidence,
+      evidence: diagnostic.persistentCommentEvidence,
       nextAction:
         "Resolve the listed configured-bot review conversations, or rerun with the verified configured-bot auto-resolve opt-in enabled.",
       automaticRetry: "no",
     }),
   };
-}
-
-function isClearableConversationResolutionResidueThread(
-  config: SupervisorConfig,
-  pr: GitHubPullRequest,
-  thread: ReviewThread,
-): boolean {
-  if (!thread.isOutdated) {
-    return false;
-  }
-
-  if (latestReviewCommentAuthorIsAllowedBot(config, thread)) {
-    return true;
-  }
-
-  return hasCodexConnectorPrSuccessCurrentHeadObservation(pr) && hasCodexConnectorFindingReviewComment(thread);
 }
 
 function hasPersistentTrackedPrMergeStageSignal(args: {


### PR DESCRIPTION
## Summary
- Extract shared conversation-resolution blocker diagnostics into a reusable DTO builder.
- Wire detailed status and tracked PR persistent comments through the shared builder.
- Add focused builder coverage plus status/comment output characterization tests.

## Verification
- npx tsx --test src/conversation-resolution-blocker-diagnostics.test.ts src/supervisor/supervisor-status-rendering-supervisor.test.ts src/tracked-pr-status-comment.test.ts
- npm run build

Part of #2201
Closes #2202