### PR TITLE
[codex] Add review policy input model

### DIFF
--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -158,6 +158,20 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   assert.equal(manualInput?.findingKind, "none");
   assert.deepEqual(manualInput?.vocabulary, ["manual_thread"]);
 
+  const idOnlyInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      processed_review_thread_ids: ["thread-p3-softened@head-new"],
+      processed_review_thread_fingerprints: [],
+    },
+    reviewThreads: [p3NitpickThread],
+  }).threads[0];
+  assert.equal(idOnlyInput?.processedEvidence.processedOnCurrentHead, true);
+  assert.equal(idOnlyInput?.headRelation, "current_head");
+
   p2Thread.comments.nodes[0]!.body = "P3: Nitpick after snapshot mutation.";
   assert.equal(p2Input?.comments[0]?.body, "P2: Preserve failed restore cleanup as a blocking verification failure.");
 });

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -81,6 +81,10 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     id: "thread-p3-softened",
     body: "P3: Nitpick: prefer a shorter helper name for readability.",
   });
+  const p3RiskThread = codexThread({
+    id: "thread-p3-risk",
+    body: "P3: This cleanup can cause a regression in the restore failure path.",
+  });
   const manualThread = createReviewThread({
     id: "thread-manual",
     comments: {
@@ -120,7 +124,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
         "thread-p2@head-old#comment-1",
       ],
     },
-    reviewThreads: [p2Thread, p3NitpickThread, manualThread],
+    reviewThreads: [p2Thread, p3NitpickThread, p3RiskThread, manualThread],
   });
 
   assert.deepEqual(input.providerIdentity, {
@@ -152,6 +156,15 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     "current_head_thread",
     "configured_bot_thread",
     "softened_p3_advisory",
+  ]);
+
+  const p3RiskInput = input.threads.find((thread) => thread.id === "thread-p3-risk");
+  assert.equal(p3RiskInput?.findingKind, "must_fix");
+  assert.deepEqual(p3RiskInput?.vocabulary, [
+    "stale_commit_thread",
+    "configured_bot_thread",
+    "must_fix_finding",
+    "escalated_p3",
   ]);
 
   const manualInput = input.threads.find((thread) => thread.id === "thread-manual");

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -185,6 +185,52 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   assert.equal(idOnlyInput?.processedEvidence.processedOnCurrentHead, true);
   assert.equal(idOnlyInput?.headRelation, "current_head");
 
+  const refreshedCommentInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      processed_review_thread_ids: ["thread-p3-softened@head-new"],
+      processed_review_thread_fingerprints: ["thread-p3-softened@head-new#old-comment"],
+    },
+    reviewThreads: [p3NitpickThread],
+  }).threads[0];
+  assert.equal(refreshedCommentInput?.processedEvidence.processedOnCurrentHead, false);
+  assert.equal(refreshedCommentInput?.headRelation, "unknown");
+
+  const priorIdOnlyInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      processed_review_thread_ids: ["thread-p3-softened@head-old"],
+      processed_review_thread_fingerprints: [],
+    },
+    reviewThreads: [p3NitpickThread],
+  }).threads[0];
+  assert.equal(priorIdOnlyInput?.processedEvidence.processedOnPriorHead, true);
+
+  const outdatedInput = buildReviewPolicyInput({
+    config,
+    pr: {
+      ...pr,
+      configuredBotCurrentHeadObservedAt: "2026-03-11T00:04:00Z",
+      configuredBotLatestReviewedCommitSha: null,
+    },
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: [],
+    },
+    reviewThreads: [{ ...p3RiskThread, id: "thread-p3-outdated", isOutdated: true }],
+  }).threads[0];
+  assert.equal(outdatedInput?.headRelation, "unknown");
+  assert.equal(outdatedInput?.findingKind, "none");
+  assert.deepEqual(outdatedInput?.vocabulary, ["configured_bot_thread"]);
+
   p2Thread.comments.nodes[0]!.body = "P3: Nitpick after snapshot mutation.";
   assert.equal(p2Input?.comments[0]?.body, "P2: Preserve failed restore cleanup as a blocking verification failure.");
 });

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -216,6 +216,20 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   }).threads[0];
   assert.equal(priorIdOnlyInput?.processedEvidence.processedOnPriorHead, true);
 
+  const priorFingerprintOnlyInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: ["thread-p3-softened@head-old#comment-1"],
+    },
+    reviewThreads: [p3NitpickThread],
+  }).threads[0];
+  assert.equal(priorFingerprintOnlyInput?.processedEvidence.processedOnPriorHead, false);
+
   const outdatedInput = buildReviewPolicyInput({
     config,
     pr: {
@@ -235,6 +249,20 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   assert.equal(outdatedInput?.headRelation, "unknown");
   assert.equal(outdatedInput?.findingKind, "none");
   assert.deepEqual(outdatedInput?.vocabulary, ["configured_bot_thread"]);
+
+  const outdatedManualInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: [],
+    },
+    reviewThreads: [{ ...manualThread, id: "thread-manual-outdated", isOutdated: true }],
+  }).threads[0];
+  assert.deepEqual(outdatedManualInput?.vocabulary, ["manual_thread"]);
 
   const codexReplyThread = createReviewThread({
     id: "thread-codex-replied",
@@ -276,6 +304,20 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     reviewThreads: [codexReplyThread],
   }).threads[0];
   assert.equal(codexReplyInput?.processedEvidence.processedOnCurrentHead, true);
+
+  const priorCodexReplyInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: ["thread-codex-replied@head-old"],
+      processed_review_thread_fingerprints: ["thread-codex-replied@head-old#comment-supervisor-reply"],
+    },
+    reviewThreads: [codexReplyThread],
+  }).threads[0];
+  assert.equal(priorCodexReplyInput?.processedEvidence.processedOnPriorHead, true);
 
   const fingerprintOnlyInput = buildReviewPolicyInput({
     config,

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -5,6 +5,7 @@ import {
   buildCodexConnectorPolicyBlockDiagnostic,
   buildCodexConnectorReviewChurnDiagnostic,
   buildCodexConnectorReviewChurnProgressSummary,
+  buildReviewPolicyInput,
   clusterConfiguredBotReviewThreads,
   compareCodexConnectorReviewChurnProgress,
   codexConnectorMustFixReviewThreads,
@@ -68,6 +69,97 @@ test("Codex Connector policy classifies must-fix, nitpick, and stale review comm
     p3Softened: 1,
     p3Escalated: 1,
   });
+});
+
+test("review policy input snapshots provider, PR, thread vocabulary, and processed evidence", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const p2Thread = codexThread({
+    id: "thread-p2",
+    body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+  });
+  const p3NitpickThread = codexThread({
+    id: "thread-p3-softened",
+    body: "P3: Nitpick: prefer a shorter helper name for readability.",
+  });
+  const manualThread = createReviewThread({
+    id: "thread-manual",
+    comments: {
+      nodes: [
+        {
+          id: "comment-human",
+          body: "Please double-check the migration note.",
+          createdAt: "2026-03-11T00:02:00Z",
+          url: "https://example.test/pr/44#discussion_human",
+          author: {
+            login: "maintainer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const pr: Pick<
+    GitHubPullRequest,
+    "number" | "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha" | "currentHeadCiGreenAt"
+  > = {
+    number: 44,
+    headRefOid: "head-new",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: "head-old",
+    currentHeadCiGreenAt: "2026-03-11T00:03:00Z",
+  };
+  const input = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: "HEAD-OLD",
+      external_review_head_sha: "HEAD-NEW",
+      processed_review_thread_ids: ["thread-p3-softened@head-new", "thread-p2@head-old"],
+      processed_review_thread_fingerprints: [
+        "thread-p3-softened@head-new#comment-1",
+        "thread-p2@head-old#comment-1",
+      ],
+    },
+    reviewThreads: [p2Thread, p3NitpickThread, manualThread],
+  });
+
+  assert.deepEqual(input.providerIdentity, {
+    configuredProviderKinds: ["codex"],
+    configuredBotLogins: ["chatgpt-codex-connector"],
+  });
+  assert.deepEqual(input.pr, {
+    number: 44,
+    headSha: "head-new",
+    currentHeadObservedAt: null,
+    latestReviewedCommitSha: "head-old",
+    providerSuccessHeadSha: "head-old",
+    externalReviewHeadSha: "head-new",
+    currentHeadCiGreenAt: "2026-03-11T00:03:00Z",
+  });
+
+  const p2Input = input.threads.find((thread) => thread.id === "thread-p2");
+  assert.equal(p2Input?.headRelation, "stale_commit");
+  assert.equal(p2Input?.findingKind, "must_fix");
+  assert.equal(p2Input?.processedEvidence.processedOnCurrentHead, false);
+  assert.equal(p2Input?.processedEvidence.processedOnPriorHead, true);
+  assert.deepEqual(p2Input?.vocabulary, ["stale_commit_thread", "configured_bot_thread", "must_fix_finding"]);
+
+  const p3Input = input.threads.find((thread) => thread.id === "thread-p3-softened");
+  assert.equal(p3Input?.headRelation, "current_head");
+  assert.equal(p3Input?.findingKind, "softened_p3_advisory");
+  assert.equal(p3Input?.processedEvidence.processedOnCurrentHead, true);
+  assert.deepEqual(p3Input?.vocabulary, [
+    "current_head_thread",
+    "configured_bot_thread",
+    "softened_p3_advisory",
+  ]);
+
+  const manualInput = input.threads.find((thread) => thread.id === "thread-manual");
+  assert.equal(manualInput?.findingKind, "none");
+  assert.deepEqual(manualInput?.vocabulary, ["manual_thread"]);
+
+  p2Thread.comments.nodes[0]!.body = "P3: Nitpick after snapshot mutation.";
+  assert.equal(p2Input?.comments[0]?.body, "P2: Preserve failed restore cleanup as a blocking verification failure.");
 });
 
 test("Codex Connector policy diagnostics and convergence stay focused in the policy module", () => {

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -118,6 +118,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     record: {
       provider_success_head_sha: "HEAD-OLD",
       external_review_head_sha: "HEAD-NEW",
+      last_head_sha: "head-new",
       processed_review_thread_ids: ["thread-p3-softened@head-new", "thread-p2@head-old"],
       processed_review_thread_fingerprints: [
         "thread-p3-softened@head-new#comment-1",
@@ -177,6 +178,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     record: {
       provider_success_head_sha: null,
       external_review_head_sha: null,
+      last_head_sha: "head-new",
       processed_review_thread_ids: ["thread-p3-softened@head-new"],
       processed_review_thread_fingerprints: [],
     },
@@ -191,6 +193,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     record: {
       provider_success_head_sha: null,
       external_review_head_sha: null,
+      last_head_sha: "head-new",
       processed_review_thread_ids: ["thread-p3-softened@head-new"],
       processed_review_thread_fingerprints: ["thread-p3-softened@head-new#old-comment"],
     },
@@ -205,6 +208,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     record: {
       provider_success_head_sha: null,
       external_review_head_sha: null,
+      last_head_sha: "head-new",
       processed_review_thread_ids: ["thread-p3-softened@head-old"],
       processed_review_thread_fingerprints: [],
     },
@@ -222,6 +226,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     record: {
       provider_success_head_sha: null,
       external_review_head_sha: null,
+      last_head_sha: "head-new",
       processed_review_thread_ids: [],
       processed_review_thread_fingerprints: [],
     },
@@ -230,6 +235,75 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   assert.equal(outdatedInput?.headRelation, "unknown");
   assert.equal(outdatedInput?.findingKind, "none");
   assert.deepEqual(outdatedInput?.vocabulary, ["configured_bot_thread"]);
+
+  const codexReplyThread = createReviewThread({
+    id: "thread-codex-replied",
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-finding",
+          body: "P2: Preserve the original Codex finding fingerprint.",
+          createdAt: "2026-03-11T00:00:00Z",
+          url: "https://example.test/pr/44#discussion_codex",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-supervisor-reply",
+          body: "Handled in the current patch.",
+          createdAt: "2026-03-11T00:01:00Z",
+          url: "https://example.test/pr/44#discussion_reply",
+          author: {
+            login: "maintainer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const codexReplyInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: ["thread-codex-replied@head-new#comment-codex-finding"],
+    },
+    reviewThreads: [codexReplyThread],
+  }).threads[0];
+  assert.equal(codexReplyInput?.processedEvidence.processedOnCurrentHead, true);
+
+  const fingerprintOnlyInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: ["thread-p3-softened@head-new#comment-1"],
+    },
+    reviewThreads: [p3NitpickThread],
+  }).threads[0];
+  assert.equal(fingerprintOnlyInput?.processedEvidence.processedOnCurrentHead, true);
+
+  const legacyRawIdInput = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: ["thread-p3-softened"],
+      processed_review_thread_fingerprints: [],
+    },
+    reviewThreads: [p3NitpickThread],
+  }).threads[0];
+  assert.equal(legacyRawIdInput?.processedEvidence.processedOnCurrentHead, true);
 
   p2Thread.comments.nodes[0]!.body = "P3: Nitpick after snapshot mutation.";
   assert.equal(p2Input?.comments[0]?.body, "P2: Preserve failed restore cleanup as a blocking verification failure.");

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -27,11 +27,7 @@ export type ReviewPolicyThreadVocabulary =
   | "escalated_p3"
   | "must_fix_finding";
 
-export type ReviewPolicyFindingKind =
-  | "none"
-  | "must_fix"
-  | "softened_p3_advisory"
-  | "escalated_p3";
+export type ReviewPolicyFindingKind = "none" | "must_fix" | "softened_p3_advisory";
 
 export type ReviewPolicyHeadRelation = "current_head" | "stale_commit" | "unknown";
 
@@ -243,14 +239,14 @@ function reviewPolicyFindingKind(thread: ReviewThread): ReviewPolicyFindingKind 
   if (
     latestCodexConnectorReview.severity === "P0" ||
     latestCodexConnectorReview.severity === "P1" ||
-    latestCodexConnectorReview.severity === "P2"
+    latestCodexConnectorReview.severity === "P2" ||
+    (latestCodexConnectorReview.severity === "P3" &&
+      hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body))
   ) {
     return "must_fix";
   }
 
-  return hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)
-    ? "escalated_p3"
-    : "softened_p3_advisory";
+  return "softened_p3_advisory";
 }
 
 function reviewPolicyThreadVocabulary(args: {
@@ -258,6 +254,7 @@ function reviewPolicyThreadVocabulary(args: {
   isManualThread: boolean;
   findingKind: ReviewPolicyFindingKind;
   headRelation: ReviewPolicyHeadRelation;
+  isEscalatedP3: boolean;
 }): ReviewPolicyThreadVocabulary[] {
   const vocabulary: ReviewPolicyThreadVocabulary[] = [];
   if (args.headRelation === "current_head") {
@@ -275,7 +272,8 @@ function reviewPolicyThreadVocabulary(args: {
     vocabulary.push("must_fix_finding");
   } else if (args.findingKind === "softened_p3_advisory") {
     vocabulary.push("softened_p3_advisory");
-  } else if (args.findingKind === "escalated_p3") {
+  }
+  if (args.isEscalatedP3) {
     vocabulary.push("escalated_p3");
   }
   return vocabulary;
@@ -347,6 +345,11 @@ export function buildReviewPolicyInput(args: {
           ? "current_head"
           : "unknown";
       const findingKind = reviewPolicyFindingKind(thread);
+      const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+      const isEscalatedP3 = Boolean(
+        latestCodexConnectorReview?.severity === "P3" &&
+          hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body),
+      );
 
       return {
         id: thread.id,
@@ -373,6 +376,7 @@ export function buildReviewPolicyInput(args: {
           isManualThread,
           findingKind,
           headRelation,
+          isEscalatedP3,
         }),
       };
     }),

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -326,11 +326,14 @@ export function buildReviewPolicyInput(args: {
       );
       const isManualThread = !thread.isResolved && !thread.isOutdated && comments.length > 0 && !isConfiguredBotThread;
       const latestCommentFingerprintValue = latestCommentFingerprint(thread);
+      const processedThreadKeys = [...(args.record.processed_review_thread_ids ?? [])];
+      const processedThreadFingerprintKeys = [...(args.record.processed_review_thread_fingerprints ?? [])];
       const processedOnCurrentHeadValue = Boolean(
-        latestCommentFingerprintValue &&
-          (args.record.processed_review_thread_fingerprints ?? []).includes(
-            processedThreadFingerprintKey(thread.id, args.pr.headRefOid, latestCommentFingerprintValue),
-          ),
+        processedThreadKeys.includes(processedThreadKey(thread.id, args.pr.headRefOid)) ||
+          (latestCommentFingerprintValue &&
+            processedThreadFingerprintKeys.includes(
+              processedThreadFingerprintKey(thread.id, args.pr.headRefOid, latestCommentFingerprintValue),
+            )),
       );
       const processedOnPriorHeadValue = processedOnPriorHead({
         record: args.record,
@@ -362,8 +365,8 @@ export function buildReviewPolicyInput(args: {
           latestCommentFingerprint: latestCommentFingerprintValue,
           processedOnCurrentHead: processedOnCurrentHeadValue,
           processedOnPriorHead: processedOnPriorHeadValue,
-          processedThreadKeys: [...(args.record.processed_review_thread_ids ?? [])],
-          processedThreadFingerprintKeys: [...(args.record.processed_review_thread_fingerprints ?? [])],
+          processedThreadKeys,
+          processedThreadFingerprintKeys,
         },
         vocabulary: reviewPolicyThreadVocabulary({
           isConfiguredBotThread,

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -194,27 +194,76 @@ function processedThreadFingerprintKey(threadId: string, headSha: string, latest
   return `${processedThreadKey(threadId, headSha)}#${latestCommentFingerprintValue}`;
 }
 
+function processedThreadHeadShas(args: {
+  processedThreadKeys: string[];
+  threadId: string;
+}): string[] {
+  const prefix = `${args.threadId}@`;
+  return args.processedThreadKeys
+    .filter((key) => key.startsWith(prefix))
+    .map((key) => key.slice(prefix.length))
+    .filter((headSha) => headSha.length > 0);
+}
+
+function hasProcessedThreadFingerprintForHead(args: {
+  processedThreadFingerprintKeys: string[];
+  threadId: string;
+  headSha: string;
+}): boolean {
+  const prefix = `${processedThreadKey(args.threadId, args.headSha)}#`;
+  return args.processedThreadFingerprintKeys.some((key) => key.startsWith(prefix));
+}
+
+function processedOnHead(args: {
+  processedThreadKeys: string[];
+  processedThreadFingerprintKeys: string[];
+  threadId: string;
+  headSha: string;
+  latestCommentFingerprint: string | null;
+}): boolean {
+  if (!args.processedThreadKeys.includes(processedThreadKey(args.threadId, args.headSha))) {
+    return false;
+  }
+
+  if (
+    hasProcessedThreadFingerprintForHead({
+      processedThreadFingerprintKeys: args.processedThreadFingerprintKeys,
+      threadId: args.threadId,
+      headSha: args.headSha,
+    })
+  ) {
+    return Boolean(
+      args.latestCommentFingerprint &&
+        args.processedThreadFingerprintKeys.includes(
+          processedThreadFingerprintKey(args.threadId, args.headSha, args.latestCommentFingerprint),
+        ),
+    );
+  }
+
+  return true;
+}
+
 function processedOnPriorHead(args: {
-  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">;
+  processedThreadKeys: string[];
+  processedThreadFingerprintKeys: string[];
   pr: Pick<GitHubPullRequest, "headRefOid">;
   thread: Pick<ReviewThread, "id" | "comments">;
   latestCommentFingerprint: string | null;
 }): boolean {
-  if (!args.latestCommentFingerprint) {
-    return false;
-  }
-
-  const processedKeys = new Set(args.record.processed_review_thread_ids ?? []);
-  const fingerprintPrefix = `${args.thread.id}@`;
-  const fingerprintSuffix = `#${args.latestCommentFingerprint}`;
-  return (args.record.processed_review_thread_fingerprints ?? []).some((key) => {
-    if (!key.startsWith(fingerprintPrefix) || !key.endsWith(fingerprintSuffix)) {
-      return false;
-    }
-
-    const headSha = key.slice(fingerprintPrefix.length, key.length - fingerprintSuffix.length);
-    return Boolean(headSha && headSha !== args.pr.headRefOid && processedKeys.has(`${args.thread.id}@${headSha}`));
-  });
+  return processedThreadHeadShas({
+    processedThreadKeys: args.processedThreadKeys,
+    threadId: args.thread.id,
+  }).some(
+    (headSha) =>
+      headSha !== args.pr.headRefOid &&
+      processedOnHead({
+        processedThreadKeys: args.processedThreadKeys,
+        processedThreadFingerprintKeys: args.processedThreadFingerprintKeys,
+        threadId: args.thread.id,
+        headSha,
+        latestCommentFingerprint: args.latestCommentFingerprint,
+      }),
+  );
 }
 
 function reviewCommentSnapshot(comment: ReviewThreadComment): ReviewPolicyThreadCommentSnapshot {
@@ -326,28 +375,31 @@ export function buildReviewPolicyInput(args: {
       const latestCommentFingerprintValue = latestCommentFingerprint(thread);
       const processedThreadKeys = [...(args.record.processed_review_thread_ids ?? [])];
       const processedThreadFingerprintKeys = [...(args.record.processed_review_thread_fingerprints ?? [])];
-      const processedOnCurrentHeadValue = Boolean(
-        processedThreadKeys.includes(processedThreadKey(thread.id, args.pr.headRefOid)) ||
-          (latestCommentFingerprintValue &&
-            processedThreadFingerprintKeys.includes(
-              processedThreadFingerprintKey(thread.id, args.pr.headRefOid, latestCommentFingerprintValue),
-            )),
-      );
+      const processedOnCurrentHeadValue = processedOnHead({
+        processedThreadKeys,
+        processedThreadFingerprintKeys,
+        threadId: thread.id,
+        headSha: args.pr.headRefOid,
+        latestCommentFingerprint: latestCommentFingerprintValue,
+      });
       const processedOnPriorHeadValue = processedOnPriorHead({
-        record: args.record,
+        processedThreadKeys,
+        processedThreadFingerprintKeys,
         pr: args.pr,
         thread,
         latestCommentFingerprint: latestCommentFingerprintValue,
       });
       const headRelation: ReviewPolicyHeadRelation = staleCommitThreadIds.has(thread.id)
         ? "stale_commit"
-        : processedOnCurrentHeadValue || Boolean(currentHeadObservedAt)
+        : processedOnCurrentHeadValue || (!thread.isOutdated && Boolean(currentHeadObservedAt))
           ? "current_head"
           : "unknown";
       const findingKind = reviewPolicyFindingKind(thread);
       const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
       const isEscalatedP3 = Boolean(
-        latestCodexConnectorReview?.severity === "P3" &&
+        !thread.isResolved &&
+          !thread.isOutdated &&
+          latestCodexConnectorReview?.severity === "P3" &&
           hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body),
       );
 

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -196,28 +196,13 @@ function processedThreadFingerprintKey(threadId: string, headSha: string, latest
 
 function processedThreadHeadShas(args: {
   processedThreadKeys: string[];
-  processedThreadFingerprintKeys: string[];
   threadId: string;
 }): string[] {
   const prefix = `${args.threadId}@`;
-  const headShas = new Set<string>();
-  for (const key of args.processedThreadKeys) {
-    if (key.startsWith(prefix)) {
-      const headSha = key.slice(prefix.length);
-      if (headSha) {
-        headShas.add(headSha);
-      }
-    }
-  }
-  for (const key of args.processedThreadFingerprintKeys) {
-    if (key.startsWith(prefix)) {
-      const headSha = key.slice(prefix.length).split("#", 1)[0];
-      if (headSha) {
-        headShas.add(headSha);
-      }
-    }
-  }
-  return [...headShas];
+  return args.processedThreadKeys
+    .filter((key) => key.startsWith(prefix))
+    .map((key) => key.slice(prefix.length))
+    .filter((headSha) => headSha.length > 0);
 }
 
 function hasProcessedThreadFingerprintForHead(args: {
@@ -271,7 +256,6 @@ function processedOnPriorHead(args: {
 }): boolean {
   return processedThreadHeadShas({
     processedThreadKeys: args.processedThreadKeys,
-    processedThreadFingerprintKeys: args.processedThreadFingerprintKeys,
     threadId: args.thread.id,
   }).some(
     (headSha) =>
@@ -397,8 +381,9 @@ export function buildReviewPolicyInput(args: {
       const isConfiguredBotThread = comments.some((comment) =>
         Boolean(comment.normalizedAuthorLogin && configuredBotLoginSet.has(comment.normalizedAuthorLogin)),
       );
-      const isManualThread = !thread.isResolved && !thread.isOutdated && comments.length > 0 && !isConfiguredBotThread;
-      const latestCommentFingerprintValue = latestCodexConnectorReviewCommentFingerprint(thread) ?? latestCommentFingerprint(thread);
+      const isManualThread = comments.length > 0 && !isConfiguredBotThread;
+      const latestThreadCommentFingerprint = latestCommentFingerprint(thread);
+      const latestCommentFingerprintValue = latestCodexConnectorReviewCommentFingerprint(thread) ?? latestThreadCommentFingerprint;
       const processedThreadKeys = [...(args.record.processed_review_thread_ids ?? [])];
       const processedThreadFingerprintKeys = [...(args.record.processed_review_thread_fingerprints ?? [])];
       const processedOnCurrentHeadValue = processedOnHead({
@@ -415,7 +400,7 @@ export function buildReviewPolicyInput(args: {
         processedThreadFingerprintKeys,
         pr: args.pr,
         thread,
-        latestCommentFingerprint: latestCommentFingerprintValue,
+        latestCommentFingerprint: latestThreadCommentFingerprint,
       });
       const headRelation: ReviewPolicyHeadRelation = staleCommitThreadIds.has(thread.id)
         ? "stale_commit"

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -196,13 +196,28 @@ function processedThreadFingerprintKey(threadId: string, headSha: string, latest
 
 function processedThreadHeadShas(args: {
   processedThreadKeys: string[];
+  processedThreadFingerprintKeys: string[];
   threadId: string;
 }): string[] {
   const prefix = `${args.threadId}@`;
-  return args.processedThreadKeys
-    .filter((key) => key.startsWith(prefix))
-    .map((key) => key.slice(prefix.length))
-    .filter((headSha) => headSha.length > 0);
+  const headShas = new Set<string>();
+  for (const key of args.processedThreadKeys) {
+    if (key.startsWith(prefix)) {
+      const headSha = key.slice(prefix.length);
+      if (headSha) {
+        headShas.add(headSha);
+      }
+    }
+  }
+  for (const key of args.processedThreadFingerprintKeys) {
+    if (key.startsWith(prefix)) {
+      const headSha = key.slice(prefix.length).split("#", 1)[0];
+      if (headSha) {
+        headShas.add(headSha);
+      }
+    }
+  }
+  return [...headShas];
 }
 
 function hasProcessedThreadFingerprintForHead(args: {
@@ -217,30 +232,34 @@ function hasProcessedThreadFingerprintForHead(args: {
 function processedOnHead(args: {
   processedThreadKeys: string[];
   processedThreadFingerprintKeys: string[];
+  lastHeadSha: string | null;
   threadId: string;
+  currentHeadSha: string;
   headSha: string;
   latestCommentFingerprint: string | null;
 }): boolean {
-  if (!args.processedThreadKeys.includes(processedThreadKey(args.threadId, args.headSha))) {
-    return false;
+  const headScopedKey = processedThreadKey(args.threadId, args.headSha);
+  const exactFingerprintKey = args.latestCommentFingerprint
+    ? processedThreadFingerprintKey(args.threadId, args.headSha, args.latestCommentFingerprint)
+    : null;
+
+  if (exactFingerprintKey && args.processedThreadFingerprintKeys.includes(exactFingerprintKey)) {
+    return true;
   }
 
-  if (
-    hasProcessedThreadFingerprintForHead({
+  if (args.processedThreadKeys.includes(headScopedKey)) {
+    if (args.latestCommentFingerprint === null) {
+      return true;
+    }
+
+    return !hasProcessedThreadFingerprintForHead({
       processedThreadFingerprintKeys: args.processedThreadFingerprintKeys,
       threadId: args.threadId,
       headSha: args.headSha,
-    })
-  ) {
-    return Boolean(
-      args.latestCommentFingerprint &&
-        args.processedThreadFingerprintKeys.includes(
-          processedThreadFingerprintKey(args.threadId, args.headSha, args.latestCommentFingerprint),
-        ),
-    );
+    });
   }
 
-  return true;
+  return args.headSha === args.currentHeadSha && args.lastHeadSha === args.currentHeadSha && args.processedThreadKeys.includes(args.threadId);
 }
 
 function processedOnPriorHead(args: {
@@ -252,6 +271,7 @@ function processedOnPriorHead(args: {
 }): boolean {
   return processedThreadHeadShas({
     processedThreadKeys: args.processedThreadKeys,
+    processedThreadFingerprintKeys: args.processedThreadFingerprintKeys,
     threadId: args.thread.id,
   }).some(
     (headSha) =>
@@ -259,7 +279,9 @@ function processedOnPriorHead(args: {
       processedOnHead({
         processedThreadKeys: args.processedThreadKeys,
         processedThreadFingerprintKeys: args.processedThreadFingerprintKeys,
+        lastHeadSha: null,
         threadId: args.thread.id,
+        currentHeadSha: args.pr.headRefOid,
         headSha,
         latestCommentFingerprint: args.latestCommentFingerprint,
       }),
@@ -340,7 +362,11 @@ export function buildReviewPolicyInput(args: {
   >;
   record: Pick<
     IssueRunRecord,
-    "provider_success_head_sha" | "external_review_head_sha" | "processed_review_thread_ids" | "processed_review_thread_fingerprints"
+    | "provider_success_head_sha"
+    | "external_review_head_sha"
+    | "last_head_sha"
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
   >;
   reviewThreads: ReviewThread[];
 }): ReviewPolicyInput {
@@ -372,13 +398,15 @@ export function buildReviewPolicyInput(args: {
         Boolean(comment.normalizedAuthorLogin && configuredBotLoginSet.has(comment.normalizedAuthorLogin)),
       );
       const isManualThread = !thread.isResolved && !thread.isOutdated && comments.length > 0 && !isConfiguredBotThread;
-      const latestCommentFingerprintValue = latestCommentFingerprint(thread);
+      const latestCommentFingerprintValue = latestCodexConnectorReviewCommentFingerprint(thread) ?? latestCommentFingerprint(thread);
       const processedThreadKeys = [...(args.record.processed_review_thread_ids ?? [])];
       const processedThreadFingerprintKeys = [...(args.record.processed_review_thread_fingerprints ?? [])];
       const processedOnCurrentHeadValue = processedOnHead({
         processedThreadKeys,
         processedThreadFingerprintKeys,
+        lastHeadSha: args.record.last_head_sha ?? null,
         threadId: thread.id,
+        currentHeadSha: args.pr.headRefOid,
         headSha: args.pr.headRefOid,
         latestCommentFingerprint: latestCommentFingerprintValue,
       });

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -1,11 +1,95 @@
-import { configuredReviewProviderKinds } from "./core/review-providers";
-import type { GitHubPullRequest, ReviewThread, SupervisorConfig } from "./core/types";
+import {
+  configuredReviewBotLogins,
+  configuredReviewProviderKinds,
+  normalizeReviewProviderLogin,
+} from "./core/review-providers";
+import type {
+  ConfiguredReviewProviderKind,
+  GitHubPullRequest,
+  IssueRunRecord,
+  ReviewThread,
+  ReviewThreadComment,
+  SupervisorConfig,
+} from "./core/types";
 import {
   type CodexConnectorPSeverity,
   extractCodexConnectorPSeverity,
   hasCodexConnectorStrongRiskWording,
   isCodexConnectorReviewer,
 } from "./external-review/external-review-normalization";
+
+export type ReviewPolicyThreadVocabulary =
+  | "current_head_thread"
+  | "stale_commit_thread"
+  | "manual_thread"
+  | "configured_bot_thread"
+  | "softened_p3_advisory"
+  | "escalated_p3"
+  | "must_fix_finding";
+
+export type ReviewPolicyFindingKind =
+  | "none"
+  | "must_fix"
+  | "softened_p3_advisory"
+  | "escalated_p3";
+
+export type ReviewPolicyHeadRelation = "current_head" | "stale_commit" | "unknown";
+
+export interface ReviewPolicyProviderIdentity {
+  configuredProviderKinds: ConfiguredReviewProviderKind[];
+  configuredBotLogins: string[];
+}
+
+export interface ReviewPolicyPrFacts {
+  number: number;
+  headSha: string;
+  currentHeadObservedAt: string | null;
+  latestReviewedCommitSha: string | null;
+  providerSuccessHeadSha: string | null;
+  externalReviewHeadSha: string | null;
+  currentHeadCiGreenAt: string | null;
+}
+
+export interface ReviewPolicyProcessedThreadEvidence {
+  threadId: string;
+  latestCommentFingerprint: string | null;
+  processedOnCurrentHead: boolean;
+  processedOnPriorHead: boolean;
+  processedThreadKeys: string[];
+  processedThreadFingerprintKeys: string[];
+}
+
+export interface ReviewPolicyThreadCommentSnapshot {
+  id: string;
+  body: string;
+  createdAt: string;
+  url: string;
+  authorLogin: string | null;
+  normalizedAuthorLogin: string | null;
+  authorTypeName: string | null;
+}
+
+export interface ReviewPolicyThreadInput {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string | null;
+  line: number | null;
+  comments: ReviewPolicyThreadCommentSnapshot[];
+  latestComment: ReviewPolicyThreadCommentSnapshot | null;
+  latestCodexConnectorSeverity: CodexConnectorPSeverity | null;
+  latestCodexConnectorCommentFingerprint: string | null;
+  findingKind: ReviewPolicyFindingKind;
+  headRelation: ReviewPolicyHeadRelation;
+  processedEvidence: ReviewPolicyProcessedThreadEvidence;
+  vocabulary: ReviewPolicyThreadVocabulary[];
+}
+
+export interface ReviewPolicyInput {
+  providerIdentity: ReviewPolicyProviderIdentity;
+  pr: ReviewPolicyPrFacts;
+  threads: ReviewPolicyThreadInput[];
+}
 
 function latestCodexConnectorReviewCommentNode(thread: ReviewThread): ReviewThread["comments"]["nodes"][number] | null {
   for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
@@ -99,6 +183,197 @@ function validPolicyTimestamp(value: string | null | undefined): string | null {
   }
 
   return value;
+}
+
+function latestCommentFingerprint(thread: Pick<ReviewThread, "comments">): string | null {
+  const comment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
+  return comment?.id || comment?.createdAt || null;
+}
+
+function processedThreadKey(threadId: string, headSha: string): string {
+  return `${threadId}@${headSha}`;
+}
+
+function processedThreadFingerprintKey(threadId: string, headSha: string, latestCommentFingerprintValue: string): string {
+  return `${processedThreadKey(threadId, headSha)}#${latestCommentFingerprintValue}`;
+}
+
+function processedOnPriorHead(args: {
+  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: Pick<ReviewThread, "id" | "comments">;
+  latestCommentFingerprint: string | null;
+}): boolean {
+  if (!args.latestCommentFingerprint) {
+    return false;
+  }
+
+  const processedKeys = new Set(args.record.processed_review_thread_ids ?? []);
+  const fingerprintPrefix = `${args.thread.id}@`;
+  const fingerprintSuffix = `#${args.latestCommentFingerprint}`;
+  return (args.record.processed_review_thread_fingerprints ?? []).some((key) => {
+    if (!key.startsWith(fingerprintPrefix) || !key.endsWith(fingerprintSuffix)) {
+      return false;
+    }
+
+    const headSha = key.slice(fingerprintPrefix.length, key.length - fingerprintSuffix.length);
+    return Boolean(headSha && headSha !== args.pr.headRefOid && processedKeys.has(`${args.thread.id}@${headSha}`));
+  });
+}
+
+function reviewCommentSnapshot(comment: ReviewThreadComment): ReviewPolicyThreadCommentSnapshot {
+  const authorLogin = comment.author?.login ?? null;
+  return {
+    id: comment.id,
+    body: comment.body,
+    createdAt: comment.createdAt,
+    url: comment.url,
+    authorLogin,
+    normalizedAuthorLogin: normalizeReviewProviderLogin(authorLogin),
+    authorTypeName: comment.author?.typeName ?? null,
+  };
+}
+
+function reviewPolicyFindingKind(thread: ReviewThread): ReviewPolicyFindingKind {
+  const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
+  if (!latestCodexConnectorReview || thread.isResolved || thread.isOutdated) {
+    return "none";
+  }
+
+  if (
+    latestCodexConnectorReview.severity === "P0" ||
+    latestCodexConnectorReview.severity === "P1" ||
+    latestCodexConnectorReview.severity === "P2"
+  ) {
+    return "must_fix";
+  }
+
+  return hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)
+    ? "escalated_p3"
+    : "softened_p3_advisory";
+}
+
+function reviewPolicyThreadVocabulary(args: {
+  isConfiguredBotThread: boolean;
+  isManualThread: boolean;
+  findingKind: ReviewPolicyFindingKind;
+  headRelation: ReviewPolicyHeadRelation;
+}): ReviewPolicyThreadVocabulary[] {
+  const vocabulary: ReviewPolicyThreadVocabulary[] = [];
+  if (args.headRelation === "current_head") {
+    vocabulary.push("current_head_thread");
+  } else if (args.headRelation === "stale_commit") {
+    vocabulary.push("stale_commit_thread");
+  }
+  if (args.isManualThread) {
+    vocabulary.push("manual_thread");
+  }
+  if (args.isConfiguredBotThread) {
+    vocabulary.push("configured_bot_thread");
+  }
+  if (args.findingKind === "must_fix") {
+    vocabulary.push("must_fix_finding");
+  } else if (args.findingKind === "softened_p3_advisory") {
+    vocabulary.push("softened_p3_advisory");
+  } else if (args.findingKind === "escalated_p3") {
+    vocabulary.push("escalated_p3");
+  }
+  return vocabulary;
+}
+
+export function buildReviewPolicyInput(args: {
+  config: Pick<SupervisorConfig, "configuredReviewProviders" | "reviewBotLogins">;
+  pr: Pick<
+    GitHubPullRequest,
+    | "number"
+    | "headRefOid"
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotLatestReviewedCommitSha"
+    | "currentHeadCiGreenAt"
+  >;
+  record: Pick<
+    IssueRunRecord,
+    "provider_success_head_sha" | "external_review_head_sha" | "processed_review_thread_ids" | "processed_review_thread_fingerprints"
+  >;
+  reviewThreads: ReviewThread[];
+}): ReviewPolicyInput {
+  const configuredBotLogins = configuredReviewBotLogins(args.config);
+  const configuredBotLoginSet = new Set(configuredBotLogins);
+  const staleCommitThreadIds = new Set(
+    codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads).map((thread) => thread.id),
+  );
+  const currentHeadObservedAt = validPolicyTimestamp(args.pr.configuredBotCurrentHeadObservedAt);
+
+  return {
+    providerIdentity: {
+      configuredProviderKinds: [...configuredReviewProviderKinds(args.config)],
+      configuredBotLogins: [...configuredBotLogins],
+    },
+    pr: {
+      number: args.pr.number,
+      headSha: args.pr.headRefOid,
+      currentHeadObservedAt,
+      latestReviewedCommitSha: normalizeCommitShaForComparison(args.pr.configuredBotLatestReviewedCommitSha),
+      providerSuccessHeadSha: normalizeCommitShaForComparison(args.record.provider_success_head_sha),
+      externalReviewHeadSha: normalizeCommitShaForComparison(args.record.external_review_head_sha),
+      currentHeadCiGreenAt: validPolicyTimestamp(args.pr.currentHeadCiGreenAt),
+    },
+    threads: args.reviewThreads.map((thread) => {
+      const comments = thread.comments.nodes.map(reviewCommentSnapshot);
+      const latestComment = comments[comments.length - 1] ?? null;
+      const isConfiguredBotThread = comments.some((comment) =>
+        Boolean(comment.normalizedAuthorLogin && configuredBotLoginSet.has(comment.normalizedAuthorLogin)),
+      );
+      const isManualThread = !thread.isResolved && !thread.isOutdated && comments.length > 0 && !isConfiguredBotThread;
+      const latestCommentFingerprintValue = latestCommentFingerprint(thread);
+      const processedOnCurrentHeadValue = Boolean(
+        latestCommentFingerprintValue &&
+          (args.record.processed_review_thread_fingerprints ?? []).includes(
+            processedThreadFingerprintKey(thread.id, args.pr.headRefOid, latestCommentFingerprintValue),
+          ),
+      );
+      const processedOnPriorHeadValue = processedOnPriorHead({
+        record: args.record,
+        pr: args.pr,
+        thread,
+        latestCommentFingerprint: latestCommentFingerprintValue,
+      });
+      const headRelation: ReviewPolicyHeadRelation = staleCommitThreadIds.has(thread.id)
+        ? "stale_commit"
+        : processedOnCurrentHeadValue || Boolean(currentHeadObservedAt)
+          ? "current_head"
+          : "unknown";
+      const findingKind = reviewPolicyFindingKind(thread);
+
+      return {
+        id: thread.id,
+        isResolved: thread.isResolved,
+        isOutdated: thread.isOutdated,
+        path: thread.path,
+        line: thread.line,
+        comments,
+        latestComment,
+        latestCodexConnectorSeverity: latestCodexConnectorPSeverity(thread),
+        latestCodexConnectorCommentFingerprint: latestCodexConnectorReviewCommentFingerprint(thread),
+        findingKind,
+        headRelation,
+        processedEvidence: {
+          threadId: thread.id,
+          latestCommentFingerprint: latestCommentFingerprintValue,
+          processedOnCurrentHead: processedOnCurrentHeadValue,
+          processedOnPriorHead: processedOnPriorHeadValue,
+          processedThreadKeys: [...(args.record.processed_review_thread_ids ?? [])],
+          processedThreadFingerprintKeys: [...(args.record.processed_review_thread_fingerprints ?? [])],
+        },
+        vocabulary: reviewPolicyThreadVocabulary({
+          isConfiguredBotThread,
+          isManualThread,
+          findingKind,
+          headRelation,
+        }),
+      };
+    }),
+  };
 }
 
 export function hasCodexConnectorPrSuccessCurrentHeadObservation(


### PR DESCRIPTION
## Summary
- add a read-only review policy input model for provider identity, PR facts, normalized review threads, and processed-thread evidence
- add typed vocabulary for current-head, stale-commit, manual, configured-bot, softened P3, escalated P3, and must-fix review policy states
- cover the new snapshot model with focused Codex Connector policy tests

## Why
Phase 2 needs Connector review decisions to move toward pure policy functions before any action-taking PR lifecycle changes. This gives later issues a typed, mutation-free input surface without changing current supervisor behavior.

## Verification
- `npx tsx --test src/codex-connector-review-policy.test.ts`
- `npx tsx --test src/codex-connector-review-policy.test.ts src/codex-connector-review-request-decision.test.ts src/supervisor/stale-review-bot-remediation.test.ts`
- `npm run build`
- `git diff --check`

Closes #2289
