### PR TITLE
[codex] Add Phase 4 closeout evidence

### DIFF
--- a/docs/phase4-closeout-evidence.md
+++ b/docs/phase4-closeout-evidence.md
@@ -1,0 +1,20 @@
+# Phase 4 Closeout Evidence
+
+Phase 4 promotes PR lifecycle action selection into Decision Kernel v2 while keeping the existing merge execution adapter and issue selection loop boundaries intact.
+
+## Evidence Map
+
+- `src/decision-kernel/v2-pr-lifecycle-action.test.ts` covers the action-taking path for current-head review requests, CI waits, stale review terminal cleanup, operator escalation, merge readiness, disabled mode, and diagnostic-only rollback mode.
+- `src/decision-kernel/pr-lifecycle-trace-presenter.test.ts` and `src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts` verify that trace diagnostics expose v2 mode, action source, selected action, safety evidence, and rollback posture.
+- `src/decision-kernel/v2-explain.test.ts` verifies that explain output distinguishes no-auto-merge readiness from configured auto-merge readiness.
+- `src/supervisor/replay-corpus-runner.test.ts` keeps the checked-in replay corpus covering stale local blocked state recovered by fresh GitHub green, clean, mergeable current-head evidence.
+
+## Rollback Posture
+
+- `disabled`: v2 is already inactive and no v2 PR lifecycle action is selected.
+- `diagnostic_only`: v2 renders diagnostics without mutation authority and can be used as the rollback posture after action-taking is disabled.
+- `pr_lifecycle_action_taking`: v2 is authoritative for PR lifecycle action selection, but merge still requires explicit passing merge gate evidence before a merge action can be selected.
+
+## Phase 5 Boundary
+
+Phase 5 should focus on operator-action vocabulary and UX integration. Phase 4 does not replace merge execution, issue selection, branch protection, or the supervisor's final auto-merge guard.

--- a/replay-corpus/decision-traces/merge-ready.json
+++ b/replay-corpus/decision-traces/merge-ready.json
@@ -46,6 +46,13 @@
       "summary": "Fresh PR lifecycle facts are merge ready."
     },
     "evidenceTokens": ["pr=1001", "head=head-merge-ready", "checks=green"],
+    "v2Mode": {
+      "mode": "pr_lifecycle_action_taking",
+      "authoritative": true,
+      "mutationAllowed": true,
+      "actionSource": "pr_lifecycle_v2",
+      "actionScope": "pr_lifecycle"
+    },
     "v2Comparison": {
       "diagnosticOnly": true,
       "current": {

--- a/replay-corpus/decision-traces/stale-local-state.json
+++ b/replay-corpus/decision-traces/stale-local-state.json
@@ -45,6 +45,13 @@
       "recommendedAction": "refresh_state",
       "summary": "Local state must refresh before action-taking evaluation."
     },
-    "evidenceTokens": ["pr=1004", "remote=head-remote-new", "local=head-local-old"]
+    "evidenceTokens": ["pr=1004", "remote=head-remote-new", "local=head-local-old"],
+    "v2Mode": {
+      "mode": "pr_lifecycle_action_taking",
+      "authoritative": true,
+      "mutationAllowed": true,
+      "actionSource": "pr_lifecycle_v2",
+      "actionScope": "pr_lifecycle"
+    }
   }
 }

--- a/replay-corpus/decision-traces/wait-ci.json
+++ b/replay-corpus/decision-traces/wait-ci.json
@@ -45,6 +45,13 @@
       "recommendedAction": "wait_ci",
       "summary": "Required checks are still pending."
     },
-    "evidenceTokens": ["pr=1002", "head=head-wait-ci", "pending_checks=2"]
+    "evidenceTokens": ["pr=1002", "head=head-wait-ci", "pending_checks=2"],
+    "v2Mode": {
+      "mode": "pr_lifecycle_action_taking",
+      "authoritative": true,
+      "mutationAllowed": true,
+      "actionSource": "pr_lifecycle_v2",
+      "actionScope": "pr_lifecycle"
+    }
   }
 }

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts
@@ -118,6 +118,8 @@ test("Decision Kernel trace fixtures render compact diagnostics without host-loc
   assert.match(diagnostics.join("\n"), /v2_comparison=manual_review_required/);
   assert.match(diagnostics.join("\n"), /v2_comparison_differences=action:no_action->merge/);
   assert.match(diagnostics.join("\n"), /v2_comparison_differences=reason:manual_review_required->manual_review_thread/);
+  assert.match(diagnostics.join("\n"), /rollback_posture=disable_to_rollback/);
+  assert.match(diagnostics.join("\n"), /rollback_posture=diagnostic_only_to_rollback/);
   assert.doesNotMatch(diagnostics.join("\n"), /\/Users\//);
   assert.doesNotMatch(diagnostics.join("\n"), /[A-Z]:\\/);
 });

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
@@ -104,6 +104,7 @@ test("formatPrLifecycleTraceDiagnostic renders a merge-ready trace line", () => 
   assert.match(line, /v2_mutation_allowed=false/);
   assert.match(line, /v2_action_source=disabled/);
   assert.match(line, /v2_action_scope=none/);
+  assert.match(line, /rollback_posture=diagnostic_only_to_rollback/);
   assert.match(line, /v2_comparison=none/);
   assert.match(line, /v2_diagnostic_only=no/);
 });
@@ -122,6 +123,21 @@ test("formatPrLifecycleTraceDiagnostic renders the gated v2 PR lifecycle action 
   assert.match(line, /v2_mutation_allowed=true/);
   assert.match(line, /v2_action_source=pr_lifecycle_v2/);
   assert.match(line, /v2_action_scope=pr_lifecycle/);
+  assert.match(line, /rollback_posture=disable_to_rollback/);
+});
+
+test("formatPrLifecycleTraceDiagnostic renders disabled v2 rollback posture", () => {
+  const line = formatPrLifecycleTraceDiagnostic(
+    buildPrLifecycleDecisionTrace(
+      traceInput({
+        v2Mode: "disabled",
+      }),
+    ),
+  );
+
+  assert.match(line, /v2_mode=disabled/);
+  assert.match(line, /v2_action_source=disabled/);
+  assert.match(line, /rollback_posture=already_disabled/);
 });
 
 test("formatPrLifecycleTraceDiagnostic renders pending CI diagnostics", () => {

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.ts
@@ -86,10 +86,21 @@ export function formatPrLifecycleTraceDiagnostic(
     `v2_mutation_allowed=${v2Mode.mutationAllowed}`,
     `v2_action_source=${v2Mode.actionSource}`,
     `v2_action_scope=${v2Mode.actionScope}`,
+    `rollback_posture=${rollbackPostureForV2Mode(v2Mode)}`,
     `v2_comparison=${v2Comparison?.category ?? "none"}`,
     `v2_diagnostic_only=${v2Comparison?.diagnosticOnly ? "yes" : "no"}`,
     `v2_comparison_differences=${formatV2ComparisonDifferences(v2Comparison?.differences ?? [])}`,
   ].join(" ");
+}
+
+function rollbackPostureForV2Mode(
+  mode: PrLifecycleDecisionTraceArtifact["v2Mode"],
+): "already_disabled" | "disable_to_rollback" | "diagnostic_only_to_rollback" {
+  if (mode.mode === "disabled") {
+    return "already_disabled";
+  }
+
+  return mode.mutationAllowed ? "disable_to_rollback" : "diagnostic_only_to_rollback";
 }
 
 function formatV2ComparisonDifferences(

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -625,6 +625,134 @@ test("evaluateDecisionKernelV2PrLifecycleAction keeps disabled and diagnostic-on
   assert.deepEqual(diagnosticOnly.reasons, ["v2_diagnostic_only"]);
 });
 
+test("Phase 4 v2 PR lifecycle action-taking replay evidence covers selected actions and rollback modes", () => {
+  const normalizedReady = normalizePrLifecycleFacts(inventory());
+  const cases = [
+    {
+      id: "request-review",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizePrLifecycleFacts(
+          inventory({
+            pullRequest: {
+              number: 2312,
+              headSha: "head-current",
+              state: "OPEN",
+              isDraft: false,
+              mergeStateStatus: "CLEAN",
+              mergeable: "MERGEABLE",
+              currentHeadReviewObservedAt: null,
+              currentHeadReviewHeadSha: null,
+            },
+          }),
+        ),
+      }),
+    },
+    {
+      id: "wait-ci",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizePrLifecycleFacts(
+          inventory({
+            checks: {
+              passingCount: 1,
+              pendingCount: 1,
+              failingCount: 0,
+              unknownCount: 0,
+            },
+          }),
+        ),
+      }),
+    },
+    {
+      id: "stale-terminal",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizedReady,
+        reviewPolicyInput: reviewPolicyInput(["stale_commit_thread"]),
+      }),
+    },
+    {
+      id: "operator-escalation",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizePrLifecycleFacts(
+          inventory({
+            reviewThreads: {
+              unresolvedManualThreadCount: 1,
+              unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+              stalePreviousHeadConfiguredBotThreadCount: 0,
+              metadataOnlyUnresolvedThreadCount: 0,
+            },
+          }),
+        ),
+      }),
+    },
+    {
+      id: "merge-ready",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizedReady,
+        checkPolicyInput: {
+          mergeReadyBlockedByRequiredChecks: false,
+          mergeReadyBlockedByLocalCi: false,
+          mergeReadyBlockedByFinalGuard: false,
+        },
+      }),
+    },
+    {
+      id: "diagnostic-rollback",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "diagnostic_only",
+        normalizedState: normalizedReady,
+      }),
+    },
+    {
+      id: "disabled-rollback",
+      decision: evaluateDecisionKernelV2PrLifecycleAction({
+        mode: "disabled",
+        normalizedState: normalizedReady,
+      }),
+    },
+  ] as const;
+
+  const traces = cases.map(({ id, decision }) =>
+    buildPrLifecycleDecisionTrace({
+      traceId: `phase4-${id}`,
+      generatedAt: "2026-06-09T00:03:00.000Z",
+      normalizedState: decision.v2Decision.normalizedState,
+      policy: {
+        name: "pr_lifecycle_decision_kernel_v2",
+        posture: "unknown",
+        reasons: decision.v2Decision.reasons,
+      },
+      decision: decision.traceDecision,
+      evidenceTokens: [`case=${id}`, ...decision.evidenceTokens],
+      v2Mode: decision.mode,
+    }),
+  );
+
+  assert.deepEqual(
+    traces.map((trace, index) => [
+      cases[index]?.id,
+      trace.v2Mode.mode,
+      trace.decision.value,
+      trace.decision.recommendedAction,
+      trace.v2Mode.actionSource,
+      trace.v2Mode.mutationAllowed,
+    ]),
+    [
+      ["request-review", "pr_lifecycle_action_taking", "request_review", "request_review", "pr_lifecycle_v2", true],
+      ["wait-ci", "pr_lifecycle_action_taking", "wait", "wait_ci", "pr_lifecycle_v2", true],
+      ["stale-terminal", "pr_lifecycle_action_taking", "do_nothing", "mark_stale_resolved", "pr_lifecycle_v2", true],
+      ["operator-escalation", "pr_lifecycle_action_taking", "ask_operator", "manual_review", "pr_lifecycle_v2", true],
+      ["merge-ready", "pr_lifecycle_action_taking", "merge", "merge", "pr_lifecycle_v2", true],
+      ["diagnostic-rollback", "diagnostic_only", "do_nothing", "no_action", "disabled", false],
+      ["disabled-rollback", "disabled", "do_nothing", "no_action", "disabled", false],
+    ],
+  );
+});
+
 test("v2 PR lifecycle action decisions can be recorded with a v2 action source trace posture", () => {
   const actionDecision = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",


### PR DESCRIPTION
## Summary
- add Phase 4 closeout evidence documentation for replay, status, rollback, and Phase 5 boundaries
- mark checked-in decision trace fixtures with explicit v2 action-taking mode where appropriate
- add rollback posture to PR lifecycle trace diagnostics
- add Phase 4 replay-style coverage for v2 action-taking selected actions and disabled/diagnostic rollback modes

## Why
Issue #2315 asks for Phase 4 evidence that operators can use to evaluate the promoted v2 PR lifecycle action path and safely roll it back. This keeps the implementation boundary unchanged while making the evidence explicit in tests, trace fixtures, diagnostics, and docs.

## Verification
- `npx tsx --test src/decision-kernel/v2-pr-lifecycle-action.test.ts src/decision-kernel/pr-lifecycle-trace-presenter.test.ts src/decision-kernel/pr-lifecycle-trace-fixtures.test.ts`
- `npx tsx --test src/decision-kernel-v2*.test.ts src/decision-kernel/*.test.ts src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts src/supervisor/replay-corpus.test.ts src/run-once*.test.ts src/post-turn-pull-request*.test.ts`
- `npm run build`
- `git diff --check`
- `node dist/index.js issue-lint 2315 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`

Closes #2315
