### PR TITLE
Refactor Codex turn verification evidence helpers

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -82,6 +82,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "run-once-issue-preparation.ts",
     "run-once-issue-selection.ts",
     "run-once-turn-execution.ts",
+    "run-once-turn-verification-evidence.ts",
     "setup-config-preview.ts",
     "setup-config-write.ts",
     "setup-readiness-first-run.ts",

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -78,6 +78,10 @@ import {
 import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate";
 import { upsertTimelineArtifact } from "./timeline-artifacts";
+import {
+  conciseCodexVerificationSummary,
+  explicitPassingCodexTurnVerificationCommand,
+} from "./run-once-turn-verification-evidence";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -128,100 +132,6 @@ export interface CodexTurnResult {
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
   "Normalize trusted durable artifacts for path hygiene";
-
-const CODEX_TURN_VERIFICATION_COMMAND_NAMES = [
-  "npm",
-  "npx",
-  "pnpm",
-  "yarn",
-  "bun",
-  "node",
-  "deno",
-  "tsx",
-  "tsc",
-  "ts-node",
-  "jest",
-  "vitest",
-  "mocha",
-  "playwright",
-  "pytest",
-  "python",
-  "python3",
-  "uv",
-  "go",
-  "cargo",
-  "make",
-  "cmake",
-  "mvn",
-  "gradle",
-  "bash",
-  "sh",
-  "zsh",
-  "ruby",
-  "bundle",
-  "rspec",
-  "eslint",
-  "prettier",
-  "ruff",
-  "mypy",
-  "gh",
-  "git",
-].join("|");
-const CODEX_TURN_VERIFICATION_COMMAND_PATTERN = new RegExp(
-  `^(?:[\\\`$]\\s*)?(?:(?:${CODEX_TURN_VERIFICATION_COMMAND_NAMES})\\b|(?:\\.{0,2}/))`,
-  "i",
-);
-
-function hasExplicitCodexTurnVerificationCommandEvidence(value: string): boolean {
-  return value
-    .split(/[\n;]+/)
-    .map((candidate) => candidate.trim().replace(/^`+|`+$/g, "").trim())
-    .filter((candidate) => candidate.length > 0)
-    .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
-}
-
-function hasExplicitNegativeCodexTurnVerificationOutcome(value: string): boolean {
-  const normalized = value.toLowerCase();
-  if (
-    normalized === "not run" ||
-    normalized === "none" ||
-    normalized === "n/a" ||
-    normalized === "na" ||
-    normalized.includes("not run") ||
-    normalized.includes("no tests") ||
-    normalized.includes("stale head") ||
-    normalized.includes("ambiguous") ||
-    normalized.includes("unclear") ||
-    normalized.includes("?")
-  ) {
-    return true;
-  }
-  return /(?:^|\s)(?:failed|failure|error|timeout|blocked|skipped)(?=$|[\s:.,;])/i.test(
-    value,
-  );
-}
-
-function explicitPassingCodexTurnVerificationCommand(
-  tests: string | null | undefined,
-): string | null {
-  const value = tests?.trim();
-  if (!value) {
-    return null;
-  }
-  if (hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
-    return null;
-  }
-  if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {
-    return null;
-  }
-  return value;
-}
-
-function conciseCodexVerificationSummary(summary: string | null | undefined): string {
-  const value = summary?.trim();
-  return truncate(value && value.length > 0 ? value : "Codex turn verification passed.", 500) ??
-    "Codex turn verification passed.";
-}
 
 export interface CodexTurnShortCircuit {
   kind: "returned";

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -1,0 +1,95 @@
+import { truncate } from "./core/utils";
+
+const CODEX_TURN_VERIFICATION_COMMAND_NAMES = [
+  "npm",
+  "npx",
+  "pnpm",
+  "yarn",
+  "bun",
+  "node",
+  "deno",
+  "tsx",
+  "tsc",
+  "ts-node",
+  "jest",
+  "vitest",
+  "mocha",
+  "playwright",
+  "pytest",
+  "python",
+  "python3",
+  "uv",
+  "go",
+  "cargo",
+  "make",
+  "cmake",
+  "mvn",
+  "gradle",
+  "bash",
+  "sh",
+  "zsh",
+  "ruby",
+  "bundle",
+  "rspec",
+  "eslint",
+  "prettier",
+  "ruff",
+  "mypy",
+  "gh",
+  "git",
+].join("|");
+const CODEX_TURN_VERIFICATION_COMMAND_PATTERN = new RegExp(
+  `^(?:[\\\`$]\\s*)?(?:(?:${CODEX_TURN_VERIFICATION_COMMAND_NAMES})\\b|(?:\\.{0,2}/))`,
+  "i",
+);
+
+function hasExplicitCodexTurnVerificationCommandEvidence(value: string): boolean {
+  return value
+    .split(/[\n;]+/)
+    .map((candidate) => candidate.trim().replace(/^`+|`+$/g, "").trim())
+    .filter((candidate) => candidate.length > 0)
+    .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
+}
+
+function hasExplicitNegativeCodexTurnVerificationOutcome(value: string): boolean {
+  const normalized = value.toLowerCase();
+  if (
+    normalized === "not run" ||
+    normalized === "none" ||
+    normalized === "n/a" ||
+    normalized === "na" ||
+    normalized.includes("not run") ||
+    normalized.includes("no tests") ||
+    normalized.includes("stale head") ||
+    normalized.includes("ambiguous") ||
+    normalized.includes("unclear") ||
+    normalized.includes("?")
+  ) {
+    return true;
+  }
+  return /(?:^|\s)(?:failed|failure|error|timeout|blocked|skipped)(?=$|[\s:.,;])/i.test(
+    value,
+  );
+}
+
+export function explicitPassingCodexTurnVerificationCommand(
+  tests: string | null | undefined,
+): string | null {
+  const value = tests?.trim();
+  if (!value) {
+    return null;
+  }
+  if (hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
+    return null;
+  }
+  if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function conciseCodexVerificationSummary(summary: string | null | undefined): string {
+  const value = summary?.trim();
+  return truncate(value && value.length > 0 ? value : "Codex turn verification passed.", 500) ??
+    "Codex turn verification passed.";
+}


### PR DESCRIPTION
## Summary
- Extract Codex turn verification evidence parsing into `src/run-once-turn-verification-evidence.ts`
- Keep `executeCodexTurnPhase` behavior unchanged by importing the existing helper surface
- Register the new top-level module in the family directory layout contract

Closes #2338

## Verification
- `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts src/family-directory-layout.test.ts`
- `npm run build`
