### PR TITLE
Promote v2 stale review terminal actions

### DIFF
--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -284,7 +284,16 @@ const prLifecyclePolicyPostures = [
   "unknown",
 ] as const satisfies readonly PrLifecyclePolicyPosture[];
 const prLifecycleDecisions = ["merge", "wait", "request_review", "run_codex", "ask_operator", "do_nothing"] as const satisfies readonly PrLifecycleDecision[];
-const prLifecycleRecommendedActions = ["merge", "wait_ci", "request_review", "repair", "manual_review", "refresh_state", "no_action"] as const satisfies readonly PrLifecycleRecommendedAction[];
+const prLifecycleRecommendedActions = [
+  "merge",
+  "wait_ci",
+  "request_review",
+  "repair",
+  "manual_review",
+  "mark_stale_resolved",
+  "refresh_state",
+  "no_action",
+] as const satisfies readonly PrLifecycleRecommendedAction[];
 const decisionKernelV2RuntimeModes = ["disabled", "diagnostic_only", "pr_lifecycle_action_taking"] as const satisfies readonly DecisionKernelV2RuntimeMode[];
 const decisionKernelV2ActionSources = ["disabled", "pr_lifecycle_v2"] as const satisfies readonly DecisionKernelV2ActionSource[];
 const decisionKernelV2ActionScopes = ["none", "pr_lifecycle"] as const satisfies readonly DecisionKernelV2ActionScope[];

--- a/src/decision-kernel/pr-lifecycle-trace.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.ts
@@ -34,6 +34,7 @@ export type PrLifecycleRecommendedAction =
   | "request_review"
   | "repair"
   | "manual_review"
+  | "mark_stale_resolved"
   | "refresh_state"
   | "no_action";
 

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -222,7 +222,7 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes ambiguous review facts 
   });
 });
 
-test("evaluateDecisionKernelV2PrLifecycleAction promotes stale previous-head reviews to terminal stale resolution", () => {
+test("evaluateDecisionKernelV2PrLifecycleAction requests current-head review before stale previous-head terminal resolution", () => {
   const decision = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
@@ -233,6 +233,16 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes stale previous-head rev
           stalePreviousHeadConfiguredBotThreadCount: 1,
           metadataOnlyUnresolvedThreadCount: 0,
         },
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: null,
+          currentHeadReviewHeadSha: null,
+        },
       }),
     ),
     reviewPolicyInput: reviewPolicyInput(["stale_commit_thread"]),
@@ -240,6 +250,31 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes stale previous-head rev
 
   assert.equal(decision.v2Decision.action, "wait");
   assert.deepEqual(decision.v2Decision.reasons, ["stale_commit_review"]);
+  assert.equal(decision.action, "request_review");
+  assert.deepEqual(decision.reasons, ["v2_stale_review_needs_current_head_review"]);
+  assert.deepEqual(decision.traceDecision, {
+    value: "request_review",
+    recommendedAction: "request_review",
+    summary: "Stale review residue needs current-head review evidence before terminal stale resolution.",
+  });
+  assert.deepEqual(decision.evidenceTokens, [
+    "terminal=stale_commit_review",
+    "missing=current_head_review",
+    "v2_reason=stale_commit_review",
+    "required_evidence=current_head_review",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction promotes stale review residue after current-head evidence exists", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(inventory()),
+    reviewPolicyInput: reviewPolicyInput(["stale_commit_thread"]),
+  });
+
+  assert.equal(decision.v2Decision.action, "wait");
+  assert.deepEqual(decision.v2Decision.reasons, ["stale_commit_review"]);
+  assert.equal(decision.v2Decision.normalizedState.reviewPosture, "current_head_review_observed");
   assert.equal(decision.action, "mark_stale_resolved");
   assert.deepEqual(decision.reasons, ["v2_mark_stale_resolved"]);
   assert.deepEqual(decision.traceDecision, {
@@ -247,11 +282,6 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes stale previous-head rev
     recommendedAction: "mark_stale_resolved",
     summary: "Review findings are tied to a stale commit and need current-head evidence.",
   });
-  assert.deepEqual(decision.evidenceTokens, [
-    "terminal=stale_commit_review",
-    "v2_reason=stale_commit_review",
-    "required_evidence=current_head_review",
-  ]);
 });
 
 test("evaluateDecisionKernelV2PrLifecycleAction treats processed metadata-only residue as terminal operator cleanup", () => {
@@ -307,6 +337,40 @@ test("evaluateDecisionKernelV2PrLifecycleAction sends exhausted reviewer loops t
     "retry_budget=repeat_stop_exhausted",
     "v2_reason=current_head_must_fix_review",
     "required_evidence=current_head_review+resolved_manual_threads",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction honors exhausted reviewer loops before requesting review", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: null,
+          currentHeadReviewHeadSha: null,
+        },
+      }),
+    ),
+    reviewerLoopTerminal: {
+      retryBudgetExhausted: true,
+      reason: "retry exhausted",
+    },
+  });
+
+  assert.equal(decision.v2Decision.action, "request_review");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_reviewer_loop_terminal"]);
+  assert.deepEqual(decision.evidenceTokens, [
+    "terminal=reviewer_loop_exhausted",
+    "retry_budget=retry_exhausted",
+    "v2_reason=missing_current_head_review",
+    "required_evidence=current_head_review",
   ]);
 });
 

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { ReviewPolicyInput } from "../codex-connector-review-policy";
 import { buildPrLifecycleDecisionTrace } from "./pr-lifecycle-trace";
 import { normalizePrLifecycleFacts, type PrLifecycleFactInventory } from "./pr-lifecycle-state";
 import { evaluateDecisionKernelV2PrLifecycleAction } from "./v2-pr-lifecycle-action";
@@ -37,6 +38,49 @@ function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecyc
     },
     configuredCurrentHeadReviewRequired: true,
     ...overrides,
+  };
+}
+
+function reviewPolicyInput(
+  outcomes: Array<ReviewPolicyInput["threads"][number]["boundaryOutcome"]>,
+): ReviewPolicyInput {
+  return {
+    providerIdentity: {
+      configuredProviderKinds: ["codex"],
+      configuredBotLogins: ["chatgpt-codex-connector"],
+    },
+    pr: {
+      number: 2312,
+      headSha: "head-current",
+      currentHeadObservedAt: "2026-06-09T00:01:00.000Z",
+      latestReviewedCommitSha: "head-current",
+      providerSuccessHeadSha: null,
+      externalReviewHeadSha: null,
+      currentHeadCiGreenAt: "2026-06-09T00:02:00.000Z",
+    },
+    threads: outcomes.map((boundaryOutcome, index) => ({
+      id: `thread-${index}`,
+      isResolved: false,
+      isOutdated: boundaryOutcome === "stale_commit_thread",
+      path: "src/example.ts",
+      line: 10 + index,
+      comments: [],
+      latestComment: null,
+      latestCodexConnectorSeverity: null,
+      latestCodexConnectorCommentFingerprint: null,
+      findingKind: boundaryOutcome === "must_fix_current_head" ? "must_fix" : "none",
+      headRelation: boundaryOutcome === "stale_commit_thread" ? "stale_commit" : "current_head",
+      boundaryOutcome,
+      processedEvidence: {
+        threadId: `thread-${index}`,
+        latestCommentFingerprint: null,
+        processedOnCurrentHead: boundaryOutcome === "metadata_only_unresolved",
+        processedOnPriorHead: boundaryOutcome === "stale_commit_thread",
+        processedThreadKeys: [`thread-${index}@head-current`],
+        processedThreadFingerprintKeys: [],
+      },
+      vocabulary: [],
+    })),
   };
 }
 
@@ -178,6 +222,115 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes ambiguous review facts 
   });
 });
 
+test("evaluateDecisionKernelV2PrLifecycleAction promotes stale previous-head reviews to terminal stale resolution", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        reviewThreads: {
+          unresolvedManualThreadCount: 0,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+          stalePreviousHeadConfiguredBotThreadCount: 1,
+          metadataOnlyUnresolvedThreadCount: 0,
+        },
+      }),
+    ),
+    reviewPolicyInput: reviewPolicyInput(["stale_commit_thread"]),
+  });
+
+  assert.equal(decision.v2Decision.action, "wait");
+  assert.deepEqual(decision.v2Decision.reasons, ["stale_commit_review"]);
+  assert.equal(decision.action, "mark_stale_resolved");
+  assert.deepEqual(decision.reasons, ["v2_mark_stale_resolved"]);
+  assert.deepEqual(decision.traceDecision, {
+    value: "do_nothing",
+    recommendedAction: "mark_stale_resolved",
+    summary: "Review findings are tied to a stale commit and need current-head evidence.",
+  });
+  assert.deepEqual(decision.evidenceTokens, [
+    "terminal=stale_commit_review",
+    "v2_reason=stale_commit_review",
+    "required_evidence=current_head_review",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction treats processed metadata-only residue as terminal operator cleanup", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        reviewThreads: {
+          unresolvedManualThreadCount: 0,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+          stalePreviousHeadConfiguredBotThreadCount: 0,
+          metadataOnlyUnresolvedThreadCount: 1,
+        },
+      }),
+    ),
+    reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+  });
+
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_metadata_terminal"]);
+  assert.deepEqual(decision.evidenceTokens, [
+    "terminal=metadata_only_review_residue",
+    "v2_reason=metadata_only_review_residue",
+    "required_evidence=resolved_metadata_residue",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction sends exhausted reviewer loops to operator instead of Codex repair", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        reviewThreads: {
+          unresolvedManualThreadCount: 0,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 1,
+          stalePreviousHeadConfiguredBotThreadCount: 0,
+          metadataOnlyUnresolvedThreadCount: 0,
+        },
+      }),
+    ),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"]),
+    reviewerLoopTerminal: {
+      retryBudgetExhausted: true,
+      reason: "repeat stop exhausted",
+    },
+  });
+
+  assert.equal(decision.v2Decision.action, "run_codex");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_reviewer_loop_terminal"]);
+  assert.deepEqual(decision.evidenceTokens, [
+    "terminal=reviewer_loop_exhausted",
+    "retry_budget=repeat_stop_exhausted",
+    "v2_reason=current_head_must_fix_review",
+    "required_evidence=current_head_review+resolved_manual_threads",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction keeps must-fix current-head reviews outside terminal promotion without retry exhaustion", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        reviewThreads: {
+          unresolvedManualThreadCount: 0,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 1,
+          stalePreviousHeadConfiguredBotThreadCount: 0,
+          metadataOnlyUnresolvedThreadCount: 0,
+        },
+      }),
+    ),
+    reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"]),
+  });
+
+  assert.equal(decision.v2Decision.action, "run_codex");
+  assert.equal(decision.action, "no_action");
+  assert.deepEqual(decision.reasons, ["v2_action_not_promoted"]);
+});
+
 test("evaluateDecisionKernelV2PrLifecycleAction fails closed when fresh fact requirements are not met", () => {
   const decision = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",
@@ -249,7 +402,7 @@ test("v2 PR lifecycle action decisions can be recorded with a v2 action source t
       reasons: actionDecision.v2Decision.reasons,
     },
     decision: actionDecision.traceDecision,
-    evidenceTokens: ["pr=2312", "action_source=pr_lifecycle_v2"],
+    evidenceTokens: ["pr=2312", "action_source=pr_lifecycle_v2", ...actionDecision.evidenceTokens],
     v2Mode: actionDecision.mode,
   });
 

--- a/src/decision-kernel/v2-pr-lifecycle-action.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.ts
@@ -32,6 +32,7 @@ export type DecisionKernelV2PrLifecycleActionReason =
   | "v2_request_review"
   | "v2_wait_ci"
   | "v2_mark_stale_resolved"
+  | "v2_stale_review_needs_current_head_review"
   | "v2_metadata_terminal"
   | "v2_reviewer_loop_terminal"
   | "v2_ask_operator"
@@ -130,6 +131,22 @@ function promoteV2Decision(args: {
 }): DecisionKernelV2PrLifecycleActionDecision {
   const { mode, guard, v2Decision, reviewerLoopTerminal } = args;
 
+  if (reviewerLoopTerminal?.retryBudgetExhausted) {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "ask_operator",
+      reasons: ["v2_reviewer_loop_terminal"],
+      evidenceTokens: [
+        "terminal=reviewer_loop_exhausted",
+        `retry_budget=${sanitizeEvidenceToken(reviewerLoopTerminal.reason)}`,
+        ...reviewEvidenceTokens(v2Decision),
+      ],
+      summary: "Reviewer loop retry budget is exhausted; require operator review instead of re-entering Codex repair.",
+    });
+  }
+
   if (v2Decision.action === "request_review") {
     return actionDecision({
       mode,
@@ -153,6 +170,18 @@ function promoteV2Decision(args: {
   }
 
   if (isStaleReviewTerminalDecision(v2Decision)) {
+    if (!hasCurrentHeadReviewEvidence(v2Decision)) {
+      return actionDecision({
+        mode,
+        guard,
+        v2Decision,
+        action: "request_review",
+        reasons: ["v2_stale_review_needs_current_head_review"],
+        evidenceTokens: ["terminal=stale_commit_review", "missing=current_head_review", ...reviewEvidenceTokens(v2Decision)],
+        summary: "Stale review residue needs current-head review evidence before terminal stale resolution.",
+      });
+    }
+
     return actionDecision({
       mode,
       guard,
@@ -173,22 +202,6 @@ function promoteV2Decision(args: {
       reasons: ["v2_metadata_terminal"],
       evidenceTokens: ["terminal=metadata_only_review_residue", ...reviewEvidenceTokens(v2Decision)],
       summary: v2Decision.summary,
-    });
-  }
-
-  if (reviewerLoopTerminal?.retryBudgetExhausted) {
-    return actionDecision({
-      mode,
-      guard,
-      v2Decision,
-      action: "ask_operator",
-      reasons: ["v2_reviewer_loop_terminal"],
-      evidenceTokens: [
-        "terminal=reviewer_loop_exhausted",
-        `retry_budget=${sanitizeEvidenceToken(reviewerLoopTerminal.reason)}`,
-        ...reviewEvidenceTokens(v2Decision),
-      ],
-      summary: "Reviewer loop retry budget is exhausted; require operator review instead of re-entering Codex repair.",
     });
   }
 
@@ -223,6 +236,13 @@ function isStaleReviewTerminalDecision(decision: DecisionKernelV2ReadOnlyDecisio
 
 function isMetadataTerminalDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
   return decision.reasons.includes("metadata_only_review_residue");
+}
+
+function hasCurrentHeadReviewEvidence(decision: DecisionKernelV2ReadOnlyDecision): boolean {
+  return (
+    decision.normalizedState.reviewPosture === "current_head_review_observed" ||
+    decision.normalizedState.reviewPosture === "no_unresolved_review"
+  );
 }
 
 function actionDecision(args: {

--- a/src/decision-kernel/v2-pr-lifecycle-action.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.ts
@@ -21,6 +21,7 @@ import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
 export type DecisionKernelV2PrLifecycleAction =
   | "request_review"
   | "wait_ci"
+  | "mark_stale_resolved"
   | "ask_operator"
   | "no_action";
 
@@ -30,14 +31,23 @@ export type DecisionKernelV2PrLifecycleActionReason =
   | "fresh_facts_guard_blocked"
   | "v2_request_review"
   | "v2_wait_ci"
+  | "v2_mark_stale_resolved"
+  | "v2_metadata_terminal"
+  | "v2_reviewer_loop_terminal"
   | "v2_ask_operator"
   | "v2_action_not_promoted";
+
+export interface DecisionKernelV2ReviewerLoopTerminalInput {
+  retryBudgetExhausted: boolean;
+  reason: string;
+}
 
 export interface DecisionKernelV2PrLifecycleActionInput {
   mode: DecisionKernelV2RuntimeMode;
   normalizedState: NormalizedPrLifecycleState;
   reviewPolicyInput?: ReviewPolicyInput | null;
   checkPolicyInput?: DecisionKernelV2CheckPolicyInput | null;
+  reviewerLoopTerminal?: DecisionKernelV2ReviewerLoopTerminalInput | null;
 }
 
 export interface DecisionKernelV2PrLifecycleActionDecision {
@@ -46,6 +56,7 @@ export interface DecisionKernelV2PrLifecycleActionDecision {
   v2Decision: DecisionKernelV2ReadOnlyDecision;
   action: DecisionKernelV2PrLifecycleAction;
   reasons: DecisionKernelV2PrLifecycleActionReason[];
+  evidenceTokens: string[];
   summary: string;
   traceDecision: {
     value: PrLifecycleDecision;
@@ -103,15 +114,21 @@ export function evaluateDecisionKernelV2PrLifecycleAction(
     });
   }
 
-  return promoteV2Decision({ mode, guard, v2Decision });
+  return promoteV2Decision({
+    mode,
+    guard,
+    v2Decision,
+    reviewerLoopTerminal: input.reviewerLoopTerminal ?? null,
+  });
 }
 
 function promoteV2Decision(args: {
   mode: DecisionKernelV2ModePosture;
   guard: PrLifecycleEvaluationGuardResult;
   v2Decision: DecisionKernelV2ReadOnlyDecision;
+  reviewerLoopTerminal: DecisionKernelV2ReviewerLoopTerminalInput | null;
 }): DecisionKernelV2PrLifecycleActionDecision {
-  const { mode, guard, v2Decision } = args;
+  const { mode, guard, v2Decision, reviewerLoopTerminal } = args;
 
   if (v2Decision.action === "request_review") {
     return actionDecision({
@@ -132,6 +149,46 @@ function promoteV2Decision(args: {
       action: "wait_ci",
       reasons: ["v2_wait_ci"],
       summary: v2Decision.summary,
+    });
+  }
+
+  if (isStaleReviewTerminalDecision(v2Decision)) {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "mark_stale_resolved",
+      reasons: ["v2_mark_stale_resolved"],
+      evidenceTokens: ["terminal=stale_commit_review", ...reviewEvidenceTokens(v2Decision)],
+      summary: v2Decision.summary,
+    });
+  }
+
+  if (isMetadataTerminalDecision(v2Decision)) {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "ask_operator",
+      reasons: ["v2_metadata_terminal"],
+      evidenceTokens: ["terminal=metadata_only_review_residue", ...reviewEvidenceTokens(v2Decision)],
+      summary: v2Decision.summary,
+    });
+  }
+
+  if (reviewerLoopTerminal?.retryBudgetExhausted) {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "ask_operator",
+      reasons: ["v2_reviewer_loop_terminal"],
+      evidenceTokens: [
+        "terminal=reviewer_loop_exhausted",
+        `retry_budget=${sanitizeEvidenceToken(reviewerLoopTerminal.reason)}`,
+        ...reviewEvidenceTokens(v2Decision),
+      ],
+      summary: "Reviewer loop retry budget is exhausted; require operator review instead of re-entering Codex repair.",
     });
   }
 
@@ -160,12 +217,21 @@ function isCiWaitDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
   return decision.reasons.includes("checks_pending") || decision.reasons.includes("checks_unknown");
 }
 
+function isStaleReviewTerminalDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
+  return decision.reasons.includes("stale_commit_review");
+}
+
+function isMetadataTerminalDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
+  return decision.reasons.includes("metadata_only_review_residue");
+}
+
 function actionDecision(args: {
   mode: DecisionKernelV2ModePosture;
   guard: PrLifecycleEvaluationGuardResult | null;
   v2Decision: DecisionKernelV2ReadOnlyDecision;
   action: DecisionKernelV2PrLifecycleAction;
   reasons: DecisionKernelV2PrLifecycleActionReason[];
+  evidenceTokens?: string[];
   summary: string;
 }): DecisionKernelV2PrLifecycleActionDecision {
   return {
@@ -174,6 +240,7 @@ function actionDecision(args: {
     v2Decision: args.v2Decision,
     action: args.action,
     reasons: [...args.reasons],
+    evidenceTokens: [...(args.evidenceTokens ?? reviewEvidenceTokens(args.v2Decision))],
     summary: args.summary,
     traceDecision: traceDecision(args.action, args.summary),
   };
@@ -188,9 +255,23 @@ function traceDecision(
       return { value: "request_review", recommendedAction: "request_review", summary };
     case "wait_ci":
       return { value: "wait", recommendedAction: "wait_ci", summary };
+    case "mark_stale_resolved":
+      return { value: "do_nothing", recommendedAction: "mark_stale_resolved", summary };
     case "ask_operator":
       return { value: "ask_operator", recommendedAction: "manual_review", summary };
     case "no_action":
       return { value: "do_nothing", recommendedAction: "no_action", summary };
   }
+}
+
+function reviewEvidenceTokens(decision: DecisionKernelV2ReadOnlyDecision): string[] {
+  const tokens = decision.reasons.map((reason) => `v2_reason=${reason}`);
+  if (decision.requiredEvidence.length > 0) {
+    tokens.push(`required_evidence=${decision.requiredEvidence.join("+")}`);
+  }
+  return tokens;
+}
+
+function sanitizeEvidenceToken(value: string): string {
+  return value.replace(/\s+/g, "_");
 }


### PR DESCRIPTION
## Summary
- promote stale previous-head review residue to a gated `mark_stale_resolved` v2 PR lifecycle terminal action
- keep processed metadata-only review residue on operator cleanup instead of Codex repair
- route exhausted reviewer-loop evidence to operator handoff instead of re-entering repair
- keep must-fix current-head review repair outside Phase 4.3 promotion unless retry exhaustion forces fail-closed operator handling

## Scope boundary
This PR does not promote merge readiness, does not loosen must-fix current-head review handling, and does not change Codex execution. Repair and merge paths remain outside the promoted terminal action boundary.

## Verification
- `npx tsx --test src/codex-connector-review-policy.test.ts src/codex-connector-review-request-decision.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/decision-kernel-v2*.test.ts src/decision-kernel/v2-pr-lifecycle-action.test.ts src/supervisor/replay-corpus.test.ts`
- `npm run build`
- `git diff --check`

Closes #2313
