### PR TITLE
Fix manual-review operator action for preserved churn blocks

### DIFF
--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -406,16 +406,16 @@ test("selectStatusOperatorAction does not continue after preserved manual-review
   );
 });
 
-test("selectRestartRecommendation treats manual-review execution metrics as a clustered churn stop gate", () => {
-  const recommendation = requireRestartRecommendation(selectRestartRecommendation({
-    detailedStatusLines: [
-      "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
-      codexConnectorChurnProgressLine(),
-    ],
-  }));
-
-  assert.equal(recommendation.category, "manual_review_before_restart");
-  assert.equal(recommendation.source, "codex_connector_review_churn_progress");
+test("selectRestartRecommendation does not treat manual-review execution metrics as a stopped gate", () => {
+  assert.equal(
+    selectRestartRecommendation({
+      detailedStatusLines: [
+        "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+        codexConnectorChurnProgressLine(),
+      ],
+    }),
+    null,
+  );
 });
 
 test("clustered Codex churn progress does not force manual review without a stopped gate", () => {
@@ -498,6 +498,36 @@ test("selectRestartRecommendation suppresses stale manual-review restart advice 
 test("clustered Codex churn does not suppress selected request-eligible Codex recovery", () => {
   const lines = [
     "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
+    codexConnectorChurnProgressLine(),
+    "no_active_tracked_record issue=#169 classification=manual_review_required state=blocked reason=manual_review",
+  ];
+
+  assert.equal(
+    selectRestartRecommendation({
+      detailedStatusLines: lines,
+      contextLines: ["selected_issue=#169"],
+    }),
+    null,
+  );
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: lines,
+      contextLines: ["selected_issue=#169"],
+    }),
+    {
+      action: "provider_outage_suspected",
+      source: "codex_connector_review_fallback",
+      priority: 70,
+      summary:
+        "A current-head Codex Connector review request is eligible; run the selected supervisor cycle to post or record it.",
+    },
+  );
+});
+
+test("stale manual-review execution metrics do not suppress selected request-eligible Codex recovery", () => {
+  const lines = [
+    "codex_connector_review_fallback status=request_eligible provider=codex current_head_sha=head-1 current_head_observed_at=none required_checks_green_at=2026-05-19T09:03:41Z timeout_action=request_review_comment requested_at=none requested_head_sha=none review_signal=missing note=request_comment_is_not_review_completion next_action=request_current_head_review wait_until=2026-05-19T09:13:41.000Z",
+    "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
     codexConnectorChurnProgressLine(),
     "no_active_tracked_record issue=#169 classification=manual_review_required state=blocked reason=manual_review",
   ];

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -390,6 +390,34 @@ test("selectStatusOperatorAction prioritizes manual review for stopped clustered
   );
 });
 
+test("selectStatusOperatorAction does not continue after preserved manual-review execution metrics", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+      ],
+    }),
+    {
+      action: "manual_review",
+      source: "execution_metrics",
+      priority: 65,
+      summary: "A tracked issue requires manual review before the supervisor should continue that path.",
+    },
+  );
+});
+
+test("selectRestartRecommendation treats manual-review execution metrics as a clustered churn stop gate", () => {
+  const recommendation = requireRestartRecommendation(selectRestartRecommendation({
+    detailedStatusLines: [
+      "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+      codexConnectorChurnProgressLine(),
+    ],
+  }));
+
+  assert.equal(recommendation.category, "manual_review_before_restart");
+  assert.equal(recommendation.source, "codex_connector_review_churn_progress");
+});
+
 test("clustered Codex churn progress does not force manual review without a stopped gate", () => {
   const activeChurnProgress =
     "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth";

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -406,6 +406,44 @@ test("selectStatusOperatorAction does not continue after preserved manual-review
   );
 });
 
+test("selectStatusOperatorAction ignores stale manual-review execution metrics while active work is rerunning", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "issue=#188",
+        "state=implementing",
+        "branch=codex/issue-188",
+        "pr=#288",
+        "blocked_reason=none",
+        "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+      ],
+    }),
+    {
+      action: "continue",
+      source: "status",
+      priority: 0,
+      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+    },
+  );
+});
+
+test("selectStatusOperatorAction keeps manual-review execution metrics when active-state evidence is missing", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "blocked_reason=none",
+        "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+      ],
+    }),
+    {
+      action: "manual_review",
+      source: "execution_metrics",
+      priority: 65,
+      summary: "A tracked issue requires manual review before the supervisor should continue that path.",
+    },
+  );
+});
+
 test("selectRestartRecommendation does not treat manual-review execution metrics as a stopped gate", () => {
   assert.equal(
     selectRestartRecommendation({

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -208,8 +208,16 @@ function hasStoppedClusteredCodexChurnManualReviewGate(
     const isLoopRuntimeBlocker = /^loop_runtime_blocker\b/u.test(line);
     const isNoActiveManualReview =
       /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line);
-    if (!isLoopRuntimeBlocker && !isNoActiveManualReview) {
+    const isManualReviewExecutionMetric =
+      /^execution_metrics\b/u.test(line) &&
+      /\bterminal_state=blocked\b/u.test(line) &&
+      /\boutcome=blocked\b/u.test(line) &&
+      /\breason=manual_review\b/u.test(line);
+    if (!isLoopRuntimeBlocker && !isNoActiveManualReview && !isManualReviewExecutionMetric) {
       return false;
+    }
+    if (isManualReviewExecutionMetric) {
+      return true;
     }
 
     const gateIssueNumber = isLoopRuntimeBlocker
@@ -523,7 +531,11 @@ export function selectStatusOperatorAction(args: {
     if (
       /^blocked_partial_work\b/.test(line) ||
       /^tracked_pr_mismatch\b/.test(line) && /\blocal_blocked_reason=manual_review\b/.test(line) ||
-      /^pre_merge_evaluation\b/.test(line) && /\bmanual_review=[1-9]\d*\b/.test(line)
+      /^pre_merge_evaluation\b/.test(line) && /\bmanual_review=[1-9]\d*\b/.test(line) ||
+      /^execution_metrics\b/.test(line) &&
+        /\bterminal_state=blocked\b/.test(line) &&
+        /\boutcome=blocked\b/.test(line) &&
+        /\breason=manual_review\b/.test(line)
     ) {
       const issueNumber = readIssueNumberToken(line, "issue");
       if (

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -208,16 +208,8 @@ function hasStoppedClusteredCodexChurnManualReviewGate(
     const isLoopRuntimeBlocker = /^loop_runtime_blocker\b/u.test(line);
     const isNoActiveManualReview =
       /^no_active_tracked_record\b/u.test(line) && /\bclassification=manual_review_required\b/u.test(line);
-    const isManualReviewExecutionMetric =
-      /^execution_metrics\b/u.test(line) &&
-      /\bterminal_state=blocked\b/u.test(line) &&
-      /\boutcome=blocked\b/u.test(line) &&
-      /\breason=manual_review\b/u.test(line);
-    if (!isLoopRuntimeBlocker && !isNoActiveManualReview && !isManualReviewExecutionMetric) {
+    if (!isLoopRuntimeBlocker && !isNoActiveManualReview) {
       return false;
-    }
-    if (isManualReviewExecutionMetric) {
-      return true;
     }
 
     const gateIssueNumber = isLoopRuntimeBlocker

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -224,6 +224,17 @@ function hasStoppedClusteredCodexChurnManualReviewGate(
   });
 }
 
+function hasUnblockedActiveIssueState(lines: string[]): boolean {
+  const state = lines
+    .map((line) => /^state=([^\s]+)$/u.exec(line)?.[1] ?? null)
+    .find((value): value is string => value !== null);
+  if (state === undefined || state === "blocked" || state === "done" || state === "failed") {
+    return false;
+  }
+
+  return lines.some((line) => /^blocked_reason=none$/u.test(line));
+}
+
 export function parseOperatorActionLine(line: string): OperatorAction | null {
   if (!/^(operator_action|doctor_operator_action)\b/u.test(line)) {
     return null;
@@ -407,6 +418,7 @@ export function selectStatusOperatorAction(args: {
     contextLines,
     requestEligibleRecoverySelectedIssues,
   );
+  const ignoreStaleManualReviewExecutionMetrics = hasUnblockedActiveIssueState(contextLines);
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
@@ -520,15 +532,20 @@ export function selectStatusOperatorAction(args: {
       continue;
     }
 
+    const isManualReviewExecutionMetrics =
+      /^execution_metrics\b/.test(line) &&
+      /\bterminal_state=blocked\b/.test(line) &&
+      /\boutcome=blocked\b/.test(line) &&
+      /\breason=manual_review\b/.test(line);
     if (
       /^blocked_partial_work\b/.test(line) ||
       /^tracked_pr_mismatch\b/.test(line) && /\blocal_blocked_reason=manual_review\b/.test(line) ||
       /^pre_merge_evaluation\b/.test(line) && /\bmanual_review=[1-9]\d*\b/.test(line) ||
-      /^execution_metrics\b/.test(line) &&
-        /\bterminal_state=blocked\b/.test(line) &&
-        /\boutcome=blocked\b/.test(line) &&
-        /\breason=manual_review\b/.test(line)
+      isManualReviewExecutionMetrics
     ) {
+      if (isManualReviewExecutionMetrics && ignoreStaleManualReviewExecutionMetrics) {
+        continue;
+      }
       const issueNumber = readIssueNumberToken(line, "issue");
       if (
         issueNumber !== null &&

--- a/src/post-turn-pull-request-local-review.test.ts
+++ b/src/post-turn-pull-request-local-review.test.ts
@@ -1664,6 +1664,113 @@ test("handlePostTurnPullRequestTransitionsPhase reruns local review on a later c
   assert.equal(second.record.pre_merge_evaluation_outcome, "mergeable");
 });
 
+test("handlePostTurnPullRequestTransitionsPhase runs missing local review when only outdated Codex Connector residue remains", async () => {
+  const headSha = "8d811a5efee0f6051c71aa3a256e858821095d2d";
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+  });
+  const issue = createIssue({
+    number: 2235,
+    title: "Align operator actions with preserved Codex Connector churn blocks",
+  });
+  const readyPr = createPullRequest({
+    number: 2238,
+    title: "Fix manual-review operator action for preserved churn blocks",
+    isDraft: false,
+    headRefName: "codex/issue-2235",
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-03T06:18:29Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "58d233bb79c3acb73c7217376a3dfc61a1826224",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const checks: PullRequestCheck[] = [
+    { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+  ];
+  const outdatedCodexThreads = createOutdatedConfiguredBotThreads(
+    ["PRRT_kwDORgvdZ86GpQJi", "PRRT_kwDORgvdZ86GpQJm", "PRRT_kwDORgvdZ86GpWfQ"],
+    readyPr.number,
+  );
+  const record = createRecord({
+    issue_number: issue.number,
+    state: "local_review",
+    branch: "codex/issue-2235",
+    pr_number: readyPr.number,
+    last_head_sha: headSha,
+    local_review_head_sha: null,
+    local_review_run_at: null,
+    last_failure_signature: `local-review-missing:${headSha}`,
+    repeated_failure_signature_count: 2,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issue.number,
+    issues: { [String(issue.number)]: record },
+  };
+  let localReviewCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub(),
+    context: createPostTurnContext({ state, record, issue, workspacePath: "/tmp/workspaces/issue-2235", pr: readyPr }),
+    derivePullRequestLifecycleSnapshot: (currentRecord, pr, currentChecks, reviewThreads) =>
+      createLifecycleSnapshot(
+        currentRecord,
+        inferStateFromPullRequest(config, currentRecord, pr, currentChecks, reviewThreads),
+      ),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: (currentRecord, pr, currentChecks, reviewThreads) =>
+      resolveBlockedReasonFromReviewState(config, currentRecord, pr, currentChecks, reviewThreads),
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runLocalReviewImpl: async () => {
+      localReviewCalls += 1;
+      return createLocalReviewResult({
+        issueNumber: issue.number,
+        headSha,
+        summary: "Local review found no blocking findings.",
+        blockerSummary: "",
+        maxSeverity: "none",
+        recommendation: "ready",
+        finalEvaluation: {
+          outcome: "mergeable",
+          residualFindings: [],
+          mustFixCount: 0,
+          manualReviewCount: 0,
+          followUpCount: 0,
+        },
+      });
+    },
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: readyPr,
+      checks,
+      reviewThreads: outdatedCodexThreads,
+    }),
+  });
+
+  assert.equal(localReviewCalls, 1);
+  assert.equal(result.record.state, "ready_to_merge");
+  assert.equal(result.record.local_review_head_sha, headSha);
+  assert.equal(result.record.pre_merge_evaluation_outcome, "mergeable");
+  assert.equal(result.record.last_failure_signature, null);
+  assert.equal(result.record.repeated_failure_signature_count, 0);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase blocks draft PRs when local review requires manual verification", async () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -46,6 +46,7 @@ import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-revie
 import { hasResolvedAllStaleConfiguredBotThreads } from "./supervisor/stale-review-bot-recovery";
 import { applyTrackedPrLifecycleState } from "./post-turn-pull-request-lifecycle";
 import { maybePromoteDraftPullRequestToReady } from "./post-turn-ready-promotion";
+import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state-codex-residue-policy";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -302,6 +303,22 @@ async function loadOpenPullRequestSnapshot(
   return { pr, checks, reviewThreads };
 }
 
+function hasEffectiveConfiguredBotReviewBlockers(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  return effectiveConfiguredBotReviewThreadsForState(
+    args.config,
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+  ).length > 0;
+}
+
 export async function handlePostTurnPullRequestTransitionsPhase(
   args: HandlePostTurnPullRequestTransitionsArgs,
 ): Promise<PostTurnPullRequestResult> {
@@ -335,7 +352,13 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     (shouldRunLocalReview(config, record, refreshed.pr) || shouldRefreshSameHeadRepairLocalReview) &&
     !refreshedCheckSummary.hasPending &&
     !refreshedCheckSummary.hasFailing &&
-    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
+    !hasEffectiveConfiguredBotReviewBlockers({
+      config,
+      record,
+      pr: refreshed.pr,
+      checks: refreshed.checks,
+      reviewThreads: refreshed.reviewThreads,
+    }) &&
     (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
     !args.mergeConflictDetected(refreshed.pr) &&
     !options.dryRun
@@ -386,7 +409,13 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     refreshed.pr.isDraft &&
     !refreshedCheckSummary.hasPending &&
     !refreshedCheckSummary.hasFailing &&
-    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
+    !hasEffectiveConfiguredBotReviewBlockers({
+      config,
+      record,
+      pr: refreshed.pr,
+      checks: refreshed.checks,
+      reviewThreads: refreshed.reviewThreads,
+    }) &&
     (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
     !args.mergeConflictDetected(refreshed.pr) &&
     !localReviewRequiresManualReview(config, record, refreshed.pr) &&

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildSupervisorDashboardWorkflowSteps } from "./supervisor-dashboard-workflow";
-import { buildRuntimeRecoverySummary } from "./supervisor-status-report";
+import { buildRuntimeRecoverySummary, renderSupervisorStatusDto } from "./supervisor-status-report";
 
 const baseLoopRuntime = {
   state: "off" as const,
@@ -199,6 +199,45 @@ test("buildRuntimeRecoverySummary recommends manual review before restarting clu
         "Clustered Codex Connector churn made no progress; inspect dominant file src/release-readiness.ts with current effective must-fix count 8 before restarting the loop.",
     },
   );
+});
+
+test("renderSupervisorStatusDto keeps stopped clustered Codex churn on manual review", () => {
+  const status = renderSupervisorStatusDto({
+    gsdSummary: null,
+    candidateDiscovery: null,
+    candidateDiscoverySummary: null,
+    loopRuntime: baseLoopRuntime,
+    activeIssue: null,
+    selectionSummary: null,
+    trackedIssues: [
+      {
+        issueNumber: 188,
+        state: "blocked",
+        branch: "codex/issue-188",
+        prNumber: 288,
+        blockedReason: "manual_review",
+      },
+    ],
+    runnableIssues: [],
+    blockedIssues: [],
+    detailedStatusLines: [
+      "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+      "codex_connector_review_churn_progress classification=unchanged current_head_sha=head-current-188 previous_head_sha=head-previous-188 current_effective_must_fix=8 previous_effective_must_fix=8 effective_must_fix_delta=0 dominant_file=src/release-readiness.ts previous_dominant_file=src/release-readiness.ts dominant_file_percent=100 cluster_category_signature=truth_source previous_cluster_category_signature=truth_source representative_threads=thread-authority,thread-truth",
+    ],
+    reconciliationPhase: null,
+    reconciliationWarning: null,
+    readinessLines: [],
+    whyLines: [
+      "loop_runtime_blocker state=off active_tracked_issues=1 first_issue=#188 first_state=blocked first_pr=#288 action=restart_loop restart_reason=recoverable_active_tracked_work_waiting_for_loop expected_outcome=loop_runtime_state_running_then_tracked_issue_advances fallback=if_blocker_remains_run_status_why_and_doctor_then_inspect_runtime_marker_and_config",
+    ],
+    warning: null,
+  });
+
+  assert.match(
+    status,
+    /^operator_action action=manual_review source=codex_connector_review_churn_progress priority=95 /m,
+  );
+  assert.doesNotMatch(status, /^operator_action action=continue /m);
 });
 
 test("buildRuntimeRecoverySummary ignores historical clustered Codex churn while the loop is active", () => {


### PR DESCRIPTION
## Summary
- Treat blocked/manual_review execution metrics as manual-review operator-action evidence.
- Use the same preserved manual-review signal as a stopped clustered Codex churn gate for restart recommendations.
- Add focused regressions for operator-action selection and rendered status output.

## Verification
- rtk npx tsx --test src/operator-actions.test.ts src/supervisor/supervisor-status-report.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
- rtk npm run build

Part of #2235