### PR TITLE
[codex] Promote v2 merge readiness action

### DIFF
--- a/replay-corpus/decision-traces/merge-ready.json
+++ b/replay-corpus/decision-traces/merge-ready.json
@@ -50,15 +50,21 @@
       "diagnosticOnly": true,
       "current": {
         "state": "ready_to_merge",
-        "actionEquivalent": "merge"
+        "actionEquivalent": "no_action"
       },
       "v2": {
         "action": "merge",
         "reasons": ["merge_ready_diagnostic_only"]
       },
-      "category": "agreement",
-      "differences": [],
-      "safetyNote": "Current and v2 decisions agree for the compared action boundary."
+      "category": "manual_review_required",
+      "differences": [
+        {
+          "field": "action",
+          "current": "no_action",
+          "v2": "merge"
+        }
+      ],
+      "safetyNote": "Current and v2 diverge in an unsafe or ambiguous way; require operator review before trusting v2."
     }
   }
 }

--- a/replay-corpus/decision-traces/merge-ready.json
+++ b/replay-corpus/decision-traces/merge-ready.json
@@ -50,10 +50,10 @@
       "diagnosticOnly": true,
       "current": {
         "state": "ready_to_merge",
-        "actionEquivalent": "no_action"
+        "actionEquivalent": "merge"
       },
       "v2": {
-        "action": "no_action",
+        "action": "merge",
         "reasons": ["merge_ready_diagnostic_only"]
       },
       "category": "agreement",

--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -104,9 +104,9 @@ function reviewPolicyInput(
 }
 
 test("Decision Kernel v2 action vocabulary is typed", () => {
-  const actions: DecisionKernelV2Action[] = ["wait", "request_review", "run_codex", "ask_operator", "no_action"];
+  const actions: DecisionKernelV2Action[] = ["merge", "wait", "request_review", "run_codex", "ask_operator", "no_action"];
 
-  assert.deepEqual(actions, ["wait", "request_review", "run_codex", "ask_operator", "no_action"]);
+  assert.deepEqual(actions, ["merge", "wait", "request_review", "run_codex", "ask_operator", "no_action"]);
 });
 
 test("Decision Kernel v2 publishes a diagnostic-only safety posture", () => {
@@ -176,13 +176,13 @@ test("evaluateDecisionKernelV2ReadOnly returns ask_operator for manual review th
   assert.deepEqual(decision.requiredEvidence, ["resolved_manual_threads"]);
 });
 
-test("evaluateDecisionKernelV2ReadOnly returns no_action for merge-ready diagnostic-only state", () => {
+test("evaluateDecisionKernelV2ReadOnly returns merge for merge-ready state", () => {
   const decision = evaluateDecisionKernelV2ReadOnlyFromFacts({ inventory: inventory() });
 
-  assert.equal(decision.action, "no_action");
+  assert.equal(decision.action, "merge");
   assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
   assert.deepEqual(decision.requiredEvidence, []);
-  assert.match(decision.summary, /diagnostic-only/);
+  assert.match(decision.summary, /merge-ready/);
 });
 
 test("evaluateDecisionKernelV2ReadOnly treats no-review-required PRs as merge-ready", () => {
@@ -203,7 +203,7 @@ test("evaluateDecisionKernelV2ReadOnly treats no-review-required PRs as merge-re
   });
 
   assert.equal(decision.normalizedState.reviewPosture, "no_unresolved_review");
-  assert.equal(decision.action, "no_action");
+  assert.equal(decision.action, "merge");
   assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
   assert.deepEqual(decision.requiredEvidence, []);
 });
@@ -352,7 +352,7 @@ test("evaluateDecisionKernelV2ReadOnly treats no-CI check policy as merge-ready 
   });
 
   assert.equal(decision.normalizedState.checkPosture, "unknown");
-  assert.equal(decision.action, "no_action");
+  assert.equal(decision.action, "merge");
   assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
   assert.deepEqual(decision.requiredEvidence, []);
 });
@@ -463,7 +463,7 @@ test("evaluateDecisionKernelV2ReadOnly ignores resolved manual policy threads", 
     reviewPolicyInput: reviewPolicyInput(["manual_thread"], {}, { isResolved: true }),
   });
 
-  assert.equal(decision.action, "no_action");
+  assert.equal(decision.action, "merge");
   assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
 });
 
@@ -513,7 +513,7 @@ test("evaluateDecisionKernelV2ReadOnly respects non-Codex provider policy input"
     reviewPolicyInput: reviewPolicyInput(["must_fix_current_head"], {}, {}, { configuredProviderKinds: ["coderabbit"] }),
   });
 
-  assert.equal(decision.action, "no_action");
+  assert.equal(decision.action, "merge");
   assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
   assert.deepEqual(decision.requiredEvidence, []);
 });
@@ -531,6 +531,6 @@ test("evaluateDecisionKernelV2ReadOnly does not repair softened P3 advisory poli
     reviewPolicyInput: reviewPolicyInput(["softened_p3_advisory"]),
   });
 
-  assert.equal(decision.action, "no_action");
+  assert.equal(decision.action, "merge");
   assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
 });

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -12,6 +12,7 @@ import { DECISION_KERNEL_V2_DIAGNOSTIC_ONLY_MODE_POSTURE } from "./decision-kern
 export const DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION = "decision_kernel_v2.read_only.v1";
 
 export type DecisionKernelV2Action =
+  | "merge"
   | "wait"
   | "request_review"
   | "run_codex"
@@ -276,12 +277,7 @@ function selectReadOnlyDecision(
     !checkPolicy.mergeReadyBlockedByFinalGuard &&
     state.mergeability === "mergeable"
   ) {
-    return decision(
-      "no_action",
-      ["merge_ready_diagnostic_only"],
-      [],
-      "PR appears merge-ready, but v2 is diagnostic-only in this phase.",
-    );
+    return decision("merge", ["merge_ready_diagnostic_only"], [], "PR appears merge-ready.");
   }
 
   return decision(

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -61,7 +61,7 @@ test("Decision Kernel trace fixtures preserve optional v2 comparison evidence", 
     fixtures.map((fixture) => [fixture.id, fixture.artifact.v2Comparison?.category ?? "none"]),
   );
 
-  assert.equal(comparisonById.get("merge-ready"), "agreement");
+  assert.equal(comparisonById.get("merge-ready"), "manual_review_required");
   assert.equal(comparisonById.get("review-blocked"), "agreement");
   assert.equal(comparisonById.get("wait-ci"), "none");
   assert.equal(fixtures.find((fixture) => fixture.id === "merge-ready")?.artifact.v2Comparison?.diagnosticOnly, true);
@@ -115,6 +115,8 @@ test("Decision Kernel trace fixtures render compact diagnostics without host-loc
   assert.match(diagnostics.join("\n"), /label=stale_local_state/);
   assert.match(diagnostics.join("\n"), /label=metadata_only_review_residue/);
   assert.match(diagnostics.join("\n"), /v2_comparison=agreement/);
+  assert.match(diagnostics.join("\n"), /v2_comparison=manual_review_required/);
+  assert.match(diagnostics.join("\n"), /v2_comparison_differences=action:no_action->merge/);
   assert.match(diagnostics.join("\n"), /v2_comparison_differences=reason:manual_review_required->manual_review_thread/);
   assert.doesNotMatch(diagnostics.join("\n"), /\/Users\//);
   assert.doesNotMatch(diagnostics.join("\n"), /[A-Z]:\\/);

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -298,7 +298,7 @@ const decisionKernelV2RuntimeModes = ["disabled", "diagnostic_only", "pr_lifecyc
 const decisionKernelV2ActionSources = ["disabled", "pr_lifecycle_v2"] as const satisfies readonly DecisionKernelV2ActionSource[];
 const decisionKernelV2ActionScopes = ["none", "pr_lifecycle"] as const satisfies readonly DecisionKernelV2ActionScope[];
 const decisionKernelV2ComparisonCategories = ["agreement", "safe_divergence", "manual_review_required"] as const satisfies readonly DecisionKernelV2ComparisonCategory[];
-const decisionKernelV2Actions = ["wait", "request_review", "run_codex", "ask_operator", "no_action"] as const satisfies readonly DecisionKernelV2Action[];
+const decisionKernelV2Actions = ["merge", "wait", "request_review", "run_codex", "ask_operator", "no_action"] as const satisfies readonly DecisionKernelV2Action[];
 const decisionKernelV2Reasons = [
   "no_pull_request",
   "pull_request_closed",

--- a/src/decision-kernel/pr-lifecycle-trace.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.test.ts
@@ -225,10 +225,10 @@ test("buildPrLifecycleDecisionTrace records optional v2 comparison evidence as d
       v2Comparison: {
         current: {
           state: "ready_to_merge",
-          actionEquivalent: "no_action",
+          actionEquivalent: "merge",
         },
         v2: {
-          action: "no_action",
+          action: "merge",
           reasons: ["merge_ready_diagnostic_only"],
         },
         category: "agreement",

--- a/src/decision-kernel/v2-comparison.test.ts
+++ b/src/decision-kernel/v2-comparison.test.ts
@@ -43,9 +43,29 @@ function v2Decision(overrides: Partial<DecisionKernelV2ReadOnlyDecision> = {}): 
   };
 }
 
-test("buildDecisionKernelV2ComparisonDto reports agreement for merge-ready merge decisions", () => {
+test("buildDecisionKernelV2ComparisonDto preserves no-auto-merge ready state as no_action", () => {
   const comparison = buildDecisionKernelV2ComparisonDto({
     currentState: "ready_to_merge",
+    v2Decision: v2Decision(),
+  });
+
+  assert.equal(comparison.category, "manual_review_required");
+  assert.equal(comparison.current.state, "ready_to_merge");
+  assert.equal(comparison.current.actionEquivalent, "no_action");
+  assert.equal(comparison.v2.action, "merge");
+  assert.deepEqual(comparison.differences, [
+    {
+      field: "action",
+      current: "no_action",
+      v2: "merge",
+    },
+  ]);
+});
+
+test("buildDecisionKernelV2ComparisonDto reports agreement for configured merge-ready merge decisions", () => {
+  const comparison = buildDecisionKernelV2ComparisonDto({
+    currentState: "ready_to_merge",
+    currentActionEquivalent: "merge",
     v2Decision: v2Decision(),
   });
 

--- a/src/decision-kernel/v2-comparison.test.ts
+++ b/src/decision-kernel/v2-comparison.test.ts
@@ -6,7 +6,7 @@ import { buildDecisionKernelV2ComparisonDto } from "./v2-comparison";
 function v2Decision(overrides: Partial<DecisionKernelV2ReadOnlyDecision> = {}): DecisionKernelV2ReadOnlyDecision {
   return {
     schemaVersion: "decision_kernel_v2.read_only.v1",
-    action: "no_action",
+    action: "merge",
     reasons: ["merge_ready_diagnostic_only"],
     requiredEvidence: [],
     safety: {
@@ -14,7 +14,7 @@ function v2Decision(overrides: Partial<DecisionKernelV2ReadOnlyDecision> = {}): 
       authoritative: false,
       mutationAllowed: false,
     },
-    summary: "PR appears merge-ready, but v2 is diagnostic-only in this phase.",
+    summary: "PR appears merge-ready.",
     normalizedState: {
       source: "fresh_github",
       observedAt: "2026-06-08T00:00:00.000Z",
@@ -43,7 +43,7 @@ function v2Decision(overrides: Partial<DecisionKernelV2ReadOnlyDecision> = {}): 
   };
 }
 
-test("buildDecisionKernelV2ComparisonDto reports agreement for merge-ready no-action decisions", () => {
+test("buildDecisionKernelV2ComparisonDto reports agreement for merge-ready merge decisions", () => {
   const comparison = buildDecisionKernelV2ComparisonDto({
     currentState: "ready_to_merge",
     v2Decision: v2Decision(),
@@ -51,8 +51,8 @@ test("buildDecisionKernelV2ComparisonDto reports agreement for merge-ready no-ac
 
   assert.equal(comparison.category, "agreement");
   assert.equal(comparison.current.state, "ready_to_merge");
-  assert.equal(comparison.current.actionEquivalent, "no_action");
-  assert.equal(comparison.v2.action, "no_action");
+  assert.equal(comparison.current.actionEquivalent, "merge");
+  assert.equal(comparison.v2.action, "merge");
   assert.deepEqual(comparison.differences, []);
 });
 

--- a/src/decision-kernel/v2-comparison.ts
+++ b/src/decision-kernel/v2-comparison.ts
@@ -89,6 +89,7 @@ function compareDecisionFields(args: {
 function actionEquivalentForCurrentState(state: RunState): DecisionKernelV2Action {
   switch (state) {
     case "ready_to_merge":
+      return "merge";
     case "done":
       return "no_action";
     case "addressing_review":

--- a/src/decision-kernel/v2-comparison.ts
+++ b/src/decision-kernel/v2-comparison.ts
@@ -89,7 +89,7 @@ function compareDecisionFields(args: {
 function actionEquivalentForCurrentState(state: RunState): DecisionKernelV2Action {
   switch (state) {
     case "ready_to_merge":
-      return "merge";
+      return "no_action";
     case "done":
       return "no_action";
     case "addressing_review":

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -154,7 +154,7 @@ test("buildDecisionKernelV2ExplainDto uses PR head for current-head review obser
 
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewHeadSha, "head-current");
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
   assert.equal(dto.comparison?.current.state, "ready_to_merge");
   assert.equal(dto.comparison?.category, "agreement");
   assert.deepEqual(dto.comparison?.differences, []);
@@ -199,7 +199,7 @@ test("buildDecisionKernelV2ExplainDto accepts external review records as current
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewObservedAt, "2026-06-08T00:01:00.000Z");
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewHeadSha, "head-current");
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto blocks merge-ready diagnostics until configured local CI passes current head", () => {
@@ -240,7 +240,7 @@ test("buildDecisionKernelV2ExplainDto allows merge-ready diagnostics after confi
     reviewThreads: [],
   });
 
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto keeps zero-check PRs out of merge-ready diagnostics", () => {
@@ -290,7 +290,7 @@ test("buildDecisionKernelV2ExplainDto accepts durable provider success as curren
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewObservedAt, "2026-06-08T00:06:00.000Z");
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewHeadSha, "head-current");
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto accepts top-level configured-provider success signals as current-head review evidence", () => {
@@ -316,7 +316,7 @@ test("buildDecisionKernelV2ExplainDto accepts top-level configured-provider succ
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewObservedAt, "2026-06-08T00:06:00.000Z");
   assert.equal(dto.inventory?.pullRequest?.currentHeadReviewHeadSha, "head-current");
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto blocks merge-ready diagnostics on blocking human review decisions", () => {
@@ -371,7 +371,7 @@ test("buildDecisionKernelV2ExplainDto ignores manual review threads when human r
 
   assert.equal(dto.reviewPolicyInput?.threads.length, 0);
   assert.equal(dto.inventory?.reviewThreads.unresolvedManualThreadCount, 0);
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto waits out configured-bot settled windows before merge-ready diagnostics", () => {
@@ -429,7 +429,7 @@ test("buildDecisionKernelV2ExplainDto applies journal-only configured-bot cleara
 
   assert.equal(dto.reviewPolicyInput?.threads.length, 0);
   assert.equal(dto.inventory?.reviewThreads.unresolvedCurrentHeadConfiguredBotThreadCount, 0);
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto blocks merge-ready diagnostics until mergeable is MERGEABLE", () => {
@@ -489,7 +489,7 @@ test("buildDecisionKernelV2ExplainDto does not require Codex no-major evidence o
   });
 
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
-  assert.equal(dto.decision?.action, "no_action");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto respects explicit current-head signal requirements for non-Codex providers", () => {

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -156,8 +156,15 @@ test("buildDecisionKernelV2ExplainDto uses PR head for current-head review obser
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
   assert.equal(dto.decision?.action, "merge");
   assert.equal(dto.comparison?.current.state, "ready_to_merge");
-  assert.equal(dto.comparison?.category, "agreement");
-  assert.deepEqual(dto.comparison?.differences, []);
+  assert.equal(dto.comparison?.current.actionEquivalent, "no_action");
+  assert.equal(dto.comparison?.category, "manual_review_required");
+  assert.deepEqual(dto.comparison?.differences, [
+    {
+      field: "action",
+      current: "no_action",
+      v2: "merge",
+    },
+  ]);
 });
 
 test("buildDecisionKernelV2ExplainDto ignores malformed current-head review timestamps", () => {
@@ -180,6 +187,27 @@ test("buildDecisionKernelV2ExplainDto ignores malformed current-head review time
   assert.equal(dto.decision?.action, "request_review");
   assert.equal(dto.comparison?.category, "manual_review_required");
   assert.deepEqual(dto.comparison?.differences.map((difference) => difference.field), ["action", "reason"]);
+});
+
+test("buildDecisionKernelV2ExplainDto compares merge as agreement only when auto-merge is configured", () => {
+  const dto = buildDecisionKernelV2ExplainDto({
+    config: codexConfig({
+      reviewBotLogins: ["coderabbitai"],
+      configuredReviewProviders: [{ kind: "coderabbit", reviewerLogins: ["coderabbitai"], signalSource: "review_threads" }],
+    }),
+    issueNumber: 2301,
+    title: "Phase 3.2",
+    record: record(),
+    pr: pullRequest({ configuredBotCurrentHeadObservationSource: "review_thread" }),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass" }],
+    reviewThreads: [],
+  });
+
+  assert.equal(dto.decision?.action, "merge");
+  assert.equal(dto.comparison?.current.state, "ready_to_merge");
+  assert.equal(dto.comparison?.current.actionEquivalent, "merge");
+  assert.equal(dto.comparison?.category, "agreement");
+  assert.deepEqual(dto.comparison?.differences, []);
 });
 
 test("buildDecisionKernelV2ExplainDto accepts external review records as current-head review evidence", () => {

--- a/src/decision-kernel/v2-explain.ts
+++ b/src/decision-kernel/v2-explain.ts
@@ -229,6 +229,10 @@ function currentActionEquivalentForV2Comparison(args: {
   currentState: ReturnType<typeof inferStateFromPullRequest>;
   nowMs?: number;
 }): DecisionKernelV2ComparisonDto["current"]["actionEquivalent"] | undefined {
+  if (args.currentState === "ready_to_merge" && autoMergePathForConfig(args.config) !== null) {
+    return "merge";
+  }
+
   if (args.currentState !== "waiting_ci") {
     return undefined;
   }

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -189,6 +189,11 @@ test("evaluateDecisionKernelV2PrLifecycleAction keeps repair outside the action 
   const mergeReady = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(inventory()),
+    checkPolicyInput: {
+      mergeReadyBlockedByRequiredChecks: false,
+      mergeReadyBlockedByLocalCi: false,
+      mergeReadyBlockedByFinalGuard: false,
+    },
   });
 
   assert.equal(failingChecks.v2Decision.action, "run_codex");
@@ -213,6 +218,49 @@ test("evaluateDecisionKernelV2PrLifecycleAction keeps repair outside the action 
     "gate=local_verification:passed",
     "gate=final_guard:passed",
   ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction requires explicit merge gate input before promoting merge", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(inventory()),
+  });
+
+  assert.equal(decision.v2Decision.action, "merge");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_merge_gate_evidence_missing"]);
+  assert.deepEqual(decision.evidenceTokens, [
+    "missing=merge_gate_input",
+    "v2_reason=merge_ready_diagnostic_only",
+    "gate=head_sha:current_head",
+    "gate=local_state:fresh",
+    "gate=review:current_head_review_observed",
+    "gate=checks:green",
+    "gate=mergeability:mergeable",
+    "gate=required_checks:missing",
+    "gate=local_verification:missing",
+    "gate=final_guard:missing",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction lets merge-ready facts bypass repair retry exhaustion", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(inventory()),
+    checkPolicyInput: {
+      mergeReadyBlockedByRequiredChecks: false,
+      mergeReadyBlockedByLocalCi: false,
+      mergeReadyBlockedByFinalGuard: false,
+    },
+    reviewerLoopTerminal: {
+      retryBudgetExhausted: true,
+      reason: "repair retry exhausted",
+    },
+  });
+
+  assert.equal(decision.v2Decision.action, "merge");
+  assert.equal(decision.action, "merge");
+  assert.deepEqual(decision.reasons, ["v2_merge_ready"]);
 });
 
 test("evaluateDecisionKernelV2PrLifecycleAction fails closed before merge when safety evidence is missing or blocking", () => {

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -172,7 +172,7 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes pending and unknown che
   assert.deepEqual(unknown.v2Decision.reasons, ["checks_unknown"]);
 });
 
-test("evaluateDecisionKernelV2PrLifecycleAction keeps repair and merge decisions outside the Phase 4.2 action boundary", () => {
+test("evaluateDecisionKernelV2PrLifecycleAction keeps repair outside the action boundary and promotes merge readiness", () => {
   const failingChecks = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
@@ -194,8 +194,147 @@ test("evaluateDecisionKernelV2PrLifecycleAction keeps repair and merge decisions
   assert.equal(failingChecks.v2Decision.action, "run_codex");
   assert.equal(failingChecks.action, "no_action");
   assert.deepEqual(failingChecks.reasons, ["v2_action_not_promoted"]);
-  assert.equal(mergeReady.v2Decision.action, "no_action");
-  assert.equal(mergeReady.action, "no_action");
+  assert.equal(mergeReady.v2Decision.action, "merge");
+  assert.equal(mergeReady.action, "merge");
+  assert.deepEqual(mergeReady.reasons, ["v2_merge_ready"]);
+  assert.deepEqual(mergeReady.traceDecision, {
+    value: "merge",
+    recommendedAction: "merge",
+    summary: "PR appears merge-ready.",
+  });
+  assert.deepEqual(mergeReady.evidenceTokens, [
+    "v2_reason=merge_ready_diagnostic_only",
+    "gate=head_sha:current_head",
+    "gate=local_state:fresh",
+    "gate=review:current_head_review_observed",
+    "gate=checks:green",
+    "gate=mergeability:mergeable",
+    "gate=required_checks:passed",
+    "gate=local_verification:passed",
+    "gate=final_guard:passed",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction fails closed before merge when safety evidence is missing or blocking", () => {
+  const cases: Array<{
+    label: string;
+    normalizedState: ReturnType<typeof normalizePrLifecycleFacts>;
+    checkPolicyInput?: Parameters<typeof evaluateDecisionKernelV2PrLifecycleAction>[0]["checkPolicyInput"];
+    expectedAction: string;
+    expectedReasons: string[];
+  }> = [
+    {
+      label: "pending CI",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          checks: { passingCount: 2, pendingCount: 1, failingCount: 0, unknownCount: 0 },
+        }),
+      ),
+      expectedAction: "wait_ci",
+      expectedReasons: ["v2_wait_ci"],
+    },
+    {
+      label: "failing CI",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          checks: { passingCount: 2, pendingCount: 0, failingCount: 1, unknownCount: 0 },
+        }),
+      ),
+      expectedAction: "no_action",
+      expectedReasons: ["v2_action_not_promoted"],
+    },
+    {
+      label: "manual review",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          reviewThreads: {
+            unresolvedManualThreadCount: 1,
+            unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+            stalePreviousHeadConfiguredBotThreadCount: 0,
+            metadataOnlyUnresolvedThreadCount: 0,
+          },
+        }),
+      ),
+      expectedAction: "ask_operator",
+      expectedReasons: ["v2_ask_operator"],
+    },
+    {
+      label: "SHA mismatch",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          pullRequest: {
+            number: 2312,
+            headSha: "head-new",
+            state: "OPEN",
+            isDraft: false,
+            mergeStateStatus: "CLEAN",
+            mergeable: "MERGEABLE",
+            currentHeadReviewObservedAt: "2026-06-09T00:01:00.000Z",
+            currentHeadReviewHeadSha: "head-new",
+          },
+          localState: {
+            trackedHeadSha: "head-current",
+            workspaceHeadSha: "head-current",
+            lastObservedPrHeadSha: "head-current",
+          },
+        }),
+      ),
+      expectedAction: "ask_operator",
+      expectedReasons: ["fresh_facts_guard_blocked"],
+    },
+    {
+      label: "merge conflict",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          pullRequest: {
+            number: 2312,
+            headSha: "head-current",
+            state: "OPEN",
+            isDraft: false,
+            mergeStateStatus: "DIRTY",
+            mergeable: "CONFLICTING",
+            currentHeadReviewObservedAt: "2026-06-09T00:01:00.000Z",
+            currentHeadReviewHeadSha: "head-current",
+          },
+        }),
+      ),
+      expectedAction: "ask_operator",
+      expectedReasons: ["v2_ask_operator"],
+    },
+    {
+      label: "missing local verification",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          localState: {
+            trackedHeadSha: null,
+            workspaceHeadSha: null,
+            lastObservedPrHeadSha: null,
+          },
+        }),
+      ),
+      expectedAction: "ask_operator",
+      expectedReasons: ["fresh_facts_guard_blocked"],
+    },
+    {
+      label: "final guard blocked",
+      normalizedState: normalizePrLifecycleFacts(inventory()),
+      checkPolicyInput: { mergeReadyBlockedByFinalGuard: true },
+      expectedAction: "ask_operator",
+      expectedReasons: ["v2_ask_operator"],
+    },
+  ];
+
+  for (const testCase of cases) {
+    const decision = evaluateDecisionKernelV2PrLifecycleAction({
+      mode: "pr_lifecycle_action_taking",
+      normalizedState: testCase.normalizedState,
+      checkPolicyInput: testCase.checkPolicyInput,
+    });
+
+    assert.equal(decision.action, testCase.expectedAction, testCase.label);
+    assert.deepEqual(decision.reasons, testCase.expectedReasons, testCase.label);
+    assert.notEqual(decision.action, "merge", testCase.label);
+  }
 });
 
 test("evaluateDecisionKernelV2PrLifecycleAction promotes ambiguous review facts to ask_operator", () => {

--- a/src/decision-kernel/v2-pr-lifecycle-action.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.ts
@@ -33,6 +33,7 @@ export type DecisionKernelV2PrLifecycleActionReason =
   | "v2_request_review"
   | "v2_wait_ci"
   | "v2_merge_ready"
+  | "v2_merge_gate_evidence_missing"
   | "v2_mark_stale_resolved"
   | "v2_stale_review_needs_current_head_review"
   | "v2_metadata_terminal"
@@ -135,6 +136,33 @@ function promoteV2Decision(args: {
 }): DecisionKernelV2PrLifecycleActionDecision {
   const { mode, guard, v2Decision, checkPolicyInput, reviewerLoopTerminal } = args;
 
+  if (v2Decision.action === "merge") {
+    if (!hasExplicitPassingMergeGateInput(checkPolicyInput)) {
+      return actionDecision({
+        mode,
+        guard,
+        v2Decision,
+        action: "ask_operator",
+        reasons: ["v2_merge_gate_evidence_missing"],
+        evidenceTokens: [
+          "missing=merge_gate_input",
+          ...mergeSafetyEvidenceTokens(v2Decision, checkPolicyInput),
+        ],
+        summary: "Decision Kernel v2 merge action requires explicit passing merge gate evidence.",
+      });
+    }
+
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "merge",
+      reasons: ["v2_merge_ready"],
+      evidenceTokens: mergeSafetyEvidenceTokens(v2Decision, checkPolicyInput),
+      summary: v2Decision.summary,
+    });
+  }
+
   if (reviewerLoopTerminal?.retryBudgetExhausted) {
     return actionDecision({
       mode,
@@ -169,18 +197,6 @@ function promoteV2Decision(args: {
       v2Decision,
       action: "wait_ci",
       reasons: ["v2_wait_ci"],
-      summary: v2Decision.summary,
-    });
-  }
-
-  if (v2Decision.action === "merge") {
-    return actionDecision({
-      mode,
-      guard,
-      v2Decision,
-      action: "merge",
-      reasons: ["v2_merge_ready"],
-      evidenceTokens: mergeSafetyEvidenceTokens(v2Decision, checkPolicyInput),
       summary: v2Decision.summary,
     });
   }
@@ -265,6 +281,18 @@ function isMergeSafetyBlockedDecision(decision: DecisionKernelV2ReadOnlyDecision
   );
 }
 
+function hasExplicitPassingMergeGateInput(checkPolicyInput: DecisionKernelV2CheckPolicyInput | null): boolean {
+  return (
+    checkPolicyInput !== null &&
+    typeof checkPolicyInput.mergeReadyBlockedByRequiredChecks === "boolean" &&
+    typeof checkPolicyInput.mergeReadyBlockedByLocalCi === "boolean" &&
+    typeof checkPolicyInput.mergeReadyBlockedByFinalGuard === "boolean" &&
+    !checkPolicyInput.mergeReadyBlockedByRequiredChecks &&
+    !checkPolicyInput.mergeReadyBlockedByLocalCi &&
+    !checkPolicyInput.mergeReadyBlockedByFinalGuard
+  );
+}
+
 function hasCurrentHeadReviewEvidence(decision: DecisionKernelV2ReadOnlyDecision): boolean {
   return (
     decision.normalizedState.reviewPosture === "current_head_review_observed" ||
@@ -333,10 +361,18 @@ function mergeSafetyEvidenceTokens(
     `gate=review:${state.reviewPosture}`,
     `gate=checks:${checkPolicyInput?.noChecksAndNoLocalCi ? "no_checks_and_no_local_ci" : state.checkPosture}`,
     `gate=mergeability:${state.mergeability}`,
-    `gate=required_checks:${checkPolicyInput?.mergeReadyBlockedByRequiredChecks ? "blocked" : "passed"}`,
-    `gate=local_verification:${checkPolicyInput?.mergeReadyBlockedByLocalCi ? "blocked" : "passed"}`,
-    `gate=final_guard:${checkPolicyInput?.mergeReadyBlockedByFinalGuard ? "blocked" : "passed"}`,
+    `gate=required_checks:${mergeGateToken(checkPolicyInput?.mergeReadyBlockedByRequiredChecks)}`,
+    `gate=local_verification:${mergeGateToken(checkPolicyInput?.mergeReadyBlockedByLocalCi)}`,
+    `gate=final_guard:${mergeGateToken(checkPolicyInput?.mergeReadyBlockedByFinalGuard)}`,
   ];
+}
+
+function mergeGateToken(blocked: boolean | undefined): "blocked" | "passed" | "missing" {
+  if (blocked === undefined) {
+    return "missing";
+  }
+
+  return blocked ? "blocked" : "passed";
 }
 
 function sanitizeEvidenceToken(value: string): string {

--- a/src/decision-kernel/v2-pr-lifecycle-action.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.ts
@@ -19,6 +19,7 @@ import {
 import type { NormalizedPrLifecycleState } from "./pr-lifecycle-state";
 
 export type DecisionKernelV2PrLifecycleAction =
+  | "merge"
   | "request_review"
   | "wait_ci"
   | "mark_stale_resolved"
@@ -31,6 +32,7 @@ export type DecisionKernelV2PrLifecycleActionReason =
   | "fresh_facts_guard_blocked"
   | "v2_request_review"
   | "v2_wait_ci"
+  | "v2_merge_ready"
   | "v2_mark_stale_resolved"
   | "v2_stale_review_needs_current_head_review"
   | "v2_metadata_terminal"
@@ -119,6 +121,7 @@ export function evaluateDecisionKernelV2PrLifecycleAction(
     mode,
     guard,
     v2Decision,
+    checkPolicyInput: input.checkPolicyInput ?? null,
     reviewerLoopTerminal: input.reviewerLoopTerminal ?? null,
   });
 }
@@ -127,9 +130,10 @@ function promoteV2Decision(args: {
   mode: DecisionKernelV2ModePosture;
   guard: PrLifecycleEvaluationGuardResult;
   v2Decision: DecisionKernelV2ReadOnlyDecision;
+  checkPolicyInput: DecisionKernelV2CheckPolicyInput | null;
   reviewerLoopTerminal: DecisionKernelV2ReviewerLoopTerminalInput | null;
 }): DecisionKernelV2PrLifecycleActionDecision {
-  const { mode, guard, v2Decision, reviewerLoopTerminal } = args;
+  const { mode, guard, v2Decision, checkPolicyInput, reviewerLoopTerminal } = args;
 
   if (reviewerLoopTerminal?.retryBudgetExhausted) {
     return actionDecision({
@@ -165,6 +169,18 @@ function promoteV2Decision(args: {
       v2Decision,
       action: "wait_ci",
       reasons: ["v2_wait_ci"],
+      summary: v2Decision.summary,
+    });
+  }
+
+  if (v2Decision.action === "merge") {
+    return actionDecision({
+      mode,
+      guard,
+      v2Decision,
+      action: "merge",
+      reasons: ["v2_merge_ready"],
+      evidenceTokens: mergeSafetyEvidenceTokens(v2Decision, checkPolicyInput),
       summary: v2Decision.summary,
     });
   }
@@ -212,6 +228,9 @@ function promoteV2Decision(args: {
       v2Decision,
       action: "ask_operator",
       reasons: ["v2_ask_operator"],
+      evidenceTokens: isMergeSafetyBlockedDecision(v2Decision)
+        ? mergeSafetyEvidenceTokens(v2Decision, checkPolicyInput)
+        : undefined,
       summary: v2Decision.summary,
     });
   }
@@ -236,6 +255,14 @@ function isStaleReviewTerminalDecision(decision: DecisionKernelV2ReadOnlyDecisio
 
 function isMetadataTerminalDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
   return decision.reasons.includes("metadata_only_review_residue");
+}
+
+function isMergeSafetyBlockedDecision(decision: DecisionKernelV2ReadOnlyDecision): boolean {
+  return (
+    decision.reasons.includes("insufficient_merge_evidence") ||
+    decision.reasons.includes("merge_conflict") ||
+    decision.reasons.includes("draft_pull_request")
+  );
 }
 
 function hasCurrentHeadReviewEvidence(decision: DecisionKernelV2ReadOnlyDecision): boolean {
@@ -275,6 +302,8 @@ function traceDecision(
       return { value: "request_review", recommendedAction: "request_review", summary };
     case "wait_ci":
       return { value: "wait", recommendedAction: "wait_ci", summary };
+    case "merge":
+      return { value: "merge", recommendedAction: "merge", summary };
     case "mark_stale_resolved":
       return { value: "do_nothing", recommendedAction: "mark_stale_resolved", summary };
     case "ask_operator":
@@ -290,6 +319,24 @@ function reviewEvidenceTokens(decision: DecisionKernelV2ReadOnlyDecision): strin
     tokens.push(`required_evidence=${decision.requiredEvidence.join("+")}`);
   }
   return tokens;
+}
+
+function mergeSafetyEvidenceTokens(
+  decision: DecisionKernelV2ReadOnlyDecision,
+  checkPolicyInput: DecisionKernelV2CheckPolicyInput | null,
+): string[] {
+  const state = decision.normalizedState;
+  return [
+    ...reviewEvidenceTokens(decision),
+    `gate=head_sha:${state.headFreshness}`,
+    `gate=local_state:${state.localStateFreshness}`,
+    `gate=review:${state.reviewPosture}`,
+    `gate=checks:${checkPolicyInput?.noChecksAndNoLocalCi ? "no_checks_and_no_local_ci" : state.checkPosture}`,
+    `gate=mergeability:${state.mergeability}`,
+    `gate=required_checks:${checkPolicyInput?.mergeReadyBlockedByRequiredChecks ? "blocked" : "passed"}`,
+    `gate=local_verification:${checkPolicyInput?.mergeReadyBlockedByLocalCi ? "blocked" : "passed"}`,
+    `gate=final_guard:${checkPolicyInput?.mergeReadyBlockedByFinalGuard ? "blocked" : "passed"}`,
+  ];
 }
 
 function sanitizeEvidenceToken(value: string): string {


### PR DESCRIPTION
## Summary
- promote Decision Kernel v2 merge-ready decisions from `no_action` to a typed `merge` action
- let the PR lifecycle action adapter select `merge` behind the Phase 4 action-taking gate
- add merge safety gate evidence tokens for head freshness, local verification, review, checks, mergeability, required checks, and final guard posture
- update replay comparison fixtures and diagnostics expectations to treat `ready_to_merge` as the current merge action equivalent

## Why
Issue #2314 moves merge-readiness action selection into the v2 decision vocabulary while keeping the existing merge execution path intact. Missing or conflicting safety evidence still fails closed to wait, operator handoff, or no mutation.

## Verification
- `npx tsx --test src/decision-kernel-v2.test.ts src/decision-kernel/v2-pr-lifecycle-action.test.ts src/decision-kernel/v2-comparison.test.ts src/decision-kernel/v2-explain.test.ts src/decision-kernel/pr-lifecycle-trace.test.ts src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts`
- `npx tsx --test src/decision-kernel-v2*.test.ts src/decision-kernel/*.test.ts src/supervisor/*merge*.test.ts src/supervisor/*status*.test.ts src/supervisor/replay-corpus.test.ts`
- `npm run build`
- `git diff --check`
- `node dist/index.js issue-lint 2314 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`

Closes #2314
