### PR TITLE
Stop churn repair after consumed dossier

### DIFF
--- a/src/post-turn-pull-request-tracked-status.test.ts
+++ b/src/post-turn-pull-request-tracked-status.test.ts
@@ -383,8 +383,11 @@ test("syncTrackedPrPersistentStatusComment comments with clustered Codex churn e
     blocked_reason: "manual_review",
     pr_number: pr.number,
     last_head_sha: pr.headRefOid,
+    codex_connector_stable_churn_dossier_consumed_signature:
+      "codex-connector-stable-same-file-churn:src/release-readiness.ts:readiness_claim_truth_source_verifier_or_issue_lint:head-previous-1390_head-current-1390",
     last_tracked_pr_repeat_failure_decision: "stop_no_progress",
-    last_tracked_pr_progress_summary: "no_progress_clustered_codex_churn current_effective_must_fix=5",
+    last_tracked_pr_progress_summary:
+      "no_progress_clustered_codex_churn current_effective_must_fix=5 dossier_attempt=consumed",
     last_tracked_pr_progress_snapshot: JSON.stringify({
       headRefOid: pr.headRefOid,
       reviewDecision: "CHANGES_REQUESTED",
@@ -471,6 +474,7 @@ test("syncTrackedPrPersistentStatusComment comments with clustered Codex churn e
     commentBodies[0] ?? "",
     /normalized category signature: `readiness_claim\+truth_source\+verifier_or_issue_lint`/,
   );
+  assert.match(commentBodies[0] ?? "", /dossier attempt marker: `codex-connector-stable-same-file-churn:/);
   assert.match(commentBodies[0] ?? "", /https:\/\/example\.test\/pr\/1390#discussion_current_0/);
   assert.match(commentBodies[0] ?? "", /manual.*before restarting the supervisor/i);
   assert.match(

--- a/src/supervisor/prepared-issue-runner.ts
+++ b/src/supervisor/prepared-issue-runner.ts
@@ -386,8 +386,12 @@ export async function runPreparedIssueFlow(
         const clusteredCodexChurnStop = trackedPrRepeatFailureDisposition.progressSummary?.match(
           /^no_progress_clustered_codex_churn current_effective_must_fix=(\S+)/,
         );
+        const stoppedAfterConsumedDossier =
+          trackedPrRepeatFailureDisposition.progressSummary?.includes("dossier_attempt=consumed") === true;
         const repeatStopLastError = clusteredCodexChurnStop
-          ? `Stopped automatic repair for clustered Codex Connector churn with current effective must-fix count ${clusteredCodexChurnStop[1]}.`
+          ? stoppedAfterConsumedDossier
+            ? `Stopped automatic repair because the stable Codex Connector churn dossier was already attempted and the current effective must-fix count is ${clusteredCodexChurnStop[1]}.`
+            : `Stopped automatic repair for clustered Codex Connector churn with current effective must-fix count ${clusteredCodexChurnStop[1]}.`
           : effectiveFailureContext.summary;
         record = stateStore.touch(record, {
           state: "blocked",
@@ -432,7 +436,9 @@ export async function runPreparedIssueFlow(
         await syncJournal(record);
         return prependRecoveryLog(
           clusteredCodexChurnStop
-            ? `Issue #${record.issue_number} blocked for manual review after non-decreasing clustered Codex Connector churn.`
+            ? stoppedAfterConsumedDossier
+              ? `Issue #${record.issue_number} blocked for manual review after a consumed Codex Connector churn dossier did not improve.`
+              : `Issue #${record.issue_number} blocked for manual review after non-decreasing clustered Codex Connector churn.`
             : `Issue #${record.issue_number} blocked after repeated identical review-related failure signatures.`,
           recoveryLog,
         );

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -1133,6 +1133,8 @@ test("runOnce blocks non-decreasing reviewed Codex Connector churn before anothe
   fixture.config.codexConnectorReviewChurnFileConcentrationPercent = 75;
   const issueNumber = 91;
   const branch = branchName(fixture.config, issueNumber);
+  const consumedSignature =
+    "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_excluded_scope_readiness_claim_truth_source_verifier_or_issue_lint:head-before-1390_head-previous-1390";
   const state: SupervisorStateFile = createSupervisorState({
     issues: [
       createTrackedSupervisorRecord(fixture.config, fixture.workspaceRoot, issueNumber, {
@@ -1142,6 +1144,7 @@ test("runOnce blocks non-decreasing reviewed Codex Connector churn before anothe
         last_head_sha: "head-current-1390",
         last_failure_signature: "codex-review-churn:P2:src/release-readiness.ts",
         repeated_failure_signature_count: 1,
+        codex_connector_stable_churn_dossier_consumed_signature: consumedSignature,
         last_tracked_pr_progress_snapshot: JSON.stringify({
           headRefOid: "head-previous-1390",
           reviewDecision: "CHANGES_REQUESTED",
@@ -1179,6 +1182,15 @@ test("runOnce blocks non-decreasing reviewed Codex Connector churn before anothe
             dominantFile: "src/release-readiness.ts",
             dominantFilePercent: 100,
             clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+            representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+          },
+          codexConnectorStableSameFileChurn: {
+            streak: 2,
+            dominantFile: "src/release-readiness.ts",
+            clusterCategorySignature:
+              "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+            currentEffectiveMustFixCount: 4,
+            reviewedHeadShas: ["head-before-1390", "head-previous-1390"],
             representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
           },
         }),
@@ -1252,7 +1264,7 @@ test("runOnce blocks non-decreasing reviewed Codex Connector churn before anothe
   };
 
   const message = await supervisor.runOnce({ dryRun: true });
-  assert.match(message, /blocked for manual review after non-decreasing clustered Codex Connector churn/);
+  assert.match(message, /blocked for manual review after a consumed Codex Connector churn dossier did not improve/);
   assert.doesNotMatch(message, /would invoke Codex/);
 
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
@@ -1261,8 +1273,12 @@ test("runOnce blocks non-decreasing reviewed Codex Connector churn before anothe
   assert.equal(record.state, "blocked");
   assert.equal(record.blocked_reason, "manual_review");
   assert.equal(record.last_tracked_pr_repeat_failure_decision, "stop_no_progress");
-  assert.equal(record.last_tracked_pr_progress_summary, "no_progress_clustered_codex_churn current_effective_must_fix=4");
-  assert.match(record.last_error ?? "", /current effective must-fix count 4/);
+  assert.equal(
+    record.last_tracked_pr_progress_summary,
+    "no_progress_clustered_codex_churn current_effective_must_fix=4 dossier_attempt=consumed",
+  );
+  assert.match(record.last_error ?? "", /stable Codex Connector churn dossier was already attempted/);
+  assert.match(record.last_error ?? "", /current effective must-fix count is 4/);
 });
 
 test("runOnce requests Codex Connector review before repeated stale configured-bot signature suppression", async () => {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -712,10 +712,13 @@ test("determineTrackedPrRepeatFailureDisposition stops no-progress clustered Cod
   assert.equal(result.progressSummary, "no_progress_clustered_codex_churn current_effective_must_fix=4");
 });
 
-test("determineTrackedPrRepeatFailureDisposition stops non-decreasing reviewed Codex churn before the generic repeat limit", () => {
+test("determineTrackedPrRepeatFailureDisposition stops non-decreasing reviewed Codex churn after dossier consumption", () => {
+  const consumedSignature =
+    "codex-connector-stable-same-file-churn:src/release-readiness.ts:claim_detection_excluded_scope_readiness_claim_truth_source_verifier_or_issue_lint:head-before-1390_head-previous-1390";
   const record = createRecord({
     last_failure_signature: "codex-review-churn:P2:src/release-readiness.ts",
     repeated_failure_signature_count: 1,
+    codex_connector_stable_churn_dossier_consumed_signature: consumedSignature,
     last_tracked_pr_progress_snapshot: JSON.stringify({
       headRefOid: "head-previous-1390",
       reviewDecision: "CHANGES_REQUESTED",
@@ -753,6 +756,14 @@ test("determineTrackedPrRepeatFailureDisposition stops non-decreasing reviewed C
         dominantFile: "src/release-readiness.ts",
         dominantFilePercent: 100,
         clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+        representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      },
+      codexConnectorStableSameFileChurn: {
+        streak: 2,
+        dominantFile: "src/release-readiness.ts",
+        clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+        currentEffectiveMustFixCount: 4,
+        reviewedHeadShas: ["head-before-1390", "head-previous-1390"],
         representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
       },
     }),
@@ -801,7 +812,114 @@ test("determineTrackedPrRepeatFailureDisposition stops non-decreasing reviewed C
 
   assert.equal(result.shouldStop, true);
   assert.equal(result.decision, "stop_no_progress");
-  assert.equal(result.progressSummary, "no_progress_clustered_codex_churn current_effective_must_fix=4");
+  assert.equal(
+    result.progressSummary,
+    "no_progress_clustered_codex_churn current_effective_must_fix=4 dossier_attempt=consumed",
+  );
+});
+
+test("determineTrackedPrRepeatFailureDisposition keeps same reviewed Codex churn retryable before dossier consumption", () => {
+  const record = createRecord({
+    last_failure_signature: "codex-review-churn:P2:src/release-readiness.ts",
+    repeated_failure_signature_count: 1,
+    codex_connector_stable_churn_dossier_consumed_signature: null,
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head-previous-1391",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "BLOCKED",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: "2026-06-01T06:09:54Z",
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: "2026-06-01T06:08:00Z",
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:09:54Z",
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      unresolvedReviewThreadFingerprints: [
+        "thread-previous-0#comment-previous-0",
+        "thread-previous-1#comment-previous-1",
+        "thread-previous-2#comment-previous-2",
+        "thread-previous-3#comment-previous-3",
+      ],
+      unresolvedReviewThreadSourceAnchors: [
+        "thread-previous-0:src/release-readiness.ts:120",
+        "thread-previous-1:src/release-readiness.ts:121",
+        "thread-previous-2:src/release-readiness.ts:122",
+        "thread-previous-3:src/release-readiness.ts:123",
+      ],
+      processedReviewThreadIds: [],
+      processedReviewThreadFingerprints: [],
+      verificationProbeOutcomes: [],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: "head-previous-1391",
+        currentEffectiveMustFixCount: 4,
+        dominantFile: "src/release-readiness.ts",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+        representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      },
+      codexConnectorStableSameFileChurn: {
+        streak: 2,
+        dominantFile: "src/release-readiness.ts",
+        clusterCategorySignature: "claim_detection+excluded_scope+readiness_claim+truth_source+verifier_or_issue_lint",
+        currentEffectiveMustFixCount: 4,
+        reviewedHeadShas: ["head-before-1391", "head-previous-1391"],
+        representativeThreadIds: ["thread-previous-0", "thread-previous-1", "thread-previous-2", "thread-previous-3"],
+      },
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head-current-1391",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "BLOCKED",
+    configuredBotCurrentHeadObservedAt: "2026-06-01T06:20:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-01T06:20:00Z",
+    currentHeadCiGreenAt: "2026-06-01T06:18:00Z",
+  });
+  const reviewThreads: ReviewThread[] = Array.from({ length: 4 }, (_, index) =>
+    createReviewThread({
+      id: `thread-current-${index}`,
+      path: "src/release-readiness.ts",
+      line: 130 + index,
+      comments: {
+        nodes: [
+          {
+            id: `comment-current-${index}`,
+            body:
+              "P2: Block release readiness truth-source claims until the verifier proves the authoritative scope.",
+            createdAt: "2026-06-01T06:20:00Z",
+            url: `https://example.test/pr/1391#discussion_current_${index}`,
+            author: { login: "chatgpt-codex-connector[bot]", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  );
+
+  const result = determineTrackedPrRepeatFailureDisposition({
+    record,
+    config: createConfig({
+      sameFailureSignatureRepeatLimit: 3,
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+      codexConnectorReviewChurnMustFixThreshold: 4,
+      codexConnectorReviewChurnFileConcentrationPercent: 75,
+    }),
+    pr,
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  });
+
+  assert.equal(result.shouldStop, false);
+  assert.equal(result.decision, "retry_on_progress");
+  assert.notEqual(
+    result.progressSummary,
+    "no_progress_clustered_codex_churn current_effective_must_fix=4 dossier_attempt=consumed",
+  );
 });
 
 test("determineTrackedPrRepeatFailureDisposition keeps changed clustered Codex categories retryable", () => {

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -325,9 +325,14 @@ function clusteredCodexChurnMadeNoProgress(
 function hasReviewedClusteredCodexChurnStopSignal(
   previous: TrackedPrProgressSnapshot | null,
   current: TrackedPrProgressSnapshot,
+  record: Pick<IssueRunRecord, "codex_connector_stable_churn_dossier_consumed_signature">,
 ): boolean {
+  const stable = previous?.codexConnectorStableSameFileChurn;
   return Boolean(
     clusteredCodexChurnMadeNoProgress(previous, current) &&
+      isCodexConnectorStableSameFileChurn(stable) &&
+      codexConnectorStableSameFileChurnSignature(stable) ===
+        record.codex_connector_stable_churn_dossier_consumed_signature &&
       previous?.configuredBotCurrentHeadObservedAt &&
       current.configuredBotCurrentHeadObservedAt &&
       current.currentHeadCiGreenAt,
@@ -507,6 +512,7 @@ export function determineTrackedPrRepeatFailureDisposition(args: {
     | "processed_review_thread_ids"
     | "processed_review_thread_fingerprints"
     | "timeline_artifacts"
+    | "codex_connector_stable_churn_dossier_consumed_signature"
   >;
   config: Pick<
     SupervisorConfig,
@@ -543,11 +549,11 @@ export function determineTrackedPrRepeatFailureDisposition(args: {
     };
   }
 
-  if (current && hasReviewedClusteredCodexChurnStopSignal(previous, current)) {
+  if (current && hasReviewedClusteredCodexChurnStopSignal(previous, current, args.record)) {
     return {
       shouldStop: true,
       progressSnapshot: snapshot,
-      progressSummary: `no_progress_clustered_codex_churn current_effective_must_fix=${current.codexConnectorReviewChurnProgress?.currentEffectiveMustFixCount ?? "unknown"}`,
+      progressSummary: `no_progress_clustered_codex_churn current_effective_must_fix=${current.codexConnectorReviewChurnProgress?.currentEffectiveMustFixCount ?? "unknown"} dossier_attempt=consumed`,
       decision: "stop_no_progress",
     };
   }

--- a/src/tracked-pr-status-comment-rendering.ts
+++ b/src/tracked-pr-status-comment-rendering.ts
@@ -248,6 +248,7 @@ export function buildTrackedPrCodexConnectorChurnStatusComment(args: {
   currentEffectiveMustFixCount: number | string;
   countTrend: string;
   clusterCategorySignature: string;
+  dossierAttemptMarker?: string | null;
   representativeThreadUrls: string[];
 }): string {
   return [
@@ -259,6 +260,7 @@ export function buildTrackedPrCodexConnectorChurnStatusComment(args: {
     `- effective must-fix count: \`${args.currentEffectiveMustFixCount}\``,
     `- count trend: \`${args.countTrend}\``,
     `- normalized category signature: \`${args.clusterCategorySignature}\``,
+    ...(args.dossierAttemptMarker ? [`- dossier attempt marker: \`${args.dossierAttemptMarker}\``] : []),
     ...args.representativeThreadUrls.map((url) => `- representative thread: ${url}`),
     "- automatic retry: no",
     "- next action: manually inspect the dominant file and representative Codex Connector threads before restarting the supervisor.",

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -400,6 +400,7 @@ function codexConnectorChurnStatusComment(
       currentEffectiveMustFixCount: churnSnapshot.progress.currentEffectiveMustFixCount,
       countTrend,
       clusterCategorySignature: churnSnapshot.progress.clusterCategorySignature,
+      dossierAttemptMarker: args.record.codex_connector_stable_churn_dossier_consumed_signature,
       representativeThreadUrls,
     }),
   };


### PR DESCRIPTION
## Summary
- stop early reviewed same-file Codex Connector churn only after the stable churn dossier marker was consumed
- mark dossier-backed stops with `dossier_attempt=consumed` and clearer manual-review messaging
- include the dossier attempt marker in the supervisor-owned tracked PR churn comment

Fixes #2251

## Verification
- `npx tsx --test src/supervisor/supervisor-lifecycle.test.ts`
- `npx tsx --test src/post-turn-pull-request-tracked-status.test.ts`
- `npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts`
- `npx tsx --test src/supervisor/supervisor-status-report.test.ts`
- `npm run build`