### PR TITLE
Track Codex Connector same-file churn history

### DIFF
--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -177,6 +177,23 @@ export interface CodexConnectorReviewChurnProgressSummary {
   representativeThreadIds: string[];
 }
 
+export interface CodexConnectorReviewChurnHistoryEntry {
+  reviewedHeadSha: string;
+  effectiveMustFixCount: number;
+  dominantFile: string;
+  clusterCategorySignature: string;
+  representativeThreadIds: string[];
+}
+
+export interface CodexConnectorStableSameFileChurn {
+  streak: number;
+  dominantFile: string;
+  clusterCategorySignature: string;
+  currentEffectiveMustFixCount: number;
+  reviewedHeadShas: string[];
+  representativeThreadIds: string[];
+}
+
 export type CodexConnectorReviewChurnProgressClassification = "improving" | "unchanged" | "worse";
 
 export interface CodexConnectorReviewChurnProgressComparison {
@@ -777,6 +794,99 @@ export function compareCodexConnectorReviewChurnProgress(
     currentEffectiveMustFixCount: current.currentEffectiveMustFixCount,
     previousEffectiveMustFixCount: previous.currentEffectiveMustFixCount,
     effectiveMustFixDelta,
+  };
+}
+
+const CODEX_CONNECTOR_REVIEW_CHURN_HISTORY_LIMIT = 5;
+const CODEX_CONNECTOR_STABLE_SAME_FILE_CHURN_MIN_STREAK = 3;
+
+function codexConnectorReviewChurnHistoryEntry(
+  progress: CodexConnectorReviewChurnProgressSummary,
+): CodexConnectorReviewChurnHistoryEntry {
+  return {
+    reviewedHeadSha: progress.currentHeadSha,
+    effectiveMustFixCount: progress.currentEffectiveMustFixCount,
+    dominantFile: progress.dominantFile,
+    clusterCategorySignature: progress.clusterCategorySignature,
+    representativeThreadIds: progress.representativeThreadIds,
+  };
+}
+
+function sameFileCategoryAndFlatOrWorse(
+  previous: CodexConnectorReviewChurnHistoryEntry,
+  current: CodexConnectorReviewChurnHistoryEntry,
+): boolean {
+  return (
+    previous.dominantFile === current.dominantFile &&
+    previous.clusterCategorySignature === current.clusterCategorySignature &&
+    current.effectiveMustFixCount >= previous.effectiveMustFixCount
+  );
+}
+
+function compactCodexConnectorReviewChurnHistory(
+  entries: CodexConnectorReviewChurnHistoryEntry[],
+): CodexConnectorReviewChurnHistoryEntry[] {
+  const compacted: CodexConnectorReviewChurnHistoryEntry[] = [];
+  for (const entry of entries) {
+    const previous = compacted[compacted.length - 1];
+    if (previous?.reviewedHeadSha === entry.reviewedHeadSha) {
+      compacted[compacted.length - 1] = entry;
+    } else {
+      compacted.push(entry);
+    }
+  }
+  return compacted.slice(-CODEX_CONNECTOR_REVIEW_CHURN_HISTORY_LIMIT);
+}
+
+export function buildCodexConnectorReviewChurnHistory(args: {
+  current: CodexConnectorReviewChurnProgressSummary;
+  previousProgress?: CodexConnectorReviewChurnProgressSummary | null;
+  previousHistory?: CodexConnectorReviewChurnHistoryEntry[] | null;
+}): CodexConnectorReviewChurnHistoryEntry[] {
+  const currentEntry = codexConnectorReviewChurnHistoryEntry(args.current);
+  const previousEntries =
+    args.previousHistory && args.previousHistory.length > 0
+      ? args.previousHistory
+      : args.previousProgress
+        ? [codexConnectorReviewChurnHistoryEntry(args.previousProgress)]
+        : [];
+  const previousEntry = previousEntries[previousEntries.length - 1] ?? null;
+  if (!previousEntry || !sameFileCategoryAndFlatOrWorse(previousEntry, currentEntry)) {
+    return [currentEntry];
+  }
+
+  return compactCodexConnectorReviewChurnHistory([...previousEntries, currentEntry]);
+}
+
+export function detectStableSameFileCodexConnectorChurn(
+  history: CodexConnectorReviewChurnHistoryEntry[] | null | undefined,
+): CodexConnectorStableSameFileChurn | null {
+  if (!history || history.length < CODEX_CONNECTOR_STABLE_SAME_FILE_CHURN_MIN_STREAK) {
+    return null;
+  }
+
+  const latest = history[history.length - 1];
+  const stableEntries = [latest];
+  for (let index = history.length - 2; index >= 0; index -= 1) {
+    const entry = history[index];
+    const newer = stableEntries[0];
+    if (!sameFileCategoryAndFlatOrWorse(entry, newer)) {
+      break;
+    }
+    stableEntries.unshift(entry);
+  }
+
+  if (stableEntries.length < CODEX_CONNECTOR_STABLE_SAME_FILE_CHURN_MIN_STREAK) {
+    return null;
+  }
+
+  return {
+    streak: stableEntries.length,
+    dominantFile: latest.dominantFile,
+    clusterCategorySignature: latest.clusterCategorySignature,
+    currentEffectiveMustFixCount: latest.effectiveMustFixCount,
+    reviewedHeadShas: stableEntries.map((entry) => entry.reviewedHeadSha),
+    representativeThreadIds: latest.representativeThreadIds,
   };
 }
 

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -5,18 +5,22 @@ import {
   buildCodexConnectorP2P3PolicyDiagnostic,
   buildCodexConnectorPolicyBlockDiagnostic,
   buildCodexConnectorReviewChurnDiagnostic,
+  buildCodexConnectorReviewChurnHistory,
   buildCodexConnectorReviewChurnProgressSummary,
   codexConnectorMustFixReviewThreads,
   codexConnectorStaleReviewCommitThreads,
   commitShasDifferForComparison,
   commitShasEqualForComparison,
   compareCodexConnectorReviewChurnProgress,
+  detectStableSameFileCodexConnectorChurn,
   evaluateCodexConnectorConvergencePolicy,
   formatCodexConnectorP2P3PolicyDiagnostic,
   formatCodexConnectorPolicyBlockDiagnostic,
   formatCodexConnectorReviewChurnDiagnostic,
   latestCodexConnectorReviewComment,
+  type CodexConnectorReviewChurnHistoryEntry,
   type CodexConnectorReviewChurnProgressSummary,
+  type CodexConnectorStableSameFileChurn,
 } from "../codex-connector-review-policy";
 import { configuredBotCurrentHeadSignalWaitWindow } from "./review-bot-wait-windows";
 import { hasCodexConnectorReviewRequestCommentIdentity } from "../codex-connector-review-request-identity";
@@ -48,6 +52,7 @@ export interface CodexConnectorDiagnosticBundle {
   currentClusterSummary: string | null;
   pendingHeadChurnSummary: string | null;
   reviewChurnProgressSummary: string | null;
+  stableSameFileChurnSummary: string | null;
   reviewFallbackSummary: string | null;
   convergenceSummary: string | null;
   operatorDiagnosticSummary: string | null;
@@ -91,6 +96,43 @@ function parsePreviousCodexConnectorReviewChurnProgress(
   }
 }
 
+function isCodexConnectorReviewChurnHistoryEntry(
+  value: unknown,
+): value is CodexConnectorReviewChurnHistoryEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<CodexConnectorReviewChurnHistoryEntry>;
+  return (
+    typeof candidate.reviewedHeadSha === "string" &&
+    typeof candidate.effectiveMustFixCount === "number" &&
+    Number.isFinite(candidate.effectiveMustFixCount) &&
+    typeof candidate.dominantFile === "string" &&
+    typeof candidate.clusterCategorySignature === "string" &&
+    Array.isArray(candidate.representativeThreadIds) &&
+    candidate.representativeThreadIds.every((threadId) => typeof threadId === "string")
+  );
+}
+
+function parsePreviousCodexConnectorReviewChurnHistory(
+  snapshot: string | null | undefined,
+): CodexConnectorReviewChurnHistoryEntry[] | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(snapshot) as { codexConnectorReviewChurnHistory?: unknown };
+    return Array.isArray(parsed.codexConnectorReviewChurnHistory) &&
+      parsed.codexConnectorReviewChurnHistory.every(isCodexConnectorReviewChurnHistoryEntry)
+      ? parsed.codexConnectorReviewChurnHistory
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function formatCodexConnectorReviewChurnProgressDiagnostic(args: {
   current: CodexConnectorReviewChurnProgressSummary;
   previous: CodexConnectorReviewChurnProgressSummary;
@@ -110,6 +152,23 @@ function formatCodexConnectorReviewChurnProgressDiagnostic(args: {
     `cluster_category_signature=${formatDiagnosticToken(args.current.clusterCategorySignature)}`,
     `previous_cluster_category_signature=${formatDiagnosticToken(args.previous.clusterCategorySignature)}`,
     `representative_threads=${args.current.representativeThreadIds.map(formatDiagnosticToken).join(",") || "none"}`,
+  ].join(" ");
+}
+
+function formatCodexConnectorStableSameFileChurnDiagnostic(
+  stableChurn: CodexConnectorStableSameFileChurn,
+): string {
+  return [
+    "codex_connector_same_file_churn_history",
+    "status=stable_same_file_churn",
+    `streak=${stableChurn.streak}`,
+    `current_head_sha=${formatDiagnosticToken(stableChurn.reviewedHeadShas[stableChurn.reviewedHeadShas.length - 1] ?? "unknown")}`,
+    `dominant_file=${formatDiagnosticToken(stableChurn.dominantFile)}`,
+    `cluster_category_signature=${formatDiagnosticToken(stableChurn.clusterCategorySignature)}`,
+    `current_effective_must_fix=${stableChurn.currentEffectiveMustFixCount}`,
+    `reviewed_heads=${stableChurn.reviewedHeadShas.map(formatDiagnosticToken).join(",") || "none"}`,
+    `representative_threads=${stableChurn.representativeThreadIds.map(formatDiagnosticToken).join(",") || "none"}`,
+    "next_action=manual_review_same_file_churn_history",
   ].join(" ");
 }
 
@@ -593,6 +652,17 @@ export function buildCodexConnectorDiagnosticBundle(args: {
   const previousReviewChurnProgress = parsePreviousCodexConnectorReviewChurnProgress(
     args.record.last_tracked_pr_progress_snapshot,
   );
+  const previousReviewChurnHistory = parsePreviousCodexConnectorReviewChurnHistory(
+    args.record.last_tracked_pr_progress_snapshot,
+  );
+  const reviewChurnHistory = currentReviewChurnProgress
+    ? buildCodexConnectorReviewChurnHistory({
+        current: currentReviewChurnProgress,
+        previousProgress: previousReviewChurnProgress,
+        previousHistory: previousReviewChurnHistory,
+      })
+    : null;
+  const stableSameFileChurn = detectStableSameFileCodexConnectorChurn(reviewChurnHistory);
   return {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
     p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
@@ -618,6 +688,9 @@ export function buildCodexConnectorDiagnosticBundle(args: {
             previous: previousReviewChurnProgress,
           })
         : null,
+    stableSameFileChurnSummary: stableSameFileChurn
+      ? formatCodexConnectorStableSameFileChurnDiagnostic(stableSameFileChurn)
+      : null,
     reviewFallbackSummary: formatCodexConnectorReviewFallbackDiagnostic({
       config: args.config,
       record: args.record,

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -237,6 +237,9 @@ export function buildActiveReviewBotProviderLines(
   if (codexConnectorDiagnostics.reviewChurnProgressSummary) {
     lines.push(codexConnectorDiagnostics.reviewChurnProgressSummary);
   }
+  if (codexConnectorDiagnostics.stableSameFileChurnSummary) {
+    lines.push(codexConnectorDiagnostics.stableSameFileChurnSummary);
+  }
   const reviewBotProfile = inferReviewBotProfile(config);
   const reviewBotStatus = reviewBotDiagnostics(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
   const copilotReviewState = pr.copilotReviewState === null ? "unknown" : (pr.copilotReviewState ?? "not_requested");

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -216,6 +216,9 @@ export function buildInactiveDetailedStatusLines(
     if (codexConnectorDiagnostics.reviewChurnProgressSummary) {
       lines.push(codexConnectorDiagnostics.reviewChurnProgressSummary);
     }
+    if (codexConnectorDiagnostics.stableSameFileChurnSummary) {
+      lines.push(codexConnectorDiagnostics.stableSameFileChurnSummary);
+    }
     if (codexConnectorDiagnostics.reviewFallbackSummary) {
       lines.push(codexConnectorDiagnostics.reviewFallbackSummary);
     }

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -722,6 +722,133 @@ test("status compares Codex Connector churn progress against the previous tracke
   );
 });
 
+test("status reports stable same-file Codex Connector churn history", async (t) => {
+  const fixture = await createSupervisorFixture();
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const issueNumber = 2249;
+  const prNumber = 3249;
+  const branch = branchName(fixture.config, issueNumber);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "addressing_review",
+        branch,
+        pr_number: prNumber,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        last_head_sha: "head-middle-2249",
+        last_tracked_pr_progress_snapshot: JSON.stringify({
+          headRefOid: "head-middle-2249",
+          reviewDecision: "CHANGES_REQUESTED",
+          mergeStateStatus: "BLOCKED",
+          copilotReviewState: null,
+          copilotReviewRequestedAt: null,
+          copilotReviewArrivedAt: null,
+          configuredBotCurrentHeadObservedAt: "2026-06-04T06:19:54Z",
+          configuredBotCurrentHeadStatusState: null,
+          currentHeadCiGreenAt: "2026-06-04T06:18:00Z",
+          configuredBotRateLimitedAt: null,
+          configuredBotDraftSkipAt: null,
+          configuredBotTopLevelReviewStrength: "blocking",
+          configuredBotTopLevelReviewSubmittedAt: "2026-06-04T06:19:54Z",
+          checks: ["build:pass:SUCCESS:CI"],
+          unresolvedReviewThreadIds: ["thread-middle-0", "thread-middle-1", "thread-middle-2", "thread-middle-3"],
+          codexConnectorReviewChurnProgress: {
+            currentHeadSha: "head-middle-2249",
+            currentEffectiveMustFixCount: 4,
+            dominantFile: "src/release-readiness.ts",
+            dominantFilePercent: 100,
+            clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+            representativeThreadIds: ["thread-middle-0", "thread-middle-1", "thread-middle-2", "thread-middle-3"],
+          },
+          codexConnectorReviewChurnHistory: [
+            {
+              reviewedHeadSha: "head-previous-2249",
+              effectiveMustFixCount: 4,
+              dominantFile: "src/release-readiness.ts",
+              clusterCategorySignature:
+                "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+              representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+            },
+            {
+              reviewedHeadSha: "head-middle-2249",
+              effectiveMustFixCount: 4,
+              dominantFile: "src/release-readiness.ts",
+              clusterCategorySignature:
+                "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+              representativeThreadIds: ["thread-middle-0", "thread-middle-1", "thread-middle-2", "thread-middle-3"],
+            },
+          ],
+        }),
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: "head-current-2249",
+    isDraft: false,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-04T06:28:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-04T06:30:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-04T06:30:00Z",
+  });
+  const reviewThreads = Array.from({ length: 4 }, (_, index) => ({
+    id: `thread-current-${index}`,
+    isResolved: false,
+    isOutdated: false,
+    path: "src/release-readiness.ts",
+    line: 130 + index,
+    comments: {
+      nodes: [
+        {
+          id: `thread-current-${index}-comment`,
+          body:
+            "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+          createdAt: "2026-06-04T06:30:00Z",
+          url: `https://example.test/pr/2249#discussion_current_${index}`,
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  }));
+
+  const supervisor = new Supervisor({
+    ...fixture.config,
+    reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    codexConnectorReviewChurnMustFixThreshold: 4,
+    codexConnectorReviewChurnFileConcentrationPercent: 75,
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    listCandidateIssues: async () => [],
+    listAllIssues: async () => [],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => reviewThreads,
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^codex_connector_same_file_churn_history status=stable_same_file_churn streak=3 current_head_sha=head-current-2249 dominant_file=src\/release-readiness\.ts cluster_category_signature=claim_detection\+excluded_scope\+readiness_claim\+truth_source\+verifier_or_issue_lint current_effective_must_fix=4 reviewed_heads=head-previous-2249,head-middle-2249,head-current-2249 representative_threads=thread-current-0,thread-current-1,thread-current-2,thread-current-3 next_action=manual_review_same_file_churn_history$/m,
+  );
+  assert.match(status, /^codex_connector_review_churn status=clustered_root_cause_repair\b/m);
+});
+
 test("status waits for current-head Codex review when non-outdated threads came from a stale review commit", async (t) => {
   const originalDateNow = Date.now;
   Date.now = () => Date.parse("2026-05-19T09:14:00Z");

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -935,7 +935,7 @@ test("determineTrackedPrRepeatFailureDisposition keeps improving clustered Codex
         currentEffectiveMustFixCount: 4,
         dominantFile: "src/release-readiness.ts",
         dominantFilePercent: 100,
-        clusterCategorySignature: "readiness_claim+truth_source",
+        clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
         representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
       },
     }),
@@ -985,6 +985,237 @@ test("determineTrackedPrRepeatFailureDisposition keeps improving clustered Codex
   assert.equal(result.shouldStop, false);
   assert.equal(result.decision, "retry_on_progress");
   assert.notEqual(result.progressSummary, "no_progress_clustered_codex_churn current_effective_must_fix=2");
+});
+
+test("summarizeTrackedPrProgress records stable same-file Codex Connector churn history across repair heads", () => {
+  const record = createRecord({
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-middle-366",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "BLOCKED",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-06-01T06:19:54Z",
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: "2026-06-01T06:18:00Z",
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:19:54Z",
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-middle-0", "thread-middle-1", "thread-middle-2", "thread-middle-3"],
+      unresolvedReviewThreadFingerprints: [
+        "thread-middle-0#comment-middle-0",
+        "thread-middle-1#comment-middle-1",
+        "thread-middle-2#comment-middle-2",
+        "thread-middle-3#comment-middle-3",
+      ],
+      unresolvedReviewThreadSourceAnchors: [
+        "thread-middle-0:src/release-readiness.ts:120",
+        "thread-middle-1:src/release-readiness.ts:121",
+        "thread-middle-2:src/release-readiness.ts:122",
+        "thread-middle-3:src/release-readiness.ts:123",
+      ],
+      processedReviewThreadIds: [],
+      processedReviewThreadFingerprints: [],
+      verificationProbeOutcomes: [],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: "head-middle-366",
+        currentEffectiveMustFixCount: 4,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+        representativeThreadIds: ["thread-middle-0", "thread-middle-1", "thread-middle-2", "thread-middle-3"],
+      },
+      codexConnectorReviewChurnHistory: [
+        {
+          reviewedHeadSha: "head-previous-366",
+          effectiveMustFixCount: 4,
+          dominantFile: "src/release-readiness.ts",
+          clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+          representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+        },
+        {
+          reviewedHeadSha: "head-middle-366",
+          effectiveMustFixCount: 4,
+          dominantFile: "src/release-readiness.ts",
+          clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+          representativeThreadIds: ["thread-middle-0", "thread-middle-1", "thread-middle-2", "thread-middle-3"],
+        },
+      ],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head-current-366",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    configuredBotCurrentHeadObservedAt: "2026-06-01T06:30:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:30:00Z",
+    currentHeadCiGreenAt: "2026-06-01T06:28:00Z",
+  });
+  const reviewThreads = Array.from({ length: 4 }, (_, index) =>
+    createReviewThread({
+      id: `thread-current-${index}`,
+      path: "src/release-readiness.ts",
+      line: 130 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-current-${index}`,
+            body:
+              "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+            createdAt: "2026-06-01T06:30:00Z",
+            url: `https://example.test/pr/366#discussion_current_${index}`,
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  );
+
+  const result = summarizeTrackedPrProgress(
+    record,
+    pr,
+    [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+    createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+      codexConnectorReviewChurnMustFixThreshold: 4,
+      codexConnectorReviewChurnFileConcentrationPercent: 75,
+    }),
+  );
+  const snapshot = JSON.parse(result.snapshot);
+
+  assert.deepEqual(
+    snapshot.codexConnectorReviewChurnHistory.map((entry: { reviewedHeadSha: string }) => entry.reviewedHeadSha),
+    ["head-previous-366", "head-middle-366", "head-current-366"],
+  );
+  assert.equal(snapshot.codexConnectorStableSameFileChurn.streak, 3);
+  assert.equal(snapshot.codexConnectorStableSameFileChurn.dominantFile, "src/release-readiness.ts");
+  assert.equal(
+    snapshot.codexConnectorStableSameFileChurn.clusterCategorySignature,
+    "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+  );
+  assert.equal(snapshot.codexConnectorStableSameFileChurn.currentEffectiveMustFixCount, 4);
+});
+
+test("summarizeTrackedPrProgress resets same-file Codex Connector churn history on file, category, or count improvement", () => {
+  const baselineRecord = createRecord({
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-previous-366",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "BLOCKED",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-06-01T06:09:54Z",
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: "2026-06-01T06:08:00Z",
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:09:54Z",
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      unresolvedReviewThreadFingerprints: [
+        "thread-previous-0#comment-previous-0",
+        "thread-previous-1#comment-previous-1",
+        "thread-previous-2#comment-previous-2",
+        "thread-previous-3#comment-previous-3",
+      ],
+      unresolvedReviewThreadSourceAnchors: [
+        "thread-previous-0:src/release-readiness.ts:120",
+        "thread-previous-1:src/release-readiness.ts:121",
+        "thread-previous-2:src/release-readiness.ts:122",
+        "thread-previous-3:src/release-readiness.ts:123",
+      ],
+      processedReviewThreadIds: [],
+      processedReviewThreadFingerprints: [],
+      verificationProbeOutcomes: [],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: "head-previous-366",
+        currentEffectiveMustFixCount: 4,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "readiness_claim+truth_source",
+        representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      },
+      codexConnectorReviewChurnHistory: [
+        {
+          reviewedHeadSha: "head-previous-366",
+          effectiveMustFixCount: 4,
+          dominantFile: "src/release-readiness.ts",
+          clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+          representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+        },
+      ],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head-current-366",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    configuredBotCurrentHeadObservedAt: "2026-06-01T06:20:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:20:00Z",
+    currentHeadCiGreenAt: "2026-06-01T06:18:00Z",
+  });
+  const summarize = (threads: ReviewThread[]) =>
+    JSON.parse(
+      summarizeTrackedPrProgress(
+        baselineRecord,
+        pr,
+        [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+        threads,
+        createConfig({
+          reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+          codexConnectorReviewChurnMustFixThreshold: 2,
+          codexConnectorReviewChurnFileConcentrationPercent: 75,
+        }),
+      ).snapshot,
+    );
+  const makeThread = (id: string, file: string, body: string) =>
+    createReviewThread({
+      id,
+      path: file,
+      comments: {
+        nodes: [
+          {
+            id: `${id}-comment`,
+            body,
+            createdAt: "2026-06-01T06:20:00Z",
+            url: `https://example.test/pr/366#discussion_${id}`,
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    });
+
+  const changedFile = summarize([
+    makeThread("thread-file-0", "src/runtime-readiness.ts", "P2: Block release readiness truth-source claims."),
+    makeThread("thread-file-1", "src/runtime-readiness.ts", "P2: Block release readiness truth-source claims."),
+    makeThread("thread-file-2", "src/runtime-readiness.ts", "P2: Block release readiness truth-source claims."),
+    makeThread("thread-file-3", "src/runtime-readiness.ts", "P2: Block release readiness truth-source claims."),
+  ]);
+  const changedCategory = summarize([
+    makeThread("thread-category-0", "src/release-readiness.ts", "P2: Block auth context until tenant scope is proven."),
+    makeThread("thread-category-1", "src/release-readiness.ts", "P2: Block auth context until tenant scope is proven."),
+    makeThread("thread-category-2", "src/release-readiness.ts", "P2: Block auth context until tenant scope is proven."),
+    makeThread("thread-category-3", "src/release-readiness.ts", "P2: Block auth context until tenant scope is proven."),
+  ]);
+  const improvedCount = summarize([
+    makeThread("thread-improved-0", "src/release-readiness.ts", "P2: Block release readiness truth-source claims."),
+    makeThread("thread-improved-1", "src/release-readiness.ts", "P2: Block release readiness truth-source claims."),
+  ]);
+
+  assert.equal(changedFile.codexConnectorReviewChurnHistory.length, 1);
+  assert.equal(changedFile.codexConnectorStableSameFileChurn, undefined);
+  assert.equal(changedCategory.codexConnectorReviewChurnHistory.length, 1);
+  assert.equal(changedCategory.codexConnectorStableSameFileChurn, undefined);
+  assert.equal(improvedCount.codexConnectorReviewChurnHistory.length, 1);
+  assert.equal(improvedCount.codexConnectorStableSameFileChurn, undefined);
 });
 
 test("summarizeTrackedPrProgress treats updated same-thread guidance as tracked PR progress", () => {

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -23,11 +23,15 @@ import { inferFailureContext } from "./supervisor-failure-context";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor-status-rendering";
 import {
   buildCodexConnectorReviewChurnDiagnostic,
+  buildCodexConnectorReviewChurnHistory,
   buildCodexConnectorReviewChurnProgressSummary,
   clusterConfiguredBotReviewThreads,
   compareCodexConnectorReviewChurnProgress,
+  detectStableSameFileCodexConnectorChurn,
+  type CodexConnectorReviewChurnHistoryEntry,
   type CodexConnectorReviewChurnProgressComparison,
   type CodexConnectorReviewChurnProgressSummary,
+  type CodexConnectorStableSameFileChurn,
 } from "../codex-connector-review-policy";
 import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
 import {
@@ -133,6 +137,8 @@ interface TrackedPrProgressSnapshot {
   verificationProbeOutcomes?: string[];
   codexConnectorReviewChurnProgress?: CodexConnectorReviewChurnProgressSummary;
   codexConnectorReviewChurnComparison?: CodexConnectorReviewChurnProgressComparison;
+  codexConnectorReviewChurnHistory?: CodexConnectorReviewChurnHistoryEntry[];
+  codexConnectorStableSameFileChurn?: CodexConnectorStableSameFileChurn;
 }
 
 export interface TrackedPrRepeatFailureDisposition {
@@ -147,7 +153,10 @@ const TRACKED_PR_PROGRESS_EXTENSION_MULTIPLIER = 2;
 function buildTrackedPrProgressSnapshot(
   record: Pick<
     IssueRunRecord,
-    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "timeline_artifacts"
+    | "last_tracked_pr_progress_snapshot"
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+    | "timeline_artifacts"
   >,
   config: Pick<
     SupervisorConfig,
@@ -164,7 +173,24 @@ function buildTrackedPrProgressSnapshot(
   const unresolvedReviewThreadClusterSignatures = clusterConfiguredBotReviewThreads(unresolvedReviewThreads)
     .map((cluster) => `${cluster.signature}:${cluster.threads.map((thread) => thread.id).sort().join(",")}`)
     .sort();
+  const previous = parseTrackedPrProgressSnapshot(record.last_tracked_pr_progress_snapshot);
   const codexConnectorReviewChurn = buildCodexConnectorReviewChurnDiagnostic(config, reviewThreads, pr);
+  const codexConnectorReviewChurnProgress = codexConnectorReviewChurn
+    ? buildCodexConnectorReviewChurnProgressSummary(
+        codexConnectorReviewChurn,
+        pr.headRefOid,
+      )
+    : null;
+  const codexConnectorReviewChurnHistory = codexConnectorReviewChurnProgress
+    ? buildCodexConnectorReviewChurnHistory({
+        current: codexConnectorReviewChurnProgress,
+        previousProgress: previous?.codexConnectorReviewChurnProgress ?? null,
+        previousHistory: previous?.codexConnectorReviewChurnHistory ?? null,
+      })
+    : null;
+  const codexConnectorStableSameFileChurn = detectStableSameFileCodexConnectorChurn(
+    codexConnectorReviewChurnHistory,
+  );
   return {
     headRefOid: pr.headRefOid,
     reviewDecision: pr.reviewDecision,
@@ -201,12 +227,15 @@ function buildTrackedPrProgressSnapshot(
     ...(unresolvedReviewThreadClusterSignatures.length > 0
       ? { unresolvedReviewThreadClusterSignatures }
       : {}),
-    ...(codexConnectorReviewChurn
+    ...(codexConnectorReviewChurnProgress
       ? {
-          codexConnectorReviewChurnProgress: buildCodexConnectorReviewChurnProgressSummary(
-            codexConnectorReviewChurn,
-            pr.headRefOid,
-          ),
+          codexConnectorReviewChurnProgress,
+          ...(codexConnectorReviewChurnHistory
+            ? { codexConnectorReviewChurnHistory }
+            : {}),
+          ...(codexConnectorStableSameFileChurn
+            ? { codexConnectorStableSameFileChurn }
+            : {}),
         }
       : {}),
   };

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -124,6 +124,7 @@ export interface SupervisorExplainDto {
   codexConnectorOperatorDiagnosticSummary?: string | null;
   codexConnectorPolicyBlockSummary?: string | null;
   codexConnectorPendingHeadChurnSummary?: string | null;
+  codexConnectorStableSameFileChurnSummary?: string | null;
   codexConnectorReviewFallbackSummary?: string | null;
   codexConnectorConvergenceSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
@@ -612,6 +613,7 @@ export async function buildIssueExplainDto(
     codexConnectorOperatorDiagnosticSummary: codexConnectorDiagnostics?.operatorDiagnosticSummary ?? null,
     codexConnectorPolicyBlockSummary: codexConnectorDiagnostics?.policyBlockSummary ?? null,
     codexConnectorPendingHeadChurnSummary: codexConnectorDiagnostics?.pendingHeadChurnSummary ?? null,
+    codexConnectorStableSameFileChurnSummary: codexConnectorDiagnostics?.stableSameFileChurnSummary ?? null,
     codexConnectorReviewFallbackSummary: codexConnectorDiagnostics?.reviewFallbackSummary ?? null,
     codexConnectorConvergenceSummary: codexConnectorDiagnostics?.convergenceSummary ?? null,
     noActiveTrackedRecordSummary,
@@ -700,6 +702,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.codexConnectorOperatorDiagnosticSummary ? [dto.codexConnectorOperatorDiagnosticSummary] : []),
     ...(dto.codexConnectorPolicyBlockSummary ? [dto.codexConnectorPolicyBlockSummary] : []),
     ...(dto.codexConnectorPendingHeadChurnSummary ? [dto.codexConnectorPendingHeadChurnSummary] : []),
+    ...(dto.codexConnectorStableSameFileChurnSummary ? [dto.codexConnectorStableSameFileChurnSummary] : []),
     ...(dto.codexConnectorReviewFallbackSummary ? [dto.codexConnectorReviewFallbackSummary] : []),
     ...(dto.codexConnectorConvergenceSummary ? [dto.codexConnectorConvergenceSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),


### PR DESCRIPTION
Summary
- Track compact same-file Codex Connector churn history across repair heads.
- Surface stable same-file churn history in status and explain diagnostics without changing repair routing or merge readiness.

Verification
- npx tsx --test src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
- npm run build

Refs #2249