### PR TITLE
[codex] Publish operator action routing contract

### DIFF
--- a/docs/operator-actions.schema.json
+++ b/docs/operator-actions.schema.json
@@ -19,51 +19,112 @@
   },
   "canonicalSource": "src/operator-actions.ts",
   "description": "Portable vocabulary contract for operator action tokens emitted by status, doctor, and WebUI surfaces. Runtime parsing and selection remain backed by src/operator-actions.ts; this artifact lets docs, UI, and external automation consume the token list without scraping TypeScript source.",
+  "routingCategories": [
+    "core_action",
+    "operator_action",
+    "external_orchestration_handoff"
+  ],
   "actions": [
     {
       "action": "continue",
       "surfaces": ["status", "doctor", "webui"],
-      "meaning": "No blocking operator action was detected; continue normal supervisor operation."
+      "meaning": "No blocking operator action was detected; continue normal supervisor operation.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "restart_loop",
       "surfaces": ["status", "webui"],
-      "meaning": "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance."
+      "meaning": "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "fix_config",
       "surfaces": ["status", "doctor", "webui"],
-      "meaning": "Repair host prerequisites, setup fields, workspace-preparation configuration, or incomplete local CI visibility before continuing."
+      "meaning": "Repair host prerequisites, setup fields, workspace-preparation configuration, or incomplete local CI visibility before continuing.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "adopt_local_ci",
       "surfaces": ["doctor", "webui"],
-      "meaning": "A repo-owned local CI candidate exists; configure it before relying on local verification posture."
+      "meaning": "A repo-owned local CI candidate exists; configure it before relying on local verification posture.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "dismiss_local_ci",
       "surfaces": ["webui"],
-      "meaning": "Explicitly dismiss a repo-owned local CI recommendation when local CI should remain unset."
+      "meaning": "Explicitly dismiss a repo-owned local CI recommendation when local CI should remain unset.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "manual_review",
       "surfaces": ["status", "doctor", "webui"],
-      "meaning": "A tracked path or diagnostic warning requires human judgment before automation should continue."
+      "meaning": "A tracked path or diagnostic warning requires human judgment before automation should continue.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "resolve_stale_review_bot",
       "surfaces": ["status", "webui"],
-      "meaning": "Code or CI is green but stale configured-bot review thread metadata still blocks the tracked PR; inspect and resolve the exact thread or leave a manual note."
+      "meaning": "Code or CI is green but stale configured-bot review thread metadata still blocks the tracked PR; inspect and resolve the exact thread or leave a manual note.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "provider_outage_suspected",
       "surfaces": ["status", "webui"],
-      "meaning": "Required checks are green but the configured review provider has not reported on the current head; wait, verify provider delivery, or escalate to manual review."
+      "meaning": "Required checks are green but the configured review provider has not reported on the current head; wait, verify provider delivery, or escalate to manual review.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
     },
     {
       "action": "safe_to_ignore",
       "surfaces": ["doctor", "webui"],
-      "meaning": "A dismissed or already-completed advisory signal does not require operator action."
+      "meaning": "A dismissed or already-completed advisory signal does not require operator action.",
+      "routingCategory": "operator_action",
+      "mutationAuthority": "none"
+    }
+  ],
+  "externalHandoffs": [
+    {
+      "handoff": "evaluate",
+      "meaning": "Read roadmap, GitHub, local status, and note state without changing supervisor runtime state.",
+      "routingCategory": "external_orchestration_handoff",
+      "mutationAuthority": "none"
+    },
+    {
+      "handoff": "route",
+      "meaning": "Route actionable changes to an operator or the next runnable issue without selecting execution authority.",
+      "routingCategory": "external_orchestration_handoff",
+      "mutationAuthority": "none"
+    },
+    {
+      "handoff": "draft",
+      "meaning": "Draft confirm-required follow-up issues without making them the default execution path.",
+      "routingCategory": "external_orchestration_handoff",
+      "mutationAuthority": "none"
+    },
+    {
+      "handoff": "record",
+      "meaning": "Record durable external history after real issue, PR, verification, or phase state changes.",
+      "routingCategory": "external_orchestration_handoff",
+      "mutationAuthority": "none"
+    },
+    {
+      "handoff": "notify",
+      "meaning": "Notify the operator about actionable state changes without modifying supervisor state.",
+      "routingCategory": "external_orchestration_handoff",
+      "mutationAuthority": "none"
+    },
+    {
+      "handoff": "prepare_evidence",
+      "meaning": "Prepare operator-facing evidence without treating that evidence as executor authority.",
+      "routingCategory": "external_orchestration_handoff",
+      "mutationAuthority": "none"
     }
   ],
   "$defs": {
@@ -92,6 +153,13 @@
             "$ref": "#/$defs/operatorAction"
           },
           "uniqueItems": true
+        },
+        "externalHandoffs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/externalHandoff"
+          },
+          "uniqueItems": true
         }
       }
     },
@@ -118,6 +186,36 @@
         "meaning": {
           "type": "string",
           "minLength": 1
+        },
+        "routingCategory": {
+          "const": "operator_action"
+        },
+        "mutationAuthority": {
+          "const": "none"
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalHandoff": {
+      "type": "object",
+      "required": [
+        "handoff",
+        "meaning"
+      ],
+      "properties": {
+        "handoff": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "meaning": {
+          "type": "string",
+          "minLength": 1
+        },
+        "routingCategory": {
+          "const": "external_orchestration_handoff"
+        },
+        "mutationAuthority": {
+          "const": "none"
         }
       },
       "additionalProperties": false

--- a/docs/operator-actions.schema.json
+++ b/docs/operator-actions.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/TommyKammy/codex-supervisor/docs/operator-actions.schema.json",
   "$ref": "#/$defs/operatorActionVocabularyContract",
   "contractName": "codex-supervisor.operator-actions",
-  "contractVersion": 1,
+  "contractVersion": 2,
   "compatibilityPolicy": {
     "versionField": "contractVersion",
     "enforcementBoundary": "src/operator-actions.ts remains the runtime enforcement boundary for operator action parsing and selection.",
@@ -134,6 +134,7 @@
         "contractName",
         "contractVersion",
         "canonicalSource",
+        "routingCategories",
         "actions",
         "externalHandoffs"
       ],
@@ -142,10 +143,22 @@
           "const": "codex-supervisor.operator-actions"
         },
         "contractVersion": {
-          "const": 1
+          "const": 2
         },
         "canonicalSource": {
           "const": "src/operator-actions.ts"
+        },
+        "routingCategories": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "core_action",
+              "operator_action",
+              "external_orchestration_handoff"
+            ]
+          },
+          "minItems": 3,
+          "uniqueItems": true
         },
         "actions": {
           "type": "array",
@@ -157,6 +170,7 @@
         },
         "externalHandoffs": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "$ref": "#/$defs/externalHandoff"
           },

--- a/docs/operator-actions.schema.json
+++ b/docs/operator-actions.schema.json
@@ -134,7 +134,8 @@
         "contractName",
         "contractVersion",
         "canonicalSource",
-        "actions"
+        "actions",
+        "externalHandoffs"
       ],
       "properties": {
         "contractName": {
@@ -168,7 +169,9 @@
       "required": [
         "action",
         "surfaces",
-        "meaning"
+        "meaning",
+        "routingCategory",
+        "mutationAuthority"
       ],
       "properties": {
         "action": {
@@ -200,7 +203,9 @@
       "type": "object",
       "required": [
         "handoff",
-        "meaning"
+        "meaning",
+        "routingCategory",
+        "mutationAuthority"
       ],
       "properties": {
         "handoff": {

--- a/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-fixtures.ts
@@ -8,9 +8,11 @@ import type {
 import {
   PR_LIFECYCLE_DECISION_TRACE_SCHEMA_VERSION,
   type PrLifecycleDecision,
+  type PrLifecycleActionRouting,
   type PrLifecycleDecisionTraceArtifact,
   type PrLifecyclePolicyPosture,
   type PrLifecycleRecommendedAction,
+  type PrLifecycleRoutingCategory,
 } from "./pr-lifecycle-trace";
 import type {
   PrLifecycleCheckPosture,
@@ -102,6 +104,7 @@ function parsePrLifecycleDecisionTraceArtifact(
   const policy = requiredRecord(value.policy, source, "artifact.policy");
   const decision = requiredRecord(value.decision, source, "artifact.decision");
   const evidenceTokens = requiredStringArray(value.evidenceTokens, source, "artifact.evidenceTokens");
+  const routing = optionalRouting(value.routing, source);
   const v2Mode = optionalV2Mode(value.v2Mode, source);
   const v2Comparison = optionalV2Comparison(value.v2Comparison, source);
   const factsSource = requiredEnum(
@@ -251,9 +254,33 @@ function parsePrLifecycleDecisionTraceArtifact(
       ),
       summary: requiredString(decision.summary, source, "artifact.decision.summary"),
     },
+    routing,
     evidenceTokens,
     v2Mode,
     v2Comparison,
+  };
+}
+
+function optionalRouting(value: unknown, source: string): PrLifecycleActionRouting | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const routing = requiredRecord(value, source, "artifact.routing");
+  return {
+    action: requiredString(routing.action, source, "artifact.routing.action"),
+    routingCategory: requiredEnum(
+      routing.routingCategory,
+      source,
+      "artifact.routing.routingCategory",
+      prLifecycleRoutingCategories,
+    ),
+    mutationAuthority: requiredEnum(
+      routing.mutationAuthority,
+      source,
+      "artifact.routing.mutationAuthority",
+      prLifecycleMutationAuthorityValues,
+    ),
   };
 }
 
@@ -294,6 +321,15 @@ const prLifecycleRecommendedActions = [
   "refresh_state",
   "no_action",
 ] as const satisfies readonly PrLifecycleRecommendedAction[];
+const prLifecycleRoutingCategories = [
+  "core_action",
+  "operator_action",
+  "external_orchestration_handoff",
+] as const satisfies readonly PrLifecycleRoutingCategory[];
+const prLifecycleMutationAuthorityValues = [
+  "core_executor_required",
+  "none",
+] as const satisfies readonly PrLifecycleActionRouting["mutationAuthority"][];
 const decisionKernelV2RuntimeModes = ["disabled", "diagnostic_only", "pr_lifecycle_action_taking"] as const satisfies readonly DecisionKernelV2RuntimeMode[];
 const decisionKernelV2ActionSources = ["disabled", "pr_lifecycle_v2"] as const satisfies readonly DecisionKernelV2ActionSource[];
 const decisionKernelV2ActionScopes = ["none", "pr_lifecycle"] as const satisfies readonly DecisionKernelV2ActionScope[];

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.test.ts
@@ -94,6 +94,8 @@ test("formatPrLifecycleTraceDiagnostic renders a merge-ready trace line", () => 
   assert.match(line, /policy=merge_ready/);
   assert.match(line, /decision=merge/);
   assert.match(line, /action=merge/);
+  assert.match(line, /routing_category=none/);
+  assert.match(line, /mutation_authority=none/);
   assert.match(line, /review=current_head_review_observed/);
   assert.match(line, /checks=green/);
   assert.match(line, /mergeability=mergeable/);
@@ -114,6 +116,11 @@ test("formatPrLifecycleTraceDiagnostic renders the gated v2 PR lifecycle action 
     buildPrLifecycleDecisionTrace(
       traceInput({
         v2Mode: "pr_lifecycle_action_taking",
+        routing: {
+          action: "merge",
+          routingCategory: "core_action",
+          mutationAuthority: "core_executor_required",
+        },
       }),
     ),
   );
@@ -123,6 +130,8 @@ test("formatPrLifecycleTraceDiagnostic renders the gated v2 PR lifecycle action 
   assert.match(line, /v2_mutation_allowed=true/);
   assert.match(line, /v2_action_source=pr_lifecycle_v2/);
   assert.match(line, /v2_action_scope=pr_lifecycle/);
+  assert.match(line, /routing_category=core_action/);
+  assert.match(line, /mutation_authority=core_executor_required/);
   assert.match(line, /rollback_posture=disable_to_rollback/);
 });
 

--- a/src/decision-kernel/pr-lifecycle-trace-presenter.ts
+++ b/src/decision-kernel/pr-lifecycle-trace-presenter.ts
@@ -58,6 +58,8 @@ export function formatPrLifecycleTraceDiagnostic(
     `policy=${trace.policy.posture}`,
     `decision=${trace.decision.value}`,
     `action=${trace.decision.recommendedAction}`,
+    `routing_category=${trace.routing?.routingCategory ?? "none"}`,
+    `mutation_authority=${trace.routing?.mutationAuthority ?? "none"}`,
     `source=${trace.facts.source}`,
     `pr=${trace.facts.pullRequestNumber ?? "none"}`,
     `head=${formatDiagnosticToken(trace.facts.headSha)}`,

--- a/src/decision-kernel/pr-lifecycle-trace.ts
+++ b/src/decision-kernel/pr-lifecycle-trace.ts
@@ -38,6 +38,14 @@ export type PrLifecycleRecommendedAction =
   | "refresh_state"
   | "no_action";
 
+export type PrLifecycleRoutingCategory = "core_action" | "operator_action" | "external_orchestration_handoff";
+
+export interface PrLifecycleActionRouting {
+  action: string;
+  routingCategory: PrLifecycleRoutingCategory;
+  mutationAuthority: "core_executor_required" | "none";
+}
+
 export interface PrLifecycleDecisionTraceInput {
   traceId: string;
   generatedAt: string;
@@ -52,6 +60,7 @@ export interface PrLifecycleDecisionTraceInput {
     recommendedAction: PrLifecycleRecommendedAction;
     summary: string;
   };
+  routing?: PrLifecycleActionRouting | null;
   evidenceTokens?: string[];
   v2Mode?: DecisionKernelV2RuntimeMode | DecisionKernelV2ModePosture;
   v2Comparison?: DecisionKernelV2ComparisonDto | null;
@@ -78,6 +87,7 @@ export interface PrLifecycleDecisionTraceArtifact {
     recommendedAction: PrLifecycleRecommendedAction;
     summary: string;
   };
+  routing: PrLifecycleActionRouting | null;
   evidenceTokens: string[];
   v2Mode: DecisionKernelV2ModePosture;
   v2Comparison: (DecisionKernelV2ComparisonDto & { diagnosticOnly: true }) | null;
@@ -109,6 +119,7 @@ export function buildPrLifecycleDecisionTrace(
       recommendedAction: input.decision.recommendedAction,
       summary: input.decision.summary,
     },
+    routing: input.routing ? snapshotRouting(input.routing) : null,
     evidenceTokens: [...(input.evidenceTokens ?? [])],
     v2Mode: snapshotV2Mode(input.v2Mode ?? "diagnostic_only"),
     v2Comparison: input.v2Comparison
@@ -117,6 +128,14 @@ export function buildPrLifecycleDecisionTrace(
         diagnosticOnly: true,
       }
       : null,
+  };
+}
+
+function snapshotRouting(routing: PrLifecycleActionRouting): PrLifecycleActionRouting {
+  return {
+    action: routing.action,
+    routingCategory: routing.routingCategory,
+    mutationAuthority: routing.mutationAuthority,
   };
 }
 

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -3,7 +3,10 @@ import test from "node:test";
 import type { ReviewPolicyInput } from "../codex-connector-review-policy";
 import { buildPrLifecycleDecisionTrace } from "./pr-lifecycle-trace";
 import { normalizePrLifecycleFacts, type PrLifecycleFactInventory } from "./pr-lifecycle-state";
-import { evaluateDecisionKernelV2PrLifecycleAction } from "./v2-pr-lifecycle-action";
+import {
+  evaluateDecisionKernelV2PrLifecycleAction,
+  routeDecisionKernelV2PrLifecycleAction,
+} from "./v2-pr-lifecycle-action";
 
 function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecycleFactInventory {
   return {
@@ -112,6 +115,44 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes missing review to reque
   });
   assert.equal(decision.mode.actionSource, "pr_lifecycle_v2");
   assert.equal(decision.guard?.decision, "allowed");
+  assert.deepEqual(decision.routing, {
+    action: "request_review",
+    routingCategory: "core_action",
+    mutationAuthority: "core_executor_required",
+  });
+});
+
+test("Decision Kernel v2 PR lifecycle action routes separate core actions from operator actions", () => {
+  assert.deepEqual(routeDecisionKernelV2PrLifecycleAction("merge"), {
+    action: "merge",
+    routingCategory: "core_action",
+    mutationAuthority: "core_executor_required",
+  });
+  assert.deepEqual(routeDecisionKernelV2PrLifecycleAction("request_review"), {
+    action: "request_review",
+    routingCategory: "core_action",
+    mutationAuthority: "core_executor_required",
+  });
+  assert.deepEqual(routeDecisionKernelV2PrLifecycleAction("wait_ci"), {
+    action: "wait_ci",
+    routingCategory: "core_action",
+    mutationAuthority: "core_executor_required",
+  });
+  assert.deepEqual(routeDecisionKernelV2PrLifecycleAction("mark_stale_resolved"), {
+    action: "mark_stale_resolved",
+    routingCategory: "core_action",
+    mutationAuthority: "core_executor_required",
+  });
+  assert.deepEqual(routeDecisionKernelV2PrLifecycleAction("ask_operator"), {
+    action: "ask_operator",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
+  });
+  assert.deepEqual(routeDecisionKernelV2PrLifecycleAction("no_action"), {
+    action: "no_action",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
+  });
 });
 
 test("evaluateDecisionKernelV2PrLifecycleAction promotes pending and unknown checks to wait_ci", () => {

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -768,6 +768,7 @@ test("Phase 4 v2 PR lifecycle action-taking replay evidence covers selected acti
         reasons: decision.v2Decision.reasons,
       },
       decision: decision.traceDecision,
+      routing: decision.routing,
       evidenceTokens: [`case=${id}`, ...decision.evidenceTokens],
       v2Mode: decision.mode,
     }),
@@ -779,17 +780,19 @@ test("Phase 4 v2 PR lifecycle action-taking replay evidence covers selected acti
       trace.v2Mode.mode,
       trace.decision.value,
       trace.decision.recommendedAction,
+      trace.routing?.routingCategory,
+      trace.routing?.mutationAuthority,
       trace.v2Mode.actionSource,
       trace.v2Mode.mutationAllowed,
     ]),
     [
-      ["request-review", "pr_lifecycle_action_taking", "request_review", "request_review", "pr_lifecycle_v2", true],
-      ["wait-ci", "pr_lifecycle_action_taking", "wait", "wait_ci", "pr_lifecycle_v2", true],
-      ["stale-terminal", "pr_lifecycle_action_taking", "do_nothing", "mark_stale_resolved", "pr_lifecycle_v2", true],
-      ["operator-escalation", "pr_lifecycle_action_taking", "ask_operator", "manual_review", "pr_lifecycle_v2", true],
-      ["merge-ready", "pr_lifecycle_action_taking", "merge", "merge", "pr_lifecycle_v2", true],
-      ["diagnostic-rollback", "diagnostic_only", "do_nothing", "no_action", "disabled", false],
-      ["disabled-rollback", "disabled", "do_nothing", "no_action", "disabled", false],
+      ["request-review", "pr_lifecycle_action_taking", "request_review", "request_review", "core_action", "core_executor_required", "pr_lifecycle_v2", true],
+      ["wait-ci", "pr_lifecycle_action_taking", "wait", "wait_ci", "core_action", "core_executor_required", "pr_lifecycle_v2", true],
+      ["stale-terminal", "pr_lifecycle_action_taking", "do_nothing", "mark_stale_resolved", "core_action", "core_executor_required", "pr_lifecycle_v2", true],
+      ["operator-escalation", "pr_lifecycle_action_taking", "ask_operator", "manual_review", "operator_action", "none", "pr_lifecycle_v2", true],
+      ["merge-ready", "pr_lifecycle_action_taking", "merge", "merge", "core_action", "core_executor_required", "pr_lifecycle_v2", true],
+      ["diagnostic-rollback", "diagnostic_only", "do_nothing", "no_action", "operator_action", "none", "disabled", false],
+      ["disabled-rollback", "disabled", "do_nothing", "no_action", "operator_action", "none", "disabled", false],
     ],
   );
 });
@@ -822,6 +825,7 @@ test("v2 PR lifecycle action decisions can be recorded with a v2 action source t
       reasons: actionDecision.v2Decision.reasons,
     },
     decision: actionDecision.traceDecision,
+    routing: actionDecision.routing,
     evidenceTokens: ["pr=2312", "action_source=pr_lifecycle_v2", ...actionDecision.evidenceTokens],
     v2Mode: actionDecision.mode,
   });
@@ -830,4 +834,9 @@ test("v2 PR lifecycle action decisions can be recorded with a v2 action source t
   assert.equal(trace.v2Mode.actionSource, "pr_lifecycle_v2");
   assert.equal(trace.decision.value, "request_review");
   assert.equal(trace.decision.recommendedAction, "request_review");
+  assert.deepEqual(trace.routing, {
+    action: "request_review",
+    routingCategory: "core_action",
+    mutationAuthority: "core_executor_required",
+  });
 });

--- a/src/decision-kernel/v2-pr-lifecycle-action.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.ts
@@ -26,6 +26,14 @@ export type DecisionKernelV2PrLifecycleAction =
   | "ask_operator"
   | "no_action";
 
+export type DecisionKernelV2PrLifecycleActionRoutingCategory = "core_action" | "operator_action";
+
+export interface DecisionKernelV2PrLifecycleActionRoute {
+  action: DecisionKernelV2PrLifecycleAction;
+  routingCategory: DecisionKernelV2PrLifecycleActionRoutingCategory;
+  mutationAuthority: "core_executor_required" | "none";
+}
+
 export type DecisionKernelV2PrLifecycleActionReason =
   | "v2_disabled"
   | "v2_diagnostic_only"
@@ -67,6 +75,22 @@ export interface DecisionKernelV2PrLifecycleActionDecision {
     recommendedAction: PrLifecycleRecommendedAction;
     summary: string;
   };
+  routing: DecisionKernelV2PrLifecycleActionRoute;
+}
+
+export function routeDecisionKernelV2PrLifecycleAction(
+  action: DecisionKernelV2PrLifecycleAction,
+): DecisionKernelV2PrLifecycleActionRoute {
+  switch (action) {
+    case "merge":
+    case "request_review":
+    case "wait_ci":
+    case "mark_stale_resolved":
+      return { action, routingCategory: "core_action", mutationAuthority: "core_executor_required" };
+    case "ask_operator":
+    case "no_action":
+      return { action, routingCategory: "operator_action", mutationAuthority: "none" };
+  }
 }
 
 export function evaluateDecisionKernelV2PrLifecycleAction(
@@ -318,6 +342,7 @@ function actionDecision(args: {
     evidenceTokens: [...(args.evidenceTokens ?? reviewEvidenceTokens(args.v2Decision))],
     summary: args.summary,
     traceDecision: traceDecision(args.action, args.summary),
+    routing: routeDecisionKernelV2PrLifecycleAction(args.action),
   };
 }
 

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -142,7 +142,7 @@ test("published operator action artifact matches the typed vocabulary", () => {
   const contract = readPublishedOperatorActionVocabulary();
 
   assert.equal(contract.contractName, "codex-supervisor.operator-actions");
-  assert.equal(contract.contractVersion, 1);
+  assert.equal(contract.contractVersion, 2);
   assert.equal(contract.canonicalSource, "src/operator-actions.ts");
   assert.deepEqual(contract.routingCategories, [
     "core_action",
@@ -174,6 +174,7 @@ test("operator action schema requires Phase 5 routing metadata", () => {
     "contractName",
     "contractVersion",
     "canonicalSource",
+    "routingCategories",
     "actions",
     "externalHandoffs",
   ]);

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -32,6 +32,17 @@ interface PublishedOperatorActionVocabulary {
     mutationAuthority?: string;
   }>;
   routingCategories?: string[];
+  $defs?: {
+    operatorActionVocabularyContract?: {
+      required?: string[];
+    };
+    operatorAction?: {
+      required?: string[];
+    };
+    externalHandoff?: {
+      required?: string[];
+    };
+  };
 }
 
 const operatorActionContractPath = resolve(process.cwd(), "docs/operator-actions.schema.json");
@@ -154,6 +165,31 @@ test("operator action routing metadata is non-authoritative and external handoff
     assert.equal(handoff.mutationAuthority, "none");
     assert.doesNotMatch(handoff.meaning, /\b(authorize|execute implementation|merge)\b/i);
   }
+});
+
+test("operator action schema requires Phase 5 routing metadata", () => {
+  const contract = readPublishedOperatorActionVocabulary();
+
+  assert.deepEqual(contract.$defs?.operatorActionVocabularyContract?.required, [
+    "contractName",
+    "contractVersion",
+    "canonicalSource",
+    "actions",
+    "externalHandoffs",
+  ]);
+  assert.deepEqual(contract.$defs?.operatorAction?.required, [
+    "action",
+    "surfaces",
+    "meaning",
+    "routingCategory",
+    "mutationAuthority",
+  ]);
+  assert.deepEqual(contract.$defs?.externalHandoff?.required, [
+    "handoff",
+    "meaning",
+    "routingCategory",
+    "mutationAuthority",
+  ]);
 });
 
 test("operator action docs and WebUI labels cannot reference tokens outside the shared vocabulary", () => {

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   buildStatusOperatorCockpitViewModel,
+  externalOrchestrationHandoffVocabulary,
   operatorActionVocabulary,
   parseOperatorActionLine,
   type RestartRecommendation,
@@ -21,7 +22,16 @@ interface PublishedOperatorActionVocabulary {
     action: string;
     surfaces: string[];
     meaning: string;
+    routingCategory?: string;
+    mutationAuthority?: string;
   }>;
+  externalHandoffs?: Array<{
+    handoff: string;
+    meaning: string;
+    routingCategory?: string;
+    mutationAuthority?: string;
+  }>;
+  routingCategories?: string[];
 }
 
 const operatorActionContractPath = resolve(process.cwd(), "docs/operator-actions.schema.json");
@@ -123,8 +133,27 @@ test("published operator action artifact matches the typed vocabulary", () => {
   assert.equal(contract.contractName, "codex-supervisor.operator-actions");
   assert.equal(contract.contractVersion, 1);
   assert.equal(contract.canonicalSource, "src/operator-actions.ts");
+  assert.deepEqual(contract.routingCategories, [
+    "core_action",
+    "operator_action",
+    "external_orchestration_handoff",
+  ]);
   assert.deepEqual(contract.actions, operatorActionVocabulary);
+  assert.deepEqual(contract.externalHandoffs, externalOrchestrationHandoffVocabulary);
   assert.deepEqual(sortedTokens(Object.keys(validOperatorActions)), sortedTokens(operatorActionVocabulary.map((entry) => entry.action)));
+});
+
+test("operator action routing metadata is non-authoritative and external handoffs cannot mutate", () => {
+  for (const entry of operatorActionVocabulary) {
+    assert.equal(entry.routingCategory, "operator_action");
+    assert.equal(entry.mutationAuthority, "none");
+  }
+
+  for (const handoff of externalOrchestrationHandoffVocabulary) {
+    assert.equal(handoff.routingCategory, "external_orchestration_handoff");
+    assert.equal(handoff.mutationAuthority, "none");
+    assert.doesNotMatch(handoff.meaning, /\b(authorize|execute implementation|merge)\b/i);
+  }
 });
 
 test("operator action docs and WebUI labels cannot reference tokens outside the shared vocabulary", () => {

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -4,6 +4,15 @@ export interface OperatorActionVocabularyEntry {
   readonly action: string;
   readonly surfaces: ReadonlyArray<"status" | "doctor" | "webui">;
   readonly meaning: string;
+  readonly routingCategory: "operator_action";
+  readonly mutationAuthority: "none";
+}
+
+export interface ExternalOrchestrationHandoffVocabularyEntry {
+  readonly handoff: string;
+  readonly meaning: string;
+  readonly routingCategory: "external_orchestration_handoff";
+  readonly mutationAuthority: "none";
 }
 
 export const operatorActionVocabulary = [
@@ -11,54 +20,111 @@ export const operatorActionVocabulary = [
     action: "continue",
     surfaces: ["status", "doctor", "webui"],
     meaning: "No blocking operator action was detected; continue normal supervisor operation.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "restart_loop",
     surfaces: ["status", "webui"],
     meaning:
       "Tracked work is active but the supervisor loop is off; restart the supported loop host so the runtime reports running and tracked work can advance.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "fix_config",
     surfaces: ["status", "doctor", "webui"],
     meaning:
       "Repair host prerequisites, setup fields, workspace-preparation configuration, or incomplete local CI visibility before continuing.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "adopt_local_ci",
     surfaces: ["doctor", "webui"],
     meaning: "A repo-owned local CI candidate exists; configure it before relying on local verification posture.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "dismiss_local_ci",
     surfaces: ["webui"],
     meaning: "Explicitly dismiss a repo-owned local CI recommendation when local CI should remain unset.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "manual_review",
     surfaces: ["status", "doctor", "webui"],
     meaning: "A tracked path or diagnostic warning requires human judgment before automation should continue.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "resolve_stale_review_bot",
     surfaces: ["status", "webui"],
     meaning:
       "Code or CI is green but stale configured-bot review thread metadata still blocks the tracked PR; inspect and resolve the exact thread or leave a manual note.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "provider_outage_suspected",
     surfaces: ["status", "webui"],
     meaning:
       "Required checks are green but the configured review provider has not reported on the current head; wait, verify provider delivery, or escalate to manual review.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
   {
     action: "safe_to_ignore",
     surfaces: ["doctor", "webui"],
     meaning: "A dismissed or already-completed advisory signal does not require operator action.",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
   },
 ] as const satisfies readonly OperatorActionVocabularyEntry[];
 
 export type OperatorActionToken = typeof operatorActionVocabulary[number]["action"];
+
+export const externalOrchestrationHandoffVocabulary = [
+  {
+    handoff: "evaluate",
+    meaning: "Read roadmap, GitHub, local status, and note state without changing supervisor runtime state.",
+    routingCategory: "external_orchestration_handoff",
+    mutationAuthority: "none",
+  },
+  {
+    handoff: "route",
+    meaning: "Route actionable changes to an operator or the next runnable issue without selecting execution authority.",
+    routingCategory: "external_orchestration_handoff",
+    mutationAuthority: "none",
+  },
+  {
+    handoff: "draft",
+    meaning: "Draft confirm-required follow-up issues without making them the default execution path.",
+    routingCategory: "external_orchestration_handoff",
+    mutationAuthority: "none",
+  },
+  {
+    handoff: "record",
+    meaning: "Record durable external history after real issue, PR, verification, or phase state changes.",
+    routingCategory: "external_orchestration_handoff",
+    mutationAuthority: "none",
+  },
+  {
+    handoff: "notify",
+    meaning: "Notify the operator about actionable state changes without modifying supervisor state.",
+    routingCategory: "external_orchestration_handoff",
+    mutationAuthority: "none",
+  },
+  {
+    handoff: "prepare_evidence",
+    meaning: "Prepare operator-facing evidence without treating that evidence as executor authority.",
+    routingCategory: "external_orchestration_handoff",
+    mutationAuthority: "none",
+  },
+] as const satisfies readonly ExternalOrchestrationHandoffVocabularyEntry[];
 
 export interface OperatorAction {
   action: OperatorActionToken;


### PR DESCRIPTION
## Summary
- add routing metadata to the published operator action contract
- publish external orchestration handoff vocabulary with no mutation authority
- add v2 PR lifecycle action routing so core actions and operator actions are distinguishable

## Scope
This implements #2323. Routing metadata is additive and non-authoritative; it does not grant external Automation executor authority or add GitHub mutation, merge, or Codex execution authority.

## Verification
- `npx tsx --test src/operator-actions.test.ts src/decision-kernel/v2-pr-lifecycle-action.test.ts`
- `npx tsx --test src/quality-kit-docs.test.ts src/supervised-automation-lane-docs.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2323 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `git diff --check`

Closes #2323
