### PR TITLE
Phase 3.5: Guard v2 diagnostic-only mode

### DIFF
--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ReviewPolicyInput } from "./codex-connector-review-policy";
 import {
+  DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE,
   DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION,
   evaluateDecisionKernelV2ReadOnly,
   evaluateDecisionKernelV2ReadOnlyFromFacts,
@@ -108,6 +109,14 @@ test("Decision Kernel v2 action vocabulary is typed", () => {
   assert.deepEqual(actions, ["wait", "request_review", "run_codex", "ask_operator", "no_action"]);
 });
 
+test("Decision Kernel v2 publishes a diagnostic-only safety posture", () => {
+  assert.deepEqual(DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE, {
+    mode: "diagnostic_only",
+    authoritative: false,
+    mutationAllowed: false,
+  });
+});
+
 test("evaluateDecisionKernelV2ReadOnly returns wait for stale local state", () => {
   const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({
     inventory: inventory({
@@ -136,6 +145,7 @@ test("evaluateDecisionKernelV2ReadOnly returns wait for stale local state", () =
   assert.equal(decision.safety.mode, "diagnostic_only");
   assert.equal(decision.safety.authoritative, false);
   assert.equal(decision.safety.mutationAllowed, false);
+  assert.deepEqual(decision.safety, DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE);
 });
 
 test("evaluateDecisionKernelV2ReadOnly returns run_codex for current-head must-fix review policy", () => {

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -53,6 +53,12 @@ export interface DecisionKernelV2SafetyPosture {
   mutationAllowed: false;
 }
 
+export const DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE = {
+  mode: "diagnostic_only",
+  authoritative: false,
+  mutationAllowed: false,
+} as const satisfies DecisionKernelV2SafetyPosture;
+
 export interface DecisionKernelV2CheckPolicyInput {
   noChecksAndNoLocalCi?: boolean;
   mergeReadyBlockedByLocalCi?: boolean;
@@ -365,11 +371,7 @@ function reviewPolicyAllowsAdvisoryOnly(reviewPolicy: ReviewPolicyBoundarySummar
 }
 
 function diagnosticOnlySafetyPosture(): DecisionKernelV2SafetyPosture {
-  return {
-    mode: "diagnostic_only",
-    authoritative: false,
-    mutationAllowed: false,
-  };
+  return DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE;
 }
 
 function snapshotNormalizedState(state: NormalizedPrLifecycleState): NormalizedPrLifecycleState {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -49,6 +49,14 @@ import {
   createReviewThread,
 } from "./turn-execution-test-helpers";
 
+test("post-turn pull request transitions do not import Decision Kernel v2 action decisions", async () => {
+  const source = await fs.readFile(path.join(process.cwd(), "src", "post-turn-pull-request.ts"), "utf8");
+
+  assert.doesNotMatch(source, /decision-kernel-v2/u);
+  assert.doesNotMatch(source, /evaluateDecisionKernelV2/u);
+  assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase emits typed review-wait change events", async () => {
   const config = createConfig();
   const issue = createIssue({ title: "Emit review wait changes" });

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -32,6 +32,14 @@ import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
 
+test("run-once turn execution does not import Decision Kernel v2 action decisions", async () => {
+  const source = await fs.readFile(path.join(process.cwd(), "src", "run-once-turn-execution.ts"), "utf8");
+
+  assert.doesNotMatch(source, /decision-kernel-v2/u);
+  assert.doesNotMatch(source, /evaluateDecisionKernelV2/u);
+  assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
+});
+
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], {
     encoding: "utf8",

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildSupervisorDashboardWorkflowSteps } from "./supervisor-dashboard-workflow";
-import { buildRuntimeRecoverySummary, renderSupervisorStatusDto } from "./supervisor-status-report";
+import {
+  buildRuntimeRecoverySummary,
+  renderDecisionKernelV2StatusLine,
+  renderSupervisorStatusDto,
+} from "./supervisor-status-report";
 
 const baseLoopRuntime = {
   state: "off" as const,
@@ -82,6 +86,38 @@ test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recover
       detailedStatusLines: ["tracked_issues=0"],
     }),
     null,
+  );
+});
+
+test("renderDecisionKernelV2StatusLine keeps v2 visibly diagnostic-only", () => {
+  assert.equal(
+    renderDecisionKernelV2StatusLine(),
+    "decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled",
+  );
+});
+
+test("renderSupervisorStatusDto includes the v2 diagnostic-only guardrail line", () => {
+  const rendered = renderSupervisorStatusDto({
+    gsdSummary: null,
+    candidateDiscovery: null,
+    candidateDiscoverySummary: null,
+    loopRuntime: baseLoopRuntime,
+    activeIssue: null,
+    selectionSummary: null,
+    trackedIssues: [],
+    runnableIssues: [],
+    blockedIssues: [],
+    detailedStatusLines: [],
+    reconciliationPhase: null,
+    reconciliationWarning: null,
+    readinessLines: [],
+    whyLines: [],
+    warning: null,
+  });
+
+  assert.match(
+    rendered,
+    /^decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled$/m,
   );
 });
 

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -5,6 +5,7 @@ import type {
   LocalCiContractSummary,
   TrustDiagnosticsSummary,
 } from "../core/types";
+import { DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE } from "../decision-kernel-v2";
 import { sanitizeStatusValue } from "./supervisor-status-rendering";
 import { truncate } from "../core/utils";
 import type { BlockedReason, RunState, SupervisorStateFile, TimelineArtifact } from "../core/types";
@@ -209,6 +210,16 @@ export function renderGitHubRateLimitLine(resource: "rest" | "graphql", budget: 
   return `github_rate_limit resource=${resource} status=${budget.state} remaining=${budget.remaining} limit=${budget.limit} reset_at=${budget.resetAt}`;
 }
 
+export function renderDecisionKernelV2StatusLine(): string {
+  return [
+    "decision_kernel_v2",
+    `mode=${DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE.mode}`,
+    `authoritative=${DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE.authoritative}`,
+    `mutation_allowed=${DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE.mutationAllowed}`,
+    "action_source=disabled",
+  ].join(" ");
+}
+
 export function renderLoopRuntimeLine(loopRuntime: SupervisorLoopRuntimeDto): string {
   const markerPath = "markerPath" in loopRuntime ? loopRuntime.markerPath : "none";
   const configPath = "configPath" in loopRuntime ? loopRuntime.configPath : null;
@@ -302,6 +313,7 @@ export function renderSupervisorStatusDto(dto: SupervisorStatusDto): string {
     operatorActionLine,
     ...githubRateLimitLines,
     renderLoopRuntimeLine(dto.loopRuntime),
+    renderDecisionKernelV2StatusLine(),
     ...(duplicateLoopDiagnosticLine ? [duplicateLoopDiagnosticLine] : []),
     ...(loopRuntimeRecoveryLine ? [loopRuntimeRecoveryLine] : []),
     `trust_mode=${trustDiagnostics.trustMode}`,


### PR DESCRIPTION
## Summary
- publish a shared Decision Kernel v2 diagnostic-only safety posture
- render a status guardrail line showing v2 is non-authoritative and mutation-disabled
- add regression tests that keep run-once and post-turn mutation paths disconnected from v2 decisions

## Verification
- npm run build
- npx tsx --test src/run-once*.test.ts src/post-turn-pull-request*.test.ts src/decision-kernel-v2*.test.ts src/supervisor/*status*.test.ts
- node dist/index.js issue-lint 2303 --config supervisor.config.codex.json
- git diff --check

Closes #2303