### PR TITLE
Recognize Codex no-major comments in stale review remediation

### DIFF
--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../codex-connector-tracked-pr-test-helpers";
 import { buildStaleReviewBotRemediation, buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-remediation";
 
-test("buildStaleReviewBotRemediation classifies same-head Codex no-major with covered evidence as stale metadata", () => {
+test("buildStaleReviewBotRemediation classifies same-head Codex no-major comment despite stale blocking review strength", () => {
   const issueNumber = 110;
   const prNumber = 115;
   const headSha = "c184c41883b831ab6b85bf3467a66a5c01fd49fa";
@@ -34,7 +34,11 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major with co
   });
   const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
   const record = createRecord(scenario.recordPatch);
-  const pr = createPullRequest(scenario.pullRequestPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
 
   const remediation = buildStaleReviewBotRemediation({
     config,
@@ -42,6 +46,14 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major with co
     pr,
     checks: scenario.passingChecks,
     reviewThreads: [scenario.reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
   });
 
   assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
@@ -54,6 +66,7 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major with co
     remediation?.verificationEvidenceSummary ?? "",
     /Focused mutation lock verifier passed on the current head.;codex_pr_success_comment_after_current_head_request/,
   );
+  assert.equal(diagnostics?.currentHeadSuccess, "yes");
 });
 
 test("buildStaleReviewBotRemediation fails closed when covered evidence lacks current-head Codex no-major signal", () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -155,7 +155,7 @@ function currentHeadSuccess(pr: GitHubPullRequest | null): StaleReviewBotThreadD
   if (!pr) {
     return "unknown";
   }
-  return pr.configuredBotCurrentHeadObservedAt && pr.configuredBotCurrentHeadStatusState === "SUCCESS" ? "yes" : "no";
+  return hasCurrentHeadSuccessSignal(pr) ? "yes" : "no";
 }
 
 export function isProvenStaleReviewMetadataClassification(
@@ -305,6 +305,24 @@ function validTimestamp(value: string | null | undefined): string | null {
   return value;
 }
 
+function hasCurrentHeadSuccessSignal(
+  pr: Pick<
+    GitHubPullRequest,
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotCurrentHeadObservationSource"
+    | "configuredBotCurrentHeadStatusState"
+  >,
+): boolean {
+  if (pr.configuredBotCurrentHeadStatusState === "SUCCESS" && validTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
+    return true;
+  }
+
+  return Boolean(
+    pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
+      validTimestamp(pr.configuredBotCurrentHeadObservedAt),
+  );
+}
+
 function currentHeadCodexNoMajorSignalEvidence(args: {
   record: Pick<
     IssueRunRecord,
@@ -322,7 +340,7 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
 }): string | null {
   if (
     args.pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment" ||
-    args.pr.configuredBotCurrentHeadStatusState !== "SUCCESS"
+    !hasCurrentHeadSuccessSignal(args.pr)
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Treat a current-head Codex Connector no-major issue comment as a success signal for stale review-bot remediation, even when there is no status context.
- Update stale review-bot diagnostics so current-head success reports `yes` for this Codex success-comment path.
- Add a regression covering the HRCore PR #193 shape where `configuredBotCurrentHeadStatusState` is null but the Codex success comment arrived after the current-head review request.

## Verification
- `npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts src/supervisor/supervisor-status-review-bot.test.ts`
- `npm run build`
- `npm run verify:paths`
- `npm run verify:subprocess-safety`
- `node dist/index.js explain 186 --config /Users/jp.infra/Dev/HRCore/HRCore-codex-supervisor/supervisor.config.codex.json` now reports `classification=verified_current_head_repair_pending_thread_resolution`, `current_head_success=yes`, and `codex_pr_success_comment_after_current_head_request`.

## Known unrelated test state
- `npm test -- src/supervisor/stale-review-bot-remediation.test.ts` invokes the repo-wide `test` script and currently fails on unrelated existing tests, including `src/family-directory-layout.test.ts` expected file lists and `src/pull-request-state-thread-reprocessing.test.ts` (`blocked` vs `waiting_ci`).
