### PR TITLE
Compact Codex Connector churn diagnostics

### DIFF
--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -575,6 +575,7 @@ function uniqueInOrder(values: string[]): string[] {
 }
 
 const CODEX_CONNECTOR_REVIEW_CATEGORY_PATTERNS: Array<{ category: string; pattern: RegExp }> = [
+  { category: "auth_context", pattern: /\b(?:auth|authentication|authorization|credential|identity)\b/i },
   { category: "rc_ga_readiness", pattern: /\b(?:rc|ga|release[- ]candidate|commercial[- ]ready|production[- ]ready|ready)\b/i },
   { category: "readiness_claim", pattern: /\b(?:readiness|ready|gate[- ]pass|mergeable|release)\b/i },
   { category: "truth_source", pattern: /\b(?:truth|source[- ]of[- ]truth|authoritative|authority|claim|assertion)\b/i },

--- a/src/review-thread-reporting.test.ts
+++ b/src/review-thread-reporting.test.ts
@@ -13,6 +13,7 @@ import {
   configuredBotReviewFollowUpState,
   effectiveReviewThreadDiagnostics,
   evaluateCodexConnectorConvergencePolicy,
+  formatEffectiveReviewThreadDiagnosticsLine,
   staleConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
@@ -240,6 +241,15 @@ test("effectiveReviewThreadDiagnostics separates raw configured-bot residue from
       { id: "thread-human", classification: "human_unresolved", effective: false },
       { id: "thread-resolved", classification: "configured_bot_resolved", effective: false },
     ],
+  );
+
+  assert.equal(
+    formatEffectiveReviewThreadDiagnosticsLine(diagnostics),
+    "review_thread_effective_diagnostics raw_configured_bot_unresolved=2 effective_configured_bot_unresolved=1 current_configured_bot_threads=1 outdated_configured_bot_residue=1 current_thread_ids=thread-current",
+  );
+  assert.match(
+    formatEffectiveReviewThreadDiagnosticsLine(diagnostics, { includeThreadDetails: true }),
+    /^review_thread_effective_diagnostics .* threads=thread-outdated:configured_bot_outdated:effective=no:path=src\/file\.ts:line=12:comment=comment-outdated:author=chatgpt-codex-connector:url=https:\/\/example\.test\/pr\/183#discussion_r1,thread-current:configured_bot_current_head:effective=yes:/,
   );
 });
 

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -190,27 +190,44 @@ function formatReviewThreadDiagnosticToken(value: string | null): string {
 
 export function formatEffectiveReviewThreadDiagnosticsLine(
   diagnostics: EffectiveReviewThreadDiagnostics,
+  options: { includeThreadDetails?: boolean } = {},
 ): string {
-  const threadTokens = diagnostics.threads
-    .map((thread) =>
-      [
-        formatReviewThreadDiagnosticToken(thread.id),
-        thread.classification,
-        `effective=${thread.effectiveConfiguredBotBlocker ? "yes" : "no"}`,
-        `path=${formatReviewThreadDiagnosticToken(thread.path)}`,
-        `line=${formatReviewThreadDiagnosticToken(thread.line)}`,
-        `comment=${formatReviewThreadDiagnosticToken(thread.latestCommentId)}`,
-        `author=${formatReviewThreadDiagnosticToken(thread.latestCommentAuthor)}`,
-        `url=${formatReviewThreadDiagnosticToken(thread.url)}`,
-      ].join(":"),
-    )
-    .join(",");
+  const currentConfiguredBotThreads = diagnostics.threads.filter(
+    (thread) => thread.classification === "configured_bot_current_head",
+  );
+  const outdatedConfiguredBotThreads = diagnostics.threads.filter(
+    (thread) => thread.classification === "configured_bot_outdated",
+  );
 
-  return [
+  const baseTokens = [
     "review_thread_effective_diagnostics",
     `raw_configured_bot_unresolved=${diagnostics.rawUnresolvedConfiguredBotThreadCount}`,
     `effective_configured_bot_unresolved=${diagnostics.effectiveUnresolvedConfiguredBotThreadCount}`,
-    `threads=${threadTokens || "none"}`,
+    `current_configured_bot_threads=${currentConfiguredBotThreads.length}`,
+    `outdated_configured_bot_residue=${outdatedConfiguredBotThreads.length}`,
+    `current_thread_ids=${currentConfiguredBotThreads.map((thread) => formatReviewThreadDiagnosticToken(thread.id)).join(",") || "none"}`,
+  ];
+
+  if (!options.includeThreadDetails) {
+    return baseTokens.join(" ");
+  }
+
+  return [
+    ...baseTokens,
+    `threads=${diagnostics.threads
+      .map((thread) =>
+        [
+          formatReviewThreadDiagnosticToken(thread.id),
+          thread.classification,
+          `effective=${thread.effectiveConfiguredBotBlocker ? "yes" : "no"}`,
+          `path=${formatReviewThreadDiagnosticToken(thread.path)}`,
+          `line=${formatReviewThreadDiagnosticToken(thread.line)}`,
+          `comment=${formatReviewThreadDiagnosticToken(thread.latestCommentId)}`,
+          `author=${formatReviewThreadDiagnosticToken(thread.latestCommentAuthor)}`,
+          `url=${formatReviewThreadDiagnosticToken(thread.url)}`,
+        ].join(":"),
+      )
+      .join(",") || "none"}`,
   ].join(" ");
 }
 

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -15,6 +15,7 @@ import {
   formatCodexConnectorP2P3PolicyDiagnostic,
   formatCodexConnectorPolicyBlockDiagnostic,
   formatCodexConnectorReviewChurnDiagnostic,
+  latestCodexConnectorReviewComment,
   type CodexConnectorReviewChurnProgressSummary,
 } from "../codex-connector-review-policy";
 import { configuredBotCurrentHeadSignalWaitWindow } from "./review-bot-wait-windows";
@@ -44,6 +45,7 @@ export interface CodexConnectorDiagnosticBundle {
   policyBlockSummary: string | null;
   p2p3PolicySummary: string | null;
   reviewChurnSummary: string | null;
+  currentClusterSummary: string | null;
   reviewChurnProgressSummary: string | null;
   reviewFallbackSummary: string | null;
   convergenceSummary: string | null;
@@ -107,6 +109,31 @@ function formatCodexConnectorReviewChurnProgressDiagnostic(args: {
     `cluster_category_signature=${formatDiagnosticToken(args.current.clusterCategorySignature)}`,
     `previous_cluster_category_signature=${formatDiagnosticToken(args.previous.clusterCategorySignature)}`,
     `representative_threads=${args.current.representativeThreadIds.map(formatDiagnosticToken).join(",") || "none"}`,
+  ].join(" ");
+}
+
+function countOutdatedUnresolvedCodexConnectorResidue(reviewThreads: ReviewThread[]): number {
+  return reviewThreads.filter((thread) => {
+    return !thread.isResolved && thread.isOutdated && latestCodexConnectorReviewComment(thread) !== null;
+  }).length;
+}
+
+function formatCodexConnectorCurrentClusterDiagnostic(args: {
+  reviewChurn: NonNullable<ReturnType<typeof buildCodexConnectorReviewChurnDiagnostic>>;
+  outdatedUnresolvedResidueCount: number;
+}): string {
+  return [
+    "codex_connector_current_clusters",
+    `current_effective_must_fix=${args.reviewChurn.mustFixCount}`,
+    `dominant_file=${formatDiagnosticToken(args.reviewChurn.dominantFile)}`,
+    `dominant_file_threads=${args.reviewChurn.dominantFileThreadCount}`,
+    `dominant_file_percent=${args.reviewChurn.dominantFilePercent}`,
+    `clusters=${args.reviewChurn.clusterCount}`,
+    `categories=${args.reviewChurn.normalizedCategories.map(formatDiagnosticToken).join("|")}`,
+    `representative_threads=${args.reviewChurn.representativeThreadIds.map(formatDiagnosticToken).join(",") || "none"}`,
+    `representative_urls=${args.reviewChurn.representativeSourceUrls.map(formatDiagnosticToken).join(",") || "none"}`,
+    `outdated_unresolved_residue=${args.outdatedUnresolvedResidueCount}`,
+    "next_action=repair_must_fix_findings",
   ].join(" ");
 }
 
@@ -507,6 +534,12 @@ export function buildCodexConnectorDiagnosticBundle(args: {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
     p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
     reviewChurnSummary: reviewChurn ? formatCodexConnectorReviewChurnDiagnostic(reviewChurn) : null,
+    currentClusterSummary: reviewChurn
+      ? formatCodexConnectorCurrentClusterDiagnostic({
+          reviewChurn,
+          outdatedUnresolvedResidueCount: countOutdatedUnresolvedCodexConnectorResidue(args.reviewThreads),
+        })
+      : null,
     reviewChurnProgressSummary:
       currentReviewChurnProgress && previousReviewChurnProgress
         ? formatCodexConnectorReviewChurnProgressDiagnostic({

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -228,6 +228,9 @@ export function buildActiveReviewBotProviderLines(
   if (codexConnectorDiagnostics.reviewChurnSummary) {
     lines.push(codexConnectorDiagnostics.reviewChurnSummary);
   }
+  if (codexConnectorDiagnostics.currentClusterSummary) {
+    lines.push(codexConnectorDiagnostics.currentClusterSummary);
+  }
   if (codexConnectorDiagnostics.reviewChurnProgressSummary) {
     lines.push(codexConnectorDiagnostics.reviewChurnProgressSummary);
   }

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -207,6 +207,9 @@ export function buildInactiveDetailedStatusLines(
     if (codexConnectorDiagnostics.reviewChurnSummary) {
       lines.push(codexConnectorDiagnostics.reviewChurnSummary);
     }
+    if (codexConnectorDiagnostics.currentClusterSummary) {
+      lines.push(codexConnectorDiagnostics.currentClusterSummary);
+    }
     if (codexConnectorDiagnostics.reviewChurnProgressSummary) {
       lines.push(codexConnectorDiagnostics.reviewChurnProgressSummary);
     }

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -493,6 +493,110 @@ test("status --why reports Codex Connector review churn for concentrated P2 casc
   );
 });
 
+test("status --why compacts Codex Connector churn around current clusters before outdated residue", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 2227;
+  const prNumber = 3227;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-2227",
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    configuredBotCurrentHeadObservedAt: "2026-06-02T05:00:00Z",
+  });
+  const currentThreads = [
+    ["thread-current-auth", 41, "P2: Require the auth context before accepting Connector churn state."],
+    ["thread-current-auth-2", 44, "P2: Require the auth context before accepting Connector churn state in the retry path."],
+    ["thread-current-scope", 88, "P2: Keep repository scope explicitly bound before selecting current clusters."],
+  ].map(([id, line, body]) => ({
+    id,
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/codex-connector-diagnostics-presenter.ts",
+    line,
+    comments: {
+      nodes: [
+        {
+          id: `${id}-comment`,
+          body,
+          createdAt: "2026-06-02T05:01:00Z",
+          url: `https://example.test/pr/3227#discussion_${id}`,
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  }));
+  const outdatedThreads = Array.from({ length: 12 }, (_, index) => ({
+    id: `thread-outdated-${index}`,
+    isResolved: false,
+    isOutdated: true,
+    path: "src/supervisor/old-diagnostic.ts",
+    line: 100 + index,
+    comments: {
+      nodes: [
+        {
+          id: `thread-outdated-${index}-comment`,
+          body: "P2: Old outdated Connector residue from an earlier head.",
+          createdAt: "2026-06-02T04:00:00Z",
+          url: `https://example.test/pr/3227#discussion_outdated_${index}`,
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  }));
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    codexConnectorReviewChurnMustFixThreshold: 3,
+    codexConnectorReviewChurnFileConcentrationPercent: 75,
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [...outdatedThreads, ...currentThreads],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^codex_connector_current_clusters current_effective_must_fix=3 dominant_file=src\/supervisor\/codex-connector-diagnostics-presenter\.ts dominant_file_threads=3 dominant_file_percent=100 clusters=2 categories=.*auth.*scope.* representative_threads=thread-current-auth,thread-current-auth-2,thread-current-scope representative_urls=https:\/\/example\.test\/pr\/3227#discussion_thread-current-auth,https:\/\/example\.test\/pr\/3227#discussion_thread-current-auth-2,https:\/\/example\.test\/pr\/3227#discussion_thread-current-scope outdated_unresolved_residue=12 next_action=repair_must_fix_findings$/m,
+  );
+  assert.doesNotMatch(status, /^codex_connector_current_clusters .*thread-outdated-/m);
+});
+
 test("status compares Codex Connector churn progress against the previous tracked PR snapshot", async (t) => {
   const fixture = await createSupervisorFixture();
   t.after(async () => {

--- a/src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
@@ -203,7 +203,7 @@ test("explain reports effective configured-bot thread diagnostics for outdated C
 
   assert.match(
     explanation,
-    /^review_thread_effective_diagnostics raw_configured_bot_unresolved=1 effective_configured_bot_unresolved=0 threads=PRRT_hrcore_183_outdated:configured_bot_outdated:effective=no:path=src\/review-policy\.ts:line=42:comment=PRRC_hrcore_183_outdated:author=chatgpt-codex-connector:url=https:\/\/example\.test\/pr\/283#discussion_r183$/m,
+    /^review_thread_effective_diagnostics raw_configured_bot_unresolved=1 effective_configured_bot_unresolved=0 current_configured_bot_threads=0 outdated_configured_bot_residue=1 current_thread_ids=none threads=PRRT_hrcore_183_outdated:configured_bot_outdated:effective=no:path=src\/review-policy\.ts:line=42:comment=PRRC_hrcore_183_outdated:author=chatgpt-codex-connector:url=https:\/\/example\.test\/pr\/283#discussion_r183$/m,
   );
 });
 

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -292,7 +292,7 @@ test("status --why reports effective configured-bot thread diagnostics for outda
   );
   assert.match(
     status,
-    /^review_thread_effective_diagnostics raw_configured_bot_unresolved=1 effective_configured_bot_unresolved=0 threads=PRRT_hrcore_183_outdated:configured_bot_outdated:effective=no:path=src\/review-policy\.ts:line=42:comment=PRRC_hrcore_183_outdated:author=chatgpt-codex-connector:url=https:\/\/example\.test\/pr\/283#discussion_r183$/m,
+    /^review_thread_effective_diagnostics raw_configured_bot_unresolved=1 effective_configured_bot_unresolved=0 current_configured_bot_threads=0 outdated_configured_bot_residue=1 current_thread_ids=none$/m,
   );
 });
 

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -496,7 +496,9 @@ export async function buildIssueExplainDto(
       : null;
   const effectiveReviewThreadDiagnosticsSummary =
     record && pr && !trackedPrHydrationFailed
-      ? formatEffectiveReviewThreadDiagnosticsLine(effectiveReviewThreadDiagnostics(config, explainReviewThreads))
+      ? formatEffectiveReviewThreadDiagnosticsLine(effectiveReviewThreadDiagnostics(config, explainReviewThreads), {
+          includeThreadDetails: true,
+        })
       : null;
   const codexConnectorReviewRequestRecoveryEligible =
     codexConnectorDiagnostics?.reviewFallbackSummary !== undefined &&

--- a/src/supervisor/supervisor-status-model.test.ts
+++ b/src/supervisor/supervisor-status-model.test.ts
@@ -428,7 +428,7 @@ test("buildDetailedStatusModel preserves active-line ordering across PR and fail
     "failing_checks=unit",
     "pending_checks=lint",
     "review_threads bot_pending=0 bot_unresolved=0 bot_effective_unresolved=0 bot_outdated_unresolved=0 manual=0",
-    "review_thread_effective_diagnostics raw_configured_bot_unresolved=0 effective_configured_bot_unresolved=0 threads=none",
+    "review_thread_effective_diagnostics raw_configured_bot_unresolved=0 effective_configured_bot_unresolved=0 current_configured_bot_threads=0 outdated_configured_bot_residue=0 current_thread_ids=none",
     "failure_context category=checks summary=build failed\\nsee logs",
     "failure_details=step one | step two",
     "runtime_failure_context category=codex summary=Host loop failed while persisting diagnostics.",

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -240,7 +240,7 @@ test("formatDetailedStatus renders core lines before appended summaries", () => 
       "pr_state=OPEN draft=no merge_state=CLEAN review_decision=none head_sha=deadbeef",
       "checks=none",
       "review_threads bot_pending=0 bot_unresolved=0 bot_effective_unresolved=0 bot_outdated_unresolved=0 manual=0",
-      "review_thread_effective_diagnostics raw_configured_bot_unresolved=0 effective_configured_bot_unresolved=0 threads=none",
+      "review_thread_effective_diagnostics raw_configured_bot_unresolved=0 effective_configured_bot_unresolved=0 current_configured_bot_threads=0 outdated_configured_bot_residue=0 current_thread_ids=none",
       "review_follow_up state=inactive remaining=0 head_sha=none actionable=0",
       "handoff_summary=blocked\\nneeds reproduction",
       "local_review_routing generic=inherit->gpt-5-codex(1) specialists=gpt-5-codex(1) verifier=gpt-5-codex",


### PR DESCRIPTION
## Summary
- add a compact `codex_connector_current_clusters` line for current effective Codex Connector churn
- summarize outdated unresolved Connector residue in default status diagnostics
- keep raw per-thread details available for explicit explain/detail paths

## Verification
- `npx tsx --test src/supervisor/supervisor-status-model-supervisor.test.ts`
- `npx tsx --test src/supervisor/supervisor-status-rendering-supervisor-status-lines.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts src/review-thread-reporting.test.ts`
- `npm run build`

Part of #2223. Closes #2227.