### PR TITLE
[codex] Add review-loop retry state

### DIFF
--- a/src/core/state-store-normalization.test.ts
+++ b/src/core/state-store-normalization.test.ts
@@ -163,6 +163,48 @@ test("normalizeStateForLoad defaults Codex Connector retry bookkeeping", () => {
   assert.equal(loaded.issues["1976"]?.codex_connector_review_request_comment_url, null);
 });
 
+test("normalizeStateForLoad defaults and preserves review-loop retry state", () => {
+  const loadedWithoutState = normalizeStateForLoad({
+    activeIssueNumber: null,
+    issues: {
+      "2269": createRecord(2269),
+    },
+  } satisfies SupervisorStateFile);
+  const loadedWithState = normalizeStateForLoad({
+    activeIssueNumber: null,
+    issues: {
+      "2270": createRecord(2270, {
+        review_loop_retry_state: [
+          {
+            fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+            pr_number: 116,
+            head_sha: "head-a",
+            thread_id: "thread-1",
+            latest_comment_fingerprint: "comment-1",
+            attempts: 2,
+            first_attempted_at: "2026-06-07T00:01:00Z",
+            last_attempted_at: "2026-06-07T00:02:00Z",
+          },
+        ],
+      }),
+    },
+  } satisfies SupervisorStateFile);
+
+  assert.deepEqual(loadedWithoutState.issues["2269"]?.review_loop_retry_state, []);
+  assert.deepEqual(loadedWithState.issues["2270"]?.review_loop_retry_state, [
+    {
+      fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+      pr_number: 116,
+      head_sha: "head-a",
+      thread_id: "thread-1",
+      latest_comment_fingerprint: "comment-1",
+      attempts: 2,
+      first_attempted_at: "2026-06-07T00:01:00Z",
+      last_attempted_at: "2026-06-07T00:02:00Z",
+    },
+  ]);
+});
+
 test("normalizeStateForLoad clamps persisted addressing review strategy fields", () => {
   const loaded = normalizeStateForLoad({
     activeIssueNumber: null,

--- a/src/core/state-store-normalization.ts
+++ b/src/core/state-store-normalization.ts
@@ -2,6 +2,7 @@ import {
   InventoryRefreshDiagnosticEntry,
   IssueRunRecord,
   JsonStateQuarantine,
+  ReviewLoopRetryStateEntry,
   StateLoadFinding,
   SupervisorStateFile,
 } from "./types";
@@ -101,6 +102,44 @@ function normalizeAddressingReviewStrategyReason(
   return strategy && typeof value === "string" && value.trim() !== "" ? value : null;
 }
 
+function normalizeReviewLoopRetryState(value: unknown): ReviewLoopRetryStateEntry[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((entry): entry is Record<string, unknown> =>
+      isRecord(entry) &&
+      typeof entry.fingerprint === "string" &&
+      entry.fingerprint.trim() !== "" &&
+      typeof entry.pr_number === "number" &&
+      Number.isInteger(entry.pr_number) &&
+      typeof entry.head_sha === "string" &&
+      entry.head_sha.trim() !== "" &&
+      typeof entry.thread_id === "string" &&
+      entry.thread_id.trim() !== "" &&
+      typeof entry.latest_comment_fingerprint === "string" &&
+      entry.latest_comment_fingerprint.trim() !== "" &&
+      typeof entry.attempts === "number" &&
+      Number.isInteger(entry.attempts) &&
+      entry.attempts > 0 &&
+      typeof entry.first_attempted_at === "string" &&
+      entry.first_attempted_at.trim() !== "" &&
+      typeof entry.last_attempted_at === "string" &&
+      entry.last_attempted_at.trim() !== "",
+    )
+    .map((entry): ReviewLoopRetryStateEntry => ({
+      fingerprint: entry.fingerprint as string,
+      pr_number: entry.pr_number as number,
+      head_sha: entry.head_sha as string,
+      thread_id: entry.thread_id as string,
+      latest_comment_fingerprint: entry.latest_comment_fingerprint as string,
+      attempts: entry.attempts as number,
+      first_attempted_at: entry.first_attempted_at as string,
+      last_attempted_at: entry.last_attempted_at as string,
+    }));
+}
+
 export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
   const addressingReviewStrategy = normalizeAddressingReviewStrategy(value.addressing_review_strategy);
 
@@ -187,6 +226,7 @@ export function normalizeIssueRecord(value: IssueRunRecord): IssueRunRecord {
     last_host_local_pr_blocker_comment_head_sha: value.last_host_local_pr_blocker_comment_head_sha ?? null,
     stale_review_bot_reply_progress_keys: value.stale_review_bot_reply_progress_keys ?? [],
     stale_review_bot_resolve_progress_keys: value.stale_review_bot_resolve_progress_keys ?? [],
+    review_loop_retry_state: normalizeReviewLoopRetryState(value.review_loop_retry_state),
     blocked_reason: value.blocked_reason ?? null,
     review_follow_up_head_sha: value.review_follow_up_head_sha ?? null,
     review_follow_up_remaining: value.review_follow_up_remaining ?? 0,

--- a/src/core/state-store.test.ts
+++ b/src/core/state-store.test.ts
@@ -110,6 +110,37 @@ test("StateStore json roundtrip preserves the active reservation and retry count
   });
 });
 
+test("StateStore touch preserves review-loop retry state patches", () => {
+  const store = new StateStore("/tmp/state.json", { backend: "json" });
+  const touched = store.touch(createRecord(2269), {
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+        pr_number: 116,
+        head_sha: "head-a",
+        thread_id: "thread-1",
+        latest_comment_fingerprint: "comment-1",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T00:01:00Z",
+        last_attempted_at: "2026-06-07T00:01:00Z",
+      },
+    ],
+  });
+
+  assert.deepEqual(touched.review_loop_retry_state, [
+    {
+      fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+      pr_number: 116,
+      head_sha: "head-a",
+      thread_id: "thread-1",
+      latest_comment_fingerprint: "comment-1",
+      attempts: 1,
+      first_attempted_at: "2026-06-07T00:01:00Z",
+      last_attempted_at: "2026-06-07T00:01:00Z",
+    },
+  ]);
+});
+
 test("StateStore json load normalizes tracked PR progress bookkeeping fields", async () => {
   await withTempDir(async (dir) => {
     const statePath = path.join(dir, "state.json");

--- a/src/core/state-store.ts
+++ b/src/core/state-store.ts
@@ -258,6 +258,8 @@ export class StateStore {
         patch.stale_review_bot_reply_progress_keys ?? record.stale_review_bot_reply_progress_keys ?? [],
       stale_review_bot_resolve_progress_keys:
         patch.stale_review_bot_resolve_progress_keys ?? record.stale_review_bot_resolve_progress_keys ?? [],
+      review_loop_retry_state:
+        patch.review_loop_retry_state ?? record.review_loop_retry_state ?? [],
       blocked_reason:
         hasOwn(patch, "blocked_reason") ? patch.blocked_reason ?? null : record.blocked_reason ?? null,
       updated_at: nowIso(),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -117,6 +117,17 @@ export interface TimelineArtifact {
   processed_review_thread_fingerprints?: string[];
 }
 
+export interface ReviewLoopRetryStateEntry {
+  fingerprint: string;
+  pr_number: number;
+  head_sha: string;
+  thread_id: string;
+  latest_comment_fingerprint: string;
+  attempts: number;
+  first_attempted_at: string;
+  last_attempted_at: string;
+}
+
 export type FailureKind = "timeout" | "command_error" | "codex_exit" | "codex_failed" | null;
 export type CommentIdentityStatus = "available" | "unavailable" | null;
 
@@ -307,6 +318,7 @@ export interface IssueRunRecord {
   last_stale_review_bot_reply_head_sha?: string | null;
   stale_review_bot_reply_progress_keys?: string[];
   stale_review_bot_resolve_progress_keys?: string[];
+  review_loop_retry_state?: ReviewLoopRetryStateEntry[];
   blocked_reason: BlockedReason;
   processed_review_thread_ids: string[];
   processed_review_thread_fingerprints: string[];

--- a/src/review-handling.test.ts
+++ b/src/review-handling.test.ts
@@ -15,8 +15,12 @@ import {
   localReviewRetryLoopCandidate,
   localReviewRetryLoopStalled,
   nextLocalReviewSignatureTracking,
+  nextReviewLoopRetryStateForThread,
   reviewDecisionAllowsSamePrRepair,
   reviewDecisionAllowsSamePrManualReviewRepair,
+  reviewLoopRetryAttemptCountForThread,
+  reviewLoopRetryFingerprintForThread,
+  reviewLoopRetryStateEntryForThread,
 } from "./review-handling";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./core/types";
 
@@ -232,6 +236,87 @@ test("hasProcessedReviewThread ignores unrelated same-head fingerprints when dec
     ),
     true,
   );
+});
+
+test("review-loop retry state counts attempts by PR, head, thread, and latest comment fingerprint", () => {
+  const pr = createPullRequest({ number: 116, headRefOid: "head-a" });
+  const thread = createReviewThread({
+    id: "thread-1",
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P2: Please address this.",
+          createdAt: "2026-06-07T00:00:00Z",
+          url: "https://example.test/pr/116#discussion_r1",
+          author: { login: "codex-connector", typeName: "Bot" },
+        },
+      ],
+    },
+  });
+
+  const firstState = nextReviewLoopRetryStateForThread({
+    record: createRecord(),
+    pr,
+    thread,
+    attemptedAt: "2026-06-07T00:01:00Z",
+  });
+  const secondState = nextReviewLoopRetryStateForThread({
+    record: createRecord({ review_loop_retry_state: firstState }),
+    pr,
+    thread,
+    attemptedAt: "2026-06-07T00:02:00Z",
+  });
+  const record = createRecord({ review_loop_retry_state: secondState });
+  const fingerprint = reviewLoopRetryFingerprintForThread(pr, thread);
+  const entry = reviewLoopRetryStateEntryForThread(record, pr, thread);
+
+  assert.equal(fingerprint, "pr=116|head=head-a|thread=thread-1|comment=comment-1");
+  assert.equal(reviewLoopRetryAttemptCountForThread(record, pr, thread), 2);
+  assert.equal(entry?.fingerprint, fingerprint);
+  assert.equal(entry?.pr_number, 116);
+  assert.equal(entry?.head_sha, "head-a");
+  assert.equal(entry?.thread_id, "thread-1");
+  assert.equal(entry?.latest_comment_fingerprint, "comment-1");
+  assert.equal(entry?.first_attempted_at, "2026-06-07T00:01:00Z");
+  assert.equal(entry?.last_attempted_at, "2026-06-07T00:02:00Z");
+});
+
+test("review-loop retry state keeps stale previous-head attempts separate from current-head attempts", () => {
+  const thread = createReviewThread({
+    id: "thread-1",
+    comments: {
+      nodes: [
+        {
+          id: "comment-1",
+          body: "P2: Please address this.",
+          createdAt: "2026-06-07T00:00:00Z",
+          url: "https://example.test/pr/116#discussion_r1",
+          author: { login: "codex-connector", typeName: "Bot" },
+        },
+      ],
+    },
+  });
+  const oldHeadPr = createPullRequest({ number: 116, headRefOid: "head-a" });
+  const currentHeadPr = createPullRequest({ number: 116, headRefOid: "head-b" });
+  const oldHeadState = nextReviewLoopRetryStateForThread({
+    record: createRecord(),
+    pr: oldHeadPr,
+    thread,
+    attemptedAt: "2026-06-07T00:01:00Z",
+  });
+  const currentHeadState = nextReviewLoopRetryStateForThread({
+    record: createRecord({ review_loop_retry_state: oldHeadState }),
+    pr: currentHeadPr,
+    thread,
+    attemptedAt: "2026-06-07T00:03:00Z",
+  });
+  const record = createRecord({ review_loop_retry_state: currentHeadState });
+
+  assert.equal(reviewLoopRetryAttemptCountForThread(record, oldHeadPr, thread), 1);
+  assert.equal(reviewLoopRetryAttemptCountForThread(record, currentHeadPr, thread), 1);
+  assert.equal(record.review_loop_retry_state?.length, 2);
+  assert.deepEqual(record.review_loop_retry_state?.map((entry) => entry.head_sha).sort(), ["head-a", "head-b"]);
 });
 
 test("local review gating respects enabled policy requirements for ready and merge transitions", () => {

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -4,6 +4,7 @@ import {
   GitHubPullRequest,
   IssueRunRecord,
   PullRequestCheck,
+  ReviewLoopRetryStateEntry,
   ReviewThread,
   SupervisorConfig,
 } from "./core/types";
@@ -30,6 +31,94 @@ export function processedReviewThreadFingerprintKey(
   latestCommentFingerprint: string,
 ): string {
   return `${processedReviewThreadKey(threadId, headSha)}#${latestCommentFingerprint}`;
+}
+
+export function reviewLoopRetryFingerprint(args: {
+  prNumber: number;
+  headSha: string;
+  threadId: string;
+  latestCommentFingerprint: string;
+}): string {
+  return [
+    `pr=${args.prNumber}`,
+    `head=${args.headSha}`,
+    `thread=${args.threadId}`,
+    `comment=${args.latestCommentFingerprint}`,
+  ].join("|");
+}
+
+export function reviewLoopRetryFingerprintForThread(
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+): string | null {
+  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
+  if (!latestCommentFingerprint) {
+    return null;
+  }
+
+  return reviewLoopRetryFingerprint({
+    prNumber: pr.number,
+    headSha: pr.headRefOid,
+    threadId: thread.id,
+    latestCommentFingerprint,
+  });
+}
+
+export function reviewLoopRetryStateEntryForThread(
+  record: Pick<IssueRunRecord, "review_loop_retry_state">,
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+): ReviewLoopRetryStateEntry | null {
+  const fingerprint = reviewLoopRetryFingerprintForThread(pr, thread);
+  if (!fingerprint) {
+    return null;
+  }
+
+  return (record.review_loop_retry_state ?? []).find((entry) => entry.fingerprint === fingerprint) ?? null;
+}
+
+export function reviewLoopRetryAttemptCountForThread(
+  record: Pick<IssueRunRecord, "review_loop_retry_state">,
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+): number {
+  return reviewLoopRetryStateEntryForThread(record, pr, thread)?.attempts ?? 0;
+}
+
+export function nextReviewLoopRetryStateForThread(args: {
+  record: Pick<IssueRunRecord, "review_loop_retry_state">;
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid">;
+  thread: Pick<ReviewThread, "id" | "comments">;
+  attemptedAt: string;
+}): ReviewLoopRetryStateEntry[] {
+  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(args.thread);
+  if (!latestCommentFingerprint) {
+    return [...(args.record.review_loop_retry_state ?? [])];
+  }
+
+  const fingerprint = reviewLoopRetryFingerprint({
+    prNumber: args.pr.number,
+    headSha: args.pr.headRefOid,
+    threadId: args.thread.id,
+    latestCommentFingerprint,
+  });
+  const existingEntries = args.record.review_loop_retry_state ?? [];
+  const existingEntry = existingEntries.find((entry) => entry.fingerprint === fingerprint);
+  const nextEntry: ReviewLoopRetryStateEntry = {
+    fingerprint,
+    pr_number: args.pr.number,
+    head_sha: args.pr.headRefOid,
+    thread_id: args.thread.id,
+    latest_comment_fingerprint: latestCommentFingerprint,
+    attempts: (existingEntry?.attempts ?? 0) + 1,
+    first_attempted_at: existingEntry?.first_attempted_at ?? args.attemptedAt,
+    last_attempted_at: args.attemptedAt,
+  };
+
+  return [
+    ...existingEntries.filter((entry) => entry.fingerprint !== fingerprint),
+    nextEntry,
+  ];
 }
 
 export function hasProcessedReviewThread(


### PR DESCRIPTION
## Summary

- Add durable `review_loop_retry_state` entries to issue run records.
- Add helpers that build and count review-loop retry fingerprints by PR number, head SHA, thread id, and latest comment fingerprint.
- Normalize old state to an empty retry-state array while preserving valid persisted entries.

## Why

Phase 0 needs a durable state model before later issues can stop repeated Codex connector review loops. This PR records the state shape and helper API without changing Codex execution, GitHub mutation, merge readiness, or issue selection behavior.

Closes #2269

## Validation

- `npx tsx --test src/review-handling.test.ts`
- `npx tsx --test src/core/state-store-normalization.test.ts`
- `npx tsx --test src/core/state-store.test.ts`
- `npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts`
- `npm run build`
