### PR TITLE
Add gated v2 PR lifecycle mode boundary

### DIFF
--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -7,6 +7,7 @@ import {
   type NormalizedPrLifecycleState,
   type PrLifecycleFactInventory,
 } from "./decision-kernel/pr-lifecycle-state";
+import { DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE } from "./decision-kernel/pr-lifecycle-evaluation-mode";
 
 export const DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION = "decision_kernel_v2.read_only.v1";
 
@@ -54,9 +55,9 @@ export interface DecisionKernelV2SafetyPosture {
 }
 
 export const DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE = {
-  mode: "diagnostic_only",
-  authoritative: false,
-  mutationAllowed: false,
+  mode: DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE.mode,
+  authoritative: DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE.authoritative,
+  mutationAllowed: DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE.mutationAllowed,
 } as const satisfies DecisionKernelV2SafetyPosture;
 
 export interface DecisionKernelV2CheckPolicyInput {

--- a/src/decision-kernel/pr-lifecycle-evaluation-mode.test.ts
+++ b/src/decision-kernel/pr-lifecycle-evaluation-mode.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   classifyPrLifecycleFactFreshness,
+  decisionKernelV2ModePosture,
   factFreshnessRequirementForMode,
   guardPrLifecycleEvaluation,
+  prLifecycleEvaluationModeForRuntime,
 } from "./pr-lifecycle-evaluation-mode";
 import {
   normalizePrLifecycleFacts,
@@ -47,18 +49,48 @@ function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecyc
 }
 
 test("factFreshnessRequirementForMode separates action-taking from diagnostics", () => {
-  assert.equal(factFreshnessRequirementForMode("action_taking"), "fresh_github_required");
+  assert.equal(factFreshnessRequirementForMode("pr_lifecycle_action_taking"), "fresh_github_required");
   assert.equal(factFreshnessRequirementForMode("diagnostic_only"), "cached_facts_allowed");
+});
+
+test("decisionKernelV2ModePosture names disabled, diagnostic, and PR lifecycle action-taking boundaries", () => {
+  assert.deepEqual(decisionKernelV2ModePosture("disabled"), {
+    mode: "disabled",
+    authoritative: false,
+    mutationAllowed: false,
+    actionSource: "disabled",
+    actionScope: "none",
+  });
+  assert.deepEqual(decisionKernelV2ModePosture("diagnostic_only"), {
+    mode: "diagnostic_only",
+    authoritative: false,
+    mutationAllowed: false,
+    actionSource: "disabled",
+    actionScope: "none",
+  });
+  assert.deepEqual(decisionKernelV2ModePosture("pr_lifecycle_action_taking"), {
+    mode: "pr_lifecycle_action_taking",
+    authoritative: true,
+    mutationAllowed: true,
+    actionSource: "pr_lifecycle_v2",
+    actionScope: "pr_lifecycle",
+  });
+});
+
+test("prLifecycleEvaluationModeForRuntime keeps disabled mode out of PR lifecycle evaluation", () => {
+  assert.equal(prLifecycleEvaluationModeForRuntime("disabled"), null);
+  assert.equal(prLifecycleEvaluationModeForRuntime("diagnostic_only"), "diagnostic_only");
+  assert.equal(prLifecycleEvaluationModeForRuntime("pr_lifecycle_action_taking"), "pr_lifecycle_action_taking");
 });
 
 test("guardPrLifecycleEvaluation allows action-taking with fresh GitHub facts", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(inventory()),
   });
 
   assert.deepEqual(result, {
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     requirement: "fresh_github_required",
     freshness: "fresh",
     decision: "allowed",
@@ -68,7 +100,7 @@ test("guardPrLifecycleEvaluation allows action-taking with fresh GitHub facts", 
 
 test("guardPrLifecycleEvaluation blocks action-taking with cached facts", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
       inventory({
         source: "cached_github",
@@ -83,7 +115,7 @@ test("guardPrLifecycleEvaluation blocks action-taking with cached facts", () => 
 
 test("guardPrLifecycleEvaluation blocks action-taking with missing fact observation", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
       inventory({
         observedAt: null,
@@ -98,7 +130,7 @@ test("guardPrLifecycleEvaluation blocks action-taking with missing fact observat
 
 test("guardPrLifecycleEvaluation blocks action-taking with malformed fact observation", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
       inventory({
         observedAt: "not-a-date",
@@ -113,7 +145,7 @@ test("guardPrLifecycleEvaluation blocks action-taking with malformed fact observ
 
 test("guardPrLifecycleEvaluation blocks action-taking when fresh GitHub facts expose stale local state", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
       inventory({
         pullRequest: {
@@ -142,7 +174,7 @@ test("guardPrLifecycleEvaluation blocks action-taking when fresh GitHub facts ex
 
 test("guardPrLifecycleEvaluation blocks action-taking when local state facts are missing", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
       inventory({
         localState: {
@@ -161,7 +193,7 @@ test("guardPrLifecycleEvaluation blocks action-taking when local state facts are
 
 test("guardPrLifecycleEvaluation blocks action-taking when local head facts are unknown", () => {
   const result = guardPrLifecycleEvaluation({
-    mode: "action_taking",
+    mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
       inventory({
         localState: {

--- a/src/decision-kernel/pr-lifecycle-evaluation-mode.ts
+++ b/src/decision-kernel/pr-lifecycle-evaluation-mode.ts
@@ -1,6 +1,41 @@
 import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
 
-export type PrLifecycleEvaluationMode = "action_taking" | "diagnostic_only";
+export type PrLifecycleEvaluationMode = "pr_lifecycle_action_taking" | "diagnostic_only";
+export type DecisionKernelV2RuntimeMode = "disabled" | PrLifecycleEvaluationMode;
+export type DecisionKernelV2ActionSource = "disabled" | "pr_lifecycle_v2";
+export type DecisionKernelV2ActionScope = "none" | "pr_lifecycle";
+
+export interface DecisionKernelV2ModePosture {
+  mode: DecisionKernelV2RuntimeMode;
+  authoritative: boolean;
+  mutationAllowed: boolean;
+  actionSource: DecisionKernelV2ActionSource;
+  actionScope: DecisionKernelV2ActionScope;
+}
+
+export const DECISION_KERNEL_V2_DISABLED_POSTURE = {
+  mode: "disabled",
+  authoritative: false,
+  mutationAllowed: false,
+  actionSource: "disabled",
+  actionScope: "none",
+} as const satisfies DecisionKernelV2ModePosture;
+
+export const DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE = {
+  mode: "diagnostic_only",
+  authoritative: false,
+  mutationAllowed: false,
+  actionSource: "disabled",
+  actionScope: "none",
+} as const satisfies DecisionKernelV2ModePosture;
+
+export const DECISION_KERNEL_V2_PR_LIFECYCLE_ACTION_TAKING_POSTURE = {
+  mode: "pr_lifecycle_action_taking",
+  authoritative: true,
+  mutationAllowed: true,
+  actionSource: "pr_lifecycle_v2",
+  actionScope: "pr_lifecycle",
+} as const satisfies DecisionKernelV2ModePosture;
 
 export type PrLifecycleFactFreshnessRequirement =
   | "fresh_github_required"
@@ -52,10 +87,31 @@ export function guardPrLifecycleEvaluation(
   };
 }
 
+export function decisionKernelV2ModePosture(mode: DecisionKernelV2RuntimeMode): DecisionKernelV2ModePosture {
+  switch (mode) {
+    case "disabled":
+      return DECISION_KERNEL_V2_DISABLED_POSTURE;
+    case "diagnostic_only":
+      return DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE;
+    case "pr_lifecycle_action_taking":
+      return DECISION_KERNEL_V2_PR_LIFECYCLE_ACTION_TAKING_POSTURE;
+  }
+}
+
+export function prLifecycleEvaluationModeForRuntime(
+  mode: DecisionKernelV2RuntimeMode,
+): PrLifecycleEvaluationMode | null {
+  if (mode === "disabled") {
+    return null;
+  }
+
+  return mode;
+}
+
 export function factFreshnessRequirementForMode(
   mode: PrLifecycleEvaluationMode,
 ): PrLifecycleFactFreshnessRequirement {
-  return mode === "action_taking" ? "fresh_github_required" : "cached_facts_allowed";
+  return mode === "pr_lifecycle_action_taking" ? "fresh_github_required" : "cached_facts_allowed";
 }
 
 export function classifyPrLifecycleFactFreshness(

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -125,11 +125,11 @@ test("Decision Kernel trace fixtures remain read-only for action-taking evaluati
     path.join(process.cwd(), "replay-corpus", "decision-traces"),
   );
   const modeById = new Map<string, PrLifecycleEvaluationMode>([
-    ["merge-ready", "action_taking"],
+    ["merge-ready", "pr_lifecycle_action_taking"],
     ["metadata-only-review-residue", "diagnostic_only"],
     ["review-blocked", "diagnostic_only"],
-    ["stale-local-state", "action_taking"],
-    ["wait-ci", "action_taking"],
+    ["stale-local-state", "pr_lifecycle_action_taking"],
+    ["wait-ci", "pr_lifecycle_action_taking"],
   ]);
   const results = fixtures.map((fixture) => [
     fixture.id,

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -275,3 +275,67 @@ test("parsePrLifecycleTraceFixture rejects top-level fact snapshots that disagre
     /artifact\.facts\.headSha must match artifact\.facts\.normalizedState/,
   );
 });
+
+test("parsePrLifecycleTraceFixture rejects v2 mode postures that disagree with the declared mode", () => {
+  assert.throws(
+    () =>
+      parsePrLifecycleTraceFixture({
+        id: "bad-v2-mode",
+        intent: "prove v2 mode posture validation fails",
+        artifact: {
+          schemaVersion: "pr_lifecycle_decision_trace.v1",
+          traceId: "bad-v2-mode",
+          generatedAt: "2026-06-07T00:00:00.000Z",
+          facts: {
+            source: "fixture",
+            observedAt: "2026-06-07T00:00:00.000Z",
+            pullRequestNumber: 100,
+            headSha: "head-current",
+            normalizedState: {
+              source: "fixture",
+              observedAt: "2026-06-07T00:00:00.000Z",
+              pullRequestNumber: 100,
+              headSha: "head-current",
+              headFreshness: "current_head",
+              reviewPosture: "current_head_review_observed",
+              checkPosture: "green",
+              mergeability: "mergeable",
+              localStateFreshness: "fresh",
+              evidence: {
+                manualReviewThreadCount: 0,
+                currentHeadConfiguredBotThreadCount: 0,
+                stalePreviousHeadConfiguredBotThreadCount: 0,
+                metadataOnlyUnresolvedThreadCount: 0,
+                passingCheckCount: 1,
+                pendingCheckCount: 0,
+                failingCheckCount: 0,
+                unknownCheckCount: 0,
+                trackedHeadSha: "head-current",
+                workspaceHeadSha: "head-current",
+                lastObservedPrHeadSha: "head-current"
+              }
+            }
+          },
+          policy: {
+            name: "pr_lifecycle_decision_kernel_v2",
+            posture: "merge_ready",
+            reasons: []
+          },
+          decision: {
+            value: "merge",
+            recommendedAction: "merge",
+            summary: "bad v2 mode"
+          },
+          evidenceTokens: [],
+          v2Mode: {
+            mode: "disabled",
+            authoritative: false,
+            mutationAllowed: true,
+            actionSource: "disabled",
+            actionScope: "none"
+          }
+        }
+      }),
+    /artifact\.v2Mode\.mutationAllowed must match the posture derived from artifact\.v2Mode\.mode/,
+  );
+});

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -410,12 +410,24 @@ function optionalV2Mode(value: unknown, source: string): DecisionKernelV2ModePos
   }
 
   const mode = requiredRecord(value, source, "artifact.v2Mode");
+  const parsedMode = requiredEnum(mode.mode, source, "artifact.v2Mode.mode", decisionKernelV2RuntimeModes);
+  const expected = decisionKernelV2ModePosture(parsedMode);
+  const authoritative = requiredAnyBoolean(mode.authoritative, source, "artifact.v2Mode.authoritative");
+  const mutationAllowed = requiredAnyBoolean(mode.mutationAllowed, source, "artifact.v2Mode.mutationAllowed");
+  const actionSource = requiredEnum(mode.actionSource, source, "artifact.v2Mode.actionSource", decisionKernelV2ActionSources);
+  const actionScope = requiredEnum(mode.actionScope, source, "artifact.v2Mode.actionScope", decisionKernelV2ActionScopes);
+
+  assertEqualV2ModePosture(authoritative, expected.authoritative, source, "artifact.v2Mode.authoritative");
+  assertEqualV2ModePosture(mutationAllowed, expected.mutationAllowed, source, "artifact.v2Mode.mutationAllowed");
+  assertEqualV2ModePosture(actionSource, expected.actionSource, source, "artifact.v2Mode.actionSource");
+  assertEqualV2ModePosture(actionScope, expected.actionScope, source, "artifact.v2Mode.actionScope");
+
   return {
-    mode: requiredEnum(mode.mode, source, "artifact.v2Mode.mode", decisionKernelV2RuntimeModes),
-    authoritative: requiredAnyBoolean(mode.authoritative, source, "artifact.v2Mode.authoritative"),
-    mutationAllowed: requiredAnyBoolean(mode.mutationAllowed, source, "artifact.v2Mode.mutationAllowed"),
-    actionSource: requiredEnum(mode.actionSource, source, "artifact.v2Mode.actionSource", decisionKernelV2ActionSources),
-    actionScope: requiredEnum(mode.actionScope, source, "artifact.v2Mode.actionScope", decisionKernelV2ActionScopes),
+    mode: parsedMode,
+    authoritative,
+    mutationAllowed,
+    actionSource,
+    actionScope,
   };
 }
 
@@ -507,6 +519,19 @@ function assertEqualFixtureField(
   if (actual !== expected) {
     throw new Error(
       `Invalid PR lifecycle trace fixture at ${source}: ${field} must match artifact.facts.normalizedState.`,
+    );
+  }
+}
+
+function assertEqualV2ModePosture(
+  actual: string | boolean,
+  expected: string | boolean,
+  source: string,
+  field: string,
+): void {
+  if (actual !== expected) {
+    throw new Error(
+      `Invalid PR lifecycle trace fixture at ${source}: ${field} must match the posture derived from artifact.v2Mode.mode.`,
     );
   }
 }

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -24,6 +24,13 @@ import type {
   DecisionKernelV2ComparisonCategory,
   DecisionKernelV2ComparisonDifference,
 } from "./v2-comparison";
+import {
+  decisionKernelV2ModePosture,
+  type DecisionKernelV2ActionScope,
+  type DecisionKernelV2ActionSource,
+  type DecisionKernelV2ModePosture,
+  type DecisionKernelV2RuntimeMode,
+} from "./pr-lifecycle-evaluation-mode";
 
 export interface PrLifecycleTraceFixture {
   id: string;
@@ -95,6 +102,7 @@ function parsePrLifecycleDecisionTraceArtifact(
   const policy = requiredRecord(value.policy, source, "artifact.policy");
   const decision = requiredRecord(value.decision, source, "artifact.decision");
   const evidenceTokens = requiredStringArray(value.evidenceTokens, source, "artifact.evidenceTokens");
+  const v2Mode = optionalV2Mode(value.v2Mode, source);
   const v2Comparison = optionalV2Comparison(value.v2Comparison, source);
   const factsSource = requiredEnum(
     facts.source,
@@ -244,6 +252,7 @@ function parsePrLifecycleDecisionTraceArtifact(
       summary: requiredString(decision.summary, source, "artifact.decision.summary"),
     },
     evidenceTokens,
+    v2Mode,
     v2Comparison,
   };
 }
@@ -276,6 +285,9 @@ const prLifecyclePolicyPostures = [
 ] as const satisfies readonly PrLifecyclePolicyPosture[];
 const prLifecycleDecisions = ["merge", "wait", "request_review", "run_codex", "ask_operator", "do_nothing"] as const satisfies readonly PrLifecycleDecision[];
 const prLifecycleRecommendedActions = ["merge", "wait_ci", "request_review", "repair", "manual_review", "refresh_state", "no_action"] as const satisfies readonly PrLifecycleRecommendedAction[];
+const decisionKernelV2RuntimeModes = ["disabled", "diagnostic_only", "pr_lifecycle_action_taking"] as const satisfies readonly DecisionKernelV2RuntimeMode[];
+const decisionKernelV2ActionSources = ["disabled", "pr_lifecycle_v2"] as const satisfies readonly DecisionKernelV2ActionSource[];
+const decisionKernelV2ActionScopes = ["none", "pr_lifecycle"] as const satisfies readonly DecisionKernelV2ActionScope[];
 const decisionKernelV2ComparisonCategories = ["agreement", "safe_divergence", "manual_review_required"] as const satisfies readonly DecisionKernelV2ComparisonCategory[];
 const decisionKernelV2Actions = ["wait", "request_review", "run_codex", "ask_operator", "no_action"] as const satisfies readonly DecisionKernelV2Action[];
 const decisionKernelV2Reasons = [
@@ -392,6 +404,21 @@ function requiredEnumArray<const T extends readonly string[]>(
   return value.map((entry, index) => requiredEnum(entry, source, `${field}[${index}]`, allowed));
 }
 
+function optionalV2Mode(value: unknown, source: string): DecisionKernelV2ModePosture {
+  if (value === undefined || value === null) {
+    return decisionKernelV2ModePosture("diagnostic_only");
+  }
+
+  const mode = requiredRecord(value, source, "artifact.v2Mode");
+  return {
+    mode: requiredEnum(mode.mode, source, "artifact.v2Mode.mode", decisionKernelV2RuntimeModes),
+    authoritative: requiredAnyBoolean(mode.authoritative, source, "artifact.v2Mode.authoritative"),
+    mutationAllowed: requiredAnyBoolean(mode.mutationAllowed, source, "artifact.v2Mode.mutationAllowed"),
+    actionSource: requiredEnum(mode.actionSource, source, "artifact.v2Mode.actionSource", decisionKernelV2ActionSources),
+    actionScope: requiredEnum(mode.actionScope, source, "artifact.v2Mode.actionScope", decisionKernelV2ActionScopes),
+  };
+}
+
 function optionalV2Comparison(
   value: unknown,
   source: string,
@@ -436,6 +463,13 @@ function optionalV2Comparison(
     ),
     safetyNote: requiredString(comparison.safetyNote, source, "artifact.v2Comparison.safetyNote"),
   };
+}
+
+function requiredAnyBoolean(value: unknown, source: string, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`Invalid PR lifecycle trace fixture at ${source}: ${field} must be a boolean.`);
+  }
+  return value;
 }
 
 function requiredBoolean(value: unknown, source: string, field: string): true {

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
@@ -99,8 +99,29 @@ test("formatPrLifecycleTraceDiagnostic renders a merge-ready trace line", () => 
   assert.match(line, /mergeability=mergeable/);
   assert.match(line, /local_state=fresh/);
   assert.match(line, /evidence=pr=2281,head=head-current,checks=green/);
+  assert.match(line, /v2_mode=diagnostic_only/);
+  assert.match(line, /v2_authoritative=false/);
+  assert.match(line, /v2_mutation_allowed=false/);
+  assert.match(line, /v2_action_source=disabled/);
+  assert.match(line, /v2_action_scope=none/);
   assert.match(line, /v2_comparison=none/);
   assert.match(line, /v2_diagnostic_only=no/);
+});
+
+test("formatPrLifecycleTraceDiagnostic renders the gated v2 PR lifecycle action source", () => {
+  const line = formatPrLifecycleTraceDiagnostic(
+    buildPrLifecycleDecisionTrace(
+      traceInput({
+        v2Mode: "pr_lifecycle_action_taking",
+      }),
+    ),
+  );
+
+  assert.match(line, /v2_mode=pr_lifecycle_action_taking/);
+  assert.match(line, /v2_authoritative=true/);
+  assert.match(line, /v2_mutation_allowed=true/);
+  assert.match(line, /v2_action_source=pr_lifecycle_v2/);
+  assert.match(line, /v2_action_scope=pr_lifecycle/);
 });
 
 test("formatPrLifecycleTraceDiagnostic renders pending CI diagnostics", () => {

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.ts
@@ -48,6 +48,7 @@ export function formatPrLifecycleTraceDiagnostic(
   const evidenceTokens = trace.evidenceTokens.map(formatDiagnosticToken).join(",") || "none";
   const policyReasons = trace.policy.reasons.map(formatDiagnosticToken).join(",") || "none";
   const v2Comparison = trace.v2Comparison;
+  const v2Mode = trace.v2Mode;
 
   return [
     "pr_lifecycle_trace",
@@ -80,6 +81,11 @@ export function formatPrLifecycleTraceDiagnostic(
     `unknown_checks=${evidence.unknownCheckCount}`,
     `reasons=${policyReasons}`,
     `evidence=${evidenceTokens}`,
+    `v2_mode=${v2Mode.mode}`,
+    `v2_authoritative=${v2Mode.authoritative}`,
+    `v2_mutation_allowed=${v2Mode.mutationAllowed}`,
+    `v2_action_source=${v2Mode.actionSource}`,
+    `v2_action_scope=${v2Mode.actionScope}`,
     `v2_comparison=${v2Comparison?.category ?? "none"}`,
     `v2_diagnostic_only=${v2Comparison?.diagnosticOnly ? "yes" : "no"}`,
     `v2_comparison_differences=${formatV2ComparisonDifferences(v2Comparison?.differences ?? [])}`,

--- a/src/decision-kernel/pr-lifecycle-trace.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.test.ts
@@ -96,6 +96,13 @@ test("buildPrLifecycleDecisionTrace records a versioned facts-policy-decision-ac
   assert.equal(trace.facts.normalizedState.reviewPosture, "current_head_review_observed");
   assert.deepEqual(trace.policy.reasons, ["checks_green", "review_observed", "mergeable"]);
   assert.deepEqual(trace.evidenceTokens, ["pr=2280", "head=head-current", "checks=green"]);
+  assert.deepEqual(trace.v2Mode, {
+    mode: "diagnostic_only",
+    authoritative: false,
+    mutationAllowed: false,
+    actionSource: "disabled",
+    actionScope: "none",
+  });
   assert.equal(trace.v2Comparison, null);
 });
 
@@ -234,4 +241,20 @@ test("buildPrLifecycleDecisionTrace records optional v2 comparison evidence as d
   assert.equal(trace.v2Comparison?.diagnosticOnly, true);
   assert.equal(trace.v2Comparison?.category, "agreement");
   assert.deepEqual(trace.v2Comparison?.v2.reasons, ["merge_ready_diagnostic_only"]);
+});
+
+test("buildPrLifecycleDecisionTrace records the explicit v2 PR lifecycle mode boundary", () => {
+  const trace = buildPrLifecycleDecisionTrace(
+    traceInput({
+      v2Mode: "pr_lifecycle_action_taking",
+    }),
+  );
+
+  assert.deepEqual(trace.v2Mode, {
+    mode: "pr_lifecycle_action_taking",
+    authoritative: true,
+    mutationAllowed: true,
+    actionSource: "pr_lifecycle_v2",
+    actionScope: "pr_lifecycle",
+  });
 });

--- a/src/decision-kernel/pr-lifecycle-trace.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.ts
@@ -1,4 +1,9 @@
 import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
+import {
+  decisionKernelV2ModePosture,
+  type DecisionKernelV2ModePosture,
+  type DecisionKernelV2RuntimeMode,
+} from "./pr-lifecycle-evaluation-mode";
 import type { DecisionKernelV2ComparisonDto } from "./v2-comparison";
 
 export const PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION = "pr_lifecycle_decision_trace.v1";
@@ -47,6 +52,7 @@ export interface PrLifecycleDecisionTraceInput {
     summary: string;
   };
   evidenceTokens?: string[];
+  v2Mode?: DecisionKernelV2RuntimeMode | DecisionKernelV2ModePosture;
   v2Comparison?: DecisionKernelV2ComparisonDto | null;
 }
 
@@ -72,6 +78,7 @@ export interface PrLifecycleDecisionTraceArtifact {
     summary: string;
   };
   evidenceTokens: string[];
+  v2Mode: DecisionKernelV2ModePosture;
   v2Comparison: (DecisionKernelV2ComparisonDto & { diagnosticOnly: true }) | null;
 }
 
@@ -102,12 +109,24 @@ export function buildPrLifecycleDecisionTrace(
       summary: input.decision.summary,
     },
     evidenceTokens: [...(input.evidenceTokens ?? [])],
+    v2Mode: snapshotV2Mode(input.v2Mode ?? "diagnostic_only"),
     v2Comparison: input.v2Comparison
       ? {
         ...snapshotV2Comparison(input.v2Comparison),
         diagnosticOnly: true,
       }
       : null,
+  };
+}
+
+function snapshotV2Mode(modeOrPosture: DecisionKernelV2RuntimeMode | DecisionKernelV2ModePosture): DecisionKernelV2ModePosture {
+  const posture = typeof modeOrPosture === "string" ? decisionKernelV2ModePosture(modeOrPosture) : modeOrPosture;
+  return {
+    mode: posture.mode,
+    authoritative: posture.authoritative,
+    mutationAllowed: posture.mutationAllowed,
+    actionSource: posture.actionSource,
+    actionScope: posture.actionScope,
   };
 }
 

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -55,6 +55,8 @@ test("post-turn pull request transitions do not import Decision Kernel v2 action
   assert.doesNotMatch(source, /decision-kernel-v2/u);
   assert.doesNotMatch(source, /evaluateDecisionKernelV2/u);
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
+  assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
+  assert.doesNotMatch(source, /prLifecycleEvaluationModeForRuntime/u);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase emits typed review-wait change events", async () => {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -38,6 +38,8 @@ test("run-once turn execution does not import Decision Kernel v2 action decision
   assert.doesNotMatch(source, /decision-kernel-v2/u);
   assert.doesNotMatch(source, /evaluateDecisionKernelV2/u);
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
+  assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
+  assert.doesNotMatch(source, /prLifecycleEvaluationModeForRuntime/u);
 });
 
 function git(cwd: string, ...args: string[]): string {

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -92,7 +92,18 @@ test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recover
 test("renderDecisionKernelV2StatusLine keeps v2 visibly diagnostic-only", () => {
   assert.equal(
     renderDecisionKernelV2StatusLine(),
-    "decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled",
+    "decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled action_scope=none",
+  );
+});
+
+test("renderDecisionKernelV2StatusLine distinguishes disabled and PR lifecycle action-taking modes", () => {
+  assert.equal(
+    renderDecisionKernelV2StatusLine("disabled"),
+    "decision_kernel_v2 mode=disabled authoritative=false mutation_allowed=false action_source=disabled action_scope=none",
+  );
+  assert.equal(
+    renderDecisionKernelV2StatusLine("pr_lifecycle_action_taking"),
+    "decision_kernel_v2 mode=pr_lifecycle_action_taking authoritative=true mutation_allowed=true action_source=pr_lifecycle_v2 action_scope=pr_lifecycle",
   );
 });
 
@@ -117,7 +128,7 @@ test("renderSupervisorStatusDto includes the v2 diagnostic-only guardrail line",
 
   assert.match(
     rendered,
-    /^decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled$/m,
+    /^decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled action_scope=none$/m,
   );
 });
 

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -5,7 +5,11 @@ import type {
   LocalCiContractSummary,
   TrustDiagnosticsSummary,
 } from "../core/types";
-import { DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE } from "../decision-kernel-v2";
+import {
+  decisionKernelV2ModePosture,
+  type DecisionKernelV2ModePosture,
+  type DecisionKernelV2RuntimeMode,
+} from "../decision-kernel/pr-lifecycle-evaluation-mode";
 import { sanitizeStatusValue } from "./supervisor-status-rendering";
 import { truncate } from "../core/utils";
 import type { BlockedReason, RunState, SupervisorStateFile, TimelineArtifact } from "../core/types";
@@ -210,13 +214,17 @@ export function renderGitHubRateLimitLine(resource: "rest" | "graphql", budget: 
   return `github_rate_limit resource=${resource} status=${budget.state} remaining=${budget.remaining} limit=${budget.limit} reset_at=${budget.resetAt}`;
 }
 
-export function renderDecisionKernelV2StatusLine(): string {
+export function renderDecisionKernelV2StatusLine(
+  modeOrPosture: DecisionKernelV2RuntimeMode | DecisionKernelV2ModePosture = "diagnostic_only",
+): string {
+  const posture = typeof modeOrPosture === "string" ? decisionKernelV2ModePosture(modeOrPosture) : modeOrPosture;
   return [
     "decision_kernel_v2",
-    `mode=${DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE.mode}`,
-    `authoritative=${DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE.authoritative}`,
-    `mutation_allowed=${DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_POSTURE.mutationAllowed}`,
-    "action_source=disabled",
+    `mode=${posture.mode}`,
+    `authoritative=${posture.authoritative}`,
+    `mutation_allowed=${posture.mutationAllowed}`,
+    `action_source=${posture.actionSource}`,
+    `action_scope=${posture.actionScope}`,
   ].join(" ");
 }
 


### PR DESCRIPTION
## Summary
- add explicit Decision Kernel v2 runtime postures for disabled, diagnostic-only, and PR lifecycle action-taking modes
- expose the active v2 mode/action source in status and PR lifecycle trace diagnostics
- keep run-once and post-turn mutation paths guarded against v2 action-taking imports

## Scope boundary
This PR introduces the Phase 4.1 gate and reporting boundary only. It does not promote any specific review, CI, stale review, or merge decision to v2 action-taking.

## Verification
- `npx tsx --test src/decision-kernel-v2*.test.ts src/decision-kernel/*.test.ts src/supervisor/*status*.test.ts src/run-once*.test.ts src/post-turn-pull-request*.test.ts`
- `npm run build`

Closes #2311
