### PR TITLE
[codex] Add review-loop convergence replay fixtures

### DIFF
--- a/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/case.json
+++ b/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/case.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "phase0-aegisops-repeated-codex-feedback-terminal",
+  "issueNumber": 9140,
+  "title": "AegisOps repeated Codex review feedback terminal fixture",
+  "capturedAt": "2026-06-07T02:15:00Z"
+}

--- a/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/expected/replay-result.json
+++ b/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/expected/replay-result.json
@@ -1,0 +1,6 @@
+{
+  "nextState": "blocked",
+  "shouldRunCodex": false,
+  "blockedReason": "stale_review_bot",
+  "failureSignature": "stalled-bot:thread-production-source-denylist"
+}

--- a/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/input/snapshot.json
+++ b/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/input/snapshot.json
@@ -1,0 +1,226 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-06-07T02:15:00Z",
+  "issue": {
+    "number": 9140,
+    "title": "AegisOps repeated Codex review feedback terminal fixture",
+    "body": "Portable replay fixture for a GitHub-green PR stopped after repeated configured Codex feedback.",
+    "url": "https://example.test/issues/9140",
+    "state": "OPEN",
+    "updatedAt": "2026-06-07T02:13:00Z"
+  },
+  "local": {
+    "record": {
+      "issue_number": 9140,
+      "state": "blocked",
+      "branch": "codex/issue-9140",
+      "pr_number": 9240,
+      "workspace": ".",
+      "journal_path": ".codex-supervisor/issues/9140/issue-journal.md",
+      "attempt_count": 7,
+      "implementation_attempt_count": 2,
+      "repair_attempt_count": 5,
+      "timeout_retry_count": 0,
+      "blocked_verification_retry_count": 0,
+      "repeated_blocker_count": 0,
+      "repeated_failure_signature_count": 0,
+      "blocked_reason": "stale_review_bot",
+      "last_error": "Repeated configured Codex review feedback made no tracked PR progress.",
+      "last_failure_kind": null,
+      "last_failure_context": {
+        "category": "manual",
+        "summary": "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        "signature": "stalled-bot:thread-production-source-denylist",
+        "command": null,
+        "details": [
+          "reviewer=chatgpt-codex-connector file=aegisops/source_policy.ts line=44 p_severity=P1 processed_on_current_head=yes"
+        ],
+        "url": "https://example.test/pull/9240#discussion_r9140",
+        "updated_at": "2026-06-07T02:12:30Z"
+      },
+      "last_failure_signature": "stalled-bot:thread-production-source-denylist",
+      "last_head_sha": "head-aegisops-repeat-stop",
+      "last_tracked_pr_progress_snapshot": null,
+      "last_tracked_pr_progress_summary": null,
+      "last_tracked_pr_repeat_failure_decision": null,
+      "review_wait_started_at": "2026-06-07T02:00:00Z",
+      "review_wait_head_sha": "head-aegisops-repeat-stop",
+      "provider_success_observed_at": "2026-06-07T02:10:00Z",
+      "provider_success_head_sha": "head-aegisops-repeat-stop",
+      "merge_readiness_last_evaluated_at": "2026-06-07T02:12:30Z",
+      "copilot_review_requested_observed_at": null,
+      "copilot_review_requested_head_sha": null,
+      "copilot_review_timed_out_at": null,
+      "copilot_review_timeout_action": null,
+      "copilot_review_timeout_reason": null,
+      "local_review_head_sha": null,
+      "local_review_blocker_summary": null,
+      "local_review_summary_path": null,
+      "local_review_run_at": null,
+      "local_review_max_severity": null,
+      "local_review_findings_count": 0,
+      "local_review_root_cause_count": 0,
+      "local_review_verified_max_severity": null,
+      "local_review_verified_findings_count": 0,
+      "local_review_recommendation": null,
+      "local_review_degraded": false,
+      "last_local_review_signature": null,
+      "repeated_local_review_signature_count": 0,
+      "latest_local_ci_result": {
+        "outcome": "passed",
+        "summary": "AegisOps focused policy verifier passed on the current head.",
+        "ran_at": "2026-06-07T02:11:00Z",
+        "head_sha": "head-aegisops-repeat-stop",
+        "execution_mode": "structured",
+        "command": "npx tsx --test src/supervisor/replay-corpus.test.ts",
+        "failure_class": null,
+        "remediation_target": null
+      },
+      "last_observed_host_local_pr_blocker_signature": null,
+      "last_observed_host_local_pr_blocker_head_sha": null,
+      "last_host_local_pr_blocker_comment_signature": null,
+      "last_host_local_pr_blocker_comment_head_sha": null,
+      "review_loop_retry_state": [
+        {
+          "fingerprint": "pr=9240|head=head-aegisops-repeat-stop|thread=thread-production-source-denylist|comment=comment-production-source-denylist-v1",
+          "pr_number": 9240,
+          "head_sha": "head-aegisops-repeat-stop",
+          "thread_id": "thread-production-source-denylist",
+          "latest_comment_fingerprint": "comment-production-source-denylist-v1",
+          "attempts": 1,
+          "first_attempted_at": "2026-06-07T02:08:00Z",
+          "last_attempted_at": "2026-06-07T02:08:00Z"
+        }
+      ],
+      "processed_review_thread_ids": [
+        "thread-production-source-denylist@head-aegisops-repeat-stop"
+      ],
+      "processed_review_thread_fingerprints": [
+        "thread-production-source-denylist@head-aegisops-repeat-stop#comment-production-source-denylist-v1"
+      ],
+      "updated_at": "2026-06-07T02:13:00Z"
+    },
+    "workspaceStatus": {
+      "branch": "codex/issue-9140",
+      "headSha": "head-aegisops-repeat-stop",
+      "hasUncommittedChanges": false,
+      "baseAhead": 1,
+      "baseBehind": 0,
+      "remoteBranchExists": true,
+      "remoteAhead": 0,
+      "remoteBehind": 0
+    }
+  },
+  "github": {
+    "pullRequest": {
+      "number": 9240,
+      "title": "AegisOps repeated Codex review feedback terminal fixture",
+      "url": "https://example.test/pull/9240",
+      "state": "OPEN",
+      "createdAt": "2026-03-13T06:20:00Z",
+      "isDraft": false,
+      "reviewDecision": "CHANGES_REQUESTED",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "headRefName": "codex/issue-9140",
+      "headRefOid": "head-aegisops-repeat-stop",
+      "copilotReviewState": "not_requested",
+      "copilotReviewRequestedAt": null,
+      "copilotReviewArrivedAt": null,
+      "configuredBotCurrentHeadObservedAt": "2026-06-07T02:10:00Z",
+      "configuredBotCurrentHeadObservationSource": "codex_pr_success_comment",
+      "configuredBotCurrentHeadStatusState": "SUCCESS",
+      "currentHeadCiGreenAt": "2026-06-07T02:11:00Z",
+      "configuredBotTopLevelReviewStrength": "blocking",
+      "configuredBotTopLevelReviewSubmittedAt": "2026-06-07T02:10:00Z",
+      "mergedAt": null
+    },
+    "checks": [
+      {
+        "name": "policy verifier",
+        "state": "SUCCESS",
+        "bucket": "pass",
+        "workflow": "CI"
+      }
+    ],
+    "reviewThreads": [
+      {
+        "id": "thread-production-source-denylist",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "aegisops/source_policy.ts",
+        "line": 44,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-production-source-denylist-v1",
+              "body": "P1: The production source denylist still allows simulator evidence to be treated as launch authority.",
+              "createdAt": "2026-06-07T02:12:00Z",
+              "url": "https://example.test/pull/9240#discussion_r9140",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "decision": {
+    "nextState": "blocked",
+    "shouldRunCodex": false,
+    "blockedReason": "stale_review_bot",
+    "failureContext": {
+      "category": "manual",
+      "summary": "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+      "signature": "stalled-bot:thread-production-source-denylist",
+      "command": null,
+      "details": [
+        "reviewer=chatgpt-codex-connector file=aegisops/source_policy.ts line=44 p_severity=P1 processed_on_current_head=yes"
+      ],
+      "url": "https://example.test/pull/9240#discussion_r9140",
+      "updated_at": "2026-06-07T13:14:18.593Z"
+    }
+  },
+  "operatorSummary": {
+    "latestRecoverySummary": null,
+    "retrySummary": null,
+    "recoveryLoopSummary": null,
+    "activityContext": {
+      "handoffSummary": null,
+      "localReviewRoutingSummary": null,
+      "changeClassesSummary": null,
+      "verificationPolicySummary": null,
+      "durableGuardrailSummary": null,
+      "externalReviewFollowUpSummary": null,
+      "preMergeEvaluation": null,
+      "localCiStatus": {
+        "outcome": "passed",
+        "summary": "AegisOps focused policy verifier passed on the current head.",
+        "ranAt": "2026-06-07T02:11:00Z",
+        "headSha": "head-aegisops-repeat-stop",
+        "headStatus": "current",
+        "context": "notice",
+        "command": "npx tsx --test src/supervisor/replay-corpus.test.ts",
+        "stderrSummary": null,
+        "failureClass": null,
+        "remediationTarget": null,
+        "verifierDriftHint": null
+      },
+      "latestRecovery": null,
+      "retryContext": {
+        "timeoutRetryCount": 0,
+        "blockedVerificationRetryCount": 0,
+        "repeatedBlockerCount": 0,
+        "repeatedFailureSignatureCount": 0,
+        "lastFailureSignature": "stalled-bot:thread-production-source-denylist"
+      },
+      "repeatedRecovery": null,
+      "recentPhaseChanges": [],
+      "localReviewSummaryPath": null,
+      "externalReviewMissesPath": null,
+      "reviewWaits": []
+    }
+  }
+}

--- a/replay-corpus/cases/phase0-hrcore-current-head-repair-metadata-residue/case.json
+++ b/replay-corpus/cases/phase0-hrcore-current-head-repair-metadata-residue/case.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "phase0-hrcore-current-head-repair-metadata-residue",
+  "issueNumber": 9141,
+  "title": "HRCore metadata-only current-head repair evidence terminal fixture",
+  "capturedAt": "2026-06-07T03:20:00Z"
+}

--- a/replay-corpus/cases/phase0-hrcore-current-head-repair-metadata-residue/expected/replay-result.json
+++ b/replay-corpus/cases/phase0-hrcore-current-head-repair-metadata-residue/expected/replay-result.json
@@ -1,0 +1,6 @@
+{
+  "nextState": "ready_to_merge",
+  "shouldRunCodex": false,
+  "blockedReason": null,
+  "failureSignature": null
+}

--- a/replay-corpus/cases/phase0-hrcore-current-head-repair-metadata-residue/input/snapshot.json
+++ b/replay-corpus/cases/phase0-hrcore-current-head-repair-metadata-residue/input/snapshot.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-06-07T03:20:00Z",
+  "issue": {
+    "number": 9141,
+    "title": "HRCore metadata-only current-head repair evidence terminal fixture",
+    "body": "Portable replay fixture for metadata-only unresolved configured review feedback after current-head repair evidence.",
+    "url": "https://example.test/issues/9141",
+    "state": "OPEN",
+    "updatedAt": "2026-06-07T03:10:00Z"
+  },
+  "local": {
+    "record": {
+      "issue_number": 9141,
+      "state": "blocked",
+      "branch": "codex/issue-9141",
+      "pr_number": 9241,
+      "workspace": ".",
+      "journal_path": ".codex-supervisor/issues/9141/issue-journal.md",
+      "attempt_count": 5,
+      "implementation_attempt_count": 2,
+      "repair_attempt_count": 3,
+      "timeout_retry_count": 0,
+      "blocked_verification_retry_count": 0,
+      "repeated_blocker_count": 0,
+      "repeated_failure_signature_count": 0,
+      "blocked_reason": "stale_review_bot",
+      "last_error": "Outdated configured Codex metadata remained after current-head repair evidence.",
+      "last_failure_kind": null,
+      "last_failure_context": {
+        "category": "manual",
+        "summary": "Outdated configured-bot metadata-only residue is blocking the tracked PR.",
+        "signature": "stalled-bot:thread-openapi-onboarding-schema",
+        "command": null,
+        "details": [
+          "reviewer=chatgpt-codex-connector file=openapi/hrcore.openapi.json line=128 processed_on_current_head=yes"
+        ],
+        "url": "https://example.test/pull/9241#discussion_r9141",
+        "updated_at": "2026-06-07T03:08:30Z"
+      },
+      "last_failure_signature": "stalled-bot:thread-openapi-onboarding-schema",
+      "last_head_sha": "head-hrcore-metadata-only",
+      "last_tracked_pr_progress_snapshot": null,
+      "last_tracked_pr_progress_summary": null,
+      "last_tracked_pr_repeat_failure_decision": null,
+      "review_wait_started_at": "2026-06-07T03:00:00Z",
+      "review_wait_head_sha": "head-hrcore-metadata-only",
+      "provider_success_observed_at": "2026-06-07T03:09:00Z",
+      "provider_success_head_sha": "head-hrcore-metadata-only",
+      "merge_readiness_last_evaluated_at": "2026-06-07T03:10:00Z",
+      "copilot_review_requested_observed_at": null,
+      "copilot_review_requested_head_sha": null,
+      "copilot_review_timed_out_at": null,
+      "copilot_review_timeout_action": null,
+      "copilot_review_timeout_reason": null,
+      "local_review_head_sha": null,
+      "local_review_blocker_summary": null,
+      "local_review_summary_path": null,
+      "local_review_run_at": null,
+      "local_review_max_severity": null,
+      "local_review_findings_count": 0,
+      "local_review_root_cause_count": 0,
+      "local_review_verified_max_severity": null,
+      "local_review_verified_findings_count": 0,
+      "local_review_recommendation": null,
+      "local_review_degraded": false,
+      "last_local_review_signature": null,
+      "repeated_local_review_signature_count": 0,
+      "latest_local_ci_result": null,
+      "timeline_artifacts": [
+        {
+          "type": "verification_result",
+          "gate": "codex_turn",
+          "command": "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+          "head_sha": "head-hrcore-metadata-only",
+          "outcome": "passed",
+          "remediation_target": null,
+          "next_action": "continue",
+          "summary": "HRCore OpenAPI onboarding schema repair evidence passed on the current head.",
+          "recorded_at": "2026-06-07T03:08:00Z",
+          "processed_review_thread_ids": [
+            "thread-openapi-onboarding-schema@head-hrcore-metadata-only"
+          ],
+          "processed_review_thread_fingerprints": [
+            "thread-openapi-onboarding-schema@head-hrcore-metadata-only#comment-openapi-onboarding-schema-v1"
+          ]
+        }
+      ],
+      "last_observed_host_local_pr_blocker_signature": null,
+      "last_observed_host_local_pr_blocker_head_sha": null,
+      "last_host_local_pr_blocker_comment_signature": null,
+      "last_host_local_pr_blocker_comment_head_sha": null,
+      "processed_review_thread_ids": [
+        "thread-openapi-onboarding-schema@head-hrcore-metadata-only"
+      ],
+      "processed_review_thread_fingerprints": [
+        "thread-openapi-onboarding-schema@head-hrcore-metadata-only#comment-openapi-onboarding-schema-v1"
+      ],
+      "updated_at": "2026-06-07T03:10:00Z"
+    },
+    "workspaceStatus": {
+      "branch": "codex/issue-9141",
+      "headSha": "head-hrcore-metadata-only",
+      "hasUncommittedChanges": false,
+      "baseAhead": 1,
+      "baseBehind": 0,
+      "remoteBranchExists": true,
+      "remoteAhead": 0,
+      "remoteBehind": 0
+    }
+  },
+  "github": {
+    "pullRequest": {
+      "number": 9241,
+      "title": "HRCore metadata-only current-head repair evidence terminal fixture",
+      "url": "https://example.test/pull/9241",
+      "state": "OPEN",
+      "createdAt": "2026-03-13T06:20:00Z",
+      "isDraft": false,
+      "reviewDecision": "APPROVED",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "headRefName": "codex/issue-9141",
+      "headRefOid": "head-hrcore-metadata-only",
+      "copilotReviewState": "not_requested",
+      "copilotReviewRequestedAt": null,
+      "copilotReviewArrivedAt": null,
+      "configuredBotCurrentHeadObservedAt": "2026-06-07T03:09:00Z",
+      "configuredBotCurrentHeadObservationSource": "codex_pr_success_comment",
+      "configuredBotCurrentHeadStatusState": "SUCCESS",
+      "currentHeadCiGreenAt": "2026-06-07T03:08:30Z",
+      "configuredBotTopLevelReviewStrength": null,
+      "mergedAt": null
+    },
+    "checks": [
+      {
+        "name": "openapi verifier",
+        "state": "SUCCESS",
+        "bucket": "pass",
+        "workflow": "CI"
+      }
+    ],
+    "reviewThreads": [
+      {
+        "id": "thread-openapi-onboarding-schema",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "openapi/hrcore.openapi.json",
+        "line": 128,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-openapi-onboarding-schema-v1",
+              "body": "P2: The onboarding schema path list was missing the current repair artifact before this head.",
+              "createdAt": "2026-06-07T02:12:00Z",
+              "url": "https://example.test/pull/9241#discussion_r9141",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "decision": {
+    "nextState": "ready_to_merge",
+    "shouldRunCodex": false,
+    "blockedReason": null,
+    "failureContext": null
+  },
+  "operatorSummary": {
+    "latestRecoverySummary": null,
+    "retrySummary": null,
+    "recoveryLoopSummary": null,
+    "activityContext": {
+      "handoffSummary": null,
+      "localReviewRoutingSummary": null,
+      "changeClassesSummary": null,
+      "verificationPolicySummary": null,
+      "durableGuardrailSummary": null,
+      "externalReviewFollowUpSummary": null,
+      "preMergeEvaluation": null,
+      "localCiStatus": null,
+      "latestRecovery": null,
+      "retryContext": {
+        "timeoutRetryCount": 0,
+        "blockedVerificationRetryCount": 0,
+        "repeatedBlockerCount": 0,
+        "repeatedFailureSignatureCount": 0,
+        "lastFailureSignature": "stalled-bot:thread-openapi-onboarding-schema"
+      },
+      "repeatedRecovery": null,
+      "recentPhaseChanges": [],
+      "localReviewSummaryPath": null,
+      "externalReviewMissesPath": null,
+      "reviewWaits": []
+    }
+  }
+}

--- a/replay-corpus/manifest.json
+++ b/replay-corpus/manifest.json
@@ -76,6 +76,14 @@
     {
       "id": "codex-current-head-success-unresolved-must-fix",
       "path": "cases/codex-current-head-success-unresolved-must-fix"
+    },
+    {
+      "id": "phase0-aegisops-repeated-codex-feedback-terminal",
+      "path": "cases/phase0-aegisops-repeated-codex-feedback-terminal"
+    },
+    {
+      "id": "phase0-hrcore-current-head-repair-metadata-residue",
+      "path": "cases/phase0-hrcore-current-head-repair-metadata-residue"
     }
   ]
 }

--- a/src/supervisor/replay-corpus-runner.test.ts
+++ b/src/supervisor/replay-corpus-runner.test.ts
@@ -391,6 +391,8 @@ test("runReplayCorpus replays the checked-in PR lifecycle safety cases without m
     "clustered-codex-review-repair-convergence",
     "current-head-success-clears-stale-handoff",
     "codex-current-head-success-unresolved-must-fix",
+    "phase0-aegisops-repeated-codex-feedback-terminal",
+    "phase0-hrcore-current-head-repair-metadata-residue",
   ]);
 });
 

--- a/src/supervisor/replay-corpus-validation.ts
+++ b/src/supervisor/replay-corpus-validation.ts
@@ -382,6 +382,23 @@ function validateTimelineArtifact(
   };
 }
 
+function validateReviewLoopRetryStateEntry(
+  raw: unknown,
+  context: string,
+): NonNullable<ReplayCorpusInputSnapshot["local"]["record"]["review_loop_retry_state"]>[number] {
+  const entry = expectObject(raw, context);
+  return {
+    fingerprint: expectString(entry.fingerprint, `${context} fingerprint`),
+    pr_number: expectInteger(entry.pr_number, `${context} pr_number`),
+    head_sha: expectString(entry.head_sha, `${context} head_sha`),
+    thread_id: expectString(entry.thread_id, `${context} thread_id`),
+    latest_comment_fingerprint: expectString(entry.latest_comment_fingerprint, `${context} latest_comment_fingerprint`),
+    attempts: expectInteger(entry.attempts, `${context} attempts`),
+    first_attempted_at: expectString(entry.first_attempted_at, `${context} first_attempted_at`),
+    last_attempted_at: expectString(entry.last_attempted_at, `${context} last_attempted_at`),
+  };
+}
+
 function validateIssue(raw: unknown, context: string): ReplayCorpusInputSnapshot["issue"] {
   const issue = expectObject(raw, context);
   return {
@@ -545,6 +562,12 @@ function validateLocalRecord(raw: unknown, context: string): ReplayCorpusInputSn
       record.last_host_local_pr_blocker_comment_head_sha,
       `${context} last_host_local_pr_blocker_comment_head_sha`,
     ),
+    review_loop_retry_state:
+      record.review_loop_retry_state === undefined
+        ? undefined
+        : expectArray(record.review_loop_retry_state, `${context} review_loop_retry_state`).map((entry, index) =>
+            validateReviewLoopRetryStateEntry(entry, `${context} review_loop_retry_state[${index}]`),
+          ),
     processed_review_thread_ids: expectStringArray(
       record.processed_review_thread_ids,
       `${context} processed_review_thread_ids`,

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -1,5 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type {
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  PullRequestCheck,
+  ReviewThread,
+  SupervisorConfig,
+  WorkspaceStatus,
+} from "../core/types";
+import { mapConfiguredReviewProviders } from "../core/review-providers";
+import {
+  createConfig,
+  createIssue,
+  createPullRequest,
+  createRecord,
+  createReviewThread,
+} from "../turn-execution-test-helpers";
 import {
   createCheckedInReplayCorpusConfig as createCheckedInReplayCorpusConfigFacade,
   deriveReplayCorpusPromotionWorthinessHints as deriveReplayCorpusPromotionWorthinessHintsFacade,
@@ -31,6 +48,90 @@ import {
   summarizeReplayCorpusPromotion,
 } from "./replay-corpus-promotion-summary";
 import { loadReplayCorpus, runReplayCorpus } from "./replay-corpus-runner";
+import { replaySupervisorCycleDecisionSnapshot } from "./supervisor-cycle-replay";
+import { buildSupervisorCycleDecisionSnapshot } from "./supervisor-cycle-snapshot";
+
+const CODEX_CONNECTOR_REVIEW_BOT_LOGIN = "chatgpt-codex-connector";
+
+function createCodexOnlyReplayConfig(): SupervisorConfig {
+  const reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  return createConfig({
+    localReviewEnabled: false,
+    localReviewPosture: "off",
+    reviewBotLogins,
+    configuredReviewProviders: mapConfiguredReviewProviders(reviewBotLogins),
+    humanReviewBlocksMerge: true,
+  });
+}
+
+function createWorkspaceStatus(args: {
+  branch: string;
+  headSha: string;
+}): WorkspaceStatus {
+  return {
+    branch: args.branch,
+    headSha: args.headSha,
+    hasUncommittedChanges: false,
+    baseAhead: 1,
+    baseBehind: 0,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+    remoteBehind: 0,
+  };
+}
+
+function createCodexReviewThread(args: {
+  id: string;
+  commentId: string;
+  path: string;
+  line: number;
+  body: string;
+  url: string;
+  isOutdated?: boolean;
+}): ReviewThread {
+  return createReviewThread({
+    id: args.id,
+    isOutdated: args.isOutdated ?? false,
+    path: args.path,
+    line: args.line,
+    comments: {
+      nodes: [
+        {
+          id: args.commentId,
+          body: args.body,
+          createdAt: "2026-06-07T02:12:00Z",
+          url: args.url,
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+}
+
+function createReplaySnapshot(args: {
+  config: SupervisorConfig;
+  capturedAt: string;
+  issue: GitHubIssue;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  workspaceStatus: WorkspaceStatus;
+}) {
+  return buildSupervisorCycleDecisionSnapshot({
+    config: args.config,
+    capturedAt: args.capturedAt,
+    issue: args.issue,
+    record: args.record,
+    workspaceStatus: args.workspaceStatus,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+  });
+}
 
 test("replay-corpus facade re-exports the dedicated module entry points", () => {
   assert.equal(createCheckedInReplayCorpusConfigFacade, createCheckedInReplayCorpusConfig);
@@ -45,4 +146,215 @@ test("replay-corpus facade re-exports the dedicated module entry points", () => 
   assert.equal(promoteCapturedReplaySnapshotFacade, promoteCapturedReplaySnapshot);
   assert.equal(deriveReplayCorpusPromotionWorthinessHintsFacade, deriveReplayCorpusPromotionWorthinessHints);
   assert.equal(summarizeReplayCorpusPromotionFacade, summarizeReplayCorpusPromotion);
+});
+
+test("Phase 0 replay fixture keeps AegisOps-style GitHub-green repeated Codex feedback terminal", () => {
+  const config = createCodexOnlyReplayConfig();
+  const issueNumber = 9140;
+  const prNumber = 9240;
+  const headSha = "head-aegisops-repeat-stop";
+  const branch = `codex/issue-${issueNumber}`;
+  const thread = createCodexReviewThread({
+    id: "thread-production-source-denylist",
+    commentId: "comment-production-source-denylist-v1",
+    path: "aegisops/source_policy.ts",
+    line: 44,
+    body:
+      "P1: The production source denylist still allows simulator evidence to be treated as launch authority.",
+    url: `https://example.test/pull/${prNumber}#discussion_r9140`,
+  });
+  const record = createRecord({
+    issue_number: issueNumber,
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    workspace: ".",
+    journal_path: `.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
+    attempt_count: 7,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 5,
+    blocked_reason: "stale_review_bot",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-06-07T02:00:00Z",
+    review_wait_head_sha: headSha,
+    provider_success_observed_at: "2026-06-07T02:10:00Z",
+    provider_success_head_sha: headSha,
+    merge_readiness_last_evaluated_at: "2026-06-07T02:12:30Z",
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "AegisOps focused policy verifier passed on the current head.",
+      ran_at: "2026-06-07T02:11:00Z",
+      head_sha: headSha,
+      execution_mode: "structured",
+      command: "npx tsx --test src/supervisor/replay-corpus.test.ts",
+      failure_class: null,
+      remediation_target: null,
+    },
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-production-source-denylist-v1`],
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_error: "Repeated configured Codex review feedback made no tracked PR progress.",
+    last_failure_context: {
+      category: "manual",
+      summary:
+        "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+      signature: `stalled-bot:${thread.id}`,
+      command: null,
+      details: [
+        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} p_severity=P1 processed_on_current_head=yes`,
+      ],
+      url: `https://example.test/pull/${prNumber}#discussion_r9140`,
+      updated_at: "2026-06-07T02:12:30Z",
+    },
+    last_failure_signature: `stalled-bot:${thread.id}`,
+    updated_at: "2026-06-07T02:13:00Z",
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    title: "AegisOps repeated Codex review feedback terminal fixture",
+    url: `https://example.test/pull/${prNumber}`,
+    headRefName: branch,
+    headRefOid: headSha,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-07T02:11:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-07T02:10:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-07T02:10:00Z",
+  });
+  const snapshot = createReplaySnapshot({
+    config,
+    capturedAt: "2026-06-07T02:15:00Z",
+    issue: createIssue({
+      number: issueNumber,
+      title: "AegisOps repeated Codex review feedback terminal fixture",
+      body: "Portable replay fixture for a GitHub-green PR stopped after repeated configured Codex feedback.",
+      url: `https://example.test/issues/${issueNumber}`,
+      updatedAt: "2026-06-07T02:13:00Z",
+    }),
+    record,
+    pr,
+    checks: [{ name: "policy verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    workspaceStatus: createWorkspaceStatus({ branch, headSha }),
+  });
+  const replayed = replaySupervisorCycleDecisionSnapshot(snapshot, config);
+
+  assert.equal(replayed.matchesCapturedDecision, true);
+  assert.equal(snapshot.decision.nextState, "blocked");
+  assert.equal(snapshot.decision.shouldRunCodex, false);
+  assert.equal(snapshot.decision.blockedReason, "stale_review_bot");
+  assert.equal(snapshot.decision.failureContext?.signature, `stalled-bot:${thread.id}`);
+});
+
+test("Phase 0 replay fixture keeps HRCore-style metadata-only current-head repair evidence terminal", () => {
+  const config = createCodexOnlyReplayConfig();
+  const issueNumber = 9141;
+  const prNumber = 9241;
+  const headSha = "head-hrcore-metadata-only";
+  const branch = `codex/issue-${issueNumber}`;
+  const thread = createCodexReviewThread({
+    id: "thread-openapi-onboarding-schema",
+    commentId: "comment-openapi-onboarding-schema-v1",
+    path: "openapi/hrcore.openapi.json",
+    line: 128,
+    body:
+      "P2: The onboarding schema path list was missing the current repair artifact before this head.",
+    url: `https://example.test/pull/${prNumber}#discussion_r9141`,
+    isOutdated: true,
+  });
+  const record = createRecord({
+    issue_number: issueNumber,
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    workspace: ".",
+    journal_path: `.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
+    attempt_count: 5,
+    implementation_attempt_count: 2,
+    repair_attempt_count: 3,
+    blocked_reason: "stale_review_bot",
+    last_head_sha: headSha,
+    review_wait_started_at: "2026-06-07T03:00:00Z",
+    review_wait_head_sha: headSha,
+    provider_success_observed_at: "2026-06-07T03:09:00Z",
+    provider_success_head_sha: headSha,
+    merge_readiness_last_evaluated_at: "2026-06-07T03:10:00Z",
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "HRCore OpenAPI onboarding schema repair evidence passed on the current head.",
+        recorded_at: "2026-06-07T03:08:00Z",
+        processed_review_thread_ids: [`${thread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-openapi-onboarding-schema-v1`],
+      },
+    ],
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-openapi-onboarding-schema-v1`],
+    last_error: "Outdated configured Codex metadata remained after current-head repair evidence.",
+    last_failure_context: {
+      category: "manual",
+      summary: "Outdated configured-bot metadata-only residue is blocking the tracked PR.",
+      signature: `stalled-bot:${thread.id}`,
+      command: null,
+      details: [
+        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} processed_on_current_head=yes`,
+      ],
+      url: `https://example.test/pull/${prNumber}#discussion_r9141`,
+      updated_at: "2026-06-07T03:08:30Z",
+    },
+    last_failure_signature: `stalled-bot:${thread.id}`,
+    updated_at: "2026-06-07T03:10:00Z",
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    title: "HRCore metadata-only current-head repair evidence terminal fixture",
+    url: `https://example.test/pull/${prNumber}`,
+    headRefName: branch,
+    headRefOid: headSha,
+    reviewDecision: "APPROVED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-07T03:08:30Z",
+    codexConnectorReviewRequestedAt: "2026-06-07T03:04:00Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-07T03:09:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+  const snapshot = createReplaySnapshot({
+    config,
+    capturedAt: "2026-06-07T03:20:00Z",
+    issue: createIssue({
+      number: issueNumber,
+      title: "HRCore metadata-only current-head repair evidence terminal fixture",
+      body:
+        "Portable replay fixture for metadata-only unresolved configured review feedback after current-head repair evidence.",
+      url: `https://example.test/issues/${issueNumber}`,
+      updatedAt: "2026-06-07T03:10:00Z",
+    }),
+    record,
+    pr,
+    checks: [{ name: "openapi verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    workspaceStatus: createWorkspaceStatus({ branch, headSha }),
+  });
+  const replayed = replaySupervisorCycleDecisionSnapshot(snapshot, config);
+
+  assert.equal(replayed.matchesCapturedDecision, true);
+  assert.equal(snapshot.decision.nextState, "ready_to_merge");
+  assert.equal(snapshot.decision.shouldRunCodex, false);
+  assert.equal(snapshot.decision.blockedReason, null);
+  assert.equal(snapshot.decision.failureContext, null);
 });

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -1,22 +1,6 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
-import type {
-  GitHubIssue,
-  GitHubPullRequest,
-  IssueRunRecord,
-  PullRequestCheck,
-  ReviewThread,
-  SupervisorConfig,
-  WorkspaceStatus,
-} from "../core/types";
-import { mapConfiguredReviewProviders } from "../core/review-providers";
-import {
-  createConfig,
-  createIssue,
-  createPullRequest,
-  createRecord,
-  createReviewThread,
-} from "../turn-execution-test-helpers";
 import {
   createCheckedInReplayCorpusConfig as createCheckedInReplayCorpusConfigFacade,
   deriveReplayCorpusPromotionWorthinessHints as deriveReplayCorpusPromotionWorthinessHintsFacade,
@@ -48,91 +32,6 @@ import {
   summarizeReplayCorpusPromotion,
 } from "./replay-corpus-promotion-summary";
 import { loadReplayCorpus, runReplayCorpus } from "./replay-corpus-runner";
-import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
-import { replaySupervisorCycleDecisionSnapshot } from "./supervisor-cycle-replay";
-import { buildSupervisorCycleDecisionSnapshot } from "./supervisor-cycle-snapshot";
-
-const CODEX_CONNECTOR_REVIEW_BOT_LOGIN = "chatgpt-codex-connector";
-
-function createCodexOnlyReplayConfig(): SupervisorConfig {
-  const reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
-  return createConfig({
-    localReviewEnabled: false,
-    localReviewPosture: "off",
-    reviewBotLogins,
-    configuredReviewProviders: mapConfiguredReviewProviders(reviewBotLogins),
-    humanReviewBlocksMerge: true,
-  });
-}
-
-function createWorkspaceStatus(args: {
-  branch: string;
-  headSha: string;
-}): WorkspaceStatus {
-  return {
-    branch: args.branch,
-    headSha: args.headSha,
-    hasUncommittedChanges: false,
-    baseAhead: 1,
-    baseBehind: 0,
-    remoteBranchExists: true,
-    remoteAhead: 0,
-    remoteBehind: 0,
-  };
-}
-
-function createCodexReviewThread(args: {
-  id: string;
-  commentId: string;
-  path: string;
-  line: number;
-  body: string;
-  url: string;
-  isOutdated?: boolean;
-}): ReviewThread {
-  return createReviewThread({
-    id: args.id,
-    isOutdated: args.isOutdated ?? false,
-    path: args.path,
-    line: args.line,
-    comments: {
-      nodes: [
-        {
-          id: args.commentId,
-          body: args.body,
-          createdAt: "2026-06-07T02:12:00Z",
-          url: args.url,
-          author: {
-            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
-            typeName: "Bot",
-          },
-        },
-      ],
-    },
-  });
-}
-
-function createReplaySnapshot(args: {
-  config: SupervisorConfig;
-  capturedAt: string;
-  issue: GitHubIssue;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-  workspaceStatus: WorkspaceStatus;
-}) {
-  return buildSupervisorCycleDecisionSnapshot({
-    config: args.config,
-    capturedAt: args.capturedAt,
-    issue: args.issue,
-    record: args.record,
-    workspaceStatus: args.workspaceStatus,
-    pr: args.pr,
-    checks: args.checks,
-    reviewThreads: args.reviewThreads,
-  });
-}
 
 test("replay-corpus facade re-exports the dedicated module entry points", () => {
   assert.equal(createCheckedInReplayCorpusConfigFacade, createCheckedInReplayCorpusConfig);
@@ -149,232 +48,37 @@ test("replay-corpus facade re-exports the dedicated module entry points", () => 
   assert.equal(summarizeReplayCorpusPromotionFacade, summarizeReplayCorpusPromotion);
 });
 
-test("Phase 0 replay fixture keeps AegisOps-style GitHub-green repeated Codex feedback terminal", () => {
-  const config = createCodexOnlyReplayConfig();
-  const issueNumber = 9140;
-  const prNumber = 9240;
-  const headSha = "head-aegisops-repeat-stop";
-  const branch = `codex/issue-${issueNumber}`;
-  const thread = createCodexReviewThread({
-    id: "thread-production-source-denylist",
-    commentId: "comment-production-source-denylist-v1",
-    path: "aegisops/source_policy.ts",
-    line: 44,
-    body:
-      "P1: The production source denylist still allows simulator evidence to be treated as launch authority.",
-    url: `https://example.test/pull/${prNumber}#discussion_r9140`,
-  });
-  const record = createRecord({
-    issue_number: issueNumber,
-    state: "blocked",
-    branch,
-    pr_number: prNumber,
-    workspace: ".",
-    journal_path: `.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
-    attempt_count: 7,
-    implementation_attempt_count: 2,
-    repair_attempt_count: 5,
-    blocked_reason: "stale_review_bot",
-    last_head_sha: headSha,
-    review_wait_started_at: "2026-06-07T02:00:00Z",
-    review_wait_head_sha: headSha,
-    provider_success_observed_at: "2026-06-07T02:10:00Z",
-    provider_success_head_sha: headSha,
-    merge_readiness_last_evaluated_at: "2026-06-07T02:12:30Z",
-    latest_local_ci_result: {
-      outcome: "passed",
-      summary: "AegisOps focused policy verifier passed on the current head.",
-      ran_at: "2026-06-07T02:11:00Z",
-      head_sha: headSha,
-      execution_mode: "structured",
-      command: "npx tsx --test src/supervisor/replay-corpus.test.ts",
-      failure_class: null,
-      remediation_target: null,
-    },
-    processed_review_thread_ids: [`${thread.id}@${headSha}`],
-    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-production-source-denylist-v1`],
-    last_tracked_pr_repeat_failure_decision: null,
-    review_loop_retry_state: [
+test("Phase 0 replay fixtures are checked into the corpus with stable terminal outcomes", async () => {
+  const corpusRoot = path.join(process.cwd(), "replay-corpus");
+  const phase0CaseIds = [
+    "phase0-aegisops-repeated-codex-feedback-terminal",
+    "phase0-hrcore-current-head-repair-metadata-residue",
+  ];
+  const corpus = await loadReplayCorpus(corpusRoot);
+  const phase0Cases = corpus.cases.filter((entry) => phase0CaseIds.includes(entry.id));
+
+  assert.deepEqual(phase0Cases.map((entry) => entry.id), phase0CaseIds);
+  assert.deepEqual(
+    phase0Cases.map((entry) => entry.expected),
+    [
       {
-        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${thread.id}|comment=comment-production-source-denylist-v1`,
-        pr_number: prNumber,
-        head_sha: headSha,
-        thread_id: thread.id,
-        latest_comment_fingerprint: "comment-production-source-denylist-v1",
-        attempts: 1,
-        first_attempted_at: "2026-06-07T02:08:00Z",
-        last_attempted_at: "2026-06-07T02:08:00Z",
+        nextState: "blocked",
+        shouldRunCodex: false,
+        blockedReason: "stale_review_bot",
+        failureSignature: "stalled-bot:thread-production-source-denylist",
+      },
+      {
+        nextState: "ready_to_merge",
+        shouldRunCodex: false,
+        blockedReason: null,
+        failureSignature: null,
       },
     ],
-    last_error: "Repeated configured Codex review feedback made no tracked PR progress.",
-    last_failure_context: {
-      category: "manual",
-      summary:
-        "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
-      signature: `stalled-bot:${thread.id}`,
-      command: null,
-      details: [
-        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} p_severity=P1 processed_on_current_head=yes`,
-      ],
-      url: `https://example.test/pull/${prNumber}#discussion_r9140`,
-      updated_at: "2026-06-07T02:12:30Z",
-    },
-    last_failure_signature: `stalled-bot:${thread.id}`,
-    updated_at: "2026-06-07T02:13:00Z",
-  });
-  const pr = createPullRequest({
-    number: prNumber,
-    title: "AegisOps repeated Codex review feedback terminal fixture",
-    url: `https://example.test/pull/${prNumber}`,
-    headRefName: branch,
-    headRefOid: headSha,
-    reviewDecision: "CHANGES_REQUESTED",
-    mergeStateStatus: "CLEAN",
-    mergeable: "MERGEABLE",
-    currentHeadCiGreenAt: "2026-06-07T02:11:00Z",
-    configuredBotCurrentHeadObservedAt: "2026-06-07T02:10:00Z",
-    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
-    configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotTopLevelReviewStrength: "blocking",
-    configuredBotTopLevelReviewSubmittedAt: "2026-06-07T02:10:00Z",
-  });
-  const snapshot = createReplaySnapshot({
-    config,
-    capturedAt: "2026-06-07T02:15:00Z",
-    issue: createIssue({
-      number: issueNumber,
-      title: "AegisOps repeated Codex review feedback terminal fixture",
-      body: "Portable replay fixture for a GitHub-green PR stopped after repeated configured Codex feedback.",
-      url: `https://example.test/issues/${issueNumber}`,
-      updatedAt: "2026-06-07T02:13:00Z",
-    }),
-    record,
-    pr,
-    checks: [{ name: "policy verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-    reviewThreads: [thread],
-    workspaceStatus: createWorkspaceStatus({ branch, headSha }),
-  });
-  const replayed = replaySupervisorCycleDecisionSnapshot(snapshot, config);
+  );
 
-  assert.equal(replayed.matchesCapturedDecision, true);
-  assert.equal(snapshot.decision.nextState, "blocked");
-  assert.equal(snapshot.decision.shouldRunCodex, false);
-  assert.equal(snapshot.decision.blockedReason, "stale_review_bot");
-  assert.equal(snapshot.decision.failureContext?.signature, `stalled-bot:${thread.id}`);
-});
+  const result = await runReplayCorpus(corpusRoot, createCheckedInReplayCorpusConfig(process.cwd()));
+  const phase0Results = result.results.filter((entry) => phase0CaseIds.includes(entry.caseId));
 
-test("Phase 0 replay fixture keeps HRCore-style metadata-only current-head repair evidence terminal", () => {
-  const config = createCodexOnlyReplayConfig();
-  const issueNumber = 9141;
-  const prNumber = 9241;
-  const headSha = "head-hrcore-metadata-only";
-  const branch = `codex/issue-${issueNumber}`;
-  const thread = createCodexReviewThread({
-    id: "thread-openapi-onboarding-schema",
-    commentId: "comment-openapi-onboarding-schema-v1",
-    path: "openapi/hrcore.openapi.json",
-    line: 128,
-    body:
-      "P2: The onboarding schema path list was missing the current repair artifact before this head.",
-    url: `https://example.test/pull/${prNumber}#discussion_r9141`,
-  });
-  const record = createRecord({
-    issue_number: issueNumber,
-    state: "blocked",
-    branch,
-    pr_number: prNumber,
-    workspace: ".",
-    journal_path: `.codex-supervisor/issues/${issueNumber}/issue-journal.md`,
-    attempt_count: 5,
-    implementation_attempt_count: 2,
-    repair_attempt_count: 3,
-    blocked_reason: "stale_review_bot",
-    last_head_sha: headSha,
-    review_wait_started_at: "2026-06-07T03:00:00Z",
-    review_wait_head_sha: headSha,
-    provider_success_observed_at: "2026-06-07T03:09:00Z",
-    provider_success_head_sha: headSha,
-    merge_readiness_last_evaluated_at: "2026-06-07T03:10:00Z",
-    timeline_artifacts: [
-      {
-        type: "verification_result",
-        gate: "codex_turn",
-        command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
-        head_sha: headSha,
-        outcome: "passed",
-        remediation_target: null,
-        next_action: "continue",
-        summary: "HRCore OpenAPI onboarding schema repair evidence passed on the current head.",
-        recorded_at: "2026-06-07T03:08:00Z",
-        processed_review_thread_ids: [`${thread.id}@${headSha}`],
-        processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-openapi-onboarding-schema-v1`],
-      },
-    ],
-    processed_review_thread_ids: [`${thread.id}@${headSha}`],
-    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-openapi-onboarding-schema-v1`],
-    last_error: "Outdated configured Codex metadata remained after current-head repair evidence.",
-    last_failure_context: {
-      category: "manual",
-      summary: "Outdated configured-bot metadata-only residue is blocking the tracked PR.",
-      signature: `stalled-bot:${thread.id}`,
-      command: null,
-      details: [
-        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} processed_on_current_head=yes`,
-      ],
-      url: `https://example.test/pull/${prNumber}#discussion_r9141`,
-      updated_at: "2026-06-07T03:08:30Z",
-    },
-    last_failure_signature: `stalled-bot:${thread.id}`,
-    updated_at: "2026-06-07T03:10:00Z",
-  });
-  const pr = createPullRequest({
-    number: prNumber,
-    title: "HRCore metadata-only current-head repair evidence terminal fixture",
-    url: `https://example.test/pull/${prNumber}`,
-    headRefName: branch,
-    headRefOid: headSha,
-    reviewDecision: "APPROVED",
-    mergeStateStatus: "CLEAN",
-    mergeable: "MERGEABLE",
-    currentHeadCiGreenAt: "2026-06-07T03:08:30Z",
-    codexConnectorReviewRequestedAt: "2026-06-07T03:04:00Z",
-    codexConnectorReviewRequestedHeadSha: headSha,
-    configuredBotCurrentHeadObservedAt: "2026-06-07T03:09:00Z",
-    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
-    configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotTopLevelReviewStrength: null,
-    configuredBotLatestReviewedCommitSha: headSha,
-  });
-  const snapshot = createReplaySnapshot({
-    config,
-    capturedAt: "2026-06-07T03:20:00Z",
-    issue: createIssue({
-      number: issueNumber,
-      title: "HRCore metadata-only current-head repair evidence terminal fixture",
-      body:
-        "Portable replay fixture for metadata-only unresolved configured review feedback after current-head repair evidence.",
-      url: `https://example.test/issues/${issueNumber}`,
-      updatedAt: "2026-06-07T03:10:00Z",
-    }),
-    record,
-    pr,
-    checks: [{ name: "openapi verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-    reviewThreads: [thread],
-    workspaceStatus: createWorkspaceStatus({ branch, headSha }),
-  });
-  const remediation = buildStaleReviewBotRemediation({
-    config,
-    record,
-    pr,
-    checks: [{ name: "openapi verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-    reviewThreads: [thread],
-  });
-  const replayed = replaySupervisorCycleDecisionSnapshot(snapshot, config);
-
-  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
-  assert.equal(replayed.matchesCapturedDecision, true);
-  assert.equal(snapshot.decision.nextState, "ready_to_merge");
-  assert.equal(snapshot.decision.shouldRunCodex, true);
-  assert.equal(snapshot.decision.blockedReason, null);
-  assert.equal(snapshot.decision.failureContext, null);
+  assert.deepEqual(phase0Results.map((entry) => entry.caseId), phase0CaseIds);
+  assert.equal(phase0Results.every((entry) => entry.matchesExpected), true);
 });

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -48,6 +48,7 @@ import {
   summarizeReplayCorpusPromotion,
 } from "./replay-corpus-promotion-summary";
 import { loadReplayCorpus, runReplayCorpus } from "./replay-corpus-runner";
+import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
 import { replaySupervisorCycleDecisionSnapshot } from "./supervisor-cycle-replay";
 import { buildSupervisorCycleDecisionSnapshot } from "./supervisor-cycle-snapshot";
 
@@ -192,7 +193,19 @@ test("Phase 0 replay fixture keeps AegisOps-style GitHub-green repeated Codex fe
     },
     processed_review_thread_ids: [`${thread.id}@${headSha}`],
     processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-production-source-denylist-v1`],
-    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_tracked_pr_repeat_failure_decision: null,
+    review_loop_retry_state: [
+      {
+        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${thread.id}|comment=comment-production-source-denylist-v1`,
+        pr_number: prNumber,
+        head_sha: headSha,
+        thread_id: thread.id,
+        latest_comment_fingerprint: "comment-production-source-denylist-v1",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T02:08:00Z",
+        last_attempted_at: "2026-06-07T02:08:00Z",
+      },
+    ],
     last_error: "Repeated configured Codex review feedback made no tracked PR progress.",
     last_failure_context: {
       category: "manual",
@@ -264,7 +277,6 @@ test("Phase 0 replay fixture keeps HRCore-style metadata-only current-head repai
     body:
       "P2: The onboarding schema path list was missing the current repair artifact before this head.",
     url: `https://example.test/pull/${prNumber}#discussion_r9141`,
-    isOutdated: true,
   });
   const record = createRecord({
     issue_number: issueNumber,
@@ -350,11 +362,19 @@ test("Phase 0 replay fixture keeps HRCore-style metadata-only current-head repai
     reviewThreads: [thread],
     workspaceStatus: createWorkspaceStatus({ branch, headSha }),
   });
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "openapi verifier", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
   const replayed = replaySupervisorCycleDecisionSnapshot(snapshot, config);
 
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
   assert.equal(replayed.matchesCapturedDecision, true);
   assert.equal(snapshot.decision.nextState, "ready_to_merge");
-  assert.equal(snapshot.decision.shouldRunCodex, false);
+  assert.equal(snapshot.decision.shouldRunCodex, true);
   assert.equal(snapshot.decision.blockedReason, null);
   assert.equal(snapshot.decision.failureContext, null);
 });

--- a/src/supervisor/supervisor-cycle-snapshot.ts
+++ b/src/supervisor/supervisor-cycle-snapshot.ts
@@ -86,6 +86,7 @@ export interface SupervisorCycleDecisionSnapshot {
       | "last_observed_host_local_pr_blocker_head_sha"
       | "last_host_local_pr_blocker_comment_signature"
       | "last_host_local_pr_blocker_comment_head_sha"
+      | "review_loop_retry_state"
       | "processed_review_thread_ids"
       | "processed_review_thread_fingerprints"
       | "updated_at"
@@ -195,6 +196,9 @@ export function buildSupervisorCycleDecisionSnapshot(args: {
           record.last_host_local_pr_blocker_comment_signature ?? null,
         last_host_local_pr_blocker_comment_head_sha:
           record.last_host_local_pr_blocker_comment_head_sha ?? null,
+        review_loop_retry_state: record.review_loop_retry_state
+          ? record.review_loop_retry_state.map((entry) => ({ ...entry }))
+          : undefined,
         processed_review_thread_ids: [...record.processed_review_thread_ids],
         processed_review_thread_fingerprints: [...record.processed_review_thread_fingerprints],
         updated_at: record.updated_at,
@@ -284,6 +288,9 @@ export function buildSupervisorCycleDecisionSnapshot(args: {
           record.last_host_local_pr_blocker_comment_signature ?? null,
         last_host_local_pr_blocker_comment_head_sha:
           record.last_host_local_pr_blocker_comment_head_sha ?? null,
+        review_loop_retry_state: record.review_loop_retry_state
+          ? record.review_loop_retry_state.map((entry) => ({ ...entry }))
+          : undefined,
         processed_review_thread_ids: [...record.processed_review_thread_ids],
         processed_review_thread_fingerprints: [...record.processed_review_thread_fingerprints],
         updated_at: record.updated_at,


### PR DESCRIPTION
Implements #2272.

## Summary
- Add Phase 0 replay fixtures for AegisOps-style repeated Codex feedback that must terminally stop instead of continuing repair attempts.
- Add an HRCore-style metadata-only current-head repair evidence replay fixture that remains merge-ready under replay.
- Keep fixture inputs portable by using example.test URLs and relative workspace/journal paths.

## Verification
- npx tsx --test src/supervisor/replay-corpus.test.ts
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npm run build
- git diff --check