### PR TITLE
[codex] Run stable Codex churn dossier repair once

### DIFF
--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -194,6 +194,35 @@ export interface CodexConnectorStableSameFileChurn {
   representativeThreadIds: string[];
 }
 
+export function isCodexConnectorStableSameFileChurn(value: unknown): value is CodexConnectorStableSameFileChurn {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const stable = value as Partial<CodexConnectorStableSameFileChurn>;
+  return (
+    typeof stable.streak === "number" &&
+    Number.isFinite(stable.streak) &&
+    typeof stable.dominantFile === "string" &&
+    typeof stable.clusterCategorySignature === "string" &&
+    typeof stable.currentEffectiveMustFixCount === "number" &&
+    Number.isFinite(stable.currentEffectiveMustFixCount) &&
+    Array.isArray(stable.reviewedHeadShas) &&
+    stable.reviewedHeadShas.every((headSha) => typeof headSha === "string") &&
+    Array.isArray(stable.representativeThreadIds) &&
+    stable.representativeThreadIds.every((threadId) => typeof threadId === "string")
+  );
+}
+
+export function codexConnectorStableSameFileChurnSignature(stable: CodexConnectorStableSameFileChurn): string {
+  return [
+    "codex-connector-stable-same-file-churn",
+    formatSignaturePart(stable.dominantFile),
+    formatSignaturePart(stable.clusterCategorySignature),
+    formatSignaturePart(stable.reviewedHeadShas.join("+")),
+  ].join(":");
+}
+
 export type CodexConnectorReviewChurnProgressClassification = "improving" | "unchanged" | "worse";
 
 export interface CodexConnectorReviewChurnProgressComparison {

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -116,3 +116,65 @@ test("resolveCodexExecutionPolicy routes bounded repair states to the explicit m
     reasoningEffort: "high",
   });
 });
+
+test("resolveCodexExecutionPolicy escalates only an unconsumed stable Codex Connector churn dossier repair turn", () => {
+  const config = createConfig({
+    boundedRepairModelStrategy: "alias",
+    boundedRepairModel: "gpt-5.4-mini",
+  });
+  const stableSnapshot = JSON.stringify({
+    headRefOid: "head-current-2250",
+    checks: [],
+    unresolvedReviewThreadIds: [],
+    codexConnectorStableSameFileChurn: {
+      streak: 3,
+      dominantFile: "src/release-readiness.ts",
+      clusterCategorySignature: "claim_detection+truth_source",
+      currentEffectiveMustFixCount: 4,
+      reviewedHeadShas: ["head-previous-2250", "head-middle-2250", "head-current-2250"],
+      representativeThreadIds: ["thread-current-0", "thread-current-1"],
+    },
+  });
+  const consumedSignature =
+    "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_truth_source:head-previous-2250_head-middle-2250_head-current-2250";
+
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "addressing_review", {
+      repeated_failure_signature_count: 0,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_tracked_pr_progress_snapshot: stableSnapshot,
+      codex_connector_stable_churn_dossier_consumed_signature: null,
+    }),
+    {
+      model: "gpt-5.4-mini",
+      reasoningEffort: "xhigh",
+    },
+  );
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "addressing_review", {
+      repeated_failure_signature_count: 0,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_tracked_pr_progress_snapshot: stableSnapshot,
+      codex_connector_stable_churn_dossier_consumed_signature: consumedSignature,
+    }),
+    {
+      model: "gpt-5.4-mini",
+      reasoningEffort: "medium",
+    },
+  );
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "repairing_ci", {
+      repeated_failure_signature_count: 0,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_tracked_pr_progress_snapshot: stableSnapshot,
+      codex_connector_stable_churn_dossier_consumed_signature: null,
+    }),
+    {
+      model: "gpt-5.4-mini",
+      reasoningEffort: "medium",
+    },
+  );
+});

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -1,4 +1,8 @@
 import { CodexExecutionTarget, IssueRunRecord, ReasoningEffort, RunState, SupervisorConfig } from "../core/types";
+import {
+  codexConnectorStableSameFileChurnSignature,
+  isCodexConnectorStableSameFileChurn,
+} from "../codex-connector-review-policy";
 
 const REASONING_ORDER: ReasoningEffort[] = ["none", "low", "medium", "high", "xhigh"];
 
@@ -40,6 +44,32 @@ type CodexExecutionPolicyConfig = Pick<
   | "codexReasoningEscalateOnRepeatedFailure"
 >;
 
+function activeStableSameFileChurnDossierSignature(
+  record?: Pick<
+    IssueRunRecord,
+    "last_tracked_pr_progress_snapshot" | "codex_connector_stable_churn_dossier_consumed_signature"
+  > | null,
+): string | null {
+  if (!record?.last_tracked_pr_progress_snapshot) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(record.last_tracked_pr_progress_snapshot) as {
+      codexConnectorStableSameFileChurn?: unknown;
+    };
+    const stable = parsed.codexConnectorStableSameFileChurn;
+    if (!isCodexConnectorStableSameFileChurn(stable)) {
+      return null;
+    }
+
+    const signature = codexConnectorStableSameFileChurnSignature(stable);
+    return signature === record.codex_connector_stable_churn_dossier_consumed_signature ? null : signature;
+  } catch {
+    return null;
+  }
+}
+
 function bumpReasoningEffort(effort: ReasoningEffort, steps = 1): ReasoningEffort {
   const index = REASONING_ORDER.indexOf(effort);
   const nextIndex = Math.min(REASONING_ORDER.length - 1, Math.max(0, index) + steps);
@@ -71,10 +101,21 @@ function clampReasoningEffortForModel(model: string | null, effort: ReasoningEff
 function resolveRequestedReasoningEffort(
   config: Pick<SupervisorConfig, "codexReasoningEffortByState" | "codexReasoningEscalateOnRepeatedFailure">,
   state: RunState,
-  record?: Pick<IssueRunRecord, "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"> | null,
+  record?: Pick<
+    IssueRunRecord,
+    | "repeated_failure_signature_count"
+    | "blocked_verification_retry_count"
+    | "timeout_retry_count"
+    | "last_tracked_pr_progress_snapshot"
+    | "codex_connector_stable_churn_dossier_consumed_signature"
+  > | null,
 ): ReasoningEffort {
   const configured = config.codexReasoningEffortByState[state];
   let effort = configured ?? DEFAULT_REASONING_BY_STATE[state];
+
+  if (state === "addressing_review" && activeStableSameFileChurnDossierSignature(record)) {
+    return "xhigh";
+  }
 
   if (
     config.codexReasoningEscalateOnRepeatedFailure &&
@@ -132,7 +173,14 @@ function resolveConfiguredModel(
 export function resolveCodexExecutionPolicy(
   config: CodexExecutionPolicyConfig,
   state: RunState,
-  record?: Pick<IssueRunRecord, "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"> | null,
+  record?: Pick<
+    IssueRunRecord,
+    | "repeated_failure_signature_count"
+    | "blocked_verification_retry_count"
+    | "timeout_retry_count"
+    | "last_tracked_pr_progress_snapshot"
+    | "codex_connector_stable_churn_dossier_consumed_signature"
+  > | null,
   target: CodexExecutionTarget = "supervisor",
 ): CodexExecutionPolicy {
   const model = resolveConfiguredModel(config, state, target);

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -1106,6 +1106,107 @@ test("buildCodexPrompt routes concentrated Codex Connector P2 cascades to root-c
   assert.match(prompt, /P0\/P1\/P2 and escalated P3 Codex Connector findings are supervisor-enforced must-fix findings/);
 });
 
+test("buildCodexPrompt adds a stable same-file Codex Connector churn repair dossier", () => {
+  const pr = createPullRequest({
+    number: 2250,
+    headRefOid: "head-current-2250",
+  });
+  const threads = ["thread-current-0", "thread-current-1"].map((id, index) =>
+    createReviewThread({
+      id,
+      path: "src/release-readiness.ts",
+      line: 120 + index,
+      comments: {
+        nodes: [
+          {
+            id: `${id}-comment`,
+            body: "P2: Keep release readiness truth-source claims blocked until the verifier proves the authoritative scope.",
+            createdAt: "2026-06-01T06:30:00Z",
+            url: `https://example.test/pr/2250#discussion_${id}`,
+            author: {
+              login: "chatgpt-codex-connector[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  );
+
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-2250",
+    workspacePath: "/tmp/workspaces/issue-2250",
+    state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 0,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_tracked_pr_progress_snapshot: JSON.stringify({
+        headRefOid: "head-current-2250",
+        reviewDecision: "CHANGES_REQUESTED",
+        mergeStateStatus: "BLOCKED",
+        checks: [],
+        unresolvedReviewThreadIds: threads.map((thread) => thread.id),
+        codexConnectorReviewChurnHistory: [
+          {
+            reviewedHeadSha: "head-previous-2250",
+            effectiveMustFixCount: 4,
+            dominantFile: "src/release-readiness.ts",
+            clusterCategorySignature: "claim_detection+truth_source",
+            representativeThreadIds: ["thread-previous-0", "thread-previous-1"],
+          },
+          {
+            reviewedHeadSha: "head-middle-2250",
+            effectiveMustFixCount: 4,
+            dominantFile: "src/release-readiness.ts",
+            clusterCategorySignature: "claim_detection+truth_source",
+            representativeThreadIds: ["thread-middle-0", "thread-middle-1"],
+          },
+          {
+            reviewedHeadSha: "head-current-2250",
+            effectiveMustFixCount: 5,
+            dominantFile: "src/release-readiness.ts",
+            clusterCategorySignature: "claim_detection+truth_source",
+            representativeThreadIds: ["thread-current-0", "thread-current-1"],
+          },
+        ],
+        codexConnectorStableSameFileChurn: {
+          streak: 3,
+          dominantFile: "src/release-readiness.ts",
+          clusterCategorySignature: "claim_detection+truth_source",
+          currentEffectiveMustFixCount: 5,
+          reviewedHeadShas: ["head-previous-2250", "head-middle-2250", "head-current-2250"],
+          representativeThreadIds: ["thread-current-0", "thread-current-1"],
+        },
+      }),
+      codex_connector_stable_churn_dossier_consumed_signature: null,
+    },
+    pr,
+    checks: [],
+    reviewThreads: threads,
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-2250/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Codex Connector stable churn dossier:/);
+  assert.match(prompt, /Active PR head: head-current-2250/);
+  assert.match(prompt, /Recent repair heads: head-previous-2250, head-middle-2250, head-current-2250/);
+  assert.match(prompt, /Must-fix count trend: head-previous-2250:4 -> head-middle-2250:4 -> head-current-2250:5/);
+  assert.match(prompt, /Category signature trend: head-previous-2250:claim_detection\+truth_source -> head-middle-2250:claim_detection\+truth_source -> head-current-2250:claim_detection\+truth_source/);
+  assert.match(prompt, /Dominant file: src\/release-readiness\.ts/);
+  assert.match(prompt, /Representative thread ids: thread-current-0, thread-current-1/);
+  assert.match(prompt, /Representative URLs: https:\/\/example\.test\/pr\/2250#discussion_thread-current-0, https:\/\/example\.test\/pr\/2250#discussion_thread-current-1/);
+  assert.match(prompt, /Route this as one root-cause repair dossier, not per-thread patching/);
+  assert.match(prompt, /Read src\/release-readiness\.ts as a whole before editing/);
+});
+
 test("buildCodexPrompt detects Codex Connector churn from all active threads when repair selection is narrow", () => {
   const pr = createPullRequest({
     number: 1388,

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -30,7 +30,9 @@ import {
 import {
   buildCodexConnectorMustFixFindingDetails,
   buildCodexConnectorReviewChurnDiagnostic,
+  codexConnectorStableSameFileChurnSignature,
   codexConnectorMustFixReviewThreads,
+  isCodexConnectorStableSameFileChurn,
 } from "../codex-connector-review-policy";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 
@@ -388,9 +390,11 @@ export interface BuildCodexStartPromptInput {
       | "repeated_failure_signature_count"
       | "last_failure_signature"
       | "last_tracked_pr_progress_summary"
+      | "last_tracked_pr_progress_snapshot"
       | "last_tracked_pr_repeat_failure_decision"
       | "addressing_review_strategy"
       | "addressing_review_strategy_reason"
+      | "codex_connector_stable_churn_dossier_consumed_signature"
     >
   > | null;
   pr: GitHubPullRequest | null;
@@ -443,6 +447,78 @@ function buildAddressingReviewStrategySwitch(input: Pick<BuildCodexStartPromptIn
     "- First reproduce the blocker or prove the unresolved-thread cluster from current code and tests.",
     "- Group the repeated comments by root cause, then make the smallest focused test update that would have caught the repeated failure.",
     "- Only after that root-cause grouping should you patch code, and do not weaken attempt limits, merge gates, or configured review-bot requirements.",
+  ];
+}
+
+function buildStableSameFileChurnDossier(input: Pick<BuildCodexStartPromptInput, "state" | "record" | "pr" | "reviewThreads">): string[] {
+  if (input.state !== "addressing_review" || !input.record?.last_tracked_pr_progress_snapshot) {
+    return [];
+  }
+
+  let snapshot: {
+    codexConnectorReviewChurnHistory?: Array<{
+      reviewedHeadSha: string;
+      effectiveMustFixCount: number;
+      clusterCategorySignature: string;
+    }>;
+    codexConnectorStableSameFileChurn?: {
+      streak: number;
+      dominantFile: string;
+      clusterCategorySignature: string;
+      currentEffectiveMustFixCount: number;
+      reviewedHeadShas: string[];
+      representativeThreadIds: string[];
+    };
+  };
+  try {
+    snapshot = JSON.parse(input.record.last_tracked_pr_progress_snapshot);
+  } catch {
+    return [];
+  }
+
+  const stable = snapshot.codexConnectorStableSameFileChurn;
+  if (!isCodexConnectorStableSameFileChurn(stable)) {
+    return [];
+  }
+
+  const signature = codexConnectorStableSameFileChurnSignature(stable);
+  if (signature === input.record.codex_connector_stable_churn_dossier_consumed_signature) {
+    return [];
+  }
+
+  const history = (snapshot.codexConnectorReviewChurnHistory ?? []).filter((entry) =>
+    stable.reviewedHeadShas.includes(entry.reviewedHeadSha),
+  );
+  const representativeSourceUrls = uniqueNonEmpty(
+    input.reviewThreads
+      .filter((thread) => stable.representativeThreadIds.includes(thread.id))
+      .flatMap((thread) => {
+        const url = latestReviewComment(thread)?.url;
+        return url ? [url] : [];
+      }),
+  );
+
+  return [
+    "Codex Connector stable churn dossier:",
+    `- Signature: ${signature}`,
+    `- Active PR head: ${input.pr?.headRefOid ?? stable.reviewedHeadShas[stable.reviewedHeadShas.length - 1] ?? "unknown"}`,
+    `- Recent repair heads: ${stable.reviewedHeadShas.join(", ")}`,
+    `- Must-fix count trend: ${
+      history.length > 0
+        ? history.map((entry) => `${entry.reviewedHeadSha}:${entry.effectiveMustFixCount}`).join(" -> ")
+        : String(stable.currentEffectiveMustFixCount)
+    }`,
+    `- Category signature trend: ${
+      history.length > 0
+        ? history.map((entry) => `${entry.reviewedHeadSha}:${entry.clusterCategorySignature}`).join(" -> ")
+        : stable.clusterCategorySignature
+    }`,
+    `- Dominant file: ${stable.dominantFile}`,
+    `- Current effective must-fix count: ${stable.currentEffectiveMustFixCount}`,
+    `- Representative thread ids: ${stable.representativeThreadIds.join(", ") || "none"}`,
+    `- Representative URLs: ${representativeSourceUrls.join(", ") || "none"}`,
+    "- Route this as one root-cause repair dossier, not per-thread patching.",
+    `- Read ${stable.dominantFile} as a whole before editing so the repair addresses the shared enforcement boundary.`,
   ];
 }
 
@@ -750,6 +826,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
         ]
       : [];
   const addressingReviewStrategySwitch = buildAddressingReviewStrategySwitch(input);
+  const stableSameFileChurnDossier = buildStableSameFileChurnDossier(input);
   const journalOperatorOverrides = useCodexConnectorReviewThreadFastPath
     ? extractJournalOperatorOverrides(input.journalExcerpt)
     : [];
@@ -821,6 +898,7 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
     "",
     ...authoritativeStateHeuristics,
     "",
+    ...(stableSameFileChurnDossier.length > 0 ? [...stableSameFileChurnDossier, ""] : []),
     ...githubIssueBodySection,
     "",
     prSummary,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -294,6 +294,7 @@ export interface IssueRunRecord {
   last_tracked_pr_repeat_failure_decision?: "retry_on_progress" | "stop_no_progress" | null;
   addressing_review_strategy?: "normal_patch" | "root_cause_analysis" | null;
   addressing_review_strategy_reason?: string | null;
+  codex_connector_stable_churn_dossier_consumed_signature?: string | null;
   last_observed_host_local_pr_blocker_signature?: string | null;
   last_observed_host_local_pr_blocker_head_sha?: string | null;
   ready_promotion_maintenance_finding_details?: string[];

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -24,6 +24,7 @@ import {
   createReviewThread,
 } from "./turn-execution-test-helpers";
 import { AgentRunner, AgentTurnRequest } from "./supervisor/agent-runner";
+import { stableSameFileCodexConnectorChurnDossierConsumptionPatch } from "./supervisor/supervisor-lifecycle";
 import { interruptedTurnMarkerPath } from "./interrupted-turn-marker";
 import type { GitHubClient } from "./github";
 import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from "./workstation-local-path-gate";
@@ -3151,6 +3152,142 @@ test("executeCodexTurnPhase writes a durable interrupted-turn marker before runT
     assert.equal(result.kind, "completed");
     assert.equal(markerSeenDuringRun, true);
     await assert.rejects(fs.access(markerPath), { code: "ENOENT" });
+  });
+});
+
+test("executeCodexTurnPhase does not consume a stable churn dossier before runTurn returns", async () => {
+  await withTempWorkspace("codex-churn-dossier-dispatch-", async (workspacePath) => {
+    const signature =
+      "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_truth_source:head-a_head-b_head-c";
+    const journalPath = path.join(
+      workspacePath,
+      ".codex-supervisor",
+      "issue-journal.md",
+    );
+    const record = createRecord({
+      state: "addressing_review",
+      workspace: workspacePath,
+      journal_path: journalPath,
+      last_tracked_pr_progress_snapshot: JSON.stringify({
+        headRefOid: "head-c",
+        reviewDecision: "CHANGES_REQUESTED",
+        mergeStateStatus: "BLOCKED",
+        checks: [],
+        unresolvedReviewThreadIds: ["thread-current-0"],
+        codexConnectorStableSameFileChurn: {
+          streak: 3,
+          dominantFile: "src/release-readiness.ts",
+          clusterCategorySignature: "claim_detection+truth_source",
+          currentEffectiveMustFixCount: 4,
+          reviewedHeadShas: ["head-a", "head-b", "head-c"],
+          representativeThreadIds: ["thread-current-0"],
+        },
+      }),
+      codex_connector_stable_churn_dossier_consumed_signature: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": record,
+      },
+    };
+    let saveCalls = 0;
+    let recoveredRecord: IssueRunRecord | null = null;
+
+    const result = await executeCodexTurnPhase({
+      config: createConfig(),
+      stateStore: {
+        touch: (currentRecord, patch) => ({
+          ...currentRecord,
+          ...patch,
+          updated_at: "2026-03-26T01:00:01.000Z",
+        }),
+        save: async () => {
+          saveCalls += 1;
+        },
+      },
+      github: {
+        resolvePullRequestForBranch: async () => null,
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => {
+          throw new Error("unexpected getExternalReviewSurface call");
+        },
+      },
+      context: createCodexTurnContext({
+        state,
+        record,
+        workspacePath,
+        journalPath,
+        pr: null,
+        workspaceStatus: {
+          branch: "codex/issue-102",
+          headSha: "head-c",
+        },
+      }),
+      acquireSessionLock: async () => null,
+      classifyFailure: () => "command_error",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-03-26T01:00:01.000Z",
+      }),
+      applyFailureSignature: () => ({
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+      }),
+      normalizeBlockerSignature: () => null,
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: () => {
+        throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
+      },
+      inferStateWithoutPullRequest: () => "stabilizing",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async ({ record: recordAtFailure }) => {
+        recoveredRecord = recordAtFailure;
+        return recordAtFailure;
+      },
+      getWorkspaceStatus: async () =>
+        createWorkspaceStatus({
+          branch: "codex/issue-102",
+          headSha: "head-c",
+        }),
+      pushBranch: async () => {
+        throw new Error("unexpected pushBranch call");
+      },
+      readIssueJournal: async () =>
+        "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair stable churn.\n",
+      agentRunner: createSuccessfulAgentRunner(async (request) => {
+        assert.equal(
+          request.record?.codex_connector_stable_churn_dossier_consumed_signature,
+          null,
+        );
+        throw new Error("dispatch failed after marker");
+      }),
+    });
+
+    const recordAtRecovery = recoveredRecord as IssueRunRecord | null;
+    assert.deepEqual(result, {
+      kind: "returned",
+      message: "Recovered from unexpected Codex turn failure for issue #102.",
+    });
+    assert.equal(saveCalls, 0);
+    assert.equal(
+      recordAtRecovery?.codex_connector_stable_churn_dossier_consumed_signature,
+      null,
+    );
+    assert.equal(
+      stableSameFileCodexConnectorChurnDossierConsumptionPatch(recordAtRecovery ?? record)
+        .codex_connector_stable_churn_dossier_consumed_signature,
+      signature,
+    );
   });
 });
 

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -3291,6 +3291,159 @@ test("executeCodexTurnPhase does not consume a stable churn dossier before runTu
   });
 });
 
+test("executeCodexTurnPhase does not consume a stable churn dossier when Codex fails before session start", async () => {
+  await withTempWorkspace("codex-churn-dossier-prelaunch-", async (workspacePath) => {
+    const signature =
+      "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_truth_source:head-a_head-b_head-c";
+    const journalPath = path.join(
+      workspacePath,
+      ".codex-supervisor",
+      "issue-journal.md",
+    );
+    const record = createRecord({
+      state: "addressing_review",
+      workspace: workspacePath,
+      journal_path: journalPath,
+      last_tracked_pr_progress_snapshot: JSON.stringify({
+        headRefOid: "head-c",
+        reviewDecision: "CHANGES_REQUESTED",
+        mergeStateStatus: "BLOCKED",
+        checks: [],
+        unresolvedReviewThreadIds: ["thread-current-0"],
+        codexConnectorStableSameFileChurn: {
+          streak: 3,
+          dominantFile: "src/release-readiness.ts",
+          clusterCategorySignature: "claim_detection+truth_source",
+          currentEffectiveMustFixCount: 4,
+          reviewedHeadShas: ["head-a", "head-b", "head-c"],
+          representativeThreadIds: ["thread-current-0"],
+        },
+      }),
+      codex_connector_stable_churn_dossier_consumed_signature: null,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 102,
+      issues: {
+        "102": record,
+      },
+    };
+    let recordAtExecutionFailure: IssueRunRecord | null = null;
+
+    const result = await executeCodexTurnPhase({
+      config: createConfig(),
+      stateStore: {
+        touch: (currentRecord, patch) => ({
+          ...currentRecord,
+          ...patch,
+          updated_at: "2026-03-26T01:00:01.000Z",
+        }),
+        save: async () => undefined,
+      },
+      github: {
+        resolvePullRequestForBranch: async () => null,
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => {
+          throw new Error("unexpected getExternalReviewSurface call");
+        },
+      },
+      context: createCodexTurnContext({
+        state,
+        record,
+        workspacePath,
+        journalPath,
+        pr: null,
+        workspaceStatus: {
+          branch: "codex/issue-102",
+          headSha: "head-c",
+        },
+      }),
+      acquireSessionLock: async () => null,
+      classifyFailure: () => "command_error",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-03-26T01:00:01.000Z",
+      }),
+      applyFailureSignature: () => ({
+        last_failure_signature: null,
+        repeated_failure_signature_count: 0,
+      }),
+      normalizeBlockerSignature: () => null,
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: () => {
+        throw new Error("unexpected derivePullRequestLifecycleSnapshot call");
+      },
+      inferStateWithoutPullRequest: () => "stabilizing",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async () => {
+        throw new Error("unexpected recoverUnexpectedCodexTurnFailure call");
+      },
+      persistCodexTurnExecutionFailure: async ({ record: recordAtFailure }) => {
+        recordAtExecutionFailure = recordAtFailure;
+        return recordAtFailure;
+      },
+      getWorkspaceStatus: async () =>
+        createWorkspaceStatus({
+          branch: "codex/issue-102",
+          headSha: "head-c",
+        }),
+      pushBranch: async () => {
+        throw new Error("unexpected pushBranch call");
+      },
+      readIssueJournal: async () =>
+        "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair stable churn.\n",
+      agentRunner: createSuccessfulAgentRunner(async (request) => {
+        assert.equal(request.kind, "start");
+        assert.equal(
+          request.record?.codex_connector_stable_churn_dossier_consumed_signature,
+          null,
+        );
+        return {
+          exitCode: 1,
+          sessionId: null,
+          supervisorMessage: "",
+          stderr: "spawn codex ENOENT",
+          stdout: "",
+          structuredResult: null,
+          failureKind: "command_error",
+          failureContext: {
+            category: "codex",
+            summary: "Codex turn execution failed.",
+            signature: "codex:Codex turn execution failed.",
+            command: null,
+            details: ["spawn codex ENOENT"],
+            url: null,
+            updated_at: "2026-03-26T01:00:01.000Z",
+          },
+        };
+      }),
+    });
+
+    const failureRecord = recordAtExecutionFailure as IssueRunRecord | null;
+    assert.deepEqual(result, {
+      kind: "returned",
+      message: "Codex turn failed for issue #102.",
+    });
+    assert.equal(
+      failureRecord?.codex_connector_stable_churn_dossier_consumed_signature,
+      null,
+    );
+    assert.equal(
+      stableSameFileCodexConnectorChurnDossierConsumptionPatch(failureRecord ?? record)
+        .codex_connector_stable_churn_dossier_consumed_signature,
+      signature,
+    );
+  });
+});
+
 test("withTempWorkspace removes the interrupted-turn workspace when the test body throws", async () => {
   let workspacePath = "";
 

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -495,14 +495,6 @@ export async function executeCodexTurnPhase(
         });
         record = preparedTurn.record;
         const { turnContext, reviewThreadsToProcess } = preparedTurn;
-        if (record.state === "addressing_review") {
-          const dossierConsumptionPatch = stableSameFileCodexConnectorChurnDossierConsumptionPatch(record);
-          if (Object.keys(dossierConsumptionPatch).length > 0) {
-            record = stateStore.touch(record, dossierConsumptionPatch);
-            state.issues[String(record.issue_number)] = record;
-            await stateStore.save(state);
-          }
-        }
         const preRunJournalFingerprint =
           await captureIssueJournalFingerprint(journalPath);
         await writeInterruptedTurnMarker({
@@ -513,6 +505,10 @@ export async function executeCodexTurnPhase(
         });
         turnMarkerWritten = true;
         const turnResult = await agentRunner.runTurn(turnContext);
+        const dossierConsumptionPatch =
+          record.state === "addressing_review"
+            ? stableSameFileCodexConnectorChurnDossierConsumptionPatch(record)
+            : {};
         const structuredResult = agentRunner.capabilities
           .supportsStructuredResult
           ? turnResult.structuredResult
@@ -537,6 +533,7 @@ export async function executeCodexTurnPhase(
         const effectiveJournalAfterRun =
           normalizedJournalAfterRun ?? journalAfterRun;
         record = stateStore.touch(record, {
+          ...dossierConsumptionPatch,
           codex_session_id: turnResult.sessionId,
           last_codex_summary: truncate(turnResult.supervisorMessage),
           last_failure_kind: turnResult.failureKind,

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -62,6 +62,7 @@ import {
   executionMetricsRetentionRootPath,
   syncExecutionMetricsRunSummarySafely,
 } from "./supervisor/execution-metrics-run-summary";
+import { stableSameFileCodexConnectorChurnDossierConsumptionPatch } from "./supervisor/supervisor-lifecycle";
 import {
   captureIssueJournalFingerprint,
   clearInterruptedTurnMarker,
@@ -494,6 +495,14 @@ export async function executeCodexTurnPhase(
         });
         record = preparedTurn.record;
         const { turnContext, reviewThreadsToProcess } = preparedTurn;
+        if (record.state === "addressing_review") {
+          const dossierConsumptionPatch = stableSameFileCodexConnectorChurnDossierConsumptionPatch(record);
+          if (Object.keys(dossierConsumptionPatch).length > 0) {
+            record = stateStore.touch(record, dossierConsumptionPatch);
+            state.issues[String(record.issue_number)] = record;
+            await stateStore.save(state);
+          }
+        }
         const preRunJournalFingerprint =
           await captureIssueJournalFingerprint(journalPath);
         await writeInterruptedTurnMarker({

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -505,8 +505,12 @@ export async function executeCodexTurnPhase(
         });
         turnMarkerWritten = true;
         const turnResult = await agentRunner.runTurn(turnContext);
+        const codexSessionStarted =
+          turnContext.kind === "start" &&
+          typeof turnResult.sessionId === "string" &&
+          turnResult.sessionId.trim().length > 0;
         const dossierConsumptionPatch =
-          record.state === "addressing_review"
+          record.state === "addressing_review" && codexSessionStarted
             ? stableSameFileCodexConnectorChurnDossierConsumptionPatch(record)
             : {};
         const structuredResult = agentRunner.capabilities

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -44,9 +44,11 @@ interface AgentRunnerBaseRequest {
         IssueRunRecord,
         | "last_failure_signature"
         | "last_tracked_pr_progress_summary"
+        | "last_tracked_pr_progress_snapshot"
         | "last_tracked_pr_repeat_failure_decision"
         | "addressing_review_strategy"
         | "addressing_review_strategy_reason"
+        | "codex_connector_stable_churn_dossier_consumed_signature"
       >
     > | null;
   repoSlug: string;

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -6,7 +6,9 @@ import {
   resetNoPrLifecycleFailureTracking,
   selectSupervisorPollIntervalMs,
   shouldRunCodex,
+  stableSameFileCodexConnectorChurnDossierConsumptionPatch,
   summarizeTrackedPrProgress,
+  unconsumedStableSameFileCodexConnectorChurnDossierSignature,
 } from "./supervisor-lifecycle";
 import { queuedReadyPromotionPathHygieneRepairContext } from "../ready-promotion-path-hygiene-repair";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
@@ -1099,6 +1101,67 @@ test("summarizeTrackedPrProgress records stable same-file Codex Connector churn 
     "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
   );
   assert.equal(snapshot.codexConnectorStableSameFileChurn.currentEffectiveMustFixCount, 4);
+});
+
+test("stable same-file Codex Connector churn dossier consumption is once per signature", () => {
+  const record = createRecord({
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-current-2250",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "BLOCKED",
+      checks: [],
+      unresolvedReviewThreadIds: ["thread-current-0", "thread-current-1"],
+      codexConnectorStableSameFileChurn: {
+        streak: 3,
+        dominantFile: "src/release-readiness.ts",
+        clusterCategorySignature: "claim_detection+truth_source",
+        currentEffectiveMustFixCount: 4,
+        reviewedHeadShas: ["head-previous-2250", "head-middle-2250", "head-current-2250"],
+        representativeThreadIds: ["thread-current-0", "thread-current-1"],
+      },
+    }),
+    codex_connector_stable_churn_dossier_consumed_signature: null,
+  });
+
+  const firstSignature = unconsumedStableSameFileCodexConnectorChurnDossierSignature(record);
+  assert.equal(
+    firstSignature,
+    "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_truth_source:head-previous-2250_head-middle-2250_head-current-2250",
+  );
+  assert.deepEqual(stableSameFileCodexConnectorChurnDossierConsumptionPatch(record), {
+    codex_connector_stable_churn_dossier_consumed_signature: firstSignature,
+  });
+  assert.deepEqual(
+    stableSameFileCodexConnectorChurnDossierConsumptionPatch({
+      ...record,
+      codex_connector_stable_churn_dossier_consumed_signature: firstSignature,
+    }),
+    {},
+  );
+
+  const changedSignature = unconsumedStableSameFileCodexConnectorChurnDossierSignature({
+    ...record,
+    codex_connector_stable_churn_dossier_consumed_signature: firstSignature,
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-next-2250",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "BLOCKED",
+      checks: [],
+      unresolvedReviewThreadIds: ["thread-next-0", "thread-next-1"],
+      codexConnectorStableSameFileChurn: {
+        streak: 3,
+        dominantFile: "src/release-readiness.ts",
+        clusterCategorySignature: "claim_detection+truth_source",
+        currentEffectiveMustFixCount: 4,
+        reviewedHeadShas: ["head-middle-2250", "head-current-2250", "head-next-2250"],
+        representativeThreadIds: ["thread-next-0", "thread-next-1"],
+      },
+    }),
+  });
+  assert.equal(
+    changedSignature,
+    "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_truth_source:head-middle-2250_head-current-2250_head-next-2250",
+  );
 });
 
 test("summarizeTrackedPrProgress resets same-file Codex Connector churn history on file, category, or count improvement", () => {

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -27,7 +27,9 @@ import {
   buildCodexConnectorReviewChurnProgressSummary,
   clusterConfiguredBotReviewThreads,
   compareCodexConnectorReviewChurnProgress,
+  codexConnectorStableSameFileChurnSignature,
   detectStableSameFileCodexConnectorChurn,
+  isCodexConnectorStableSameFileChurn,
   type CodexConnectorReviewChurnHistoryEntry,
   type CodexConnectorReviewChurnProgressComparison,
   type CodexConnectorReviewChurnProgressSummary,
@@ -149,6 +151,32 @@ export interface TrackedPrRepeatFailureDisposition {
 }
 
 const TRACKED_PR_PROGRESS_EXTENSION_MULTIPLIER = 2;
+
+export function unconsumedStableSameFileCodexConnectorChurnDossierSignature(
+  record: Pick<
+    IssueRunRecord,
+    "last_tracked_pr_progress_snapshot" | "codex_connector_stable_churn_dossier_consumed_signature"
+  >,
+): string | null {
+  const snapshot = parseTrackedPrProgressSnapshot(record.last_tracked_pr_progress_snapshot);
+  const stable = snapshot?.codexConnectorStableSameFileChurn;
+  if (!isCodexConnectorStableSameFileChurn(stable)) {
+    return null;
+  }
+
+  const signature = codexConnectorStableSameFileChurnSignature(stable);
+  return signature === record.codex_connector_stable_churn_dossier_consumed_signature ? null : signature;
+}
+
+export function stableSameFileCodexConnectorChurnDossierConsumptionPatch(
+  record: Pick<
+    IssueRunRecord,
+    "last_tracked_pr_progress_snapshot" | "codex_connector_stable_churn_dossier_consumed_signature"
+  >,
+): Pick<IssueRunRecord, "codex_connector_stable_churn_dossier_consumed_signature"> | Record<string, never> {
+  const signature = unconsumedStableSameFileCodexConnectorChurnDossierSignature(record);
+  return signature ? { codex_connector_stable_churn_dossier_consumed_signature: signature } : {};
+}
 
 function buildTrackedPrProgressSnapshot(
   record: Pick<


### PR DESCRIPTION
## Summary
- Add a stable same-file Codex Connector churn dossier to addressing-review prompts.
- Escalate only the unconsumed dossier repair turn to xhigh reasoning when model routing permits it.
- Persist one-shot dossier consumption by stable churn signature before dispatch while preserving the unconsumed turn context.

## Verification
- `npx tsx --test src/codex/codex-prompt.test.ts`
- `npx tsx --test src/codex/codex-policy.test.ts`
- `npx tsx --test src/supervisor/supervisor-lifecycle.test.ts`
- `npm run build`
- `git diff --check`

Closes #2250