### PR TITLE
Prioritize manual review for clustered Codex churn

### DIFF
--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -523,31 +523,30 @@ test("clustered Codex churn preserves first-issue request-eligible recovery", ()
   );
 });
 
-test("unanchored clustered Codex churn does not override selected request-eligible recovery", () => {
+test("unrelated stopped clustered Codex churn still overrides selected request-eligible recovery", () => {
   const lines = [
     "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
+    "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=inspect_runtime",
     codexConnectorChurnProgressLine(),
-    "no_active_tracked_record issue=#170 classification=manual_review_required state=blocked reason=manual_review",
   ];
 
-  assert.equal(
-    requireRestartRecommendation(selectRestartRecommendation({
-      detailedStatusLines: lines,
-      contextLines: ["selected_issue=#169"],
-    })).source,
-    "no_active_tracked_record",
-  );
+  const recommendation = requireRestartRecommendation(selectRestartRecommendation({
+    detailedStatusLines: lines,
+    contextLines: ["selected_issue=#169"],
+  }));
+  assert.equal(recommendation.category, "manual_review_before_restart");
+  assert.equal(recommendation.source, "codex_connector_review_churn_progress");
   assert.deepEqual(
     selectStatusOperatorAction({
       detailedStatusLines: lines,
       contextLines: ["selected_issue=#169"],
     }),
     {
-      action: "provider_outage_suspected",
-      source: "codex_connector_review_fallback",
-      priority: 70,
+      action: "manual_review",
+      source: "codex_connector_review_churn_progress",
+      priority: 95,
       summary:
-        "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
+        "Clustered Codex Connector churn made no progress; inspect dominant file src/release-readiness.ts with current effective must-fix count 8 before restarting the loop.",
     },
   );
 });

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -357,6 +357,57 @@ test("selectStatusOperatorAction prioritizes manual review for stopped clustered
   );
 });
 
+test("clustered Codex churn progress does not force manual review without a stopped gate", () => {
+  const activeChurnProgress =
+    "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth";
+
+  assert.equal(
+    selectRestartRecommendation({
+      detailedStatusLines: [
+        "issue=#188",
+        "state=addressing_review",
+        "loop_runtime state=running host_mode=tmux run_mode=supervisor marker_path=<loop-marker> config_path=<supervisor-config-path> state_file=<state-file> pid=4242 started_at=2026-06-01T06:20:00Z ownership_confidence=live_lock detail=running",
+        activeChurnProgress,
+      ],
+    }),
+    null,
+  );
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "issue=#188",
+        "state=addressing_review",
+        "loop_runtime state=running host_mode=tmux run_mode=supervisor marker_path=<loop-marker> config_path=<supervisor-config-path> state_file=<state-file> pid=4242 started_at=2026-06-01T06:20:00Z ownership_confidence=live_lock detail=running",
+        activeChurnProgress,
+      ],
+    }),
+    {
+      action: "continue",
+      source: "status",
+      priority: 0,
+      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+    },
+  );
+});
+
+test("selectStatusOperatorAction accepts no-active manual review as a clustered churn stop gate", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "codex_connector_review_churn_progress classification=worse current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=9 previous_effective_must_fix=8 effective_must_fix_delta=1 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+        "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
+      ],
+    }),
+    {
+      action: "manual_review",
+      source: "codex_connector_review_churn_progress",
+      priority: 95,
+      summary:
+        "Clustered Codex Connector churn made no progress; inspect dominant file src/release-readiness.ts with current effective must-fix count 9 before restarting the loop.",
+    },
+  );
+});
+
 test("selectRestartRecommendation suppresses stale manual-review restart advice for selected request-eligible Codex recovery", () => {
   assert.equal(
     selectRestartRecommendation({

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -324,6 +324,39 @@ test("selectRestartRecommendation does not let safe restart outrank manual revie
   );
 });
 
+test("selectRestartRecommendation prioritizes manual review for stopped clustered Codex churn", () => {
+  const recommendation = requireRestartRecommendation(selectRestartRecommendation({
+    detailedStatusLines: [
+      "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
+      "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+      "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
+    ],
+  }));
+
+  assert.equal(recommendation.category, "manual_review_before_restart");
+  assert.equal(recommendation.source, "codex_connector_review_churn_progress");
+  assert.match(recommendation.summary, /current effective must-fix count 8/);
+  assert.match(recommendation.summary, /src\/release-readiness\.ts/);
+});
+
+test("selectStatusOperatorAction prioritizes manual review for stopped clustered Codex churn", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
+        "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+      ],
+    }),
+    {
+      action: "manual_review",
+      source: "codex_connector_review_churn_progress",
+      priority: 95,
+      summary:
+        "Clustered Codex Connector churn made no progress; inspect dominant file src/release-readiness.ts with current effective must-fix count 8 before restarting the loop.",
+    },
+  );
+});
+
 test("selectRestartRecommendation suppresses stale manual-review restart advice for selected request-eligible Codex recovery", () => {
   assert.equal(
     selectRestartRecommendation({

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -459,3 +459,32 @@ test("clustered Codex churn does not suppress selected request-eligible Codex re
     },
   );
 });
+
+test("unanchored clustered Codex churn does not override selected request-eligible recovery", () => {
+  const lines = [
+    "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
+    "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-1 previous_head_sha=head-0 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+    "no_active_tracked_record issue=#170 classification=manual_review_required state=blocked reason=manual_review",
+  ];
+
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: lines,
+      contextLines: ["selected_issue=#169"],
+    })).source,
+    "no_active_tracked_record",
+  );
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: lines,
+      contextLines: ["selected_issue=#169"],
+    }),
+    {
+      action: "provider_outage_suspected",
+      source: "codex_connector_review_fallback",
+      priority: 70,
+      summary:
+        "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
+    },
+  );
+});

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -560,6 +560,10 @@ test("clustered Codex churn needs stable cluster identity before manual review",
       clusterCategorySignature: "readiness_claim",
       previousClusterCategorySignature: "truth_source",
     }),
+    codexConnectorChurnProgressLine({
+      clusterCategorySignature: "readiness_claim+truth_source",
+      previousClusterCategorySignature: "truth_source",
+    }),
   ]) {
     const lines = [
       "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -41,6 +41,39 @@ function requireRestartRecommendation(recommendation: RestartRecommendation | nu
   return recommendation;
 }
 
+function codexConnectorChurnProgressLine(args: {
+  classification?: "improving" | "unchanged" | "worse";
+  currentEffectiveMustFix?: number;
+  previousEffectiveMustFix?: number;
+  dominantFile?: string;
+  previousDominantFile?: string;
+  clusterCategorySignature?: string;
+  previousClusterCategorySignature?: string;
+} = {}): string {
+  const classification = args.classification ?? "unchanged";
+  const currentEffectiveMustFix = args.currentEffectiveMustFix ?? 8;
+  const previousEffectiveMustFix = args.previousEffectiveMustFix ?? 8;
+  const dominantFile = args.dominantFile ?? "src/release-readiness.ts";
+  const previousDominantFile = args.previousDominantFile ?? dominantFile;
+  const clusterCategorySignature = args.clusterCategorySignature ?? "truth_source";
+  const previousClusterCategorySignature = args.previousClusterCategorySignature ?? clusterCategorySignature;
+  return [
+    "codex_connector_review_churn_progress",
+    `classification=${classification}`,
+    "current_head_sha=head-current-188",
+    "previous_head_sha=head-previous-188",
+    `current_effective_must_fix=${currentEffectiveMustFix}`,
+    `previous_effective_must_fix=${previousEffectiveMustFix}`,
+    `effective_must_fix_delta=${currentEffectiveMustFix - previousEffectiveMustFix}`,
+    `dominant_file=${dominantFile}`,
+    `previous_dominant_file=${previousDominantFile}`,
+    "dominant_file_percent=100",
+    `cluster_category_signature=${clusterCategorySignature}`,
+    `previous_cluster_category_signature=${previousClusterCategorySignature}`,
+    "representative_threads=thread-authority,thread-truth",
+  ].join(" ");
+}
+
 test("selectRestartRecommendation classifies every restart recommendation category from shared status lines", () => {
   assert.equal(
     requireRestartRecommendation(selectRestartRecommendation({
@@ -326,12 +359,12 @@ test("selectRestartRecommendation does not let safe restart outrank manual revie
 
 test("selectRestartRecommendation prioritizes manual review for stopped clustered Codex churn", () => {
   const recommendation = requireRestartRecommendation(selectRestartRecommendation({
-    detailedStatusLines: [
-      "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
-      "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
-      "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
-    ],
-  }));
+      detailedStatusLines: [
+        "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
+        codexConnectorChurnProgressLine(),
+        "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
+      ],
+    }));
 
   assert.equal(recommendation.category, "manual_review_before_restart");
   assert.equal(recommendation.source, "codex_connector_review_churn_progress");
@@ -344,7 +377,7 @@ test("selectStatusOperatorAction prioritizes manual review for stopped clustered
     selectStatusOperatorAction({
       detailedStatusLines: [
         "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
-        "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+        codexConnectorChurnProgressLine(),
       ],
     }),
     {
@@ -394,7 +427,10 @@ test("selectStatusOperatorAction accepts no-active manual review as a clustered 
   assert.deepEqual(
     selectStatusOperatorAction({
       detailedStatusLines: [
-        "codex_connector_review_churn_progress classification=worse current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=9 previous_effective_must_fix=8 effective_must_fix_delta=1 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+        codexConnectorChurnProgressLine({
+          classification: "worse",
+          currentEffectiveMustFix: 9,
+        }),
         "no_active_tracked_record issue=#188 classification=manual_review_required state=blocked reason=manual_review",
       ],
     }),
@@ -434,7 +470,7 @@ test("selectRestartRecommendation suppresses stale manual-review restart advice 
 test("clustered Codex churn does not suppress selected request-eligible Codex recovery", () => {
   const lines = [
     "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
-    "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-1 previous_head_sha=head-0 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+    codexConnectorChurnProgressLine(),
     "no_active_tracked_record issue=#169 classification=manual_review_required state=blocked reason=manual_review",
   ];
 
@@ -460,10 +496,37 @@ test("clustered Codex churn does not suppress selected request-eligible Codex re
   );
 });
 
+test("clustered Codex churn preserves first-issue request-eligible recovery", () => {
+  const lines = [
+    "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
+    "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#169 first_state=addressing_review first_pr=#177 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=inspect_runtime",
+    codexConnectorChurnProgressLine(),
+  ];
+
+  assert.equal(
+    requireRestartRecommendation(selectRestartRecommendation({
+      detailedStatusLines: lines,
+    })).source,
+    "loop_runtime_blocker",
+  );
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: lines,
+    }),
+    {
+      action: "restart_loop",
+      source: "loop_runtime_blocker",
+      priority: 90,
+      summary:
+        "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance.",
+    },
+  );
+});
+
 test("unanchored clustered Codex churn does not override selected request-eligible recovery", () => {
   const lines = [
     "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
-    "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-1 previous_head_sha=head-0 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+    codexConnectorChurnProgressLine(),
     "no_active_tracked_record issue=#170 classification=manual_review_required state=blocked reason=manual_review",
   ];
 
@@ -487,4 +550,40 @@ test("unanchored clustered Codex churn does not override selected request-eligib
         "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
     },
   );
+});
+
+test("clustered Codex churn needs stable cluster identity before manual review", () => {
+  for (const churnLine of [
+    codexConnectorChurnProgressLine({
+      previousDominantFile: "src/old-release-readiness.ts",
+    }),
+    codexConnectorChurnProgressLine({
+      clusterCategorySignature: "readiness_claim",
+      previousClusterCategorySignature: "truth_source",
+    }),
+  ]) {
+    const lines = [
+      "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
+      churnLine,
+    ];
+
+    assert.equal(
+      requireRestartRecommendation(selectRestartRecommendation({
+        detailedStatusLines: lines,
+      })).source,
+      "loop_runtime_blocker",
+    );
+    assert.deepEqual(
+      selectStatusOperatorAction({
+        detailedStatusLines: lines,
+      }),
+      {
+        action: "restart_loop",
+        source: "loop_runtime_blocker",
+        priority: 90,
+        summary:
+          "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance.",
+      },
+    );
+  }
 });

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -430,3 +430,32 @@ test("selectRestartRecommendation suppresses stale manual-review restart advice 
     "manual_review_before_restart",
   );
 });
+
+test("clustered Codex churn does not suppress selected request-eligible Codex recovery", () => {
+  const lines = [
+    "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
+    "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-1 previous_head_sha=head-0 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+    "no_active_tracked_record issue=#169 classification=manual_review_required state=blocked reason=manual_review",
+  ];
+
+  assert.equal(
+    selectRestartRecommendation({
+      detailedStatusLines: lines,
+      contextLines: ["selected_issue=#169"],
+    }),
+    null,
+  );
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: lines,
+      contextLines: ["selected_issue=#169"],
+    }),
+    {
+      action: "provider_outage_suspected",
+      source: "codex_connector_review_fallback",
+      priority: 70,
+      summary:
+        "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
+    },
+  );
+});

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -184,6 +184,13 @@ function clusteredCodexChurnManualReviewSummary(line: string): string | null {
   return `Clustered Codex Connector churn made no progress; inspect dominant file ${dominantFile} with current effective must-fix count ${currentEffectiveMustFix} before restarting the loop.`;
 }
 
+function hasStoppedClusteredCodexChurnManualReviewGate(lines: string[]): boolean {
+  return lines.some((line) =>
+    /^loop_runtime_blocker\b/u.test(line) ||
+    /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line)
+  );
+}
+
 export function parseOperatorActionLine(line: string): OperatorAction | null {
   if (!/^(operator_action|doctor_operator_action)\b/u.test(line)) {
     return null;
@@ -223,10 +230,11 @@ export function selectRestartRecommendation(args: {
   const recommendations: RestartRecommendation[] = [];
   const contextLines = [...args.detailedStatusLines, ...(args.contextLines ?? [])];
   const requestEligibleRecoverySelectedIssues = selectedRequestEligibleRecoveryIssues(contextLines);
+  const allowClusteredChurnManualReview = hasStoppedClusteredCodexChurnManualReviewGate(contextLines);
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
-    if (clusteredChurnManualReviewSummary !== null) {
+    if (clusteredChurnManualReviewSummary !== null && allowClusteredChurnManualReview) {
       recommendations.push({
         category: "manual_review_before_restart",
         source: "codex_connector_review_churn_progress",
@@ -359,10 +367,11 @@ export function selectStatusOperatorAction(args: {
   const actions: OperatorAction[] = [];
   const contextLines = [...args.detailedStatusLines, ...(args.contextLines ?? [])];
   const requestEligibleRecoverySelectedIssues = selectedRequestEligibleRecoveryIssues(contextLines);
+  const allowClusteredChurnManualReview = hasStoppedClusteredCodexChurnManualReviewGate(contextLines);
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
-    if (clusteredChurnManualReviewSummary !== null) {
+    if (clusteredChurnManualReviewSummary !== null && allowClusteredChurnManualReview) {
       actions.push({
         action: "manual_review",
         source: "codex_connector_review_churn_progress",

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -214,15 +214,23 @@ function hasStoppedClusteredCodexChurnManualReviewGate(
   lines: string[],
   requestEligibleRecoveryIssues: ReadonlySet<number>,
 ): boolean {
-  if (requestEligibleRecoveryIssues.size > 0) {
-    return false;
-  }
-
   return lines.some((line) => {
-    return (
-      /^loop_runtime_blocker\b/u.test(line) ||
-      /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line)
-    );
+    const isLoopRuntimeBlocker = /^loop_runtime_blocker\b/u.test(line);
+    const isNoActiveManualReview =
+      /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line);
+    if (!isLoopRuntimeBlocker && !isNoActiveManualReview) {
+      return false;
+    }
+
+    const gateIssueNumber = isLoopRuntimeBlocker
+      ? readIssueNumberToken(line, "first_issue")
+      : readIssueNumberToken(line, "issue");
+
+    if (gateIssueNumber === null) {
+      return requestEligibleRecoveryIssues.size === 0;
+    }
+
+    return !requestEligibleRecoveryIssues.has(gateIssueNumber);
   });
 }
 

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -165,6 +165,25 @@ function readIssueNumberToken(line: string, key: string): number | null {
   return match === null ? null : Number.parseInt(match[1], 10);
 }
 
+function clusteredCodexChurnManualReviewSummary(line: string): string | null {
+  if (!/^codex_connector_review_churn_progress\b/u.test(line)) {
+    return null;
+  }
+
+  const classification = readTokenValue(line, "classification");
+  if (classification !== "unchanged" && classification !== "worse") {
+    return null;
+  }
+
+  const currentEffectiveMustFix = readTokenValue(line, "current_effective_must_fix");
+  const dominantFile = readTokenValue(line, "dominant_file");
+  if (currentEffectiveMustFix === null || dominantFile === null) {
+    return null;
+  }
+
+  return `Clustered Codex Connector churn made no progress; inspect dominant file ${dominantFile} with current effective must-fix count ${currentEffectiveMustFix} before restarting the loop.`;
+}
+
 export function parseOperatorActionLine(line: string): OperatorAction | null {
   if (!/^(operator_action|doctor_operator_action)\b/u.test(line)) {
     return null;
@@ -206,6 +225,17 @@ export function selectRestartRecommendation(args: {
   const requestEligibleRecoverySelectedIssues = selectedRequestEligibleRecoveryIssues(contextLines);
 
   for (const line of args.detailedStatusLines) {
+    const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
+    if (clusteredChurnManualReviewSummary !== null) {
+      recommendations.push({
+        category: "manual_review_before_restart",
+        source: "codex_connector_review_churn_progress",
+        priority: 95,
+        summary: clusteredChurnManualReviewSummary,
+      });
+      continue;
+    }
+
     if (/^loop_runtime_blocker\b/.test(line)) {
       recommendations.push({
         category: "restart_required_for_convergence",
@@ -331,6 +361,17 @@ export function selectStatusOperatorAction(args: {
   const requestEligibleRecoverySelectedIssues = selectedRequestEligibleRecoveryIssues(contextLines);
 
   for (const line of args.detailedStatusLines) {
+    const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
+    if (clusteredChurnManualReviewSummary !== null) {
+      actions.push({
+        action: "manual_review",
+        source: "codex_connector_review_churn_progress",
+        priority: 95,
+        summary: clusteredChurnManualReviewSummary,
+      });
+      continue;
+    }
+
     if (/^loop_runtime_blocker\b/.test(line)) {
       actions.push({
         action: "restart_loop",

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -165,6 +165,16 @@ function readIssueNumberToken(line: string, key: string): number | null {
   return match === null ? null : Number.parseInt(match[1], 10);
 }
 
+function categorySignatureTokens(signature: string): Set<string> {
+  return new Set(signature.split("+").filter((token) => token.length > 0));
+}
+
+function categorySignatureIncludesAll(current: string, previous: string): boolean {
+  const currentTokens = categorySignatureTokens(current);
+  const previousTokens = categorySignatureTokens(previous);
+  return previousTokens.size > 0 && [...previousTokens].every((token) => currentTokens.has(token));
+}
+
 function clusteredCodexChurnManualReviewSummary(line: string): string | null {
   if (!/^codex_connector_review_churn_progress\b/u.test(line)) {
     return null;
@@ -177,7 +187,23 @@ function clusteredCodexChurnManualReviewSummary(line: string): string | null {
 
   const currentEffectiveMustFix = readTokenValue(line, "current_effective_must_fix");
   const dominantFile = readTokenValue(line, "dominant_file");
-  if (currentEffectiveMustFix === null || dominantFile === null) {
+  const previousDominantFile = readTokenValue(line, "previous_dominant_file");
+  const clusterCategorySignature = readTokenValue(line, "cluster_category_signature");
+  const previousClusterCategorySignature = readTokenValue(line, "previous_cluster_category_signature");
+  if (
+    currentEffectiveMustFix === null ||
+    dominantFile === null ||
+    previousDominantFile === null ||
+    clusterCategorySignature === null ||
+    previousClusterCategorySignature === null
+  ) {
+    return null;
+  }
+
+  if (
+    dominantFile !== previousDominantFile ||
+    !categorySignatureIncludesAll(clusterCategorySignature, previousClusterCategorySignature)
+  ) {
     return null;
   }
 
@@ -548,6 +574,12 @@ function selectedRequestEligibleRecoveryIssues(lines: string[]): ReadonlySet<num
       /^tracked_pr_mismatch\b/u.test(line)
     ) {
       const issueNumber = readIssueNumberToken(line, "issue");
+      if (issueNumber !== null) {
+        diagnosticIssueNumbers.add(issueNumber);
+      }
+    }
+    if (/^loop_runtime_blocker\b/u.test(line)) {
+      const issueNumber = readIssueNumberToken(line, "first_issue");
       if (issueNumber !== null) {
         diagnosticIssueNumbers.add(issueNumber);
       }

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -165,16 +165,6 @@ function readIssueNumberToken(line: string, key: string): number | null {
   return match === null ? null : Number.parseInt(match[1], 10);
 }
 
-function categorySignatureTokens(signature: string): Set<string> {
-  return new Set(signature.split("+").filter((token) => token.length > 0));
-}
-
-function categorySignatureIncludesAll(current: string, previous: string): boolean {
-  const currentTokens = categorySignatureTokens(current);
-  const previousTokens = categorySignatureTokens(previous);
-  return previousTokens.size > 0 && [...previousTokens].every((token) => currentTokens.has(token));
-}
-
 function clusteredCodexChurnManualReviewSummary(line: string): string | null {
   if (!/^codex_connector_review_churn_progress\b/u.test(line)) {
     return null;
@@ -202,7 +192,7 @@ function clusteredCodexChurnManualReviewSummary(line: string): string | null {
 
   if (
     dominantFile !== previousDominantFile ||
-    !categorySignatureIncludesAll(clusterCategorySignature, previousClusterCategorySignature)
+    clusterCategorySignature !== previousClusterCategorySignature
   ) {
     return null;
   }

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -184,31 +184,19 @@ function clusteredCodexChurnManualReviewSummary(line: string): string | null {
   return `Clustered Codex Connector churn made no progress; inspect dominant file ${dominantFile} with current effective must-fix count ${currentEffectiveMustFix} before restarting the loop.`;
 }
 
-function gateIssueNumber(line: string): number | null {
-  return readIssueNumberToken(line, "issue") ?? readIssueNumberToken(line, "first_issue");
-}
-
-function isRequestEligibleRecoveryGate(
-  line: string,
-  requestEligibleRecoveryIssues: ReadonlySet<number>,
-): boolean {
-  if (requestEligibleRecoveryIssues.size === 0) {
-    return false;
-  }
-
-  const issueNumber = gateIssueNumber(line);
-  return issueNumber === null || requestEligibleRecoveryIssues.has(issueNumber);
-}
-
 function hasStoppedClusteredCodexChurnManualReviewGate(
   lines: string[],
   requestEligibleRecoveryIssues: ReadonlySet<number>,
 ): boolean {
+  if (requestEligibleRecoveryIssues.size > 0) {
+    return false;
+  }
+
   return lines.some((line) => {
-    const isStoppedGate =
+    return (
       /^loop_runtime_blocker\b/u.test(line) ||
-      /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line);
-    return isStoppedGate && !isRequestEligibleRecoveryGate(line, requestEligibleRecoveryIssues);
+      /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line)
+    );
   });
 }
 

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -184,11 +184,32 @@ function clusteredCodexChurnManualReviewSummary(line: string): string | null {
   return `Clustered Codex Connector churn made no progress; inspect dominant file ${dominantFile} with current effective must-fix count ${currentEffectiveMustFix} before restarting the loop.`;
 }
 
-function hasStoppedClusteredCodexChurnManualReviewGate(lines: string[]): boolean {
-  return lines.some((line) =>
-    /^loop_runtime_blocker\b/u.test(line) ||
-    /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line)
-  );
+function gateIssueNumber(line: string): number | null {
+  return readIssueNumberToken(line, "issue") ?? readIssueNumberToken(line, "first_issue");
+}
+
+function isRequestEligibleRecoveryGate(
+  line: string,
+  requestEligibleRecoveryIssues: ReadonlySet<number>,
+): boolean {
+  if (requestEligibleRecoveryIssues.size === 0) {
+    return false;
+  }
+
+  const issueNumber = gateIssueNumber(line);
+  return issueNumber === null || requestEligibleRecoveryIssues.has(issueNumber);
+}
+
+function hasStoppedClusteredCodexChurnManualReviewGate(
+  lines: string[],
+  requestEligibleRecoveryIssues: ReadonlySet<number>,
+): boolean {
+  return lines.some((line) => {
+    const isStoppedGate =
+      /^loop_runtime_blocker\b/u.test(line) ||
+      /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line);
+    return isStoppedGate && !isRequestEligibleRecoveryGate(line, requestEligibleRecoveryIssues);
+  });
 }
 
 export function parseOperatorActionLine(line: string): OperatorAction | null {
@@ -230,7 +251,10 @@ export function selectRestartRecommendation(args: {
   const recommendations: RestartRecommendation[] = [];
   const contextLines = [...args.detailedStatusLines, ...(args.contextLines ?? [])];
   const requestEligibleRecoverySelectedIssues = selectedRequestEligibleRecoveryIssues(contextLines);
-  const allowClusteredChurnManualReview = hasStoppedClusteredCodexChurnManualReviewGate(contextLines);
+  const allowClusteredChurnManualReview = hasStoppedClusteredCodexChurnManualReviewGate(
+    contextLines,
+    requestEligibleRecoverySelectedIssues,
+  );
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
@@ -367,7 +391,10 @@ export function selectStatusOperatorAction(args: {
   const actions: OperatorAction[] = [];
   const contextLines = [...args.detailedStatusLines, ...(args.contextLines ?? [])];
   const requestEligibleRecoverySelectedIssues = selectedRequestEligibleRecoveryIssues(contextLines);
-  const allowClusteredChurnManualReview = hasStoppedClusteredCodexChurnManualReviewGate(contextLines);
+  const allowClusteredChurnManualReview = hasStoppedClusteredCodexChurnManualReviewGate(
+    contextLines,
+    requestEligibleRecoverySelectedIssues,
+  );
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -102,8 +102,10 @@ function formatCodexConnectorReviewChurnProgressDiagnostic(args: {
     `previous_effective_must_fix=${comparison.previousEffectiveMustFixCount}`,
     `effective_must_fix_delta=${comparison.effectiveMustFixDelta}`,
     `dominant_file=${formatDiagnosticToken(args.current.dominantFile)}`,
+    `previous_dominant_file=${formatDiagnosticToken(args.previous.dominantFile)}`,
     `dominant_file_percent=${args.current.dominantFilePercent}`,
     `cluster_category_signature=${formatDiagnosticToken(args.current.clusterCategorySignature)}`,
+    `previous_cluster_category_signature=${formatDiagnosticToken(args.previous.clusterCategorySignature)}`,
     `representative_threads=${args.current.representativeThreadIds.map(formatDiagnosticToken).join(",") || "none"}`,
   ].join(" ");
 }

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -614,7 +614,7 @@ test("status compares Codex Connector churn progress against the previous tracke
 
   assert.match(
     status,
-    /^codex_connector_review_churn_progress classification=improving current_head_sha=head-current-1391 previous_head_sha=head-previous-1391 current_effective_must_fix=2 previous_effective_must_fix=4 effective_must_fix_delta=-2 dominant_file=src\/release-readiness\.ts dominant_file_percent=100 cluster_category_signature=.*truth_source.* representative_threads=thread-current-0,thread-current-1$/m,
+    /^codex_connector_review_churn_progress classification=improving current_head_sha=head-current-1391 previous_head_sha=head-previous-1391 current_effective_must_fix=2 previous_effective_must_fix=4 effective_must_fix_delta=-2 dominant_file=src\/release-readiness\.ts previous_dominant_file=src\/release-readiness\.ts dominant_file_percent=100 cluster_category_signature=.*truth_source.* previous_cluster_category_signature=.*readiness_claim.*truth_source.* representative_threads=thread-current-0,thread-current-1$/m,
   );
 });
 

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -658,7 +658,7 @@ test("determineTrackedPrRepeatFailureDisposition stops no-progress clustered Cod
         currentEffectiveMustFixCount: 4,
         dominantFile: "src/release-readiness.ts",
         dominantFilePercent: 100,
-        clusterCategorySignature: "readiness_claim+truth_source",
+        clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
         representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
       },
     }),
@@ -708,6 +708,99 @@ test("determineTrackedPrRepeatFailureDisposition stops no-progress clustered Cod
   assert.equal(result.shouldStop, true);
   assert.equal(result.decision, "stop_no_progress");
   assert.equal(result.progressSummary, "no_progress_clustered_codex_churn current_effective_must_fix=4");
+});
+
+test("determineTrackedPrRepeatFailureDisposition keeps changed clustered Codex categories retryable", () => {
+  const record = createRecord({
+    last_failure_signature: "codex-review-churn:P2:src/release-readiness.ts",
+    repeated_failure_signature_count: 3,
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-previous-366",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "BLOCKED",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-06-01T06:09:54Z",
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: "2026-06-01T06:08:00Z",
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:09:54Z",
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      unresolvedReviewThreadFingerprints: [
+        "thread-previous-0#comment-previous-0",
+        "thread-previous-1#comment-previous-1",
+        "thread-previous-2#comment-previous-2",
+        "thread-previous-3#comment-previous-3",
+      ],
+      unresolvedReviewThreadSourceAnchors: [
+        "thread-previous-0:src/release-readiness.ts:120",
+        "thread-previous-1:src/release-readiness.ts:121",
+        "thread-previous-2:src/release-readiness.ts:122",
+        "thread-previous-3:src/release-readiness.ts:123",
+      ],
+      processedReviewThreadIds: [],
+      processedReviewThreadFingerprints: [],
+      verificationProbeOutcomes: [],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: "head-previous-366",
+        currentEffectiveMustFixCount: 4,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "truth_source",
+        representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      },
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head-current-366",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    configuredBotCurrentHeadObservedAt: "2026-06-01T06:20:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:20:00Z",
+    currentHeadCiGreenAt: "2026-06-01T06:18:00Z",
+  });
+  const reviewThreads: ReviewThread[] = Array.from({ length: 4 }, (_, index) =>
+    createReviewThread({
+      id: `thread-current-${index}`,
+      path: "src/release-readiness.ts",
+      line: 130 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-current-${index}`,
+            body:
+              "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+            createdAt: "2026-06-01T06:20:00Z",
+            url: `https://example.test/pr/366#discussion_current_${index}`,
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  );
+
+  const result = determineTrackedPrRepeatFailureDisposition({
+    record,
+    config: createConfig({
+      sameFailureSignatureRepeatLimit: 3,
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+      codexConnectorReviewChurnMustFixThreshold: 4,
+      codexConnectorReviewChurnFileConcentrationPercent: 75,
+    }),
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  });
+
+  assert.equal(result.shouldStop, false);
+  assert.equal(result.decision, "retry_on_progress");
+  assert.match(result.progressSummary ?? "", /review_thread_cluster_identity_changed/);
+  assert.notEqual(result.progressSummary, "no_progress_clustered_codex_churn current_effective_must_fix=4");
 });
 
 test("determineTrackedPrRepeatFailureDisposition keeps improving clustered Codex repairs retryable", () => {

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -245,15 +245,6 @@ function joinProgressValues(values: string[] | undefined): string | null {
   return Array.isArray(values) && values.length > 0 ? values.join("|") : null;
 }
 
-function categorySignatureTokens(signature: string): Set<string> {
-  return new Set(signature.split("+").filter((token) => token.length > 0));
-}
-
-function categorySignatureIncludesAll(current: string, previous: string): boolean {
-  const currentTokens = categorySignatureTokens(current);
-  return [...categorySignatureTokens(previous)].every((token) => currentTokens.has(token));
-}
-
 function clusteredCodexChurnMadeNoProgress(
   previous: TrackedPrProgressSnapshot | null,
   current: TrackedPrProgressSnapshot,
@@ -267,10 +258,7 @@ function clusteredCodexChurnMadeNoProgress(
   return (
     currentChurn.dominantFile === previousChurn.dominantFile &&
     currentChurn.currentEffectiveMustFixCount >= previousChurn.currentEffectiveMustFixCount &&
-    categorySignatureIncludesAll(
-      currentChurn.clusterCategorySignature,
-      previousChurn.clusterCategorySignature,
-    )
+    currentChurn.clusterCategorySignature === previousChurn.clusterCategorySignature
   );
 }
 
@@ -313,6 +301,19 @@ function listChangedSignals(previous: TrackedPrProgressSnapshot | null, current:
     previousThreadFingerprints !== currentThreadFingerprints;
   if (sameThreadGuidanceChanged) {
     signals.push("same_review_thread_guidance_changed");
+  }
+  if (
+    !noProgressClusteredCodexChurn &&
+    previous?.codexConnectorReviewChurnProgress &&
+    current.codexConnectorReviewChurnProgress &&
+    (
+      previous.codexConnectorReviewChurnProgress.dominantFile !==
+        current.codexConnectorReviewChurnProgress.dominantFile ||
+      previous.codexConnectorReviewChurnProgress.clusterCategorySignature !==
+        current.codexConnectorReviewChurnProgress.clusterCategorySignature
+    )
+  ) {
+    signals.push("review_thread_cluster_identity_changed");
   }
   if (
     !noProgressClusteredCodexChurn &&

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -200,3 +200,32 @@ test("buildRuntimeRecoverySummary recommends manual review before restarting clu
     },
   );
 });
+
+test("buildRuntimeRecoverySummary ignores historical clustered Codex churn while the loop is active", () => {
+  assert.equal(
+    buildRuntimeRecoverySummary({
+      loopRuntime: {
+        ...baseLoopRuntime,
+        state: "running",
+        hostMode: "tmux",
+        pid: 4242,
+        ownershipConfidence: "live_lock",
+        detail: "running",
+      },
+      trackedIssues: [
+        {
+          issueNumber: 188,
+          state: "addressing_review",
+          branch: "codex/issue-188",
+          prNumber: 288,
+          blockedReason: null,
+        },
+      ],
+      detailedStatusLines: [
+        "loop_runtime state=running host_mode=tmux run_mode=supervisor marker_path=<loop-marker> config_path=<supervisor-config-path> state_file=<state-file> pid=4242 started_at=2026-06-01T06:20:00Z ownership_confidence=live_lock detail=running",
+        "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+      ],
+    }),
+    null,
+  );
+});

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -173,3 +173,30 @@ test("buildRuntimeRecoverySummary reuses restart recommendation vocabulary and c
     },
   );
 });
+
+test("buildRuntimeRecoverySummary recommends manual review before restarting clustered Codex churn", () => {
+  assert.deepEqual(
+    buildRuntimeRecoverySummary({
+      loopRuntime: baseLoopRuntime,
+      trackedIssues: [
+        {
+          issueNumber: 188,
+          state: "blocked",
+          branch: "codex/issue-188",
+          prNumber: 288,
+          blockedReason: "manual_review",
+        },
+      ],
+      detailedStatusLines: [
+        "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
+        "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+      ],
+    })?.recommendation,
+    {
+      category: "manual_review_before_restart",
+      source: "codex_connector_review_churn_progress",
+      summary:
+        "Clustered Codex Connector churn made no progress; inspect dominant file src/release-readiness.ts with current effective must-fix count 8 before restarting the loop.",
+    },
+  );
+});

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -189,7 +189,7 @@ test("buildRuntimeRecoverySummary recommends manual review before restarting clu
       ],
       detailedStatusLines: [
         "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
-        "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+        "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts previous_dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source previous_cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
       ],
     })?.recommendation,
     {


### PR DESCRIPTION
## Summary
- prioritize manual_review/manual_review_before_restart when Codex Connector churn progress is unchanged or worse
- include dominant file and current effective must-fix count in the operator-facing summary
- add focused selector and runtime recovery summary regressions

## Verification
- npx tsx --test src/operator-actions.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
- npx tsx --test src/supervisor/supervisor-status-report.test.ts
- npm run build

Closes #2226