### PR TITLE
[codex] Recover stale tracked PR review requests

### DIFF
--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -559,6 +559,226 @@ Parallelizable: No
   }
 });
 
+test("resolveRunnableIssueContext reuses omitted stale tracked PR recovery in active dependency checks", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const staleIssueNumber = 281;
+  const downstreamIssueNumber = 282;
+  const prNumber = 289;
+  const branch = "codex/issue-281";
+  const headSha = "head-281-current";
+  const staleIssue: GitHubIssue = {
+    number: staleIssueNumber,
+    title: "Recover stale tracked PR",
+    body: executionReadyBody("Request current-head Codex review for a stale tracked PR blocker."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${staleIssueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const downstreamIssue: GitHubIssue = {
+    number: downstreamIssueNumber,
+    title: "Active downstream candidate",
+    body: `${executionReadyBody("Do not run before the stale tracked PR recovery root.")}
+
+Depends on: #${staleIssueNumber}
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${downstreamIssueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const staleRecord = createRecord(staleIssueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-281-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const downstreamRecord = createRecord(downstreamIssueNumber, {
+    state: "queued",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: downstreamIssueNumber,
+    issues: {
+      [String(staleIssueNumber)]: staleRecord,
+      [String(downstreamIssueNumber)]: downstreamRecord,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-281-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const savedStates: SupervisorStateFile[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [downstreamIssue],
+      getIssue: async (issueNumber) =>
+        issueNumber === staleIssueNumber ? staleIssue : downstreamIssue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: downstreamRecord,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: `/tmp/workspaces/issue-${selectedRecord.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.deepEqual(result, { kind: "restart" });
+  assert.equal(state.activeIssueNumber, null);
+  assert.match(state.issues[String(downstreamIssueNumber)]?.last_error ?? "", /depends on #281/);
+  assert.equal(savedStates.length, 1);
+});
+
+test("resolveRunnableIssueContext skips direct stale tracked PR recovery when filters cannot be verified", async () => {
+  const baseConfig = {
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment" as const,
+  };
+  const issueNumber = 281;
+  const prNumber = 289;
+  const branch = "codex/issue-281";
+  const headSha = "head-281-current";
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-281-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-281-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const scenarios: Array<{ name: string; config: SupervisorConfig; issue: GitHubIssue }> = [
+    {
+      name: "missing configured issue label",
+      config: createConfig({ ...baseConfig, issueLabel: "codex" }),
+      issue: {
+        number: issueNumber,
+        title: "Unlabeled stale tracked PR",
+        body: executionReadyBody("Do not recover without the configured runnable label."),
+        createdAt: "2026-05-22T00:00:00Z",
+        updatedAt: "2026-05-22T00:00:00Z",
+        url: `https://example.test/issues/${issueNumber}`,
+        labels: [],
+        state: "OPEN",
+      },
+    },
+    {
+      name: "issueSearch configured",
+      config: createConfig({ ...baseConfig, issueSearch: "label:codex" }),
+      issue: {
+        number: issueNumber,
+        title: "Search-filtered stale tracked PR",
+        body: executionReadyBody("Do not recover direct issues when issueSearch cannot be verified."),
+        createdAt: "2026-05-22T00:00:00Z",
+        updatedAt: "2026-05-22T00:00:00Z",
+        url: `https://example.test/issues/${issueNumber}`,
+        labels: [{ name: "codex" }],
+        state: "OPEN",
+      },
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const state: SupervisorStateFile = {
+      activeIssueNumber: null,
+      issues: {
+        [String(issueNumber)]: record,
+      },
+    };
+    const savedStates: SupervisorStateFile[] = [];
+
+    const result = await resolveRunnableIssueContext({
+      github: {
+        listCandidateIssues: async () => [],
+        getIssue: async () => scenario.issue,
+        getPullRequestIfExists: async () => pr,
+        getChecks: async () => checks,
+        getUnresolvedReviewThreads: async () => [],
+      },
+      config: scenario.config,
+      stateStore: createTouchStateStore(savedStates),
+      state,
+      currentRecord: null,
+    });
+
+    assert.equal(result, "No matching open issue found.", scenario.name);
+    assert.equal(state.activeIssueNumber, null, scenario.name);
+  }
+});
+
 test("resolveRunnableIssueContext selects stale-review-bot tracked PR when Codex current-head review request is eligible", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -559,7 +559,7 @@ Parallelizable: No
   }
 });
 
-test("resolveRunnableIssueContext reuses omitted stale tracked PR recovery in active dependency checks", async () => {
+test("resolveRunnableIssueContext keeps omitted non-actionable tracked PR blocker in active dependency checks", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],
     configuredBotInitialGraceWaitSeconds: 0,
@@ -635,13 +635,13 @@ Parallelizable: No
     headRefName: branch,
     headRefOid: headSha,
     mergedAt: null,
-    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    currentHeadCiGreenAt: null,
     configuredBotLatestReviewedCommitSha: "head-281-stale",
     configuredBotCurrentHeadObservedAt: null,
     codexConnectorReviewRequestedAt: null,
     codexConnectorReviewRequestedHeadSha: null,
   };
-  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const checks: PullRequestCheck[] = [{ name: "build", state: "PENDING", bucket: "pending", workflow: "CI" }];
   const savedStates: SupervisorStateFile[] = [];
 
   const result = await resolveRunnableIssueContext({
@@ -672,6 +672,211 @@ Parallelizable: No
   assert.equal(state.activeIssueNumber, null);
   assert.match(state.issues[String(downstreamIssueNumber)]?.last_error ?? "", /depends on #281/);
   assert.equal(savedStates.length, 1);
+});
+
+test("resolveRunnableIssueContext normalizes label filters for direct stale tracked PR recovery", async () => {
+  const config = createConfig({
+    issueLabel: "codex",
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 281;
+  const prNumber = 289;
+  const branch = "codex/issue-281";
+  const headSha = "head-281-current";
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Case-varied label stale tracked PR",
+    body: executionReadyBody("Recover when GitHub label casing differs from config casing."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [{ name: "Codex" }],
+    state: "OPEN",
+  };
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-281-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: record,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-281-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [],
+      getIssue: async () => issue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: `/tmp/workspaces/issue-${selectedRecord.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.notEqual(typeof result, "string");
+  if (typeof result !== "string") {
+    assert.equal(result.kind, "ready");
+    if (result.kind === "ready") {
+      assert.equal(result.record.issue_number, issueNumber);
+      await result.issueLock.release();
+    }
+  }
+});
+
+test("resolveRunnableIssueContext orders recovered stale tracked PRs with normal candidates", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const issueNumber = 281;
+  const laterIssueNumber = 400;
+  const prNumber = 289;
+  const branch = "codex/issue-281";
+  const headSha = "head-281-current";
+  const staleIssue: GitHubIssue = {
+    number: issueNumber,
+    title: "Older stale tracked PR",
+    body: executionReadyBody("Recover before later normal candidates."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const laterIssue: GitHubIssue = {
+    number: laterIssueNumber,
+    title: "Later normal candidate",
+    body: executionReadyBody("A normal candidate that should keep candidate ordering."),
+    createdAt: "2026-05-22T00:05:00Z",
+    updatedAt: "2026-05-22T00:05:00Z",
+    url: `https://example.test/issues/${laterIssueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const staleRecord = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-281-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: staleRecord,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-281-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [laterIssue],
+      getIssue: async (selectedIssueNumber) =>
+        selectedIssueNumber === issueNumber ? staleIssue : laterIssue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: `/tmp/workspaces/issue-${selectedRecord.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.notEqual(typeof result, "string");
+  if (typeof result !== "string") {
+    assert.equal(result.kind, "ready");
+    if (result.kind === "ready") {
+      assert.equal(result.record.issue_number, issueNumber);
+      await result.issueLock.release();
+    }
+  }
 });
 
 test("resolveRunnableIssueContext skips direct stale tracked PR recovery when filters cannot be verified", async () => {

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -674,6 +674,98 @@ Parallelizable: No
   assert.equal(savedStates.length, 1);
 });
 
+test("resolveRunnableIssueContext fails closed when omitted tracked PR blocker fetch fails", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const staleIssueNumber = 281;
+  const downstreamIssueNumber = 282;
+  const prNumber = 289;
+  const branch = "codex/issue-281";
+  const downstreamIssue: GitHubIssue = {
+    number: downstreamIssueNumber,
+    title: "Active downstream candidate",
+    body: `${executionReadyBody("Do not run before the stale tracked PR recovery root.")}
+
+Depends on: #${staleIssueNumber}
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+    createdAt: "2026-05-22T00:05:00Z",
+    updatedAt: "2026-05-22T00:05:00Z",
+    url: `https://example.test/issues/${downstreamIssueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const staleRecord = createRecord(staleIssueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: "head-281-current",
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: "head-281-current",
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+  });
+  const downstreamRecord = createRecord(downstreamIssueNumber, {
+    state: "queued",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: downstreamIssueNumber,
+    issues: {
+      [String(staleIssueNumber)]: staleRecord,
+      [String(downstreamIssueNumber)]: downstreamRecord,
+    },
+  };
+  let lockAcquired = false;
+
+  await assert.rejects(
+    resolveRunnableIssueContext({
+      github: {
+        listCandidateIssues: async () => [downstreamIssue],
+        getIssue: async (issueNumber) => {
+          if (issueNumber === staleIssueNumber) {
+            throw new Error("GitHub rate limit");
+          }
+          return downstreamIssue;
+        },
+        getPullRequestIfExists: async () => {
+          throw new Error("unexpected PR fetch");
+        },
+        getChecks: async () => {
+          throw new Error("unexpected checks fetch");
+        },
+        getUnresolvedReviewThreads: async () => {
+          throw new Error("unexpected review thread fetch");
+        },
+      },
+      config,
+      stateStore: createTouchStateStore([]),
+      state,
+      currentRecord: downstreamRecord,
+      acquireIssueLock: async () => {
+        lockAcquired = true;
+        return {
+          acquired: true,
+          release: async () => {},
+        };
+      },
+      ensureRecordJournalContext: async (selectedRecord) => ({
+        workspace: selectedRecord.workspace,
+        journal_path: `/tmp/workspaces/issue-${selectedRecord.issue_number}/.codex-supervisor/issue-journal.md`,
+      }),
+      syncIssueJournal: async () => {},
+    }),
+    /Failed to fetch recoverable tracked PR issue #281/,
+  );
+  assert.equal(lockAcquired, true);
+});
+
 test("resolveRunnableIssueContext normalizes label filters for direct stale tracked PR recovery", async () => {
   const config = createConfig({
     issueLabel: "codex",

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -442,6 +442,123 @@ test("resolveRunnableIssueContext selects manual-review tracked PR when Codex cu
   }
 });
 
+test("resolveRunnableIssueContext discovers omitted stale tracked PR recovery and keeps downstream work blocked", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const staleIssueNumber = 281;
+  const downstreamIssueNumber = 282;
+  const prNumber = 289;
+  const branch = "codex/issue-281";
+  const headSha = "head-281-current";
+  const staleIssue: GitHubIssue = {
+    number: staleIssueNumber,
+    title: "Recover stale tracked PR",
+    body: executionReadyBody("Request current-head Codex review for a stale tracked PR blocker."),
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${staleIssueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const downstreamIssue: GitHubIssue = {
+    number: downstreamIssueNumber,
+    title: "Downstream candidate",
+    body: `${executionReadyBody("Wait for the stale tracked PR recovery root before continuing.")}
+
+Depends on: #${staleIssueNumber}
+Parallelizable: No
+
+## Execution order
+1 of 1`,
+    createdAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T00:00:00Z",
+    url: `https://example.test/issues/${downstreamIssueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const staleRecord = createRecord(staleIssueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-05-22T00:00:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: "2026-05-22T00:10:00.000Z",
+    copilot_review_timeout_action: "request_review_comment",
+    codex_connector_review_requested_observed_at: null,
+    codex_connector_review_requested_head_sha: null,
+    provider_success_head_sha: "head-281-stale",
+    provider_success_observed_at: "2026-05-21T23:50:00Z",
+  });
+  const downstreamRecord = createRecord(downstreamIssueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(staleIssueNumber)]: staleRecord,
+      [String(downstreamIssueNumber)]: downstreamRecord,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-05-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-05-22T00:00:00Z",
+    configuredBotLatestReviewedCommitSha: "head-281-stale",
+    configuredBotCurrentHeadObservedAt: null,
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [downstreamIssue],
+      getIssue: async (issueNumber) =>
+        issueNumber === staleIssueNumber ? staleIssue : downstreamIssue,
+      getPullRequestIfExists: async () => pr,
+      getChecks: async () => checks,
+      getUnresolvedReviewThreads: async () => [],
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: `/tmp/workspaces/issue-${selectedRecord.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.notEqual(typeof result, "string");
+  if (typeof result !== "string") {
+    assert.equal(result.kind, "ready");
+    if (result.kind === "ready") {
+      assert.equal(result.record.issue_number, staleIssueNumber);
+      assert.equal(state.activeIssueNumber, staleIssueNumber);
+      await result.issueLock.release();
+    }
+  }
+});
+
 test("resolveRunnableIssueContext selects stale-review-bot tracked PR when Codex current-head review request is eligible", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -119,7 +119,8 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
 }
 
 function issueHasLabel(issue: GitHubIssue, label: string): boolean {
-  return (issue.labels ?? []).some((candidate) => candidate.name === label);
+  const normalizedLabel = label.trim().toLowerCase();
+  return (issue.labels ?? []).some((candidate) => candidate.name.trim().toLowerCase() === normalizedLabel);
 }
 
 function issueMatchesDirectRecoverySelectionFilters(config: SupervisorConfig, issue: GitHubIssue): boolean {
@@ -130,7 +131,31 @@ function issueMatchesDirectRecoverySelectionFilters(config: SupervisorConfig, is
   return !config.issueSearch || config.issueSearch.trim() === "";
 }
 
-async function discoverCodexConnectorReviewRequestRecoveryIssues(
+function shouldFetchDirectTrackedPrRecoveryIssue(
+  config: SupervisorConfig,
+  record: IssueRunRecord,
+): boolean {
+  return (
+    record.state === "blocked" &&
+    (record.blocked_reason === "manual_review" || record.blocked_reason === "stale_review_bot") &&
+    record.pr_number !== null &&
+    configuredReviewProviderKinds(config).includes("codex") &&
+    config.configuredBotCurrentHeadSignalTimeoutAction === "request_review_comment"
+  );
+}
+
+function sortIssuesForSelection(issues: GitHubIssue[]): GitHubIssue[] {
+  return [...issues].sort((left, right) => {
+    const createdAtOrder = left.createdAt.localeCompare(right.createdAt);
+    if (createdAtOrder !== 0) {
+      return createdAtOrder;
+    }
+
+    return left.number - right.number;
+  });
+}
+
+async function discoverTrackedPrRecoveryInventoryIssues(
   github: IssueSelectionCandidateGitHub,
   config: SupervisorConfig,
   state: SupervisorStateFile,
@@ -147,7 +172,7 @@ async function discoverCodexConnectorReviewRequestRecoveryIssues(
     .sort((left, right) => left.issue_number - right.issue_number);
 
   for (const record of records) {
-    if (!(await shouldSelectCodexConnectorReviewRequestRecovery(github, config, record))) {
+    if (!shouldFetchDirectTrackedPrRecoveryIssue(config, record)) {
       continue;
     }
 
@@ -170,8 +195,8 @@ async function listSelectableIssuesWithRecoveredBlockers(
   state: SupervisorStateFile,
 ): Promise<GitHubIssue[]> {
   const issues = await github.listCandidateIssues();
-  const recoveryIssues = await discoverCodexConnectorReviewRequestRecoveryIssues(github, config, state, issues);
-  return [...issues, ...recoveryIssues];
+  const recoveryIssues = await discoverTrackedPrRecoveryInventoryIssues(github, config, state, issues);
+  return sortIssuesForSelection([...issues, ...recoveryIssues]);
 }
 
 interface SelectedIssueRecord {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -118,6 +118,18 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
   }
 }
 
+function issueHasLabel(issue: GitHubIssue, label: string): boolean {
+  return (issue.labels ?? []).some((candidate) => candidate.name === label);
+}
+
+function issueMatchesDirectRecoverySelectionFilters(config: SupervisorConfig, issue: GitHubIssue): boolean {
+  if (config.issueLabel && !issueHasLabel(issue, config.issueLabel)) {
+    return false;
+  }
+
+  return !config.issueSearch || config.issueSearch.trim() === "";
+}
+
 async function discoverCodexConnectorReviewRequestRecoveryIssues(
   github: IssueSelectionCandidateGitHub,
   config: SupervisorConfig,
@@ -141,7 +153,7 @@ async function discoverCodexConnectorReviewRequestRecoveryIssues(
 
     try {
       const issue = await github.getIssue(record.issue_number);
-      if (issue.state === "OPEN") {
+      if (issue.state === "OPEN" && issueMatchesDirectRecoverySelectionFilters(config, issue)) {
         recoveryIssues.push(issue);
       }
     } catch {
@@ -150,6 +162,16 @@ async function discoverCodexConnectorReviewRequestRecoveryIssues(
   }
 
   return recoveryIssues;
+}
+
+async function listSelectableIssuesWithRecoveredBlockers(
+  github: IssueSelectionCandidateGitHub,
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+): Promise<GitHubIssue[]> {
+  const issues = await github.listCandidateIssues();
+  const recoveryIssues = await discoverCodexConnectorReviewRequestRecoveryIssues(github, config, state, issues);
+  return [...issues, ...recoveryIssues];
 }
 
 interface SelectedIssueRecord {
@@ -455,9 +477,7 @@ async function selectIssueRecord(
   }
 
   if (!record || !isEligibleForSelection(record, config)) {
-    const issues = await github.listCandidateIssues();
-    const recoveryIssues = await discoverCodexConnectorReviewRequestRecoveryIssues(github, config, state, issues);
-    const selectableIssues = [...issues, ...recoveryIssues];
+    const selectableIssues = await listSelectableIssuesWithRecoveredBlockers(github, config, state);
     record = null;
     for (const issue of selectableIssues) {
       if (config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix))) {
@@ -803,8 +823,8 @@ export async function resolveRunnableIssueContext(
         return { kind: "restart" };
       }
     } else {
-      const candidateIssues = await github.listCandidateIssues();
-      const blockingIssue = findBlockingIssue(issue, candidateIssues, state);
+      const selectableIssues = await listSelectableIssuesWithRecoveredBlockers(github, config, state);
+      const blockingIssue = findBlockingIssue(issue, selectableIssues, state);
       if (blockingIssue) {
         record = stateStore.touch(record, {
           state: "queued",

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -181,8 +181,12 @@ async function discoverTrackedPrRecoveryInventoryIssues(
       if (issue.state === "OPEN" && issueMatchesDirectRecoverySelectionFilters(config, issue)) {
         recoveryIssues.push(issue);
       }
-    } catch {
-      continue;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to fetch recoverable tracked PR issue #${record.issue_number}; refusing to treat it as absent: ${message}`,
+        { cause: error },
+      );
     }
   }
 

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -64,7 +64,7 @@ export interface RestartRunOnce {
 type IssueSelectionResult = ReadyIssueContext | RestartRunOnce | string;
 
 type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues"> &
-  Partial<Pick<GitHubClient, "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
+  Partial<Pick<GitHubClient, "getIssue" | "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
 type IssueSelectionGitHub = IssueSelectionCandidateGitHub
   & Pick<GitHubClient, "getIssue">
   & Partial<Pick<GitHubClient, "addIssueComment" | "getIssueComments" | "updateIssueComment">>;
@@ -116,6 +116,40 @@ async function shouldSelectCodexConnectorReviewRequestRecovery(
   } catch {
     return false;
   }
+}
+
+async function discoverCodexConnectorReviewRequestRecoveryIssues(
+  github: IssueSelectionCandidateGitHub,
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+  existingIssues: GitHubIssue[],
+): Promise<GitHubIssue[]> {
+  if (!github.getIssue) {
+    return [];
+  }
+
+  const existingIssueNumbers = new Set(existingIssues.map((issue) => issue.number));
+  const recoveryIssues: GitHubIssue[] = [];
+  const records = Object.values(state.issues)
+    .filter((record) => !existingIssueNumbers.has(record.issue_number))
+    .sort((left, right) => left.issue_number - right.issue_number);
+
+  for (const record of records) {
+    if (!(await shouldSelectCodexConnectorReviewRequestRecovery(github, config, record))) {
+      continue;
+    }
+
+    try {
+      const issue = await github.getIssue(record.issue_number);
+      if (issue.state === "OPEN") {
+        recoveryIssues.push(issue);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return recoveryIssues;
 }
 
 interface SelectedIssueRecord {
@@ -422,13 +456,15 @@ async function selectIssueRecord(
 
   if (!record || !isEligibleForSelection(record, config)) {
     const issues = await github.listCandidateIssues();
+    const recoveryIssues = await discoverCodexConnectorReviewRequestRecoveryIssues(github, config, state, issues);
+    const selectableIssues = [...issues, ...recoveryIssues];
     record = null;
-    for (const issue of issues) {
+    for (const issue of selectableIssues) {
       if (config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix))) {
         continue;
       }
 
-      if (findBlockingIssue(issue, issues, state)) {
+      if (findBlockingIssue(issue, selectableIssues, state)) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- add a stale tracked PR recovery discovery pass to run-once issue selection
- include request-eligible Codex Connector current-head review recoveries even when the issue fell outside normal candidate discovery
- keep downstream candidates blocked by augmenting dependency checks with the recovered root issue

## Verification
- `npx tsx --test src/run-once-issue-selection.test.ts`
- `npx tsx --test src/recovery-blocked-issue-reconciliation.test.ts src/run-once-cycle-prelude.test.ts`
- `npx tsx --test src/run-once-issue-selection.test.ts src/supervisor/supervisor-diagnostics-explain-codex-connector.test.ts`
- `npm run build`

Closes #2219
