### PR TITLE
Suppress duplicate Codex review request retries

### DIFF
--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -439,6 +439,73 @@ test("codexConnectorReviewRequestAction selects retry after the same-head reques
   });
 });
 
+test("codexConnectorReviewRequestAction suppresses retry when the same-head request comment is still tracked", () => {
+  const scenario = createCodexConnectorRequestRetryScenario();
+
+  assert.deepEqual(
+    decide({
+      record: {
+        ...scenario.recordPatch,
+        codex_connector_review_request_comment_identity_status: "available",
+        codex_connector_review_request_comment_database_id: 1995001,
+        codex_connector_review_request_comment_node_id: "IC_head_1995",
+        codex_connector_review_request_comment_url:
+          "https://github.com/owner/repo/issues/1995#issuecomment-1995001",
+      },
+      pr: scenario.pullRequestPatch,
+      checks: scenario.checks,
+      reviewThreads: scenario.reviewThreads,
+      configuredThreads: scenario.configuredThreads,
+      now: scenario.now,
+    }),
+    { kind: "none" },
+  );
+});
+
+test("codexConnectorReviewRequestAction suppresses retry when the same-head request comment is hydrated from GitHub", () => {
+  const scenario = createCodexConnectorRequestRetryScenario();
+
+  assert.deepEqual(
+    decide({
+      record: scenario.recordPatch,
+      pr: {
+        ...scenario.pullRequestPatch,
+        codexConnectorReviewRequestCommentDatabaseId: 1995001,
+      },
+      checks: scenario.checks,
+      reviewThreads: scenario.reviewThreads,
+      configuredThreads: scenario.configuredThreads,
+      now: scenario.now,
+    }),
+    { kind: "none" },
+  );
+});
+
+test("codexConnectorReviewRequestAction ignores stale request comment identity when retrying the current head", () => {
+  const scenario = createCodexConnectorRequestRetryScenario();
+
+  assert.deepEqual(
+    decide({
+      record: {
+        ...scenario.recordPatch,
+        codex_connector_review_requested_observed_at: null,
+        codex_connector_review_requested_head_sha: "head-old",
+        codex_connector_review_request_comment_identity_status: "available",
+        codex_connector_review_request_comment_database_id: 1994001,
+      },
+      pr: {
+        ...scenario.pullRequestPatch,
+        codexConnectorReviewRequestCommentDatabaseId: null,
+      },
+      checks: scenario.checks,
+      reviewThreads: scenario.reviewThreads,
+      configuredThreads: scenario.configuredThreads,
+      now: scenario.now,
+    }),
+    { kind: "retry", retryCount: 0, retryAttempt: 1 },
+  );
+});
+
 test("codexConnectorReviewRequestAction suppresses request while same-head request wait is active", () => {
   assert.deepEqual(
     decideScenario(

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -23,6 +23,7 @@ import {
   hasCodexConnectorStrongRiskWording,
   isCodexConnectorReviewer,
 } from "./external-review/external-review-normalization";
+import { hasCodexConnectorReviewRequestCommentIdentity } from "./codex-connector-review-request-identity";
 
 export type CodexConnectorReviewRequestAction =
   | { kind: "none" }
@@ -345,6 +346,10 @@ export function codexConnectorReviewRequestAction(
 
   if (!requestMatchesCurrentHead) {
     return { kind: "initial" };
+  }
+
+  if (hasCodexConnectorReviewRequestCommentIdentity({ record: args.record, pr: args.pr })) {
+    return { kind: "none" };
   }
 
   const retryLimit = args.config.codexConnectorReviewRequestRetryLimit ?? 1;

--- a/src/codex-connector-review-request-identity.ts
+++ b/src/codex-connector-review-request-identity.ts
@@ -1,0 +1,41 @@
+import type { GitHubPullRequest, IssueRunRecord } from "./core/types";
+
+export function hasCodexConnectorReviewRequestCommentIdentity(args: {
+  record: Pick<
+    IssueRunRecord,
+    | "codex_connector_review_requested_observed_at"
+    | "codex_connector_review_requested_head_sha"
+    | "codex_connector_review_request_comment_identity_status"
+    | "codex_connector_review_request_comment_database_id"
+    | "codex_connector_review_request_comment_node_id"
+    | "codex_connector_review_request_comment_url"
+  >;
+  pr: Pick<
+    GitHubPullRequest,
+    | "codexConnectorReviewRequestedAt"
+    | "codexConnectorReviewRequestedHeadSha"
+    | "headRefOid"
+    | "codexConnectorReviewRequestCommentDatabaseId"
+    | "codexConnectorReviewRequestCommentNodeId"
+    | "codexConnectorReviewRequestCommentUrl"
+  >;
+}): boolean {
+  const recordRequestMatchesCurrentHead = Boolean(
+    args.record.codex_connector_review_requested_observed_at &&
+      args.record.codex_connector_review_requested_head_sha === args.pr.headRefOid,
+  );
+  const prRequestMatchesCurrentHead = Boolean(
+    args.pr.codexConnectorReviewRequestedAt && args.pr.codexConnectorReviewRequestedHeadSha === args.pr.headRefOid,
+  );
+  return Boolean(
+    (recordRequestMatchesCurrentHead &&
+      (args.record.codex_connector_review_request_comment_identity_status === "available" ||
+        args.record.codex_connector_review_request_comment_database_id ||
+        args.record.codex_connector_review_request_comment_node_id ||
+        args.record.codex_connector_review_request_comment_url)) ||
+      (prRequestMatchesCurrentHead &&
+        (args.pr.codexConnectorReviewRequestCommentDatabaseId ||
+          args.pr.codexConnectorReviewRequestCommentNodeId ||
+          args.pr.codexConnectorReviewRequestCommentUrl)),
+  );
+}

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -15,6 +15,7 @@ import {
   formatCodexConnectorReviewChurnDiagnostic,
 } from "../codex-connector-review-policy";
 import { configuredBotCurrentHeadSignalWaitWindow } from "./review-bot-wait-windows";
+import { hasCodexConnectorReviewRequestCommentIdentity } from "../codex-connector-review-request-identity";
 import {
   formatStaleReviewMetadataConvergenceDiagnostic,
   formatStaleReviewResidueOperatorDiagnostic,
@@ -86,10 +87,14 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
     : null;
   const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
   const retryConfigured = timeoutAction === "request_review_comment";
+  const existingRequestCommentIdentity = requestMatchesCurrentHead
+    ? hasCodexConnectorReviewRequestCommentIdentity({ record: args.record, pr: args.pr })
+    : false;
   const requestNoResponseElapsed = Boolean(
     retryConfigured &&
     requestMatchesCurrentHead &&
     !currentHeadObservedAt &&
+    !existingRequestCommentIdentity &&
     retryWaitUntil &&
     Date.now() >= Date.parse(retryWaitUntil),
   );

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -945,7 +945,7 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
         }),
         pr: waitingPr,
       }),
-      "codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-03-16T00:10:00.000Z request_comment_identity=database_id=340001,node_id=IC_kwDOhead340,url=https://github.com/owner/repo/issues/340#issuecomment-340001 next_action=retry_request_review_comment wait_until=2026-03-16T00:20:00.000Z",
+      "codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-03-16T00:20:00.000Z",
     );
 
     assert.equal(


### PR DESCRIPTION
## Summary
- suppress Codex Connector retry requests when the same-head `@codex review` request comment is already tracked or hydrated from GitHub
- keep retry behavior for same-head requests without durable comment identity, and ignore stale/partial identity from older heads
- align `status --why` diagnostics so tracked request comments remain in `request_posted` instead of reporting retry eligibility

## Verification
- `rtk npm run build`
- `rtk npx tsx --test src/codex-connector-review-request-decision.test.ts src/supervisor/supervisor-status-review-bot.test.ts src/post-turn-pull-request-codex-connector.test.ts src/pull-request-state-sync.test.ts src/github/github-pull-request-hydrator.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-explain-codex-connector.test.ts`
- `rtk git diff --check`