### PR TITLE
[codex] Add external orchestration safety coverage

### DIFF
--- a/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/case.json
+++ b/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/case.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "phase5-aegisops-external-handoff-review-ci-merge",
+  "issueNumber": 9150,
+  "title": "AegisOps external orchestration handoff bounded review CI merge fixture",
+  "capturedAt": "2026-06-07T02:15:00Z"
+}

--- a/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/expected/replay-result.json
+++ b/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/expected/replay-result.json
@@ -1,0 +1,6 @@
+{
+  "nextState": "blocked",
+  "shouldRunCodex": false,
+  "blockedReason": "stale_review_bot",
+  "failureSignature": "stalled-bot:thread-production-source-denylist"
+}

--- a/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/input/snapshot.json
+++ b/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/input/snapshot.json
@@ -188,7 +188,7 @@
     "retrySummary": null,
     "recoveryLoopSummary": null,
     "activityContext": {
-      "handoffSummary": null,
+      "handoffSummary": "routingCategory=external_orchestration_handoff mutationAuthority=none externalHandoff=prepare_evidence coreSafetyGates=preserved boundedNextAction=ask_operator",
       "localReviewRoutingSummary": null,
       "changeClassesSummary": null,
       "verificationPolicySummary": null,

--- a/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/input/snapshot.json
+++ b/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/input/snapshot.json
@@ -1,0 +1,226 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-06-07T02:15:00Z",
+  "issue": {
+    "number": 9150,
+    "title": "AegisOps external orchestration handoff bounded review CI merge fixture",
+    "body": "Phase 5 replay fixture for external orchestration handoff evidence that must remain bounded by core review, CI, and merge gates.",
+    "url": "https://example.test/issues/9150",
+    "state": "OPEN",
+    "updatedAt": "2026-06-07T02:13:00Z"
+  },
+  "local": {
+    "record": {
+      "issue_number": 9150,
+      "state": "blocked",
+      "branch": "codex/issue-9150",
+      "pr_number": 9250,
+      "workspace": ".",
+      "journal_path": ".codex-supervisor/issues/9150/issue-journal.md",
+      "attempt_count": 7,
+      "implementation_attempt_count": 2,
+      "repair_attempt_count": 5,
+      "timeout_retry_count": 0,
+      "blocked_verification_retry_count": 0,
+      "repeated_blocker_count": 0,
+      "repeated_failure_signature_count": 0,
+      "blocked_reason": "stale_review_bot",
+      "last_error": "Repeated configured Codex review feedback made no tracked PR progress.",
+      "last_failure_kind": null,
+      "last_failure_context": {
+        "category": "manual",
+        "summary": "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+        "signature": "stalled-bot:thread-production-source-denylist",
+        "command": null,
+        "details": [
+          "reviewer=chatgpt-codex-connector file=aegisops/source_policy.ts line=44 p_severity=P1 processed_on_current_head=yes"
+        ],
+        "url": "https://example.test/pull/9250#discussion_r9150",
+        "updated_at": "2026-06-07T02:12:30Z"
+      },
+      "last_failure_signature": "stalled-bot:thread-production-source-denylist",
+      "last_head_sha": "head-aegisops-repeat-stop",
+      "last_tracked_pr_progress_snapshot": null,
+      "last_tracked_pr_progress_summary": null,
+      "last_tracked_pr_repeat_failure_decision": null,
+      "review_wait_started_at": "2026-06-07T02:00:00Z",
+      "review_wait_head_sha": "head-aegisops-repeat-stop",
+      "provider_success_observed_at": "2026-06-07T02:10:00Z",
+      "provider_success_head_sha": "head-aegisops-repeat-stop",
+      "merge_readiness_last_evaluated_at": "2026-06-07T02:12:30Z",
+      "copilot_review_requested_observed_at": null,
+      "copilot_review_requested_head_sha": null,
+      "copilot_review_timed_out_at": null,
+      "copilot_review_timeout_action": null,
+      "copilot_review_timeout_reason": null,
+      "local_review_head_sha": null,
+      "local_review_blocker_summary": null,
+      "local_review_summary_path": null,
+      "local_review_run_at": null,
+      "local_review_max_severity": null,
+      "local_review_findings_count": 0,
+      "local_review_root_cause_count": 0,
+      "local_review_verified_max_severity": null,
+      "local_review_verified_findings_count": 0,
+      "local_review_recommendation": null,
+      "local_review_degraded": false,
+      "last_local_review_signature": null,
+      "repeated_local_review_signature_count": 0,
+      "latest_local_ci_result": {
+        "outcome": "passed",
+        "summary": "AegisOps focused policy verifier passed on the current head.",
+        "ran_at": "2026-06-07T02:11:00Z",
+        "head_sha": "head-aegisops-repeat-stop",
+        "execution_mode": "structured",
+        "command": "npx tsx --test src/supervisor/replay-corpus.test.ts",
+        "failure_class": null,
+        "remediation_target": null
+      },
+      "last_observed_host_local_pr_blocker_signature": null,
+      "last_observed_host_local_pr_blocker_head_sha": null,
+      "last_host_local_pr_blocker_comment_signature": null,
+      "last_host_local_pr_blocker_comment_head_sha": null,
+      "review_loop_retry_state": [
+        {
+          "fingerprint": "pr=9250|head=head-aegisops-repeat-stop|thread=thread-production-source-denylist|comment=comment-production-source-denylist-v1",
+          "pr_number": 9250,
+          "head_sha": "head-aegisops-repeat-stop",
+          "thread_id": "thread-production-source-denylist",
+          "latest_comment_fingerprint": "comment-production-source-denylist-v1",
+          "attempts": 1,
+          "first_attempted_at": "2026-06-07T02:08:00Z",
+          "last_attempted_at": "2026-06-07T02:08:00Z"
+        }
+      ],
+      "processed_review_thread_ids": [
+        "thread-production-source-denylist@head-aegisops-repeat-stop"
+      ],
+      "processed_review_thread_fingerprints": [
+        "thread-production-source-denylist@head-aegisops-repeat-stop#comment-production-source-denylist-v1"
+      ],
+      "updated_at": "2026-06-07T02:13:00Z"
+    },
+    "workspaceStatus": {
+      "branch": "codex/issue-9150",
+      "headSha": "head-aegisops-repeat-stop",
+      "hasUncommittedChanges": false,
+      "baseAhead": 1,
+      "baseBehind": 0,
+      "remoteBranchExists": true,
+      "remoteAhead": 0,
+      "remoteBehind": 0
+    }
+  },
+  "github": {
+    "pullRequest": {
+      "number": 9250,
+      "title": "AegisOps external orchestration handoff bounded review CI merge fixture",
+      "url": "https://example.test/pull/9250",
+      "state": "OPEN",
+      "createdAt": "2026-03-13T06:20:00Z",
+      "isDraft": false,
+      "reviewDecision": "CHANGES_REQUESTED",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "headRefName": "codex/issue-9150",
+      "headRefOid": "head-aegisops-repeat-stop",
+      "copilotReviewState": "not_requested",
+      "copilotReviewRequestedAt": null,
+      "copilotReviewArrivedAt": null,
+      "configuredBotCurrentHeadObservedAt": "2026-06-07T02:10:00Z",
+      "configuredBotCurrentHeadObservationSource": "codex_pr_success_comment",
+      "configuredBotCurrentHeadStatusState": "SUCCESS",
+      "currentHeadCiGreenAt": "2026-06-07T02:11:00Z",
+      "configuredBotTopLevelReviewStrength": "blocking",
+      "configuredBotTopLevelReviewSubmittedAt": "2026-06-07T02:10:00Z",
+      "mergedAt": null
+    },
+    "checks": [
+      {
+        "name": "policy verifier",
+        "state": "SUCCESS",
+        "bucket": "pass",
+        "workflow": "CI"
+      }
+    ],
+    "reviewThreads": [
+      {
+        "id": "thread-production-source-denylist",
+        "isResolved": false,
+        "isOutdated": false,
+        "path": "aegisops/source_policy.ts",
+        "line": 44,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-production-source-denylist-v1",
+              "body": "P1: The production source denylist still allows simulator evidence to be treated as launch authority.",
+              "createdAt": "2026-06-07T02:12:00Z",
+              "url": "https://example.test/pull/9250#discussion_r9150",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "decision": {
+    "nextState": "blocked",
+    "shouldRunCodex": false,
+    "blockedReason": "stale_review_bot",
+    "failureContext": {
+      "category": "manual",
+      "summary": "1 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+      "signature": "stalled-bot:thread-production-source-denylist",
+      "command": null,
+      "details": [
+        "reviewer=chatgpt-codex-connector file=aegisops/source_policy.ts line=44 p_severity=P1 processed_on_current_head=yes"
+      ],
+      "url": "https://example.test/pull/9250#discussion_r9150",
+      "updated_at": "2026-06-07T13:14:18.593Z"
+    }
+  },
+  "operatorSummary": {
+    "latestRecoverySummary": null,
+    "retrySummary": null,
+    "recoveryLoopSummary": null,
+    "activityContext": {
+      "handoffSummary": null,
+      "localReviewRoutingSummary": null,
+      "changeClassesSummary": null,
+      "verificationPolicySummary": null,
+      "durableGuardrailSummary": null,
+      "externalReviewFollowUpSummary": null,
+      "preMergeEvaluation": null,
+      "localCiStatus": {
+        "outcome": "passed",
+        "summary": "AegisOps focused policy verifier passed on the current head.",
+        "ranAt": "2026-06-07T02:11:00Z",
+        "headSha": "head-aegisops-repeat-stop",
+        "headStatus": "current",
+        "context": "notice",
+        "command": "npx tsx --test src/supervisor/replay-corpus.test.ts",
+        "stderrSummary": null,
+        "failureClass": null,
+        "remediationTarget": null,
+        "verifierDriftHint": null
+      },
+      "latestRecovery": null,
+      "retryContext": {
+        "timeoutRetryCount": 0,
+        "blockedVerificationRetryCount": 0,
+        "repeatedBlockerCount": 0,
+        "repeatedFailureSignatureCount": 0,
+        "lastFailureSignature": "stalled-bot:thread-production-source-denylist"
+      },
+      "repeatedRecovery": null,
+      "recentPhaseChanges": [],
+      "localReviewSummaryPath": null,
+      "externalReviewMissesPath": null,
+      "reviewWaits": []
+    }
+  }
+}

--- a/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/case.json
+++ b/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/case.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "phase5-hrcore-external-handoff-metadata-residue",
+  "issueNumber": 9151,
+  "title": "HRCore external orchestration handoff metadata residue fixture",
+  "capturedAt": "2026-06-07T03:20:00Z"
+}

--- a/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/expected/replay-result.json
+++ b/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/expected/replay-result.json
@@ -1,0 +1,6 @@
+{
+  "nextState": "ready_to_merge",
+  "shouldRunCodex": false,
+  "blockedReason": null,
+  "failureSignature": null
+}

--- a/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/input/snapshot.json
+++ b/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/input/snapshot.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-06-07T03:20:00Z",
+  "issue": {
+    "number": 9151,
+    "title": "HRCore external orchestration handoff metadata residue fixture",
+    "body": "Phase 5 replay fixture for external orchestration handoff evidence that must remain bounded by metadata residue and fresh core safety gates.",
+    "url": "https://example.test/issues/9151",
+    "state": "OPEN",
+    "updatedAt": "2026-06-07T03:10:00Z"
+  },
+  "local": {
+    "record": {
+      "issue_number": 9151,
+      "state": "blocked",
+      "branch": "codex/issue-9151",
+      "pr_number": 9251,
+      "workspace": ".",
+      "journal_path": ".codex-supervisor/issues/9151/issue-journal.md",
+      "attempt_count": 5,
+      "implementation_attempt_count": 2,
+      "repair_attempt_count": 3,
+      "timeout_retry_count": 0,
+      "blocked_verification_retry_count": 0,
+      "repeated_blocker_count": 0,
+      "repeated_failure_signature_count": 0,
+      "blocked_reason": "stale_review_bot",
+      "last_error": "Outdated configured Codex metadata remained after current-head repair evidence.",
+      "last_failure_kind": null,
+      "last_failure_context": {
+        "category": "manual",
+        "summary": "Outdated configured-bot metadata-only residue is blocking the tracked PR.",
+        "signature": "stalled-bot:thread-openapi-onboarding-schema",
+        "command": null,
+        "details": [
+          "reviewer=chatgpt-codex-connector file=openapi/hrcore.openapi.json line=128 processed_on_current_head=yes"
+        ],
+        "url": "https://example.test/pull/9251#discussion_r9151",
+        "updated_at": "2026-06-07T03:08:30Z"
+      },
+      "last_failure_signature": "stalled-bot:thread-openapi-onboarding-schema",
+      "last_head_sha": "head-hrcore-metadata-only",
+      "last_tracked_pr_progress_snapshot": null,
+      "last_tracked_pr_progress_summary": null,
+      "last_tracked_pr_repeat_failure_decision": null,
+      "review_wait_started_at": "2026-06-07T03:00:00Z",
+      "review_wait_head_sha": "head-hrcore-metadata-only",
+      "provider_success_observed_at": "2026-06-07T03:09:00Z",
+      "provider_success_head_sha": "head-hrcore-metadata-only",
+      "merge_readiness_last_evaluated_at": "2026-06-07T03:10:00Z",
+      "copilot_review_requested_observed_at": null,
+      "copilot_review_requested_head_sha": null,
+      "copilot_review_timed_out_at": null,
+      "copilot_review_timeout_action": null,
+      "copilot_review_timeout_reason": null,
+      "local_review_head_sha": null,
+      "local_review_blocker_summary": null,
+      "local_review_summary_path": null,
+      "local_review_run_at": null,
+      "local_review_max_severity": null,
+      "local_review_findings_count": 0,
+      "local_review_root_cause_count": 0,
+      "local_review_verified_max_severity": null,
+      "local_review_verified_findings_count": 0,
+      "local_review_recommendation": null,
+      "local_review_degraded": false,
+      "last_local_review_signature": null,
+      "repeated_local_review_signature_count": 0,
+      "latest_local_ci_result": null,
+      "timeline_artifacts": [
+        {
+          "type": "verification_result",
+          "gate": "codex_turn",
+          "command": "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+          "head_sha": "head-hrcore-metadata-only",
+          "outcome": "passed",
+          "remediation_target": null,
+          "next_action": "continue",
+          "summary": "HRCore OpenAPI onboarding schema repair evidence passed on the current head.",
+          "recorded_at": "2026-06-07T03:08:00Z",
+          "processed_review_thread_ids": [
+            "thread-openapi-onboarding-schema@head-hrcore-metadata-only"
+          ],
+          "processed_review_thread_fingerprints": [
+            "thread-openapi-onboarding-schema@head-hrcore-metadata-only#comment-openapi-onboarding-schema-v1"
+          ]
+        }
+      ],
+      "last_observed_host_local_pr_blocker_signature": null,
+      "last_observed_host_local_pr_blocker_head_sha": null,
+      "last_host_local_pr_blocker_comment_signature": null,
+      "last_host_local_pr_blocker_comment_head_sha": null,
+      "processed_review_thread_ids": [
+        "thread-openapi-onboarding-schema@head-hrcore-metadata-only"
+      ],
+      "processed_review_thread_fingerprints": [
+        "thread-openapi-onboarding-schema@head-hrcore-metadata-only#comment-openapi-onboarding-schema-v1"
+      ],
+      "updated_at": "2026-06-07T03:10:00Z"
+    },
+    "workspaceStatus": {
+      "branch": "codex/issue-9151",
+      "headSha": "head-hrcore-metadata-only",
+      "hasUncommittedChanges": false,
+      "baseAhead": 1,
+      "baseBehind": 0,
+      "remoteBranchExists": true,
+      "remoteAhead": 0,
+      "remoteBehind": 0
+    }
+  },
+  "github": {
+    "pullRequest": {
+      "number": 9251,
+      "title": "HRCore external orchestration handoff metadata residue fixture",
+      "url": "https://example.test/pull/9251",
+      "state": "OPEN",
+      "createdAt": "2026-03-13T06:20:00Z",
+      "isDraft": false,
+      "reviewDecision": "APPROVED",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "headRefName": "codex/issue-9151",
+      "headRefOid": "head-hrcore-metadata-only",
+      "copilotReviewState": "not_requested",
+      "copilotReviewRequestedAt": null,
+      "copilotReviewArrivedAt": null,
+      "configuredBotCurrentHeadObservedAt": "2026-06-07T03:09:00Z",
+      "configuredBotCurrentHeadObservationSource": "codex_pr_success_comment",
+      "configuredBotCurrentHeadStatusState": "SUCCESS",
+      "currentHeadCiGreenAt": "2026-06-07T03:08:30Z",
+      "configuredBotTopLevelReviewStrength": null,
+      "mergedAt": null
+    },
+    "checks": [
+      {
+        "name": "openapi verifier",
+        "state": "SUCCESS",
+        "bucket": "pass",
+        "workflow": "CI"
+      }
+    ],
+    "reviewThreads": [
+      {
+        "id": "thread-openapi-onboarding-schema",
+        "isResolved": false,
+        "isOutdated": true,
+        "path": "openapi/hrcore.openapi.json",
+        "line": 128,
+        "comments": {
+          "nodes": [
+            {
+              "id": "comment-openapi-onboarding-schema-v1",
+              "body": "P2: The onboarding schema path list was missing the current repair artifact before this head.",
+              "createdAt": "2026-06-07T02:12:00Z",
+              "url": "https://example.test/pull/9251#discussion_r9151",
+              "author": {
+                "login": "chatgpt-codex-connector",
+                "typeName": "Bot"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "decision": {
+    "nextState": "ready_to_merge",
+    "shouldRunCodex": false,
+    "blockedReason": null,
+    "failureContext": null
+  },
+  "operatorSummary": {
+    "latestRecoverySummary": null,
+    "retrySummary": null,
+    "recoveryLoopSummary": null,
+    "activityContext": {
+      "handoffSummary": null,
+      "localReviewRoutingSummary": null,
+      "changeClassesSummary": null,
+      "verificationPolicySummary": null,
+      "durableGuardrailSummary": null,
+      "externalReviewFollowUpSummary": null,
+      "preMergeEvaluation": null,
+      "localCiStatus": null,
+      "latestRecovery": null,
+      "retryContext": {
+        "timeoutRetryCount": 0,
+        "blockedVerificationRetryCount": 0,
+        "repeatedBlockerCount": 0,
+        "repeatedFailureSignatureCount": 0,
+        "lastFailureSignature": "stalled-bot:thread-openapi-onboarding-schema"
+      },
+      "repeatedRecovery": null,
+      "recentPhaseChanges": [],
+      "localReviewSummaryPath": null,
+      "externalReviewMissesPath": null,
+      "reviewWaits": []
+    }
+  }
+}

--- a/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/input/snapshot.json
+++ b/replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/input/snapshot.json
@@ -175,7 +175,7 @@
     "retrySummary": null,
     "recoveryLoopSummary": null,
     "activityContext": {
-      "handoffSummary": null,
+      "handoffSummary": "routingCategory=external_orchestration_handoff mutationAuthority=none externalHandoff=prepare_evidence coreSafetyGates=preserved boundedNextAction=ask_operator",
       "localReviewRoutingSummary": null,
       "changeClassesSummary": null,
       "verificationPolicySummary": null,

--- a/replay-corpus/manifest.json
+++ b/replay-corpus/manifest.json
@@ -84,6 +84,14 @@
     {
       "id": "phase0-hrcore-current-head-repair-metadata-residue",
       "path": "cases/phase0-hrcore-current-head-repair-metadata-residue"
+    },
+    {
+      "id": "phase5-aegisops-external-handoff-review-ci-merge",
+      "path": "cases/phase5-aegisops-external-handoff-review-ci-merge"
+    },
+    {
+      "id": "phase5-hrcore-external-handoff-metadata-residue",
+      "path": "cases/phase5-hrcore-external-handoff-metadata-residue"
     }
   ]
 }

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -284,6 +284,100 @@ test("evaluateDecisionKernelV2PrLifecycleAction requires explicit merge gate inp
   ]);
 });
 
+test("evaluateDecisionKernelV2PrLifecycleAction ignores external handoff metadata as mutation authority", () => {
+  const unsafeExternalHandoff = {
+    routing_category: "external_orchestration_handoff",
+    mutation_authority: "core_executor_required",
+    external_handoff: "merge",
+    observed_at: "2026-06-09T00:05:00.000Z",
+    asserted_core_safety_gates: "passed",
+  };
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(inventory()),
+    externalOrchestrationHandoff: unsafeExternalHandoff,
+  } as Parameters<typeof evaluateDecisionKernelV2PrLifecycleAction>[0] & {
+    externalOrchestrationHandoff: typeof unsafeExternalHandoff;
+  });
+
+  assert.equal(decision.v2Decision.action, "merge");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_merge_gate_evidence_missing"]);
+  assert.deepEqual(decision.routing, {
+    action: "ask_operator",
+    routingCategory: "operator_action",
+    mutationAuthority: "none",
+  });
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction fails closed when external handoff evidence is malformed or stale", () => {
+  const cases = [
+    {
+      label: "malformed handoff cannot replace missing merge gates",
+      normalizedState: normalizePrLifecycleFacts(inventory()),
+      externalOrchestrationHandoff: {
+        routing_category: "core_action",
+        mutation_authority: "core_executor_required",
+        external_handoff: "merge",
+        observed_at: "not-a-date",
+      },
+      expectedAction: "ask_operator",
+      expectedReasons: ["v2_merge_gate_evidence_missing"],
+    },
+    {
+      label: "stale handoff cannot refresh cached facts",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          source: "cached_github",
+        }),
+      ),
+      externalOrchestrationHandoff: {
+        routing_category: "external_orchestration_handoff",
+        mutation_authority: "none",
+        external_handoff: "prepare_evidence",
+        observed_at: "2026-06-08T00:00:00.000Z",
+      },
+      expectedAction: "ask_operator",
+      expectedReasons: ["fresh_facts_guard_blocked"],
+    },
+    {
+      label: "handoff cannot override failing checks",
+      normalizedState: normalizePrLifecycleFacts(
+        inventory({
+          checks: {
+            passingCount: 2,
+            pendingCount: 0,
+            failingCount: 1,
+            unknownCount: 0,
+          },
+        }),
+      ),
+      externalOrchestrationHandoff: {
+        routing_category: "external_orchestration_handoff",
+        mutation_authority: "none",
+        external_handoff: "prepare_evidence",
+        asserted_next_action: "merge",
+      },
+      expectedAction: "no_action",
+      expectedReasons: ["v2_action_not_promoted"],
+    },
+  ];
+
+  for (const testCase of cases) {
+    const decision = evaluateDecisionKernelV2PrLifecycleAction({
+      mode: "pr_lifecycle_action_taking",
+      normalizedState: testCase.normalizedState,
+      externalOrchestrationHandoff: testCase.externalOrchestrationHandoff,
+    } as Parameters<typeof evaluateDecisionKernelV2PrLifecycleAction>[0] & {
+      externalOrchestrationHandoff: unknown;
+    });
+
+    assert.equal(decision.action, testCase.expectedAction, testCase.label);
+    assert.deepEqual(decision.reasons, testCase.expectedReasons, testCase.label);
+    assert.notEqual(decision.action, "merge", testCase.label);
+  }
+});
+
 test("evaluateDecisionKernelV2PrLifecycleAction lets merge-ready facts bypass repair retry exhaustion", () => {
   const decision = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -6,6 +6,7 @@ import { normalizePrLifecycleFacts, type PrLifecycleFactInventory } from "./pr-l
 import {
   evaluateDecisionKernelV2PrLifecycleAction,
   routeDecisionKernelV2PrLifecycleAction,
+  type DecisionKernelV2PrLifecycleActionInput,
 } from "./v2-pr-lifecycle-action";
 
 function inventory(overrides: Partial<PrLifecycleFactInventory> = {}): PrLifecycleFactInventory {
@@ -284,79 +285,63 @@ test("evaluateDecisionKernelV2PrLifecycleAction requires explicit merge gate inp
   ]);
 });
 
-test("evaluateDecisionKernelV2PrLifecycleAction ignores external handoff metadata as mutation authority", () => {
-  const unsafeExternalHandoff = {
-    routing_category: "external_orchestration_handoff",
-    mutation_authority: "core_executor_required",
-    external_handoff: "merge",
-    observed_at: "2026-06-09T00:05:00.000Z",
-    asserted_core_safety_gates: "passed",
-  };
-  const decision = evaluateDecisionKernelV2PrLifecycleAction({
-    mode: "pr_lifecycle_action_taking",
-    normalizedState: normalizePrLifecycleFacts(inventory()),
-    externalOrchestrationHandoff: unsafeExternalHandoff,
-  } as Parameters<typeof evaluateDecisionKernelV2PrLifecycleAction>[0] & {
-    externalOrchestrationHandoff: typeof unsafeExternalHandoff;
-  });
+test("DecisionKernelV2PrLifecycleActionInput excludes external handoff authority fields", () => {
+  const actionInputKeys = {
+    mode: true,
+    normalizedState: true,
+    reviewPolicyInput: true,
+    checkPolicyInput: true,
+    reviewerLoopTerminal: true,
+  } satisfies Record<keyof DecisionKernelV2PrLifecycleActionInput, true>;
 
-  assert.equal(decision.v2Decision.action, "merge");
-  assert.equal(decision.action, "ask_operator");
-  assert.deepEqual(decision.reasons, ["v2_merge_gate_evidence_missing"]);
-  assert.deepEqual(decision.routing, {
-    action: "ask_operator",
-    routingCategory: "operator_action",
-    mutationAuthority: "none",
-  });
+  assert.equal("externalOrchestrationHandoff" in actionInputKeys, false);
+  assert.equal("routingCategory" in actionInputKeys, false);
+  assert.equal("mutationAuthority" in actionInputKeys, false);
 });
 
-test("evaluateDecisionKernelV2PrLifecycleAction fails closed when external handoff evidence is malformed or stale", () => {
-  const cases = [
+test("evaluateDecisionKernelV2PrLifecycleAction fails closed without core safety gate evidence", () => {
+  const cases: Array<{
+    label: string;
+    input: DecisionKernelV2PrLifecycleActionInput;
+    expectedAction: string;
+    expectedReasons: string[];
+  }> = [
     {
-      label: "malformed handoff cannot replace missing merge gates",
-      normalizedState: normalizePrLifecycleFacts(inventory()),
-      externalOrchestrationHandoff: {
-        routing_category: "core_action",
-        mutation_authority: "core_executor_required",
-        external_handoff: "merge",
-        observed_at: "not-a-date",
+      label: "missing merge gates",
+      input: {
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizePrLifecycleFacts(inventory()),
       },
       expectedAction: "ask_operator",
       expectedReasons: ["v2_merge_gate_evidence_missing"],
     },
     {
-      label: "stale handoff cannot refresh cached facts",
-      normalizedState: normalizePrLifecycleFacts(
-        inventory({
-          source: "cached_github",
-        }),
-      ),
-      externalOrchestrationHandoff: {
-        routing_category: "external_orchestration_handoff",
-        mutation_authority: "none",
-        external_handoff: "prepare_evidence",
-        observed_at: "2026-06-08T00:00:00.000Z",
+      label: "cached facts",
+      input: {
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizePrLifecycleFacts(
+          inventory({
+            source: "cached_github",
+          }),
+        ),
       },
       expectedAction: "ask_operator",
       expectedReasons: ["fresh_facts_guard_blocked"],
     },
     {
-      label: "handoff cannot override failing checks",
-      normalizedState: normalizePrLifecycleFacts(
-        inventory({
-          checks: {
-            passingCount: 2,
-            pendingCount: 0,
-            failingCount: 1,
-            unknownCount: 0,
-          },
-        }),
-      ),
-      externalOrchestrationHandoff: {
-        routing_category: "external_orchestration_handoff",
-        mutation_authority: "none",
-        external_handoff: "prepare_evidence",
-        asserted_next_action: "merge",
+      label: "failing checks",
+      input: {
+        mode: "pr_lifecycle_action_taking",
+        normalizedState: normalizePrLifecycleFacts(
+          inventory({
+            checks: {
+              passingCount: 2,
+              pendingCount: 0,
+              failingCount: 1,
+              unknownCount: 0,
+            },
+          }),
+        ),
       },
       expectedAction: "no_action",
       expectedReasons: ["v2_action_not_promoted"],
@@ -364,13 +349,7 @@ test("evaluateDecisionKernelV2PrLifecycleAction fails closed when external hando
   ];
 
   for (const testCase of cases) {
-    const decision = evaluateDecisionKernelV2PrLifecycleAction({
-      mode: "pr_lifecycle_action_taking",
-      normalizedState: testCase.normalizedState,
-      externalOrchestrationHandoff: testCase.externalOrchestrationHandoff,
-    } as Parameters<typeof evaluateDecisionKernelV2PrLifecycleAction>[0] & {
-      externalOrchestrationHandoff: unknown;
-    });
+    const decision = evaluateDecisionKernelV2PrLifecycleAction(testCase.input);
 
     assert.equal(decision.action, testCase.expectedAction, testCase.label);
     assert.deepEqual(decision.reasons, testCase.expectedReasons, testCase.label);

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -57,6 +57,7 @@ test("post-turn pull request transitions do not import Decision Kernel v2 action
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
   assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
   assert.doesNotMatch(source, /prLifecycleEvaluationModeForRuntime/u);
+  assert.doesNotMatch(source, /external_orchestration_handoff/u);
   assert.doesNotMatch(source, /external_handoff/u);
   assert.doesNotMatch(source, /mutation_authority/u);
   assert.doesNotMatch(source, /v2_routing/u);

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -60,6 +60,9 @@ test("post-turn pull request transitions do not import Decision Kernel v2 action
   assert.doesNotMatch(source, /external_handoff/u);
   assert.doesNotMatch(source, /mutation_authority/u);
   assert.doesNotMatch(source, /v2_routing/u);
+  assert.doesNotMatch(source, /externalOrchestrationHandoff/u);
+  assert.doesNotMatch(source, /routingCategory/u);
+  assert.doesNotMatch(source, /mutationAuthority/u);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase emits typed review-wait change events", async () => {

--- a/src/post-turn-pull-request.test.ts
+++ b/src/post-turn-pull-request.test.ts
@@ -57,6 +57,9 @@ test("post-turn pull request transitions do not import Decision Kernel v2 action
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
   assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
   assert.doesNotMatch(source, /prLifecycleEvaluationModeForRuntime/u);
+  assert.doesNotMatch(source, /external_handoff/u);
+  assert.doesNotMatch(source, /mutation_authority/u);
+  assert.doesNotMatch(source, /v2_routing/u);
 });
 
 test("handlePostTurnPullRequestTransitionsPhase emits typed review-wait change events", async () => {

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -28,6 +28,7 @@ test("run-once issue selection does not consume external orchestration handoff a
   assert.doesNotMatch(source, /evaluateDecisionKernelV2/u);
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
   assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
+  assert.doesNotMatch(source, /external_orchestration_handoff/u);
   assert.doesNotMatch(source, /external_handoff/u);
   assert.doesNotMatch(source, /mutation_authority/u);
   assert.doesNotMatch(source, /v2_routing/u);

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -21,6 +21,18 @@ import {
   syncRequirementsBlockerIssueComment,
 } from "./requirements-blocker-issue-comment";
 
+test("run-once issue selection does not consume external orchestration handoff authority", async () => {
+  const source = await fs.readFile(path.join(process.cwd(), "src", "run-once-issue-selection.ts"), "utf8");
+
+  assert.doesNotMatch(source, /decision-kernel-v2/u);
+  assert.doesNotMatch(source, /evaluateDecisionKernelV2/u);
+  assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
+  assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
+  assert.doesNotMatch(source, /external_handoff/u);
+  assert.doesNotMatch(source, /mutation_authority/u);
+  assert.doesNotMatch(source, /v2_routing/u);
+});
+
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
     repoPath: "/tmp/repo",

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -31,6 +31,9 @@ test("run-once issue selection does not consume external orchestration handoff a
   assert.doesNotMatch(source, /external_handoff/u);
   assert.doesNotMatch(source, /mutation_authority/u);
   assert.doesNotMatch(source, /v2_routing/u);
+  assert.doesNotMatch(source, /externalOrchestrationHandoff/u);
+  assert.doesNotMatch(source, /routingCategory/u);
+  assert.doesNotMatch(source, /mutationAuthority/u);
 });
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -40,6 +40,7 @@ test("run-once turn execution does not import Decision Kernel v2 action decision
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
   assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
   assert.doesNotMatch(source, /prLifecycleEvaluationModeForRuntime/u);
+  assert.doesNotMatch(source, /external_orchestration_handoff/u);
   assert.doesNotMatch(source, /external_handoff/u);
   assert.doesNotMatch(source, /mutation_authority/u);
   assert.doesNotMatch(source, /v2_routing/u);

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -43,6 +43,9 @@ test("run-once turn execution does not import Decision Kernel v2 action decision
   assert.doesNotMatch(source, /external_handoff/u);
   assert.doesNotMatch(source, /mutation_authority/u);
   assert.doesNotMatch(source, /v2_routing/u);
+  assert.doesNotMatch(source, /externalOrchestrationHandoff/u);
+  assert.doesNotMatch(source, /routingCategory/u);
+  assert.doesNotMatch(source, /mutationAuthority/u);
 });
 
 function git(cwd: string, ...args: string[]): string {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -40,6 +40,9 @@ test("run-once turn execution does not import Decision Kernel v2 action decision
   assert.doesNotMatch(source, /buildDecisionKernelV2ExplainDto/u);
   assert.doesNotMatch(source, /pr_lifecycle_action_taking/u);
   assert.doesNotMatch(source, /prLifecycleEvaluationModeForRuntime/u);
+  assert.doesNotMatch(source, /external_handoff/u);
+  assert.doesNotMatch(source, /mutation_authority/u);
+  assert.doesNotMatch(source, /v2_routing/u);
 });
 
 function git(cwd: string, ...args: string[]): string {

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -130,38 +130,38 @@ test("Phase 2 Connector review policy replay fixtures cover typed boundary outco
   assert.equal(repeatStopFixture?.repeatStopSuppressedReason, "repeat_stop_exhausted");
 });
 
-test("Phase 5 external orchestration fixtures keep complex project handoffs bounded", () => {
-  const fixtures = [
-    {
-      id: "phase5-aegisops-external-handoff-review-ci-merge",
-      projectShape: "aegisops",
-      externalHandoff: {
-        routingCategory: "external_orchestration_handoff",
-        mutationAuthority: "none",
-        handoff: "prepare_evidence",
-      },
-      coreSafetyGates: ["fresh_pr_facts", "current_head_review", "green_checks", "mergeable_state"],
-      boundedNextAction: "ask_operator",
-    },
-    {
-      id: "phase5-hrcore-external-handoff-metadata-residue",
-      projectShape: "hrcore",
-      externalHandoff: {
-        routingCategory: "external_orchestration_handoff",
-        mutationAuthority: "none",
-        handoff: "prepare_evidence",
-      },
-      coreSafetyGates: ["fresh_pr_facts", "current_head_review", "resolved_metadata_residue"],
-      boundedNextAction: "ask_operator",
-    },
+test("Phase 5 replay corpus cases keep external orchestration handoffs bounded", async () => {
+  const corpusRoot = path.join(process.cwd(), "replay-corpus");
+  const phase5CaseIds = [
+    "phase5-aegisops-external-handoff-review-ci-merge",
+    "phase5-hrcore-external-handoff-metadata-residue",
   ];
+  const corpus = await loadReplayCorpus(corpusRoot);
+  const phase5Cases = corpus.cases.filter((entry) => phase5CaseIds.includes(entry.id));
 
-  assert.deepEqual(new Set(fixtures.map((fixture) => fixture.projectShape)), new Set(["aegisops", "hrcore"]));
-  assert.equal(fixtures.every((fixture) => fixture.externalHandoff.mutationAuthority === "none"), true);
-  assert.equal(fixtures.every((fixture) => fixture.externalHandoff.handoff === "prepare_evidence"), true);
-  assert.deepEqual(new Set(fixtures.map((fixture) => fixture.boundedNextAction)), new Set(["ask_operator"]));
-  assert.equal(
-    fixtures.every((fixture) => fixture.coreSafetyGates.length > 0 && fixture.coreSafetyGates.includes("fresh_pr_facts")),
-    true,
+  assert.deepEqual(phase5Cases.map((entry) => entry.id), phase5CaseIds);
+  assert.deepEqual(
+    phase5Cases.map((entry) => entry.expected),
+    [
+      {
+        nextState: "blocked",
+        shouldRunCodex: false,
+        blockedReason: "stale_review_bot",
+        failureSignature: "stalled-bot:thread-production-source-denylist",
+      },
+      {
+        nextState: "ready_to_merge",
+        shouldRunCodex: false,
+        blockedReason: null,
+        failureSignature: null,
+      },
+    ],
   );
+
+  const result = await runReplayCorpus(corpusRoot, createCheckedInReplayCorpusConfig(process.cwd()));
+  const phase5Results = result.results.filter((entry) => phase5CaseIds.includes(entry.caseId));
+
+  assert.deepEqual(phase5Results.map((entry) => entry.caseId), phase5CaseIds);
+  assert.equal(phase5Results.every((entry) => entry.matchesExpected), true);
+  assert.equal(phase5Results.every((entry) => entry.actual.shouldRunCodex === false), true);
 });

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -157,6 +157,12 @@ test("Phase 5 replay corpus cases keep external orchestration handoffs bounded",
       },
     ],
   );
+  const handoffSummaries = phase5Cases.map((entry) =>
+    entry.input.snapshot.operatorSummary?.activityContext?.handoffSummary ?? "",
+  );
+  assert.equal(handoffSummaries.every((summary) => summary.includes("external_orchestration_handoff")), true);
+  assert.equal(handoffSummaries.every((summary) => summary.includes("mutationAuthority=none")), true);
+  assert.equal(handoffSummaries.every((summary) => summary.includes("boundedNextAction=ask_operator")), true);
 
   const result = await runReplayCorpus(corpusRoot, createCheckedInReplayCorpusConfig(process.cwd()));
   const phase5Results = result.results.filter((entry) => phase5CaseIds.includes(entry.caseId));

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -129,3 +129,39 @@ test("Phase 2 Connector review policy replay fixtures cover typed boundary outco
   const repeatStopFixture = fixtures.find((fixture) => fixture.id === "phase2-hrcore-metadata-residue");
   assert.equal(repeatStopFixture?.repeatStopSuppressedReason, "repeat_stop_exhausted");
 });
+
+test("Phase 5 external orchestration fixtures keep complex project handoffs bounded", () => {
+  const fixtures = [
+    {
+      id: "phase5-aegisops-external-handoff-review-ci-merge",
+      projectShape: "aegisops",
+      externalHandoff: {
+        routingCategory: "external_orchestration_handoff",
+        mutationAuthority: "none",
+        handoff: "prepare_evidence",
+      },
+      coreSafetyGates: ["fresh_pr_facts", "current_head_review", "green_checks", "mergeable_state"],
+      boundedNextAction: "ask_operator",
+    },
+    {
+      id: "phase5-hrcore-external-handoff-metadata-residue",
+      projectShape: "hrcore",
+      externalHandoff: {
+        routingCategory: "external_orchestration_handoff",
+        mutationAuthority: "none",
+        handoff: "prepare_evidence",
+      },
+      coreSafetyGates: ["fresh_pr_facts", "current_head_review", "resolved_metadata_residue"],
+      boundedNextAction: "ask_operator",
+    },
+  ];
+
+  assert.deepEqual(new Set(fixtures.map((fixture) => fixture.projectShape)), new Set(["aegisops", "hrcore"]));
+  assert.equal(fixtures.every((fixture) => fixture.externalHandoff.mutationAuthority === "none"), true);
+  assert.equal(fixtures.every((fixture) => fixture.externalHandoff.handoff === "prepare_evidence"), true);
+  assert.deepEqual(new Set(fixtures.map((fixture) => fixture.boundedNextAction)), new Set(["ask_operator"]));
+  assert.equal(
+    fixtures.every((fixture) => fixture.coreSafetyGates.length > 0 && fixture.coreSafetyGates.includes("fresh_pr_facts")),
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- add regression coverage that external orchestration handoff metadata cannot authorize PR lifecycle mutation
- extend issue-selection, run-once execution, and post-turn transition source guards so handoff evidence stays out of core execution paths
- add Phase 5 AegisOps/HRCore-style replay fixture coverage for bounded external handoffs

## Scope
This implements #2325. It only adds tests and fixtures for the Phase 5 safety boundary; it does not loosen merge, review, local CI, branch protection, issue-lint, fresh-facts, issue selection, Codex execution, PR mutation, merge execution, or loop ownership behavior.

## Verification
- `npx tsx --test src/run-once-issue-selection.test.ts src/run-once-turn-execution.test.ts src/post-turn-pull-request.test.ts src/decision-kernel/v2-pr-lifecycle-action.test.ts src/supervisor/replay-corpus.test.ts`
- `npx tsx --test src/run-once*.test.ts src/post-turn-pull-request*.test.ts src/decision-kernel/*.test.ts src/supervisor/replay-corpus.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2325 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `git diff --check`

Closes #2325