### PR TITLE
[codex] Surface Phase 5 handoff routing evidence

### DIFF
--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
-import { buildDecisionKernelV2ExplainDto } from "./v2-explain";
+import { buildDecisionKernelV2ExplainDto, renderDecisionKernelV2ExplainDto } from "./v2-explain";
 
 function record(overrides: Partial<IssueRunRecord> = {}): IssueRunRecord {
   return {
@@ -165,6 +165,44 @@ test("buildDecisionKernelV2ExplainDto uses PR head for current-head review obser
       v2: "merge",
     },
   ]);
+});
+
+test("renderDecisionKernelV2ExplainDto surfaces core action routing without granting mutation authority", () => {
+  const dto = buildDecisionKernelV2ExplainDto({
+    config: codexConfig(),
+    issueNumber: 2301,
+    title: "Phase 3.2",
+    record: record(),
+    pr: pullRequest(),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass" }],
+    reviewThreads: [],
+  });
+
+  const rendered = renderDecisionKernelV2ExplainDto(dto);
+
+  assert.match(
+    rendered,
+    /^v2_routing action=merge routing_category=core_action mutation_authority=none external_handoff=prepare_evidence core_safety_gates=preserved$/m,
+  );
+});
+
+test("renderDecisionKernelV2ExplainDto surfaces operator-action routing for manual gates", () => {
+  const dto = buildDecisionKernelV2ExplainDto({
+    config: codexConfig({ localCiCommand: "npm run verify:pre-pr" }),
+    issueNumber: 2301,
+    title: "Phase 3.2",
+    record: record(),
+    pr: pullRequest(),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass" }],
+    reviewThreads: [],
+  });
+
+  const rendered = renderDecisionKernelV2ExplainDto(dto);
+
+  assert.match(
+    rendered,
+    /^v2_routing action=ask_operator routing_category=operator_action mutation_authority=none external_handoff=prepare_evidence core_safety_gates=preserved$/m,
+  );
 });
 
 test("buildDecisionKernelV2ExplainDto ignores malformed current-head review timestamps", () => {

--- a/src/decision-kernel/v2-explain.ts
+++ b/src/decision-kernel/v2-explain.ts
@@ -18,6 +18,7 @@ import { buildDecisionKernelV2ComparisonDto, type DecisionKernelV2ComparisonDto 
 import {
   DECISION_KERNEL_V2_READ_ONLY_SCHEMA_VERSION,
   evaluateDecisionKernelV2ReadOnlyFromFacts,
+  type DecisionKernelV2Action,
   type DecisionKernelV2ReadOnlyDecision,
 } from "../decision-kernel-v2";
 import { inferStateFromPullRequest } from "../pull-request-state";
@@ -184,6 +185,7 @@ export function renderDecisionKernelV2ExplainDto(dto: DecisionKernelV2ExplainDto
 
   if (dto.decision) {
     const state = dto.decision.normalizedState;
+    const routing = routeDecisionKernelV2ExplainAction(dto.decision.action);
     lines.push(
       [
         "v2_normalized",
@@ -199,6 +201,14 @@ export function renderDecisionKernelV2ExplainDto(dto: DecisionKernelV2ExplainDto
         `reasons=${dto.decision.reasons.length === 0 ? "none" : dto.decision.reasons.join("|")}`,
         `required_evidence=${dto.decision.requiredEvidence.length === 0 ? "none" : dto.decision.requiredEvidence.join("|")}`,
         `summary=${dto.decision.summary.replace(/\s+/g, "_")}`,
+      ].join(" "),
+      [
+        "v2_routing",
+        `action=${dto.decision.action}`,
+        `routing_category=${routing.routingCategory}`,
+        "mutation_authority=none",
+        "external_handoff=prepare_evidence",
+        "core_safety_gates=preserved",
       ].join(" "),
     );
   }
@@ -218,6 +228,21 @@ export function renderDecisionKernelV2ExplainDto(dto: DecisionKernelV2ExplainDto
   }
 
   return lines.join("\n");
+}
+
+function routeDecisionKernelV2ExplainAction(action: DecisionKernelV2Action): {
+  routingCategory: "core_action" | "operator_action";
+} {
+  switch (action) {
+    case "merge":
+    case "wait":
+    case "request_review":
+    case "run_codex":
+      return { routingCategory: "core_action" };
+    case "ask_operator":
+    case "no_action":
+      return { routingCategory: "operator_action" };
+  }
 }
 
 function currentActionEquivalentForV2Comparison(args: {

--- a/src/supervisor/supervisor-status-report.test.ts
+++ b/src/supervisor/supervisor-status-report.test.ts
@@ -92,18 +92,18 @@ test("buildRuntimeRecoverySummary stays quiet when no actionable runtime recover
 test("renderDecisionKernelV2StatusLine keeps v2 visibly diagnostic-only", () => {
   assert.equal(
     renderDecisionKernelV2StatusLine(),
-    "decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled action_scope=none",
+    "decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled action_scope=none routing_category=external_orchestration_handoff mutation_authority=none external_handoff=prepare_evidence core_safety_gates=preserved",
   );
 });
 
 test("renderDecisionKernelV2StatusLine distinguishes disabled and PR lifecycle action-taking modes", () => {
   assert.equal(
     renderDecisionKernelV2StatusLine("disabled"),
-    "decision_kernel_v2 mode=disabled authoritative=false mutation_allowed=false action_source=disabled action_scope=none",
+    "decision_kernel_v2 mode=disabled authoritative=false mutation_allowed=false action_source=disabled action_scope=none routing_category=external_orchestration_handoff mutation_authority=none external_handoff=prepare_evidence core_safety_gates=preserved",
   );
   assert.equal(
     renderDecisionKernelV2StatusLine("pr_lifecycle_action_taking"),
-    "decision_kernel_v2 mode=pr_lifecycle_action_taking authoritative=true mutation_allowed=true action_source=pr_lifecycle_v2 action_scope=pr_lifecycle",
+    "decision_kernel_v2 mode=pr_lifecycle_action_taking authoritative=true mutation_allowed=true action_source=pr_lifecycle_v2 action_scope=pr_lifecycle routing_category=core_action mutation_authority=core_executor_required external_handoff=none core_safety_gates=preserved",
   );
 });
 
@@ -128,7 +128,7 @@ test("renderSupervisorStatusDto includes the v2 diagnostic-only guardrail line",
 
   assert.match(
     rendered,
-    /^decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled action_scope=none$/m,
+    /^decision_kernel_v2 mode=diagnostic_only authoritative=false mutation_allowed=false action_source=disabled action_scope=none routing_category=external_orchestration_handoff mutation_authority=none external_handoff=prepare_evidence core_safety_gates=preserved$/m,
   );
 });
 

--- a/src/supervisor/supervisor-status-report.ts
+++ b/src/supervisor/supervisor-status-report.ts
@@ -218,6 +218,17 @@ export function renderDecisionKernelV2StatusLine(
   modeOrPosture: DecisionKernelV2RuntimeMode | DecisionKernelV2ModePosture = "diagnostic_only",
 ): string {
   const posture = typeof modeOrPosture === "string" ? decisionKernelV2ModePosture(modeOrPosture) : modeOrPosture;
+  const routing = posture.mode === "pr_lifecycle_action_taking"
+    ? {
+      category: "core_action",
+      mutationAuthority: "core_executor_required",
+      externalHandoff: "none",
+    }
+    : {
+      category: "external_orchestration_handoff",
+      mutationAuthority: "none",
+      externalHandoff: "prepare_evidence",
+    };
   return [
     "decision_kernel_v2",
     `mode=${posture.mode}`,
@@ -225,6 +236,10 @@ export function renderDecisionKernelV2StatusLine(
     `mutation_allowed=${posture.mutationAllowed}`,
     `action_source=${posture.actionSource}`,
     `action_scope=${posture.actionScope}`,
+    `routing_category=${routing.category}`,
+    `mutation_authority=${routing.mutationAuthority}`,
+    `external_handoff=${routing.externalHandoff}`,
+    "core_safety_gates=preserved",
   ].join(" ");
 }
 


### PR DESCRIPTION
## Summary
- add Phase 5 routing evidence to the Decision Kernel v2 status line
- add `v2_routing` lines to v2 explain output for core and operator-action decisions
- keep external handoff evidence non-mutating while preserving core safety gates

## Scope
This implements #2324. It only changes typed status/explain presentation and focused tests; it does not change issue selection, Codex execution, PR mutation, merge execution, or loop ownership.

## Verification
- `npx tsx --test src/supervisor/supervisor-status-report.test.ts src/decision-kernel/v2-explain.test.ts src/decision-kernel/pr-lifecycle-trace-presenter.test.ts`
- `npx tsx --test src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts src/decision-kernel/pr-lifecycle-trace-presenter.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2324 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `git diff --check`

Closes #2324