### PR TITLE
Phase 3.3: Compare current and v2 decisions

### DIFF
--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -62,6 +62,7 @@ function createV2ExplainDto(overrides: Partial<DecisionKernelV2ExplainDto> = {})
     inventory: null,
     reviewPolicyInput: null,
     decision: null,
+    comparison: null,
     ...overrides,
   };
 }
@@ -879,6 +880,30 @@ test("runSupervisorCommand renders v2 explain diagnostics through the read-only 
                 },
               },
             },
+            comparison: {
+              current: {
+                state: "pr_open",
+                actionEquivalent: "ask_operator",
+              },
+              v2: {
+                action: "request_review",
+                reasons: ["missing_current_head_review"],
+              },
+              category: "manual_review_required",
+              differences: [
+                {
+                  field: "action",
+                  current: "ask_operator",
+                  v2: "request_review",
+                },
+                {
+                  field: "reason",
+                  current: "insufficient_merge_evidence",
+                  v2: "missing_current_head_review",
+                },
+              ],
+              safetyNote: "Current and v2 diverge in an unsafe or ambiguous way; require operator review before trusting v2.",
+            },
           });
         },
         runRecoveryAction: async () => {
@@ -915,6 +940,7 @@ test("runSupervisorCommand renders v2 explain diagnostics through the read-only 
   assert.match(stdout[0] ?? "", /^v2_authoritative=false$/m);
   assert.match(stdout[0] ?? "", /^v2_mutation_allowed=false$/m);
   assert.match(stdout[0] ?? "", /^v2_decision action=request_review/m);
+  assert.match(stdout[0] ?? "", /^v2_comparison category=manual_review_required current_state=pr_open/m);
 });
 
 test("runSupervisorCommand renders issue-lint output from the structured DTO", async () => {

--- a/src/cli/supervisor-runtime.test.ts
+++ b/src/cli/supervisor-runtime.test.ts
@@ -883,7 +883,7 @@ test("runSupervisorCommand renders v2 explain diagnostics through the read-only 
             comparison: {
               current: {
                 state: "pr_open",
-                actionEquivalent: "ask_operator",
+                actionEquivalent: "wait",
               },
               v2: {
                 action: "request_review",
@@ -893,7 +893,7 @@ test("runSupervisorCommand renders v2 explain diagnostics through the read-only 
               differences: [
                 {
                   field: "action",
-                  current: "ask_operator",
+                  current: "wait",
                   v2: "request_review",
                 },
                 {

--- a/src/decision-kernel/v2-comparison.test.ts
+++ b/src/decision-kernel/v2-comparison.test.ts
@@ -102,6 +102,29 @@ test("buildDecisionKernelV2ComparisonDto does not equate loop-advanceable PR sta
   }
 });
 
+test("buildDecisionKernelV2ComparisonDto preserves request-review equivalence for request-eligible waits", () => {
+  const comparison = buildDecisionKernelV2ComparisonDto({
+    currentState: "waiting_ci",
+    currentActionEquivalent: "request_review",
+    v2Decision: v2Decision({
+      action: "request_review",
+      reasons: ["missing_current_head_review"],
+      requiredEvidence: ["current_head_review"],
+      summary: "Current-head review evidence is missing.",
+    }),
+  });
+
+  assert.equal(comparison.current.actionEquivalent, "request_review");
+  assert.equal(comparison.category, "agreement");
+  assert.deepEqual(comparison.differences, [
+    {
+      field: "reason",
+      current: "checks_pending",
+      v2: "missing_current_head_review",
+    },
+  ]);
+});
+
 test("buildDecisionKernelV2ComparisonDto fails closed on unsafe or ambiguous divergence", () => {
   const comparison = buildDecisionKernelV2ComparisonDto({
     currentState: "blocked",

--- a/src/decision-kernel/v2-comparison.test.ts
+++ b/src/decision-kernel/v2-comparison.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DecisionKernelV2ReadOnlyDecision } from "../decision-kernel-v2";
+import { buildDecisionKernelV2ComparisonDto } from "./v2-comparison";
+
+function v2Decision(overrides: Partial<DecisionKernelV2ReadOnlyDecision> = {}): DecisionKernelV2ReadOnlyDecision {
+  return {
+    schemaVersion: "decision_kernel_v2.read_only.v1",
+    action: "no_action",
+    reasons: ["merge_ready_diagnostic_only"],
+    requiredEvidence: [],
+    safety: {
+      mode: "diagnostic_only",
+      authoritative: false,
+      mutationAllowed: false,
+    },
+    summary: "PR appears merge-ready, but v2 is diagnostic-only in this phase.",
+    normalizedState: {
+      source: "fresh_github",
+      observedAt: "2026-06-08T00:00:00.000Z",
+      pullRequestNumber: 2302,
+      headSha: "head-current",
+      headFreshness: "current_head",
+      reviewPosture: "current_head_review_observed",
+      checkPosture: "green",
+      mergeability: "mergeable",
+      localStateFreshness: "fresh",
+      evidence: {
+        manualReviewThreadCount: 0,
+        currentHeadConfiguredBotThreadCount: 0,
+        stalePreviousHeadConfiguredBotThreadCount: 0,
+        metadataOnlyUnresolvedThreadCount: 0,
+        passingCheckCount: 1,
+        pendingCheckCount: 0,
+        failingCheckCount: 0,
+        unknownCheckCount: 0,
+        trackedHeadSha: "head-current",
+        workspaceHeadSha: null,
+        lastObservedPrHeadSha: "head-current",
+      },
+    },
+    ...overrides,
+  };
+}
+
+test("buildDecisionKernelV2ComparisonDto reports agreement for merge-ready no-action decisions", () => {
+  const comparison = buildDecisionKernelV2ComparisonDto({
+    currentState: "ready_to_merge",
+    v2Decision: v2Decision(),
+  });
+
+  assert.equal(comparison.category, "agreement");
+  assert.equal(comparison.current.state, "ready_to_merge");
+  assert.equal(comparison.current.actionEquivalent, "no_action");
+  assert.equal(comparison.v2.action, "no_action");
+  assert.deepEqual(comparison.differences, []);
+});
+
+test("buildDecisionKernelV2ComparisonDto classifies conservative v2 divergence as safe", () => {
+  const comparison = buildDecisionKernelV2ComparisonDto({
+    currentState: "addressing_review",
+    v2Decision: v2Decision({
+      action: "ask_operator",
+      reasons: ["insufficient_merge_evidence"],
+      requiredEvidence: ["current_head", "fresh_local_state"],
+      summary: "The read-only v2 model lacks enough evidence to recommend an automated action.",
+    }),
+  });
+
+  assert.equal(comparison.category, "safe_divergence");
+  assert.deepEqual(comparison.differences, [
+    {
+      field: "action",
+      current: "run_codex",
+      v2: "ask_operator",
+    },
+    {
+      field: "reason",
+      current: "current_head_must_fix_review",
+      v2: "insufficient_merge_evidence",
+    },
+  ]);
+});
+
+test("buildDecisionKernelV2ComparisonDto fails closed on unsafe or ambiguous divergence", () => {
+  const comparison = buildDecisionKernelV2ComparisonDto({
+    currentState: "blocked",
+    v2Decision: v2Decision({
+      action: "run_codex",
+      reasons: ["current_head_must_fix_review"],
+      requiredEvidence: ["current_head_review"],
+      summary: "Current-head review findings require source repair.",
+    }),
+  });
+
+  assert.equal(comparison.category, "manual_review_required");
+  assert.match(comparison.safetyNote, /operator review/u);
+  assert.deepEqual(comparison.differences, [
+    {
+      field: "action",
+      current: "ask_operator",
+      v2: "run_codex",
+    },
+    {
+      field: "reason",
+      current: "manual_review_required",
+      v2: "current_head_must_fix_review",
+    },
+  ]);
+});

--- a/src/decision-kernel/v2-comparison.test.ts
+++ b/src/decision-kernel/v2-comparison.test.ts
@@ -82,6 +82,26 @@ test("buildDecisionKernelV2ComparisonDto classifies conservative v2 divergence a
   ]);
 });
 
+test("buildDecisionKernelV2ComparisonDto does not equate loop-advanceable PR states with operator handoff", () => {
+  for (const currentState of ["draft_pr", "local_review", "pr_open"] as const) {
+    const comparison = buildDecisionKernelV2ComparisonDto({
+      currentState,
+      v2Decision: v2Decision({
+        action: "ask_operator",
+        reasons: ["insufficient_merge_evidence"],
+        requiredEvidence: ["current_head", "fresh_local_state"],
+        summary: "The read-only v2 model lacks enough evidence to recommend an automated action.",
+      }),
+    });
+
+    assert.equal(comparison.current.actionEquivalent, "wait");
+    assert.equal(comparison.category, "safe_divergence");
+    assert.equal(comparison.differences[0]?.field, "action");
+    assert.equal(comparison.differences[0]?.current, "wait");
+    assert.equal(comparison.differences[0]?.v2, "ask_operator");
+  }
+});
+
 test("buildDecisionKernelV2ComparisonDto fails closed on unsafe or ambiguous divergence", () => {
   const comparison = buildDecisionKernelV2ComparisonDto({
     currentState: "blocked",

--- a/src/decision-kernel/v2-comparison.ts
+++ b/src/decision-kernel/v2-comparison.ts
@@ -32,9 +32,10 @@ export interface DecisionKernelV2ComparisonDto {
 
 export function buildDecisionKernelV2ComparisonDto(args: {
   currentState: RunState;
+  currentActionEquivalent?: DecisionKernelV2Action;
   v2Decision: DecisionKernelV2ReadOnlyDecision;
 }): DecisionKernelV2ComparisonDto {
-  const currentActionEquivalent = actionEquivalentForCurrentState(args.currentState);
+  const currentActionEquivalent = args.currentActionEquivalent ?? actionEquivalentForCurrentState(args.currentState);
   const differences = compareDecisionFields({
     currentState: args.currentState,
     currentActionEquivalent,

--- a/src/decision-kernel/v2-comparison.ts
+++ b/src/decision-kernel/v2-comparison.ts
@@ -1,0 +1,188 @@
+import type { RunState } from "../core/types";
+import type {
+  DecisionKernelV2Action,
+  DecisionKernelV2ReadOnlyDecision,
+  DecisionKernelV2Reason,
+} from "../decision-kernel-v2";
+
+export type DecisionKernelV2ComparisonCategory =
+  | "agreement"
+  | "safe_divergence"
+  | "manual_review_required";
+
+export interface DecisionKernelV2ComparisonDifference {
+  field: string;
+  current: string;
+  v2: string;
+}
+
+export interface DecisionKernelV2ComparisonDto {
+  current: {
+    state: RunState;
+    actionEquivalent: DecisionKernelV2Action;
+  };
+  v2: {
+    action: DecisionKernelV2Action;
+    reasons: DecisionKernelV2Reason[];
+  };
+  category: DecisionKernelV2ComparisonCategory;
+  differences: DecisionKernelV2ComparisonDifference[];
+  safetyNote: string;
+}
+
+export function buildDecisionKernelV2ComparisonDto(args: {
+  currentState: RunState;
+  v2Decision: DecisionKernelV2ReadOnlyDecision;
+}): DecisionKernelV2ComparisonDto {
+  const currentActionEquivalent = actionEquivalentForCurrentState(args.currentState);
+  const differences = compareDecisionFields({
+    currentState: args.currentState,
+    currentActionEquivalent,
+    v2Decision: args.v2Decision,
+  });
+  const category = comparisonCategory(currentActionEquivalent, args.v2Decision.action);
+
+  return {
+    current: {
+      state: args.currentState,
+      actionEquivalent: currentActionEquivalent,
+    },
+    v2: {
+      action: args.v2Decision.action,
+      reasons: [...args.v2Decision.reasons],
+    },
+    category,
+    differences,
+    safetyNote: safetyNoteForCategory(category),
+  };
+}
+
+function compareDecisionFields(args: {
+  currentState: RunState;
+  currentActionEquivalent: DecisionKernelV2Action;
+  v2Decision: DecisionKernelV2ReadOnlyDecision;
+}): DecisionKernelV2ComparisonDifference[] {
+  const differences: DecisionKernelV2ComparisonDifference[] = [];
+
+  if (args.currentActionEquivalent !== args.v2Decision.action) {
+    differences.push({
+      field: "action",
+      current: args.currentActionEquivalent,
+      v2: args.v2Decision.action,
+    });
+  }
+
+  const currentStateReason = reasonEquivalentForCurrentState(args.currentState);
+  const v2Reasons = args.v2Decision.reasons.join("|") || "none";
+  if (currentStateReason !== v2Reasons) {
+    differences.push({
+      field: "reason",
+      current: currentStateReason,
+      v2: v2Reasons,
+    });
+  }
+
+  return differences;
+}
+
+function actionEquivalentForCurrentState(state: RunState): DecisionKernelV2Action {
+  switch (state) {
+    case "ready_to_merge":
+    case "done":
+      return "no_action";
+    case "addressing_review":
+    case "local_review_fix":
+    case "repairing_ci":
+    case "resolving_conflict":
+      return "run_codex";
+    case "queued":
+    case "planning":
+    case "reproducing":
+    case "implementing":
+    case "stabilizing":
+    case "waiting_ci":
+    case "merging":
+      return "wait";
+    case "blocked":
+    case "draft_pr":
+    case "failed":
+    case "local_review":
+    case "pr_open":
+      return "ask_operator";
+  }
+}
+
+function reasonEquivalentForCurrentState(state: RunState): string {
+  switch (state) {
+    case "ready_to_merge":
+      return "merge_ready_diagnostic_only";
+    case "done":
+      return "pull_request_closed";
+    case "addressing_review":
+      return "current_head_must_fix_review";
+    case "repairing_ci":
+      return "checks_failing";
+    case "resolving_conflict":
+      return "merge_conflict";
+    case "waiting_ci":
+      return "checks_pending";
+    case "draft_pr":
+      return "draft_pull_request";
+    case "blocked":
+      return "manual_review_required";
+    case "local_review":
+    case "local_review_fix":
+      return "local_review";
+    case "failed":
+      return "failed";
+    case "pr_open":
+      return "insufficient_merge_evidence";
+    case "queued":
+    case "planning":
+    case "reproducing":
+    case "implementing":
+    case "stabilizing":
+    case "merging":
+      return "workflow_in_progress";
+  }
+}
+
+function comparisonCategory(
+  currentActionEquivalent: DecisionKernelV2Action,
+  v2Action: DecisionKernelV2Action,
+): DecisionKernelV2ComparisonCategory {
+  if (currentActionEquivalent === v2Action) {
+    return "agreement";
+  }
+
+  return isConservativeV2Divergence(currentActionEquivalent, v2Action)
+    ? "safe_divergence"
+    : "manual_review_required";
+}
+
+function isConservativeV2Divergence(
+  currentActionEquivalent: DecisionKernelV2Action,
+  v2Action: DecisionKernelV2Action,
+): boolean {
+  if (v2Action === "ask_operator") {
+    return true;
+  }
+
+  if (v2Action === "wait" && (currentActionEquivalent === "run_codex" || currentActionEquivalent === "request_review")) {
+    return true;
+  }
+
+  return false;
+}
+
+function safetyNoteForCategory(category: DecisionKernelV2ComparisonCategory): string {
+  if (category === "agreement") {
+    return "Current and v2 decisions agree for the compared action boundary.";
+  }
+
+  if (category === "safe_divergence") {
+    return "V2 is more conservative than the current decision and remains diagnostic-only.";
+  }
+
+  return "Current and v2 diverge in an unsafe or ambiguous way; require operator review before trusting v2.";
+}

--- a/src/decision-kernel/v2-comparison.ts
+++ b/src/decision-kernel/v2-comparison.ts
@@ -101,13 +101,13 @@ function actionEquivalentForCurrentState(state: RunState): DecisionKernelV2Actio
     case "implementing":
     case "stabilizing":
     case "waiting_ci":
+    case "draft_pr":
+    case "local_review":
     case "merging":
+    case "pr_open":
       return "wait";
     case "blocked":
-    case "draft_pr":
     case "failed":
-    case "local_review":
-    case "pr_open":
       return "ask_operator";
   }
 }

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -155,6 +155,9 @@ test("buildDecisionKernelV2ExplainDto uses PR head for current-head review obser
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewHeadSha, "head-current");
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
   assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.comparison?.current.state, "ready_to_merge");
+  assert.equal(dto.comparison?.category, "agreement");
+  assert.deepEqual(dto.comparison?.differences, []);
 });
 
 test("buildDecisionKernelV2ExplainDto ignores malformed current-head review timestamps", () => {
@@ -175,6 +178,8 @@ test("buildDecisionKernelV2ExplainDto ignores malformed current-head review time
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewHeadSha, null);
   assert.equal(dto.decision?.normalizedState.reviewPosture, "missing_current_head_review");
   assert.equal(dto.decision?.action, "request_review");
+  assert.equal(dto.comparison?.category, "manual_review_required");
+  assert.deepEqual(dto.comparison?.differences.map((difference) => difference.field), ["action", "reason"]);
 });
 
 test("buildDecisionKernelV2ExplainDto accepts external review records as current-head review evidence", () => {

--- a/src/decision-kernel/v2-explain.ts
+++ b/src/decision-kernel/v2-explain.ts
@@ -13,11 +13,13 @@ import type {
   ReviewThread,
   SupervisorConfig,
 } from "../core/types";
+import { buildDecisionKernelV2ComparisonDto, type DecisionKernelV2ComparisonDto } from "./v2-comparison";
 import {
   DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION,
   evaluateDecisionKernelV2ReadOnlyFromFacts,
   type DecisionKernelV2ReadOnlyDecision,
 } from "../decision-kernel-v2";
+import { inferStateFromPullRequest } from "../pull-request-state";
 import {
   currentHeadObservationSatisfiesActiveWait,
   hasCurrentHeadProviderSuccess,
@@ -40,6 +42,7 @@ export interface DecisionKernelV2ExplainDto {
   inventory: PrLifecycleFactInventory | null;
   reviewPolicyInput: ReviewPolicyInput | null;
   decision: DecisionKernelV2ReadOnlyDecision | null;
+  comparison: DecisionKernelV2ComparisonDto | null;
 }
 
 export function buildDecisionKernelV2ExplainDto(args: {
@@ -112,6 +115,18 @@ export function buildDecisionKernelV2ExplainDto(args: {
       }),
     },
   });
+  const currentState = inferStateFromPullRequest(
+    args.config,
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+    args.nowMs,
+  );
+  const comparison = buildDecisionKernelV2ComparisonDto({
+    currentState,
+    v2Decision: decision,
+  });
 
   return {
     issueNumber: args.issueNumber,
@@ -122,6 +137,7 @@ export function buildDecisionKernelV2ExplainDto(args: {
     inventory,
     reviewPolicyInput,
     decision,
+    comparison,
   };
 }
 
@@ -176,7 +192,31 @@ export function renderDecisionKernelV2ExplainDto(dto: DecisionKernelV2ExplainDto
     );
   }
 
+  if (dto.comparison) {
+    lines.push(
+      [
+        "v2_comparison",
+        `category=${dto.comparison.category}`,
+        `current_state=${dto.comparison.current.state}`,
+        `current_action=${dto.comparison.current.actionEquivalent}`,
+        `v2_action=${dto.comparison.v2.action}`,
+        `differences=${renderComparisonDifferences(dto.comparison.differences)}`,
+        `safety=${dto.comparison.safetyNote.replace(/\s+/g, "_")}`,
+      ].join(" "),
+    );
+  }
+
   return lines.join("\n");
+}
+
+function renderComparisonDifferences(differences: DecisionKernelV2ComparisonDto["differences"]): string {
+  if (differences.length === 0) {
+    return "none";
+  }
+
+  return differences
+    .map((difference) => `${difference.field}:${difference.current}->${difference.v2}`)
+    .join("|");
 }
 
 function missingTarget(
@@ -197,6 +237,7 @@ function missingTarget(
     inventory: null,
     reviewPolicyInput: null,
     decision: null,
+    comparison: null,
   };
 }
 

--- a/src/decision-kernel/v2-explain.ts
+++ b/src/decision-kernel/v2-explain.ts
@@ -4,6 +4,7 @@ import {
   hasCodexConnectorPrSuccessCurrentHeadObservation,
   type ReviewPolicyInput,
 } from "../codex-connector-review-policy";
+import { codexConnectorReviewRequestAction } from "../codex-connector-review-request-decision";
 import { displayLocalCiCommand } from "../core/config-parsing";
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import type {
@@ -30,7 +31,8 @@ import {
   effectiveConfiguredBotReviewThreadsForState,
   hasConfiguredProviderSuccess,
 } from "../pull-request-state-codex-residue-policy";
-import { manualReviewThreads } from "../review-thread-reporting";
+import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
+import { mergeConflictDetected } from "../supervisor/supervisor-reporting";
 import type { PrLifecycleFactInventory } from "./pr-lifecycle-state";
 
 export interface DecisionKernelV2ExplainDto {
@@ -125,6 +127,15 @@ export function buildDecisionKernelV2ExplainDto(args: {
   );
   const comparison = buildDecisionKernelV2ComparisonDto({
     currentState,
+    currentActionEquivalent: currentActionEquivalentForV2Comparison({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads,
+      currentState,
+      nowMs: args.nowMs,
+    }),
     v2Decision: decision,
   });
 
@@ -207,6 +218,42 @@ export function renderDecisionKernelV2ExplainDto(dto: DecisionKernelV2ExplainDto
   }
 
   return lines.join("\n");
+}
+
+function currentActionEquivalentForV2Comparison(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  currentState: ReturnType<typeof inferStateFromPullRequest>;
+  nowMs?: number;
+}): DecisionKernelV2ComparisonDto["current"]["actionEquivalent"] | undefined {
+  if (args.currentState !== "waiting_ci") {
+    return undefined;
+  }
+
+  const requestAction = codexConnectorReviewRequestAction({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+    summarizeChecks: summarizeRequestChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected,
+    nowMs: args.nowMs === undefined ? undefined : () => args.nowMs as number,
+  });
+
+  return requestAction.kind === "none" ? undefined : "request_review";
+}
+
+function summarizeRequestChecks(checks: PullRequestCheck[]): { hasPending: boolean; hasFailing: boolean } {
+  return {
+    hasPending: checks.some((check) => check.bucket === "pending" || check.bucket === "cancel"),
+    hasFailing: checks.some((check) => check.bucket === "fail"),
+  };
 }
 
 function renderComparisonDifferences(differences: DecisionKernelV2ComparisonDto["differences"]): string {

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -142,6 +142,7 @@ const EXPECTED_FAMILY_FILES = {
     "pr-lifecycle-trace-fixtures.ts",
     "pr-lifecycle-trace-presenter.ts",
     "pr-lifecycle-trace.ts",
+    "v2-comparison.ts",
     "v2-explain.ts",
   ],
   "external-review": [


### PR DESCRIPTION
## Summary
- add a Decision Kernel v2 comparison DTO that compares current inferred RunState with v2 read-only decisions
- surface agreement, safe divergence, and fail-closed manual-review-required categories in `explain --v2` output
- add focused comparison, v2 explain, CLI render, and family layout coverage

## Verification
- `npx tsx --test src/decision-kernel/v2-comparison.test.ts src/decision-kernel/v2-explain.test.ts src/supervisor/supervisor-v2-explain-report.test.ts src/cli/supervisor-runtime.test.ts src/family-directory-layout.test.ts`
- `npx tsx --test src/decision-kernel-v2*.test.ts src/supervisor/*explain*.test.ts src/decision-kernel/v2-comparison.test.ts`
- `npx tsx --test src/decision-kernel/*.test.ts src/cli/supervisor-runtime.test.ts src/supervisor/supervisor-v2-explain-report.test.ts src/family-directory-layout.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2302 --config supervisor.config.codex.json`
- `git diff --check`

Known pre-existing verification note:
- The exact issue verification command including `src/pull-request-state-policy.test.ts` still fails one existing case: `inferStateFromPullRequest advances past proven Codex Connector stale metadata residue` expected `ready_to_merge`, actual `addressing_review`. This branch does not modify `src/pull-request-state-policy.ts` or its test.

Closes #2302