### PR TITLE
[codex] Add Phase 5 closeout evidence

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -60,6 +60,9 @@ External orchestration can help route, record, and explain work, but it cannot
 authorize implementation turns, GitHub mutations, merges, or safety-gate
 bypasses.
 
+Closeout evidence for the implemented boundary, rollback posture, and broad
+verification surface is recorded in [Phase 5 closeout evidence](./phase5-closeout-evidence.md).
+
 ## Safety Contract
 
 Automation must stay quiet when there is no actionable change. It should not

--- a/docs/phase5-closeout-evidence.md
+++ b/docs/phase5-closeout-evidence.md
@@ -1,0 +1,68 @@
+# Phase 5 Closeout Evidence
+
+Phase 5 defines the external orchestration boundary around the thin supervisor core. The core keeps executor-owned mutation, safety gates, and PR lifecycle decisions. External orchestration may prepare evidence and route operator attention, but it cannot authorize Codex execution, GitHub mutation, or merge execution.
+
+## Child Issue Outcomes
+
+- `#2322` added the Phase 5 boundary inventory in [automation](./automation.md) and the portable [Codex Automation connector boundary](./codex-automation-connector-boundary.schema.json).
+- `#2323` published operator-action routing metadata in [operator actions](./operator-actions.schema.json), separating core actions from external orchestration handoffs.
+- `#2324` surfaced handoff evidence in status and explain output with `routing_category`, `mutation_authority`, `external_handoff`, and preserved core safety gate fields.
+- `#2325` added regression coverage proving external orchestration handoff evidence cannot bypass issue selection, run-once execution, post-turn PR transitions, Decision Kernel v2 action input, or replay-corpus safety expectations.
+- `#2326` records this closeout evidence, rollback posture, and broad verification surface.
+
+## Responsibility Boundary
+
+Core responsibilities remain inside `codex-supervisor`:
+
+- issue contract validation and `issue-lint` readiness
+- issue selection, per-issue worktree ownership, and journal ownership
+- Codex execution and resume orchestration
+- PR lifecycle action selection, including review, CI, stale-review terminal handling, operator escalation, and merge-readiness decisions
+- branch protection, head-SHA, local CI, review, mergeability, and final auto-merge safety gates
+- replay, status, and explain evidence for supervisor-owned decisions
+
+External orchestration responsibilities remain outside core:
+
+- evaluate roadmap, GitHub, local status, and external note state
+- route actionable changes to the operator or the next runnable issue
+- draft confirm-required follow-up issues
+- record durable Obsidian or external history after real state changes
+- notify the operator about actionable state changes
+- prepare operator-facing evidence without treating that evidence as executor authority
+
+## Contract Surfaces
+
+- [automation](./automation.md) states the Phase 5 boundary inventory and non-goals.
+- [Codex Automation connector boundary](./codex-automation-connector-boundary.schema.json) publishes the portable connector artifact.
+- [operator actions](./operator-actions.schema.json) defines `external_orchestration_handoff` and requires routing metadata.
+- `src/supervisor/supervisor-status-report.ts` renders Decision Kernel v2 mode and handoff evidence for status.
+- `src/decision-kernel/v2-explain.ts` renders `v2_routing` evidence for explain output.
+- `src/decision-kernel/v2-pr-lifecycle-action.ts` keeps PR lifecycle action input typed around core safety evidence, without external handoff authority fields.
+- `replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/` and `replay-corpus/cases/phase5-hrcore-external-handoff-metadata-residue/` preserve representative Phase 5 handoff evidence.
+
+## Safety Evidence
+
+- Source guards in `src/run-once-issue-selection.test.ts`, `src/run-once-turn-execution.test.ts`, and `src/post-turn-pull-request.test.ts` fail if issue selection, Codex execution, or post-turn PR transitions consume `external_orchestration_handoff`, `externalOrchestrationHandoff`, `routingCategory`, or `mutationAuthority` as authority.
+- `src/decision-kernel/v2-pr-lifecycle-action.test.ts` verifies that `DecisionKernelV2PrLifecycleActionInput` excludes external handoff authority fields and still fails closed without explicit core merge gate evidence.
+- `src/supervisor/replay-corpus.test.ts` runs the checked-in Phase 5 replay cases and verifies handoff evidence remains bounded with `mutationAuthority=none` and `boundedNextAction=ask_operator`.
+- Status and explain tests verify external handoff evidence is reported as non-mutating evidence while core safety gates remain preserved.
+
+## Rollback Posture
+
+The rollback path is core-only behavior:
+
+- Disable or ignore external orchestration handoff metadata.
+- Keep issue selection, Codex execution, post-turn PR transitions, review handling, local CI, branch protection, and merge execution unchanged.
+- Use `disabled` or `diagnostic_only` Decision Kernel v2 mode when PR lifecycle action-taking must be rolled back.
+- Continue treating external orchestration output as operator-facing evidence only; do not map it into executor authority or merge authority.
+- Preserve checked-in replay corpus cases so operators can confirm that external evidence is still bounded after rollback.
+
+## Verification Evidence
+
+Phase 5 closeout is accepted only with broad boundary verification:
+
+- `npx tsx --test src/decision-kernel*.test.ts src/decision-kernel/*.test.ts src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts src/run-once*.test.ts src/post-turn-pull-request*.test.ts src/supervisor/replay-corpus.test.ts`
+- `npm run build`
+- `git diff --check`
+
+No Phase 5 closeout step changes issue selection, Codex execution, PR mutation, merge execution, branch protection, or loop ownership.

--- a/docs/quality-kit.md
+++ b/docs/quality-kit.md
@@ -16,6 +16,7 @@ The public package surface is the docs-first bundle recommended by the [Quality 
 - `docs/trust-posture-config.schema.json`: explicit trust and execution-safety posture vocabulary
 - `docs/supervised-automation-state-machine.schema.json`: operator-facing lifecycle vocabulary mapped to runtime `RunState`
 - `docs/codex-automation-connector-boundary.schema.json`: Codex app Automation boundary for orchestration without executor authority
+- `docs/phase5-closeout-evidence.md`: [Phase 5 closeout evidence](./phase5-closeout-evidence.md) for the implemented external orchestration boundary, rollback posture, and verification evidence
 - `docs/templates/quality-primitives/`: [quality primitive templates](./templates/quality-primitives/README.md) for copying the issue contract, AGENTS.md guidance, local CI gate, evidence timeline, trust posture, and operator action vocabulary into a new repo
 - `docs/quality-kit-adoption-checklist.md`: [Quality kit adoption checklist](./quality-kit-adoption-checklist.md) for introducing the docs-first kit to one repository and one safe issue before broader automation
 - `docs/kaname-bootstrap-handoff.md`: [KANAME bootstrap handoff](./kaname-bootstrap-handoff.md) for mapping the quality kit to KANAME-000 through KANAME-006 without creating a new repo or runtime

--- a/src/quality-kit-docs.test.ts
+++ b/src/quality-kit-docs.test.ts
@@ -9,6 +9,7 @@ const kanameBootstrapHandoffPath = path.join("docs", "kaname-bootstrap-handoff.m
 const qualityKitPackageSurfacesPath = path.join("docs", "quality-kit-package-surfaces.md");
 const qualityGateExamplesPath = path.join("docs", "examples", "quality-gate-examples.md");
 const automationBoundaryPath = path.join("docs", "automation.md");
+const phase5CloseoutEvidencePath = path.join("docs", "phase5-closeout-evidence.md");
 const qualityKitTemplatesPath = path.join("docs", "templates", "quality-primitives");
 const publicSchemaArtifactPaths = [
   "docs/issue-body-contract.schema.json",
@@ -174,12 +175,21 @@ test("quality kit entrypoint defines the public package surface boundary", async
 });
 
 test("automation boundary publishes the Phase 5 core and external responsibility inventory", async () => {
-  const automationBoundary = await readRepoFile(automationBoundaryPath);
+  const [automationBoundary, closeoutEvidence, qualityKit] = await Promise.all([
+    readRepoFile(automationBoundaryPath),
+    readRepoFile(phase5CloseoutEvidencePath),
+    readRepoFile(qualityKitPath),
+  ]);
 
   assert.match(automationBoundary, /^## Phase 5 Boundary Inventory$/m);
+  assert.match(automationBoundary, /\[Phase 5 closeout evidence\]\(\.\/phase5-closeout-evidence\.md\)/);
+  assert.match(qualityKit, /\[Phase 5 closeout evidence\]\(\.\/phase5-closeout-evidence\.md\)/);
   assert.doesNotMatch(automationBoundary, /\/Users\/[A-Za-z0-9._-]+\//);
   assert.doesNotMatch(automationBoundary, /\/home\/[A-Za-z0-9._-]+\//);
   assert.doesNotMatch(automationBoundary, /C:\\Users\\[A-Za-z0-9._-]+\\/);
+  assert.doesNotMatch(closeoutEvidence, /\/Users\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(closeoutEvidence, /\/home\/[A-Za-z0-9._-]+\//);
+  assert.doesNotMatch(closeoutEvidence, /C:\\Users\\[A-Za-z0-9._-]+\\/);
 
   for (const coreResponsibility of [
     "issue contract validation and `issue-lint` readiness",
@@ -228,6 +238,35 @@ test("automation boundary publishes the Phase 5 core and external responsibility
   assert.match(automationBoundary, /cannot\s+authorize implementation turns/i);
   assert.match(automationBoundary, /GitHub mutations/i);
   assert.match(automationBoundary, /safety-gate\s+bypasses/i);
+
+  for (const heading of [
+    "Child Issue Outcomes",
+    "Responsibility Boundary",
+    "Contract Surfaces",
+    "Safety Evidence",
+    "Rollback Posture",
+    "Verification Evidence",
+  ]) {
+    assert.match(closeoutEvidence, new RegExp(`^## ${heading}$`, "m"), `expected ${heading} section`);
+  }
+
+  for (const closeoutFact of [
+    "#2322",
+    "#2323",
+    "#2324",
+    "#2325",
+    "#2326",
+    "external_orchestration_handoff",
+    "mutationAuthority=none",
+    "boundedNextAction=ask_operator",
+    "Disable or ignore external orchestration handoff metadata",
+    "No Phase 5 closeout step changes issue selection",
+    "npx tsx --test src/decision-kernel*.test.ts",
+    "npm run build",
+    "git diff --check",
+  ]) {
+    assert.match(closeoutEvidence, new RegExp(escapeRegExp(closeoutFact)), `expected closeout fact: ${closeoutFact}`);
+  }
 });
 
 test("public schema artifacts publish versioning and compatibility guidance", async () => {


### PR DESCRIPTION
## Summary
- add Phase 5 closeout evidence for the external orchestration boundary
- document core vs external responsibilities, contract surfaces, safety evidence, rollback posture, and verification commands
- link the closeout evidence from the automation boundary and quality-kit entrypoint
- add docs regression coverage for the closeout evidence surface

## Scope
This implements #2326. It only adds documentation and documentation tests; it does not change runtime behavior, issue selection, Codex execution, PR mutation, merge execution, branch protection, or loop ownership.

## Verification
- `npx tsx --test src/quality-kit-docs.test.ts src/supervisor/replay-corpus.test.ts src/supervisor/supervisor-status-report.test.ts src/decision-kernel/v2-explain.test.ts`
- `npx tsx --test src/decision-kernel*.test.ts src/decision-kernel/*.test.ts src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts src/run-once*.test.ts src/post-turn-pull-request*.test.ts src/supervisor/replay-corpus.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2326 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `git diff --check`

Closes #2326