### PR TITLE
[codex] Add v2 read-only decision model

### DIFF
--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -56,6 +56,7 @@ function state(overrides: Partial<PrLifecycleFactInventory> = {}): NormalizedPrL
 function reviewPolicyInput(
   outcomes: Array<ReviewPolicyInput["threads"][number]["boundaryOutcome"]>,
   overrides: Partial<ReviewPolicyInput["pr"]> = {},
+  threadOverrides: Partial<ReviewPolicyInput["threads"][number]> = {},
 ): ReviewPolicyInput {
   return {
     providerIdentity: {
@@ -94,6 +95,7 @@ function reviewPolicyInput(
         processedThreadFingerprintKeys: [],
       },
       vocabulary: [],
+      ...threadOverrides,
     })),
   };
 }
@@ -260,4 +262,71 @@ test("evaluateDecisionKernelV2ReadOnly treats configured-bot residue as metadata
   assert.equal(decision.action, "ask_operator");
   assert.deepEqual(decision.reasons, ["metadata_only_review_residue"]);
   assert.deepEqual(decision.requiredEvidence, ["resolved_metadata_residue"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly ignores resolved manual policy threads", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state(),
+    reviewPolicyInput: reviewPolicyInput(["manual_thread"], {}, { isResolved: true }),
+  });
+
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly requires local head evidence before repair actions", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state({
+      localState: {
+        trackedHeadSha: null,
+        workspaceHeadSha: null,
+        lastObservedPrHeadSha: "head-current",
+      },
+    }),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"]),
+  });
+
+  assert.equal(decision.action, "wait");
+  assert.deepEqual(decision.reasons, ["fresh_local_state_required"]);
+  assert.deepEqual(decision.requiredEvidence, ["fresh_local_state"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly repairs failing checks before waiting for stale review", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      reviewThreads: {
+        unresolvedManualThreadCount: 0,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+        stalePreviousHeadConfiguredBotThreadCount: 1,
+        metadataOnlyUnresolvedThreadCount: 0,
+      },
+      checks: {
+        passingCount: 1,
+        pendingCount: 0,
+        failingCount: 1,
+        unknownCount: 0,
+      },
+    }),
+  });
+
+  assert.equal(decision.action, "run_codex");
+  assert.deepEqual(decision.reasons, ["checks_failing"]);
+  assert.deepEqual(decision.requiredEvidence, ["green_checks"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly does not repair softened P3 advisory policy threads", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state({
+      reviewThreads: {
+        unresolvedManualThreadCount: 0,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 1,
+        stalePreviousHeadConfiguredBotThreadCount: 0,
+        metadataOnlyUnresolvedThreadCount: 0,
+      },
+    }),
+    reviewPolicyInput: reviewPolicyInput(["softened_p3_advisory"]),
+  });
+
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
 });

--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -173,6 +173,29 @@ test("evaluateDecisionKernelV2ReadOnly returns no_action for merge-ready diagnos
   assert.match(decision.summary, /diagnostic-only/);
 });
 
+test("evaluateDecisionKernelV2ReadOnly treats no-review-required PRs as merge-ready", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+      configuredCurrentHeadReviewRequired: false,
+    }),
+  });
+
+  assert.equal(decision.normalizedState.reviewPosture, "no_unresolved_review");
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.deepEqual(decision.requiredEvidence, []);
+});
+
 test("evaluateDecisionKernelV2ReadOnly snapshots normalized state", () => {
   const normalizedState = state();
   const decision = evaluateDecisionKernelV2ReadOnly({ normalizedState });
@@ -242,6 +265,65 @@ test("evaluateDecisionKernelV2ReadOnly waits for checks before requesting review
   assert.deepEqual(decision.requiredEvidence, ["green_checks"]);
 });
 
+test("evaluateDecisionKernelV2ReadOnly requests review when no CI is configured", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+      checks: {
+        passingCount: 0,
+        pendingCount: 0,
+        failingCount: 0,
+        unknownCount: 0,
+      },
+    }),
+    checkPolicyInput: {
+      noChecksAndNoLocalCi: true,
+    },
+  });
+
+  assert.equal(decision.normalizedState.checkPosture, "unknown");
+  assert.equal(decision.action, "request_review");
+  assert.deepEqual(decision.reasons, ["missing_current_head_review"]);
+  assert.deepEqual(decision.requiredEvidence, ["current_head_review"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly waits for unknown checks without no-CI evidence", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+      checks: {
+        passingCount: 0,
+        pendingCount: 0,
+        failingCount: 0,
+        unknownCount: 0,
+      },
+    }),
+  });
+
+  assert.equal(decision.normalizedState.checkPosture, "unknown");
+  assert.equal(decision.action, "wait");
+  assert.deepEqual(decision.reasons, ["checks_unknown"]);
+  assert.deepEqual(decision.requiredEvidence, ["green_checks"]);
+});
+
 test("evaluateDecisionKernelV2ReadOnly fails closed on mismatched review policy input", () => {
   const decision = evaluateDecisionKernelV2ReadOnly({
     normalizedState: state(),
@@ -262,6 +344,29 @@ test("evaluateDecisionKernelV2ReadOnly treats configured-bot residue as metadata
   assert.equal(decision.action, "ask_operator");
   assert.deepEqual(decision.reasons, ["metadata_only_review_residue"]);
   assert.deepEqual(decision.requiredEvidence, ["resolved_metadata_residue"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly requests current-head review before metadata cleanup", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+    }),
+    reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+  });
+
+  assert.equal(decision.normalizedState.reviewPosture, "missing_current_head_review");
+  assert.equal(decision.action, "request_review");
+  assert.deepEqual(decision.reasons, ["missing_current_head_review"]);
+  assert.deepEqual(decision.requiredEvidence, ["current_head_review"]);
 });
 
 test("evaluateDecisionKernelV2ReadOnly ignores resolved manual policy threads", () => {

--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ReviewPolicyInput } from "./codex-connector-review-policy";
+import {
+  DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION,
+  evaluateDecisionKernelV2ReadOnly,
+  evaluateDecisionKernelV2ReadOnlyFromFacts,
+  type DecisionKernelV2Action,
+} from "./decision-kernel-v2";
+import {
+  normalizePrLifecycleFacts,
+  type NormalizedPrLifecycleState,
+  type PrLifecycleFactInventory,
+} from "./decision-kernel/pr-lifecycle-state";
+
+function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecycleFactInventory {
+  return {
+    source: "fixture",
+    observedAt: "2026-06-08T00:00:00.000Z",
+    pullRequest: {
+      number: 2300,
+      headSha: "head-current",
+      state: "OPEN",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      currentHeadReviewObservedAt: "2026-06-08T00:01:00.000Z",
+      currentHeadReviewHeadSha: "head-current",
+    },
+    reviewThreads: {
+      unresolvedManualThreadCount: 0,
+      unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+      stalePreviousHeadConfiguredBotThreadCount: 0,
+      metadataOnlyUnresolvedThreadCount: 0,
+    },
+    checks: {
+      passingCount: 3,
+      pendingCount: 0,
+      failingCount: 0,
+      unknownCount: 0,
+    },
+    localState: {
+      trackedHeadSha: "head-current",
+      workspaceHeadSha: "head-current",
+      lastObservedPrHeadSha: "head-current",
+    },
+    configuredCurrentHeadReviewRequired: true,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<PrLifecycleFactInventory> = {}): NormalizedPrLifecycleState {
+  return normalizePrLifecycleFacts(inventory(overrides));
+}
+
+function reviewPolicyInput(outcomes: Array<ReviewPolicyInput["threads"][number]["boundaryOutcome"]>): ReviewPolicyInput {
+  return {
+    providerIdentity: {
+      configuredProviderKinds: ["codex"],
+      configuredBotLogins: ["chatgpt-codex-connector"],
+    },
+    pr: {
+      number: 2300,
+      headSha: "head-current",
+      currentHeadObservedAt: "2026-06-08T00:01:00.000Z",
+      latestReviewedCommitSha: "head-current",
+      providerSuccessHeadSha: null,
+      externalReviewHeadSha: null,
+      currentHeadCiGreenAt: "2026-06-08T00:02:00.000Z",
+    },
+    threads: outcomes.map((boundaryOutcome, index) => ({
+      id: `thread-${index}`,
+      isResolved: false,
+      isOutdated: false,
+      path: "src/example.ts",
+      line: 10 + index,
+      comments: [],
+      latestComment: null,
+      latestCodexConnectorSeverity: null,
+      latestCodexConnectorCommentFingerprint: null,
+      findingKind: boundaryOutcome === "softened_p3_advisory" ? "softened_p3_advisory" : "none",
+      headRelation: boundaryOutcome === "stale_commit_thread" ? "stale_commit" : "current_head",
+      boundaryOutcome,
+      processedEvidence: {
+        threadId: `thread-${index}`,
+        latestCommentFingerprint: null,
+        processedOnCurrentHead: true,
+        processedOnPriorHead: false,
+        processedThreadKeys: [],
+        processedThreadFingerprintKeys: [],
+      },
+      vocabulary: [],
+    })),
+  };
+}
+
+test("Decision Kernel v2 action vocabulary is typed", () => {
+  const actions: DecisionKernelV2Action[] = ["wait", "request_review", "run_codex", "ask_operator", "no_action"];
+
+  assert.deepEqual(actions, ["wait", "request_review", "run_codex", "ask_operator", "no_action"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly returns wait for stale local state", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-new",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: "2026-06-08T00:01:00.000Z",
+        currentHeadReviewHeadSha: "head-new",
+      },
+      localState: {
+        trackedHeadSha: "head-old",
+        workspaceHeadSha: "head-old",
+        lastObservedPrHeadSha: "head-old",
+      },
+    }),
+  });
+
+  assert.equal(decision.schemaVersion, DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION);
+  assert.equal(decision.action, "wait");
+  assert.deepEqual(decision.reasons, ["stale_local_state"]);
+  assert.deepEqual(decision.requiredEvidence, ["current_head", "fresh_local_state"]);
+  assert.equal(decision.safety.mode, "diagnostic_only");
+  assert.equal(decision.safety.authoritative, false);
+  assert.equal(decision.safety.mutationAllowed, false);
+});
+
+test("evaluateDecisionKernelV2ReadOnly returns run_codex for current-head must-fix review policy", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state(),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"]),
+  });
+
+  assert.equal(decision.action, "run_codex");
+  assert.deepEqual(decision.reasons, ["current_head_must_fix_review"]);
+  assert.deepEqual(decision.requiredEvidence, ["current_head_review", "resolved_manual_threads"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly returns ask_operator for manual review threads", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      reviewThreads: {
+        unresolvedManualThreadCount: 1,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+        stalePreviousHeadConfiguredBotThreadCount: 0,
+        metadataOnlyUnresolvedThreadCount: 0,
+      },
+    }),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["manual_review_thread"]);
+  assert.deepEqual(decision.requiredEvidence, ["resolved_manual_threads"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly returns no_action for merge-ready diagnostic-only state", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({ inventory: inventory() });
+
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.deepEqual(decision.requiredEvidence, []);
+  assert.match(decision.summary, /diagnostic-only/);
+});
+
+test("evaluateDecisionKernelV2ReadOnly snapshots normalized state", () => {
+  const normalizedState = state();
+  const decision = evaluateDecisionKernelV2ReadOnly({ normalizedState });
+
+  normalizedState.headFreshness = "stale_head";
+  normalizedState.evidence.workspaceHeadSha = "mutated-after-decision";
+
+  assert.equal(decision.normalizedState.headFreshness, "current_head");
+  assert.equal(decision.normalizedState.evidence.workspaceHeadSha, "head-current");
+  assert.notEqual(decision.normalizedState, normalizedState);
+  assert.notEqual(decision.normalizedState.evidence, normalizedState.evidence);
+});
+
+test("evaluateDecisionKernelV2ReadOnly keeps metadata residue distinct from source repair", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state(),
+    reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["metadata_only_review_residue"]);
+  assert.deepEqual(decision.requiredEvidence, ["resolved_metadata_residue"]);
+});

--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -53,7 +53,10 @@ function state(overrides: Partial<PrLifecycleFactInventory> = {}): NormalizedPrL
   return normalizePrLifecycleFacts(inventory(overrides));
 }
 
-function reviewPolicyInput(outcomes: Array<ReviewPolicyInput["threads"][number]["boundaryOutcome"]>): ReviewPolicyInput {
+function reviewPolicyInput(
+  outcomes: Array<ReviewPolicyInput["threads"][number]["boundaryOutcome"]>,
+  overrides: Partial<ReviewPolicyInput["pr"]> = {},
+): ReviewPolicyInput {
   return {
     providerIdentity: {
       configuredProviderKinds: ["codex"],
@@ -67,6 +70,7 @@ function reviewPolicyInput(outcomes: Array<ReviewPolicyInput["threads"][number][
       providerSuccessHeadSha: null,
       externalReviewHeadSha: null,
       currentHeadCiGreenAt: "2026-06-08T00:02:00.000Z",
+      ...overrides,
     },
     threads: outcomes.map((boundaryOutcome, index) => ({
       id: `thread-${index}`,
@@ -184,6 +188,73 @@ test("evaluateDecisionKernelV2ReadOnly keeps metadata residue distinct from sour
   const decision = evaluateDecisionKernelV2ReadOnly({
     normalizedState: state(),
     reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["metadata_only_review_residue"]);
+  assert.deepEqual(decision.requiredEvidence, ["resolved_metadata_residue"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly honors manual review blockers before bot repairs", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state({
+      reviewThreads: {
+        unresolvedManualThreadCount: 1,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 1,
+        stalePreviousHeadConfiguredBotThreadCount: 0,
+        metadataOnlyUnresolvedThreadCount: 0,
+      },
+    }),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"]),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["manual_review_thread"]);
+  assert.deepEqual(decision.requiredEvidence, ["resolved_manual_threads"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly waits for checks before requesting review", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+      checks: {
+        passingCount: 1,
+        pendingCount: 1,
+        failingCount: 0,
+        unknownCount: 0,
+      },
+    }),
+  });
+
+  assert.equal(decision.action, "wait");
+  assert.deepEqual(decision.reasons, ["checks_pending"]);
+  assert.deepEqual(decision.requiredEvidence, ["green_checks"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly fails closed on mismatched review policy input", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state(),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"], { headSha: "head-old" }),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["review_policy_input_mismatch"]);
+  assert.deepEqual(decision.requiredEvidence, ["matching_review_policy_input"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly treats configured-bot residue as metadata cleanup", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state(),
+    reviewPolicyInput: reviewPolicyInput(["configured_bot_thread"]),
   });
 
   assert.equal(decision.action, "ask_operator");

--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -57,11 +57,13 @@ function reviewPolicyInput(
   outcomes: Array<ReviewPolicyInput["threads"][number]["boundaryOutcome"]>,
   overrides: Partial<ReviewPolicyInput["pr"]> = {},
   threadOverrides: Partial<ReviewPolicyInput["threads"][number]> = {},
+  providerIdentityOverrides: Partial<ReviewPolicyInput["providerIdentity"]> = {},
 ): ReviewPolicyInput {
   return {
     providerIdentity: {
       configuredProviderKinds: ["codex"],
       configuredBotLogins: ["chatgpt-codex-connector"],
+      ...providerIdentityOverrides,
     },
     pr: {
       number: 2300,
@@ -324,6 +326,54 @@ test("evaluateDecisionKernelV2ReadOnly waits for unknown checks without no-CI ev
   assert.deepEqual(decision.requiredEvidence, ["green_checks"]);
 });
 
+test("evaluateDecisionKernelV2ReadOnly treats no-CI check policy as merge-ready evidence", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      checks: {
+        passingCount: 0,
+        pendingCount: 0,
+        failingCount: 0,
+        unknownCount: 0,
+      },
+    }),
+    checkPolicyInput: {
+      noChecksAndNoLocalCi: true,
+    },
+  });
+
+  assert.equal(decision.normalizedState.checkPosture, "unknown");
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.deepEqual(decision.requiredEvidence, []);
+});
+
+test("evaluateDecisionKernelV2ReadOnly does not require workspace freshness to request review", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+      localState: {
+        trackedHeadSha: null,
+        workspaceHeadSha: null,
+        lastObservedPrHeadSha: "head-current",
+      },
+    }),
+  });
+
+  assert.equal(decision.normalizedState.localStateFreshness, "unknown");
+  assert.equal(decision.action, "request_review");
+  assert.deepEqual(decision.reasons, ["missing_current_head_review"]);
+  assert.deepEqual(decision.requiredEvidence, ["current_head_review"]);
+});
+
 test("evaluateDecisionKernelV2ReadOnly fails closed on mismatched review policy input", () => {
   const decision = evaluateDecisionKernelV2ReadOnly({
     normalizedState: state(),
@@ -367,6 +417,34 @@ test("evaluateDecisionKernelV2ReadOnly requests current-head review before metad
   assert.equal(decision.action, "request_review");
   assert.deepEqual(decision.reasons, ["missing_current_head_review"]);
   assert.deepEqual(decision.requiredEvidence, ["current_head_review"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly requires a clean merge state before reporting merge-ready", () => {
+  const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
+    inventory: inventory({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "BLOCKED",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: "2026-06-08T00:01:00.000Z",
+        currentHeadReviewHeadSha: "head-current",
+      },
+    }),
+  });
+
+  assert.equal(decision.normalizedState.mergeability, "unknown");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["insufficient_merge_evidence"]);
+  assert.deepEqual(decision.requiredEvidence, [
+    "current_head",
+    "fresh_local_state",
+    "current_head_review",
+    "green_checks",
+    "mergeable_state",
+  ]);
 });
 
 test("evaluateDecisionKernelV2ReadOnly ignores resolved manual policy threads", () => {
@@ -417,6 +495,17 @@ test("evaluateDecisionKernelV2ReadOnly repairs failing checks before waiting for
   assert.equal(decision.action, "run_codex");
   assert.deepEqual(decision.reasons, ["checks_failing"]);
   assert.deepEqual(decision.requiredEvidence, ["green_checks"]);
+});
+
+test("evaluateDecisionKernelV2ReadOnly respects non-Codex provider policy input", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state(),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"], {}, {}, { configuredProviderKinds: ["coderabbit"] }),
+  });
+
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.deepEqual(decision.requiredEvidence, []);
 });
 
 test("evaluateDecisionKernelV2ReadOnly does not repair softened P3 advisory policy threads", () => {

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -23,6 +23,7 @@ export type DecisionKernelV2Reason =
   | "draft_pull_request"
   | "merge_conflict"
   | "stale_local_state"
+  | "fresh_local_state_required"
   | "manual_review_thread"
   | "metadata_only_review_residue"
   | "current_head_must_fix_review"
@@ -68,6 +69,7 @@ export interface DecisionKernelV2ReadOnlyDecision {
 }
 
 interface ReviewPolicyBoundarySummary {
+  hasInput: boolean;
   currentHeadMustFix: number;
   metadataOnly: number;
   manual: number;
@@ -132,6 +134,15 @@ function selectReadOnlyDecision(
     );
   }
 
+  if (state.localStateFreshness === "missing" || state.localStateFreshness === "unknown") {
+    return decision(
+      "wait",
+      ["fresh_local_state_required"],
+      ["fresh_local_state"],
+      "Fresh local state is required before v2 can recommend source repair.",
+    );
+  }
+
   if (reviewPolicy.inputMismatch) {
     return decision(
       "ask_operator",
@@ -150,7 +161,10 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (reviewPolicy.currentHeadMustFix > 0 || state.evidence.currentHeadConfiguredBotThreadCount > 0) {
+  if (
+    reviewPolicy.currentHeadMustFix > 0 ||
+    (!reviewPolicy.hasInput && state.evidence.currentHeadConfiguredBotThreadCount > 0)
+  ) {
     return decision(
       "run_codex",
       ["current_head_must_fix_review"],
@@ -168,15 +182,6 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (state.reviewPosture === "stale_previous_head_review" || reviewPolicy.staleCommit > 0) {
-    return decision(
-      "wait",
-      ["stale_commit_review"],
-      ["current_head_review"],
-      "Review findings are tied to a stale commit and need current-head evidence.",
-    );
-  }
-
   if (state.checkPosture === "failing") {
     return decision("run_codex", ["checks_failing"], ["green_checks"], "Required checks are failing.");
   }
@@ -187,6 +192,15 @@ function selectReadOnlyDecision(
 
   if (state.checkPosture === "unknown") {
     return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
+  }
+
+  if (state.reviewPosture === "stale_previous_head_review" || reviewPolicy.staleCommit > 0) {
+    return decision(
+      "wait",
+      ["stale_commit_review"],
+      ["current_head_review"],
+      "Review findings are tied to a stale commit and need current-head evidence.",
+    );
   }
 
   if (state.reviewPosture === "missing_current_head_review") {
@@ -201,7 +215,8 @@ function selectReadOnlyDecision(
   if (
     state.headFreshness === "current_head" &&
     state.localStateFreshness === "fresh" &&
-    state.reviewPosture === "current_head_review_observed" &&
+    (state.reviewPosture === "current_head_review_observed" ||
+      (state.reviewPosture === "review_blocked" && reviewPolicyAllowsAdvisoryOnly(reviewPolicy))) &&
     state.checkPosture === "green" &&
     state.mergeability === "mergeable"
   ) {
@@ -235,6 +250,7 @@ function summarizeReviewPolicyBoundaries(
   state: NormalizedPrLifecycleState,
 ): ReviewPolicyBoundarySummary {
   const summary: ReviewPolicyBoundarySummary = {
+    hasInput: value !== null,
     currentHeadMustFix: 0,
     metadataOnly: 0,
     manual: 0,
@@ -248,6 +264,10 @@ function summarizeReviewPolicyBoundaries(
   }
 
   for (const thread of value?.threads ?? []) {
+    if (thread.isResolved) {
+      continue;
+    }
+
     if (isCurrentHeadMustFixBoundary(thread.boundaryOutcome)) {
       summary.currentHeadMustFix += 1;
     } else if (
@@ -267,6 +287,17 @@ function summarizeReviewPolicyBoundaries(
 
 function isCurrentHeadMustFixBoundary(outcome: ReviewPolicyBoundaryOutcome): boolean {
   return outcome === "must_fix_current_head" || outcome === "escalated_p3";
+}
+
+function reviewPolicyAllowsAdvisoryOnly(reviewPolicy: ReviewPolicyBoundarySummary): boolean {
+  return (
+    reviewPolicy.hasInput &&
+    !reviewPolicy.inputMismatch &&
+    reviewPolicy.currentHeadMustFix === 0 &&
+    reviewPolicy.metadataOnly === 0 &&
+    reviewPolicy.manual === 0 &&
+    reviewPolicy.staleCommit === 0
+  );
 }
 
 function diagnosticOnlySafetyPosture(): DecisionKernelV2SafetyPosture {

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -79,6 +79,7 @@ interface CheckPolicyBoundarySummary {
 
 interface ReviewPolicyBoundarySummary {
   hasInput: boolean;
+  hasCodexProvider: boolean;
   currentHeadMustFix: number;
   metadataOnly: number;
   manual: number;
@@ -147,15 +148,6 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (state.localStateFreshness === "missing" || state.localStateFreshness === "unknown") {
-    return decision(
-      "wait",
-      ["fresh_local_state_required"],
-      ["fresh_local_state"],
-      "Fresh local state is required before v2 can recommend source repair.",
-    );
-  }
-
   if (reviewPolicy.inputMismatch) {
     return decision(
       "ask_operator",
@@ -171,6 +163,49 @@ function selectReadOnlyDecision(
       ["manual_review_thread"],
       ["resolved_manual_threads"],
       "Manual review threads require operator review.",
+    );
+  }
+
+  const needsCurrentHeadReview = state.reviewPosture === "missing_current_head_review";
+  const needsFreshLocalState =
+    state.localStateFreshness === "missing" || state.localStateFreshness === "unknown";
+
+  if (needsCurrentHeadReview) {
+    if (state.checkPosture === "failing") {
+      if (needsFreshLocalState) {
+        return decision(
+          "wait",
+          ["fresh_local_state_required"],
+          ["fresh_local_state"],
+          "Fresh local state is required before v2 can recommend source repair.",
+        );
+      }
+
+      return decision("run_codex", ["checks_failing"], ["green_checks"], "Required checks are failing.");
+    }
+
+    if (state.checkPosture === "pending") {
+      return decision("wait", ["checks_pending"], ["green_checks"], "Required checks are still pending.");
+    }
+
+    if (state.checkPosture === "unknown" && !checkPolicy.noChecksAndNoLocalCi) {
+      return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
+    }
+
+    return decision(
+      "request_review",
+      ["missing_current_head_review"],
+      ["current_head_review"],
+      "Current-head review evidence is missing.",
+    );
+  }
+
+  if (needsFreshLocalState) {
+    return decision(
+      "wait",
+      ["fresh_local_state_required"],
+      ["fresh_local_state"],
+      "Fresh local state is required before v2 can recommend source repair.",
     );
   }
 
@@ -194,19 +229,8 @@ function selectReadOnlyDecision(
     return decision("wait", ["checks_pending"], ["green_checks"], "Required checks are still pending.");
   }
 
-  const needsCurrentHeadReview = state.reviewPosture === "missing_current_head_review";
-
-  if (state.checkPosture === "unknown" && !(needsCurrentHeadReview && checkPolicy.noChecksAndNoLocalCi)) {
+  if (state.checkPosture === "unknown" && !checkPolicy.noChecksAndNoLocalCi) {
     return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
-  }
-
-  if (needsCurrentHeadReview) {
-    return decision(
-      "request_review",
-      ["missing_current_head_review"],
-      ["current_head_review"],
-      "Current-head review evidence is missing.",
-    );
   }
 
   if (state.reviewPosture === "metadata_only_unresolved" || reviewPolicy.metadataOnly > 0) {
@@ -233,7 +257,7 @@ function selectReadOnlyDecision(
     (state.reviewPosture === "current_head_review_observed" ||
       state.reviewPosture === "no_unresolved_review" ||
       (state.reviewPosture === "review_blocked" && reviewPolicyAllowsAdvisoryOnly(reviewPolicy))) &&
-    state.checkPosture === "green" &&
+    (state.checkPosture === "green" || checkPolicy.noChecksAndNoLocalCi) &&
     state.mergeability === "mergeable"
   ) {
     return decision(
@@ -273,6 +297,7 @@ function summarizeReviewPolicyBoundaries(
 ): ReviewPolicyBoundarySummary {
   const summary: ReviewPolicyBoundarySummary = {
     hasInput: value !== null,
+    hasCodexProvider: value === null || value.providerIdentity.configuredProviderKinds.includes("codex"),
     currentHeadMustFix: 0,
     metadataOnly: 0,
     manual: 0,
@@ -282,6 +307,10 @@ function summarizeReviewPolicyBoundaries(
 
   if (value && (value.pr.number !== state.pullRequestNumber || value.pr.headSha !== state.headSha)) {
     summary.inputMismatch = true;
+    return summary;
+  }
+
+  if (!summary.hasCodexProvider) {
     return summary;
   }
 
@@ -314,6 +343,7 @@ function isCurrentHeadMustFixBoundary(outcome: ReviewPolicyBoundaryOutcome): boo
 function reviewPolicyAllowsAdvisoryOnly(reviewPolicy: ReviewPolicyBoundarySummary): boolean {
   return (
     reviewPolicy.hasInput &&
+    reviewPolicy.hasCodexProvider &&
     !reviewPolicy.inputMismatch &&
     reviewPolicy.currentHeadMustFix === 0 &&
     reviewPolicy.metadataOnly === 0 &&

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -27,6 +27,7 @@ export type DecisionKernelV2Reason =
   | "metadata_only_review_residue"
   | "current_head_must_fix_review"
   | "stale_commit_review"
+  | "review_policy_input_mismatch"
   | "missing_current_head_review"
   | "checks_failing"
   | "checks_pending"
@@ -39,6 +40,7 @@ export type DecisionKernelV2RequiredEvidence =
   | "current_head"
   | "fresh_local_state"
   | "current_head_review"
+  | "matching_review_policy_input"
   | "resolved_manual_threads"
   | "resolved_metadata_residue"
   | "green_checks"
@@ -70,13 +72,14 @@ interface ReviewPolicyBoundarySummary {
   metadataOnly: number;
   manual: number;
   staleCommit: number;
+  inputMismatch: boolean;
 }
 
 export function evaluateDecisionKernelV2ReadOnly(
   input: DecisionKernelV2ReadOnlyInput,
 ): DecisionKernelV2ReadOnlyDecision {
   const normalizedState = snapshotNormalizedState(input.normalizedState);
-  const reviewPolicy = summarizeReviewPolicyBoundaries(input.reviewPolicyInput ?? null);
+  const reviewPolicy = summarizeReviewPolicyBoundaries(input.reviewPolicyInput ?? null, normalizedState);
   const selected = selectReadOnlyDecision(normalizedState, reviewPolicy);
 
   return {
@@ -129,12 +132,12 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (reviewPolicy.currentHeadMustFix > 0 || state.evidence.currentHeadConfiguredBotThreadCount > 0) {
+  if (reviewPolicy.inputMismatch) {
     return decision(
-      "run_codex",
-      ["current_head_must_fix_review"],
-      ["current_head_review", "resolved_manual_threads"],
-      "Current-head review findings require source repair.",
+      "ask_operator",
+      ["review_policy_input_mismatch"],
+      ["matching_review_policy_input"],
+      "Review policy input does not match the normalized pull request facts.",
     );
   }
 
@@ -144,6 +147,15 @@ function selectReadOnlyDecision(
       ["manual_review_thread"],
       ["resolved_manual_threads"],
       "Manual review threads require operator review.",
+    );
+  }
+
+  if (reviewPolicy.currentHeadMustFix > 0 || state.evidence.currentHeadConfiguredBotThreadCount > 0) {
+    return decision(
+      "run_codex",
+      ["current_head_must_fix_review"],
+      ["current_head_review", "resolved_manual_threads"],
+      "Current-head review findings require source repair.",
     );
   }
 
@@ -165,15 +177,6 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (state.reviewPosture === "missing_current_head_review") {
-    return decision(
-      "request_review",
-      ["missing_current_head_review"],
-      ["current_head_review"],
-      "Current-head review evidence is missing.",
-    );
-  }
-
   if (state.checkPosture === "failing") {
     return decision("run_codex", ["checks_failing"], ["green_checks"], "Required checks are failing.");
   }
@@ -184,6 +187,15 @@ function selectReadOnlyDecision(
 
   if (state.checkPosture === "unknown") {
     return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
+  }
+
+  if (state.reviewPosture === "missing_current_head_review") {
+    return decision(
+      "request_review",
+      ["missing_current_head_review"],
+      ["current_head_review"],
+      "Current-head review evidence is missing.",
+    );
   }
 
   if (
@@ -218,18 +230,30 @@ function decision(
   return { action, reasons, requiredEvidence, summary };
 }
 
-function summarizeReviewPolicyBoundaries(value: ReviewPolicyInput | null): ReviewPolicyBoundarySummary {
+function summarizeReviewPolicyBoundaries(
+  value: ReviewPolicyInput | null,
+  state: NormalizedPrLifecycleState,
+): ReviewPolicyBoundarySummary {
   const summary: ReviewPolicyBoundarySummary = {
     currentHeadMustFix: 0,
     metadataOnly: 0,
     manual: 0,
     staleCommit: 0,
+    inputMismatch: false,
   };
+
+  if (value && (value.pr.number !== state.pullRequestNumber || value.pr.headSha !== state.headSha)) {
+    summary.inputMismatch = true;
+    return summary;
+  }
 
   for (const thread of value?.threads ?? []) {
     if (isCurrentHeadMustFixBoundary(thread.boundaryOutcome)) {
       summary.currentHeadMustFix += 1;
-    } else if (thread.boundaryOutcome === "metadata_only_unresolved") {
+    } else if (
+      thread.boundaryOutcome === "metadata_only_unresolved" ||
+      thread.boundaryOutcome === "configured_bot_thread"
+    ) {
       summary.metadataOnly += 1;
     } else if (thread.boundaryOutcome === "manual_thread") {
       summary.manual += 1;

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -1,0 +1,263 @@
+import type {
+  ReviewPolicyBoundaryOutcome,
+  ReviewPolicyInput,
+} from "./codex-connector-review-policy";
+import {
+  normalizePrLifecycleFacts,
+  type NormalizedPrLifecycleState,
+  type PrLifecycleFactInventory,
+} from "./decision-kernel/pr-lifecycle-state";
+
+export const DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION = "decision_kernel_v2.read_only.v1";
+
+export type DecisionKernelV2Action =
+  | "wait"
+  | "request_review"
+  | "run_codex"
+  | "ask_operator"
+  | "no_action";
+
+export type DecisionKernelV2Reason =
+  | "no_pull_request"
+  | "pull_request_closed"
+  | "draft_pull_request"
+  | "merge_conflict"
+  | "stale_local_state"
+  | "manual_review_thread"
+  | "metadata_only_review_residue"
+  | "current_head_must_fix_review"
+  | "stale_commit_review"
+  | "missing_current_head_review"
+  | "checks_failing"
+  | "checks_pending"
+  | "checks_unknown"
+  | "merge_ready_diagnostic_only"
+  | "insufficient_merge_evidence";
+
+export type DecisionKernelV2RequiredEvidence =
+  | "pull_request"
+  | "current_head"
+  | "fresh_local_state"
+  | "current_head_review"
+  | "resolved_manual_threads"
+  | "resolved_metadata_residue"
+  | "green_checks"
+  | "mergeable_state";
+
+export interface DecisionKernelV2SafetyPosture {
+  mode: "diagnostic_only";
+  authoritative: false;
+  mutationAllowed: false;
+}
+
+export interface DecisionKernelV2ReadOnlyInput {
+  normalizedState: NormalizedPrLifecycleState;
+  reviewPolicyInput?: ReviewPolicyInput | null;
+}
+
+export interface DecisionKernelV2ReadOnlyDecision {
+  schemaVersion: typeof DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION;
+  action: DecisionKernelV2Action;
+  reasons: DecisionKernelV2Reason[];
+  requiredEvidence: DecisionKernelV2RequiredEvidence[];
+  safety: DecisionKernelV2SafetyPosture;
+  summary: string;
+  normalizedState: NormalizedPrLifecycleState;
+}
+
+interface ReviewPolicyBoundarySummary {
+  currentHeadMustFix: number;
+  metadataOnly: number;
+  manual: number;
+  staleCommit: number;
+}
+
+export function evaluateDecisionKernelV2ReadOnly(
+  input: DecisionKernelV2ReadOnlyInput,
+): DecisionKernelV2ReadOnlyDecision {
+  const normalizedState = snapshotNormalizedState(input.normalizedState);
+  const reviewPolicy = summarizeReviewPolicyBoundaries(input.reviewPolicyInput ?? null);
+  const selected = selectReadOnlyDecision(normalizedState, reviewPolicy);
+
+  return {
+    schemaVersion: DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION,
+    action: selected.action,
+    reasons: [...selected.reasons],
+    requiredEvidence: [...selected.requiredEvidence],
+    safety: diagnosticOnlySafetyPosture(),
+    summary: selected.summary,
+    normalizedState,
+  };
+}
+
+export function evaluateDecisionKernelV2ReadOnlyFromFacts(args: {
+  inventory: PrLifecycleFactInventory;
+  reviewPolicyInput?: ReviewPolicyInput | null;
+}): DecisionKernelV2ReadOnlyDecision {
+  return evaluateDecisionKernelV2ReadOnly({
+    normalizedState: normalizePrLifecycleFacts(args.inventory),
+    reviewPolicyInput: args.reviewPolicyInput ?? null,
+  });
+}
+
+function selectReadOnlyDecision(
+  state: NormalizedPrLifecycleState,
+  reviewPolicy: ReviewPolicyBoundarySummary,
+): Omit<DecisionKernelV2ReadOnlyDecision, "schemaVersion" | "safety" | "normalizedState"> {
+  if (!state.pullRequestNumber || !state.headSha || state.headFreshness === "no_pull_request") {
+    return decision("no_action", ["no_pull_request"], ["pull_request"], "No tracked pull request facts are available.");
+  }
+
+  if (state.mergeability === "closed") {
+    return decision("no_action", ["pull_request_closed"], [], "The pull request is no longer open.");
+  }
+
+  if (state.mergeability === "draft") {
+    return decision("ask_operator", ["draft_pull_request"], ["mergeable_state"], "The pull request is still draft.");
+  }
+
+  if (state.mergeability === "conflicted") {
+    return decision("ask_operator", ["merge_conflict"], ["mergeable_state"], "The pull request is conflicted.");
+  }
+
+  if (state.headFreshness === "stale_head" || state.localStateFreshness === "stale") {
+    return decision(
+      "wait",
+      ["stale_local_state"],
+      ["current_head", "fresh_local_state"],
+      "Local state is stale relative to the pull request head.",
+    );
+  }
+
+  if (reviewPolicy.currentHeadMustFix > 0 || state.evidence.currentHeadConfiguredBotThreadCount > 0) {
+    return decision(
+      "run_codex",
+      ["current_head_must_fix_review"],
+      ["current_head_review", "resolved_manual_threads"],
+      "Current-head review findings require source repair.",
+    );
+  }
+
+  if (state.evidence.manualReviewThreadCount > 0 || reviewPolicy.manual > 0) {
+    return decision(
+      "ask_operator",
+      ["manual_review_thread"],
+      ["resolved_manual_threads"],
+      "Manual review threads require operator review.",
+    );
+  }
+
+  if (state.reviewPosture === "metadata_only_unresolved" || reviewPolicy.metadataOnly > 0) {
+    return decision(
+      "ask_operator",
+      ["metadata_only_review_residue"],
+      ["resolved_metadata_residue"],
+      "Unresolved review metadata remains after source repair evidence.",
+    );
+  }
+
+  if (state.reviewPosture === "stale_previous_head_review" || reviewPolicy.staleCommit > 0) {
+    return decision(
+      "wait",
+      ["stale_commit_review"],
+      ["current_head_review"],
+      "Review findings are tied to a stale commit and need current-head evidence.",
+    );
+  }
+
+  if (state.reviewPosture === "missing_current_head_review") {
+    return decision(
+      "request_review",
+      ["missing_current_head_review"],
+      ["current_head_review"],
+      "Current-head review evidence is missing.",
+    );
+  }
+
+  if (state.checkPosture === "failing") {
+    return decision("run_codex", ["checks_failing"], ["green_checks"], "Required checks are failing.");
+  }
+
+  if (state.checkPosture === "pending") {
+    return decision("wait", ["checks_pending"], ["green_checks"], "Required checks are still pending.");
+  }
+
+  if (state.checkPosture === "unknown") {
+    return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
+  }
+
+  if (
+    state.headFreshness === "current_head" &&
+    state.localStateFreshness === "fresh" &&
+    state.reviewPosture === "current_head_review_observed" &&
+    state.checkPosture === "green" &&
+    state.mergeability === "mergeable"
+  ) {
+    return decision(
+      "no_action",
+      ["merge_ready_diagnostic_only"],
+      [],
+      "PR appears merge-ready, but v2 is diagnostic-only in this phase.",
+    );
+  }
+
+  return decision(
+    "ask_operator",
+    ["insufficient_merge_evidence"],
+    ["current_head", "fresh_local_state", "current_head_review", "green_checks", "mergeable_state"],
+    "The read-only v2 model lacks enough evidence to recommend an automated action.",
+  );
+}
+
+function decision(
+  action: DecisionKernelV2Action,
+  reasons: DecisionKernelV2Reason[],
+  requiredEvidence: DecisionKernelV2RequiredEvidence[],
+  summary: string,
+): Omit<DecisionKernelV2ReadOnlyDecision, "schemaVersion" | "safety" | "normalizedState"> {
+  return { action, reasons, requiredEvidence, summary };
+}
+
+function summarizeReviewPolicyBoundaries(value: ReviewPolicyInput | null): ReviewPolicyBoundarySummary {
+  const summary: ReviewPolicyBoundarySummary = {
+    currentHeadMustFix: 0,
+    metadataOnly: 0,
+    manual: 0,
+    staleCommit: 0,
+  };
+
+  for (const thread of value?.threads ?? []) {
+    if (isCurrentHeadMustFixBoundary(thread.boundaryOutcome)) {
+      summary.currentHeadMustFix += 1;
+    } else if (thread.boundaryOutcome === "metadata_only_unresolved") {
+      summary.metadataOnly += 1;
+    } else if (thread.boundaryOutcome === "manual_thread") {
+      summary.manual += 1;
+    } else if (thread.boundaryOutcome === "stale_commit_thread") {
+      summary.staleCommit += 1;
+    }
+  }
+
+  return summary;
+}
+
+function isCurrentHeadMustFixBoundary(outcome: ReviewPolicyBoundaryOutcome): boolean {
+  return outcome === "must_fix_current_head" || outcome === "escalated_p3";
+}
+
+function diagnosticOnlySafetyPosture(): DecisionKernelV2SafetyPosture {
+  return {
+    mode: "diagnostic_only",
+    authoritative: false,
+    mutationAllowed: false,
+  };
+}
+
+function snapshotNormalizedState(state: NormalizedPrLifecycleState): NormalizedPrLifecycleState {
+  return {
+    ...state,
+    evidence: {
+      ...state.evidence,
+    },
+  };
+}

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -53,9 +53,14 @@ export interface DecisionKernelV2SafetyPosture {
   mutationAllowed: false;
 }
 
+export interface DecisionKernelV2CheckPolicyInput {
+  noChecksAndNoLocalCi?: boolean;
+}
+
 export interface DecisionKernelV2ReadOnlyInput {
   normalizedState: NormalizedPrLifecycleState;
   reviewPolicyInput?: ReviewPolicyInput | null;
+  checkPolicyInput?: DecisionKernelV2CheckPolicyInput | null;
 }
 
 export interface DecisionKernelV2ReadOnlyDecision {
@@ -66,6 +71,10 @@ export interface DecisionKernelV2ReadOnlyDecision {
   safety: DecisionKernelV2SafetyPosture;
   summary: string;
   normalizedState: NormalizedPrLifecycleState;
+}
+
+interface CheckPolicyBoundarySummary {
+  noChecksAndNoLocalCi: boolean;
 }
 
 interface ReviewPolicyBoundarySummary {
@@ -82,7 +91,8 @@ export function evaluateDecisionKernelV2ReadOnly(
 ): DecisionKernelV2ReadOnlyDecision {
   const normalizedState = snapshotNormalizedState(input.normalizedState);
   const reviewPolicy = summarizeReviewPolicyBoundaries(input.reviewPolicyInput ?? null, normalizedState);
-  const selected = selectReadOnlyDecision(normalizedState, reviewPolicy);
+  const checkPolicy = summarizeCheckPolicyBoundaries(input.checkPolicyInput ?? null);
+  const selected = selectReadOnlyDecision(normalizedState, reviewPolicy, checkPolicy);
 
   return {
     schemaVersion: DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION,
@@ -98,16 +108,19 @@ export function evaluateDecisionKernelV2ReadOnly(
 export function evaluateDecisionKernelV2ReadOnlyFromFacts(args: {
   inventory: PrLifecycleFactInventory;
   reviewPolicyInput?: ReviewPolicyInput | null;
+  checkPolicyInput?: DecisionKernelV2CheckPolicyInput | null;
 }): DecisionKernelV2ReadOnlyDecision {
   return evaluateDecisionKernelV2ReadOnly({
     normalizedState: normalizePrLifecycleFacts(args.inventory),
     reviewPolicyInput: args.reviewPolicyInput ?? null,
+    checkPolicyInput: args.checkPolicyInput ?? null,
   });
 }
 
 function selectReadOnlyDecision(
   state: NormalizedPrLifecycleState,
   reviewPolicy: ReviewPolicyBoundarySummary,
+  checkPolicy: CheckPolicyBoundarySummary,
 ): Omit<DecisionKernelV2ReadOnlyDecision, "schemaVersion" | "safety" | "normalizedState"> {
   if (!state.pullRequestNumber || !state.headSha || state.headFreshness === "no_pull_request") {
     return decision("no_action", ["no_pull_request"], ["pull_request"], "No tracked pull request facts are available.");
@@ -173,15 +186,6 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (state.reviewPosture === "metadata_only_unresolved" || reviewPolicy.metadataOnly > 0) {
-    return decision(
-      "ask_operator",
-      ["metadata_only_review_residue"],
-      ["resolved_metadata_residue"],
-      "Unresolved review metadata remains after source repair evidence.",
-    );
-  }
-
   if (state.checkPosture === "failing") {
     return decision("run_codex", ["checks_failing"], ["green_checks"], "Required checks are failing.");
   }
@@ -190,8 +194,28 @@ function selectReadOnlyDecision(
     return decision("wait", ["checks_pending"], ["green_checks"], "Required checks are still pending.");
   }
 
-  if (state.checkPosture === "unknown") {
+  const needsCurrentHeadReview = state.reviewPosture === "missing_current_head_review";
+
+  if (state.checkPosture === "unknown" && !(needsCurrentHeadReview && checkPolicy.noChecksAndNoLocalCi)) {
     return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
+  }
+
+  if (needsCurrentHeadReview) {
+    return decision(
+      "request_review",
+      ["missing_current_head_review"],
+      ["current_head_review"],
+      "Current-head review evidence is missing.",
+    );
+  }
+
+  if (state.reviewPosture === "metadata_only_unresolved" || reviewPolicy.metadataOnly > 0) {
+    return decision(
+      "ask_operator",
+      ["metadata_only_review_residue"],
+      ["resolved_metadata_residue"],
+      "Unresolved review metadata remains after source repair evidence.",
+    );
   }
 
   if (state.reviewPosture === "stale_previous_head_review" || reviewPolicy.staleCommit > 0) {
@@ -203,19 +227,11 @@ function selectReadOnlyDecision(
     );
   }
 
-  if (state.reviewPosture === "missing_current_head_review") {
-    return decision(
-      "request_review",
-      ["missing_current_head_review"],
-      ["current_head_review"],
-      "Current-head review evidence is missing.",
-    );
-  }
-
   if (
     state.headFreshness === "current_head" &&
     state.localStateFreshness === "fresh" &&
     (state.reviewPosture === "current_head_review_observed" ||
+      state.reviewPosture === "no_unresolved_review" ||
       (state.reviewPosture === "review_blocked" && reviewPolicyAllowsAdvisoryOnly(reviewPolicy))) &&
     state.checkPosture === "green" &&
     state.mergeability === "mergeable"
@@ -234,6 +250,12 @@ function selectReadOnlyDecision(
     ["current_head", "fresh_local_state", "current_head_review", "green_checks", "mergeable_state"],
     "The read-only v2 model lacks enough evidence to recommend an automated action.",
   );
+}
+
+function summarizeCheckPolicyBoundaries(value: DecisionKernelV2CheckPolicyInput | null): CheckPolicyBoundarySummary {
+  return {
+    noChecksAndNoLocalCi: value?.noChecksAndNoLocalCi === true,
+  };
 }
 
 function decision(

--- a/src/decision-kernel/pr-lifecycle-state.test.ts
+++ b/src/decision-kernel/pr-lifecycle-state.test.ts
@@ -126,6 +126,25 @@ test("normalizePrLifecycleFacts surfaces missing review, pending checks, and con
   assert.equal(state.mergeability, "conflicted");
 });
 
+test("normalizePrLifecycleFacts requires a clean merge state for mergeable posture", () => {
+  const state = normalizePrLifecycleFacts(
+    inventory({
+      pullRequest: {
+        number: 2278,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "BLOCKED",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: "2026-06-07T00:01:00.000Z",
+        currentHeadReviewHeadSha: "head-current",
+      },
+    }),
+  );
+
+  assert.equal(state.mergeability, "unknown");
+});
+
 test("normalizePrLifecycleFacts prioritizes live review blockers and failing checks", () => {
   const state = normalizePrLifecycleFacts(
     inventory({

--- a/src/decision-kernel/pr-lifecycle-state.ts
+++ b/src/decision-kernel/pr-lifecycle-state.ts
@@ -206,7 +206,7 @@ function normalizeMergeability(
     return "conflicted";
   }
 
-  if (pullRequest.mergeStateStatus === "CLEAN" || pullRequest.mergeable === "MERGEABLE") {
+  if (pullRequest.mergeStateStatus === "CLEAN") {
     return "mergeable";
   }
 

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "committed-guardrails.ts",
     "conversation-resolution-blocker-diagnostics.ts",
     "conversation-resolution-policy.ts",
+    "decision-kernel-v2.ts",
     "diagnostics-dto.ts",
     "doctor.ts",
     "durable-artifact-provenance.ts",


### PR DESCRIPTION
## Summary
- Add a typed Decision Kernel v2 read-only evaluator for Phase 3.1
- Model v2 action, reason, required-evidence, and diagnostic-only safety posture vocabulary
- Accept existing normalized PR lifecycle facts plus optional Phase 2 review policy input without wiring into mutation paths

## Verification
- `npx tsx --test src/decision-kernel-v2.test.ts src/decision-kernel/*.test.ts src/family-directory-layout.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2300 --config supervisor.config.codex.json`

Closes #2300
