### PR TITLE
[codex] Fix stale interrupted marker test fixture

### DIFF
--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -4006,7 +4006,6 @@ test("runOnce clears a stale interrupted-turn marker when the journal changed af
   const interruptedIssueNumber = 91;
   const nextIssueNumber = 92;
   const interruptedBranch = branchName(fixture.config, interruptedIssueNumber);
-  const nextBranch = branchName(fixture.config, nextIssueNumber);
   const interruptedWorkspace = path.join(fixture.workspaceRoot, `issue-${interruptedIssueNumber}`);
   const interruptedJournalPath = path.join(interruptedWorkspace, ".codex-supervisor", "issue-journal.md");
   const state: SupervisorStateFile = {
@@ -4092,10 +4091,10 @@ test("runOnce clears a stale interrupted-turn marker when the journal changed af
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [nextIssue, interruptedIssue],
-    listCandidateIssues: async () => [nextIssue],
+    listCandidateIssues: async () => [nextIssue, interruptedIssue],
     getIssue: async (issueNumber: number) => (issueNumber === nextIssueNumber ? nextIssue : interruptedIssue),
     resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
-      assert.equal(branchName, nextBranch);
+      assert.equal(branchName, interruptedBranch);
       assert.equal(prNumber, null);
       return null;
     },
@@ -4117,12 +4116,13 @@ test("runOnce clears a stale interrupted-turn marker when the journal changed af
     /recovery issue=#91 reason=stale_state_cleanup: cleared stale active reservation after issue lock and session lock were missing/,
   );
   assert.doesNotMatch(message, /interrupted_turn_recovery/);
-  assert.match(message, /Dry run: would invoke Codex for issue #92\./);
+  assert.match(message, /Dry run: would invoke Codex for issue #91\./);
+  assert.doesNotMatch(message, /Dry run: would invoke Codex for issue #92\./);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const interruptedRecord = persisted.issues[String(interruptedIssueNumber)]!;
-  assert.equal(persisted.activeIssueNumber, nextIssueNumber);
-  assert.equal(interruptedRecord.state, "implementing");
+  assert.equal(persisted.activeIssueNumber, interruptedIssueNumber);
+  assert.equal(interruptedRecord.state, "stabilizing");
   assert.equal(interruptedRecord.codex_session_id, null);
   assert.equal(interruptedRecord.blocked_reason, null);
   assert.equal(interruptedRecord.last_error, null);

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -4030,6 +4030,12 @@ test("runOnce clears a stale interrupted-turn marker when the journal changed af
     },
   };
   await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  const preparedInterruptedWorkspace = await ensureWorkspace(
+    fixture.config,
+    interruptedIssueNumber,
+    interruptedBranch,
+  );
+  assert.equal(preparedInterruptedWorkspace.workspacePath, interruptedWorkspace);
   await fs.mkdir(path.dirname(interruptedJournalPath), { recursive: true });
   await fs.writeFile(interruptedJournalPath, "# issue journal\n", "utf8");
   const initialJournalFingerprint = await captureIssueJournalFingerprint(interruptedJournalPath);
@@ -4086,7 +4092,7 @@ test("runOnce clears a stale interrupted-turn marker when the journal changed af
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [nextIssue, interruptedIssue],
-    listCandidateIssues: async () => [nextIssue, interruptedIssue],
+    listCandidateIssues: async () => [nextIssue],
     getIssue: async (issueNumber: number) => (issueNumber === nextIssueNumber ? nextIssue : interruptedIssue),
     resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
       assert.equal(branchName, nextBranch);


### PR DESCRIPTION
## Summary
- create the interrupted issue worktree before writing the stale marker test journal and marker
- keep issue #91 visible to recovery while only advertising issue #92 as the next runnable candidate

## Root cause
The focused interrupted-turn marker test wrote files under `workspaces/issue-91` before preparing a linked git worktree. The later real `ensureWorkspace` call correctly rejected that existing non-worktree directory.

## Verification
- `npx tsx --test --test-name-pattern "runOnce clears a stale interrupted-turn marker" src/supervisor/supervisor-execution-orchestration.test.ts`
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`
- `npm run build`

Fixes #2246