### PR TITLE
[codex] Add decision trace replay fixtures

### DIFF
--- a/replay-corpus/decision-traces/merge-ready.json
+++ b/replay-corpus/decision-traces/merge-ready.json
@@ -1,0 +1,50 @@
+{
+  "id": "merge-ready",
+  "intent": "Stable read-only trace for a PR lifecycle decision that is ready to merge.",
+  "artifact": {
+    "schemaVersion": "pr_lifecycle_decision_trace.v1",
+    "traceId": "merge-ready",
+    "generatedAt": "2026-06-07T00:10:00.000Z",
+    "facts": {
+      "source": "fresh_github",
+      "observedAt": "2026-06-07T00:09:00.000Z",
+      "pullRequestNumber": 1001,
+      "headSha": "head-merge-ready",
+      "normalizedState": {
+        "source": "fresh_github",
+        "observedAt": "2026-06-07T00:09:00.000Z",
+        "pullRequestNumber": 1001,
+        "headSha": "head-merge-ready",
+        "headFreshness": "current_head",
+        "reviewPosture": "current_head_review_observed",
+        "checkPosture": "green",
+        "mergeability": "mergeable",
+        "localStateFreshness": "fresh",
+        "evidence": {
+          "manualReviewThreadCount": 0,
+          "currentHeadConfiguredBotThreadCount": 0,
+          "stalePreviousHeadConfiguredBotThreadCount": 0,
+          "metadataOnlyUnresolvedThreadCount": 0,
+          "passingCheckCount": 3,
+          "pendingCheckCount": 0,
+          "failingCheckCount": 0,
+          "unknownCheckCount": 0,
+          "trackedHeadSha": "head-merge-ready",
+          "workspaceHeadSha": "head-merge-ready",
+          "lastObservedPrHeadSha": "head-merge-ready"
+        }
+      }
+    },
+    "policy": {
+      "name": "pr_lifecycle_decision_kernel_v2",
+      "posture": "merge_ready",
+      "reasons": ["checks_green", "current_head_review_observed", "mergeable"]
+    },
+    "decision": {
+      "value": "merge",
+      "recommendedAction": "merge",
+      "summary": "Fresh PR lifecycle facts are merge ready."
+    },
+    "evidenceTokens": ["pr=1001", "head=head-merge-ready", "checks=green"]
+  }
+}

--- a/replay-corpus/decision-traces/metadata-only-review-residue.json
+++ b/replay-corpus/decision-traces/metadata-only-review-residue.json
@@ -1,0 +1,50 @@
+{
+  "id": "metadata-only-review-residue",
+  "intent": "Stable read-only trace for metadata-only unresolved review residue after current-head evidence exists.",
+  "artifact": {
+    "schemaVersion": "pr_lifecycle_decision_trace.v1",
+    "traceId": "metadata-only-review-residue",
+    "generatedAt": "2026-06-07T00:50:00.000Z",
+    "facts": {
+      "source": "fresh_github",
+      "observedAt": "2026-06-07T00:49:00.000Z",
+      "pullRequestNumber": 1005,
+      "headSha": "head-metadata-residue",
+      "normalizedState": {
+        "source": "fresh_github",
+        "observedAt": "2026-06-07T00:49:00.000Z",
+        "pullRequestNumber": 1005,
+        "headSha": "head-metadata-residue",
+        "headFreshness": "current_head",
+        "reviewPosture": "metadata_only_unresolved",
+        "checkPosture": "green",
+        "mergeability": "mergeable",
+        "localStateFreshness": "fresh",
+        "evidence": {
+          "manualReviewThreadCount": 0,
+          "currentHeadConfiguredBotThreadCount": 0,
+          "stalePreviousHeadConfiguredBotThreadCount": 0,
+          "metadataOnlyUnresolvedThreadCount": 2,
+          "passingCheckCount": 3,
+          "pendingCheckCount": 0,
+          "failingCheckCount": 0,
+          "unknownCheckCount": 0,
+          "trackedHeadSha": "head-metadata-residue",
+          "workspaceHeadSha": "head-metadata-residue",
+          "lastObservedPrHeadSha": "head-metadata-residue"
+        }
+      }
+    },
+    "policy": {
+      "name": "pr_lifecycle_decision_kernel_v2",
+      "posture": "metadata_only_review_residue",
+      "reasons": ["verified_current_head_evidence", "metadata_only_unresolved_threads"]
+    },
+    "decision": {
+      "value": "ask_operator",
+      "recommendedAction": "manual_review",
+      "summary": "Review residue is metadata-only and needs explicit operator handling."
+    },
+    "evidenceTokens": ["pr=1005", "metadata_only_threads=2", "checks=green"]
+  }
+}

--- a/replay-corpus/decision-traces/review-blocked.json
+++ b/replay-corpus/decision-traces/review-blocked.json
@@ -1,0 +1,50 @@
+{
+  "id": "review-blocked",
+  "intent": "Stable read-only trace for a PR lifecycle decision blocked by current-head review threads.",
+  "artifact": {
+    "schemaVersion": "pr_lifecycle_decision_trace.v1",
+    "traceId": "review-blocked",
+    "generatedAt": "2026-06-07T00:30:00.000Z",
+    "facts": {
+      "source": "fresh_github",
+      "observedAt": "2026-06-07T00:29:00.000Z",
+      "pullRequestNumber": 1003,
+      "headSha": "head-review-blocked",
+      "normalizedState": {
+        "source": "fresh_github",
+        "observedAt": "2026-06-07T00:29:00.000Z",
+        "pullRequestNumber": 1003,
+        "headSha": "head-review-blocked",
+        "headFreshness": "current_head",
+        "reviewPosture": "review_blocked",
+        "checkPosture": "green",
+        "mergeability": "mergeable",
+        "localStateFreshness": "fresh",
+        "evidence": {
+          "manualReviewThreadCount": 1,
+          "currentHeadConfiguredBotThreadCount": 2,
+          "stalePreviousHeadConfiguredBotThreadCount": 0,
+          "metadataOnlyUnresolvedThreadCount": 0,
+          "passingCheckCount": 3,
+          "pendingCheckCount": 0,
+          "failingCheckCount": 0,
+          "unknownCheckCount": 0,
+          "trackedHeadSha": "head-review-blocked",
+          "workspaceHeadSha": "head-review-blocked",
+          "lastObservedPrHeadSha": "head-review-blocked"
+        }
+      }
+    },
+    "policy": {
+      "name": "pr_lifecycle_decision_kernel_v2",
+      "posture": "blocked_by_review",
+      "reasons": ["manual_review_thread", "configured_bot_thread"]
+    },
+    "decision": {
+      "value": "ask_operator",
+      "recommendedAction": "manual_review",
+      "summary": "Current-head review threads block automated merge."
+    },
+    "evidenceTokens": ["pr=1003", "manual_threads=1", "current_bot_threads=2"]
+  }
+}

--- a/replay-corpus/decision-traces/stale-local-state.json
+++ b/replay-corpus/decision-traces/stale-local-state.json
@@ -1,0 +1,50 @@
+{
+  "id": "stale-local-state",
+  "intent": "Stable read-only trace for a PR lifecycle decision where fresh GitHub facts show stale local state.",
+  "artifact": {
+    "schemaVersion": "pr_lifecycle_decision_trace.v1",
+    "traceId": "stale-local-state",
+    "generatedAt": "2026-06-07T00:40:00.000Z",
+    "facts": {
+      "source": "fresh_github",
+      "observedAt": "2026-06-07T00:39:00.000Z",
+      "pullRequestNumber": 1004,
+      "headSha": "head-remote-new",
+      "normalizedState": {
+        "source": "fresh_github",
+        "observedAt": "2026-06-07T00:39:00.000Z",
+        "pullRequestNumber": 1004,
+        "headSha": "head-remote-new",
+        "headFreshness": "stale_head",
+        "reviewPosture": "current_head_review_observed",
+        "checkPosture": "green",
+        "mergeability": "mergeable",
+        "localStateFreshness": "stale",
+        "evidence": {
+          "manualReviewThreadCount": 0,
+          "currentHeadConfiguredBotThreadCount": 0,
+          "stalePreviousHeadConfiguredBotThreadCount": 0,
+          "metadataOnlyUnresolvedThreadCount": 0,
+          "passingCheckCount": 3,
+          "pendingCheckCount": 0,
+          "failingCheckCount": 0,
+          "unknownCheckCount": 0,
+          "trackedHeadSha": "head-local-old",
+          "workspaceHeadSha": "head-local-old",
+          "lastObservedPrHeadSha": "head-local-old"
+        }
+      }
+    },
+    "policy": {
+      "name": "pr_lifecycle_decision_kernel_v2",
+      "posture": "stale_local_state",
+      "reasons": ["local_head_differs_from_pr_head"]
+    },
+    "decision": {
+      "value": "do_nothing",
+      "recommendedAction": "refresh_state",
+      "summary": "Local state must refresh before action-taking evaluation."
+    },
+    "evidenceTokens": ["pr=1004", "remote=head-remote-new", "local=head-local-old"]
+  }
+}

--- a/replay-corpus/decision-traces/wait-ci.json
+++ b/replay-corpus/decision-traces/wait-ci.json
@@ -1,0 +1,50 @@
+{
+  "id": "wait-ci",
+  "intent": "Stable read-only trace for a PR lifecycle decision that waits for pending CI.",
+  "artifact": {
+    "schemaVersion": "pr_lifecycle_decision_trace.v1",
+    "traceId": "wait-ci",
+    "generatedAt": "2026-06-07T00:20:00.000Z",
+    "facts": {
+      "source": "fresh_github",
+      "observedAt": "2026-06-07T00:19:00.000Z",
+      "pullRequestNumber": 1002,
+      "headSha": "head-wait-ci",
+      "normalizedState": {
+        "source": "fresh_github",
+        "observedAt": "2026-06-07T00:19:00.000Z",
+        "pullRequestNumber": 1002,
+        "headSha": "head-wait-ci",
+        "headFreshness": "current_head",
+        "reviewPosture": "current_head_review_observed",
+        "checkPosture": "pending",
+        "mergeability": "mergeable",
+        "localStateFreshness": "fresh",
+        "evidence": {
+          "manualReviewThreadCount": 0,
+          "currentHeadConfiguredBotThreadCount": 0,
+          "stalePreviousHeadConfiguredBotThreadCount": 0,
+          "metadataOnlyUnresolvedThreadCount": 0,
+          "passingCheckCount": 1,
+          "pendingCheckCount": 2,
+          "failingCheckCount": 0,
+          "unknownCheckCount": 0,
+          "trackedHeadSha": "head-wait-ci",
+          "workspaceHeadSha": "head-wait-ci",
+          "lastObservedPrHeadSha": "head-wait-ci"
+        }
+      }
+    },
+    "policy": {
+      "name": "pr_lifecycle_decision_kernel_v2",
+      "posture": "wait_for_ci",
+      "reasons": ["checks_pending"]
+    },
+    "decision": {
+      "value": "wait",
+      "recommendedAction": "wait_ci",
+      "summary": "Required checks are still pending."
+    },
+    "evidenceTokens": ["pr=1002", "head=head-wait-ci", "pending_checks=2"]
+  }
+}

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import {
+  guardPrLifecycleEvaluation,
+  type PrLifecycleEvaluationMode,
+} from "./pr-lifecycle-evaluation-mode";
+import {
+  loadPrLifecycleTraceFixtures,
+  parsePrLifecycleTraceFixture,
+} from "./pr-lifecycle-trace-fixtures";
+import { formatPrLifecycleTraceDiagnostic } from "./pr-lifecycle-trace-presenter";
+
+const expectedFixtureIds = [
+  "merge-ready",
+  "metadata-only-review-residue",
+  "review-blocked",
+  "stale-local-state",
+  "wait-ci",
+];
+
+test("Decision Kernel trace fixtures load from the replay corpus with stable ids", async () => {
+  const fixtures = await loadPrLifecycleTraceFixtures(
+    path.join(process.cwd(), "replay-corpus", "decision-traces"),
+  );
+
+  assert.deepEqual(fixtures.map((fixture) => fixture.id), expectedFixtureIds);
+  assert.equal(fixtures.every((fixture) => fixture.intent.length > 0), true);
+  assert.equal(fixtures.every((fixture) => fixture.artifact.traceId === fixture.id), true);
+});
+
+test("Decision Kernel trace fixtures preserve representative policy and decision outcomes", async () => {
+  const fixtures = await loadPrLifecycleTraceFixtures(
+    path.join(process.cwd(), "replay-corpus", "decision-traces"),
+  );
+
+  assert.deepEqual(
+    fixtures.map((fixture) => [
+      fixture.id,
+      fixture.artifact.policy.posture,
+      fixture.artifact.decision.value,
+      fixture.artifact.decision.recommendedAction,
+    ]),
+    [
+      ["merge-ready", "merge_ready", "merge", "merge"],
+      ["metadata-only-review-residue", "metadata_only_review_residue", "ask_operator", "manual_review"],
+      ["review-blocked", "blocked_by_review", "ask_operator", "manual_review"],
+      ["stale-local-state", "stale_local_state", "do_nothing", "refresh_state"],
+      ["wait-ci", "wait_for_ci", "wait", "wait_ci"],
+    ],
+  );
+});
+
+test("Decision Kernel trace fixtures render compact diagnostics without host-local paths", async () => {
+  const fixtures = await loadPrLifecycleTraceFixtures(
+    path.join(process.cwd(), "replay-corpus", "decision-traces"),
+  );
+  const diagnostics = fixtures.map((fixture) => formatPrLifecycleTraceDiagnostic(fixture.artifact));
+
+  assert.equal(diagnostics.every((line) => line.startsWith("pr_lifecycle_trace ")), true);
+  assert.match(diagnostics.join("\n"), /label=merge_ready/);
+  assert.match(diagnostics.join("\n"), /label=ci_pending/);
+  assert.match(diagnostics.join("\n"), /label=review_blocked/);
+  assert.match(diagnostics.join("\n"), /label=stale_local_state/);
+  assert.match(diagnostics.join("\n"), /label=metadata_only_review_residue/);
+  assert.doesNotMatch(diagnostics.join("\n"), /\/Users\//);
+  assert.doesNotMatch(diagnostics.join("\n"), /[A-Z]:\\/);
+});
+
+test("Decision Kernel trace fixtures remain read-only for action-taking evaluation", async () => {
+  const fixtures = await loadPrLifecycleTraceFixtures(
+    path.join(process.cwd(), "replay-corpus", "decision-traces"),
+  );
+  const modeById = new Map<string, PrLifecycleEvaluationMode>([
+    ["merge-ready", "action_taking"],
+    ["metadata-only-review-residue", "diagnostic_only"],
+    ["review-blocked", "diagnostic_only"],
+    ["stale-local-state", "action_taking"],
+    ["wait-ci", "action_taking"],
+  ]);
+  const results = fixtures.map((fixture) => [
+    fixture.id,
+    guardPrLifecycleEvaluation({
+      mode: modeById.get(fixture.id) ?? "diagnostic_only",
+      normalizedState: fixture.artifact.facts.normalizedState,
+    }).decision,
+  ]);
+
+  assert.deepEqual(results, [
+    ["merge-ready", "allowed"],
+    ["metadata-only-review-residue", "allowed"],
+    ["review-blocked", "allowed"],
+    ["stale-local-state", "blocked"],
+    ["wait-ci", "allowed"],
+  ]);
+});
+
+test("parsePrLifecycleTraceFixture rejects schema drift", () => {
+  assert.throws(
+    () =>
+      parsePrLifecycleTraceFixture({
+        id: "bad-schema",
+        intent: "prove schema validation fails",
+        artifact: {
+          schemaVersion: "future-schema",
+        },
+      }),
+    /unsupported schemaVersion future-schema/,
+  );
+});
+
+test("parsePrLifecycleTraceFixture rejects invalid enum fields", () => {
+  assert.throws(
+    () =>
+      parsePrLifecycleTraceFixture({
+        id: "bad-review-posture",
+        intent: "prove enum validation fails",
+        artifact: {
+          schemaVersion: "pr_lifecycle_decision_trace.v1",
+          traceId: "bad-review-posture",
+          generatedAt: "2026-06-07T00:00:00.000Z",
+          facts: {
+            source: "fixture",
+            observedAt: "2026-06-07T00:00:00.000Z",
+            pullRequestNumber: 100,
+            headSha: "head",
+            normalizedState: {
+              source: "fixture",
+              observedAt: "2026-06-07T00:00:00.000Z",
+              pullRequestNumber: 100,
+              headSha: "head",
+              headFreshness: "current_head",
+              reviewPosture: "review-blocked",
+              checkPosture: "green",
+              mergeability: "mergeable",
+              localStateFreshness: "fresh",
+              evidence: {
+                manualReviewThreadCount: 0,
+                currentHeadConfiguredBotThreadCount: 0,
+                stalePreviousHeadConfiguredBotThreadCount: 0,
+                metadataOnlyUnresolvedThreadCount: 0,
+                passingCheckCount: 1,
+                pendingCheckCount: 0,
+                failingCheckCount: 0,
+                unknownCheckCount: 0,
+                trackedHeadSha: "head",
+                workspaceHeadSha: "head",
+                lastObservedPrHeadSha: "head"
+              }
+            }
+          },
+          policy: {
+            name: "pr_lifecycle_decision_kernel_v2",
+            posture: "merge_ready",
+            reasons: []
+          },
+          decision: {
+            value: "merge",
+            recommendedAction: "merge",
+            summary: "bad enum"
+          },
+          evidenceTokens: []
+        }
+      }),
+    /artifact\.facts\.normalizedState\.reviewPosture must be one of/,
+  );
+});
+
+test("parsePrLifecycleTraceFixture rejects top-level fact snapshots that disagree with normalized state", () => {
+  assert.throws(
+    () =>
+      parsePrLifecycleTraceFixture({
+        id: "bad-snapshot",
+        intent: "prove duplicated snapshot validation fails",
+        artifact: {
+          schemaVersion: "pr_lifecycle_decision_trace.v1",
+          traceId: "bad-snapshot",
+          generatedAt: "2026-06-07T00:00:00.000Z",
+          facts: {
+            source: "fixture",
+            observedAt: "2026-06-07T00:00:00.000Z",
+            pullRequestNumber: 100,
+            headSha: "head-old",
+            normalizedState: {
+              source: "fixture",
+              observedAt: "2026-06-07T00:00:00.000Z",
+              pullRequestNumber: 100,
+              headSha: "head-current",
+              headFreshness: "current_head",
+              reviewPosture: "current_head_review_observed",
+              checkPosture: "green",
+              mergeability: "mergeable",
+              localStateFreshness: "fresh",
+              evidence: {
+                manualReviewThreadCount: 0,
+                currentHeadConfiguredBotThreadCount: 0,
+                stalePreviousHeadConfiguredBotThreadCount: 0,
+                metadataOnlyUnresolvedThreadCount: 0,
+                passingCheckCount: 1,
+                pendingCheckCount: 0,
+                failingCheckCount: 0,
+                unknownCheckCount: 0,
+                trackedHeadSha: "head-current",
+                workspaceHeadSha: "head-current",
+                lastObservedPrHeadSha: "head-current"
+              }
+            }
+          },
+          policy: {
+            name: "pr_lifecycle_decision_kernel_v2",
+            posture: "merge_ready",
+            reasons: []
+          },
+          decision: {
+            value: "merge",
+            recommendedAction: "merge",
+            summary: "bad snapshot"
+          },
+          evidenceTokens: []
+        }
+      }),
+    /artifact\.facts\.headSha must match artifact\.facts\.normalizedState/,
+  );
+});

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -1,0 +1,341 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION,
+  type PrLifecycleDecision,
+  type PrLifecycleDecisionTraceArtifact,
+  type PrLifecyclePolicyPosture,
+  type PrLifecycleRecommendedAction,
+} from "./pr-lifecycle-trace";
+import type {
+  PrLifecycleCheckPosture,
+  PrLifecycleFactSource,
+  PrLifecycleHeadFreshness,
+  PrLifecycleLocalStateFreshness,
+  PrLifecycleMergeabilityPosture,
+  PrLifecycleReviewPosture,
+} from "./pr-lifecycle-state";
+
+export interface PrLifecycleTraceFixture {
+  id: string;
+  intent: string;
+  artifact: PrLifecycleDecisionTraceArtifact;
+}
+
+export async function loadPrLifecycleTraceFixtures(
+  rootPath: string,
+): Promise<PrLifecycleTraceFixture[]> {
+  const entries = await fs.readdir(rootPath, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name)
+    .sort();
+
+  const fixtures: PrLifecycleTraceFixture[] = [];
+  for (const file of files) {
+    const fixturePath = path.join(rootPath, file);
+    const parsed = JSON.parse(await fs.readFile(fixturePath, "utf8")) as unknown;
+    fixtures.push(parsePrLifecycleTraceFixture(parsed, fixturePath));
+  }
+
+  return fixtures;
+}
+
+export function parsePrLifecycleTraceFixture(
+  value: unknown,
+  source = "inline",
+): PrLifecycleTraceFixture {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: expected object.`);
+  }
+
+  const id = requiredString(value.id, source, "id");
+  const intent = requiredString(value.intent, source, "intent");
+  const artifact = parsePrLifecycleDecisionTraceArtifact(value.artifact, source);
+  if (artifact.traceId !== id) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: id must match artifact.traceId.`);
+  }
+
+  return { id, intent, artifact };
+}
+
+function parsePrLifecycleDecisionTraceArtifact(
+  value: unknown,
+  source: string,
+): PrLifecycleDecisionTraceArtifact {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid PR lifecycle trace artifact at ${source}: expected artifact object.`);
+  }
+
+  const schemaVersion = requiredString(value.schemaVersion, source, "artifact.schemaVersion");
+  if (schemaVersion !== PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION) {
+    throw new Error(
+      `Invalid PR lifecycle trace artifact at ${source}: unsupported schemaVersion ${schemaVersion}.`,
+    );
+  }
+
+  const traceId = requiredString(value.traceId, source, "artifact.traceId");
+  const generatedAt = requiredString(value.generatedAt, source, "artifact.generatedAt");
+  const facts = requiredRecord(value.facts, source, "artifact.facts");
+  const normalizedState = requiredRecord(facts.normalizedState, source, "artifact.facts.normalizedState");
+  const evidence = requiredRecord(
+    normalizedState.evidence,
+    source,
+    "artifact.facts.normalizedState.evidence",
+  );
+  const policy = requiredRecord(value.policy, source, "artifact.policy");
+  const decision = requiredRecord(value.decision, source, "artifact.decision");
+  const evidenceTokens = requiredStringArray(value.evidenceTokens, source, "artifact.evidenceTokens");
+  const factsSource = requiredEnum(
+    facts.source,
+    source,
+    "artifact.facts.source",
+    prLifecycleFactSources,
+  );
+  const factsObservedAt = nullableString(facts.observedAt, source, "artifact.facts.observedAt");
+  const factsPullRequestNumber = nullableNumber(facts.pullRequestNumber, source, "artifact.facts.pullRequestNumber");
+  const factsHeadSha = nullableString(facts.headSha, source, "artifact.facts.headSha");
+  const normalizedSource = requiredEnum(
+    normalizedState.source,
+    source,
+    "artifact.facts.normalizedState.source",
+    prLifecycleFactSources,
+  );
+  const normalizedObservedAt = nullableString(
+    normalizedState.observedAt,
+    source,
+    "artifact.facts.normalizedState.observedAt",
+  );
+  const normalizedPullRequestNumber = nullableNumber(
+    normalizedState.pullRequestNumber,
+    source,
+    "artifact.facts.normalizedState.pullRequestNumber",
+  );
+  const normalizedHeadSha = nullableString(normalizedState.headSha, source, "artifact.facts.normalizedState.headSha");
+
+  assertEqualFixtureField(factsSource, normalizedSource, source, "artifact.facts.source");
+  assertEqualFixtureField(factsObservedAt, normalizedObservedAt, source, "artifact.facts.observedAt");
+  assertEqualFixtureField(
+    factsPullRequestNumber,
+    normalizedPullRequestNumber,
+    source,
+    "artifact.facts.pullRequestNumber",
+  );
+  assertEqualFixtureField(factsHeadSha, normalizedHeadSha, source, "artifact.facts.headSha");
+
+  return {
+    schemaVersion: PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION,
+    traceId,
+    generatedAt,
+    facts: {
+      source: factsSource,
+      observedAt: factsObservedAt,
+      pullRequestNumber: factsPullRequestNumber,
+      headSha: factsHeadSha,
+      normalizedState: {
+        source: normalizedSource,
+        observedAt: normalizedObservedAt,
+        pullRequestNumber: normalizedPullRequestNumber,
+        headSha: normalizedHeadSha,
+        headFreshness: requiredEnum(
+          normalizedState.headFreshness,
+          source,
+          "artifact.facts.normalizedState.headFreshness",
+          prLifecycleHeadFreshnessValues,
+        ),
+        reviewPosture: requiredEnum(
+          normalizedState.reviewPosture,
+          source,
+          "artifact.facts.normalizedState.reviewPosture",
+          prLifecycleReviewPostures,
+        ),
+        checkPosture: requiredEnum(
+          normalizedState.checkPosture,
+          source,
+          "artifact.facts.normalizedState.checkPosture",
+          prLifecycleCheckPostures,
+        ),
+        mergeability: requiredEnum(
+          normalizedState.mergeability,
+          source,
+          "artifact.facts.normalizedState.mergeability",
+          prLifecycleMergeabilityPostures,
+        ),
+        localStateFreshness: requiredEnum(
+          normalizedState.localStateFreshness,
+          source,
+          "artifact.facts.normalizedState.localStateFreshness",
+          prLifecycleLocalStateFreshnessValues,
+        ),
+        evidence: {
+          manualReviewThreadCount: requiredNumber(
+            evidence.manualReviewThreadCount,
+            source,
+            "artifact.facts.normalizedState.evidence.manualReviewThreadCount",
+          ),
+          currentHeadConfiguredBotThreadCount: requiredNumber(
+            evidence.currentHeadConfiguredBotThreadCount,
+            source,
+            "artifact.facts.normalizedState.evidence.currentHeadConfiguredBotThreadCount",
+          ),
+          stalePreviousHeadConfiguredBotThreadCount: requiredNumber(
+            evidence.stalePreviousHeadConfiguredBotThreadCount,
+            source,
+            "artifact.facts.normalizedState.evidence.stalePreviousHeadConfiguredBotThreadCount",
+          ),
+          metadataOnlyUnresolvedThreadCount: requiredNumber(
+            evidence.metadataOnlyUnresolvedThreadCount,
+            source,
+            "artifact.facts.normalizedState.evidence.metadataOnlyUnresolvedThreadCount",
+          ),
+          passingCheckCount: requiredNumber(
+            evidence.passingCheckCount,
+            source,
+            "artifact.facts.normalizedState.evidence.passingCheckCount",
+          ),
+          pendingCheckCount: requiredNumber(
+            evidence.pendingCheckCount,
+            source,
+            "artifact.facts.normalizedState.evidence.pendingCheckCount",
+          ),
+          failingCheckCount: requiredNumber(
+            evidence.failingCheckCount,
+            source,
+            "artifact.facts.normalizedState.evidence.failingCheckCount",
+          ),
+          unknownCheckCount: requiredNumber(
+            evidence.unknownCheckCount,
+            source,
+            "artifact.facts.normalizedState.evidence.unknownCheckCount",
+          ),
+          trackedHeadSha: nullableString(evidence.trackedHeadSha, source, "artifact.facts.normalizedState.evidence.trackedHeadSha"),
+          workspaceHeadSha: nullableString(evidence.workspaceHeadSha, source, "artifact.facts.normalizedState.evidence.workspaceHeadSha"),
+          lastObservedPrHeadSha: nullableString(
+            evidence.lastObservedPrHeadSha,
+            source,
+            "artifact.facts.normalizedState.evidence.lastObservedPrHeadSha",
+          ),
+        },
+      },
+    },
+    policy: {
+      name: requiredString(policy.name, source, "artifact.policy.name") as PrLifecycleDecisionTraceArtifact["policy"]["name"],
+      posture: requiredEnum(policy.posture, source, "artifact.policy.posture", prLifecyclePolicyPostures),
+      reasons: requiredStringArray(policy.reasons, source, "artifact.policy.reasons"),
+    },
+    decision: {
+      value: requiredEnum(decision.value, source, "artifact.decision.value", prLifecycleDecisions),
+      recommendedAction: requiredEnum(
+        decision.recommendedAction,
+        source,
+        "artifact.decision.recommendedAction",
+        prLifecycleRecommendedActions,
+      ),
+      summary: requiredString(decision.summary, source, "artifact.decision.summary"),
+    },
+    evidenceTokens,
+  };
+}
+
+const prLifecycleFactSources = ["fresh_github", "cached_github", "local_state", "fixture"] as const satisfies readonly PrLifecycleFactSource[];
+const prLifecycleHeadFreshnessValues = ["no_pull_request", "current_head", "stale_head", "unknown"] as const satisfies readonly PrLifecycleHeadFreshness[];
+const prLifecycleReviewPostures = [
+  "current_head_review_observed",
+  "missing_current_head_review",
+  "review_blocked",
+  "stale_previous_head_review",
+  "metadata_only_unresolved",
+  "no_unresolved_review",
+  "unknown",
+] as const satisfies readonly PrLifecycleReviewPosture[];
+const prLifecycleCheckPostures = ["green", "pending", "failing", "unknown"] as const satisfies readonly PrLifecycleCheckPosture[];
+const prLifecycleMergeabilityPostures = ["mergeable", "conflicted", "draft", "closed", "unknown"] as const satisfies readonly PrLifecycleMergeabilityPosture[];
+const prLifecycleLocalStateFreshnessValues = ["fresh", "stale", "missing", "unknown"] as const satisfies readonly PrLifecycleLocalStateFreshness[];
+const prLifecyclePolicyPostures = [
+  "merge_ready",
+  "wait_for_ci",
+  "request_current_head_review",
+  "repair_current_head_review",
+  "blocked_by_review",
+  "blocked_by_conflict",
+  "stale_local_state",
+  "metadata_only_review_residue",
+  "no_pull_request",
+  "unknown",
+] as const satisfies readonly PrLifecyclePolicyPosture[];
+const prLifecycleDecisions = ["merge", "wait", "request_review", "run_codex", "ask_operator", "do_nothing"] as const satisfies readonly PrLifecycleDecision[];
+const prLifecycleRecommendedActions = ["merge", "wait_ci", "request_review", "repair", "manual_review", "refresh_state", "no_action"] as const satisfies readonly PrLifecycleRecommendedAction[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredRecord(value: unknown, source: string, field: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be an object.`);
+  }
+  return value;
+}
+
+function requiredString(value: unknown, source: string, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be a string.`);
+  }
+  return value;
+}
+
+function requiredEnum<const T extends readonly string[]>(
+  value: unknown,
+  source: string,
+  field: string,
+  allowed: T,
+): T[number] {
+  const candidate = requiredString(value, source, field);
+  if (!allowed.includes(candidate)) {
+    throw new Error(
+      `Invalid PR lifecycle trace fixture at ${source}: ${field} must be one of ${allowed.join(", ")}.`,
+    );
+  }
+  return candidate;
+}
+
+function nullableString(value: unknown, source: string, field: string): string | null {
+  if (value === null) {
+    return null;
+  }
+  return requiredString(value, source, field);
+}
+
+function requiredNumber(value: unknown, source: string, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be a number.`);
+  }
+  return value;
+}
+
+function nullableNumber(value: unknown, source: string, field: string): number | null {
+  if (value === null) {
+    return null;
+  }
+  return requiredNumber(value, source, field);
+}
+
+function requiredStringArray(value: unknown, source: string, field: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be a string array.`);
+  }
+  return [...value];
+}
+
+function assertEqualFixtureField(
+  actual: string | number | null,
+  expected: string | number | null,
+  source: string,
+  field: string,
+): void {
+  if (actual !== expected) {
+    throw new Error(
+      `Invalid PR lifecycle trace fixture at ${source}: ${field} must match artifact.facts.normalizedState.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add read-only Decision Kernel v2 PR lifecycle trace fixtures under `replay-corpus/decision-traces`.
- Add a fixture loader/validator for the versioned trace artifact schema.
- Cover merge-ready, wait-CI, review-blocked, stale-local-state, and metadata-only review residue fixtures.

Closes #2283

## Verification
- `npx tsx --test src/decision-kernel/*.test.ts src/supervisor/replay-corpus.test.ts`
- `node dist/index.js issue-lint 2283 --config supervisor.config.codex.json`
- `npm run build`

## Scope boundary
This PR only adds read-only trace fixture/replay coverage. It does not replace current replay decisions or enable Decision Kernel v2 action-taking behavior.
