### PR TITLE
Post comment for clustered Codex churn stops

### DIFF
--- a/src/post-turn-pull-request-tracked-status.test.ts
+++ b/src/post-turn-pull-request-tracked-status.test.ts
@@ -484,6 +484,112 @@ test("syncTrackedPrPersistentStatusComment comments with clustered Codex churn e
   );
 });
 
+test("syncTrackedPrPersistentStatusComment skips clustered Codex churn comments from stale snapshot heads", async () => {
+  const config = createConfig({
+    configuredReviewProviders: [
+      {
+        kind: "codex",
+        reviewerLogins: ["chatgpt-codex-connector[bot]"],
+        signalSource: "review_threads",
+      },
+    ],
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const pr = createPullRequest({
+    number: 116,
+    title: "Clustered Connector churn repair",
+    isDraft: false,
+    headRefOid: "head-current-1390",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-current-0",
+      path: "src/release-readiness.ts",
+      line: 130,
+      comments: {
+        nodes: [
+          {
+            id: "comment-current-0",
+            body: "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+            createdAt: "2026-03-10T23:20:00Z",
+            url: "https://example.test/pr/1390#discussion_current_0",
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+  const record = createRecord({
+    issue_number: 102,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: pr.number,
+    last_head_sha: pr.headRefOid,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_tracked_pr_progress_summary: "no_progress_clustered_codex_churn current_effective_must_fix=5",
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-previous-1390",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      checks: ["build:pass:SUCCESS:CI"],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: "head-previous-1390",
+        currentEffectiveMustFixCount: 5,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "readiness_claim+truth_source+verifier_or_issue_lint",
+        representativeThreadIds: ["thread-current-0"],
+      },
+      codexConnectorReviewChurnComparison: {
+        classification: "unchanged",
+        currentHeadSha: "head-previous-1390",
+        previousHeadSha: "head-previous-1389",
+        currentEffectiveMustFixCount: 5,
+        previousEffectiveMustFixCount: 5,
+        effectiveMustFixDelta: 0,
+      },
+    }),
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: { "102": record },
+  };
+  const commentBodies: string[] = [];
+
+  const result = await syncTrackedPrPersistentStatusComment({
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    stateStore: createNoopStateStore(),
+    state,
+    record,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    syncJournal: async () => undefined,
+    config,
+    failureContext: {
+      category: "review",
+      summary: "Clustered Codex Connector churn made no progress.",
+      signature: "codex-review-churn:P2:src/release-readiness.ts",
+      command: null,
+      details: ["stale churn snapshot should not publish current-head evidence"],
+      url: null,
+      updated_at: "2026-03-10T23:20:00Z",
+    },
+    summarizeChecks,
+    manualReviewThreadCount: 0,
+    skipAutoHandleStaleConfiguredBotReview: true,
+  });
+
+  assert.deepEqual(commentBodies, []);
+  assert.equal(result.last_host_local_pr_blocker_comment_head_sha, null);
+  assert.equal(result.last_host_local_pr_blocker_comment_signature, null);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays blocked on stale configured-bot review state near merge", async () => {
   const { config, context, pr, failureContext } = createStaleConfiguredBotBlockerScenario();
   const commentBodies: string[] = [];

--- a/src/post-turn-pull-request-tracked-status.test.ts
+++ b/src/post-turn-pull-request-tracked-status.test.ts
@@ -590,6 +590,136 @@ test("syncTrackedPrPersistentStatusComment skips clustered Codex churn comments 
   assert.equal(result.last_host_local_pr_blocker_comment_signature, null);
 });
 
+test("syncTrackedPrPersistentStatusComment rejects clustered Codex churn snapshots with mixed heads", async () => {
+  const config = createConfig({
+    configuredReviewProviders: [
+      {
+        kind: "codex",
+        reviewerLogins: ["chatgpt-codex-connector[bot]"],
+        signalSource: "review_threads",
+      },
+    ],
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const pr = createPullRequest({
+    number: 116,
+    title: "Clustered Connector churn repair",
+    isDraft: false,
+    headRefOid: "head-current-1390",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-current-0",
+      path: "src/release-readiness.ts",
+      line: 130,
+      comments: {
+        nodes: [
+          {
+            id: "comment-current-0",
+            body: "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+            createdAt: "2026-03-10T23:20:00Z",
+            url: "https://example.test/pr/1390#discussion_current_0",
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+
+  for (const scenario of [
+    {
+      name: "stale snapshot head with current progress head",
+      snapshotHeadSha: "head-previous-1390",
+      progressHeadSha: pr.headRefOid,
+    },
+    {
+      name: "current snapshot head with stale progress head",
+      snapshotHeadSha: pr.headRefOid,
+      progressHeadSha: "head-previous-1390",
+    },
+    {
+      name: "missing persisted heads",
+      snapshotHeadSha: null,
+      progressHeadSha: null,
+    },
+  ]) {
+    const snapshot: Record<string, unknown> = {
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      checks: ["build:pass:SUCCESS:CI"],
+      codexConnectorReviewChurnProgress: {
+        currentEffectiveMustFixCount: 5,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "readiness_claim+truth_source+verifier_or_issue_lint",
+        representativeThreadIds: ["thread-current-0"],
+      },
+      codexConnectorReviewChurnComparison: {
+        classification: "unchanged",
+        previousHeadSha: "head-previous-1389",
+        currentEffectiveMustFixCount: 5,
+        previousEffectiveMustFixCount: 5,
+        effectiveMustFixDelta: 0,
+      },
+    };
+    if (scenario.snapshotHeadSha) {
+      snapshot.headRefOid = scenario.snapshotHeadSha;
+    }
+    if (scenario.progressHeadSha) {
+      (snapshot.codexConnectorReviewChurnProgress as Record<string, unknown>).currentHeadSha = scenario.progressHeadSha;
+      (snapshot.codexConnectorReviewChurnComparison as Record<string, unknown>).currentHeadSha = scenario.progressHeadSha;
+    }
+    const record = createRecord({
+      issue_number: 102,
+      state: "blocked",
+      blocked_reason: "manual_review",
+      pr_number: pr.number,
+      last_head_sha: pr.headRefOid,
+      last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      last_tracked_pr_progress_summary: "no_progress_clustered_codex_churn current_effective_must_fix=5",
+      last_tracked_pr_progress_snapshot: JSON.stringify(snapshot),
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: null,
+      issues: { "102": record },
+    };
+    const commentBodies: string[] = [];
+
+    const result = await syncTrackedPrPersistentStatusComment({
+      github: createDefaultGithub({
+        addIssueComment: async (_prNumber: number, body: string) => {
+          commentBodies.push(body);
+        },
+      }),
+      stateStore: createNoopStateStore(),
+      state,
+      record,
+      pr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads,
+      syncJournal: async () => undefined,
+      config,
+      failureContext: {
+        category: "review",
+        summary: `Clustered Codex Connector churn made no progress: ${scenario.name}.`,
+        signature: "codex-review-churn:P2:src/release-readiness.ts",
+        command: null,
+        details: ["mixed or missing churn snapshot heads should not publish current-head evidence"],
+        url: null,
+        updated_at: "2026-03-10T23:20:00Z",
+      },
+      summarizeChecks,
+      manualReviewThreadCount: 0,
+      skipAutoHandleStaleConfiguredBotReview: true,
+    });
+
+    assert.deepEqual(commentBodies, [], scenario.name);
+    assert.equal(result.last_host_local_pr_blocker_comment_head_sha, null, scenario.name);
+    assert.equal(result.last_host_local_pr_blocker_comment_signature, null, scenario.name);
+  }
+});
+
 test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays blocked on stale configured-bot review state near merge", async () => {
   const { config, context, pr, failureContext } = createStaleConfiguredBotBlockerScenario();
   const commentBodies: string[] = [];

--- a/src/post-turn-pull-request-tracked-status.test.ts
+++ b/src/post-turn-pull-request-tracked-status.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { handlePostTurnPullRequestTransitionsPhase, type PullRequestLifecycleSnapshot } from "./post-turn-pull-request";
+import { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 import { IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorStateFile } from "./core/types";
 import { blockedReasonFromReviewState as resolveBlockedReasonFromReviewState, inferStateFromPullRequest } from "./pull-request-state";
 import { derivePullRequestLifecycleSnapshot as deriveSupervisorPullRequestLifecycleSnapshot } from "./supervisor/supervisor-lifecycle";
@@ -338,6 +339,149 @@ test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays
   assert.match(commentBodies[0] ?? "", /reason code: `manual_review`/i);
   assert.match(commentBodies[0] ?? "", /require human attention/i);
   assert.match(commentBodies[0] ?? "", /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/);
+});
+
+test("syncTrackedPrPersistentStatusComment comments with clustered Codex churn evidence when manual-review stop fires", async () => {
+  const config = createConfig({
+    configuredReviewProviders: [
+      {
+        kind: "codex",
+        reviewerLogins: ["chatgpt-codex-connector[bot]"],
+        signalSource: "review_threads",
+      },
+    ],
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+  });
+  const pr = createPullRequest({
+    number: 116,
+    title: "Clustered Connector churn repair",
+    isDraft: false,
+    headRefOid: "head-current-1390",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads = Array.from({ length: 2 }, (_, index) =>
+    createReviewThread({
+      id: `thread-current-${index}`,
+      path: "src/release-readiness.ts",
+      line: 130 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-current-${index}`,
+            body: "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+            createdAt: "2026-03-10T23:20:00Z",
+            url: `https://example.test/pr/1390#discussion_current_${index}`,
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  );
+  const record = createRecord({
+    issue_number: 102,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: pr.number,
+    last_head_sha: pr.headRefOid,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_tracked_pr_progress_summary: "no_progress_clustered_codex_churn current_effective_must_fix=5",
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: pr.headRefOid,
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-03-10T23:20:00Z",
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: "2026-03-10T23:18:00Z",
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewSubmittedAt: "2026-03-10T23:20:00Z",
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-current-0", "thread-current-1"],
+      unresolvedReviewThreadFingerprints: ["thread-current-0#comment-current-0", "thread-current-1#comment-current-1"],
+      unresolvedReviewThreadSourceAnchors: [
+        "thread-current-0:src/release-readiness.ts:130",
+        "thread-current-1:src/release-readiness.ts:131",
+      ],
+      processedReviewThreadIds: [],
+      processedReviewThreadFingerprints: [],
+      verificationProbeOutcomes: [],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: pr.headRefOid,
+        currentEffectiveMustFixCount: 5,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "readiness_claim+truth_source+verifier_or_issue_lint",
+        representativeThreadIds: ["thread-current-0", "thread-current-1"],
+      },
+      codexConnectorReviewChurnComparison: {
+        classification: "worse",
+        currentHeadSha: pr.headRefOid,
+        previousHeadSha: "head-previous-1390",
+        currentEffectiveMustFixCount: 5,
+        previousEffectiveMustFixCount: 4,
+        effectiveMustFixDelta: 1,
+      },
+    }),
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: { "102": record },
+  };
+  const commentBodies: string[] = [];
+
+  const result = await syncTrackedPrPersistentStatusComment({
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        commentBodies.push(body);
+      },
+    }),
+    stateStore: createNoopStateStore(),
+    state,
+    record,
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    syncJournal: async () => undefined,
+    config,
+    failureContext: {
+      category: "review",
+      summary: "Clustered Codex Connector churn made no progress.",
+      signature: "codex-review-churn:P2:src/release-readiness.ts",
+      command: null,
+      details: [],
+      url: null,
+      updated_at: "2026-03-10T23:20:00Z",
+    },
+    summarizeChecks,
+    manualReviewThreadCount: 0,
+    skipAutoHandleStaleConfiguredBotReview: true,
+  });
+
+  assert.equal(commentBodies.length, 1);
+  assert.match(commentBodies[0] ?? "", /reason code: `codex_connector_churn`/);
+  assert.match(commentBodies[0] ?? "", /current PR head: `head-current-1390`/);
+  assert.match(commentBodies[0] ?? "", /dominant file: `src\/release-readiness\.ts`/);
+  assert.match(commentBodies[0] ?? "", /effective must-fix count: `5`/);
+  assert.match(commentBodies[0] ?? "", /count trend: `worse`/);
+  assert.match(
+    commentBodies[0] ?? "",
+    /normalized category signature: `readiness_claim\+truth_source\+verifier_or_issue_lint`/,
+  );
+  assert.match(commentBodies[0] ?? "", /https:\/\/example\.test\/pr\/1390#discussion_current_0/);
+  assert.match(commentBodies[0] ?? "", /manual.*before restarting the supervisor/i);
+  assert.match(
+    commentBodies[0] ?? "",
+    /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/,
+  );
+  assert.equal(result.last_host_local_pr_blocker_comment_head_sha, pr.headRefOid);
+  assert.equal(
+    result.last_host_local_pr_blocker_comment_signature,
+    "codex_connector_churn:head-current-1390:src/release-readiness.ts:5:worse:readiness_claim+truth_source+verifier_or_issue_lint:thread-current-0,thread-current-1",
+  );
 });
 
 test("handlePostTurnPullRequestTransitionsPhase comments when a tracked PR stays blocked on stale configured-bot review state near merge", async () => {

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -25,6 +25,8 @@ import {
   buildCodexConnectorReviewChurnDiagnostic,
   buildCodexConnectorReviewChurnProgressSummary,
   clusterConfiguredBotReviewThreads,
+  compareCodexConnectorReviewChurnProgress,
+  type CodexConnectorReviewChurnProgressComparison,
   type CodexConnectorReviewChurnProgressSummary,
 } from "../codex-connector-review-policy";
 import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
@@ -130,6 +132,7 @@ interface TrackedPrProgressSnapshot {
   processedReviewThreadFingerprints?: string[];
   verificationProbeOutcomes?: string[];
   codexConnectorReviewChurnProgress?: CodexConnectorReviewChurnProgressSummary;
+  codexConnectorReviewChurnComparison?: CodexConnectorReviewChurnProgressComparison;
 }
 
 export interface TrackedPrRepeatFailureDisposition {
@@ -410,9 +413,22 @@ export function summarizeTrackedPrProgress(
   const current = buildTrackedPrProgressSnapshot(record, config, pr, checks, reviewThreads);
   const previous = parseTrackedPrProgressSnapshot(record.last_tracked_pr_progress_snapshot);
   const signals = listChangedSignals(previous, current);
+  const churnComparison =
+    current.codexConnectorReviewChurnProgress && previous?.codexConnectorReviewChurnProgress
+      ? compareCodexConnectorReviewChurnProgress(
+          current.codexConnectorReviewChurnProgress,
+          previous.codexConnectorReviewChurnProgress,
+        )
+      : null;
+  const snapshot = churnComparison
+    ? JSON.stringify({
+        ...current,
+        codexConnectorReviewChurnComparison: churnComparison,
+      })
+    : JSON.stringify(current);
 
   return {
-    snapshot: JSON.stringify(current),
+    snapshot,
     summary: signals.length > 0 ? signals.join(" | ") : null,
   };
 }

--- a/src/tracked-pr-status-comment-rendering.ts
+++ b/src/tracked-pr-status-comment-rendering.ts
@@ -14,6 +14,7 @@ export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_REQUIRED_CHECK_MISMATCH = "re
 export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CONVERSATION_RESOLUTION_BLOCKED =
   "conversation_resolution_blocked";
 export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_TRACKED_LIFECYCLE_MISMATCH = "tracked_lifecycle_mismatch";
+export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CODEX_CONNECTOR_CHURN = "codex_connector_churn";
 export const TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED = "cleared";
 
 export function workspacePreparationFailureClass(
@@ -238,6 +239,29 @@ export function buildTrackedPrPersistentStatusComment(args: {
     ...args.evidence.map((detail) => `- evidence: ${detail}`),
     `- automatic retry: ${args.automaticRetry}`,
     `- next action: ${args.nextAction}`,
+  ].join("\n");
+}
+
+export function buildTrackedPrCodexConnectorChurnStatusComment(args: {
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  dominantFile: string;
+  currentEffectiveMustFixCount: number | string;
+  countTrend: string;
+  clusterCategorySignature: string;
+  representativeThreadUrls: string[];
+}): string {
+  return [
+    `Tracked PR head \`${args.pr.headRefOid}\` stopped because clustered Codex Connector review churn did not converge.`,
+    "",
+    `- current PR head: \`${args.pr.headRefOid}\``,
+    `- reason code: \`${TRACKED_PR_STATUS_COMMENT_REASON_CODE_CODEX_CONNECTOR_CHURN}\``,
+    `- dominant file: \`${args.dominantFile}\``,
+    `- effective must-fix count: \`${args.currentEffectiveMustFixCount}\``,
+    `- count trend: \`${args.countTrend}\``,
+    `- normalized category signature: \`${args.clusterCategorySignature}\``,
+    ...args.representativeThreadUrls.map((url) => `- representative thread: ${url}`),
+    "- automatic retry: no",
+    "- next action: manually inspect the dominant file and representative Codex Connector threads before restarting the supervisor.",
   ].join("\n");
 }
 

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -21,6 +21,7 @@ import { displayRelativeArtifactPath } from "./supervisor/supervisor-status-summ
 import { publishTrackedPrStatusComment } from "./tracked-pr-status-comment-publisher";
 import {
   buildTrackedPrClearedStatusComment,
+  buildTrackedPrCodexConnectorChurnStatusComment,
   buildTrackedPrDraftReviewSuppressedComment,
   buildTrackedPrHostLocalBlockerComment,
   buildTrackedPrManualReviewStatusComment,
@@ -30,6 +31,7 @@ import {
   isTrackedPrActiveStatusState,
   TRACKED_PR_STATUS_COMMENT_REASON_CODE_DRAFT_REVIEW_PROVIDER_SUPPRESSED,
   TRACKED_PR_STATUS_COMMENT_REASON_CODE_CLEARED,
+  TRACKED_PR_STATUS_COMMENT_REASON_CODE_CODEX_CONNECTOR_CHURN,
   TRACKED_PR_STATUS_COMMENT_REASON_CODE_CONVERSATION_RESOLUTION_BLOCKED,
   TRACKED_PR_STATUS_COMMENT_REASON_CODE_HANDOFF_MISSING,
   TRACKED_PR_STATUS_COMMENT_REASON_CODE_MANUAL_REVIEW,
@@ -87,6 +89,83 @@ interface PersistentTrackedPrStatusCommentContext {
 type PersistentTrackedPrStatusCommentStrategy = (
   args: PersistentTrackedPrStatusCommentContext,
 ) => PersistentTrackedPrStatusComment | null;
+
+interface TrackedPrCodexConnectorChurnProgress {
+  currentEffectiveMustFixCount: number;
+  dominantFile: string;
+  clusterCategorySignature: string;
+  representativeThreadIds: string[];
+}
+
+interface TrackedPrCodexConnectorChurnComparison {
+  classification: "improving" | "unchanged" | "worse";
+}
+
+function parseTrackedPrCodexConnectorChurnSnapshot(
+  snapshot: string | null | undefined,
+): {
+  progress: TrackedPrCodexConnectorChurnProgress;
+  comparison: TrackedPrCodexConnectorChurnComparison | null;
+} | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(snapshot) as {
+      codexConnectorReviewChurnProgress?: Partial<TrackedPrCodexConnectorChurnProgress>;
+      codexConnectorReviewChurnComparison?: Partial<TrackedPrCodexConnectorChurnComparison>;
+    };
+    const progress = parsed.codexConnectorReviewChurnProgress;
+    if (
+      !progress ||
+      typeof progress.currentEffectiveMustFixCount !== "number" ||
+      typeof progress.dominantFile !== "string" ||
+      typeof progress.clusterCategorySignature !== "string" ||
+      !Array.isArray(progress.representativeThreadIds) ||
+      !progress.representativeThreadIds.every((id) => typeof id === "string")
+    ) {
+      return null;
+    }
+
+    const comparison =
+      parsed.codexConnectorReviewChurnComparison?.classification === "unchanged" ||
+      parsed.codexConnectorReviewChurnComparison?.classification === "worse"
+        ? { classification: parsed.codexConnectorReviewChurnComparison.classification }
+        : null;
+    return {
+      progress: {
+        currentEffectiveMustFixCount: progress.currentEffectiveMustFixCount,
+        dominantFile: progress.dominantFile,
+        clusterCategorySignature: progress.clusterCategorySignature,
+        representativeThreadIds: progress.representativeThreadIds,
+      },
+      comparison,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function latestReviewThreadUrl(thread: ReviewThread): string | null {
+  const latestComment = thread.comments.nodes.at(-1);
+  return typeof latestComment?.url === "string" && latestComment.url.length > 0 ? latestComment.url : null;
+}
+
+function representativeReviewThreadUrls(reviewThreads: ReviewThread[], representativeThreadIds: string[]): string[] {
+  const urls: string[] = [];
+  const ids = new Set(representativeThreadIds);
+  for (const thread of reviewThreads) {
+    if (!ids.has(thread.id)) {
+      continue;
+    }
+    const url = latestReviewThreadUrl(thread);
+    if (url && !urls.includes(url)) {
+      urls.push(url);
+    }
+  }
+  return urls;
+}
 
 function currentHeadManualReviewStatusComment(args: {
   config: SupervisorConfig;
@@ -247,6 +326,52 @@ function manualReviewStatusComment(
   };
 }
 
+function codexConnectorChurnStatusComment(
+  args: PersistentTrackedPrStatusCommentContext,
+): PersistentTrackedPrStatusComment | null {
+  if (args.record.state !== "blocked" || args.record.blocked_reason !== "manual_review") {
+    return null;
+  }
+  if (
+    args.record.last_tracked_pr_repeat_failure_decision !== "stop_no_progress" ||
+    !args.record.last_tracked_pr_progress_summary?.startsWith("no_progress_clustered_codex_churn ")
+  ) {
+    return null;
+  }
+
+  const churnSnapshot = parseTrackedPrCodexConnectorChurnSnapshot(args.record.last_tracked_pr_progress_snapshot);
+  if (!churnSnapshot) {
+    return null;
+  }
+
+  const representativeThreadUrls = representativeReviewThreadUrls(
+    args.reviewThreads,
+    churnSnapshot.progress.representativeThreadIds,
+  );
+  const countTrend = churnSnapshot.comparison?.classification ?? "unchanged_or_increased";
+  const blockerSignature = [
+    TRACKED_PR_STATUS_COMMENT_REASON_CODE_CODEX_CONNECTOR_CHURN,
+    args.pr.headRefOid,
+    churnSnapshot.progress.dominantFile,
+    churnSnapshot.progress.currentEffectiveMustFixCount,
+    countTrend,
+    churnSnapshot.progress.clusterCategorySignature,
+    churnSnapshot.progress.representativeThreadIds.join(","),
+  ].join(":");
+
+  return {
+    blockerSignature,
+    body: buildTrackedPrCodexConnectorChurnStatusComment({
+      pr: args.pr,
+      dominantFile: churnSnapshot.progress.dominantFile,
+      currentEffectiveMustFixCount: churnSnapshot.progress.currentEffectiveMustFixCount,
+      countTrend,
+      clusterCategorySignature: churnSnapshot.progress.clusterCategorySignature,
+      representativeThreadUrls,
+    }),
+  };
+}
+
 function staleReviewBotStatusComment(
   args: PersistentTrackedPrStatusCommentContext,
 ): PersistentTrackedPrStatusComment | null {
@@ -359,6 +484,7 @@ function requiredCheckMismatchStatusComment(
 
 const persistentTrackedPrStatusCommentStrategies: PersistentTrackedPrStatusCommentStrategy[] = [
   handoffMissingStatusComment,
+  codexConnectorChurnStatusComment,
   manualReviewStatusComment,
   staleReviewBotStatusComment,
   trackedLifecycleMismatchStatusComment,

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -91,6 +91,7 @@ type PersistentTrackedPrStatusCommentStrategy = (
 ) => PersistentTrackedPrStatusComment | null;
 
 interface TrackedPrCodexConnectorChurnProgress {
+  currentHeadSha?: string;
   currentEffectiveMustFixCount: number;
   dominantFile: string;
   clusterCategorySignature: string;
@@ -104,6 +105,8 @@ interface TrackedPrCodexConnectorChurnComparison {
 function parseTrackedPrCodexConnectorChurnSnapshot(
   snapshot: string | null | undefined,
 ): {
+  snapshotHeadSha: string | null;
+  progressHeadSha: string | null;
   progress: TrackedPrCodexConnectorChurnProgress;
   comparison: TrackedPrCodexConnectorChurnComparison | null;
 } | null {
@@ -113,6 +116,7 @@ function parseTrackedPrCodexConnectorChurnSnapshot(
 
   try {
     const parsed = JSON.parse(snapshot) as {
+      headRefOid?: unknown;
       codexConnectorReviewChurnProgress?: Partial<TrackedPrCodexConnectorChurnProgress>;
       codexConnectorReviewChurnComparison?: Partial<TrackedPrCodexConnectorChurnComparison>;
     };
@@ -128,13 +132,22 @@ function parseTrackedPrCodexConnectorChurnSnapshot(
       return null;
     }
 
+    const snapshotHeadSha =
+      typeof parsed.headRefOid === "string" && parsed.headRefOid.length > 0 ? parsed.headRefOid : null;
+    const progressHeadSha =
+      typeof progress.currentHeadSha === "string" && progress.currentHeadSha.length > 0
+        ? progress.currentHeadSha
+        : null;
     const comparison =
       parsed.codexConnectorReviewChurnComparison?.classification === "unchanged" ||
       parsed.codexConnectorReviewChurnComparison?.classification === "worse"
         ? { classification: parsed.codexConnectorReviewChurnComparison.classification }
         : null;
     return {
+      snapshotHeadSha,
+      progressHeadSha,
       progress: {
+        ...(progressHeadSha ? { currentHeadSha: progressHeadSha } : {}),
         currentEffectiveMustFixCount: progress.currentEffectiveMustFixCount,
         dominantFile: progress.dominantFile,
         clusterCategorySignature: progress.clusterCategorySignature,
@@ -145,6 +158,26 @@ function parseTrackedPrCodexConnectorChurnSnapshot(
   } catch {
     return null;
   }
+}
+
+function isCodexConnectorChurnStopRecord(record: IssueRunRecord): boolean {
+  return (
+    record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+    record.last_tracked_pr_progress_summary?.startsWith("no_progress_clustered_codex_churn ") === true
+  );
+}
+
+function codexConnectorChurnSnapshotMatchesHead(
+  snapshot: {
+    snapshotHeadSha: string | null;
+    progressHeadSha: string | null;
+  },
+  headRefOid: string,
+): boolean {
+  const observedHeadShas = [snapshot.snapshotHeadSha, snapshot.progressHeadSha].filter(
+    (headSha): headSha is string => headSha !== null,
+  );
+  return observedHeadShas.length > 0 && observedHeadShas.every((headSha) => headSha === headRefOid);
 }
 
 function latestReviewThreadUrl(thread: ReviewThread): string | null {
@@ -309,6 +342,9 @@ function manualReviewStatusComment(
   if (args.record.state !== "blocked" || args.record.blocked_reason !== "manual_review") {
     return null;
   }
+  if (isCodexConnectorChurnStopRecord(args.record)) {
+    return null;
+  }
 
   const summary =
     args.failureContext?.summary ?? "Unresolved manual or unconfigured review feedback still requires human attention.";
@@ -332,15 +368,12 @@ function codexConnectorChurnStatusComment(
   if (args.record.state !== "blocked" || args.record.blocked_reason !== "manual_review") {
     return null;
   }
-  if (
-    args.record.last_tracked_pr_repeat_failure_decision !== "stop_no_progress" ||
-    !args.record.last_tracked_pr_progress_summary?.startsWith("no_progress_clustered_codex_churn ")
-  ) {
+  if (!isCodexConnectorChurnStopRecord(args.record)) {
     return null;
   }
 
   const churnSnapshot = parseTrackedPrCodexConnectorChurnSnapshot(args.record.last_tracked_pr_progress_snapshot);
-  if (!churnSnapshot) {
+  if (!churnSnapshot || !codexConnectorChurnSnapshotMatchesHead(churnSnapshot, args.pr.headRefOid)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- post a churn-specific sticky tracked PR status comment when clustered Codex Connector churn stops for manual review
- carry the churn comparison in the persisted tracked PR progress snapshot
- cover the comment evidence at the sticky status sync boundary

## Verification
- npx tsx --test src/post-turn-pull-request-tracked-status.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
- npm run build

Closes #2243