### PR TITLE
[codex] Add PR lifecycle evaluation mode contracts

### DIFF
--- a/src/decision-kernel/pr-lifecycle-evaluation-mode.test.ts
+++ b/src/decision-kernel/pr-lifecycle-evaluation-mode.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyPrLifecycleFactFreshness,
+  factFreshnessRequirementForMode,
+  guardPrLifecycleEvaluation,
+} from "./pr-lifecycle-evaluation-mode";
+import {
+  normalizePrLifecycleFacts,
+  type PrLifecycleFactInventory,
+} from "./pr-lifecycle-state";
+
+function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecycleFactInventory {
+  return {
+    source: "fresh_github",
+    observedAt: "2026-06-07T00:00:00.000Z",
+    pullRequest: {
+      number: 2282,
+      headSha: "head-current",
+      state: "OPEN",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      currentHeadReviewObservedAt: "2026-06-07T00:01:00.000Z",
+      currentHeadReviewHeadSha: "head-current",
+    },
+    reviewThreads: {
+      unresolvedManualThreadCount: 0,
+      unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+      stalePreviousHeadConfiguredBotThreadCount: 0,
+      metadataOnlyUnresolvedThreadCount: 0,
+    },
+    checks: {
+      passingCount: 3,
+      pendingCount: 0,
+      failingCount: 0,
+      unknownCount: 0,
+    },
+    localState: {
+      trackedHeadSha: "head-current",
+      workspaceHeadSha: "head-current",
+      lastObservedPrHeadSha: "head-current",
+    },
+    configuredCurrentHeadReviewRequired: true,
+    ...overrides,
+  };
+}
+
+test("factFreshnessRequirementForMode separates action-taking from diagnostics", () => {
+  assert.equal(factFreshnessRequirementForMode("action_taking"), "fresh_github_required");
+  assert.equal(factFreshnessRequirementForMode("diagnostic_only"), "cached_facts_allowed");
+});
+
+test("guardPrLifecycleEvaluation allows action-taking with fresh GitHub facts", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(inventory()),
+  });
+
+  assert.deepEqual(result, {
+    mode: "action_taking",
+    requirement: "fresh_github_required",
+    freshness: "fresh",
+    decision: "allowed",
+    reasons: ["fresh_github_facts_available"],
+  });
+});
+
+test("guardPrLifecycleEvaluation blocks action-taking with cached facts", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        source: "cached_github",
+      }),
+    ),
+  });
+
+  assert.equal(result.freshness, "cached");
+  assert.equal(result.decision, "blocked");
+  assert.deepEqual(result.reasons, ["fresh_github_facts_required"]);
+});
+
+test("guardPrLifecycleEvaluation blocks action-taking with missing fact observation", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        observedAt: null,
+      }),
+    ),
+  });
+
+  assert.equal(result.freshness, "missing");
+  assert.equal(result.decision, "blocked");
+  assert.deepEqual(result.reasons, ["observed_at_required"]);
+});
+
+test("guardPrLifecycleEvaluation blocks action-taking with malformed fact observation", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        observedAt: "not-a-date",
+      }),
+    ),
+  });
+
+  assert.equal(result.freshness, "missing");
+  assert.equal(result.decision, "blocked");
+  assert.deepEqual(result.reasons, ["valid_observed_at_required"]);
+});
+
+test("guardPrLifecycleEvaluation blocks action-taking when fresh GitHub facts expose stale local state", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2282,
+          headSha: "head-new",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: "2026-06-07T00:01:00.000Z",
+          currentHeadReviewHeadSha: "head-new",
+        },
+        localState: {
+          trackedHeadSha: "head-old",
+          workspaceHeadSha: "head-old",
+          lastObservedPrHeadSha: "head-old",
+        },
+      }),
+    ),
+  });
+
+  assert.equal(result.freshness, "stale_local_state");
+  assert.equal(result.decision, "blocked");
+  assert.deepEqual(result.reasons, ["stale_local_state_blocks_action"]);
+});
+
+test("guardPrLifecycleEvaluation blocks action-taking when local state facts are missing", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        localState: {
+          trackedHeadSha: null,
+          workspaceHeadSha: null,
+          lastObservedPrHeadSha: null,
+        },
+      }),
+    ),
+  });
+
+  assert.equal(result.freshness, "missing");
+  assert.equal(result.decision, "blocked");
+  assert.deepEqual(result.reasons, ["fresh_local_state_required"]);
+});
+
+test("guardPrLifecycleEvaluation blocks action-taking when local head facts are unknown", () => {
+  const result = guardPrLifecycleEvaluation({
+    mode: "action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        localState: {
+          trackedHeadSha: null,
+          workspaceHeadSha: null,
+          lastObservedPrHeadSha: "head-current",
+        },
+      }),
+    ),
+  });
+
+  assert.equal(result.freshness, "missing");
+  assert.equal(result.decision, "blocked");
+  assert.deepEqual(result.reasons, ["fresh_local_state_required"]);
+});
+
+test("guardPrLifecycleEvaluation allows diagnostic rendering for cached, missing, and stale facts", () => {
+  const cached = guardPrLifecycleEvaluation({
+    mode: "diagnostic_only",
+    normalizedState: normalizePrLifecycleFacts(inventory({ source: "cached_github" })),
+  });
+  const missing = guardPrLifecycleEvaluation({
+    mode: "diagnostic_only",
+    normalizedState: normalizePrLifecycleFacts(inventory({ source: "local_state", observedAt: null })),
+  });
+  const stale = guardPrLifecycleEvaluation({
+    mode: "diagnostic_only",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2282,
+          headSha: "head-new",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: "2026-06-07T00:01:00.000Z",
+          currentHeadReviewHeadSha: "head-new",
+        },
+        localState: {
+          trackedHeadSha: "head-old",
+          workspaceHeadSha: "head-old",
+          lastObservedPrHeadSha: "head-old",
+        },
+      }),
+    ),
+  });
+
+  assert.equal(cached.decision, "allowed");
+  assert.equal(missing.decision, "allowed");
+  assert.equal(stale.decision, "allowed");
+  assert.deepEqual(cached.reasons, ["diagnostic_rendering_allows_cached_facts"]);
+  assert.deepEqual(missing.reasons, ["diagnostic_rendering_allows_missing_facts"]);
+  assert.deepEqual(stale.reasons, ["diagnostic_rendering_allows_stale_local_state_facts"]);
+});
+
+test("classifyPrLifecycleFactFreshness distinguishes fixture facts as cached", () => {
+  assert.equal(
+    classifyPrLifecycleFactFreshness(normalizePrLifecycleFacts(inventory({ source: "fixture" }))),
+    "cached",
+  );
+});

--- a/src/decision-kernel/pr-lifecycle-evaluation-mode.ts
+++ b/src/decision-kernel/pr-lifecycle-evaluation-mode.ts
@@ -1,0 +1,111 @@
+import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
+
+export type PrLifecycleEvaluationMode = "action_taking" | "diagnostic_only";
+
+export type PrLifecycleFactFreshnessRequirement =
+  | "fresh_github_required"
+  | "cached_facts_allowed";
+
+export type PrLifecycleFactFreshnessStatus =
+  | "fresh"
+  | "cached"
+  | "missing"
+  | "stale_local_state";
+
+export type PrLifecycleEvaluationGuardDecision = "allowed" | "blocked";
+
+export interface PrLifecycleEvaluationGuardInput {
+  mode: PrLifecycleEvaluationMode;
+  normalizedState: NormalizedPrLifecycleState;
+}
+
+export interface PrLifecycleEvaluationGuardResult {
+  mode: PrLifecycleEvaluationMode;
+  requirement: PrLifecycleFactFreshnessRequirement;
+  freshness: PrLifecycleFactFreshnessStatus;
+  decision: PrLifecycleEvaluationGuardDecision;
+  reasons: string[];
+}
+
+export function guardPrLifecycleEvaluation(
+  input: PrLifecycleEvaluationGuardInput,
+): PrLifecycleEvaluationGuardResult {
+  const requirement = factFreshnessRequirementForMode(input.mode);
+  const freshness = classifyPrLifecycleFactFreshness(input.normalizedState);
+  if (input.mode === "diagnostic_only") {
+    return {
+      mode: input.mode,
+      requirement,
+      freshness,
+      decision: "allowed",
+      reasons: [`diagnostic_rendering_allows_${freshness}_facts`],
+    };
+  }
+
+  const reasons = actionTakingBlockReasons(input.normalizedState, freshness);
+  return {
+    mode: input.mode,
+    requirement,
+    freshness,
+    decision: reasons.length === 0 ? "allowed" : "blocked",
+    reasons: reasons.length === 0 ? ["fresh_github_facts_available"] : reasons,
+  };
+}
+
+export function factFreshnessRequirementForMode(
+  mode: PrLifecycleEvaluationMode,
+): PrLifecycleFactFreshnessRequirement {
+  return mode === "action_taking" ? "fresh_github_required" : "cached_facts_allowed";
+}
+
+export function classifyPrLifecycleFactFreshness(
+  normalizedState: NormalizedPrLifecycleState,
+): PrLifecycleFactFreshnessStatus {
+  if (
+    !validObservationTimestamp(normalizedState.observedAt) ||
+    normalizedState.source === "local_state" ||
+    normalizedState.localStateFreshness === "missing" ||
+    normalizedState.localStateFreshness === "unknown"
+  ) {
+    return "missing";
+  }
+
+  if (normalizedState.localStateFreshness === "stale") {
+    return "stale_local_state";
+  }
+
+  return normalizedState.source === "fresh_github" ? "fresh" : "cached";
+}
+
+function actionTakingBlockReasons(
+  normalizedState: NormalizedPrLifecycleState,
+  freshness: PrLifecycleFactFreshnessStatus,
+): string[] {
+  const reasons: string[] = [];
+  if (normalizedState.source !== "fresh_github") {
+    reasons.push("fresh_github_facts_required");
+  }
+
+  if (!normalizedState.observedAt) {
+    reasons.push("observed_at_required");
+  } else if (!validObservationTimestamp(normalizedState.observedAt)) {
+    reasons.push("valid_observed_at_required");
+  }
+
+  if (
+    normalizedState.localStateFreshness === "missing" ||
+    normalizedState.localStateFreshness === "unknown"
+  ) {
+    reasons.push("fresh_local_state_required");
+  }
+
+  if (freshness === "stale_local_state") {
+    reasons.push("stale_local_state_blocks_action");
+  }
+
+  return reasons;
+}
+
+function validObservationTimestamp(value: string | null): boolean {
+  return Boolean(value && !Number.isNaN(Date.parse(value)));
+}


### PR DESCRIPTION
## Summary
- Add read-only Decision Kernel v2 evaluation-mode contracts for PR lifecycle evaluation.
- Represent `action_taking` versus `diagnostic_only` modes and their fact-freshness requirements.
- Add pure guard helpers that fail closed for action-taking when facts are cached, missing, or fresh GitHub facts expose stale local state while still allowing diagnostic rendering.

Closes #2282

## Verification
- `npx tsx --test src/decision-kernel/*.test.ts`
- `node dist/index.js issue-lint 2282 --config supervisor.config.codex.json`
- `npm run build`

## Scope boundary
This PR only adds mode and fact-freshness contracts. It does not change live supervisor command routing, GitHub mutation behavior, or merge readiness decisions.
