### PR TITLE
[codex] Recover verified Codex repair residue from green checks

### DIFF
--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -69,6 +69,86 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major comment
   assert.equal(diagnostics?.currentHeadSuccess, "yes");
 });
 
+test("buildStaleReviewBotRemediation accepts green current-head checks as verified repair evidence after no-major", () => {
+  const issueNumber = 187;
+  const prNumber = 194;
+  const headSha = "69b6043b941527645dd5df24535cd095cd627a0a";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_current_head_repaired_residue",
+    commentId: "PRRC_current_head_repaired_residue",
+    path: "src/app.ts",
+    line: 76,
+    severity: "P2",
+    commentBody: "P2: Earlier current-diff finding is repaired on the latest head.",
+    discussionUrl: "https://example.test/pr/194#discussion_r3316522484",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-28T09:31:32Z",
+      observedAt: "2026-05-28T09:35:46Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: "older-repair-head",
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "A previous repair head passed before the latest cleanup commit.",
+        recorded_at: "2026-05-28T09:02:10Z",
+      },
+    ],
+    repair_attempt_count: 2,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-05-28T09:22:05Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const checks = [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass" as const, workflow: "CI" }];
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [scenario.reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /current_head_checks_passed:verify-pre-pr;codex_pr_success_comment_after_current_head_request/,
+  );
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
+  assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
+  assert.equal(diagnostics?.repeatStopExhausted, "no");
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
+});
+
 test("buildStaleReviewBotRemediation fails closed when covered evidence lacks current-head Codex no-major signal", () => {
   const issueNumber = 110;
   const prNumber = 115;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -118,7 +118,10 @@ test("buildStaleReviewBotRemediation accepts green current-head checks as verifi
     configuredBotCurrentHeadStatusState: null,
     configuredBotTopLevelReviewStrength: "blocking",
   });
-  const checks = [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass" as const, workflow: "CI" }];
+  const checks = [
+    { name: CODEX_CONNECTOR_REVIEW_BOT_LOGIN, state: "SUCCESS", bucket: "pass" as const },
+    { name: "verify-pre-pr", state: "SUCCESS", bucket: "pass" as const, workflow: "CI" },
+  ];
 
   const remediation = buildStaleReviewBotRemediation({
     config,
@@ -147,6 +150,70 @@ test("buildStaleReviewBotRemediation accepts green current-head checks as verifi
   assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
   assert.equal(diagnostics?.repeatStopExhausted, "no");
   assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
+});
+
+test("buildStaleReviewBotRemediation rejects review-bot-only checks as verified repair evidence", () => {
+  const issueNumber = 187;
+  const prNumber = 194;
+  const headSha = "69b6043b941527645dd5df24535cd095cd627a0a";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_current_head_repaired_residue",
+    commentId: "PRRC_current_head_repaired_residue",
+    path: "src/app.ts",
+    line: 76,
+    severity: "P2",
+    commentBody: "P2: Earlier current-diff finding is repaired on the latest head.",
+    discussionUrl: "https://example.test/pr/194#discussion_r3316522484",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-28T09:31:32Z",
+      observedAt: "2026-05-28T09:35:46Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    latest_local_ci_result: null,
+    timeline_artifacts: [],
+    repair_attempt_count: 2,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-05-28T09:22:05Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const checks = [{ name: CODEX_CONNECTOR_REVIEW_BOT_LOGIN, state: "SUCCESS", bucket: "pass" as const }];
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [scenario.reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+  assert.equal(remediation?.verificationEvidenceSummary, null);
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 0);
+  assert.equal(diagnostics?.missingVerificationEvidenceThreads, 1);
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "repeat_stop_exhausted");
 });
 
 test("buildStaleReviewBotRemediation fails closed when covered evidence lacks current-head Codex no-major signal", () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -221,10 +221,10 @@ function classifyAutoRepairSuppression(args: {
   if (remediation.missingProbeReason) {
     return "missing_verification_probe";
   }
-  if (clusterConfiguredBotReviewThreads(args.actionableMustFixThreads).length > 1) {
-    return "too_many_clusters";
-  }
   if (!isVerifiedStaleResidueClassification(remediation.classification)) {
+    if (clusterConfiguredBotReviewThreads(args.actionableMustFixThreads).length > 1) {
+      return "too_many_clusters";
+    }
     return "not_verified_stale_residue";
   }
   if (!verifiedAutoResolveEnabled(config, remediation.classification)) {
@@ -265,6 +265,8 @@ function codexConnectorCurrentHeadReviewState(args: {
 function currentHeadVerificationEvidenceSummary(
   record: Pick<IssueRunRecord, "latest_local_ci_result" | "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
+  checks: Pick<PullRequestCheck, "bucket" | "name">[],
+  allowCheckEvidence: boolean,
 ): string | null {
   const latestLocalCi = record.latest_local_ci_result;
   if (latestLocalCi?.outcome === "passed" && latestLocalCi.head_sha === pr.headRefOid) {
@@ -280,6 +282,15 @@ function currentHeadVerificationEvidenceSummary(
   );
   if (timelineEvidence) {
     return timelineEvidence.summary || timelineEvidence.command || "current_head_verification_passed";
+  }
+
+  if (allowCheckEvidence && allChecksPassing(checks)) {
+    const checkNames = checks
+      .map((check) => check.name?.trim())
+      .filter((name): name is string => Boolean(name))
+      .slice(0, 3)
+      .join(",");
+    return checkNames ? `current_head_checks_passed:${checkNames}` : "current_head_checks_passed";
   }
 
   return null;
@@ -421,7 +432,13 @@ function classifyCodexMetadataOnly(args: {
         summary: STALE_REVIEW_BOT_SUMMARY,
       };
     }
-    const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(args.record, args.pr);
+    const checkEvidenceCanProveRepair = args.record.repair_attempt_count > 0;
+    const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(
+      args.record,
+      args.pr,
+      args.checks,
+      checkEvidenceCanProveRepair,
+    );
     if (verificationEvidenceSummary) {
       const noMajorSignalEvidence = currentHeadCodexNoMajorSignalEvidence({
         record: args.record,
@@ -435,7 +452,8 @@ function classifyCodexMetadataOnly(args: {
           missingProbeReason: "current_head_codex_no_major_signal_missing",
         };
       }
-      const verifiedCurrentHeadRepair = hasCurrentHeadCodexTurnVerification(args.record, args.pr);
+      const verifiedCurrentHeadRepair =
+        hasCurrentHeadCodexTurnVerification(args.record, args.pr) || args.record.repair_attempt_count > 0;
       return {
         classification: verifiedCurrentHeadRepair
           ? "verified_current_head_repair_pending_thread_resolution"
@@ -606,14 +624,15 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
   const currentHeadReviewRequestPending =
     remediation.classification === "metadata_only_missing_current_head_review" &&
     remediation.codexCurrentHeadReviewState === "missing";
+  const isVerifiedResidue = isVerifiedStaleResidueClassification(remediation.classification);
   const repeatStopExhausted =
-    currentHeadReviewRequestPending
+    currentHeadReviewRequestPending || isVerifiedResidue
       ? false
       : args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
         (config && args.pr
           ? configuredBotReviewFollowUpState(config, args.record, args.pr, configuredThreads) === "exhausted"
           : false);
-  const verifiedStaleResidueThreads = isVerifiedStaleResidueClassification(remediation.classification)
+  const verifiedStaleResidueThreads = isVerifiedResidue
     ? unresolvedConfiguredThreads.length
     : 0;
   const missingVerificationEvidenceThreads = remediation.missingProbeReason ? Math.max(actionableMustFixThreads.length, 1) : 0;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -13,7 +13,11 @@ import {
   nonActionableConfiguredBotReviewThreads,
   pendingBotReviewThreads,
 } from "../review-thread-reporting";
-import { configuredReviewProviderKinds } from "../core/review-providers";
+import {
+  configuredReviewBotLogins,
+  configuredReviewProviderKinds,
+  normalizeReviewProviderLogin,
+} from "../core/review-providers";
 
 export interface StaleReviewBotRemediationDto {
   issueNumber: number;
@@ -133,6 +137,45 @@ function codeCiState(
 
 function allChecksPassing(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
   return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+}
+
+function isConfiguredReviewBotCheck(
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
+  check: Pick<PullRequestCheck, "name" | "workflow">,
+): boolean {
+  const configuredBotLogins = configuredReviewBotLogins(config);
+  const configuredProviderKinds = configuredReviewProviderKinds(config);
+  const labels = [check.name, check.workflow].flatMap((label) => {
+    const normalized = label?.trim().toLowerCase();
+    return normalized ? [normalized] : [];
+  });
+
+  return labels.some((label) => {
+    const login = normalizeReviewProviderLogin(label);
+    if (login && configuredBotLogins.includes(login)) {
+      return true;
+    }
+    if (configuredBotLogins.some((configuredLogin) => label.includes(configuredLogin))) {
+      return true;
+    }
+    if (configuredProviderKinds.includes("codex") && label.includes("codex") && (label.includes("connector") || label.includes("review"))) {
+      return true;
+    }
+    if (configuredProviderKinds.includes("coderabbit") && label.includes("coderabbit")) {
+      return true;
+    }
+    return configuredProviderKinds.includes("copilot") && label.includes("copilot") && label.includes("review");
+  });
+}
+
+function currentHeadPassingNonReviewChecks(
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
+  checks: Pick<PullRequestCheck, "bucket" | "name" | "workflow">[],
+): Pick<PullRequestCheck, "bucket" | "name" | "workflow">[] {
+  if (!allChecksPassing(checks)) {
+    return [];
+  }
+  return checks.filter((check) => check.bucket === "pass" && !isConfiguredReviewBotCheck(config, check));
 }
 
 function hasFailingChecks(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
@@ -263,9 +306,10 @@ function codexConnectorCurrentHeadReviewState(args: {
 }
 
 function currentHeadVerificationEvidenceSummary(
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
   record: Pick<IssueRunRecord, "latest_local_ci_result" | "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
-  checks: Pick<PullRequestCheck, "bucket" | "name">[],
+  checks: Pick<PullRequestCheck, "bucket" | "name" | "workflow">[],
   allowCheckEvidence: boolean,
 ): string | null {
   const latestLocalCi = record.latest_local_ci_result;
@@ -284,8 +328,9 @@ function currentHeadVerificationEvidenceSummary(
     return timelineEvidence.summary || timelineEvidence.command || "current_head_verification_passed";
   }
 
-  if (allowCheckEvidence && allChecksPassing(checks)) {
-    const checkNames = checks
+  const nonReviewChecks = currentHeadPassingNonReviewChecks(config, checks);
+  if (allowCheckEvidence && nonReviewChecks.length > 0) {
+    const checkNames = nonReviewChecks
       .map((check) => check.name?.trim())
       .filter((name): name is string => Boolean(name))
       .slice(0, 3)
@@ -434,6 +479,7 @@ function classifyCodexMetadataOnly(args: {
     }
     const checkEvidenceCanProveRepair = args.record.repair_attempt_count > 0;
     const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(
+      args.config,
       args.record,
       args.pr,
       args.checks,

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -161,8 +161,10 @@ export function buildInactiveDetailedStatusLines(
     latestRecord &&
     pr &&
     latestRecord.last_head_sha === pr.headRefOid &&
-    (pr.configuredBotCurrentHeadObservedAt || configTargetsCodex) &&
-    pr.configuredBotCurrentHeadStatusState === "SUCCESS"
+    (pr.configuredBotCurrentHeadStatusState === "SUCCESS" ||
+      (configTargetsCodex &&
+        pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
+        Boolean(pr.configuredBotCurrentHeadObservedAt)))
   ) {
     staleReviewBotRemediation = buildStaleReviewBotRemediation({
       config,

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1170,7 +1170,11 @@ test("status --why names missing verification for manual-review Codex no-major r
     labels: [],
     state: "OPEN",
   };
-  const pr = createPullRequest(scenario.pullRequestPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
   const outdatedThreads = outdatedThreadIds.map((threadId, index) => ({
     ...scenario.reviewThread,
     id: threadId,
@@ -1314,7 +1318,11 @@ test("status --why converges processed current-head Codex no-major review thread
     labels: [],
     state: "OPEN",
   };
-  const pr = createPullRequest(scenario.pullRequestPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
 
   const supervisor = new Supervisor(fixture.config);
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
@@ -1330,7 +1338,7 @@ test("status --why converges processed current-head Codex no-major review thread
   assert.match(status, /^no_active_tracked_record issue=#171 classification=stale_review_bot_remediation state=blocked reason=verified_current_head_repair_pending_thread_resolution$/m);
   assert.match(
     status,
-    /^stale_review_bot_thread_diagnostics issue=#171 pr=#180 current_head_success=yes unresolved_current_threads=9 actionable_must_fix_threads=9 verified_stale_residue_threads=9 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=too_many_clusters$/m,
+    /^stale_review_bot_thread_diagnostics issue=#171 pr=#180 current_head_success=yes unresolved_current_threads=9 actionable_must_fix_threads=9 verified_stale_residue_threads=9 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=opt_in_disabled$/m,
   );
   assert.match(
     status,


### PR DESCRIPTION
## Summary
- Treat green current-head checks plus a current-head Codex no-major response as verification evidence for repaired Codex Connector review residue after a tracked PR has repair attempts.
- Keep inactive `status --why` / `explain` aligned when the current-head success signal is a Codex PR comment rather than a SUCCESS status context.
- Stop reporting repeat-stop or multi-cluster suppression once the residue is verified and the relevant auto-resolve opt-in is enabled.

## Root cause
HRCore PR #194 had a current-head Codex no-major response and green `verify-pre-pr`, but the supervisor still required either `latest_local_ci_result` or a current-head `codex_turn` timeline artifact. The local state only had older verification artifacts, so the PR stayed in stale-review-bot/manual-review recovery even though the configured bot residue was effectively verified.

## Verification
- `npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts src/post-turn-pull-request-codex-connector.test.ts`
- `npm run build`
- `node dist/index.js explain 187 --config /Users/jp.infra/Dev/HRCore/HRCore-codex-supervisor/supervisor.config.codex.json`
- `node dist/index.js status --why --config /Users/jp.infra/Dev/HRCore/HRCore-codex-supervisor/supervisor.config.codex.json`

## HRCore #194 probe
The updated build classifies issue #187 / PR #194 as `verified_current_head_repair_pending_thread_resolution`, reports `verification_evidence=current_head_checks_passed:verify-pre-pr;codex_pr_success_comment_after_current_head_request`, `repeat_stop_exhausted=no`, `auto_repair_suppressed_reason=none`, and `codex_connector_convergence ... merge_effect=ready`.
