### PR TITLE
[codex] Document Codex churn latch release

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -682,14 +682,14 @@ The WebUI uses the same config and the same `SupervisorService` boundary as the 
 node dist/index.js web --config /path/to/supervisor.config.json
 ```
 
-Current safe command surface:
+Current WebUI command surface:
 
 - `run-once`
 - `requeue`
 - `prune-orphaned-workspaces`
 - `reset-corrupt-json-state`
 
-Use the dashboard when you want a browser view of the same supervisor state, not a separate execution model.
+Use the dashboard when you want a browser view of the same supervisor state, not a separate execution model. CLI-only recovery commands, such as `release-codex-churn-latch <issue-number>` for explicitly releasing a stopped Codex Connector churn latch after manual inspection, are intentionally not implied by this WebUI surface.
 
 ## Related Docs
 

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -217,7 +217,7 @@ host ごとの loop 運用ルール:
 - Linux で launcher-managed な background loop を使いたい時は `./scripts/install-systemd.sh` を使います。
 - macOS で launcher-managed な WebUI を使いたい時は `./scripts/install-launchd-web.sh` を使います。こちらは loop ではなく WebUI entrypoint を host する path なので引き続きサポート対象です。
 
-WebUI は CLI と同じ `SupervisorService` を使い、typed な `status`、`doctor`、`explain`、`issue-lint` を読みます。現在の safe command surface は `run-once`、`requeue`、`prune-orphaned-workspaces`、`reset-corrupt-json-state` です。
+WebUI は CLI と同じ `SupervisorService` を使い、typed な `status`、`doctor`、`explain`、`issue-lint` を読みます。現在の WebUI command surface は `run-once`、`requeue`、`prune-orphaned-workspaces`、`reset-corrupt-json-state` です。`release-codex-churn-latch <issue-number>` のような CLI-only recovery command は WebUI の外に残します。
 
 WebUI は operator surface であり、loop run mode ではありません。`status` と `doctor` が表示する loop runtime は、WebUI process ではなく観測可能な loop runtime marker に基づきます。launcher-managed WebUI restart は WebUI process だけを対象にし、background loop の所有権を意味しません。
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -496,7 +496,7 @@ Supported run-mode vocabulary:
 
 `status` and `doctor` report `run_mode=...` next to the loop runtime marker fields when the mode can be inferred from the loop's own runtime marker. If diagnostics show `run_mode=unknown`, `ownership_confidence=ambiguous_owner`, or duplicate loop processes, inspect the marker and listed PIDs instead of deleting marker files or killing processes automatically.
 
-The WebUI uses the same `SupervisorService` boundary as the CLI. It reads the same typed status, doctor, explain, and issue-lint data, and it only exposes the current safe command set: `run-once`, `requeue`, `prune-orphaned-workspaces`, and `reset-corrupt-json-state`. A WebUI session is an operator surface, not a loop run mode; launcher-backed WebUI restart capability applies to the WebUI process only and does not imply ownership of the background loop.
+The WebUI uses the same `SupervisorService` boundary as the CLI. It reads the same typed status, doctor, explain, and issue-lint data, and it only exposes the current WebUI command set: `run-once`, `requeue`, `prune-orphaned-workspaces`, and `reset-corrupt-json-state`. CLI-only recovery commands, such as `release-codex-churn-latch <issue-number>`, remain outside the WebUI. A WebUI session is an operator surface, not a loop run mode; launcher-backed WebUI restart capability applies to the WebUI process only and does not imply ownership of the background loop.
 
 In normal operation, the supervisor will:
 

--- a/docs/operator-dashboard.md
+++ b/docs/operator-dashboard.md
@@ -110,9 +110,9 @@ If local CI is configured, remember that the config can now use either:
 
 Use the [Configuration reference](./configuration.md) when you need to confirm which execution mode is active or when a local CI failure looks like a workspace toolchain problem instead of a repo command failure.
 
-## Current safe command surface
+## Current WebUI command surface
 
-The dashboard currently exposes only the same narrow safe commands that the CLI exposes:
+The dashboard currently exposes only this narrow WebUI mutation surface:
 
 - `run-once`
 - `requeue`
@@ -120,6 +120,8 @@ The dashboard currently exposes only the same narrow safe commands that the CLI 
 - `reset-corrupt-json-state`
 
 These commands still go through the backend service boundary. The browser does not mutate the state file directly, and each command now requires the local mutation token described above.
+
+CLI-only recovery commands, such as `release-codex-churn-latch <issue-number>` for explicitly releasing a stopped Codex Connector churn latch after manual inspection, remain outside the WebUI command surface.
 
 ## Panel expectations
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -44,6 +44,8 @@ Inspect commands:
 
 Repair commands:
   requeue <issue-number>            Requeue a blocked or failed issue.
+  release-codex-churn-latch <issue-number>
+                                    Release a stopped Codex Connector churn latch.
   reset-corrupt-json-state          Move corrupt JSON state aside after inspection.
 
 Maintenance commands:

--- a/src/post-turn-pull-request-tracked-status.test.ts
+++ b/src/post-turn-pull-request-tracked-status.test.ts
@@ -476,7 +476,7 @@ test("syncTrackedPrPersistentStatusComment comments with clustered Codex churn e
   );
   assert.match(commentBodies[0] ?? "", /dossier attempt marker: `codex-connector-stable-same-file-churn:/);
   assert.match(commentBodies[0] ?? "", /https:\/\/example\.test\/pr\/1390#discussion_current_0/);
-  assert.match(commentBodies[0] ?? "", /manual.*before restarting the supervisor/i);
+  assert.match(commentBodies[0] ?? "", /manual.*release-codex-churn-latch 102.*before restarting automation/i);
   assert.match(
     commentBodies[0] ?? "",
     /<!-- codex-supervisor:tracked-pr-status-comment issue=102 pr=116 kind=status -->/,

--- a/src/tracked-pr-status-comment-rendering.ts
+++ b/src/tracked-pr-status-comment-rendering.ts
@@ -243,6 +243,7 @@ export function buildTrackedPrPersistentStatusComment(args: {
 }
 
 export function buildTrackedPrCodexConnectorChurnStatusComment(args: {
+  issueNumber: number;
   pr: Pick<GitHubPullRequest, "headRefOid">;
   dominantFile: string;
   currentEffectiveMustFixCount: number | string;
@@ -263,7 +264,7 @@ export function buildTrackedPrCodexConnectorChurnStatusComment(args: {
     ...(args.dossierAttemptMarker ? [`- dossier attempt marker: \`${args.dossierAttemptMarker}\``] : []),
     ...args.representativeThreadUrls.map((url) => `- representative thread: ${url}`),
     "- automatic retry: no",
-    "- next action: manually inspect the dominant file and representative Codex Connector threads before restarting the supervisor.",
+    `- next action: manually inspect the dominant file and representative Codex Connector threads, then run \`release-codex-churn-latch ${args.issueNumber}\` before restarting automation for this stopped fingerprint.`,
   ].join("\n");
 }
 

--- a/src/tracked-pr-status-comment.ts
+++ b/src/tracked-pr-status-comment.ts
@@ -396,6 +396,7 @@ function codexConnectorChurnStatusComment(
   return {
     blockerSignature,
     body: buildTrackedPrCodexConnectorChurnStatusComment({
+      issueNumber: args.record.issue_number,
       pr: args.pr,
       dominantFile: churnSnapshot.progress.dominantFile,
       currentEffectiveMustFixCount: churnSnapshot.progress.currentEffectiveMustFixCount,

--- a/src/validation-checklist-docs.test.ts
+++ b/src/validation-checklist-docs.test.ts
@@ -74,6 +74,7 @@ test("operators can discover the release-readiness checklist from docs and CLI h
   assert.match(readme, /\[Release readiness checklist\]\(\.\/docs\/validation-checklist\.md\)/i);
   assert.match(gettingStarted, /\[Release readiness checklist\]\(\.\/validation-checklist\.md\)/i);
   assert.match(help, /readiness-checklist\s+Print the release-readiness checklist/i);
+  assert.match(help, /release-codex-churn-latch <issue-number>\s+Release a stopped Codex Connector churn latch/i);
   assert.match(help, /node dist\/index\.js help/);
   assert.match(help, /node dist\/index\.js web --config <supervisor-config-path>\s+# open \/setup/);
   assert.match(help, /node dist\/index\.js issue-lint <issue-number> --config <supervisor-config-path>/);


### PR DESCRIPTION
## Summary
- surface the concrete `release-codex-churn-latch <issue-number>` command in clustered Codex Connector churn stop comments
- add the release command to CLI help
- clarify WebUI docs so CLI-only recovery commands are not implied by the WebUI command surface

## Why
Issue #2264 added the terminal churn latch and explicit release command, but operator-facing surfaces still made the release path too easy to miss. This keeps the latch safety behavior intact while making the manual release step discoverable after inspection.

Closes #2266

## Verification
- `npx tsx --test src/post-turn-pull-request-codex-connector.test.ts src/post-turn-pull-request-tracked-status.test.ts`
- `npx tsx --test src/cli/*.test.ts src/validation-checklist-docs.test.ts src/getting-started-docs.test.ts`
- `npm run build`
- `git diff --check`
