### PR TITLE
[codex] Stop repeated review loop repairs

### DIFF
--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -2,6 +2,10 @@ import {
   codexConnectorCurrentHeadReviewReadiness,
 } from "./codex-connector-review-request-decision";
 import {
+  hasProcessedReviewThread,
+  reviewLoopRetryBudgetExhaustedForThread,
+} from "./review-handling";
+import {
   codexConnectorMustFixReviewThreads,
   codexConnectorNitpickOnlyReviewThreads,
   evaluateCodexConnectorConvergencePolicy,
@@ -26,7 +30,6 @@ import {
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
 } from "./review-thread-reporting";
-import { hasProcessedReviewThread } from "./review-handling";
 import {
   mergeConflictDetected,
   summarizeChecks,
@@ -321,8 +324,7 @@ export function processedCodexConnectorMustFixThreadsExhaustedRepeatBudget(args:
   if (
     !configuredReviewProviderKinds(args.config).includes("codex") ||
     args.codexConnectorMustFixThreads.length === 0 ||
-    args.manualThreads.length > 0 ||
-    args.record.last_tracked_pr_repeat_failure_decision !== "stop_no_progress"
+    args.manualThreads.length > 0
   ) {
     return false;
   }
@@ -332,9 +334,16 @@ export function processedCodexConnectorMustFixThreadsExhaustedRepeatBudget(args:
     return false;
   }
 
-  return args.codexConnectorMustFixThreads.every((thread) =>
-    hasProcessedReviewThread(args.record, args.pr, thread),
+  const exhaustedByReviewLoopRetryState = args.codexConnectorMustFixThreads.every((thread) =>
+    reviewLoopRetryBudgetExhaustedForThread(args.record, args.pr, thread),
   );
+  const exhaustedByLegacyRepeatStop =
+    args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+    args.codexConnectorMustFixThreads.every((thread) =>
+      hasProcessedReviewThread(args.record, args.pr, thread),
+    );
+
+  return exhaustedByReviewLoopRetryState || exhaustedByLegacyRepeatStop;
 }
 
 function isMergeCriticalPullRequest(pr: GitHubPullRequest): boolean {

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -347,6 +347,7 @@ export function processedCodexConnectorMustFixThreadsExhaustedRepeatBudget(args:
   const exhaustedByLegacyRepeatStop =
     args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
     args.codexConnectorMustFixThreads.every((thread) =>
+      hasProcessedReviewThread(args.record, args.pr, thread) ||
       hasProcessedReviewThread(args.record, args.pr, thread, latestCodexConnectorReviewCommentFingerprint(thread)),
     );
 

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -11,6 +11,7 @@ import {
   evaluateCodexConnectorConvergencePolicy,
   hasCodexConnectorFindingReviewComment,
   hasCodexConnectorPrSuccessCurrentHeadObservation,
+  latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
 import {
   IssueRunRecord,
@@ -335,12 +336,18 @@ export function processedCodexConnectorMustFixThreadsExhaustedRepeatBudget(args:
   }
 
   const exhaustedByReviewLoopRetryState = args.codexConnectorMustFixThreads.every((thread) =>
-    reviewLoopRetryBudgetExhaustedForThread(args.record, args.pr, thread),
+    reviewLoopRetryBudgetExhaustedForThread(
+      args.record,
+      args.pr,
+      thread,
+      1,
+      latestCodexConnectorReviewCommentFingerprint(thread),
+    ),
   );
   const exhaustedByLegacyRepeatStop =
     args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
     args.codexConnectorMustFixThreads.every((thread) =>
-      hasProcessedReviewThread(args.record, args.pr, thread),
+      hasProcessedReviewThread(args.record, args.pr, thread, latestCodexConnectorReviewCommentFingerprint(thread)),
     );
 
   return exhaustedByReviewLoopRetryState || exhaustedByLegacyRepeatStop;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1066,6 +1066,71 @@ test("inferStateFromPullRequest still blocks a journal-only configured-bot threa
   assert.equal(blockedReasonFromReviewState(config, record, pr, [...checks], reviewThreads), "manual_review");
 });
 
+test("inferStateFromPullRequest blocks exhausted Codex Connector must-fix threads instead of starting an empty repair turn", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-codex"],
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-1|comment=comment-codex",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-1",
+        latest_comment_fingerprint: "comment-codex",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotTopLevelReviewStrength: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P2: Apply retry exhaustion before entering another repair turn.",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+          {
+            id: "comment-reply",
+            body: "A later non-connector reply after the first repair attempt.",
+            createdAt: "2026-06-07T01:20:00Z",
+            url: "https://example.test/pr/44#discussion_r2",
+            author: {
+              login: "github-actions[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+});
+
 test("inferStateFromPullRequest keeps human review gates in place when only a journal-only configured-bot thread remains", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1131,6 +1131,63 @@ test("inferStateFromPullRequest blocks exhausted Codex Connector must-fix thread
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
 });
 
+test("inferStateFromPullRequest blocks exhausted non-Codex follow-up threads instead of starting an empty repair turn", () => {
+  const config = createConfig({
+    reviewBotLogins: ["copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+    review_follow_up_head_sha: "head123",
+    review_follow_up_remaining: 1,
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-1|comment=comment-1",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-1",
+        latest_comment_fingerprint: "comment-1",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotTopLevelReviewStrength: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-1",
+            body: "Please address this same-head follow-up before merging.",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+});
+
 test("inferStateFromPullRequest keeps human review gates in place when only a journal-only configured-bot thread remains", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1258,6 +1258,133 @@ test("inferStateFromPullRequest honors legacy repeat-stop evidence stored on lat
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
 });
 
+test("inferStateFromPullRequest keeps pending non-Codex bot feedback runnable despite exhausted Codex findings", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "copilot-pull-request-reviewer"],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-codex@head123"],
+    processed_review_thread_fingerprints: ["thread-codex@head123#comment-codex"],
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-codex|comment=comment-codex",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-codex",
+        latest_comment_fingerprint: "comment-codex",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotTopLevelReviewStrength: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-codex",
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P2: Apply retry exhaustion before entering another repair turn.",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-copilot",
+      comments: {
+        nodes: [
+          {
+            id: "comment-copilot",
+            body: "Please handle this fresh configured-bot feedback.",
+            createdAt: "2026-06-07T01:10:00Z",
+            url: "https://example.test/pr/44#discussion_copilot",
+            author: {
+              login: "copilot-pull-request-reviewer",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "addressing_review");
+});
+
+test("inferStateFromPullRequest preserves merge-conflict repair when only exhausted Codex findings remain", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-codex"],
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-1|comment=comment-codex",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-1",
+        latest_comment_fingerprint: "comment-codex",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotTopLevelReviewStrength: null,
+    mergeStateStatus: "DIRTY",
+    mergeable: "CONFLICTING",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P2: Apply retry exhaustion before entering another repair turn.",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "resolving_conflict");
+});
+
 test("inferStateFromPullRequest blocks exhausted non-Codex follow-up threads instead of starting an empty repair turn", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1131,6 +1131,133 @@ test("inferStateFromPullRequest blocks exhausted Codex Connector must-fix thread
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
 });
 
+test("inferStateFromPullRequest blocks exhausted Codex Connector repairs even with nonblocking human threads", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-codex"],
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-1|comment=comment-codex",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-1",
+        latest_comment_fingerprint: "comment-codex",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotTopLevelReviewStrength: "blocking",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P2: Apply retry exhaustion before entering another repair turn.",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-human",
+      comments: {
+        nodes: [
+          {
+            id: "comment-human",
+            body: "A nonblocking human note remains unresolved.",
+            createdAt: "2026-06-07T01:10:00Z",
+            url: "https://example.test/pr/44#discussion_human",
+            author: {
+              login: "human-reviewer",
+              typeName: "User",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+});
+
+test("inferStateFromPullRequest honors legacy repeat-stop evidence stored on later Codex thread replies", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-reply"],
+    review_loop_retry_state: [],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotTopLevelReviewStrength: "blocking",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P2: Apply retry exhaustion before entering another repair turn.",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+          {
+            id: "comment-reply",
+            body: "Supervisor reply after the legacy repair attempt.",
+            createdAt: "2026-06-07T01:20:00Z",
+            url: "https://example.test/pr/44#discussion_r2",
+            author: {
+              login: "github-actions[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+});
+
 test("inferStateFromPullRequest blocks exhausted non-Codex follow-up threads instead of starting an empty repair turn", () => {
   const config = createConfig({
     reviewBotLogins: ["copilot-pull-request-reviewer"],

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -20,6 +20,7 @@ import {
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
 import {
+  actionableConfiguredBotReviewThreads,
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
   manualReviewThreads,
@@ -277,20 +278,29 @@ export function inferStateFromPullRequest(
     reviewThreads,
   });
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
-  const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
-  const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
+  const codexConnectorMustFixThreadIds = new Set(codexConnectorMustFixThreads.map((thread) => thread.id));
+  const retryFingerprintForThread = (thread: ReviewThread) =>
+    codexConnectorMustFixThreadIds.has(thread.id) ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined;
+  const reviewLoopRetryBudgetAvailable = (thread: ReviewThread) =>
+    !reviewLoopRetryBudgetExhaustedForThread(record, pr, thread, 1, retryFingerprintForThread(thread));
+  const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads).filter(
+    reviewLoopRetryBudgetAvailable,
+  );
+  const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
+  const actionableFollowUpThreads = actionableConfiguredBotReviewThreads(config, unresolvedBotThreads).filter(
+    (thread) => !thread.isResolved && !thread.isOutdated,
+  );
+  const availableActionableFollowUpThreads = actionableFollowUpThreads.filter(reviewLoopRetryBudgetAvailable);
+  const botFollowUpStateEligibleWithRetryBudget =
+    botFollowUpState === "eligible" && availableActionableFollowUpThreads.length > 0;
+  const botFollowUpStateExhaustedByRetryBudget =
+    botFollowUpState === "eligible" &&
+    actionableFollowUpThreads.length > 0 &&
+    availableActionableFollowUpThreads.length === 0;
   const codexConnectorMustFixThreadsExhausted =
     codexConnectorMustFixThreads.length > 0 &&
-    codexConnectorMustFixThreads.every((thread) =>
-      reviewLoopRetryBudgetExhaustedForThread(
-        record,
-        pr,
-        thread,
-        1,
-        latestCodexConnectorReviewCommentFingerprint(thread),
-      ),
-    );
+    codexConnectorMustFixThreads.every((thread) => !reviewLoopRetryBudgetAvailable(thread));
   const checkSummary = summarizeChecks(checks);
   const staleCodexWaitHasOnlyOutdatedResidue = staleSameHeadCodexWaitHasOnlyOutdatedResidue(
     config,
@@ -334,7 +344,7 @@ export function inferStateFromPullRequest(
       return "blocked";
     }
 
-    if (pendingBotThreads.length > 0 || (botFollowUpState === "eligible" && manualThreads.length === 0)) {
+    if (pendingBotThreads.length > 0 || (botFollowUpStateEligibleWithRetryBudget && manualThreads.length === 0)) {
       return "addressing_review";
     }
 
@@ -439,8 +449,18 @@ export function inferStateFromPullRequest(
     return "repairing_ci";
   }
 
-  if (pendingBotThreads.length > 0 || (botFollowUpState === "eligible" && manualThreads.length === 0)) {
+  if (pendingBotThreads.length > 0 || (botFollowUpStateEligibleWithRetryBudget && manualThreads.length === 0)) {
     return "addressing_review";
+  }
+
+  if (
+    botFollowUpStateExhaustedByRetryBudget &&
+    manualThreads.length === 0 &&
+    !checkSummary.hasFailing &&
+    !checkSummary.hasPending &&
+    !mergeConflictDetected(pr)
+  ) {
+    return "blocked";
   }
 
   if (unresolvedBotThreads.length > 0) {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -442,7 +442,14 @@ export function inferStateFromPullRequest(
     return "addressing_review";
   }
 
-  if (codexConnectorMustFixThreadsExhausted && !checkSummary.hasFailing && !checkSummary.hasPending) {
+  if (
+    codexConnectorMustFixThreadsExhausted &&
+    pendingBotThreads.length === 0 &&
+    !botFollowUpStateEligibleWithRetryBudget &&
+    !checkSummary.hasFailing &&
+    !checkSummary.hasPending &&
+    !mergeConflictDetected(pr)
+  ) {
     return "blocked";
   }
 
@@ -462,6 +469,15 @@ export function inferStateFromPullRequest(
     !mergeConflictDetected(pr)
   ) {
     return "blocked";
+  }
+
+  if (
+    mergeConflictDetected(pr) &&
+    codexConnectorMustFixThreadsExhausted &&
+    unresolvedBotThreads.length > 0 &&
+    unresolvedBotThreads.every((thread) => codexConnectorMustFixThreadIds.has(thread.id))
+  ) {
+    return "resolving_conflict";
   }
 
   if (unresolvedBotThreads.length > 0) {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -15,7 +15,10 @@ import {
   mergeConflictDetected,
   summarizeChecks,
 } from "./supervisor/supervisor-reporting";
-import { codexConnectorMustFixReviewThreads } from "./codex-connector-review-policy";
+import {
+  codexConnectorMustFixReviewThreads,
+  latestCodexConnectorReviewCommentFingerprint,
+} from "./codex-connector-review-policy";
 import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
@@ -45,6 +48,7 @@ import {
   shouldWaitForConfiguredBotLatestHeadRearm,
   shouldWaitForCopilotReviewPropagation,
 } from "./pull-request-state-current-head-policy";
+import { reviewLoopRetryBudgetExhaustedForThread } from "./review-handling";
 import {
   effectiveConfiguredBotReviewThreadsForState,
   hasConfiguredProviderSuccess,
@@ -276,6 +280,17 @@ export function inferStateFromPullRequest(
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads);
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
+  const codexConnectorMustFixThreadsExhausted =
+    codexConnectorMustFixThreads.length > 0 &&
+    codexConnectorMustFixThreads.every((thread) =>
+      reviewLoopRetryBudgetExhaustedForThread(
+        record,
+        pr,
+        thread,
+        1,
+        latestCodexConnectorReviewCommentFingerprint(thread),
+      ),
+    );
   const checkSummary = summarizeChecks(checks);
   const staleCodexWaitHasOnlyOutdatedResidue = staleSameHeadCodexWaitHasOnlyOutdatedResidue(
     config,
@@ -407,12 +422,17 @@ export function inferStateFromPullRequest(
 
   if (
     codexConnectorMustFixThreads.length > 0 &&
+    !codexConnectorMustFixThreadsExhausted &&
     !checkSummary.hasFailing &&
     !checkSummary.hasPending &&
     (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
     !mergeConflictDetected(pr)
   ) {
     return "addressing_review";
+  }
+
+  if (codexConnectorMustFixThreadsExhausted && !checkSummary.hasFailing && !checkSummary.hasPending) {
+    return "blocked";
   }
 
   if (checkSummary.hasFailing) {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -356,6 +356,7 @@ export function inferStateFromPullRequest(
     if (unresolvedBotThreads.length > 0 || pr.configuredBotTopLevelReviewStrength === "blocking") {
       if (
         codexConnectorMustFixThreads.length > 0 &&
+        !codexConnectorMustFixThreadsExhausted &&
         !checkSummary.hasFailing &&
         !checkSummary.hasPending &&
         (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -85,6 +85,18 @@ export function reviewLoopRetryAttemptCountForThread(
   return reviewLoopRetryStateEntryForThread(record, pr, thread)?.attempts ?? 0;
 }
 
+export function reviewLoopRetryBudgetExhaustedForThread(
+  record: Pick<IssueRunRecord, "review_loop_retry_state">,
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
+  thread: Pick<ReviewThread, "id" | "comments">,
+  retryLimit = 1,
+): boolean {
+  if (retryLimit <= 0) {
+    return true;
+  }
+  return reviewLoopRetryAttemptCountForThread(record, pr, thread) >= retryLimit;
+}
+
 export function nextReviewLoopRetryStateForThread(args: {
   record: Pick<IssueRunRecord, "review_loop_retry_state">;
   pr: Pick<GitHubPullRequest, "number" | "headRefOid">;

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -50,8 +50,9 @@ export function reviewLoopRetryFingerprint(args: {
 export function reviewLoopRetryFingerprintForThread(
   pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
   thread: Pick<ReviewThread, "id" | "comments">,
+  latestCommentFingerprintOverride?: string | null,
 ): string | null {
-  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
+  const latestCommentFingerprint = latestCommentFingerprintOverride ?? latestReviewThreadCommentFingerprint(thread);
   if (!latestCommentFingerprint) {
     return null;
   }
@@ -68,8 +69,9 @@ export function reviewLoopRetryStateEntryForThread(
   record: Pick<IssueRunRecord, "review_loop_retry_state">,
   pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
   thread: Pick<ReviewThread, "id" | "comments">,
+  latestCommentFingerprintOverride?: string | null,
 ): ReviewLoopRetryStateEntry | null {
-  const fingerprint = reviewLoopRetryFingerprintForThread(pr, thread);
+  const fingerprint = reviewLoopRetryFingerprintForThread(pr, thread, latestCommentFingerprintOverride);
   if (!fingerprint) {
     return null;
   }
@@ -81,8 +83,9 @@ export function reviewLoopRetryAttemptCountForThread(
   record: Pick<IssueRunRecord, "review_loop_retry_state">,
   pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
   thread: Pick<ReviewThread, "id" | "comments">,
+  latestCommentFingerprintOverride?: string | null,
 ): number {
-  return reviewLoopRetryStateEntryForThread(record, pr, thread)?.attempts ?? 0;
+  return reviewLoopRetryStateEntryForThread(record, pr, thread, latestCommentFingerprintOverride)?.attempts ?? 0;
 }
 
 export function reviewLoopRetryBudgetExhaustedForThread(
@@ -90,11 +93,12 @@ export function reviewLoopRetryBudgetExhaustedForThread(
   pr: Pick<GitHubPullRequest, "number" | "headRefOid">,
   thread: Pick<ReviewThread, "id" | "comments">,
   retryLimit = 1,
+  latestCommentFingerprintOverride?: string | null,
 ): boolean {
   if (retryLimit <= 0) {
     return true;
   }
-  return reviewLoopRetryAttemptCountForThread(record, pr, thread) >= retryLimit;
+  return reviewLoopRetryAttemptCountForThread(record, pr, thread, latestCommentFingerprintOverride) >= retryLimit;
 }
 
 export function nextReviewLoopRetryStateForThread(args: {
@@ -102,8 +106,10 @@ export function nextReviewLoopRetryStateForThread(args: {
   pr: Pick<GitHubPullRequest, "number" | "headRefOid">;
   thread: Pick<ReviewThread, "id" | "comments">;
   attemptedAt: string;
+  latestCommentFingerprintOverride?: string | null;
 }): ReviewLoopRetryStateEntry[] {
-  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(args.thread);
+  const latestCommentFingerprint =
+    args.latestCommentFingerprintOverride ?? latestReviewThreadCommentFingerprint(args.thread);
   if (!latestCommentFingerprint) {
     return [...(args.record.review_loop_retry_state ?? [])];
   }
@@ -140,11 +146,12 @@ export function hasProcessedReviewThread(
   >,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   thread: Pick<ReviewThread, "id" | "comments">,
+  latestCommentFingerprintOverride?: string | null,
 ): boolean {
   const processedKeys = record.processed_review_thread_ids ?? [];
   const processedFingerprints = record.processed_review_thread_fingerprints ?? [];
   const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
-  const latestCommentFingerprint = latestReviewThreadCommentFingerprint(thread);
+  const latestCommentFingerprint = latestCommentFingerprintOverride ?? latestReviewThreadCommentFingerprint(thread);
   if (
     latestCommentFingerprint &&
     processedFingerprints.includes(

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -1186,6 +1186,7 @@ export async function executeCodexTurnPhase(
           !workspaceStatus.hasUncommittedChanges &&
           changedFilesAfterPublication.length === 0;
         const processedReviewThreadPatch = nextProcessedReviewThreadPatch({
+          config,
           preRunState,
           record,
           currentPr: pr,

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -565,6 +565,77 @@ test("buildStaleReviewBotRemediation rejects review-bot-only checks as verified 
   assert.equal(diagnostics?.autoRepairSuppressedReason, "repeat_stop_exhausted");
 });
 
+test("buildStaleReviewBotThreadDiagnostics reports repeat-stop when review-loop retry state is exhausted", () => {
+  const issueNumber = 2270;
+  const prNumber = 2273;
+  const headSha = "b8500b1addreviewloopretrystate";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-review-loop-budget",
+    commentId: "comment-review-loop-budget",
+    path: "src/review-handling.ts",
+    line: 42,
+    severity: "P2",
+    commentBody: "P2: Preserve review-loop retry budget before another repair turn.",
+    discussionUrl: "https://example.test/pr/2273#discussion_r2270",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-07T01:03:00Z",
+      observedAt: "2026-06-07T01:07:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    latest_local_ci_result: null,
+    timeline_artifacts: [],
+    last_tracked_pr_repeat_failure_decision: null,
+    review_loop_retry_state: [
+      {
+        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${scenario.reviewThread.id}|comment=comment-review-loop-budget`,
+        pr_number: prNumber,
+        head_sha: headSha,
+        thread_id: scenario.reviewThread.id,
+        latest_comment_fingerprint: "comment-review-loop-budget",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-07T01:02:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const checks = [{ name: "repo-ci", state: "SUCCESS", bucket: "pass" as const }];
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [scenario.reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(diagnostics?.repeatStopExhausted, "yes");
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "repeat_stop_exhausted");
+});
+
 test("buildStaleReviewBotRemediation fails closed when covered evidence lacks current-head Codex no-major signal", () => {
   const issueNumber = 110;
   const prNumber = 115;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -636,6 +636,95 @@ test("buildStaleReviewBotThreadDiagnostics reports repeat-stop when review-loop 
   assert.equal(diagnostics?.autoRepairSuppressedReason, "repeat_stop_exhausted");
 });
 
+test("buildStaleReviewBotThreadDiagnostics uses Codex finding fingerprints for replied exhausted retries", () => {
+  const issueNumber = 2270;
+  const prNumber = 2273;
+  const headSha = "b8500b1addreviewloopretrystate";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-review-loop-budget-replied",
+    commentId: "comment-review-loop-budget",
+    path: "src/review-handling.ts",
+    line: 42,
+    severity: "P2",
+    commentBody: "P2: Preserve review-loop retry budget before another repair turn.",
+    discussionUrl: "https://example.test/pr/2273#discussion_r2270",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-07T01:03:00Z",
+      observedAt: "2026-06-07T01:07:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    latest_local_ci_result: null,
+    timeline_artifacts: [],
+    last_tracked_pr_repeat_failure_decision: null,
+    review_loop_retry_state: [
+      {
+        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${scenario.reviewThread.id}|comment=comment-review-loop-budget`,
+        pr_number: prNumber,
+        head_sha: headSha,
+        thread_id: scenario.reviewThread.id,
+        latest_comment_fingerprint: "comment-review-loop-budget",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-07T01:02:00Z",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const reviewThread = {
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "comment-reply",
+          body: "Supervisor reply after the retry attempt.",
+          createdAt: "2026-06-07T01:05:00Z",
+          url: "https://example.test/pr/2273#discussion_r2270_reply",
+          author: {
+            login: "github-actions[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+  const checks = [{ name: "repo-ci", state: "SUCCESS", bucket: "pass" as const }];
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: [reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "unresolved_work");
+  assert.equal(diagnostics?.repeatStopExhausted, "yes");
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "repeat_stop_exhausted");
+});
+
 test("buildStaleReviewBotRemediation fails closed when covered evidence lacks current-head Codex no-major signal", () => {
   const issueNumber = 110;
   const prNumber = 115;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -11,6 +11,7 @@ import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
+  latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
 } from "../codex-connector-review-policy";
@@ -1149,7 +1150,8 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
   const reviewThreads = args.reviewThreads ?? [];
   const configuredThreads = config ? configuredBotReviewThreads(config, reviewThreads) : [];
   const unresolvedConfiguredThreads = configuredThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-  const actionableMustFixThreads = config && configuredReviewProviderKinds(config).includes("codex")
+  const codexConfigured = config ? configuredReviewProviderKinds(config).includes("codex") : false;
+  const actionableMustFixThreads = config && codexConfigured
     ? codexConnectorMustFixReviewThreads(reviewThreads)
     : config && args.pr
       ? pendingBotReviewThreads(config, args.record, args.pr, configuredThreads)
@@ -1161,7 +1163,13 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
   const reviewLoopRetryExhausted =
     config && args.pr && actionableMustFixThreads.length > 0
       ? actionableMustFixThreads.every((thread) =>
-          reviewLoopRetryBudgetExhaustedForThread(args.record, args.pr!, thread),
+          reviewLoopRetryBudgetExhaustedForThread(
+            args.record,
+            args.pr!,
+            thread,
+            1,
+            codexConfigured ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined,
+          ),
         )
       : false;
   const repeatStopExhausted =

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -4,6 +4,7 @@ import {
   latestReviewThreadCommentFingerprint,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
+  reviewLoopRetryBudgetExhaustedForThread,
 } from "../review-handling";
 import {
   clusterConfiguredBotReviewThreads,
@@ -1157,10 +1158,17 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
     remediation.classification === "metadata_only_missing_current_head_review" &&
     remediation.codexCurrentHeadReviewState === "missing";
   const isVerifiedResidue = isVerifiedStaleResidueClassification(remediation.classification);
+  const reviewLoopRetryExhausted =
+    config && args.pr && actionableMustFixThreads.length > 0
+      ? actionableMustFixThreads.every((thread) =>
+          reviewLoopRetryBudgetExhaustedForThread(args.record, args.pr!, thread),
+        )
+      : false;
   const repeatStopExhausted =
     currentHeadReviewRequestPending || isVerifiedResidue
       ? false
-      : args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
+      : reviewLoopRetryExhausted ||
+        args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
         (config && args.pr
           ? configuredBotReviewFollowUpState(config, args.record, args.pr, configuredThreads) === "exhausted"
           : false);

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -26,6 +26,7 @@ import {
 
 test("nextProcessedReviewThreadPatch refreshes reprocessed same-head ids to the newest position before trimming", () => {
   const patch = nextProcessedReviewThreadPatch({
+    config: createConfig({ reviewBotLogins: ["copilot-pull-request-reviewer"] }),
     preRunState: "addressing_review",
     record: {
       processed_review_thread_ids: Array.from({ length: 200 }, (_, index) => `thread-${index}@head-a`),
@@ -33,8 +34,9 @@ test("nextProcessedReviewThreadPatch refreshes reprocessed same-head ids to the 
         { length: 200 },
         (_, index) => `thread-${index}@head-a#comment-${index}`,
       ),
+      review_loop_retry_state: [],
     },
-    currentPr: { headRefOid: "head-a" },
+    currentPr: { number: 116, headRefOid: "head-a" },
     evaluatedReviewHeadSha: "head-a",
     reviewThreadsToProcess: [
       createReviewThread({
@@ -69,6 +71,53 @@ test("nextProcessedReviewThreadPatch refreshes reprocessed same-head ids to the 
     patch.processed_review_thread_fingerprints[patch.processed_review_thread_fingerprints.length - 1],
     "thread-0@head-a#comment-0",
   );
+});
+
+test("nextProcessedReviewThreadPatch records review-loop retry attempts for current-head configured bot threads", () => {
+  const patch = nextProcessedReviewThreadPatch({
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: [],
+      review_loop_retry_state: [],
+    },
+    currentPr: { number: 2270, headRefOid: "head-a" },
+    evaluatedReviewHeadSha: "head-a",
+    attemptedAt: "2026-06-07T01:00:00Z",
+    reviewThreadsToProcess: [
+      createReviewThread({
+        id: "thread-codex",
+        comments: {
+          nodes: [
+            {
+              id: "comment-codex",
+              body: "P2: Preserve the retry state before sending this back into Codex.",
+              createdAt: "2026-06-07T00:55:00Z",
+              url: "https://example.test/pr/2270#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(patch.review_loop_retry_state, [
+    {
+      fingerprint: "pr=2270|head=head-a|thread=thread-codex|comment=comment-codex",
+      pr_number: 2270,
+      head_sha: "head-a",
+      thread_id: "thread-codex",
+      latest_comment_fingerprint: "comment-codex",
+      attempts: 1,
+      first_attempted_at: "2026-06-07T01:00:00Z",
+      last_attempted_at: "2026-06-07T01:00:00Z",
+    },
+  ]);
 });
 
 test("nextProcessedReviewThreadPatch persists local-review no-change current-head verification evidence", () => {
@@ -111,12 +160,14 @@ test("nextProcessedReviewThreadPatch persists local-review no-change current-hea
   ];
 
   const patch = nextProcessedReviewThreadPatch({
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
     preRunState: "local_review_fix",
     record: {
       processed_review_thread_ids: [],
       processed_review_thread_fingerprints: [],
+      review_loop_retry_state: [],
     },
-    currentPr: { headRefOid: headSha },
+    currentPr: { number: 498, headRefOid: headSha },
     evaluatedReviewHeadSha: headSha,
     reviewThreadsToProcess: reviewThreads,
     verifiedNoSourceChangeReviewThreads: reviewThreads,
@@ -141,12 +192,14 @@ test("nextProcessedReviewThreadPatch scopes local-review no-change evidence to v
   const verifiedThread = createReviewThread({ id: "thread-verified" });
   const unrelatedThread = createReviewThread({ id: "thread-unrelated" });
   const patch = nextProcessedReviewThreadPatch({
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
     preRunState: "local_review_fix",
     record: {
       processed_review_thread_ids: [],
       processed_review_thread_fingerprints: [],
+      review_loop_retry_state: [],
     },
-    currentPr: { headRefOid: headSha },
+    currentPr: { number: 498, headRefOid: headSha },
     evaluatedReviewHeadSha: headSha,
     reviewThreadsToProcess: [verifiedThread, unrelatedThread],
     verifiedNoSourceChangeReviewThreads: [verifiedThread],
@@ -457,12 +510,14 @@ test("selectVerifiedNoSourceChangeReviewThreads fails closed without exact threa
 
 test("nextProcessedReviewThreadPatch fails closed for local-review current-head threads without no-change verification", () => {
   const patch = nextProcessedReviewThreadPatch({
+    config: createConfig(),
     preRunState: "local_review_fix",
     record: {
       processed_review_thread_ids: [],
       processed_review_thread_fingerprints: [],
+      review_loop_retry_state: [],
     },
-    currentPr: { headRefOid: "head-a" },
+    currentPr: { number: 498, headRefOid: "head-a" },
     evaluatedReviewHeadSha: "head-a",
     reviewThreadsToProcess: [createReviewThread({ id: "thread-1" })],
   });
@@ -529,6 +584,56 @@ test("selectReviewThreadsForTurn re-includes processed Codex Connector must-fix 
 
   assert.equal(selected.length, 1);
   assert.equal(selected[0]?.id, "thread-1");
+});
+
+test("selectReviewThreadsForTurn excludes Codex Connector must-fix threads after review-loop retry budget exhaustion", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-1",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
 });
 
 test("selectReviewThreadsForTurn switches churned Codex reviews from pending-only to root-cause repair", () => {

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -120,6 +120,63 @@ test("nextProcessedReviewThreadPatch records review-loop retry attempts for curr
   ]);
 });
 
+test("nextProcessedReviewThreadPatch records Codex must-fix retries when a later reply is newest", () => {
+  const patch = nextProcessedReviewThreadPatch({
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: [],
+      review_loop_retry_state: [],
+    },
+    currentPr: { number: 2270, headRefOid: "head-a" },
+    evaluatedReviewHeadSha: "head-a",
+    attemptedAt: "2026-06-07T01:00:00Z",
+    reviewThreadsToProcess: [
+      createReviewThread({
+        id: "thread-codex",
+        comments: {
+          nodes: [
+            {
+              id: "comment-codex",
+              body: "P2: Preserve the retry state before sending this back into Codex.",
+              createdAt: "2026-06-07T00:55:00Z",
+              url: "https://example.test/pr/2270#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-reply",
+              body: "Supervisor reply after the first repair attempt.",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/2270#discussion_r2",
+              author: {
+                login: "github-actions[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(patch.review_loop_retry_state, [
+    {
+      fingerprint: "pr=2270|head=head-a|thread=thread-codex|comment=comment-codex",
+      pr_number: 2270,
+      head_sha: "head-a",
+      thread_id: "thread-codex",
+      latest_comment_fingerprint: "comment-codex",
+      attempts: 1,
+      first_attempted_at: "2026-06-07T01:00:00Z",
+      last_attempted_at: "2026-06-07T01:00:00Z",
+    },
+  ]);
+});
+
 test("nextProcessedReviewThreadPatch persists local-review no-change current-head verification evidence", () => {
   const headSha = "7a77d998712882166f79c3710dd4c567da6da779";
   const reviewThreads = [
@@ -716,6 +773,66 @@ test("selectReviewThreadsForTurn matches Codex Connector retry exhaustion to the
               url: "https://example.test/pr/116#discussion_r2",
               author: {
                 login: "github-actions[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
+});
+
+test("selectReviewThreadsForTurn does not reselect exhausted Codex findings through pending same-bot replies", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-codex"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-codex",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-codex",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-codex",
+              body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-codex-reply",
+              body: "Connector follow-up without a new P-severity finding.",
+              createdAt: "2026-06-07T01:20:00Z",
+              url: "https://example.test/pr/116#discussion_r2",
+              author: {
+                login: "chatgpt-codex-connector",
                 typeName: "Bot",
               },
             },

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -547,6 +547,38 @@ test("selectReviewThreadsForTurn re-includes same-head configured-bot threads wh
   assert.equal(selected[0]?.id, "thread-1");
 });
 
+test("selectReviewThreadsForTurn excludes exhausted same-head configured-bot threads when follow-up allowance is active", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-1",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: "head-a",
+      review_follow_up_remaining: 1,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [createReviewThread({ id: "thread-1" })],
+  });
+
+  assert.deepEqual(selected, []);
+});
+
 test("selectReviewThreadsForTurn re-includes processed Codex Connector must-fix threads for same-PR repair", () => {
   const selected = selectReviewThreadsForTurn({
     config: createConfig({

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -668,6 +668,66 @@ test("selectReviewThreadsForTurn excludes Codex Connector must-fix threads after
   assert.deepEqual(selected, []);
 });
 
+test("selectReviewThreadsForTurn matches Codex Connector retry exhaustion to the finding comment after later replies", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-codex"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-codex",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-codex",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-codex",
+              body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-reply",
+              body: "Supervisor reply after the first repair attempt.",
+              createdAt: "2026-06-07T01:20:00Z",
+              url: "https://example.test/pr/116#discussion_r2",
+              author: {
+                login: "github-actions[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
+});
+
 test("selectReviewThreadsForTurn switches churned Codex reviews from pending-only to root-cause repair", () => {
   const reviewThreads = Array.from({ length: 8 }, (_, index) =>
     createReviewThread({

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -14,8 +14,10 @@ import { loadLocalReviewRepairContext } from "./local-review/repair-context";
 import {
   hasProcessedReviewThread,
   latestReviewThreadCommentFingerprint,
+  nextReviewLoopRetryStateForThread,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
+  reviewLoopRetryBudgetExhaustedForThread,
 } from "./review-handling";
 import {
   buildCodexConnectorReviewChurnDiagnostic,
@@ -174,6 +176,7 @@ export function selectReviewThreadsForTurn(args: {
     | "last_head_sha"
     | "review_follow_up_head_sha"
     | "review_follow_up_remaining"
+    | "review_loop_retry_state"
   >;
   pr: GitHubPullRequest | null;
   reviewThreads: ReviewThread[];
@@ -190,10 +193,13 @@ export function selectReviewThreadsForTurn(args: {
   const activeConfiguredBotThreads = configuredBotReviewThreads(args.config as SupervisorConfig, args.reviewThreads).filter(
     (thread) => !thread.isResolved && !thread.isOutdated,
   );
+  const reviewLoopRetryBudgetAvailable = (thread: ReviewThread) =>
+    !reviewLoopRetryBudgetExhaustedForThread(args.record, currentPr, thread);
   const pendingThreads = actionableFollowUpThreads.filter(
-    (thread) => !hasProcessedReviewThread(args.record, currentPr, thread),
+    (thread) => !hasProcessedReviewThread(args.record, currentPr, thread) && reviewLoopRetryBudgetAvailable(thread),
   );
-  const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(activeConfiguredBotThreads);
+  const codexConnectorMustFixThreads =
+    codexConnectorMustFixReviewThreads(activeConfiguredBotThreads).filter(reviewLoopRetryBudgetAvailable);
   const codexConnectorReviewChurnDiagnostic = buildCodexConnectorReviewChurnDiagnostic(
     args.config,
     activeConfiguredBotThreads,
@@ -387,14 +393,19 @@ export async function prepareCodexTurnPrompt(args: {
 }
 
 export function nextProcessedReviewThreadPatch(args: {
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">;
   preRunState: IssueRunRecord["state"];
-  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">;
-  currentPr: Pick<GitHubPullRequest, "headRefOid"> | null;
+  record: Pick<
+    IssueRunRecord,
+    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "review_loop_retry_state"
+  >;
+  currentPr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
   evaluatedReviewHeadSha: string;
   reviewThreadsToProcess: ReviewThread[];
   persistVerifiedNoSourceChangeCurrentHead?: boolean;
   verifiedNoSourceChangeReviewThreads?: ReviewThread[];
-}): Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints"> {
+  attemptedAt?: string;
+}): Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "review_loop_retry_state"> {
   const shouldPersistCurrentHeadThreadEvidence =
     args.preRunState === "addressing_review" ||
     (args.preRunState === "local_review_fix" && args.persistVerifiedNoSourceChangeCurrentHead === true);
@@ -427,6 +438,24 @@ export function nextProcessedReviewThreadPatch(args: {
             : [];
         })
       : [];
+  const reviewLoopRetryState =
+    args.preRunState === "addressing_review" &&
+    args.currentPr &&
+    args.currentPr.headRefOid === args.evaluatedReviewHeadSha
+      ? actionableConfiguredBotReviewThreads(args.config as SupervisorConfig, args.reviewThreadsToProcess)
+          .filter((thread) => !thread.isResolved && !thread.isOutdated)
+          .reduce(
+            (state, thread) =>
+              nextReviewLoopRetryStateForThread({
+                record: { review_loop_retry_state: state },
+                pr: args.currentPr!,
+                thread,
+                attemptedAt: args.attemptedAt ?? new Date().toISOString(),
+              }),
+            args.record.review_loop_retry_state ?? [],
+          )
+          .slice(-200)
+      : args.record.review_loop_retry_state ?? [];
 
   return {
     processed_review_thread_ids:
@@ -451,6 +480,7 @@ export function nextProcessedReviewThreadPatch(args: {
             ]),
           ).slice(-200)
         : args.record.processed_review_thread_fingerprints,
+    review_loop_retry_state: reviewLoopRetryState,
   };
 }
 

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -22,6 +22,7 @@ import {
 import {
   buildCodexConnectorReviewChurnDiagnostic,
   codexConnectorMustFixReviewThreads,
+  latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
 import {
   actionableConfiguredBotReviewThreads,
@@ -193,14 +194,17 @@ export function selectReviewThreadsForTurn(args: {
   const activeConfiguredBotThreads = configuredBotReviewThreads(args.config as SupervisorConfig, args.reviewThreads).filter(
     (thread) => !thread.isResolved && !thread.isOutdated,
   );
-  const reviewLoopRetryBudgetAvailable = (thread: ReviewThread) =>
-    !reviewLoopRetryBudgetExhaustedForThread(args.record, currentPr, thread);
-  const availableActionableFollowUpThreads = actionableFollowUpThreads.filter(reviewLoopRetryBudgetAvailable);
+  const reviewLoopRetryBudgetAvailable = (thread: ReviewThread, latestCommentFingerprintOverride?: string | null) =>
+    !reviewLoopRetryBudgetExhaustedForThread(args.record, currentPr, thread, 1, latestCommentFingerprintOverride);
+  const availableActionableFollowUpThreads = actionableFollowUpThreads.filter((thread) =>
+    reviewLoopRetryBudgetAvailable(thread),
+  );
   const pendingThreads = actionableFollowUpThreads.filter(
     (thread) => !hasProcessedReviewThread(args.record, currentPr, thread) && reviewLoopRetryBudgetAvailable(thread),
   );
-  const codexConnectorMustFixThreads =
-    codexConnectorMustFixReviewThreads(activeConfiguredBotThreads).filter(reviewLoopRetryBudgetAvailable);
+  const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(activeConfiguredBotThreads).filter((thread) =>
+    reviewLoopRetryBudgetAvailable(thread, latestCodexConnectorReviewCommentFingerprint(thread)),
+  );
   const codexConnectorReviewChurnDiagnostic = buildCodexConnectorReviewChurnDiagnostic(
     args.config,
     activeConfiguredBotThreads,
@@ -452,6 +456,7 @@ export function nextProcessedReviewThreadPatch(args: {
                 pr: args.currentPr!,
                 thread,
                 attemptedAt: args.attemptedAt ?? new Date().toISOString(),
+                latestCommentFingerprintOverride: latestCodexConnectorReviewCommentFingerprint(thread),
               }),
             args.record.review_loop_retry_state ?? [],
           )

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -195,6 +195,7 @@ export function selectReviewThreadsForTurn(args: {
   );
   const reviewLoopRetryBudgetAvailable = (thread: ReviewThread) =>
     !reviewLoopRetryBudgetExhaustedForThread(args.record, currentPr, thread);
+  const availableActionableFollowUpThreads = actionableFollowUpThreads.filter(reviewLoopRetryBudgetAvailable);
   const pendingThreads = actionableFollowUpThreads.filter(
     (thread) => !hasProcessedReviewThread(args.record, currentPr, thread) && reviewLoopRetryBudgetAvailable(thread),
   );
@@ -223,9 +224,9 @@ export function selectReviewThreadsForTurn(args: {
   return (
     args.record.review_follow_up_head_sha === currentPr.headRefOid &&
     (args.record.review_follow_up_remaining ?? 0) > 0 &&
-    actionableFollowUpThreads.length > 0
+    availableActionableFollowUpThreads.length > 0
   )
-    ? actionableFollowUpThreads
+    ? availableActionableFollowUpThreads
     : pendingThreads;
 }
 

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -194,15 +194,21 @@ export function selectReviewThreadsForTurn(args: {
   const activeConfiguredBotThreads = configuredBotReviewThreads(args.config as SupervisorConfig, args.reviewThreads).filter(
     (thread) => !thread.isResolved && !thread.isOutdated,
   );
+  const codexConnectorMustFixThreadCandidates = codexConnectorMustFixReviewThreads(activeConfiguredBotThreads);
+  const codexConnectorMustFixThreadIds = new Set(codexConnectorMustFixThreadCandidates.map((thread) => thread.id));
+  const retryFingerprintForThread = (thread: ReviewThread) =>
+    codexConnectorMustFixThreadIds.has(thread.id) ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined;
   const reviewLoopRetryBudgetAvailable = (thread: ReviewThread, latestCommentFingerprintOverride?: string | null) =>
     !reviewLoopRetryBudgetExhaustedForThread(args.record, currentPr, thread, 1, latestCommentFingerprintOverride);
   const availableActionableFollowUpThreads = actionableFollowUpThreads.filter((thread) =>
-    reviewLoopRetryBudgetAvailable(thread),
+    reviewLoopRetryBudgetAvailable(thread, retryFingerprintForThread(thread)),
   );
   const pendingThreads = actionableFollowUpThreads.filter(
-    (thread) => !hasProcessedReviewThread(args.record, currentPr, thread) && reviewLoopRetryBudgetAvailable(thread),
+    (thread) =>
+      !hasProcessedReviewThread(args.record, currentPr, thread, retryFingerprintForThread(thread)) &&
+      reviewLoopRetryBudgetAvailable(thread, retryFingerprintForThread(thread)),
   );
-  const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(activeConfiguredBotThreads).filter((thread) =>
+  const codexConnectorMustFixThreads = codexConnectorMustFixThreadCandidates.filter((thread) =>
     reviewLoopRetryBudgetAvailable(thread, latestCodexConnectorReviewCommentFingerprint(thread)),
   );
   const codexConnectorReviewChurnDiagnostic = buildCodexConnectorReviewChurnDiagnostic(
@@ -443,20 +449,34 @@ export function nextProcessedReviewThreadPatch(args: {
             : [];
         })
       : [];
+  const unresolvedConfiguredThreadsToProcess = configuredBotReviewThreads(
+    args.config as SupervisorConfig,
+    args.reviewThreadsToProcess,
+  ).filter((thread) => !thread.isResolved && !thread.isOutdated);
+  const actionableThreadsToTrack = actionableConfiguredBotReviewThreads(
+    args.config as SupervisorConfig,
+    args.reviewThreadsToProcess,
+  ).filter((thread) => !thread.isResolved && !thread.isOutdated);
+  const codexMustFixThreadsToTrack = codexConnectorMustFixReviewThreads(unresolvedConfiguredThreadsToProcess);
+  const retryThreadsToTrack = uniqueReviewThreadsInOrder(
+    unresolvedConfiguredThreadsToProcess,
+    new Set([...actionableThreadsToTrack, ...codexMustFixThreadsToTrack].map((thread) => thread.id)),
+  );
+  const codexMustFixThreadIdsToTrack = new Set(codexMustFixThreadsToTrack.map((thread) => thread.id));
   const reviewLoopRetryState =
     args.preRunState === "addressing_review" &&
     args.currentPr &&
     args.currentPr.headRefOid === args.evaluatedReviewHeadSha
-      ? actionableConfiguredBotReviewThreads(args.config as SupervisorConfig, args.reviewThreadsToProcess)
-          .filter((thread) => !thread.isResolved && !thread.isOutdated)
-          .reduce(
+      ? retryThreadsToTrack.reduce(
             (state, thread) =>
               nextReviewLoopRetryStateForThread({
                 record: { review_loop_retry_state: state },
                 pr: args.currentPr!,
                 thread,
                 attemptedAt: args.attemptedAt ?? new Date().toISOString(),
-                latestCommentFingerprintOverride: latestCodexConnectorReviewCommentFingerprint(thread),
+                latestCommentFingerprintOverride: codexMustFixThreadIdsToTrack.has(thread.id)
+                  ? latestCodexConnectorReviewCommentFingerprint(thread)
+                  : undefined,
               }),
             args.record.review_loop_retry_state ?? [],
           )


### PR DESCRIPTION
## Summary

- Record review-loop retry attempts when current-head configured bot review threads are sent through a Codex repair turn.
- Stop selecting Codex Connector must-fix threads for another repair after the same PR/head/thread/comment fingerprint has exhausted its retry budget.
- Surface retry-state exhaustion through stale review diagnostics as `repeat_stop_exhausted`, while preserving the legacy repeat-stop path.

## Why

Phase 0 needs to stop repeated Codex connector review feedback from driving unbounded repair loops. #2269 introduced durable retry-state storage; this PR starts using that state before reprocessing the same current-head review fingerprint.

First-seen current-head P1/P2 feedback still routes into repair. Exhausted same-fingerprint feedback becomes terminal instead of being sent back into Codex again.

Closes #2270

## Validation

- `npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts`
- `npx tsx --test src/codex-connector-review-request-decision.test.ts`
- `npx tsx --test src/turn-execution-orchestration.test.ts`
- `npx tsx --test src/review-handling.test.ts`
- `npm run build`
- `git diff --check`
