### PR TITLE
Stop local-review-missing loops for ready tracked PRs

### DIFF
--- a/src/post-turn-pull-request-local-review.test.ts
+++ b/src/post-turn-pull-request-local-review.test.ts
@@ -1664,6 +1664,113 @@ test("handlePostTurnPullRequestTransitionsPhase reruns local review on a later c
   assert.equal(second.record.pre_merge_evaluation_outcome, "mergeable");
 });
 
+test("handlePostTurnPullRequestTransitionsPhase runs missing local review when only outdated Codex Connector residue remains", async () => {
+  const headSha = "8d811a5efee0f6051c71aa3a256e858821095d2d";
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+  });
+  const issue = createIssue({
+    number: 2235,
+    title: "Align operator actions with preserved Codex Connector churn blocks",
+  });
+  const readyPr = createPullRequest({
+    number: 2238,
+    title: "Fix manual-review operator action for preserved churn blocks",
+    isDraft: false,
+    headRefName: "codex/issue-2235",
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-03T06:18:29Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "58d233bb79c3acb73c7217376a3dfc61a1826224",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const checks: PullRequestCheck[] = [
+    { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+  ];
+  const outdatedCodexThreads = createOutdatedConfiguredBotThreads(
+    ["PRRT_kwDORgvdZ86GpQJi", "PRRT_kwDORgvdZ86GpQJm", "PRRT_kwDORgvdZ86GpWfQ"],
+    readyPr.number,
+  );
+  const record = createRecord({
+    issue_number: issue.number,
+    state: "local_review",
+    branch: "codex/issue-2235",
+    pr_number: readyPr.number,
+    last_head_sha: headSha,
+    local_review_head_sha: null,
+    local_review_run_at: null,
+    last_failure_signature: `local-review-missing:${headSha}`,
+    repeated_failure_signature_count: 2,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issue.number,
+    issues: { [String(issue.number)]: record },
+  };
+  let localReviewCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub(),
+    context: createPostTurnContext({ state, record, issue, workspacePath: "/tmp/workspaces/issue-2235", pr: readyPr }),
+    derivePullRequestLifecycleSnapshot: (currentRecord, pr, currentChecks, reviewThreads) =>
+      createLifecycleSnapshot(
+        currentRecord,
+        inferStateFromPullRequest(config, currentRecord, pr, currentChecks, reviewThreads),
+      ),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: (currentRecord, pr, currentChecks, reviewThreads) =>
+      resolveBlockedReasonFromReviewState(config, currentRecord, pr, currentChecks, reviewThreads),
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    runLocalReviewImpl: async () => {
+      localReviewCalls += 1;
+      return createLocalReviewResult({
+        issueNumber: issue.number,
+        headSha,
+        summary: "Local review found no blocking findings.",
+        blockerSummary: "",
+        maxSeverity: "none",
+        recommendation: "ready",
+        finalEvaluation: {
+          outcome: "mergeable",
+          residualFindings: [],
+          mustFixCount: 0,
+          manualReviewCount: 0,
+          followUpCount: 0,
+        },
+      });
+    },
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: readyPr,
+      checks,
+      reviewThreads: outdatedCodexThreads,
+    }),
+  });
+
+  assert.equal(localReviewCalls, 1);
+  assert.equal(result.record.state, "ready_to_merge");
+  assert.equal(result.record.local_review_head_sha, headSha);
+  assert.equal(result.record.pre_merge_evaluation_outcome, "mergeable");
+  assert.equal(result.record.last_failure_signature, null);
+  assert.equal(result.record.repeated_failure_signature_count, 0);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase blocks draft PRs when local review requires manual verification", async () => {
   const config = createConfig({
     localReviewEnabled: true,

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -46,6 +46,7 @@ import { maybeRequestCodexConnectorReviewComment } from "./codex-connector-revie
 import { hasResolvedAllStaleConfiguredBotThreads } from "./supervisor/stale-review-bot-recovery";
 import { applyTrackedPrLifecycleState } from "./post-turn-pull-request-lifecycle";
 import { maybePromoteDraftPullRequestToReady } from "./post-turn-ready-promotion";
+import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state-codex-residue-policy";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -302,6 +303,22 @@ async function loadOpenPullRequestSnapshot(
   return { pr, checks, reviewThreads };
 }
 
+function hasEffectiveConfiguredBotReviewBlockers(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  return effectiveConfiguredBotReviewThreadsForState(
+    args.config,
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+  ).length > 0;
+}
+
 export async function handlePostTurnPullRequestTransitionsPhase(
   args: HandlePostTurnPullRequestTransitionsArgs,
 ): Promise<PostTurnPullRequestResult> {
@@ -335,7 +352,13 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     (shouldRunLocalReview(config, record, refreshed.pr) || shouldRefreshSameHeadRepairLocalReview) &&
     !refreshedCheckSummary.hasPending &&
     !refreshedCheckSummary.hasFailing &&
-    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
+    !hasEffectiveConfiguredBotReviewBlockers({
+      config,
+      record,
+      pr: refreshed.pr,
+      checks: refreshed.checks,
+      reviewThreads: refreshed.reviewThreads,
+    }) &&
     (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
     !args.mergeConflictDetected(refreshed.pr) &&
     !options.dryRun
@@ -386,7 +409,13 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     refreshed.pr.isDraft &&
     !refreshedCheckSummary.hasPending &&
     !refreshedCheckSummary.hasFailing &&
-    args.configuredBotReviewThreads(config, refreshed.reviewThreads).length === 0 &&
+    !hasEffectiveConfiguredBotReviewBlockers({
+      config,
+      record,
+      pr: refreshed.pr,
+      checks: refreshed.checks,
+      reviewThreads: refreshed.reviewThreads,
+    }) &&
     (!config.humanReviewBlocksMerge || args.manualReviewThreads(config, refreshed.reviewThreads).length === 0) &&
     !args.mergeConflictDetected(refreshed.pr) &&
     !localReviewRequiresManualReview(config, record, refreshed.pr) &&


### PR DESCRIPTION
## Summary
- Let post-turn local-review and draft-ready promotion use the same effective Codex Connector residue policy as PR lifecycle/convergence.
- Prevent ready tracked PRs from looping on `local-review-missing:<head>` when only outdated Codex Connector review residue remains.
- Add a regression test for the PR #2238/#2235 shape: clean current-head success evidence plus outdated unresolved bot threads.

## Root Cause
The post-turn local-review entrance still checked raw configured-bot review threads. That raw check counted outdated Codex Connector residue that the lifecycle/convergence path already treats as non-blocking once current-head success evidence exists, so ready PRs could stay stuck in local-review recovery instead of running the missing local review.

## Stack
- Stacked on #2238 (`codex/issue-2235`) to avoid conflicts with the operator-action work.
- Addresses #2239.

## Verification
- `npx tsx --test src/post-turn-pull-request-local-review.test.ts`
- `npx tsx --test src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts`
- `npm run build`
- `git diff --check`

Known local validation note:
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts` still fails in the pre-existing unrelated fixture path `runOnce clears a stale interrupted-turn marker when the journal changed after the turn began` with `Workspace path exists but is not a git worktree: .../workspaces/issue-91`. This is outside this diff; the focused regression and affected diagnostics pass.
