### PR TITLE
[codex] Surface terminal review-loop stop reasons

### DIFF
--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -58,7 +58,9 @@ export function formatStaleReviewBotTerminalStopLine(args: {
   diagnostics: StaleReviewBotThreadDiagnosticsDto;
 }): string | null {
   const { remediation, diagnostics } = args;
-  const metadataTerminal = isProvenStaleReviewMetadataClassification(remediation.classification);
+  const metadataTerminal =
+    isProvenStaleReviewMetadataClassification(remediation.classification) ||
+    remediation.classification === "metadata_only_missing_current_head_review";
   if (diagnostics.repeatStopExhausted !== "yes" && !metadataTerminal) {
     return null;
   }

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -53,6 +53,43 @@ export function formatStaleReviewBotThreadDiagnosticsLine(
   ].join(" ");
 }
 
+export function formatStaleReviewBotTerminalStopLine(args: {
+  remediation: StaleReviewBotRemediationDto;
+  diagnostics: StaleReviewBotThreadDiagnosticsDto;
+}): string | null {
+  const { remediation, diagnostics } = args;
+  const metadataTerminal = isProvenStaleReviewMetadataClassification(remediation.classification);
+  if (diagnostics.repeatStopExhausted !== "yes" && !metadataTerminal) {
+    return null;
+  }
+
+  const terminalReason =
+    diagnostics.repeatStopExhausted === "yes"
+      ? "retry_budget_exhausted"
+      : "metadata_only_review_thread_resolution_pending";
+  const nextAction =
+    diagnostics.repeatStopExhausted === "yes"
+      ? "manual_review_thread_handling"
+      : remediation.classification === "metadata_only_missing_current_head_review"
+        ? "request_current_head_review"
+        : remediation.classification === "verified_no_source_change_pending_thread_resolution" ||
+            remediation.classification === "verified_current_head_repair_pending_thread_resolution"
+          ? "resolve_verified_review_thread_metadata"
+          : "manual_review_thread_handling";
+
+  return [
+    "stale_review_bot_terminal_stop",
+    `issue=#${diagnostics.issueNumber}`,
+    `pr=${diagnostics.prNumber === null ? "none" : `#${diagnostics.prNumber}`}`,
+    `reason=${terminalReason}`,
+    `classification=${remediation.classification}`,
+    `head_freshness=processed_on_current_head:${remediation.processedOnCurrentHead},current_head_success:${diagnostics.currentHeadSuccess}`,
+    `review_thread_classification=unresolved:${diagnostics.unresolvedCurrentThreads},must_fix:${diagnostics.actionableMustFixThreads},verified_residue:${diagnostics.verifiedStaleResidueThreads}`,
+    `auto_repair_suppressed_reason=${diagnostics.autoRepairSuppressedReason}`,
+    `next_action=${nextAction}`,
+  ].join(" ");
+}
+
 export function formatStaleReviewResidueOperatorDiagnostic(remediation: StaleReviewBotRemediationDto): string {
   const latestConfiguredBotReviewSha =
     remediation.processedOnCurrentHead === "yes" ? remediation.currentHeadSha : "none";

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -32,6 +32,7 @@ import {
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
+  formatStaleReviewBotTerminalStopLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
 import { buildIssueActivityContext, formatLocalCiStatusLine } from "./supervisor-operator-activity-context";
@@ -190,6 +191,10 @@ export function buildActiveStaleReviewBotDiagnosticLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
+      const terminalStopLine = formatStaleReviewBotTerminalStopLine({ remediation, diagnostics });
+      if (terminalStopLine) {
+        lines.push(terminalStopLine);
+      }
     }
   }
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -11,6 +11,7 @@ import {
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
+  formatStaleReviewBotTerminalStopLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
 import type { IssueRunRecord } from "../core/types";
@@ -190,6 +191,13 @@ export function buildInactiveDetailedStatusLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
+      const terminalStopLine = formatStaleReviewBotTerminalStopLine({
+        remediation: staleReviewBotRemediation,
+        diagnostics,
+      });
+      if (terminalStopLine) {
+        lines.push(terminalStopLine);
+      }
     }
   }
   if (latestRecord && pr) {

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1203,6 +1203,10 @@ test("status --why requests Codex current-head review for metadata-only missing 
   );
   assert.match(
     status,
+    /^stale_review_bot_terminal_stop issue=#144 pr=#148 reason=metadata_only_review_thread_resolution_pending classification=metadata_only_missing_current_head_review head_freshness=processed_on_current_head:unknown,current_head_success:no review_thread_classification=unresolved:0,must_fix:0,verified_residue:0 auto_repair_suppressed_reason=not_verified_stale_residue next_action=request_current_head_review$/m,
+  );
+  assert.match(
+    status,
     /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=f3addc310b0ff8e4fc53d9f3e0ab783af70a552f latest_configured_bot_review_sha=none current_head_review_signal=missing actionable_current_diff_threads=0 next_action=request_current_head_review$/m,
   );
   assert.doesNotMatch(status, /^codex_connector_operator_diagnostic .*next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m);

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1766,6 +1766,14 @@ test("status --why names missing verification for manual-review Codex no-major r
   );
   assert.match(
     status,
+    /^stale_review_bot_terminal_stop issue=#171 pr=#180 reason=retry_budget_exhausted classification=unknown_needs_operator head_freshness=processed_on_current_head:unknown,current_head_success:yes review_thread_classification=unresolved:9,must_fix:9,verified_residue:0 auto_repair_suppressed_reason=repeat_stop_exhausted next_action=manual_review_thread_handling$/m,
+  );
+  assert.match(
+    explanation,
+    /^stale_review_bot_terminal_stop issue=#171 pr=#180 reason=retry_budget_exhausted classification=unknown_needs_operator head_freshness=processed_on_current_head:unknown,current_head_success:yes review_thread_classification=unresolved:9,must_fix:9,verified_residue:0 auto_repair_suppressed_reason=repeat_stop_exhausted next_action=manual_review_thread_handling$/m,
+  );
+  assert.match(
+    status,
     /^codex_connector_operator_diagnostic interpretation=stale_review_residue current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 latest_configured_bot_review_sha=none current_head_review_signal=observed actionable_current_diff_threads=unknown next_action=inspect_exact_review_thread_then_resolve_or_leave_manual_note$/m,
   );
   assert.doesNotMatch(status, /^codex_connector_convergence\b/m);

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -207,6 +207,10 @@ test("status --why classifies current-head processed configured-bot success as s
     status,
     /^stale_review_bot_remediation issue=#365 pr=#372 reason=stale_review_bot code_ci=green current_head_sha=5de0d3844468d4a77cab512f8dcbe46171166c3a processed_on_current_head=yes classification=metadata_only review_thread_url=https:\/\/example\.test\/pr\/372#discussion_r365 manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note summary=stale_configured_bot_thread_metadata_only$/m,
   );
+  assert.match(
+    status,
+    /^stale_review_bot_terminal_stop issue=#365 pr=#372 reason=metadata_only_review_thread_resolution_pending classification=metadata_only head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:1,must_fix:\d+,verified_residue:0 auto_repair_suppressed_reason=not_verified_stale_residue next_action=manual_review_thread_handling$/m,
+  );
   assert.match(status, /^operator_action action=resolve_stale_review_bot /m);
   assert.doesNotMatch(status, /provider_outage_suspected/);
   assert.doesNotMatch(status, /stale_review_bot_provider_signal_missing/);

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./supervisor-diagnostics-status-scenarios";
 import {
   formatStaleReviewMetadataConvergenceDiagnostic,
+  formatStaleReviewBotTerminalStopLine,
 } from "./stale-review-bot-diagnostics-presenter";
 import { formatStaleReviewResidueOperatorDiagnostic } from "./supervisor-status-review-bot";
 import {
@@ -102,6 +103,23 @@ test("stale review-bot presenter keeps residue and metadata diagnostic lines sta
       }),
     }),
     "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=deadbeef current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=deadbeef highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=metadata_only",
+  );
+  assert.equal(
+    formatStaleReviewBotTerminalStopLine({
+      remediation,
+      diagnostics: {
+        issueNumber: 366,
+        prNumber: 44,
+        currentHeadSuccess: "yes",
+        unresolvedCurrentThreads: 1,
+        actionableMustFixThreads: 0,
+        verifiedStaleResidueThreads: 0,
+        missingVerificationEvidenceThreads: 0,
+        repeatStopExhausted: "no",
+        autoRepairSuppressedReason: "not_verified_stale_residue",
+      },
+    }),
+    "stale_review_bot_terminal_stop issue=#366 pr=#44 reason=metadata_only_review_thread_resolution_pending classification=metadata_only_missing_current_head_review head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:1,must_fix:0,verified_residue:0 auto_repair_suppressed_reason=not_verified_stale_residue next_action=request_current_head_review",
   );
 });
 

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -76,6 +76,7 @@ import {
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
+  formatStaleReviewBotTerminalStopLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
 import { formatMergedPrConvergenceOperatorEventLine } from "./supervisor-operator-events";
@@ -697,6 +698,14 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
     ...(dto.staleReviewBotThreadDiagnostics
       ? [formatStaleReviewBotThreadDiagnosticsLine(dto.staleReviewBotThreadDiagnostics)]
+      : []),
+    ...(dto.staleReviewBotRemediation && dto.staleReviewBotThreadDiagnostics
+      ? [
+          formatStaleReviewBotTerminalStopLine({
+            remediation: dto.staleReviewBotRemediation,
+            diagnostics: dto.staleReviewBotThreadDiagnostics,
+          }),
+        ].filter((line): line is string => line !== null)
       : []),
     ...(dto.effectiveReviewThreadDiagnosticsSummary ? [dto.effectiveReviewThreadDiagnosticsSummary] : []),
     ...(dto.codexConnectorOperatorDiagnosticSummary ? [dto.codexConnectorOperatorDiagnosticSummary] : []),

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -135,6 +135,7 @@ test("buildRuntimeRecoverySummary reuses restart recommendation vocabulary and c
       detailedStatusLines: [
         "loop_runtime_blocker issue=#171 reason=recoverable_active_tracked_work_waiting_for_loop expected=loop_runtime_state_running_then_tracked_issue_advances",
         "stale_review_bot_remediation issue=#171 pr=#271 reason=stale_review_bot classification=metadata_only manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+        "stale_review_bot_terminal_stop issue=#171 pr=#271 reason=retry_budget_exhausted classification=unknown_needs_operator head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:1,must_fix:1,verified_residue:0 auto_repair_suppressed_reason=repeat_stop_exhausted next_action=manual_review_thread_handling",
         "no_active_tracked_record issue=#178 classification=repair_already_queued state=repairing_ci reason=repairable_path_hygiene_retry_state",
       ],
     }),
@@ -158,6 +159,11 @@ test("buildRuntimeRecoverySummary reuses restart recommendation vocabulary and c
           kind: "stale_review_bot_remediation",
           summary:
             "stale_review_bot_remediation issue=#171 pr=#271 reason=stale_review_bot classification=metadata_only manual_next_step=inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+        },
+        {
+          kind: "stale_review_bot_terminal_stop",
+          summary:
+            "stale_review_bot_terminal_stop issue=#171 pr=#271 reason=retry_budget_exhausted classification=unknown_needs_operator head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:1,must_fix:1,verified_residue:0 auto_repair_suppressed_reason=repeat_stop_exhausted next_action=manual_review_thread_handling",
         },
         {
           kind: "repairable_path_hygiene",

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -60,6 +60,7 @@ export interface SupervisorRuntimeRecoverySignalDto {
     | "loop_runtime_stale_lock"
     | "loop_runtime_ambiguous_owner"
     | "stale_review_bot_remediation"
+    | "stale_review_bot_terminal_stop"
     | "repairable_path_hygiene";
   summary: string;
 }
@@ -149,6 +150,14 @@ function collectRuntimeRecoverySignals(args: {
   for (const line of args.detailedStatusLines) {
     if (line.startsWith("stale_review_bot_remediation ")) {
       push("stale_review_bot_remediation", line);
+      continue;
+    }
+    if (line.startsWith("stale_review_bot_terminal_stop ")) {
+      const key = `stale_review_bot_terminal_stop\0${line}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        signals.push({ kind: "stale_review_bot_terminal_stop", summary: sanitizeStatusValue(line) ?? line });
+      }
       continue;
     }
     if (


### PR DESCRIPTION
Implements #2271.

## Summary
- Add a stable stale_review_bot_terminal_stop status line for retry-budget exhaustion and metadata-only terminal review-loop states.
- Surface the line in active status, inactive detailed status, issue explain output, and runtime recovery summaries.
- Preserve the full terminal stop signal in recovery summaries so operator-facing next-action tokens are not truncated.

## Verification
- npx tsx --test src/supervisor/supervisor-diagnostics-explain.test.ts src/supervisor/supervisor-status-rendering.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts src/supervisor/supervisor-status-report.test.ts
- npm run build
- git diff --check