### PR TITLE
[codex] Add Phase 5 boundary inventory

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -30,6 +30,36 @@ External automation may evaluate, route, draft, record, notify, and prepare
 operator-facing evidence. It may not execute implementation changes, decide
 merge readiness, or turn advisory context into supervisor authority.
 
+## Phase 5 Boundary Inventory
+
+Phase 5 keeps `codex-supervisor` core focused on executor-owned state changes
+and safety gates. These responsibilities stay inside core:
+
+- issue contract validation and `issue-lint` readiness
+- per-issue worktree and journal ownership
+- Codex execution and resume orchestration
+- PR lifecycle action selection, including review, CI, stale-review terminal,
+  operator escalation, and merge-readiness decisions
+- CI, review, branch-protection, head-SHA, and merge safety gates
+- evidence capture, replay, status, and explain output for supervisor-owned
+  decisions
+
+These responsibilities remain external orchestration:
+
+- evaluate roadmap, GitHub, local status, and note state
+- route actionable changes to the operator or the next runnable issue
+- draft confirm-required follow-up issues
+- record durable Obsidian or external history after real state changes
+- notify the operator about actionable state changes
+- prepare operator-facing evidence without treating that evidence as execution
+  authority
+
+Compatibility note: Phase 5 does not replace issue selection, Codex execution,
+merge execution, branch protection, or the supervisor's final auto-merge guard.
+External orchestration can help route, record, and explain work, but it cannot
+authorize implementation turns, GitHub mutations, merges, or safety-gate
+bypasses.
+
 ## Safety Contract
 
 Automation must stay quiet when there is no actionable change. It should not

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -8,6 +8,7 @@ const qualityKitAdoptionChecklistPath = path.join("docs", "quality-kit-adoption-
 const kanameBootstrapHandoffPath = path.join("docs", "kaname-bootstrap-handoff.md");
 const qualityKitPackageSurfacesPath = path.join("docs", "quality-kit-package-surfaces.md");
 const qualityGateExamplesPath = path.join("docs", "examples", "quality-gate-examples.md");
+const automationBoundaryPath = path.join("docs", "automation.md");
 const qualityKitTemplatesPath = path.join("docs", "templates", "quality-primitives");
 const publicSchemaArtifactPaths = [
   "docs/issue-body-contract.schema.json",
@@ -170,6 +171,63 @@ test("quality kit entrypoint defines the public package surface boundary", async
     readme,
     /\[AI coding quality kit\]\(\.\/docs\/quality-kit\.md\): compact primitive map and public package surface/i,
   );
+});
+
+test("automation boundary publishes the Phase 5 core and external responsibility inventory", async () => {
+  const automationBoundary = await readRepoFile(automationBoundaryPath);
+
+  assert.match(automationBoundary, /^## Phase 5 Boundary Inventory$/m);
+  assert.doesNotMatch(automationBoundary, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(automationBoundary, /\/home\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(automationBoundary, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+
+  for (const coreResponsibility of [
+    "issue contract validation and `issue-lint` readiness",
+    "per-issue worktree and journal ownership",
+    "Codex execution and resume orchestration",
+    "PR lifecycle action selection",
+    "CI, review, branch-protection, head-SHA, and merge safety gates",
+    "evidence capture, replay, status, and explain output",
+  ]) {
+    assert.match(
+      automationBoundary,
+      new RegExp(escapeRegExp(coreResponsibility)),
+      `expected core responsibility: ${coreResponsibility}`,
+    );
+  }
+
+  for (const externalResponsibility of [
+    "evaluate roadmap, GitHub, local status, and note state",
+    "route actionable changes to the operator or the next runnable issue",
+    "draft confirm-required follow-up issues",
+    "record durable Obsidian or external history",
+    "notify the operator about actionable state changes",
+    "prepare operator-facing evidence",
+  ]) {
+    assert.match(
+      automationBoundary,
+      new RegExp(escapeRegExp(externalResponsibility)),
+      `expected external responsibility: ${externalResponsibility}`,
+    );
+  }
+
+  for (const unchangedBoundary of [
+    "does not replace issue selection",
+    "Codex execution",
+    "merge execution",
+    "branch protection",
+    "final auto-merge guard",
+  ]) {
+    assert.match(
+      automationBoundary,
+      new RegExp(escapeRegExp(unchangedBoundary), "i"),
+      `expected unchanged boundary: ${unchangedBoundary}`,
+    );
+  }
+
+  assert.match(automationBoundary, /cannot\s+authorize implementation turns/i);
+  assert.match(automationBoundary, /GitHub mutations/i);
+  assert.match(automationBoundary, /safety-gate\s+bypasses/i);
 });
 
 test("public schema artifacts publish versioning and compatibility guidance", async () => {


### PR DESCRIPTION
## Summary
- add a Phase 5 boundary inventory to `docs/automation.md`
- separate supervisor core responsibilities from external orchestration responsibilities
- add docs regression coverage so the boundary keeps core safety-gate language

## Scope
This is the Phase 5.1 implementation for #2322. It documents the thin-core boundary only; it does not add runtime authority, Automation execution paths, merge behavior, or issue selection behavior.

## Verification
- `npx tsx --test src/quality-kit-docs.test.ts src/readme-docs.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2322 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `git diff --check`

Closes #2322
