### PR TITLE
Phase 3.4: Record v2 comparison trace evidence

### DIFF
--- a/replay-corpus/decision-traces/merge-ready.json
+++ b/replay-corpus/decision-traces/merge-ready.json
@@ -45,6 +45,20 @@
       "recommendedAction": "merge",
       "summary": "Fresh PR lifecycle facts are merge ready."
     },
-    "evidenceTokens": ["pr=1001", "head=head-merge-ready", "checks=green"]
+    "evidenceTokens": ["pr=1001", "head=head-merge-ready", "checks=green"],
+    "v2Comparison": {
+      "diagnosticOnly": true,
+      "current": {
+        "state": "ready_to_merge",
+        "actionEquivalent": "no_action"
+      },
+      "v2": {
+        "action": "no_action",
+        "reasons": ["merge_ready_diagnostic_only"]
+      },
+      "category": "agreement",
+      "differences": [],
+      "safetyNote": "Current and v2 decisions agree for the compared action boundary."
+    }
   }
 }

--- a/replay-corpus/decision-traces/review-blocked.json
+++ b/replay-corpus/decision-traces/review-blocked.json
@@ -45,6 +45,31 @@
       "recommendedAction": "manual_review",
       "summary": "Current-head review threads block automated merge."
     },
-    "evidenceTokens": ["pr=1003", "manual_threads=1", "current_bot_threads=2"]
+    "evidenceTokens": ["pr=1003", "manual_threads=1", "current_bot_threads=2"],
+    "v2Comparison": {
+      "diagnosticOnly": true,
+      "current": {
+        "state": "blocked",
+        "actionEquivalent": "ask_operator"
+      },
+      "v2": {
+        "action": "run_codex",
+        "reasons": ["current_head_must_fix_review"]
+      },
+      "category": "manual_review_required",
+      "differences": [
+        {
+          "field": "action",
+          "current": "ask_operator",
+          "v2": "run_codex"
+        },
+        {
+          "field": "reason",
+          "current": "manual_review_required",
+          "v2": "current_head_must_fix_review"
+        }
+      ],
+      "safetyNote": "Current and v2 diverge in an unsafe or ambiguous way; require operator review before trusting v2."
+    }
   }
 }

--- a/replay-corpus/decision-traces/review-blocked.json
+++ b/replay-corpus/decision-traces/review-blocked.json
@@ -53,23 +53,18 @@
         "actionEquivalent": "ask_operator"
       },
       "v2": {
-        "action": "run_codex",
-        "reasons": ["current_head_must_fix_review"]
+        "action": "ask_operator",
+        "reasons": ["manual_review_thread"]
       },
-      "category": "manual_review_required",
+      "category": "agreement",
       "differences": [
-        {
-          "field": "action",
-          "current": "ask_operator",
-          "v2": "run_codex"
-        },
         {
           "field": "reason",
           "current": "manual_review_required",
-          "v2": "current_head_must_fix_review"
+          "v2": "manual_review_thread"
         }
       ],
-      "safetyNote": "Current and v2 diverge in an unsafe or ambiguous way; require operator review before trusting v2."
+      "safetyNote": "Current and v2 decisions agree for the compared action boundary."
     }
   }
 }

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -51,6 +51,20 @@ test("Decision Kernel trace fixtures preserve representative policy and decision
   );
 });
 
+test("Decision Kernel trace fixtures preserve optional v2 comparison evidence", async () => {
+  const fixtures = await loadPrLifecycleTraceFixtures(
+    path.join(process.cwd(), "replay-corpus", "decision-traces"),
+  );
+  const comparisonById = new Map(
+    fixtures.map((fixture) => [fixture.id, fixture.artifact.v2Comparison?.category ?? "none"]),
+  );
+
+  assert.equal(comparisonById.get("merge-ready"), "agreement");
+  assert.equal(comparisonById.get("review-blocked"), "manual_review_required");
+  assert.equal(comparisonById.get("wait-ci"), "none");
+  assert.equal(fixtures.find((fixture) => fixture.id === "merge-ready")?.artifact.v2Comparison?.diagnosticOnly, true);
+});
+
 test("Decision Kernel trace fixtures render compact diagnostics without host-local paths", async () => {
   const fixtures = await loadPrLifecycleTraceFixtures(
     path.join(process.cwd(), "replay-corpus", "decision-traces"),
@@ -63,6 +77,8 @@ test("Decision Kernel trace fixtures render compact diagnostics without host-loc
   assert.match(diagnostics.join("\n"), /label=review_blocked/);
   assert.match(diagnostics.join("\n"), /label=stale_local_state/);
   assert.match(diagnostics.join("\n"), /label=metadata_only_review_residue/);
+  assert.match(diagnostics.join("\n"), /v2_comparison=agreement/);
+  assert.match(diagnostics.join("\n"), /v2_comparison=manual_review_required/);
   assert.doesNotMatch(diagnostics.join("\n"), /\/Users\//);
   assert.doesNotMatch(diagnostics.join("\n"), /[A-Z]:\\/);
 });

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -5,11 +5,13 @@ import {
   guardPrLifecycleEvaluation,
   type PrLifecycleEvaluationMode,
 } from "./pr-lifecycle-evaluation-mode";
+import { evaluateDecisionKernelV2ReadOnly } from "../decision-kernel-v2";
 import {
   loadPrLifecycleTraceFixtures,
   parsePrLifecycleTraceFixture,
 } from "./pr-lifecycle-trace-fixtures";
 import { formatPrLifecycleTraceDiagnostic } from "./pr-lifecycle-trace-presenter";
+import { buildDecisionKernelV2ComparisonDto } from "./v2-comparison";
 
 const expectedFixtureIds = [
   "merge-ready",
@@ -60,9 +62,44 @@ test("Decision Kernel trace fixtures preserve optional v2 comparison evidence", 
   );
 
   assert.equal(comparisonById.get("merge-ready"), "agreement");
-  assert.equal(comparisonById.get("review-blocked"), "manual_review_required");
+  assert.equal(comparisonById.get("review-blocked"), "agreement");
   assert.equal(comparisonById.get("wait-ci"), "none");
   assert.equal(fixtures.find((fixture) => fixture.id === "merge-ready")?.artifact.v2Comparison?.diagnosticOnly, true);
+  assert.deepEqual(fixtures.find((fixture) => fixture.id === "review-blocked")?.artifact.v2Comparison?.differences, [
+    {
+      field: "reason",
+      current: "manual_review_required",
+      v2: "manual_review_thread",
+    },
+  ]);
+});
+
+test("Decision Kernel trace fixtures keep v2 comparison evidence reproducible from fixture facts", async () => {
+  const fixtures = await loadPrLifecycleTraceFixtures(
+    path.join(process.cwd(), "replay-corpus", "decision-traces"),
+  );
+
+  for (const fixture of fixtures) {
+    const comparison = fixture.artifact.v2Comparison;
+    if (!comparison) {
+      continue;
+    }
+
+    assert.deepEqual(
+      comparison,
+      {
+        diagnosticOnly: true,
+        ...buildDecisionKernelV2ComparisonDto({
+          currentState: comparison.current.state,
+          currentActionEquivalent: comparison.current.actionEquivalent,
+          v2Decision: evaluateDecisionKernelV2ReadOnly({
+            normalizedState: fixture.artifact.facts.normalizedState,
+          }),
+        }),
+      },
+      fixture.id,
+    );
+  }
 });
 
 test("Decision Kernel trace fixtures render compact diagnostics without host-local paths", async () => {
@@ -78,7 +115,7 @@ test("Decision Kernel trace fixtures render compact diagnostics without host-loc
   assert.match(diagnostics.join("\n"), /label=stale_local_state/);
   assert.match(diagnostics.join("\n"), /label=metadata_only_review_residue/);
   assert.match(diagnostics.join("\n"), /v2_comparison=agreement/);
-  assert.match(diagnostics.join("\n"), /v2_comparison=manual_review_required/);
+  assert.match(diagnostics.join("\n"), /v2_comparison_differences=reason:manual_review_required->manual_review_thread/);
   assert.doesNotMatch(diagnostics.join("\n"), /\/Users\//);
   assert.doesNotMatch(diagnostics.join("\n"), /[A-Z]:\\/);
 });

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { RunState } from "../core/types";
+import type {
+  DecisionKernelV2Action,
+  DecisionKernelV2Reason,
+} from "../decision-kernel-v2";
 import {
   PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION,
   type PrLifecycleDecision,
@@ -15,6 +20,10 @@ import type {
   PrLifecycleMergeabilityPosture,
   PrLifecycleReviewPosture,
 } from "./pr-lifecycle-state";
+import type {
+  DecisionKernelV2ComparisonCategory,
+  DecisionKernelV2ComparisonDifference,
+} from "./v2-comparison";
 
 export interface PrLifecycleTraceFixture {
   id: string;
@@ -86,6 +95,7 @@ function parsePrLifecycleDecisionTraceArtifact(
   const policy = requiredRecord(value.policy, source, "artifact.policy");
   const decision = requiredRecord(value.decision, source, "artifact.decision");
   const evidenceTokens = requiredStringArray(value.evidenceTokens, source, "artifact.evidenceTokens");
+  const v2Comparison = optionalV2Comparison(value.v2Comparison, source);
   const factsSource = requiredEnum(
     facts.source,
     source,
@@ -234,6 +244,7 @@ function parsePrLifecycleDecisionTraceArtifact(
       summary: requiredString(decision.summary, source, "artifact.decision.summary"),
     },
     evidenceTokens,
+    v2Comparison,
   };
 }
 
@@ -265,6 +276,47 @@ const prLifecyclePolicyPostures = [
 ] as const satisfies readonly PrLifecyclePolicyPosture[];
 const prLifecycleDecisions = ["merge", "wait", "request_review", "run_codex", "ask_operator", "do_nothing"] as const satisfies readonly PrLifecycleDecision[];
 const prLifecycleRecommendedActions = ["merge", "wait_ci", "request_review", "repair", "manual_review", "refresh_state", "no_action"] as const satisfies readonly PrLifecycleRecommendedAction[];
+const decisionKernelV2ComparisonCategories = ["agreement", "safe_divergence", "manual_review_required"] as const satisfies readonly DecisionKernelV2ComparisonCategory[];
+const decisionKernelV2Actions = ["wait", "request_review", "run_codex", "ask_operator", "no_action"] as const satisfies readonly DecisionKernelV2Action[];
+const decisionKernelV2Reasons = [
+  "no_pull_request",
+  "pull_request_closed",
+  "draft_pull_request",
+  "merge_conflict",
+  "stale_local_state",
+  "fresh_local_state_required",
+  "manual_review_thread",
+  "metadata_only_review_residue",
+  "current_head_must_fix_review",
+  "stale_commit_review",
+  "review_policy_input_mismatch",
+  "missing_current_head_review",
+  "checks_failing",
+  "checks_pending",
+  "checks_unknown",
+  "merge_ready_diagnostic_only",
+  "insufficient_merge_evidence",
+] as const satisfies readonly DecisionKernelV2Reason[];
+const runStates = [
+  "queued",
+  "planning",
+  "reproducing",
+  "implementing",
+  "local_review_fix",
+  "stabilizing",
+  "draft_pr",
+  "local_review",
+  "pr_open",
+  "repairing_ci",
+  "resolving_conflict",
+  "waiting_ci",
+  "addressing_review",
+  "ready_to_merge",
+  "merging",
+  "done",
+  "blocked",
+  "failed",
+] as const satisfies readonly RunState[];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -325,6 +377,91 @@ function requiredStringArray(value: unknown, source: string, field: string): str
     throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be a string array.`);
   }
   return [...value];
+}
+
+function requiredEnumArray<const T extends readonly string[]>(
+  value: unknown,
+  source: string,
+  field: string,
+  allowed: T,
+): T[number][] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be an array.`);
+  }
+
+  return value.map((entry, index) => requiredEnum(entry, source, `${field}[${index}]`, allowed));
+}
+
+function optionalV2Comparison(
+  value: unknown,
+  source: string,
+): PrLifecycleDecisionTraceArtifact["v2Comparison"] {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const comparison = requiredRecord(value, source, "artifact.v2Comparison");
+  const current = requiredRecord(comparison.current, source, "artifact.v2Comparison.current");
+  const v2 = requiredRecord(comparison.v2, source, "artifact.v2Comparison.v2");
+  return {
+    diagnosticOnly: requiredBoolean(comparison.diagnosticOnly, source, "artifact.v2Comparison.diagnosticOnly"),
+    current: {
+      state: requiredEnum(current.state, source, "artifact.v2Comparison.current.state", runStates),
+      actionEquivalent: requiredEnum(
+        current.actionEquivalent,
+        source,
+        "artifact.v2Comparison.current.actionEquivalent",
+        decisionKernelV2Actions,
+      ),
+    },
+    v2: {
+      action: requiredEnum(v2.action, source, "artifact.v2Comparison.v2.action", decisionKernelV2Actions),
+      reasons: requiredEnumArray(
+        v2.reasons,
+        source,
+        "artifact.v2Comparison.v2.reasons",
+        decisionKernelV2Reasons,
+      ),
+    },
+    category: requiredEnum(
+      comparison.category,
+      source,
+      "artifact.v2Comparison.category",
+      decisionKernelV2ComparisonCategories,
+    ),
+    differences: requiredComparisonDifferences(
+      comparison.differences,
+      source,
+      "artifact.v2Comparison.differences",
+    ),
+    safetyNote: requiredString(comparison.safetyNote, source, "artifact.v2Comparison.safetyNote"),
+  };
+}
+
+function requiredBoolean(value: unknown, source: string, field: string): true {
+  if (value !== true) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be true.`);
+  }
+  return true;
+}
+
+function requiredComparisonDifferences(
+  value: unknown,
+  source: string,
+  field: string,
+): DecisionKernelV2ComparisonDifference[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be an array.`);
+  }
+
+  return value.map((entry, index) => {
+    const difference = requiredRecord(entry, source, `${field}[${index}]`);
+    return {
+      field: requiredString(difference.field, source, `${field}[${index}].field`),
+      current: requiredString(difference.current, source, `${field}[${index}].current`),
+      v2: requiredString(difference.v2, source, `${field}[${index}].v2`),
+    };
+  });
 }
 
 function assertEqualFixtureField(

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
@@ -99,6 +99,8 @@ test("formatPrLifecycleTraceDiagnostic renders a merge-ready trace line", () => 
   assert.match(line, /mergeability=mergeable/);
   assert.match(line, /local_state=fresh/);
   assert.match(line, /evidence=pr=2281,head=head-current,checks=green/);
+  assert.match(line, /v2_comparison=none/);
+  assert.match(line, /v2_diagnostic_only=no/);
 });
 
 test("formatPrLifecycleTraceDiagnostic renders pending CI diagnostics", () => {
@@ -205,6 +207,38 @@ test("formatPrLifecycleTraceDiagnostic renders review-blocked diagnostics", () =
   assert.match(line, /review=review_blocked/);
   assert.match(line, /manual_threads=1/);
   assert.match(line, /current_bot_threads=2/);
+});
+
+test("formatPrLifecycleTraceDiagnostic renders diagnostic-only v2 comparison evidence", () => {
+  const line = formatPrLifecycleTraceDiagnostic(
+    buildPrLifecycleDecisionTrace(
+      traceInput({
+        v2Comparison: {
+          current: {
+            state: "blocked",
+            actionEquivalent: "ask_operator",
+          },
+          v2: {
+            action: "run_codex",
+            reasons: ["current_head_must_fix_review"],
+          },
+          category: "manual_review_required",
+          differences: [
+            {
+              field: "action",
+              current: "ask_operator",
+              v2: "run_codex",
+            },
+          ],
+          safetyNote: "Current and v2 diverge in an unsafe or ambiguous way; require operator review before trusting v2.",
+        },
+      }),
+    ),
+  );
+
+  assert.match(line, /v2_comparison=manual_review_required/);
+  assert.match(line, /v2_diagnostic_only=yes/);
+  assert.match(line, /v2_comparison_differences=action:ask_operator->run_codex/);
 });
 
 test("formatPrLifecycleTraceDiagnostic renders stale local state versus fresh GitHub facts", () => {

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.ts
@@ -47,6 +47,7 @@ export function formatPrLifecycleTraceDiagnostic(
   const evidence = state.evidence;
   const evidenceTokens = trace.evidenceTokens.map(formatDiagnosticToken).join(",") || "none";
   const policyReasons = trace.policy.reasons.map(formatDiagnosticToken).join(",") || "none";
+  const v2Comparison = trace.v2Comparison;
 
   return [
     "pr_lifecycle_trace",
@@ -79,7 +80,23 @@ export function formatPrLifecycleTraceDiagnostic(
     `unknown_checks=${evidence.unknownCheckCount}`,
     `reasons=${policyReasons}`,
     `evidence=${evidenceTokens}`,
+    `v2_comparison=${v2Comparison?.category ?? "none"}`,
+    `v2_diagnostic_only=${v2Comparison?.diagnosticOnly ? "yes" : "no"}`,
+    `v2_comparison_differences=${formatV2ComparisonDifferences(v2Comparison?.differences ?? [])}`,
   ].join(" ");
+}
+
+function formatV2ComparisonDifferences(
+  differences: NonNullable<PrLifecycleDecisionTraceArtifact["v2Comparison"]>["differences"],
+): string {
+  if (differences.length === 0) {
+    return "none";
+  }
+
+  return differences
+    .map((difference) => `${difference.field}:${difference.current}->${difference.v2}`)
+    .map(formatDiagnosticToken)
+    .join(",");
 }
 
 function formatDiagnosticToken(value: string | null): string {

--- a/src/decision-kernel/pr-lifecycle-trace.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.test.ts
@@ -62,6 +62,7 @@ function traceInput(overrides: Partial<PrLifecycleDecisionTraceInput> = {}): PrL
       summary: "PR lifecycle facts are merge ready.",
     },
     evidenceTokens: ["pr=2280", "head=head-current", "checks=green"],
+    v2Comparison: null,
     ...overrides,
   };
 }
@@ -95,6 +96,7 @@ test("buildPrLifecycleDecisionTrace records a versioned facts-policy-decision-ac
   assert.equal(trace.facts.normalizedState.reviewPosture, "current_head_review_observed");
   assert.deepEqual(trace.policy.reasons, ["checks_green", "review_observed", "mergeable"]);
   assert.deepEqual(trace.evidenceTokens, ["pr=2280", "head=head-current", "checks=green"]);
+  assert.equal(trace.v2Comparison, null);
 });
 
 test("buildPrLifecycleDecisionTrace is byte-stable for the same explicit input", () => {
@@ -208,4 +210,28 @@ test("buildPrLifecycleDecisionTrace represents stale local state without side ef
   assert.equal(trace.facts.normalizedState.localStateFreshness, "stale");
   assert.equal(trace.policy.posture, "stale_local_state");
   assert.equal(trace.decision.recommendedAction, "refresh_state");
+});
+
+test("buildPrLifecycleDecisionTrace records optional v2 comparison evidence as diagnostic-only", () => {
+  const trace = buildPrLifecycleDecisionTrace(
+    traceInput({
+      v2Comparison: {
+        current: {
+          state: "ready_to_merge",
+          actionEquivalent: "no_action",
+        },
+        v2: {
+          action: "no_action",
+          reasons: ["merge_ready_diagnostic_only"],
+        },
+        category: "agreement",
+        differences: [],
+        safetyNote: "Current and v2 decisions agree for the compared action boundary.",
+      },
+    }),
+  );
+
+  assert.equal(trace.v2Comparison?.diagnosticOnly, true);
+  assert.equal(trace.v2Comparison?.category, "agreement");
+  assert.deepEqual(trace.v2Comparison?.v2.reasons, ["merge_ready_diagnostic_only"]);
 });

--- a/src/decision-kernel/pr-lifecycle-trace.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.ts
@@ -1,4 +1,5 @@
 import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
+import type { DecisionKernelV2ComparisonDto } from "./v2-comparison";
 
 export const PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION = "pr_lifecycle_decision_trace.v1";
 
@@ -46,6 +47,7 @@ export interface PrLifecycleDecisionTraceInput {
     summary: string;
   };
   evidenceTokens?: string[];
+  v2Comparison?: DecisionKernelV2ComparisonDto | null;
 }
 
 export interface PrLifecycleDecisionTraceArtifact {
@@ -70,6 +72,7 @@ export interface PrLifecycleDecisionTraceArtifact {
     summary: string;
   };
   evidenceTokens: string[];
+  v2Comparison: (DecisionKernelV2ComparisonDto & { diagnosticOnly: true }) | null;
 }
 
 export function buildPrLifecycleDecisionTrace(
@@ -99,6 +102,28 @@ export function buildPrLifecycleDecisionTrace(
       summary: input.decision.summary,
     },
     evidenceTokens: [...(input.evidenceTokens ?? [])],
+    v2Comparison: input.v2Comparison
+      ? {
+        ...snapshotV2Comparison(input.v2Comparison),
+        diagnosticOnly: true,
+      }
+      : null,
+  };
+}
+
+function snapshotV2Comparison(comparison: DecisionKernelV2ComparisonDto): DecisionKernelV2ComparisonDto {
+  return {
+    current: {
+      state: comparison.current.state,
+      actionEquivalent: comparison.current.actionEquivalent,
+    },
+    v2: {
+      action: comparison.v2.action,
+      reasons: [...comparison.v2.reasons],
+    },
+    category: comparison.category,
+    differences: comparison.differences.map((difference) => ({ ...difference })),
+    safetyNote: comparison.safetyNote,
   };
 }
 


### PR DESCRIPTION
## Summary
- add optional diagnostic-only v2 comparison evidence to PR lifecycle decision trace artifacts
- validate v2 comparison fixture fields and render compact replay diagnostics
- seed replay corpus coverage for agreement and manual-review-required divergence examples

## Verification
- npm run build
- npx tsx --test src/decision-kernel/pr-lifecycle-trace.test.ts src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts src/decision-kernel/pr-lifecycle-trace-presenter.test.ts src/supervisor/replay-corpus.test.ts src/decision-kernel-v2.test.ts
- npx tsx --test src/decision-kernel/*.test.ts src/supervisor/replay-corpus.test.ts src/decision-kernel-v2*.test.ts
- node dist/index.js issue-lint 2304 --config supervisor.config.codex.json
- git diff --check

Closes #2304