### PR TITLE
Verify Codex repair residue without no-major signal

### DIFF
--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2457,6 +2457,134 @@ test("handlePostTurnPullRequestTransitionsPhase does not probe files from dirty 
   assert.match(requestComments[0] ?? "", /reason code: `stale_review_bot`/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase does not probe symlink targets as committed repair evidence", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Reject symlink repair probe target" });
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const { workspacePath } = await createTrackedIssueBranchRepo("codex/issue-2258-symlink");
+  const externalTargetDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-symlink-target-"));
+  const externalTargetPath = path.join(externalTargetDir, "policy-source.ts");
+  await fs.mkdir(path.join(workspacePath, "src"), { recursive: true });
+  await fs.writeFile(
+    externalTargetPath,
+    [
+      "const LOADER_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+      "const POLICY_SCAN_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.symlink(externalTargetPath, path.join(workspacePath, policyPath));
+  git(workspacePath, "add", policyPath);
+  git(workspacePath, "commit", "-m", "add symlink policy source");
+  git(workspacePath, "push");
+  const headSha = git(workspacePath, "rev-parse", "HEAD").trim();
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 2261,
+    headSha,
+    threadId: "thread-codex-symlink-workspace-repair",
+    commentId: "comment-codex-symlink-workspace-repair",
+    path: policyPath,
+    line: 7,
+    severity: "P2",
+    commentBody:
+      `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/2261#discussion_r2261",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:18:00Z",
+      command: "npx tsx --test src/post-turn-pull-request-codex-connector.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        ...scenario.recordPatch,
+        repair_attempt_count: 1,
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    },
+  };
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  const requestComments: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 2261001,
+          nodeId: "IC_kwDO2261",
+          url: "https://example.test/pr/2261#issuecomment-2261001",
+        };
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath,
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.deepEqual(replyCalls, []);
+  assert.deepEqual(resolveCalls, []);
+  assert.equal(requestComments.length, 1);
+  assert.match(requestComments[0] ?? "", /reason code: `stale_review_bot`/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads even when review state falls through to manual_review", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2336,6 +2336,127 @@ test("handlePostTurnPullRequestTransitionsPhase does not probe files when worksp
   assert.match(requestComments[0] ?? "", /reason code: `stale_review_bot`/);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase does not probe files from dirty workspaces", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Reject dirty workspace repair probe" });
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const { workspacePath, headSha } = await createTrackedIssueBranchRepo("codex/issue-2258-dirty");
+  await fs.mkdir(path.join(workspacePath, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(workspacePath, policyPath),
+    [
+      "const LOADER_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+      "const POLICY_SCAN_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+    ].join("\n"),
+    "utf8",
+  );
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 2260,
+    headSha,
+    threadId: "thread-codex-dirty-workspace-repair",
+    commentId: "comment-codex-dirty-workspace-repair",
+    path: policyPath,
+    line: 7,
+    severity: "P2",
+    commentBody:
+      `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/2260#discussion_r2260",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:18:00Z",
+      command: "npx tsx --test src/post-turn-pull-request-codex-connector.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        ...scenario.recordPatch,
+        repair_attempt_count: 1,
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    },
+  };
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  const requestComments: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 2260001,
+          nodeId: "IC_kwDO2260",
+          url: "https://example.test/pr/2260#issuecomment-2260001",
+        };
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath,
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.deepEqual(replyCalls, []);
+  assert.deepEqual(resolveCalls, []);
+  assert.equal(requestComments.length, 1);
+  assert.match(requestComments[0] ?? "", /reason code: `stale_review_bot`/);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads even when review state falls through to manual_review", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2092,7 +2092,7 @@ test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P
   const issue = createIssue({ title: "Resolve mechanically verified Codex repair residue" });
   const policyPath = "src/mvp-a-onboarding-traceability.ts";
   const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
-  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-mechanical-repair-"));
+  const { workspacePath } = await createTrackedIssueBranchRepo("codex/issue-2258");
   await fs.mkdir(path.join(workspacePath, "src"), { recursive: true });
   await fs.writeFile(
     path.join(workspacePath, policyPath),
@@ -2106,10 +2106,14 @@ test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P
     ].join("\n"),
     "utf8",
   );
+  git(workspacePath, "add", policyPath);
+  git(workspacePath, "commit", "-m", "repair policy paths");
+  git(workspacePath, "push");
+  const headSha = git(workspacePath, "rev-parse", "HEAD").trim();
   const scenario = createCodexConnectorTrackedReviewResidueScenario({
     issueNumber: issue.number,
     prNumber: 2258,
-    headSha: "head-2258",
+    headSha,
     threadId: "thread-codex-mechanical-repair",
     commentId: "comment-codex-mechanical-repair",
     path: policyPath,
@@ -2206,6 +2210,130 @@ test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P
   assert.deepEqual(resolveCalls, ["thread-codex-mechanical-repair"]);
   assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
   assert.equal(requestComments.length, 0);
+});
+
+test("handlePostTurnPullRequestTransitionsPhase does not probe files when workspace HEAD differs from PR head", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Reject stale workspace repair probe" });
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const { workspacePath, headSha: localHeadSha } = await createTrackedIssueBranchRepo("codex/issue-2258-stale");
+  await fs.mkdir(path.join(workspacePath, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(workspacePath, policyPath),
+    [
+      "const LOADER_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+      "const POLICY_SCAN_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+    ].join("\n"),
+    "utf8",
+  );
+  git(workspacePath, "add", policyPath);
+  git(workspacePath, "commit", "-m", "local-only repair evidence");
+  const remoteHeadSha = "f".repeat(40);
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 2259,
+    headSha: remoteHeadSha === localHeadSha ? "e".repeat(40) : remoteHeadSha,
+    threadId: "thread-codex-stale-workspace-repair",
+    commentId: "comment-codex-stale-workspace-repair",
+    path: policyPath,
+    line: 7,
+    severity: "P2",
+    commentBody:
+      `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/2259#discussion_r2259",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:18:00Z",
+      command: "npx tsx --test src/post-turn-pull-request-codex-connector.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        ...scenario.recordPatch,
+        repair_attempt_count: 1,
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    },
+  };
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  const requestComments: string[] = [];
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 2259001,
+          nodeId: "IC_kwDO2259",
+          url: "https://example.test/pr/2259#issuecomment-2259001",
+        };
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath,
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => ({
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads,
+    }),
+  });
+
+  assert.equal(result.record.state, "blocked");
+  assert.deepEqual(replyCalls, []);
+  assert.deepEqual(resolveCalls, []);
+  assert.equal(requestComments.length, 1);
+  assert.match(requestComments[0] ?? "", /reason code: `stale_review_bot`/);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads even when review state falls through to manual_review", async () => {

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2083,6 +2083,131 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
   assert.equal(requestComments.length, 0);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P2 repair residue without no-major signal", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Resolve mechanically verified Codex repair residue" });
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-mechanical-repair-"));
+  await fs.mkdir(path.join(workspacePath, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(workspacePath, policyPath),
+    [
+      "const LOADER_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+      "const POLICY_SCAN_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+    ].join("\n"),
+    "utf8",
+  );
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 2258,
+    headSha: "head-2258",
+    threadId: "thread-codex-mechanical-repair",
+    commentId: "comment-codex-mechanical-repair",
+    path: policyPath,
+    line: 7,
+    severity: "P2",
+    commentBody:
+      `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/2258#discussion_r2258",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:18:00Z",
+      command: "npx tsx --test src/post-turn-pull-request-codex-connector.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        ...scenario.recordPatch,
+        repair_attempt_count: 1,
+        last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      }),
+    },
+  };
+  const reviewThreads = [scenario.reviewThread] satisfies ReviewThread[];
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  const requestComments: string[] = [];
+  let snapshotLoads = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      addIssueComment: async (_prNumber: number, body: string) => {
+        requestComments.push(body);
+        return {
+          databaseId: 2258001,
+          nodeId: "IC_kwDO2258",
+          url: "https://example.test/pr/2258#issuecomment-2258001",
+        };
+      },
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath,
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr,
+        checks: scenario.passingChecks,
+        reviewThreads: snapshotLoads <= 2 ? reviewThreads : [],
+      };
+    },
+  });
+
+  assert.equal(result.record.state, "waiting_ci");
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-mechanical-repair"]);
+  assert.deepEqual(resolveCalls, ["thread-codex-mechanical-repair"]);
+  assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
+  assert.equal(requestComments.length, 0);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads even when review state falls through to manual_review", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/post-turn-pull-request-test-support.ts
+++ b/src/post-turn-pull-request-test-support.ts
@@ -29,6 +29,7 @@ export async function createTrackedRepo(): Promise<string> {
   git(repoPath, "config", "user.name", "Codex Supervisor");
   git(repoPath, "config", "user.email", "codex@example.test");
   git(repoPath, "init", "--bare", "origin.git");
+  await fs.appendFile(path.join(repoPath, ".git", "info", "exclude"), "\n/origin.git/\n", "utf8");
   await fs.writeFile(path.join(repoPath, "README.md"), "# fixture\n", "utf8");
   git(repoPath, "add", "README.md");
   git(repoPath, "commit", "-m", "seed");

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -47,6 +47,7 @@ import { hasResolvedAllStaleConfiguredBotThreads } from "./supervisor/stale-revi
 import { applyTrackedPrLifecycleState } from "./post-turn-pull-request-lifecycle";
 import { maybePromoteDraftPullRequestToReady } from "./post-turn-ready-promotion";
 import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state-codex-residue-policy";
+import { getWorkspaceStatus } from "./core/workspace";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -319,6 +320,37 @@ function hasEffectiveConfiguredBotReviewBlockers(args: {
   ).length > 0;
 }
 
+function staleReviewRepairProbeMayReadWorkspace(args: {
+  config: Pick<SupervisorConfig, "verifiedCurrentHeadRepairReviewThreadAutoResolve">;
+  record: Pick<IssueRunRecord, "blocked_reason" | "state">;
+}): boolean {
+  return (
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    (args.record.state === "blocked" || args.record.state === "pr_open") &&
+    (args.record.blocked_reason === "stale_review_bot" ||
+      args.record.blocked_reason === "manual_review" ||
+      args.record.state === "pr_open")
+  );
+}
+
+async function currentHeadWorkspacePathForStaleReviewRepairProbe(args: {
+  config: Pick<SupervisorConfig, "defaultBranch" | "verifiedCurrentHeadRepairReviewThreadAutoResolve">;
+  record: Pick<IssueRunRecord, "blocked_reason" | "branch" | "state">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  workspacePath: string;
+}): Promise<string | undefined> {
+  if (!staleReviewRepairProbeMayReadWorkspace(args)) {
+    return undefined;
+  }
+
+  try {
+    const workspaceStatus = await getWorkspaceStatus(args.workspacePath, args.record.branch, args.config.defaultBranch);
+    return workspaceStatus.headSha === args.pr.headRefOid ? args.workspacePath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function handlePostTurnPullRequestTransitionsPhase(
   args: HandlePostTurnPullRequestTransitionsArgs,
 ): Promise<PostTurnPullRequestResult> {
@@ -537,6 +569,12 @@ export async function handlePostTurnPullRequestTransitionsPhase(
       effectiveFailureContext = currentHeadLocalCiGate.failureContext;
     }
   }
+  const currentHeadWorkspacePath = await currentHeadWorkspacePathForStaleReviewRepairProbe({
+    config,
+    record,
+    pr: postReady.pr,
+    workspacePath,
+  });
   record = await trackedPrStatusComments.maybeCommentOnTrackedPrPersistentStatus({
     github,
     stateStore,
@@ -550,7 +588,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     config,
     failureContext: effectiveFailureContext,
     summarizeChecks: args.summarizeChecks,
-    workspacePath,
+    workspacePath: currentHeadWorkspacePath,
   });
   const staleReviewBotReplySignature =
     record.last_stale_review_bot_reply_signature ??

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -550,6 +550,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
     config,
     failureContext: effectiveFailureContext,
     summarizeChecks: args.summarizeChecks,
+    workspacePath,
   });
   const staleReviewBotReplySignature =
     record.last_stale_review_bot_reply_signature ??
@@ -615,6 +616,7 @@ export async function handlePostTurnPullRequestTransitionsPhase(
           failureContext: effectiveFailureContext,
           summarizeChecks: args.summarizeChecks,
           skipAutoHandleStaleConfiguredBotReview: true,
+          workspacePath,
         });
       }
       record = await maybeRequestCodexConnectorReviewComment({

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -345,7 +345,9 @@ async function currentHeadWorkspacePathForStaleReviewRepairProbe(args: {
 
   try {
     const workspaceStatus = await getWorkspaceStatus(args.workspacePath, args.record.branch, args.config.defaultBranch);
-    return workspaceStatus.headSha === args.pr.headRefOid ? args.workspacePath : undefined;
+    return workspaceStatus.headSha === args.pr.headRefOid && !workspaceStatus.hasUncommittedChanges
+      ? args.workspacePath
+      : undefined;
   } catch {
     return undefined;
   }

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -1,5 +1,6 @@
-import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
 import path from "node:path";
+import { promisify } from "node:util";
 import type { GitHubClient } from "./github";
 import type { IssueJournalSync } from "./run-once-issue-preparation";
 import type { StateStore } from "./core/state-store";
@@ -30,12 +31,54 @@ export interface StaleConfiguredBotReviewRemediationResult {
 
 type RepositoryFileContents = Record<string, string | null | undefined>;
 
+const execFileAsync = promisify(execFile);
+const MAX_REPAIR_PROBE_FILE_BYTES = 512_000;
+
 function normalizeReviewThreadPath(value: string | null | undefined): string | null {
   const normalized = value?.trim().replace(/\\/g, "/").replace(/^\.\/+/u, "");
   if (!normalized || normalized.startsWith("/") || normalized.includes("\0") || normalized.split("/").includes("..")) {
     return null;
   }
   return normalized;
+}
+
+async function readCommittedRepositoryFile(args: {
+  workspacePath: string;
+  expectedHeadSha: string;
+  relativePath: string;
+}): Promise<string | null> {
+  const objectSpec = `${args.expectedHeadSha}:${args.relativePath}`;
+  const treeEntry = await execFileAsync(
+    "git",
+    ["-C", args.workspacePath, "ls-tree", "-z", args.expectedHeadSha, "--", args.relativePath],
+    { encoding: "utf8", maxBuffer: 64_000 },
+  );
+  const entry = treeEntry.stdout.split("\0").find((line) => line.endsWith(`\t${args.relativePath}`));
+  if (!entry) {
+    return null;
+  }
+
+  const mode = entry.match(/^(\d{6})\s/u)?.[1] ?? null;
+  if (mode === "120000" || (mode !== "100644" && mode !== "100755")) {
+    return null;
+  }
+
+  const sizeResult = await execFileAsync(
+    "git",
+    ["-C", args.workspacePath, "cat-file", "-s", objectSpec],
+    { encoding: "utf8", maxBuffer: 64_000 },
+  );
+  const size = Number.parseInt(sizeResult.stdout.trim(), 10);
+  if (!Number.isFinite(size) || size > MAX_REPAIR_PROBE_FILE_BYTES) {
+    return null;
+  }
+
+  const blobResult = await execFileAsync(
+    "git",
+    ["-C", args.workspacePath, "show", objectSpec],
+    { encoding: "utf8", maxBuffer: MAX_REPAIR_PROBE_FILE_BYTES + 1024 },
+  );
+  return blobResult.stdout;
 }
 
 async function loadReviewThreadFileContents(args: {
@@ -73,11 +116,15 @@ async function loadReviewThreadFileContents(args: {
       continue;
     }
     try {
-      const stat = await fs.stat(absolutePath);
-      if (!stat.isFile() || stat.size > 512_000) {
+      const committedContent = await readCommittedRepositoryFile({
+        workspacePath: workspaceRoot,
+        expectedHeadSha: args.expectedHeadSha,
+        relativePath,
+      });
+      if (committedContent === null) {
         continue;
       }
-      contents[relativePath] = await fs.readFile(absolutePath, "utf8");
+      contents[relativePath] = committedContent;
     } catch {
       contents[relativePath] = null;
     }

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -12,6 +12,7 @@ import type {
   SupervisorConfig,
   SupervisorStateFile,
 } from "./core/types";
+import { getWorkspaceStatus } from "./core/workspace";
 import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
 import {
   recoverStaleConfiguredBotReviewThreads,
@@ -38,10 +39,22 @@ function normalizeReviewThreadPath(value: string | null | undefined): string | n
 }
 
 async function loadReviewThreadFileContents(args: {
+  defaultBranch: string;
+  expectedHeadSha: string;
+  branch: string;
   workspacePath?: string;
   reviewThreads: ReviewThread[];
 }): Promise<RepositoryFileContents | undefined> {
   if (!args.workspacePath) {
+    return undefined;
+  }
+
+  try {
+    const workspaceStatus = await getWorkspaceStatus(args.workspacePath, args.branch, args.defaultBranch);
+    if (workspaceStatus.headSha !== args.expectedHeadSha) {
+      return undefined;
+    }
+  } catch {
     return undefined;
   }
 
@@ -106,6 +119,9 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
           checks: args.checks,
           reviewThreads: args.reviewThreads,
           repositoryFileContents: await loadReviewThreadFileContents({
+            defaultBranch: args.config.defaultBranch,
+            expectedHeadSha: args.pr.headRefOid,
+            branch: remediationRecord.branch,
             workspacePath: args.workspacePath,
             reviewThreads: args.reviewThreads,
           }),

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -51,7 +51,7 @@ async function loadReviewThreadFileContents(args: {
 
   try {
     const workspaceStatus = await getWorkspaceStatus(args.workspacePath, args.branch, args.defaultBranch);
-    if (workspaceStatus.headSha !== args.expectedHeadSha) {
+    if (workspaceStatus.headSha !== args.expectedHeadSha || workspaceStatus.hasUncommittedChanges) {
       return undefined;
     }
   } catch {

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { GitHubClient } from "./github";
 import type { IssueJournalSync } from "./run-once-issue-preparation";
 import type { StateStore } from "./core/state-store";
@@ -25,6 +27,52 @@ export interface StaleConfiguredBotReviewRemediationResult {
   record: IssueRunRecord;
 }
 
+type RepositoryFileContents = Record<string, string | null | undefined>;
+
+function normalizeReviewThreadPath(value: string | null | undefined): string | null {
+  const normalized = value?.trim().replace(/\\/g, "/").replace(/^\.\/+/u, "");
+  if (!normalized || normalized.startsWith("/") || normalized.includes("\0") || normalized.split("/").includes("..")) {
+    return null;
+  }
+  return normalized;
+}
+
+async function loadReviewThreadFileContents(args: {
+  workspacePath?: string;
+  reviewThreads: ReviewThread[];
+}): Promise<RepositoryFileContents | undefined> {
+  if (!args.workspacePath) {
+    return undefined;
+  }
+
+  const workspaceRoot = path.resolve(args.workspacePath);
+  const contents: RepositoryFileContents = {};
+  const paths = Array.from(
+    new Set(args.reviewThreads.flatMap((thread) => {
+      const normalized = normalizeReviewThreadPath(thread.path);
+      return normalized ? [normalized] : [];
+    })),
+  ).slice(0, 20);
+
+  for (const relativePath of paths) {
+    const absolutePath = path.resolve(workspaceRoot, relativePath);
+    if (absolutePath !== workspaceRoot && !absolutePath.startsWith(`${workspaceRoot}${path.sep}`)) {
+      continue;
+    }
+    try {
+      const stat = await fs.stat(absolutePath);
+      if (!stat.isFile() || stat.size > 512_000) {
+        continue;
+      }
+      contents[relativePath] = await fs.readFile(absolutePath, "utf8");
+    } catch {
+      contents[relativePath] = null;
+    }
+  }
+
+  return Object.keys(contents).length > 0 ? contents : undefined;
+}
+
 export async function handleStaleConfiguredBotReviewRemediation(args: {
   github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
   stateStore: Pick<StateStore, "touch" | "save">;
@@ -41,6 +89,7 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
   statusCommentAvailable: boolean;
   conversationResolutionBlocker: StaleConfiguredBotConversationResolutionBlocker | null;
   skipAutoHandleStaleConfiguredBotReview?: boolean;
+  workspacePath?: string;
 }): Promise<StaleConfiguredBotReviewRemediationResult> {
   const remediationRecord =
     args.record.state === "blocked" &&
@@ -56,6 +105,10 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
           pr: args.pr,
           checks: args.checks,
           reviewThreads: args.reviewThreads,
+          repositoryFileContents: await loadReviewThreadFileContents({
+            workspacePath: args.workspacePath,
+            reviewThreads: args.reviewThreads,
+          }),
         })
       : null;
   const canResolveStaleConfiguredBotReview =

--- a/src/supervisor/prepared-issue-runner.ts
+++ b/src/supervisor/prepared-issue-runner.ts
@@ -178,6 +178,9 @@ function shouldTryVerifiedStaleConfiguredBotAutoResolveBeforeRepeatStop(args: {
     (remediation.classification === "verified_no_source_change_pending_thread_resolution" &&
       args.config.verifiedNoSourceChangeReviewThreadAutoResolve === true) ||
     (remediation.classification === "verified_current_head_repair_pending_thread_resolution" &&
+      args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true) ||
+    (remediation.classification === "unknown_needs_operator" &&
+      remediation.missingProbeReason === "current_head_codex_no_major_signal_missing" &&
       args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true)
   );
 }
@@ -355,6 +358,7 @@ export async function runPreparedIssueFlow(
           failureContext: effectiveFailureContext,
           summarizeChecks,
           manualReviewThreadCount: manualReviewThreads(config, reviewThreads).length,
+          workspacePath,
         });
         handledStaleConfiguredBotResidueBeforeRepeatStop = didAutoResolveStaleConfiguredBotBeforeRepeatStop({
           before: recordBeforeAutoResolve,

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -603,6 +603,158 @@ test("buildStaleReviewBotRemediation does not truncate longer path extensions du
   assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
 });
 
+test("buildStaleReviewBotRemediation requires exact path token matches during repair probes", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "3d3b78d7ddc0ee8a31382bd131998c13226b5d63";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const requestedDocumentPath = "docs/page.md";
+  const siblingDocumentPath = "docs/page.mdx";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-exact-path-residue",
+    commentId: "comment-hrcore-exact-path-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${requestedDocumentPath}\` to the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_exact",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const POLICY_SCAN_PATHS = [",
+        `  "${siblingDocumentPath}",`,
+        `  "${siblingDocumentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+});
+
+test("buildStaleReviewBotRemediation requires every requested path before proving repair residue", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "93cd2756e7a4721e3c6e1fc0f9fe3259b6f7e8f0";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const componentPath = "src/view.tsx";
+  const documentPath = "docs/page.mdx";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-every-path-residue",
+    commentId: "comment-hrcore-every-path-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${componentPath}\` and \`${documentPath}\` to the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_every",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const missingDocumentRemediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const POLICY_SCAN_PATHS = [",
+        `  "${componentPath}",`,
+        `  "${componentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+  const completeRemediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const LOADER_PATHS = [",
+        `  "${componentPath}",`,
+        `  "${documentPath}",`,
+        "];",
+        "const POLICY_SCAN_PATHS = [",
+        `  "${componentPath}",`,
+        `  "${documentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(missingDocumentRemediation?.classification, "unknown_needs_operator");
+  assert.equal(missingDocumentRemediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(missingDocumentRemediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+  assert.equal(completeRemediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.match(
+    completeRemediation?.verificationEvidenceSummary ?? "",
+    /deterministic_repair_probe:path_present_in_reviewed_file:src\/view\.tsx:2/,
+  );
+  assert.match(
+    completeRemediation?.verificationEvidenceSummary ?? "",
+    /deterministic_repair_probe:path_present_in_reviewed_file:docs\/page\.mdx:2/,
+  );
+});
+
 test("buildStaleReviewBotRemediation fails closed when current-head no-major has unprocessed must-fix threads", () => {
   const issueNumber = 110;
   const prNumber = 115;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -604,6 +604,70 @@ test("buildStaleReviewBotRemediation ignores unrelated arrays during path-list r
   assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
 });
 
+test("buildStaleReviewBotRemediation rejects inverse path-list arrays during repair probes", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "a9ac8914f2679f0d9f273776f352c9e4efc2258";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/page.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-inverse-path-list-residue",
+    commentId: "comment-hrcore-inverse-path-list-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${documentPath}\` to the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_inverse_path_list",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const excludedPolicyScanPaths = [",
+        `  "${documentPath}",`,
+        "];",
+        "const disabledPolicyScanPaths = [",
+        `  "${documentPath}",`,
+        "];",
+        "const POLICY_SCAN_PATHS = [];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+});
+
 test("buildStaleReviewBotRemediation rejects non-additive path-list findings", () => {
   const issueNumber = 2258;
   const prNumber = 3258;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -314,6 +314,85 @@ test("buildStaleReviewBotRemediation fails closed when covered evidence lacks cu
   assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
 });
 
+test("buildStaleReviewBotRemediation verifies concrete P2 path-list repair without no-major signal", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "a74dcf7f47e4282b0f944ab0f1a43b53fa9c87de";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-path-list-residue",
+    commentId: "comment-hrcore-path-list-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody:
+      `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const LOADER_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+        "const POLICY_SCAN_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /deterministic_repair_probe:path_present_in_reviewed_file:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
+  );
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
+  assert.equal(diagnostics?.repeatStopExhausted, "no");
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
+});
+
 test("buildStaleReviewBotRemediation fails closed when current-head no-major has unprocessed must-fix threads", () => {
   const issueNumber = 110;
   const prNumber = 115;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -386,7 +386,7 @@ test("buildStaleReviewBotRemediation verifies concrete P2 path-list repair witho
   assert.equal(remediation?.missingProbeReason, null);
   assert.match(
     remediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_reviewed_file:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
+    /deterministic_repair_probe:path_present_in_live_list:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
   );
   assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
   assert.equal(diagnostics?.repeatStopExhausted, "no");
@@ -474,8 +474,70 @@ test("buildStaleReviewBotRemediation probes the Codex finding when a supervisor 
   assert.equal(remediation?.missingProbeReason, null);
   assert.match(
     remediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_reviewed_file:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
+    /deterministic_repair_probe:path_present_in_live_list:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
   );
+});
+
+test("buildStaleReviewBotRemediation requires live path-list membership during repair probes", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "0cc6dbde508f41a64c314c50d46d31d859cf2258";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/page.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-live-list-residue",
+    commentId: "comment-hrcore-live-list-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_live_list",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const LOADER_PATHS = [",
+        `  // "${documentPath}",`,
+        "];",
+        "const POLICY_SCAN_PATHS = [];",
+        `const repairNote = "The requested ${documentPath} path is mentioned twice: ${documentPath}.";`,
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
 });
 
 test("buildStaleReviewBotRemediation rejects non-additive path-list findings", () => {
@@ -747,11 +809,11 @@ test("buildStaleReviewBotRemediation requires every requested path before provin
   assert.equal(completeRemediation?.classification, "verified_current_head_repair_pending_thread_resolution");
   assert.match(
     completeRemediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_reviewed_file:src\/view\.tsx:2/,
+    /deterministic_repair_probe:path_present_in_live_list:src\/view\.tsx:2/,
   );
   assert.match(
     completeRemediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_reviewed_file:docs\/page\.mdx:2/,
+    /deterministic_repair_probe:path_present_in_live_list:docs\/page\.mdx:2/,
   );
 });
 

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -665,6 +665,66 @@ test("buildStaleReviewBotRemediation rejects non-additive path-list findings", (
   assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
 });
 
+test("buildStaleReviewBotRemediation rejects missing-validation path-list findings", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "a9bb7f424b43657f0e17722c6a4769ad1b3c2258";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/page.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-path-list-missing-validation-residue",
+    commentId: "comment-hrcore-path-list-missing-validation-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: The policy scan path list is missing validation for \`${documentPath}\`.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_missing_validation",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const POLICY_SCAN_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+});
+
 test("buildStaleReviewBotRemediation does not truncate longer path extensions during repair probes", () => {
   const issueNumber = 2258;
   const prNumber = 3258;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -393,6 +393,216 @@ test("buildStaleReviewBotRemediation verifies concrete P2 path-list repair witho
   assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
 });
 
+test("buildStaleReviewBotRemediation probes the Codex finding when a supervisor reply is newest", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "c6437ebc0252efc8d09a28e20d8339f5957afd98";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-path-list-reply-residue",
+    commentId: "comment-hrcore-path-list-reply-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${documentPath}\` to both the loader path list and the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_reply",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_fingerprints: [`${scenario.reviewThread.id}@${headSha}#comment-supervisor-reply`],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const reviewThread = {
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "comment-supervisor-reply",
+          body: "Supervisor reply: verified the repair and attempting thread resolution.",
+          createdAt: "2026-06-05T21:12:30Z",
+          url: "https://example.test/pr/3258#discussion_r2258_reply_followup",
+          author: {
+            login: "github-actions[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const LOADER_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+        "const POLICY_SCAN_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /deterministic_repair_probe:path_present_in_reviewed_file:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
+  );
+});
+
+test("buildStaleReviewBotRemediation rejects non-additive path-list findings", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "42b76077b9db2fcac4b9d1c7c05c5d03a1f0f12a";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/mvp-a/policy/onboarding-traceability.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-path-list-deduplicate-residue",
+    commentId: "comment-hrcore-path-list-deduplicate-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Deduplicate \`${documentPath}\` from the loader path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_deduplicate",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const LOADER_PATHS = [",
+        `  "${documentPath}",`,
+        `  "${documentPath}",`,
+        "];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+});
+
+test("buildStaleReviewBotRemediation does not truncate longer path extensions during repair probes", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "ac62cb8f11f71737ccd02f93f9c81c917797d6b3";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const componentPath = "src/view.tsx";
+  const documentPath = "docs/page.mdx";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-long-extension-residue",
+    commentId: "comment-hrcore-long-extension-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${componentPath}\` and \`${documentPath}\` to the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_extensions",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const POLICY_SCAN_PATHS = [",
+        "  \"src/view.ts\",",
+        "  \"src/view.ts\",",
+        "  \"docs/page.md\",",
+        "  \"docs/page.md\",",
+        "];",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+});
+
 test("buildStaleReviewBotRemediation fails closed when current-head no-major has unprocessed must-fix threads", () => {
   const issueNumber = 110;
   const prNumber = 115;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -386,7 +386,7 @@ test("buildStaleReviewBotRemediation verifies concrete P2 path-list repair witho
   assert.equal(remediation?.missingProbeReason, null);
   assert.match(
     remediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_live_list:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
+    /deterministic_repair_probe:path_present_in_requested_live_lists:docs\/mvp-a\/policy\/onboarding-traceability\.md:loader,policy_scan/,
   );
   assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
   assert.equal(diagnostics?.repeatStopExhausted, "no");
@@ -474,7 +474,7 @@ test("buildStaleReviewBotRemediation probes the Codex finding when a supervisor 
   assert.equal(remediation?.missingProbeReason, null);
   assert.match(
     remediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_live_list:docs\/mvp-a\/policy\/onboarding-traceability\.md:2/,
+    /deterministic_repair_probe:path_present_in_requested_live_lists:docs\/mvp-a\/policy\/onboarding-traceability\.md:loader,policy_scan/,
   );
 });
 
@@ -531,6 +531,70 @@ test("buildStaleReviewBotRemediation requires live path-list membership during r
         "];",
         "const POLICY_SCAN_PATHS = [];",
         `const repairNote = "The requested ${documentPath} path is mentioned twice: ${documentPath}.";`,
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.doesNotMatch(remediation?.verificationEvidenceSummary ?? "", /deterministic_repair_probe/);
+});
+
+test("buildStaleReviewBotRemediation ignores unrelated arrays during path-list repair probes", () => {
+  const issueNumber = 2258;
+  const prNumber = 3258;
+  const headSha = "7e4c599e0cb94657b22589293314ebf06a52d258";
+  const policyPath = "src/mvp-a-onboarding-traceability.ts";
+  const documentPath = "docs/page.md";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-hrcore-unrelated-arrays-residue",
+    commentId: "comment-hrcore-unrelated-arrays-residue",
+    path: policyPath,
+    line: 42,
+    severity: "P2",
+    commentBody: `P2: Add \`${documentPath}\` to the policy scan path list.`,
+    discussionUrl: "https://example.test/pr/3258#discussion_r2258_unrelated_arrays",
+    verifiedRepair: {
+      summary: "Focused traceability verifier passed after the repair commit.",
+      ranAt: "2026-06-05T21:10:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-05T21:12:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    repositoryFileContents: {
+      [policyPath]: [
+        "const EXPECTED_POLICY_SCAN_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+        "const FIXTURE_POLICY_SCAN_PATHS = [",
+        `  "${documentPath}",`,
+        "];",
+        "const POLICY_SCAN_PATHS = [];",
       ].join("\n"),
     },
   });
@@ -791,10 +855,6 @@ test("buildStaleReviewBotRemediation requires every requested path before provin
     reviewThreads: [scenario.reviewThread],
     repositoryFileContents: {
       [policyPath]: [
-        "const LOADER_PATHS = [",
-        `  "${componentPath}",`,
-        `  "${documentPath}",`,
-        "];",
         "const POLICY_SCAN_PATHS = [",
         `  "${componentPath}",`,
         `  "${documentPath}",`,
@@ -809,11 +869,11 @@ test("buildStaleReviewBotRemediation requires every requested path before provin
   assert.equal(completeRemediation?.classification, "verified_current_head_repair_pending_thread_resolution");
   assert.match(
     completeRemediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_live_list:src\/view\.tsx:2/,
+    /deterministic_repair_probe:path_present_in_requested_live_lists:src\/view\.tsx:policy_scan/,
   );
   assert.match(
     completeRemediation?.verificationEvidenceSummary ?? "",
-    /deterministic_repair_probe:path_present_in_live_list:docs\/page\.mdx:2/,
+    /deterministic_repair_probe:path_present_in_requested_live_lists:docs\/page\.mdx:policy_scan/,
   );
 });
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -535,13 +535,96 @@ function directStringValuesInArray(source: string, start: number, end: number): 
   return values;
 }
 
-function countLiveRepoPathArrayMemberships(source: string, repoPath: string): number {
+interface RequestedPathListSelector {
+  label: string;
+  requiredTokens: string[];
+  allowExpectationTokens: boolean;
+}
+
+function requestedPathListSelectors(body: string): RequestedPathListSelector[] {
+  const selectors: RequestedPathListSelector[] = [];
+  const normalizedBody = body.toLowerCase();
+  const addSelector = (selector: RequestedPathListSelector) => {
+    if (!selectors.some((candidate) => candidate.label === selector.label)) {
+      selectors.push(selector);
+    }
+  };
+
+  if (/\bload(?:er|ers|ing)?\b/iu.test(body)) {
+    addSelector({ label: "loader", requiredTokens: ["loader"], allowExpectationTokens: false });
+  }
+  if (/\bpolicy\s+scans?\b/iu.test(body)) {
+    addSelector({ label: "policy_scan", requiredTokens: ["policy", "scan"], allowExpectationTokens: false });
+  } else if (/\bscans?\b/iu.test(body)) {
+    addSelector({ label: "scan", requiredTokens: ["scan"], allowExpectationTokens: false });
+  }
+  if (/\bcoverage\b/iu.test(body) && /\bexpect(?:ation|ations|ed)?\b/iu.test(body)) {
+    addSelector({
+      label: "coverage_expectation",
+      requiredTokens: ["coverage", "expect"],
+      allowExpectationTokens: true,
+    });
+  }
+
+  return normalizedBody.includes("list") || normalizedBody.includes("array") ? selectors : [];
+}
+
+function identifierTokens(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/gu, "$1 $2")
+    .split(/[^A-Za-z0-9]+/u)
+    .map((token) => token.toLowerCase())
+    .filter(Boolean)
+    .map((token) => {
+      const singular = token.replace(/s$/u, "");
+      return singular.startsWith("expect") ? "expect" : singular;
+    });
+}
+
+function arrayIdentifierContextTokens(source: string, arrayStart: number): string[] {
+  const prefix = source.slice(Math.max(0, arrayStart - 160), arrayStart);
+  const candidates = [
+    ...prefix.matchAll(/\b([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)?)\s*(?::\s*[^=:\r\n]+)?=\s*$/gu),
+    ...prefix.matchAll(/\b([A-Za-z_$][\w$]*)\s*:\s*$/gu),
+  ];
+  const context = candidates[candidates.length - 1]?.[1] ?? "";
+  return identifierTokens(context);
+}
+
+function arrayMatchesRequestedSelector(tokens: string[], selector: RequestedPathListSelector): boolean {
+  if (tokens.length === 0 || !selector.requiredTokens.every((token) => tokens.includes(token))) {
+    return false;
+  }
+
+  if (!selector.allowExpectationTokens && tokens.some((token) => (
+    token === "expect" ||
+    token === "expected" ||
+    token === "expectation" ||
+    token === "fixture" ||
+    token === "mock" ||
+    token === "sample" ||
+    token === "test"
+  ))) {
+    return false;
+  }
+
+  return true;
+}
+
+function requestedLiveRepoPathArrayMemberships(
+  source: string,
+  repoPath: string,
+  selectors: RequestedPathListSelector[],
+): string[] | null {
   if (countExactRepoPathOccurrences(source, repoPath) === 0) {
-    return 0;
+    return null;
+  }
+  if (selectors.length === 0) {
+    return null;
   }
 
   const uncommentedSource = maskComments(source);
-  let membershipCount = 0;
+  const matchedSelectors = new Set<string>();
   for (let index = 0; index < uncommentedSource.length; index += 1) {
     const char = uncommentedSource[index];
     if (char === "\"" || char === "'" || char === "`") {
@@ -560,13 +643,23 @@ function countLiveRepoPathArrayMemberships(source: string, repoPath: string): nu
     if (end === null) {
       continue;
     }
-    if (directStringValuesInArray(uncommentedSource, index, end).has(repoPath)) {
-      membershipCount += 1;
+    if (!directStringValuesInArray(uncommentedSource, index, end).has(repoPath)) {
+      index = end;
+      continue;
+    }
+
+    const contextTokens = arrayIdentifierContextTokens(uncommentedSource, index);
+    for (const selector of selectors) {
+      if (arrayMatchesRequestedSelector(contextTokens, selector)) {
+        matchedSelectors.add(selector.label);
+      }
     }
     index = end;
   }
 
-  return membershipCount;
+  return selectors.every((selector) => matchedSelectors.has(selector.label))
+    ? selectors.map((selector) => selector.label)
+    : null;
 }
 
 function deterministicRepairProbeEvidence(args: {
@@ -589,18 +682,22 @@ function deterministicRepairProbeEvidence(args: {
     if (!hasAdditivePathListRepairIntent(codexFindingBody)) {
       return null;
     }
+    const requestedPathLists = requestedPathListSelectors(codexFindingBody);
+    if (requestedPathLists.length === 0) {
+      return null;
+    }
     const concretePaths = extractConcreteRepoPaths(codexFindingBody);
     if (concretePaths.length === 0) {
       return null;
     }
     const pathEvidence: string[] = [];
     for (const concretePath of concretePaths) {
-      const liveListMemberships = countLiveRepoPathArrayMemberships(source, concretePath);
-      if (liveListMemberships < 2) {
+      const liveListMemberships = requestedLiveRepoPathArrayMemberships(source, concretePath, requestedPathLists);
+      if (!liveListMemberships) {
         return null;
       }
       pathEvidence.push(
-        `deterministic_repair_probe:path_present_in_live_list:${concretePath}:${liveListMemberships}`,
+        `deterministic_repair_probe:path_present_in_requested_live_lists:${concretePath}:${liveListMemberships.join(",")}`,
       );
     }
     evidence.push(...pathEvidence);

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -92,6 +92,8 @@ interface StaleReviewBotClassification {
   missingProbeReason?: string | null;
 }
 
+type RepositoryFileContents = Record<string, string | null | undefined>;
+
 export function formatStaleReviewBotTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
 }
@@ -359,6 +361,85 @@ function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[
   return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
 }
 
+function latestReviewThreadBody(thread: ReviewThread): string {
+  const comments = thread.comments?.nodes ?? [];
+  return comments[comments.length - 1]?.body ?? "";
+}
+
+function normalizeRepositoryPath(value: string): string {
+  return value.trim().replace(/^\.\/+/u, "").replace(/\\/gu, "/");
+}
+
+function repositoryFileContent(
+  contents: RepositoryFileContents | undefined,
+  path: string | null | undefined,
+): string | null {
+  if (!contents || !path) {
+    return null;
+  }
+  const normalizedPath = normalizeRepositoryPath(path);
+  return contents[normalizedPath] ?? contents[path] ?? null;
+}
+
+function extractConcreteRepoPaths(body: string): string[] {
+  const paths = new Set<string>();
+  const pathPattern =
+    /(?:`([^`\r\n]+\.(?:md|mdx|txt|ts|tsx|js|jsx|json|ya?ml|py|rb|go|rs|java|kt|cs|php|sh|sql|toml|ini|cfg|conf|csv|tsv|html|css|scss))`)|((?:[\w.-]+\/)+[\w.-]+\.(?:md|mdx|txt|ts|tsx|js|jsx|json|ya?ml|py|rb|go|rs|java|kt|cs|php|sh|sql|toml|ini|cfg|conf|csv|tsv|html|css|scss))/giu;
+  for (const match of body.matchAll(pathPattern)) {
+    const path = normalizeRepositoryPath(match[1] ?? match[2] ?? "");
+    if (path && !path.startsWith("/") && !/^[a-z]:\//iu.test(path) && path.includes("/")) {
+      paths.add(path);
+    }
+  }
+  return [...paths].sort((left, right) => left.localeCompare(right));
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) {
+    return 0;
+  }
+  let count = 0;
+  let cursor = 0;
+  while (cursor < haystack.length) {
+    const index = haystack.indexOf(needle, cursor);
+    if (index === -1) {
+      break;
+    }
+    count += 1;
+    cursor = index + needle.length;
+  }
+  return count;
+}
+
+function deterministicRepairProbeEvidence(args: {
+  reviewThreads: ReviewThread[];
+  repositoryFileContents?: RepositoryFileContents;
+}): string | null {
+  const mustFixThreads = codexConnectorMustFixReviewThreads(args.reviewThreads);
+  if (!allCodexConnectorRepairResidueThreadsAreP2(mustFixThreads)) {
+    return null;
+  }
+
+  const evidence: string[] = [];
+  for (const thread of mustFixThreads) {
+    const source = repositoryFileContent(args.repositoryFileContents, thread.path);
+    if (!source) {
+      return null;
+    }
+
+    const concretePaths = extractConcreteRepoPaths(latestReviewThreadBody(thread));
+    const matchedPath = concretePaths.find((path) => countOccurrences(source, path) >= 2);
+    if (!matchedPath) {
+      return null;
+    }
+    evidence.push(
+      `deterministic_repair_probe:path_present_in_reviewed_file:${matchedPath}:${countOccurrences(source, matchedPath)}`,
+    );
+  }
+
+  return evidence.length > 0 ? evidence.join(";") : null;
+}
+
 function validTimestamp(value: string | null | undefined): string | null {
   if (!value || Number.isNaN(Date.parse(value))) {
     return null;
@@ -433,6 +514,7 @@ function classifyCodexMetadataOnly(args: {
   pr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  repositoryFileContents?: RepositoryFileContents;
 }): StaleReviewBotClassification {
   const unresolvedWork = {
     classification: "unresolved_work" as const,
@@ -496,6 +578,17 @@ function classifyCodexMetadataOnly(args: {
         pr: args.pr,
       });
       if (!noMajorSignalEvidence) {
+        const deterministicProbeEvidence = deterministicRepairProbeEvidence({
+          reviewThreads: args.reviewThreads,
+          repositoryFileContents: args.repositoryFileContents,
+        });
+        if (deterministicProbeEvidence) {
+          return {
+            classification: "verified_current_head_repair_pending_thread_resolution",
+            summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
+            verificationEvidenceSummary: `${verificationEvidenceSummary};${deterministicProbeEvidence}`,
+          };
+        }
         return {
           classification: "unknown_needs_operator",
           summary: STALE_REVIEW_BOT_SUMMARY,
@@ -551,6 +644,7 @@ function classifyRemediation(args: {
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  repositoryFileContents?: RepositoryFileContents;
 }): StaleReviewBotClassification {
   const unresolvedWork = {
     classification: "unresolved_work" as const,
@@ -569,6 +663,7 @@ function classifyRemediation(args: {
       pr,
       checks,
       reviewThreads,
+      repositoryFileContents: args.repositoryFileContents,
     });
   }
 
@@ -599,6 +694,7 @@ export function buildStaleReviewBotRemediation(args: {
   pr: GitHubPullRequest | null;
   checks: PullRequestCheck[];
   reviewThreads?: ReviewThread[];
+  repositoryFileContents?: RepositoryFileContents;
 }): StaleReviewBotRemediationDto | null {
   if (args.record.blocked_reason !== "stale_review_bot" && args.record.blocked_reason !== "manual_review") {
     return null;
@@ -614,6 +710,7 @@ export function buildStaleReviewBotRemediation(args: {
       pr: args.pr,
       checks: args.checks,
       reviewThreads: args.reviewThreads ?? [],
+      repositoryFileContents: args.repositoryFileContents,
     });
   if (
     args.record.blocked_reason === "manual_review" &&
@@ -659,6 +756,7 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
   checks: PullRequestCheck[];
   reviewThreads?: ReviewThread[];
   remediation?: StaleReviewBotRemediationDto | null;
+  repositoryFileContents?: RepositoryFileContents;
 }): StaleReviewBotThreadDiagnosticsDto | null {
   const remediation =
     args.remediation ??
@@ -668,6 +766,7 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
       pr: args.pr,
       checks: args.checks,
       reviewThreads: args.reviewThreads,
+      repositoryFileContents: args.repositoryFileContents,
     });
   if (!remediation) {
     return null;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -415,6 +415,160 @@ function countExactRepoPathOccurrences(haystack: string, repoPath: string): numb
   return Array.from(haystack.matchAll(pattern)).length;
 }
 
+function maskComments(source: string): string {
+  let masked = "";
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (char === "\"" || char === "'" || char === "`") {
+      const literal = readStringLiteral(source, index);
+      if (!literal) {
+        masked += char;
+        continue;
+      }
+      masked += source.slice(index, literal.next);
+      index = literal.next - 1;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      masked += "  ";
+      index += 2;
+      while (index < source.length && source[index] !== "\n") {
+        masked += " ";
+        index += 1;
+      }
+      if (source[index] === "\n") {
+        masked += "\n";
+      }
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      masked += "  ";
+      index += 2;
+      while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) {
+        masked += source[index] === "\n" ? "\n" : " ";
+        index += 1;
+      }
+      if (index < source.length) {
+        masked += "  ";
+        index += 1;
+      }
+      continue;
+    }
+    masked += char;
+  }
+  return masked;
+}
+
+function readStringLiteral(source: string, start: number): { value: string; next: number } | null {
+  const quote = source[start];
+  if (quote !== "\"" && quote !== "'" && quote !== "`") {
+    return null;
+  }
+
+  let value = "";
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "\\") {
+      const escaped = source[index + 1];
+      if (escaped !== undefined) {
+        value += escaped;
+        index += 1;
+      }
+      continue;
+    }
+    if (char === quote) {
+      return { value, next: index + 1 };
+    }
+    value += char;
+  }
+
+  return null;
+}
+
+function matchingArrayEnd(source: string, start: number): number | null {
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "\"" || char === "'" || char === "`") {
+      const literal = readStringLiteral(source, index);
+      if (!literal) {
+        return null;
+      }
+      index = literal.next - 1;
+      continue;
+    }
+    if (char === "[") {
+      depth += 1;
+    } else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return null;
+}
+
+function directStringValuesInArray(source: string, start: number, end: number): Set<string> {
+  const values = new Set<string>();
+  let nestingDepth = 0;
+  for (let index = start + 1; index < end; index += 1) {
+    const char = source[index];
+    if (char === "\"" || char === "'" || char === "`") {
+      const literal = readStringLiteral(source, index);
+      if (!literal) {
+        return values;
+      }
+      if (nestingDepth === 0) {
+        values.add(literal.value);
+      }
+      index = literal.next - 1;
+      continue;
+    }
+    if (char === "[" || char === "{" || char === "(") {
+      nestingDepth += 1;
+    } else if ((char === "]" || char === "}" || char === ")") && nestingDepth > 0) {
+      nestingDepth -= 1;
+    }
+  }
+  return values;
+}
+
+function countLiveRepoPathArrayMemberships(source: string, repoPath: string): number {
+  if (countExactRepoPathOccurrences(source, repoPath) === 0) {
+    return 0;
+  }
+
+  const uncommentedSource = maskComments(source);
+  let membershipCount = 0;
+  for (let index = 0; index < uncommentedSource.length; index += 1) {
+    const char = uncommentedSource[index];
+    if (char === "\"" || char === "'" || char === "`") {
+      const literal = readStringLiteral(uncommentedSource, index);
+      if (!literal) {
+        continue;
+      }
+      index = literal.next - 1;
+      continue;
+    }
+    if (char !== "[") {
+      continue;
+    }
+
+    const end = matchingArrayEnd(uncommentedSource, index);
+    if (end === null) {
+      continue;
+    }
+    if (directStringValuesInArray(uncommentedSource, index, end).has(repoPath)) {
+      membershipCount += 1;
+    }
+    index = end;
+  }
+
+  return membershipCount;
+}
+
 function deterministicRepairProbeEvidence(args: {
   reviewThreads: ReviewThread[];
   repositoryFileContents?: RepositoryFileContents;
@@ -441,12 +595,12 @@ function deterministicRepairProbeEvidence(args: {
     }
     const pathEvidence: string[] = [];
     for (const concretePath of concretePaths) {
-      const exactCount = countExactRepoPathOccurrences(source, concretePath);
-      if (exactCount < 2) {
+      const liveListMemberships = countLiveRepoPathArrayMemberships(source, concretePath);
+      if (liveListMemberships < 2) {
         return null;
       }
       pathEvidence.push(
-        `deterministic_repair_probe:path_present_in_reviewed_file:${concretePath}:${exactCount}`,
+        `deterministic_repair_probe:path_present_in_live_list:${concretePath}:${liveListMemberships}`,
       );
     }
     evidence.push(...pathEvidence);

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -596,6 +596,22 @@ function arrayMatchesRequestedSelector(tokens: string[], selector: RequestedPath
     return false;
   }
 
+  if (tokens.some((token) => (
+    token === "disable" ||
+    token === "disabled" ||
+    token === "exclude" ||
+    token === "excluded" ||
+    token === "exclusion" ||
+    token === "ignore" ||
+    token === "ignored" ||
+    token === "omit" ||
+    token === "omitted" ||
+    token === "skip" ||
+    token === "skipped"
+  ))) {
+    return false;
+  }
+
   if (!selector.allowExpectationTokens && tokens.some((token) => (
     token === "expect" ||
     token === "expected" ||

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -400,7 +400,7 @@ function hasAdditivePathListRepairIntent(body: string): boolean {
   }
 
   return (
-    /\b(?:add|include|insert|append|restore|register|wire|missing|omitted)\b/iu.test(body) &&
+    /\b(?:add|include|insert|append|restore|register|wire)\b/iu.test(body) &&
     /\b(?:path|paths|list|lists|array|arrays|loader|loaders|scan|scans|coverage|expectation|expectations)\b/iu.test(body)
   );
 }

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -405,21 +405,14 @@ function hasAdditivePathListRepairIntent(body: string): boolean {
   );
 }
 
-function countOccurrences(haystack: string, needle: string): number {
-  if (!needle) {
-    return 0;
-  }
-  let count = 0;
-  let cursor = 0;
-  while (cursor < haystack.length) {
-    const index = haystack.indexOf(needle, cursor);
-    if (index === -1) {
-      break;
-    }
-    count += 1;
-    cursor = index + needle.length;
-  }
-  return count;
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function countExactRepoPathOccurrences(haystack: string, repoPath: string): number {
+  const pathTokenBoundary = "[A-Za-z0-9._/-]";
+  const pattern = new RegExp(`(?<!${pathTokenBoundary})${escapeRegExp(repoPath)}(?!${pathTokenBoundary})`, "gu");
+  return Array.from(haystack.matchAll(pattern)).length;
 }
 
 function deterministicRepairProbeEvidence(args: {
@@ -443,13 +436,20 @@ function deterministicRepairProbeEvidence(args: {
       return null;
     }
     const concretePaths = extractConcreteRepoPaths(codexFindingBody);
-    const matchedPath = concretePaths.find((path) => countOccurrences(source, path) >= 2);
-    if (!matchedPath) {
+    if (concretePaths.length === 0) {
       return null;
     }
-    evidence.push(
-      `deterministic_repair_probe:path_present_in_reviewed_file:${matchedPath}:${countOccurrences(source, matchedPath)}`,
-    );
+    const pathEvidence: string[] = [];
+    for (const concretePath of concretePaths) {
+      const exactCount = countExactRepoPathOccurrences(source, concretePath);
+      if (exactCount < 2) {
+        return null;
+      }
+      pathEvidence.push(
+        `deterministic_repair_probe:path_present_in_reviewed_file:${concretePath}:${exactCount}`,
+      );
+    }
+    evidence.push(...pathEvidence);
   }
 
   return evidence.length > 0 ? evidence.join(";") : null;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -6,6 +6,7 @@ import {
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
   latestCodexConnectorPSeverity,
+  latestCodexConnectorReviewComment,
 } from "../codex-connector-review-policy";
 import {
   configuredBotReviewFollowUpState,
@@ -361,11 +362,6 @@ function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[
   return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
 }
 
-function latestReviewThreadBody(thread: ReviewThread): string {
-  const comments = thread.comments?.nodes ?? [];
-  return comments[comments.length - 1]?.body ?? "";
-}
-
 function normalizeRepositoryPath(value: string): string {
   return value.trim().replace(/^\.\/+/u, "").replace(/\\/gu, "/");
 }
@@ -384,7 +380,7 @@ function repositoryFileContent(
 function extractConcreteRepoPaths(body: string): string[] {
   const paths = new Set<string>();
   const pathPattern =
-    /(?:`([^`\r\n]+\.(?:md|mdx|txt|ts|tsx|js|jsx|json|ya?ml|py|rb|go|rs|java|kt|cs|php|sh|sql|toml|ini|cfg|conf|csv|tsv|html|css|scss))`)|((?:[\w.-]+\/)+[\w.-]+\.(?:md|mdx|txt|ts|tsx|js|jsx|json|ya?ml|py|rb|go|rs|java|kt|cs|php|sh|sql|toml|ini|cfg|conf|csv|tsv|html|css|scss))/giu;
+    /(?:`([^`\r\n]+\.(?:tsx|jsx|mdx|ya?ml|toml|json|scss|html|conf|txt|ts|js|md|py|rb|go|rs|java|kt|cs|php|sh|sql|ini|cfg|csv|tsv|css))(?![\w.-])`)|((?:[\w.-]+\/)+[\w.-]+\.(?:tsx|jsx|mdx|ya?ml|toml|json|scss|html|conf|txt|ts|js|md|py|rb|go|rs|java|kt|cs|php|sh|sql|ini|cfg|csv|tsv|css))(?![\w.-])/giu;
   for (const match of body.matchAll(pathPattern)) {
     const path = normalizeRepositoryPath(match[1] ?? match[2] ?? "");
     if (path && !path.startsWith("/") && !/^[a-z]:\//iu.test(path) && path.includes("/")) {
@@ -392,6 +388,21 @@ function extractConcreteRepoPaths(body: string): string[] {
     }
   }
   return [...paths].sort((left, right) => left.localeCompare(right));
+}
+
+function hasAdditivePathListRepairIntent(body: string): boolean {
+  if (
+    /\b(?:remove|delete|drop|exclude|avoid|deduplicat(?:e|ed|es|ing|ion)|de-duplicat(?:e|ed|es|ing|ion))\b/iu.test(
+      body,
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    /\b(?:add|include|insert|append|restore|register|wire|missing|omitted)\b/iu.test(body) &&
+    /\b(?:path|paths|list|lists|array|arrays|loader|loaders|scan|scans|coverage|expectation|expectations)\b/iu.test(body)
+  );
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -427,7 +438,11 @@ function deterministicRepairProbeEvidence(args: {
       return null;
     }
 
-    const concretePaths = extractConcreteRepoPaths(latestReviewThreadBody(thread));
+    const codexFindingBody = latestCodexConnectorReviewComment(thread)?.body ?? "";
+    if (!hasAdditivePathListRepairIntent(codexFindingBody)) {
+      return null;
+    }
+    const concretePaths = extractConcreteRepoPaths(codexFindingBody);
     const matchedPath = concretePaths.find((path) => countOccurrences(source, path) >= 2);
     if (!matchedPath) {
       return null;

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -2378,9 +2378,24 @@ test("runPreparedIssue preserves prepared stale-review residue eligibility befor
   fixture.config.configuredBotRequireCurrentHeadSignal = true;
   const issueNumber = 2215;
   const prNumber = 3215;
-  const headSha = "head-2215";
   const branch = branchName(fixture.config, issueNumber);
   const { workspacePath, journalPath } = trackedIssuePaths(fixture.workspaceRoot, issueNumber);
+  const policyPath = "src/current-repair.ts";
+  const documentPath = "docs/page.md";
+  git(["-C", fixture.repoPath, "worktree", "add", "-b", branch, workspacePath, "main"]);
+  await fs.mkdir(path.join(workspacePath, "src"), { recursive: true });
+  await fs.writeFile(
+    path.join(workspacePath, policyPath),
+    [
+      "const POLICY_SCAN_PATHS = [",
+      `  "${documentPath}",`,
+      "];",
+    ].join("\n"),
+    "utf8",
+  );
+  git(["add", policyPath], workspacePath);
+  git(["commit", "-m", "register policy scan path"], workspacePath);
+  const headSha = git(["rev-parse", "HEAD"], workspacePath);
   const threadIds = ["PRRT_prepared_repair_1", "PRRT_prepared_repair_2"];
   const staleSignature = threadIds.map((threadId) => `stalled-bot:${threadId}`).join("|");
   const staleFailureContext = {
@@ -2391,7 +2406,7 @@ test("runPreparedIssue preserves prepared stale-review residue eligibility befor
     command: null,
     details: threadIds.map(
       (threadId, index) =>
-        `reviewer=chatgpt-codex-connector thread=${threadId} file=src/current-repair.ts line=${20 + index} processed_on_current_head=yes`,
+        `reviewer=chatgpt-codex-connector thread=${threadId} file=${policyPath} line=${20 + index} processed_on_current_head=yes`,
     ),
     url: "https://example.test/pr/3215#discussion_r1",
     updated_at: "2026-05-30T01:00:00Z",
@@ -2441,7 +2456,7 @@ test("runPreparedIssue preserves prepared stale-review residue eligibility befor
       unresolvedReviewThreadIds: threadIds,
       unresolvedReviewThreadFingerprints: threadIds.map((threadId) => `${threadId}#comment-${threadId}`),
       unresolvedReviewThreadSourceAnchors: threadIds.map(
-        (threadId, index) => `${threadId}:src/current-repair.ts:${20 + index}`,
+        (threadId, index) => `${threadId}:${policyPath}:${20 + index}`,
       ),
       processedReviewThreadIds: threadIds.map((threadId) => `${threadId}@${headSha}`),
       processedReviewThreadFingerprints: threadIds.map((threadId) => `${threadId}@${headSha}#comment-${threadId}`),
@@ -2472,9 +2487,9 @@ test("runPreparedIssue preserves prepared stale-review residue eligibility befor
     currentHeadCiGreenAt: "2026-05-30T01:03:00Z",
     codexConnectorReviewRequestedAt: "2026-05-30T00:58:00Z",
     codexConnectorReviewRequestedHeadSha: headSha,
-    configuredBotCurrentHeadObservedAt: "2026-05-30T01:04:00Z",
-    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
-    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
     configuredBotLatestReviewedCommitSha: headSha,
     configuredBotTopLevelReviewStrength: null,
   });
@@ -2483,13 +2498,13 @@ test("runPreparedIssue preserves prepared stale-review residue eligibility befor
     createReviewThread({
       id: threadId,
       isOutdated: false,
-      path: "src/current-repair.ts",
+      path: policyPath,
       line: 20 + index,
       comments: {
         nodes: [
           {
             id: `comment-${threadId}`,
-            body: "P2: Reject unsafe input before continuing.",
+            body: `P2: Add \`${documentPath}\` to the policy scan path list.`,
             createdAt: "2026-05-30T00:40:00Z",
             url: `https://example.test/pr/3215#discussion_${threadId}`,
             author: {
@@ -2609,7 +2624,7 @@ test("runPreparedIssue preserves prepared stale-review residue eligibility befor
   assert.deepEqual(resolveCalls, threadIds);
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
-  assert.equal(record.state, "ready_to_merge");
+  assert.equal(record.state, "waiting_ci");
   assert.equal(record.blocked_reason, null);
   assert.equal(record.last_failure_context, null);
   assert.equal(record.last_failure_signature, null);

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -84,6 +84,7 @@ interface PersistentTrackedPrStatusCommentContext {
   reviewThreads: ReviewThread[];
   failureContext: FailureContext | null;
   summarizeChecks: (checks: PullRequestCheck[]) => CheckSummary;
+  workspacePath?: string;
 }
 
 type PersistentTrackedPrStatusCommentStrategy = (
@@ -698,6 +699,7 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
   failureContext: FailureContext | null;
   summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
   skipAutoHandleStaleConfiguredBotReview?: boolean;
+  workspacePath?: string;
 }): Promise<IssueRunRecord> {
   const comment = derivePersistentTrackedPrStatusComment({
     config: args.config,
@@ -707,6 +709,7 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
     reviewThreads: args.reviewThreads,
     failureContext: args.failureContext,
     summarizeChecks: args.summarizeChecks,
+    workspacePath: args.workspacePath,
   });
   const conversationResolutionBlocker = buildConversationResolutionBlocker({
     config: args.config,
@@ -732,6 +735,7 @@ export async function maybeCommentOnTrackedPrPersistentStatus(args: {
       statusCommentAvailable: comment !== null,
       conversationResolutionBlocker,
       skipAutoHandleStaleConfiguredBotReview: args.skipAutoHandleStaleConfiguredBotReview,
+      workspacePath: args.workspacePath,
     });
   currentRecord = staleReviewBotRemediationResult.record;
   if (staleReviewBotRemediationResult.handled) {
@@ -836,6 +840,7 @@ export async function syncTrackedPrPersistentStatusComment(args: {
   summarizeChecks: (checks: PullRequestCheck[]) => { hasPending: boolean; hasFailing: boolean };
   manualReviewThreadCount: number;
   skipAutoHandleStaleConfiguredBotReview?: boolean;
+  workspacePath?: string;
 }): Promise<IssueRunRecord> {
   return maybeCommentOnTrackedPrPersistentStatus(args);
 }


### PR DESCRIPTION
## Summary
- add a deterministic P2 repair-residue probe for concrete path-list findings when same-head no-major evidence is missing
- wire post-turn stale configured-bot auto-handle to read safe repo-relative review-thread files from the active workspace
- add pure remediation and post-turn regressions for mechanically verified Codex Connector residue

## Verification
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts src/post-turn-pull-request-codex-connector.test.ts
- npx tsx --test src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
- npx tsx --test src/post-turn-pull-request-tracked-status.test.ts
- npx tsx --test src/supervisor/supervisor-execution-orchestration.test.ts
- npm run build
- git diff --check

Closes #2258