### PR TITLE
Report pending-head Codex churn risk

### DIFF
--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -46,6 +46,7 @@ export interface CodexConnectorDiagnosticBundle {
   p2p3PolicySummary: string | null;
   reviewChurnSummary: string | null;
   currentClusterSummary: string | null;
+  pendingHeadChurnSummary: string | null;
   reviewChurnProgressSummary: string | null;
   reviewFallbackSummary: string | null;
   convergenceSummary: string | null;
@@ -134,6 +135,68 @@ function formatCodexConnectorCurrentClusterDiagnostic(args: {
     `representative_urls=${args.reviewChurn.representativeSourceUrls.map(formatDiagnosticToken).join(",") || "none"}`,
     `outdated_unresolved_residue=${args.outdatedUnresolvedResidueCount}`,
     "next_action=repair_must_fix_findings",
+  ].join(" ");
+}
+
+function formatCodexConnectorPendingHeadChurnDiagnostic(args: {
+  config: SupervisorConfig;
+  record: Pick<
+    IssueRunRecord,
+    | "codex_connector_review_requested_observed_at"
+    | "codex_connector_review_requested_head_sha"
+  >;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+}): string | null {
+  const staleReviewCommitThreads = codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads);
+  if (staleReviewCommitThreads.length === 0 || args.pr.configuredBotCurrentHeadObservedAt) {
+    return null;
+  }
+
+  const reviewChurn = buildCodexConnectorReviewChurnDiagnostic(args.config, staleReviewCommitThreads, null);
+  if (!reviewChurn) {
+    return null;
+  }
+
+  const currentHeadSha = args.pr.headRefOid;
+  const latestReviewedHeadSha = args.pr.configuredBotLatestReviewedCommitSha ?? "none";
+  const requestMatchesCurrentHead = Boolean(
+    args.record.codex_connector_review_requested_observed_at &&
+      commitShasEqualForComparison(args.record.codex_connector_review_requested_head_sha, currentHeadSha),
+  );
+  const hydratedRequestMatchesCurrentHead = Boolean(
+    !requestMatchesCurrentHead &&
+      args.pr.codexConnectorReviewRequestedAt &&
+      commitShasEqualForComparison(args.pr.codexConnectorReviewRequestedHeadSha, currentHeadSha),
+  );
+  const waitWindow = configuredBotCurrentHeadSignalWaitWindow(args.config, args.pr);
+  const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
+  const nextAction =
+    requestMatchesCurrentHead || hydratedRequestMatchesCurrentHead
+      ? "wait_for_requested_review"
+      : waitWindow.status === "active"
+        ? "wait_for_current_head_signal"
+        : timeoutAction === "request_review_comment"
+          ? "request_current_head_review"
+          : "wait_for_current_head_signal";
+
+  return [
+    "codex_connector_pending_head_churn",
+    "status=pending_current_head_review",
+    `current_head_sha=${formatDiagnosticToken(currentHeadSha)}`,
+    `latest_reviewed_head_sha=${formatDiagnosticToken(latestReviewedHeadSha)}`,
+    "current_head_review_signal=missing",
+    `current_effective_must_fix=${reviewChurn.mustFixCount}`,
+    `threshold=${reviewChurn.threshold}`,
+    `highest_severity=${reviewChurn.highestSeverity}`,
+    `dominant_file=${formatDiagnosticToken(reviewChurn.dominantFile)}`,
+    `dominant_file_threads=${reviewChurn.dominantFileThreadCount}`,
+    `dominant_file_percent=${reviewChurn.dominantFilePercent}`,
+    `categories=${reviewChurn.normalizedCategories.map(formatDiagnosticToken).join("|")}`,
+    `representative_threads=${reviewChurn.representativeThreadIds.map(formatDiagnosticToken).join(",") || "none"}`,
+    `representative_urls=${reviewChurn.representativeSourceUrls.map(formatDiagnosticToken).join(",") || "none"}`,
+    `stale_review_commit_threads=${staleReviewCommitThreads.length}`,
+    `next_action=${nextAction}`,
   ].join(" ");
 }
 
@@ -540,6 +603,14 @@ export function buildCodexConnectorDiagnosticBundle(args: {
           outdatedUnresolvedResidueCount: countOutdatedUnresolvedCodexConnectorResidue(args.reviewThreads),
         })
       : null,
+    pendingHeadChurnSummary: suppressActionableReviewPolicy
+      ? null
+      : formatCodexConnectorPendingHeadChurnDiagnostic({
+          config: args.config,
+          record: args.record,
+          pr: args.pr,
+          reviewThreads: args.reviewThreads,
+        }),
     reviewChurnProgressSummary:
       currentReviewChurnProgress && previousReviewChurnProgress
         ? formatCodexConnectorReviewChurnProgressDiagnostic({

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -231,6 +231,9 @@ export function buildActiveReviewBotProviderLines(
   if (codexConnectorDiagnostics.currentClusterSummary) {
     lines.push(codexConnectorDiagnostics.currentClusterSummary);
   }
+  if (codexConnectorDiagnostics.pendingHeadChurnSummary) {
+    lines.push(codexConnectorDiagnostics.pendingHeadChurnSummary);
+  }
   if (codexConnectorDiagnostics.reviewChurnProgressSummary) {
     lines.push(codexConnectorDiagnostics.reviewChurnProgressSummary);
   }

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -210,6 +210,9 @@ export function buildInactiveDetailedStatusLines(
     if (codexConnectorDiagnostics.currentClusterSummary) {
       lines.push(codexConnectorDiagnostics.currentClusterSummary);
     }
+    if (codexConnectorDiagnostics.pendingHeadChurnSummary) {
+      lines.push(codexConnectorDiagnostics.pendingHeadChurnSummary);
+    }
     if (codexConnectorDiagnostics.reviewChurnProgressSummary) {
       lines.push(codexConnectorDiagnostics.reviewChurnProgressSummary);
     }

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -855,6 +855,111 @@ test("status waits for current-head Codex review when non-outdated threads came 
   assert.doesNotMatch(status, /^codex_connector_policy_block /m);
 });
 
+test("status reports pending-head Codex Connector churn risk from latest reviewed head", async (t) => {
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse("2026-06-03T05:30:00Z");
+  t.after(() => {
+    Date.now = originalDateNow;
+  });
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 2234;
+  const prNumber = 3234;
+  const branch = branchName(fixture.config, issueNumber);
+  const currentHead = "head-current-2234";
+  const latestReviewedHead = "head-reviewed-2234";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: currentHead,
+        provider_success_head_sha: latestReviewedHead,
+        provider_success_observed_at: "2026-06-03T05:00:00Z",
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-03T05:10:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: latestReviewedHead,
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-03T05:00:00Z",
+  });
+  const staleClusterThreads = [
+    ["thread-pending-auth", 40, "P2: Require the auth context before accepting pending-head churn evidence."],
+    ["thread-pending-auth-retry", 44, "P2: Keep auth context validation fail-closed during retry routing."],
+    ["thread-pending-scope", 72, "P2: Bind the repository scope before summarizing pending-head churn evidence."],
+    ["thread-pending-scope-retry", 78, "P2: Reject scope inference when pending-head Connector evidence is stale."],
+  ].map(([id, line, body]) => ({
+    id,
+    isResolved: false,
+    isOutdated: false,
+    path: "src/supervisor/codex-connector-diagnostics-presenter.ts",
+    line,
+    comments: {
+      nodes: [
+        {
+          id: `${id}-comment`,
+          body,
+          createdAt: "2026-06-03T05:01:00Z",
+          url: `https://example.test/pr/3234#discussion_${id}`,
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  }));
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    codexConnectorReviewChurnMustFixThreshold: 4,
+    codexConnectorReviewChurnFileConcentrationPercent: 75,
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => staleClusterThreads,
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^codex_connector_pending_head_churn status=pending_current_head_review current_head_sha=head-current-2234 latest_reviewed_head_sha=head-reviewed-2234 current_head_review_signal=missing current_effective_must_fix=4 threshold=4 highest_severity=P2 dominant_file=src\/supervisor\/codex-connector-diagnostics-presenter\.ts dominant_file_threads=4 dominant_file_percent=100 categories=.*auth_context.*excluded_scope.* representative_threads=thread-pending-auth,thread-pending-auth-retry,thread-pending-scope,thread-pending-scope-retry representative_urls=https:\/\/example\.test\/pr\/3234#discussion_thread-pending-auth,https:\/\/example\.test\/pr\/3234#discussion_thread-pending-auth-retry,https:\/\/example\.test\/pr\/3234#discussion_thread-pending-scope,https:\/\/example\.test\/pr\/3234#discussion_thread-pending-scope-retry stale_review_commit_threads=4 next_action=request_current_head_review$/m,
+  );
+  assert.match(
+    status,
+    /^codex_connector_convergence status=stale_review_commit_residue provider=codex current_head_sha=head-current-2234 current_head_observed_at=none latest_signal_head_sha=head-reviewed-2234 highest_severity=none finding_count=0 merge_effect=blocked next_action=request_current_head_review stale_review_commit_threads=4 stale_review_commit_thread_ids=thread-pending-auth,thread-pending-auth-retry,thread-pending-scope,thread-pending-scope-retry$/m,
+  );
+  assert.match(status, /^codex_connector_operator_diagnostic .*current_head_review_signal=missing .*next_action=request_current_head_review$/m);
+  assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);
+});
+
 test("status --why requests Codex current-head review for metadata-only missing review residue", async (t) => {
   const originalDateNow = Date.now;
   Date.now = () => Date.parse("2026-05-21T20:45:06Z");

--- a/src/supervisor/supervisor-diagnostics-explain-scenarios.ts
+++ b/src/supervisor/supervisor-diagnostics-explain-scenarios.ts
@@ -55,6 +55,7 @@ export function codexConnectorDiagnosticLines(text: string): string[] {
     .split("\n")
     .filter((line) =>
       line.startsWith("codex_connector_policy_block ") ||
+      line.startsWith("codex_connector_pending_head_churn ") ||
       line.startsWith("codex_connector_review_fallback ") ||
       line.startsWith("codex_connector_convergence ") ||
       line.startsWith("codex_connector_operator_diagnostic ")

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -123,6 +123,7 @@ export interface SupervisorExplainDto {
   effectiveReviewThreadDiagnosticsSummary?: string | null;
   codexConnectorOperatorDiagnosticSummary?: string | null;
   codexConnectorPolicyBlockSummary?: string | null;
+  codexConnectorPendingHeadChurnSummary?: string | null;
   codexConnectorReviewFallbackSummary?: string | null;
   codexConnectorConvergenceSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
@@ -610,6 +611,7 @@ export async function buildIssueExplainDto(
     effectiveReviewThreadDiagnosticsSummary,
     codexConnectorOperatorDiagnosticSummary: codexConnectorDiagnostics?.operatorDiagnosticSummary ?? null,
     codexConnectorPolicyBlockSummary: codexConnectorDiagnostics?.policyBlockSummary ?? null,
+    codexConnectorPendingHeadChurnSummary: codexConnectorDiagnostics?.pendingHeadChurnSummary ?? null,
     codexConnectorReviewFallbackSummary: codexConnectorDiagnostics?.reviewFallbackSummary ?? null,
     codexConnectorConvergenceSummary: codexConnectorDiagnostics?.convergenceSummary ?? null,
     noActiveTrackedRecordSummary,
@@ -697,6 +699,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.effectiveReviewThreadDiagnosticsSummary ? [dto.effectiveReviewThreadDiagnosticsSummary] : []),
     ...(dto.codexConnectorOperatorDiagnosticSummary ? [dto.codexConnectorOperatorDiagnosticSummary] : []),
     ...(dto.codexConnectorPolicyBlockSummary ? [dto.codexConnectorPolicyBlockSummary] : []),
+    ...(dto.codexConnectorPendingHeadChurnSummary ? [dto.codexConnectorPendingHeadChurnSummary] : []),
     ...(dto.codexConnectorReviewFallbackSummary ? [dto.codexConnectorReviewFallbackSummary] : []),
     ...(dto.codexConnectorConvergenceSummary ? [dto.codexConnectorConvergenceSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),


### PR DESCRIPTION
## Summary
- Add a pending-head Codex Connector churn diagnostic derived from latest-reviewed-head stale residue when the current PR head still lacks same-head Connector signal
- Render the diagnostic in status and explain without treating it as current-head repair or merge-ready evidence
- Add a focused status regression for clustered pending-head churn risk

## Verification
- `npx tsx --test src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-explain-codex-connector.test.ts`
- `npx tsx --test src/codex-connector-review-policy.test.ts`
- `npm run build`

Part of #2234