### PR TITLE
[codex] Add PR lifecycle state draft

### DIFF
--- a/src/decision-kernel/pr-lifecycle-state.test.ts
+++ b/src/decision-kernel/pr-lifecycle-state.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizePrLifecycleFacts,
+  type PrLifecycleFactInventory,
+} from "./pr-lifecycle-state";
+
+function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecycleFactInventory {
+  return {
+    source: "fixture",
+    observedAt: "2026-06-07T00:00:00.000Z",
+    pullRequest: {
+      number: 2278,
+      headSha: "head-current",
+      state: "OPEN",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      currentHeadReviewObservedAt: "2026-06-07T00:01:00.000Z",
+      currentHeadReviewHeadSha: "head-current",
+    },
+    reviewThreads: {
+      unresolvedManualThreadCount: 0,
+      unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+      stalePreviousHeadConfiguredBotThreadCount: 0,
+      metadataOnlyUnresolvedThreadCount: 0,
+    },
+    checks: {
+      passingCount: 3,
+      pendingCount: 0,
+      failingCount: 0,
+      unknownCount: 0,
+    },
+    localState: {
+      trackedHeadSha: "head-current",
+      workspaceHeadSha: "head-current",
+      lastObservedPrHeadSha: "head-current",
+    },
+    configuredCurrentHeadReviewRequired: true,
+    ...overrides,
+  };
+}
+
+test("normalizePrLifecycleFacts records a mergeable current-head trace draft", () => {
+  const state = normalizePrLifecycleFacts(inventory());
+
+  assert.deepEqual(
+    {
+      pullRequestNumber: state.pullRequestNumber,
+      headSha: state.headSha,
+      headFreshness: state.headFreshness,
+      reviewPosture: state.reviewPosture,
+      checkPosture: state.checkPosture,
+      mergeability: state.mergeability,
+      localStateFreshness: state.localStateFreshness,
+    },
+    {
+      pullRequestNumber: 2278,
+      headSha: "head-current",
+      headFreshness: "current_head",
+      reviewPosture: "current_head_review_observed",
+      checkPosture: "green",
+      mergeability: "mergeable",
+      localStateFreshness: "fresh",
+    },
+  );
+});
+
+test("normalizePrLifecycleFacts distinguishes stale local state and stale previous-head review residue", () => {
+  const state = normalizePrLifecycleFacts(
+    inventory({
+      pullRequest: {
+        number: 2278,
+        headSha: "head-new",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: "2026-06-07T00:01:00.000Z",
+        currentHeadReviewHeadSha: "head-old",
+      },
+      reviewThreads: {
+        unresolvedManualThreadCount: 0,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+        stalePreviousHeadConfiguredBotThreadCount: 2,
+        metadataOnlyUnresolvedThreadCount: 0,
+      },
+      localState: {
+        trackedHeadSha: "head-old",
+        workspaceHeadSha: "head-old",
+        lastObservedPrHeadSha: "head-old",
+      },
+    }),
+  );
+
+  assert.equal(state.headFreshness, "stale_head");
+  assert.equal(state.reviewPosture, "stale_previous_head_review");
+  assert.equal(state.localStateFreshness, "stale");
+  assert.equal(state.evidence.stalePreviousHeadConfiguredBotThreadCount, 2);
+});
+
+test("normalizePrLifecycleFacts surfaces missing review, pending checks, and conflicts independently", () => {
+  const state = normalizePrLifecycleFacts(
+    inventory({
+      pullRequest: {
+        number: 2278,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "DIRTY",
+        mergeable: "CONFLICTING",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+      checks: {
+        passingCount: 1,
+        pendingCount: 1,
+        failingCount: 0,
+        unknownCount: 0,
+      },
+    }),
+  );
+
+  assert.equal(state.reviewPosture, "missing_current_head_review");
+  assert.equal(state.checkPosture, "pending");
+  assert.equal(state.mergeability, "conflicted");
+});
+
+test("normalizePrLifecycleFacts prioritizes live review blockers and failing checks", () => {
+  const state = normalizePrLifecycleFacts(
+    inventory({
+      reviewThreads: {
+        unresolvedManualThreadCount: 1,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 2,
+        stalePreviousHeadConfiguredBotThreadCount: 3,
+        metadataOnlyUnresolvedThreadCount: 4,
+      },
+      checks: {
+        passingCount: 1,
+        pendingCount: 1,
+        failingCount: 1,
+        unknownCount: 1,
+      },
+    }),
+  );
+
+  assert.equal(state.reviewPosture, "review_blocked");
+  assert.equal(state.checkPosture, "failing");
+  assert.deepEqual(state.evidence, {
+    manualReviewThreadCount: 1,
+    currentHeadConfiguredBotThreadCount: 2,
+    stalePreviousHeadConfiguredBotThreadCount: 3,
+    metadataOnlyUnresolvedThreadCount: 4,
+    passingCheckCount: 1,
+    pendingCheckCount: 1,
+    failingCheckCount: 1,
+    unknownCheckCount: 1,
+    trackedHeadSha: "head-current",
+    workspaceHeadSha: "head-current",
+    lastObservedPrHeadSha: "head-current",
+  });
+});
+
+test("normalizePrLifecycleFacts is deterministic for the same explicit inventory", () => {
+  const input = inventory({
+    observedAt: null,
+    source: "cached_github",
+    checks: {
+      passingCount: 0,
+      pendingCount: 0,
+      failingCount: 0,
+      unknownCount: 1,
+    },
+  });
+
+  assert.deepEqual(normalizePrLifecycleFacts(input), normalizePrLifecycleFacts(input));
+});

--- a/src/decision-kernel/pr-lifecycle-state.ts
+++ b/src/decision-kernel/pr-lifecycle-state.ts
@@ -1,0 +1,235 @@
+export type PrLifecycleFactSource = "fresh_github" | "cached_github" | "local_state" | "fixture";
+
+export type PrLifecycleHeadFreshness =
+  | "no_pull_request"
+  | "current_head"
+  | "stale_head"
+  | "unknown";
+
+export type PrLifecycleReviewPosture =
+  | "current_head_review_observed"
+  | "missing_current_head_review"
+  | "review_blocked"
+  | "stale_previous_head_review"
+  | "metadata_only_unresolved"
+  | "no_unresolved_review"
+  | "unknown";
+
+export type PrLifecycleCheckPosture = "green" | "pending" | "failing" | "unknown";
+
+export type PrLifecycleMergeabilityPosture =
+  | "mergeable"
+  | "conflicted"
+  | "draft"
+  | "closed"
+  | "unknown";
+
+export type PrLifecycleLocalStateFreshness = "fresh" | "stale" | "missing" | "unknown";
+
+export interface PrLifecyclePullRequestFacts {
+  number: number;
+  headSha: string;
+  state: "OPEN" | "CLOSED" | "MERGED" | string;
+  isDraft: boolean;
+  mergeStateStatus: string | null;
+  mergeable: string | null;
+  currentHeadReviewObservedAt: string | null;
+  currentHeadReviewHeadSha: string | null;
+}
+
+export interface PrLifecycleReviewThreadFacts {
+  unresolvedManualThreadCount: number;
+  unresolvedCurrentHeadConfiguredBotThreadCount: number;
+  stalePreviousHeadConfiguredBotThreadCount: number;
+  metadataOnlyUnresolvedThreadCount: number;
+}
+
+export interface PrLifecycleCheckFacts {
+  passingCount: number;
+  pendingCount: number;
+  failingCount: number;
+  unknownCount: number;
+}
+
+export interface PrLifecycleLocalStateFacts {
+  trackedHeadSha: string | null;
+  workspaceHeadSha: string | null;
+  lastObservedPrHeadSha: string | null;
+}
+
+export interface PrLifecycleFactInventory {
+  source: PrLifecycleFactSource;
+  observedAt: string | null;
+  pullRequest: PrLifecyclePullRequestFacts | null;
+  reviewThreads: PrLifecycleReviewThreadFacts;
+  checks: PrLifecycleCheckFacts;
+  localState: PrLifecycleLocalStateFacts;
+  configuredCurrentHeadReviewRequired: boolean;
+}
+
+export interface NormalizedPrLifecycleState {
+  source: PrLifecycleFactSource;
+  observedAt: string | null;
+  pullRequestNumber: number | null;
+  headSha: string | null;
+  headFreshness: PrLifecycleHeadFreshness;
+  reviewPosture: PrLifecycleReviewPosture;
+  checkPosture: PrLifecycleCheckPosture;
+  mergeability: PrLifecycleMergeabilityPosture;
+  localStateFreshness: PrLifecycleLocalStateFreshness;
+  evidence: {
+    manualReviewThreadCount: number;
+    currentHeadConfiguredBotThreadCount: number;
+    stalePreviousHeadConfiguredBotThreadCount: number;
+    metadataOnlyUnresolvedThreadCount: number;
+    passingCheckCount: number;
+    pendingCheckCount: number;
+    failingCheckCount: number;
+    unknownCheckCount: number;
+    trackedHeadSha: string | null;
+    workspaceHeadSha: string | null;
+    lastObservedPrHeadSha: string | null;
+  };
+}
+
+export function normalizePrLifecycleFacts(
+  inventory: PrLifecycleFactInventory,
+): NormalizedPrLifecycleState {
+  const pullRequest = inventory.pullRequest;
+
+  return {
+    source: inventory.source,
+    observedAt: inventory.observedAt,
+    pullRequestNumber: pullRequest?.number ?? null,
+    headSha: pullRequest?.headSha ?? null,
+    headFreshness: normalizeHeadFreshness(inventory),
+    reviewPosture: normalizeReviewPosture(inventory),
+    checkPosture: normalizeCheckPosture(inventory.checks),
+    mergeability: normalizeMergeability(pullRequest),
+    localStateFreshness: normalizeLocalStateFreshness(inventory),
+    evidence: {
+      manualReviewThreadCount: inventory.reviewThreads.unresolvedManualThreadCount,
+      currentHeadConfiguredBotThreadCount:
+        inventory.reviewThreads.unresolvedCurrentHeadConfiguredBotThreadCount,
+      stalePreviousHeadConfiguredBotThreadCount:
+        inventory.reviewThreads.stalePreviousHeadConfiguredBotThreadCount,
+      metadataOnlyUnresolvedThreadCount: inventory.reviewThreads.metadataOnlyUnresolvedThreadCount,
+      passingCheckCount: inventory.checks.passingCount,
+      pendingCheckCount: inventory.checks.pendingCount,
+      failingCheckCount: inventory.checks.failingCount,
+      unknownCheckCount: inventory.checks.unknownCount,
+      trackedHeadSha: inventory.localState.trackedHeadSha,
+      workspaceHeadSha: inventory.localState.workspaceHeadSha,
+      lastObservedPrHeadSha: inventory.localState.lastObservedPrHeadSha,
+    },
+  };
+}
+
+function normalizeHeadFreshness(inventory: PrLifecycleFactInventory): PrLifecycleHeadFreshness {
+  const prHeadSha = inventory.pullRequest?.headSha ?? null;
+  if (!prHeadSha) {
+    return "no_pull_request";
+  }
+
+  const localHeadSha = inventory.localState.workspaceHeadSha ?? inventory.localState.trackedHeadSha;
+  if (!localHeadSha) {
+    return "unknown";
+  }
+
+  return localHeadSha === prHeadSha ? "current_head" : "stale_head";
+}
+
+function normalizeReviewPosture(inventory: PrLifecycleFactInventory): PrLifecycleReviewPosture {
+  const prHeadSha = inventory.pullRequest?.headSha ?? null;
+  if (!prHeadSha) {
+    return "unknown";
+  }
+
+  if (inventory.reviewThreads.unresolvedManualThreadCount > 0) {
+    return "review_blocked";
+  }
+
+  if (inventory.reviewThreads.unresolvedCurrentHeadConfiguredBotThreadCount > 0) {
+    return "review_blocked";
+  }
+
+  if (inventory.reviewThreads.metadataOnlyUnresolvedThreadCount > 0) {
+    return "metadata_only_unresolved";
+  }
+
+  const observedHeadSha = inventory.pullRequest?.currentHeadReviewHeadSha ?? null;
+  if (observedHeadSha === prHeadSha && inventory.pullRequest?.currentHeadReviewObservedAt) {
+    return "current_head_review_observed";
+  }
+
+  if (inventory.reviewThreads.stalePreviousHeadConfiguredBotThreadCount > 0) {
+    return "stale_previous_head_review";
+  }
+
+  return inventory.configuredCurrentHeadReviewRequired
+    ? "missing_current_head_review"
+    : "no_unresolved_review";
+}
+
+function normalizeCheckPosture(checks: PrLifecycleCheckFacts): PrLifecycleCheckPosture {
+  if (checks.failingCount > 0) {
+    return "failing";
+  }
+
+  if (checks.pendingCount > 0) {
+    return "pending";
+  }
+
+  if (checks.unknownCount > 0) {
+    return "unknown";
+  }
+
+  return checks.passingCount > 0 ? "green" : "unknown";
+}
+
+function normalizeMergeability(
+  pullRequest: PrLifecyclePullRequestFacts | null,
+): PrLifecycleMergeabilityPosture {
+  if (!pullRequest) {
+    return "unknown";
+  }
+
+  if (pullRequest.state !== "OPEN") {
+    return "closed";
+  }
+
+  if (pullRequest.isDraft) {
+    return "draft";
+  }
+
+  if (pullRequest.mergeStateStatus === "DIRTY" || pullRequest.mergeable === "CONFLICTING") {
+    return "conflicted";
+  }
+
+  if (pullRequest.mergeStateStatus === "CLEAN" || pullRequest.mergeable === "MERGEABLE") {
+    return "mergeable";
+  }
+
+  return "unknown";
+}
+
+function normalizeLocalStateFreshness(
+  inventory: PrLifecycleFactInventory,
+): PrLifecycleLocalStateFreshness {
+  const prHeadSha = inventory.pullRequest?.headSha ?? null;
+  const lastObservedPrHeadSha = inventory.localState.lastObservedPrHeadSha;
+  if (!prHeadSha || !lastObservedPrHeadSha) {
+    return "missing";
+  }
+
+  if (lastObservedPrHeadSha !== prHeadSha) {
+    return "stale";
+  }
+
+  const localHeadSha = inventory.localState.workspaceHeadSha ?? inventory.localState.trackedHeadSha;
+  if (!localHeadSha) {
+    return "unknown";
+  }
+
+  return localHeadSha === prHeadSha ? "fresh" : "stale";
+}


### PR DESCRIPTION
## Summary
- Add a read-only Decision Kernel v2 PR lifecycle fact inventory.
- Add a pure normalizer for head freshness, review posture, check posture, mergeability, and local-state freshness.
- Cover representative normalized states with focused tests.

Closes #2278

## Verification
- `npx tsx --test src/decision-kernel/pr-lifecycle-state.test.ts`
- `node dist/index.js issue-lint 2278 --config supervisor.config.codex.json`
- `npm run build`

## Scope boundary
This PR only adds a read-only draft model and tests. It does not connect the model to issue selection, Codex execution, GitHub mutation, status rendering, or merge readiness decisions.
