### PR TITLE
[codex] Lock Codex review boundary outcomes

### DIFF
--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -376,6 +376,10 @@ test("review policy input exposes typed boundary outcomes for current-head and m
     id: "thread-metadata-only",
     body: "P2: Older finding that lacks current-head processing evidence.",
   });
+  const metadataOnlyP3RiskThread = codexThread({
+    id: "thread-metadata-only-p3-risk",
+    body: "P3: This cleanup can cause a regression before the current-head review is observed.",
+  });
   const manualThread = createReviewThread({
     id: "thread-manual-current",
     comments: {
@@ -418,7 +422,14 @@ test("review policy input exposes typed boundary outcomes for current-head and m
         "thread-p3-soft-current@head-new#comment-1",
       ],
     },
-    reviewThreads: [p1Thread, p3RiskThread, p3NitpickThread, metadataOnlyThread, manualThread],
+    reviewThreads: [
+      p1Thread,
+      p3RiskThread,
+      p3NitpickThread,
+      metadataOnlyThread,
+      metadataOnlyP3RiskThread,
+      manualThread,
+    ],
   });
 
   assert.deepEqual(
@@ -428,6 +439,7 @@ test("review policy input exposes typed boundary outcomes for current-head and m
       ["thread-p3-risk-current", "escalated_p3"],
       ["thread-p3-soft-current", "softened_p3_advisory"],
       ["thread-metadata-only", "metadata_only_unresolved"],
+      ["thread-metadata-only-p3-risk", "metadata_only_unresolved"],
       ["thread-manual-current", "manual_thread"],
     ],
   );

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -478,6 +478,11 @@ test("Codex Connector policy diagnostics and convergence stay focused in the pol
   };
   assert.equal(buildCodexConnectorPolicyBlockDiagnostic(config, [p1Thread], stalePr), null);
   assert.equal(buildCodexConnectorP2P3PolicyDiagnostic(config, [p1Thread], stalePr), null);
+  const staleP3NitpickThread = codexThread({
+    id: "thread-stale-p3-nitpick",
+    body: "P3: Nitpick: prefer a shorter helper name for readability.",
+  });
+  assert.equal(buildCodexConnectorP2P3PolicyDiagnostic(config, [p1Thread, staleP3NitpickThread], stalePr), null);
   assert.equal(
     evaluateCodexConnectorConvergencePolicy(config, { configuredBotCurrentHeadObservedAt: "2026-03-11T00:04:00Z" }, [
       p0Thread,

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -145,6 +145,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   const p2Input = input.threads.find((thread) => thread.id === "thread-p2");
   assert.equal(p2Input?.headRelation, "stale_commit");
   assert.equal(p2Input?.findingKind, "must_fix");
+  assert.equal(p2Input?.boundaryOutcome, "stale_commit_thread");
   assert.equal(p2Input?.processedEvidence.processedOnCurrentHead, false);
   assert.equal(p2Input?.processedEvidence.processedOnPriorHead, true);
   assert.deepEqual(p2Input?.vocabulary, ["stale_commit_thread", "configured_bot_thread", "must_fix_finding"]);
@@ -152,6 +153,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   const p3Input = input.threads.find((thread) => thread.id === "thread-p3-softened");
   assert.equal(p3Input?.headRelation, "current_head");
   assert.equal(p3Input?.findingKind, "softened_p3_advisory");
+  assert.equal(p3Input?.boundaryOutcome, "softened_p3_advisory");
   assert.equal(p3Input?.processedEvidence.processedOnCurrentHead, true);
   assert.deepEqual(p3Input?.vocabulary, [
     "current_head_thread",
@@ -161,6 +163,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
 
   const p3RiskInput = input.threads.find((thread) => thread.id === "thread-p3-risk");
   assert.equal(p3RiskInput?.findingKind, "must_fix");
+  assert.equal(p3RiskInput?.boundaryOutcome, "stale_commit_thread");
   assert.deepEqual(p3RiskInput?.vocabulary, [
     "stale_commit_thread",
     "configured_bot_thread",
@@ -170,6 +173,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
 
   const manualInput = input.threads.find((thread) => thread.id === "thread-manual");
   assert.equal(manualInput?.findingKind, "none");
+  assert.equal(manualInput?.boundaryOutcome, "manual_thread");
   assert.deepEqual(manualInput?.vocabulary, ["manual_thread"]);
 
   const idOnlyInput = buildReviewPolicyInput({
@@ -201,6 +205,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   }).threads[0];
   assert.equal(refreshedCommentInput?.processedEvidence.processedOnCurrentHead, false);
   assert.equal(refreshedCommentInput?.headRelation, "unknown");
+  assert.equal(refreshedCommentInput?.boundaryOutcome, "softened_p3_advisory");
 
   const priorIdOnlyInput = buildReviewPolicyInput({
     config,
@@ -248,6 +253,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   }).threads[0];
   assert.equal(outdatedInput?.headRelation, "unknown");
   assert.equal(outdatedInput?.findingKind, "none");
+  assert.equal(outdatedInput?.boundaryOutcome, "configured_bot_thread");
   assert.deepEqual(outdatedInput?.vocabulary, ["configured_bot_thread"]);
 
   const outdatedManualInput = buildReviewPolicyInput({
@@ -263,6 +269,7 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
     reviewThreads: [{ ...manualThread, id: "thread-manual-outdated", isOutdated: true }],
   }).threads[0];
   assert.deepEqual(outdatedManualInput?.vocabulary, ["manual_thread"]);
+  assert.equal(outdatedManualInput?.boundaryOutcome, "manual_thread");
 
   const codexReplyThread = createReviewThread({
     id: "thread-codex-replied",
@@ -351,6 +358,81 @@ test("review policy input snapshots provider, PR, thread vocabulary, and process
   assert.equal(p2Input?.comments[0]?.body, "P2: Preserve failed restore cleanup as a blocking verification failure.");
 });
 
+test("review policy input exposes typed boundary outcomes for current-head and metadata residue cases", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const p1Thread = codexThread({
+    id: "thread-p1-current",
+    body: "P1: Keep current-head source fixes blocking until repaired.",
+  });
+  const p3RiskThread = codexThread({
+    id: "thread-p3-risk-current",
+    body: "P3: This cleanup can cause a regression in the restore failure path.",
+  });
+  const p3NitpickThread = codexThread({
+    id: "thread-p3-soft-current",
+    body: "P3: Nitpick: prefer a shorter helper name for readability.",
+  });
+  const metadataOnlyThread = codexThread({
+    id: "thread-metadata-only",
+    body: "P2: Older finding that lacks current-head processing evidence.",
+  });
+  const manualThread = createReviewThread({
+    id: "thread-manual-current",
+    comments: {
+      nodes: [
+        {
+          id: "comment-human-current",
+          body: "Manual review note.",
+          createdAt: "2026-03-11T00:02:00Z",
+          url: "https://example.test/pr/44#discussion_human_current",
+          author: {
+            login: "maintainer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const pr = {
+    number: 44,
+    headRefOid: "head-new",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: null,
+    currentHeadCiGreenAt: "2026-03-11T00:03:00Z",
+  };
+  const input = buildReviewPolicyInput({
+    config,
+    pr,
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: "head-new",
+      processed_review_thread_ids: [
+        "thread-p1-current@head-new",
+        "thread-p3-risk-current@head-new",
+        "thread-p3-soft-current@head-new",
+      ],
+      processed_review_thread_fingerprints: [
+        "thread-p1-current@head-new#comment-1",
+        "thread-p3-risk-current@head-new#comment-1",
+        "thread-p3-soft-current@head-new#comment-1",
+      ],
+    },
+    reviewThreads: [p1Thread, p3RiskThread, p3NitpickThread, metadataOnlyThread, manualThread],
+  });
+
+  assert.deepEqual(
+    input.threads.map((thread) => [thread.id, thread.boundaryOutcome]),
+    [
+      ["thread-p1-current", "must_fix_current_head"],
+      ["thread-p3-risk-current", "escalated_p3"],
+      ["thread-p3-soft-current", "softened_p3_advisory"],
+      ["thread-metadata-only", "metadata_only_unresolved"],
+      ["thread-manual-current", "manual_thread"],
+    ],
+  );
+});
+
 test("Codex Connector policy diagnostics and convergence stay focused in the policy module", () => {
   const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
   const p1Thread = codexThread({
@@ -374,6 +456,16 @@ test("Codex Connector policy diagnostics and convergence stay focused in the pol
     threadUrl: "https://example.test/pr/44#discussion_r1",
     nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
   });
+  const stalePr: Pick<
+    GitHubPullRequest,
+    "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha"
+  > = {
+    headRefOid: "head-new",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotLatestReviewedCommitSha: "head-old",
+  };
+  assert.equal(buildCodexConnectorPolicyBlockDiagnostic(config, [p1Thread], stalePr), null);
+  assert.equal(buildCodexConnectorP2P3PolicyDiagnostic(config, [p1Thread], stalePr), null);
   assert.equal(
     evaluateCodexConnectorConvergencePolicy(config, { configuredBotCurrentHeadObservedAt: "2026-03-11T00:04:00Z" }, [
       p0Thread,

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -721,6 +721,15 @@ function formatDiagnosticToken(value: string): string {
   return value.replace(/\s+/g, "_");
 }
 
+function hasPendingCurrentHeadReviewSignal(
+  pr: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+): boolean {
+  return Boolean(
+    !validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt) &&
+      commitShasDifferForComparison(pr.configuredBotLatestReviewedCommitSha, pr.headRefOid),
+  );
+}
+
 function buildDiagnosticReviewPolicyInput(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
@@ -848,6 +857,9 @@ export function buildCodexConnectorP2P3PolicyDiagnostic(
   pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
 ): CodexConnectorP2P3PolicyDiagnostic | null {
   if (!configuredReviewProviderKinds(config).includes("codex")) {
+    return null;
+  }
+  if (pr && hasPendingCurrentHeadReviewSignal(pr)) {
     return null;
   }
   const policyInput = buildDiagnosticReviewPolicyInput(config, reviewThreads, pr);

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -31,6 +31,16 @@ export type ReviewPolicyFindingKind = "none" | "must_fix" | "softened_p3_advisor
 
 export type ReviewPolicyHeadRelation = "current_head" | "stale_commit" | "unknown";
 
+export type ReviewPolicyBoundaryOutcome =
+  | "must_fix_current_head"
+  | "metadata_only_unresolved"
+  | "softened_p3_advisory"
+  | "escalated_p3"
+  | "manual_thread"
+  | "configured_bot_thread"
+  | "stale_commit_thread"
+  | "none";
+
 export interface ReviewPolicyProviderIdentity {
   configuredProviderKinds: ConfiguredReviewProviderKind[];
   configuredBotLogins: string[];
@@ -77,6 +87,7 @@ export interface ReviewPolicyThreadInput {
   latestCodexConnectorCommentFingerprint: string | null;
   findingKind: ReviewPolicyFindingKind;
   headRelation: ReviewPolicyHeadRelation;
+  boundaryOutcome: ReviewPolicyBoundaryOutcome;
   processedEvidence: ReviewPolicyProcessedThreadEvidence;
   vocabulary: ReviewPolicyThreadVocabulary[];
 }
@@ -334,6 +345,34 @@ function reviewPolicyThreadVocabulary(args: {
   return vocabulary;
 }
 
+function reviewPolicyBoundaryOutcome(args: {
+  isConfiguredBotThread: boolean;
+  isManualThread: boolean;
+  findingKind: ReviewPolicyFindingKind;
+  headRelation: ReviewPolicyHeadRelation;
+  isEscalatedP3: boolean;
+}): ReviewPolicyBoundaryOutcome {
+  if (args.headRelation === "stale_commit") {
+    return "stale_commit_thread";
+  }
+  if (args.isManualThread) {
+    return "manual_thread";
+  }
+  if (args.findingKind === "softened_p3_advisory") {
+    return "softened_p3_advisory";
+  }
+  if (args.findingKind === "must_fix") {
+    if (args.isEscalatedP3) {
+      return "escalated_p3";
+    }
+    return args.headRelation === "current_head" ? "must_fix_current_head" : "metadata_only_unresolved";
+  }
+  if (args.isConfiguredBotThread) {
+    return "configured_bot_thread";
+  }
+  return "none";
+}
+
 export function buildReviewPolicyInput(args: {
   config: Pick<SupervisorConfig, "configuredReviewProviders" | "reviewBotLogins">;
   pr: Pick<
@@ -415,6 +454,13 @@ export function buildReviewPolicyInput(args: {
           latestCodexConnectorReview?.severity === "P3" &&
           hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body),
       );
+      const boundaryOutcome = reviewPolicyBoundaryOutcome({
+        isConfiguredBotThread,
+        isManualThread,
+        findingKind,
+        headRelation,
+        isEscalatedP3,
+      });
 
       return {
         id: thread.id,
@@ -428,6 +474,7 @@ export function buildReviewPolicyInput(args: {
         latestCodexConnectorCommentFingerprint: latestCodexConnectorReviewCommentFingerprint(thread),
         findingKind,
         headRelation,
+        boundaryOutcome,
         processedEvidence: {
           threadId: thread.id,
           latestCommentFingerprint: latestCommentFingerprintValue,
@@ -674,6 +721,35 @@ function formatDiagnosticToken(value: string): string {
   return value.replace(/\s+/g, "_");
 }
 
+function buildDiagnosticReviewPolicyInput(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+): ReviewPolicyInput {
+  const currentHeadSha = pr?.headRefOid ?? "diagnostic-current-head";
+  const hasStaleCommitResidue = pr ? codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0 : false;
+  return buildReviewPolicyInput({
+    config,
+    pr: {
+      number: 0,
+      headRefOid: currentHeadSha,
+      configuredBotCurrentHeadObservedAt: hasStaleCommitResidue
+        ? pr?.configuredBotCurrentHeadObservedAt ?? null
+        : pr?.configuredBotCurrentHeadObservedAt ?? "1970-01-01T00:00:00.000Z",
+      configuredBotLatestReviewedCommitSha: pr?.configuredBotLatestReviewedCommitSha ?? null,
+      currentHeadCiGreenAt: null,
+    },
+    record: {
+      provider_success_head_sha: null,
+      external_review_head_sha: null,
+      last_head_sha: currentHeadSha,
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: [],
+    },
+    reviewThreads,
+  });
+}
+
 export function evaluateCodexConnectorConvergencePolicy(
   config: SupervisorConfig,
   pr: Pick<GitHubPullRequest, "configuredBotCurrentHeadObservedAt">,
@@ -741,11 +817,13 @@ export function buildCodexConnectorPolicyBlockDiagnostic(
   if (!configuredReviewProviderKinds(config).includes("codex")) {
     return null;
   }
-  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
-    return null;
-  }
-
-  const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
+  const policyInput = buildDiagnosticReviewPolicyInput(config, reviewThreads, pr);
+  const currentHeadMustFixThreadIds = new Set(
+    policyInput.threads
+      .filter((thread) => thread.boundaryOutcome === "must_fix_current_head" || thread.boundaryOutcome === "escalated_p3")
+      .map((thread) => thread.id),
+  );
+  const mustFixThreads = reviewThreads.filter((thread) => currentHeadMustFixThreadIds.has(thread.id));
   if (mustFixThreads.length === 0) {
     return null;
   }
@@ -772,9 +850,7 @@ export function buildCodexConnectorP2P3PolicyDiagnostic(
   if (!configuredReviewProviderKinds(config).includes("codex")) {
     return null;
   }
-  if (pr && codexConnectorStaleReviewCommitThreads(pr, reviewThreads).length > 0) {
-    return null;
-  }
+  const policyInput = buildDiagnosticReviewPolicyInput(config, reviewThreads, pr);
 
   const diagnostic: CodexConnectorP2P3PolicyDiagnostic = {
     p2Actionable: 0,
@@ -782,20 +858,13 @@ export function buildCodexConnectorP2P3PolicyDiagnostic(
     p3Escalated: 0,
   };
 
-  for (const thread of reviewThreads) {
-    if (thread.isResolved || thread.isOutdated) {
-      continue;
-    }
-
-    const latestCodexConnectorReview = latestCodexConnectorReviewComment(thread);
-    if (latestCodexConnectorReview?.severity === "P2") {
+  for (const thread of policyInput.threads) {
+    if (thread.boundaryOutcome === "must_fix_current_head" && thread.latestCodexConnectorSeverity === "P2") {
       diagnostic.p2Actionable += 1;
-    } else if (latestCodexConnectorReview?.severity === "P3") {
-      if (hasCodexConnectorStrongRiskWording(latestCodexConnectorReview.body)) {
-        diagnostic.p3Escalated += 1;
-      } else {
-        diagnostic.p3Softened += 1;
-      }
+    } else if (thread.boundaryOutcome === "escalated_p3") {
+      diagnostic.p3Escalated += 1;
+    } else if (thread.boundaryOutcome === "softened_p3_advisory") {
+      diagnostic.p3Softened += 1;
     }
   }
 

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -362,10 +362,10 @@ function reviewPolicyBoundaryOutcome(args: {
     return "softened_p3_advisory";
   }
   if (args.findingKind === "must_fix") {
-    if (args.isEscalatedP3) {
-      return "escalated_p3";
+    if (args.headRelation !== "current_head") {
+      return "metadata_only_unresolved";
     }
-    return args.headRelation === "current_head" ? "must_fix_current_head" : "metadata_only_unresolved";
+    return args.isEscalatedP3 ? "escalated_p3" : "must_fix_current_head";
   }
   if (args.isConfiguredBotThread) {
     return "configured_bot_thread";


### PR DESCRIPTION
## Summary
- Add typed `ReviewPolicyBoundaryOutcome` values to the Codex Connector review policy input model.
- Route policy block and P2/P3 diagnostics through those typed boundary outcomes so status diagnostics do not re-derive the boundary from raw review text.
- Add focused tests for current-head must-fix, stale commit residue, metadata-only unresolved residue, softened P3 advisory, escalated P3, manual thread, and configured-bot outcomes.

## Verification
- `npx tsx --test src/codex-connector-review-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts`
- `npx tsx --test src/review-thread-reporting.test.ts`
- `git diff --check`
- `npm run build`

Closes #2292