### PR TITLE
Promote v2 review and CI lifecycle actions

### DIFF
--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildPrLifecycleDecisionTrace } from "./pr-lifecycle-trace";
+import { normalizePrLifecycleFacts, type PrLifecycleFactInventory } from "./pr-lifecycle-state";
+import { evaluateDecisionKernelV2PrLifecycleAction } from "./v2-pr-lifecycle-action";
+
+function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecycleFactInventory {
+  return {
+    source: "fresh_github",
+    observedAt: "2026-06-09T00:00:00.000Z",
+    pullRequest: {
+      number: 2312,
+      headSha: "head-current",
+      state: "OPEN",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+      currentHeadReviewObservedAt: "2026-06-09T00:01:00.000Z",
+      currentHeadReviewHeadSha: "head-current",
+    },
+    reviewThreads: {
+      unresolvedManualThreadCount: 0,
+      unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+      stalePreviousHeadConfiguredBotThreadCount: 0,
+      metadataOnlyUnresolvedThreadCount: 0,
+    },
+    checks: {
+      passingCount: 3,
+      pendingCount: 0,
+      failingCount: 0,
+      unknownCount: 0,
+    },
+    localState: {
+      trackedHeadSha: "head-current",
+      workspaceHeadSha: "head-current",
+      lastObservedPrHeadSha: "head-current",
+    },
+    configuredCurrentHeadReviewRequired: true,
+    ...overrides,
+  };
+}
+
+test("evaluateDecisionKernelV2PrLifecycleAction promotes missing review to request_review behind the PR lifecycle gate", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: null,
+          currentHeadReviewHeadSha: null,
+        },
+      }),
+    ),
+  });
+
+  assert.equal(decision.action, "request_review");
+  assert.deepEqual(decision.reasons, ["v2_request_review"]);
+  assert.deepEqual(decision.traceDecision, {
+    value: "request_review",
+    recommendedAction: "request_review",
+    summary: "Current-head review evidence is missing.",
+  });
+  assert.equal(decision.mode.actionSource, "pr_lifecycle_v2");
+  assert.equal(decision.guard?.decision, "allowed");
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction promotes pending and unknown checks to wait_ci", () => {
+  const pending = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: null,
+          currentHeadReviewHeadSha: null,
+        },
+        checks: {
+          passingCount: 1,
+          pendingCount: 1,
+          failingCount: 0,
+          unknownCount: 0,
+        },
+      }),
+    ),
+  });
+  const unknown = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: null,
+          currentHeadReviewHeadSha: null,
+        },
+        checks: {
+          passingCount: 0,
+          pendingCount: 0,
+          failingCount: 0,
+          unknownCount: 0,
+        },
+      }),
+    ),
+  });
+
+  assert.equal(pending.action, "wait_ci");
+  assert.equal(unknown.action, "wait_ci");
+  assert.deepEqual(pending.traceDecision, {
+    value: "wait",
+    recommendedAction: "wait_ci",
+    summary: "Required checks are still pending.",
+  });
+  assert.deepEqual(unknown.v2Decision.reasons, ["checks_unknown"]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction keeps repair and merge decisions outside the Phase 4.2 action boundary", () => {
+  const failingChecks = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        checks: {
+          passingCount: 1,
+          pendingCount: 0,
+          failingCount: 1,
+          unknownCount: 0,
+        },
+      }),
+    ),
+  });
+  const mergeReady = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(inventory()),
+  });
+
+  assert.equal(failingChecks.v2Decision.action, "run_codex");
+  assert.equal(failingChecks.action, "no_action");
+  assert.deepEqual(failingChecks.reasons, ["v2_action_not_promoted"]);
+  assert.equal(mergeReady.v2Decision.action, "no_action");
+  assert.equal(mergeReady.action, "no_action");
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction promotes ambiguous review facts to ask_operator", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        reviewThreads: {
+          unresolvedManualThreadCount: 1,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+          stalePreviousHeadConfiguredBotThreadCount: 0,
+          metadataOnlyUnresolvedThreadCount: 0,
+        },
+      }),
+    ),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_ask_operator"]);
+  assert.deepEqual(decision.traceDecision, {
+    value: "ask_operator",
+    recommendedAction: "manual_review",
+    summary: "Manual review threads require operator review.",
+  });
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction fails closed when fresh fact requirements are not met", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        source: "cached_github",
+      }),
+    ),
+  });
+
+  assert.equal(decision.guard?.decision, "blocked");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["fresh_facts_guard_blocked"]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction keeps disabled and diagnostic-only modes non-mutating", () => {
+  const normalizedState = normalizePrLifecycleFacts(
+    inventory({
+      pullRequest: {
+        number: 2312,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "CLEAN",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: null,
+        currentHeadReviewHeadSha: null,
+      },
+    }),
+  );
+  const disabled = evaluateDecisionKernelV2PrLifecycleAction({ mode: "disabled", normalizedState });
+  const diagnosticOnly = evaluateDecisionKernelV2PrLifecycleAction({ mode: "diagnostic_only", normalizedState });
+
+  assert.equal(disabled.v2Decision.action, "request_review");
+  assert.equal(disabled.action, "no_action");
+  assert.equal(disabled.mode.actionSource, "disabled");
+  assert.deepEqual(disabled.reasons, ["v2_disabled"]);
+  assert.equal(diagnosticOnly.v2Decision.action, "request_review");
+  assert.equal(diagnosticOnly.action, "no_action");
+  assert.equal(diagnosticOnly.mode.actionSource, "disabled");
+  assert.deepEqual(diagnosticOnly.reasons, ["v2_diagnostic_only"]);
+});
+
+test("v2 PR lifecycle action decisions can be recorded with a v2 action source trace posture", () => {
+  const actionDecision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: null,
+          currentHeadReviewHeadSha: null,
+        },
+      }),
+    ),
+  });
+  const trace = buildPrLifecycleDecisionTrace({
+    traceId: "trace-2312",
+    generatedAt: "2026-06-09T00:02:00.000Z",
+    normalizedState: actionDecision.v2Decision.normalizedState,
+    policy: {
+      name: "pr_lifecycle_decision_kernel_v2",
+      posture: "request_current_head_review",
+      reasons: actionDecision.v2Decision.reasons,
+    },
+    decision: actionDecision.traceDecision,
+    evidenceTokens: ["pr=2312", "action_source=pr_lifecycle_v2"],
+    v2Mode: actionDecision.mode,
+  });
+
+  assert.equal(trace.v2Mode.mode, "pr_lifecycle_action_taking");
+  assert.equal(trace.v2Mode.actionSource, "pr_lifecycle_v2");
+  assert.equal(trace.decision.value, "request_review");
+  assert.equal(trace.decision.recommendedAction, "request_review");
+});

--- a/src/decision-kernel/v2-pr-lifecycle-action.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.ts
@@ -1,0 +1,196 @@
+import {
+  evaluateDecisionKernelV2ReadOnly,
+  type DecisionKernelV2CheckPolicyInput,
+  type DecisionKernelV2ReadOnlyDecision,
+} from "../decision-kernel-v2";
+import type { ReviewPolicyInput } from "../codex-connector-review-policy";
+import type {
+  PrLifecycleDecision,
+  PrLifecycleRecommendedAction,
+} from "./pr-lifecycle-trace";
+import {
+  decisionKernelV2ModePosture,
+  guardPrLifecycleEvaluation,
+  prLifecycleEvaluationModeForRuntime,
+  type DecisionKernelV2ModePosture,
+  type DecisionKernelV2RuntimeMode,
+  type PrLifecycleEvaluationGuardResult,
+} from "./pr-lifecycle-evaluation-mode";
+import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
+
+export type DecisionKernelV2PrLifecycleAction =
+  | "request_review"
+  | "wait_ci"
+  | "ask_operator"
+  | "no_action";
+
+export type DecisionKernelV2PrLifecycleActionReason =
+  | "v2_disabled"
+  | "v2_diagnostic_only"
+  | "fresh_facts_guard_blocked"
+  | "v2_request_review"
+  | "v2_wait_ci"
+  | "v2_ask_operator"
+  | "v2_action_not_promoted";
+
+export interface DecisionKernelV2PrLifecycleActionInput {
+  mode: DecisionKernelV2RuntimeMode;
+  normalizedState: NormalizedPrLifecycleState;
+  reviewPolicyInput?: ReviewPolicyInput | null;
+  checkPolicyInput?: DecisionKernelV2CheckPolicyInput | null;
+}
+
+export interface DecisionKernelV2PrLifecycleActionDecision {
+  mode: DecisionKernelV2ModePosture;
+  guard: PrLifecycleEvaluationGuardResult | null;
+  v2Decision: DecisionKernelV2ReadOnlyDecision;
+  action: DecisionKernelV2PrLifecycleAction;
+  reasons: DecisionKernelV2PrLifecycleActionReason[];
+  summary: string;
+  traceDecision: {
+    value: PrLifecycleDecision;
+    recommendedAction: PrLifecycleRecommendedAction;
+    summary: string;
+  };
+}
+
+export function evaluateDecisionKernelV2PrLifecycleAction(
+  input: DecisionKernelV2PrLifecycleActionInput,
+): DecisionKernelV2PrLifecycleActionDecision {
+  const mode = decisionKernelV2ModePosture(input.mode);
+  const evaluationMode = prLifecycleEvaluationModeForRuntime(input.mode);
+  const v2Decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: input.normalizedState,
+    reviewPolicyInput: input.reviewPolicyInput ?? null,
+    checkPolicyInput: input.checkPolicyInput ?? null,
+  });
+
+  if (evaluationMode === null) {
+    return actionDecision({
+      mode,
+      guard: null,
+      v2Decision,
+      action: "no_action",
+      reasons: ["v2_disabled"],
+      summary: "Decision Kernel v2 is disabled; no v2 PR lifecycle action is selected.",
+    });
+  }
+
+  const guard = guardPrLifecycleEvaluation({
+    mode: evaluationMode,
+    normalizedState: v2Decision.normalizedState,
+  });
+
+  if (evaluationMode === "diagnostic_only") {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "no_action",
+      reasons: ["v2_diagnostic_only"],
+      summary: "Decision Kernel v2 is diagnostic-only; the selected v2 decision is reported without taking action.",
+    });
+  }
+
+  if (guard.decision === "blocked") {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "ask_operator",
+      reasons: ["fresh_facts_guard_blocked"],
+      summary: "Decision Kernel v2 PR lifecycle action-taking requires fresh, consistent PR lifecycle facts.",
+    });
+  }
+
+  return promoteV2Decision({ mode, guard, v2Decision });
+}
+
+function promoteV2Decision(args: {
+  mode: DecisionKernelV2ModePosture;
+  guard: PrLifecycleEvaluationGuardResult;
+  v2Decision: DecisionKernelV2ReadOnlyDecision;
+}): DecisionKernelV2PrLifecycleActionDecision {
+  const { mode, guard, v2Decision } = args;
+
+  if (v2Decision.action === "request_review") {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "request_review",
+      reasons: ["v2_request_review"],
+      summary: v2Decision.summary,
+    });
+  }
+
+  if (v2Decision.action === "wait" && isCiWaitDecision(v2Decision)) {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "wait_ci",
+      reasons: ["v2_wait_ci"],
+      summary: v2Decision.summary,
+    });
+  }
+
+  if (v2Decision.action === "ask_operator") {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "ask_operator",
+      reasons: ["v2_ask_operator"],
+      summary: v2Decision.summary,
+    });
+  }
+
+  return actionDecision({
+    mode,
+    guard,
+    v2Decision,
+    action: "no_action",
+    reasons: ["v2_action_not_promoted"],
+    summary: "The v2 decision is outside the Phase 4.2 PR lifecycle action boundary.",
+  });
+}
+
+function isCiWaitDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
+  return decision.reasons.includes("checks_pending") || decision.reasons.includes("checks_unknown");
+}
+
+function actionDecision(args: {
+  mode: DecisionKernelV2ModePosture;
+  guard: PrLifecycleEvaluationGuardResult | null;
+  v2Decision: DecisionKernelV2ReadOnlyDecision;
+  action: DecisionKernelV2PrLifecycleAction;
+  reasons: DecisionKernelV2PrLifecycleActionReason[];
+  summary: string;
+}): DecisionKernelV2PrLifecycleActionDecision {
+  return {
+    mode: args.mode,
+    guard: args.guard,
+    v2Decision: args.v2Decision,
+    action: args.action,
+    reasons: [...args.reasons],
+    summary: args.summary,
+    traceDecision: traceDecision(args.action, args.summary),
+  };
+}
+
+function traceDecision(
+  action: DecisionKernelV2PrLifecycleAction,
+  summary: string,
+): DecisionKernelV2PrLifecycleActionDecision["traceDecision"] {
+  switch (action) {
+    case "request_review":
+      return { value: "request_review", recommendedAction: "request_review", summary };
+    case "wait_ci":
+      return { value: "wait", recommendedAction: "wait_ci", summary };
+    case "ask_operator":
+      return { value: "ask_operator", recommendedAction: "manual_review", summary };
+    case "no_action":
+      return { value: "do_nothing", recommendedAction: "no_action", summary };
+  }
+}

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -144,6 +144,7 @@ const EXPECTED_FAMILY_FILES = {
     "pr-lifecycle-trace.ts",
     "v2-comparison.ts",
     "v2-explain.ts",
+    "v2-pr-lifecycle-action.ts",
   ],
   "external-review": [
     "external-review-classifier.ts",


### PR DESCRIPTION
## Summary
- add a gated v2 PR lifecycle action adapter for Phase 4.2
- promote v2 `request_review`, CI wait, and `ask_operator` decisions only when `pr_lifecycle_action_taking` mode is enabled
- keep disabled and diagnostic-only modes non-mutating, and keep repair/merge decisions outside the Phase 4.2 boundary
- record v2 action source posture through the existing PR lifecycle trace surface

## Scope boundary
This PR does not change stale review terminal handling, merge readiness, issue selection, Codex execution, or merge execution. Repair and merge actions remain outside the promoted Phase 4.2 action boundary.

## Verification
- `npx tsx --test src/decision-kernel-v2*.test.ts src/decision-kernel/*.test.ts src/supervisor/*review*.test.ts src/supervisor/*status*.test.ts`
- `npx tsx --test src/family-directory-layout.test.ts`
- `npm run build`
- `git diff --check`

Closes #2312
