### PR TITLE
Limit verified repair auto-resolve to P2 residue

### DIFF
--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -1988,7 +1988,8 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
     commentId: "comment-codex-repair",
     path: "src/review.ts",
     line: 7,
-    commentBody: "P1: Verify the repair covers this finding before merge.",
+    severity: "P2",
+    commentBody: "P2: Verify the repair covers this finding before merge.",
     discussionUrl: "https://example.test/pr/1988#discussion_r1988",
     verifiedRepair: {
       summary: "Focused verifier passed after the repair commit.",
@@ -2406,4 +2407,99 @@ test("handlePostTurnPullRequestTransitionsPhase keeps verified repair thread res
     assert.deepEqual(replyCalls, [], testCase.name);
     assert.deepEqual(resolveCalls, [], testCase.name);
   }
+});
+
+test("handlePostTurnPullRequestTransitionsPhase keeps P1 verified current-head repair residue blocked", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Do not auto-resolve P1 verified current-head repair residue" });
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 2035,
+    headSha: "head-2035",
+    threadId: "thread-codex-p1-repair",
+    commentId: "comment-codex-p1-repair",
+    path: "src/review.ts",
+    line: 301,
+    severity: "P1",
+    commentBody: "P1: Keep higher-severity current-head repair residue blocked for operator review.",
+    discussionUrl: "https://example.test/pr/2035#discussion_r2035",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-18T07:18:00Z",
+      command: "npx tsx --test src/post-turn-pull-request-codex-connector.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-18T07:12:00Z",
+      observedAt: "2026-05-18T07:17:00Z",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord(scenario.recordPatch),
+    },
+  };
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async () => {
+        throw new Error("unexpected addIssueComment call");
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState) =>
+      createLifecycleSnapshot(recordForState, "blocked", {
+        failureContext: scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: () => "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.deepEqual(replyCalls, []);
+  assert.deepEqual(resolveCalls, []);
 });

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -19,7 +19,8 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major comment
     commentId: "comment-mutation-lock-stale-recovery",
     path: "src/mutation-lock.ts",
     line: 42,
-    commentBody: "P1: Verify stale mutation lock recovery only releases the acquired lock instance.",
+    severity: "P2",
+    commentBody: "P2: Verify stale mutation lock recovery only releases the acquired lock instance.",
     discussionUrl: "https://example.test/pr/115#discussion_r115",
     verifiedRepair: {
       summary: "Focused mutation lock verifier passed on the current head.",
@@ -150,6 +151,65 @@ test("buildStaleReviewBotRemediation accepts green current-head checks as verifi
   assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
   assert.equal(diagnostics?.repeatStopExhausted, "no");
   assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
+});
+
+test("buildStaleReviewBotRemediation keeps P1 current-head repair residue blocked after no-major", () => {
+  const issueNumber = 188;
+  const prNumber = 195;
+  const headSha = "f2b1be31eaf78a3d1c7f1ccd28e730bb38e00b1d";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_current_head_repaired_p1_residue",
+    commentId: "PRRC_current_head_repaired_p1_residue",
+    path: "src/app.ts",
+    line: 88,
+    severity: "P1",
+    commentBody: "P1: Do not auto-resolve higher-severity current-head repair residue.",
+    discussionUrl: "https://example.test/pr/195#discussion_r3316522485",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-28T09:38:46Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-28T09:31:32Z",
+      observedAt: "2026-05-28T09:35:46Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "unresolved_work");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 0);
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "not_verified_stale_residue");
 });
 
 test("buildStaleReviewBotRemediation rejects review-bot-only checks as verified repair evidence", () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -5,6 +5,7 @@ import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
+  latestCodexConnectorPSeverity,
 } from "../codex-connector-review-policy";
 import {
   configuredBotReviewFollowUpState,
@@ -354,6 +355,10 @@ function hasCurrentHeadCodexTurnVerification(
   );
 }
 
+function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[]): boolean {
+  return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
+}
+
 function validTimestamp(value: string | null | undefined): string | null {
   if (!value || Number.isNaN(Date.parse(value))) {
     return null;
@@ -500,6 +505,16 @@ function classifyCodexMetadataOnly(args: {
       }
       const verifiedCurrentHeadRepair =
         hasCurrentHeadCodexTurnVerification(args.record, args.pr) || args.record.repair_attempt_count > 0;
+      if (
+        verifiedCurrentHeadRepair &&
+        !allCodexConnectorRepairResidueThreadsAreP2(codexConnectorMustFixReviewThreads(args.reviewThreads))
+      ) {
+        return {
+          classification: "unresolved_work",
+          summary: STALE_REVIEW_BOT_SUMMARY,
+          verificationEvidenceSummary,
+        };
+      }
       return {
         classification: verifiedCurrentHeadRepair
           ? "verified_current_head_repair_pending_thread_resolution"

--- a/src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
@@ -784,7 +784,8 @@ test("explain distinguishes Codex verified current-head repair residue from no-s
     commentId: "comment-199",
     path: "src/repair.ts",
     line: 42,
-    commentBody: "P1: Verify the repaired authorization guard before merge.",
+    severity: "P2",
+    commentBody: "P2: Verify the repaired authorization guard before merge.",
     discussionUrl: "https://example.test/pr/399#discussion_r399",
     verifiedRepair: {
       summary: "Focused verifier passed after the repair commit.",

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -310,7 +310,8 @@ test("status --why uses the shared stale review-bot presenter for active verifie
     commentId: "comment-400",
     path: "src/auth-boundary.ts",
     line: 91,
-    commentBody: "P1: Prove the repaired auth boundary is covered before merge.",
+    severity: "P2",
+    commentBody: "P2: Prove the repaired auth boundary is covered before merge.",
     discussionUrl: "https://example.test/pr/500#discussion_r400",
     verifiedRepair: {
       summary: "Focused verifier passed after the repair commit.",


### PR DESCRIPTION
## Summary
- limit verified current-head Codex Connector repair auto-resolve to latest P2 repair residue
- keep P1 verified repair residue blocked even with current-head no-major evidence and verification
- update post-turn and diagnostics fixtures so eligible paths use P2

## Verification
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npx tsx --test src/post-turn-pull-request-codex-connector.test.ts
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts src/post-turn-pull-request-tracked-status.test.ts src/supervisor/supervisor-execution-orchestration.test.ts
- npm ci
- npm run build

Closes #2256