### PR TITLE
Detect generic review-loop trends

### DIFF
--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -233,7 +233,7 @@ test("addressingReviewStrategyPatch switches repeated review failures to root-ca
     {
       addressing_review_strategy: "root_cause_analysis",
       addressing_review_strategy_reason:
-        "trigger=provider_neutral_review_loop; repeated_failure_signature_count=2; signature=review-thread-cluster-a; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
+        "trigger=repeated_failure_signature; repeated_failure_signature_count=2; signature=review-thread-cluster-a; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
     },
   );
 
@@ -241,6 +241,7 @@ test("addressingReviewStrategyPatch switches repeated review failures to root-ca
     addressingReviewStrategyPatch(
       createRecord({
         state: "addressing_review",
+        last_head_sha: "head-a",
         last_failure_signature: "review-thread-cluster-a",
         repeated_failure_signature_count: 1,
         last_tracked_pr_progress_summary:
@@ -253,6 +254,25 @@ test("addressingReviewStrategyPatch switches repeated review failures to root-ca
       addressing_review_strategy: "root_cause_analysis",
       addressing_review_strategy_reason:
         "trigger=provider_neutral_review_loop; repeated_failure_signature_count=1; signature=review-thread-cluster-a; tracked_pr_progress=no_progress_review_loop current_unresolved_threads=2 processed_review_threads=2 head=head-a; repeat_decision=retry_on_progress",
+    },
+  );
+
+  assert.deepEqual(
+    addressingReviewStrategyPatch(
+      createRecord({
+        state: "addressing_review",
+        last_head_sha: "head-b",
+        last_failure_signature: "review-thread-cluster-a",
+        repeated_failure_signature_count: 1,
+        last_tracked_pr_progress_summary:
+          "no_progress_review_loop current_unresolved_threads=2 processed_review_threads=2 head=head-a",
+        last_tracked_pr_repeat_failure_decision: "retry_on_progress",
+      }),
+      "addressing_review",
+    ),
+    {
+      addressing_review_strategy: "normal_patch",
+      addressing_review_strategy_reason: null,
     },
   );
 

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -233,7 +233,26 @@ test("addressingReviewStrategyPatch switches repeated review failures to root-ca
     {
       addressing_review_strategy: "root_cause_analysis",
       addressing_review_strategy_reason:
-        "repeated_failure_signature_count=2; signature=review-thread-cluster-a; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
+        "trigger=provider_neutral_review_loop; repeated_failure_signature_count=2; signature=review-thread-cluster-a; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
+    },
+  );
+
+  assert.deepEqual(
+    addressingReviewStrategyPatch(
+      createRecord({
+        state: "addressing_review",
+        last_failure_signature: "review-thread-cluster-a",
+        repeated_failure_signature_count: 1,
+        last_tracked_pr_progress_summary:
+          "no_progress_review_loop current_unresolved_threads=2 processed_review_threads=2 head=head-a",
+        last_tracked_pr_repeat_failure_decision: "retry_on_progress",
+      }),
+      "addressing_review",
+    ),
+    {
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason:
+        "trigger=provider_neutral_review_loop; repeated_failure_signature_count=1; signature=review-thread-cluster-a; tracked_pr_progress=no_progress_review_loop current_unresolved_threads=2 processed_review_threads=2 head=head-a; repeat_decision=retry_on_progress",
     },
   );
 

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -171,6 +171,7 @@ export function addressingReviewStrategyPatch(
   record: Pick<
     IssueRunRecord,
     | "last_failure_signature"
+    | "last_head_sha"
     | "repeated_failure_signature_count"
     | "last_tracked_pr_progress_summary"
     | "last_tracked_pr_repeat_failure_decision"
@@ -187,10 +188,13 @@ export function addressingReviewStrategyPatch(
   const progressSummary = record.last_tracked_pr_progress_summary ?? "no progress baseline";
   const repeatDecision = record.last_tracked_pr_repeat_failure_decision ?? "pending";
   const repeatedFailureSignal = Boolean(record.last_failure_signature && record.repeated_failure_signature_count >= 2);
+  const providerNeutralReviewLoopHead = record.last_tracked_pr_progress_summary?.match(
+    /^no_progress_review_loop\b.*(?:^|\s)head=(\S+)/,
+  )?.[1];
   const providerNeutralReviewLoopSignal =
-    record.last_tracked_pr_progress_summary?.startsWith("no_progress_review_loop ") === true ||
-    record.last_tracked_pr_progress_summary === "no_meaningful_tracked_pr_progress" ||
-    record.last_tracked_pr_progress_summary === "suppressed_same_head_same_review_thread_blocker";
+    typeof providerNeutralReviewLoopHead === "string" &&
+    providerNeutralReviewLoopHead.length > 0 &&
+    providerNeutralReviewLoopHead === record.last_head_sha;
   if (!repeatedFailureSignal && !providerNeutralReviewLoopSignal) {
     return {
       addressing_review_strategy: "normal_patch",

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -177,24 +177,33 @@ export function addressingReviewStrategyPatch(
   >,
   nextState: IssueRunRecord["state"],
 ): Pick<IssueRunRecord, "addressing_review_strategy" | "addressing_review_strategy_reason"> {
-  if (
-    nextState !== "addressing_review" ||
-    !record.last_failure_signature ||
-    record.repeated_failure_signature_count < 2
-  ) {
+  if (nextState !== "addressing_review") {
     return {
-      addressing_review_strategy: nextState === "addressing_review" ? "normal_patch" : null,
+      addressing_review_strategy: null,
       addressing_review_strategy_reason: null,
     };
   }
 
   const progressSummary = record.last_tracked_pr_progress_summary ?? "no progress baseline";
   const repeatDecision = record.last_tracked_pr_repeat_failure_decision ?? "pending";
+  const repeatedFailureSignal = Boolean(record.last_failure_signature && record.repeated_failure_signature_count >= 2);
+  const providerNeutralReviewLoopSignal =
+    record.last_tracked_pr_progress_summary?.startsWith("no_progress_review_loop ") === true ||
+    record.last_tracked_pr_progress_summary === "no_meaningful_tracked_pr_progress" ||
+    record.last_tracked_pr_progress_summary === "suppressed_same_head_same_review_thread_blocker";
+  if (!repeatedFailureSignal && !providerNeutralReviewLoopSignal) {
+    return {
+      addressing_review_strategy: "normal_patch",
+      addressing_review_strategy_reason: null,
+    };
+  }
+
   return {
     addressing_review_strategy: "root_cause_analysis",
     addressing_review_strategy_reason:
+      `trigger=${providerNeutralReviewLoopSignal ? "provider_neutral_review_loop" : "repeated_failure_signature"}; ` +
       `repeated_failure_signature_count=${record.repeated_failure_signature_count}; ` +
-      `signature=${record.last_failure_signature}; ` +
+      `signature=${record.last_failure_signature ?? "none"}; ` +
       `tracked_pr_progress=${progressSummary}; repeat_decision=${repeatDecision}`,
   };
 }

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -1563,6 +1563,64 @@ test("summarizeTrackedPrProgress ignores processed fingerprints for resolved rev
   assert.equal(result.summary, null);
 });
 
+test("summarizeTrackedPrProgress ignores stale processed fingerprints for updated review guidance", () => {
+  const record = createRecord({
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-old"],
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head123",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: null,
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-1"],
+      unresolvedReviewThreadFingerprints: ["thread-1#comment-new"],
+      unresolvedReviewThreadSourceAnchors: ["thread-1:src/file.ts:12"],
+      processedReviewThreadIds: ["thread-1@head123"],
+      processedReviewThreadFingerprints: ["thread-1@head123#comment-old"],
+      verificationProbeOutcomes: [],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads: ReviewThread[] = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-new",
+            body: "Please address this updated guidance.",
+            createdAt: "2026-03-13T06:25:00Z",
+            url: "https://example.test/pr/42#discussion_new",
+            author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const result = summarizeTrackedPrProgress(
+    record,
+    pr,
+    [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  );
+
+  assert.equal(result.summary, null);
+});
+
 test("summarizeTrackedPrProgress treats changed review-thread cluster membership as tracked PR progress", () => {
   const record = createRecord({
     last_tracked_pr_progress_snapshot: JSON.stringify({

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -1505,6 +1505,64 @@ test("summarizeTrackedPrProgress reports provider-neutral no-progress review loo
   );
 });
 
+test("summarizeTrackedPrProgress ignores processed fingerprints for resolved review threads", () => {
+  const record = createRecord({
+    processed_review_thread_fingerprints: ["thread-resolved@head123#comment-resolved"],
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head123",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: null,
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-unprocessed"],
+      unresolvedReviewThreadFingerprints: ["thread-unprocessed#comment-unprocessed"],
+      unresolvedReviewThreadSourceAnchors: ["thread-unprocessed:src/file.ts:12"],
+      processedReviewThreadIds: ["thread-resolved@head123"],
+      processedReviewThreadFingerprints: ["thread-resolved@head123#comment-resolved"],
+      verificationProbeOutcomes: [],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads: ReviewThread[] = [
+    createReviewThread({
+      id: "thread-unprocessed",
+      comments: {
+        nodes: [
+          {
+            id: "comment-unprocessed",
+            body: "Please address this still-unprocessed thread.",
+            createdAt: "2026-03-13T06:20:00Z",
+            url: "https://example.test/pr/42#discussion_unprocessed",
+            author: { login: "copilot-pull-request-reviewer", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const result = summarizeTrackedPrProgress(
+    record,
+    pr,
+    [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  );
+
+  assert.equal(result.summary, null);
+});
+
 test("summarizeTrackedPrProgress treats changed review-thread cluster membership as tracked PR progress", () => {
   const record = createRecord({
     last_tracked_pr_progress_snapshot: JSON.stringify({

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -1459,6 +1459,52 @@ test("summarizeTrackedPrProgress treats updated same-thread guidance as tracked 
   assert.match(result.summary ?? "", /same_review_thread_guidance_changed/);
 });
 
+test("summarizeTrackedPrProgress reports provider-neutral no-progress review loops", () => {
+  const record = createRecord({
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-1"],
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: "head123",
+      reviewDecision: "CHANGES_REQUESTED",
+      mergeStateStatus: "CLEAN",
+      copilotReviewState: null,
+      copilotReviewRequestedAt: null,
+      copilotReviewArrivedAt: null,
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: null,
+      currentHeadCiGreenAt: null,
+      configuredBotRateLimitedAt: null,
+      configuredBotDraftSkipAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["build:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: ["thread-1"],
+      unresolvedReviewThreadFingerprints: ["thread-1#comment-1"],
+      unresolvedReviewThreadSourceAnchors: ["thread-1:src/file.ts:12"],
+      processedReviewThreadIds: ["thread-1@head123"],
+      processedReviewThreadFingerprints: ["thread-1@head123#comment-1"],
+      verificationProbeOutcomes: [],
+    }),
+  });
+  const pr = createPullRequest({
+    headRefOid: "head123",
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+  });
+  const reviewThreads: ReviewThread[] = [createReviewThread({ id: "thread-1" })];
+
+  const result = summarizeTrackedPrProgress(
+    record,
+    pr,
+    [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads,
+  );
+
+  assert.equal(
+    result.summary,
+    "no_progress_review_loop current_unresolved_threads=1 processed_review_threads=1 head=head123",
+  );
+});
+
 test("summarizeTrackedPrProgress treats changed review-thread cluster membership as tracked PR progress", () => {
   const record = createRecord({
     last_tracked_pr_progress_snapshot: JSON.stringify({

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -305,11 +305,23 @@ function joinProgressValues(values: string[] | undefined): string | null {
   return Array.isArray(values) && values.length > 0 ? values.join("|") : null;
 }
 
+function processedCurrentUnresolvedReviewThreadFingerprints(current: TrackedPrProgressSnapshot): string[] {
+  const unresolvedThreadIds = new Set(current.unresolvedReviewThreadIds);
+  return (current.processedReviewThreadFingerprints ?? []).filter((fingerprint) => {
+    const match = fingerprint.match(/^(.+)@([^#]+)#/);
+    if (!match) {
+      return false;
+    }
+    const [, threadId, headSha] = match;
+    return headSha === current.headRefOid && unresolvedThreadIds.has(threadId);
+  });
+}
+
 function providerNeutralReviewLoopMadeNoProgress(
   previous: TrackedPrProgressSnapshot | null,
   current: TrackedPrProgressSnapshot,
 ): boolean {
-  const currentProcessedFingerprints = current.processedReviewThreadFingerprints ?? [];
+  const currentProcessedFingerprints = processedCurrentUnresolvedReviewThreadFingerprints(current);
   if (
     previous === null ||
     previous.headRefOid !== current.headRefOid ||
@@ -468,7 +480,7 @@ function listChangedSignals(previous: TrackedPrProgressSnapshot | null, current:
   }
 
   if (signals.length === 0 && providerNeutralReviewLoopMadeNoProgress(previous, current)) {
-    const currentProcessedFingerprints = current.processedReviewThreadFingerprints ?? [];
+    const currentProcessedFingerprints = processedCurrentUnresolvedReviewThreadFingerprints(current);
     signals.push(
       [
         "no_progress_review_loop",

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -305,6 +305,29 @@ function joinProgressValues(values: string[] | undefined): string | null {
   return Array.isArray(values) && values.length > 0 ? values.join("|") : null;
 }
 
+function providerNeutralReviewLoopMadeNoProgress(
+  previous: TrackedPrProgressSnapshot | null,
+  current: TrackedPrProgressSnapshot,
+): boolean {
+  const currentProcessedFingerprints = current.processedReviewThreadFingerprints ?? [];
+  if (
+    previous === null ||
+    previous.headRefOid !== current.headRefOid ||
+    current.unresolvedReviewThreadIds.length === 0 ||
+    currentProcessedFingerprints.length === 0
+  ) {
+    return false;
+  }
+
+  return (
+    previous.unresolvedReviewThreadIds.join("|") === current.unresolvedReviewThreadIds.join("|") &&
+    joinProgressValues(previous.unresolvedReviewThreadFingerprints) ===
+      joinProgressValues(current.unresolvedReviewThreadFingerprints) &&
+    joinProgressValues(previous.unresolvedReviewThreadSourceAnchors) ===
+      joinProgressValues(current.unresolvedReviewThreadSourceAnchors)
+  );
+}
+
 function clusteredCodexChurnMadeNoProgress(
   previous: TrackedPrProgressSnapshot | null,
   current: TrackedPrProgressSnapshot,
@@ -442,6 +465,18 @@ function listChangedSignals(previous: TrackedPrProgressSnapshot | null, current:
     (previous?.copilotReviewArrivedAt ?? null) !== current.copilotReviewArrivedAt;
   if (previous !== null && !noProgressClusteredCodexChurn && botLifecycleChanged && !signals.includes("ci_state_changed")) {
     signals.push("ci_state_changed");
+  }
+
+  if (signals.length === 0 && providerNeutralReviewLoopMadeNoProgress(previous, current)) {
+    const currentProcessedFingerprints = current.processedReviewThreadFingerprints ?? [];
+    signals.push(
+      [
+        "no_progress_review_loop",
+        `current_unresolved_threads=${current.unresolvedReviewThreadIds.length}`,
+        `processed_review_threads=${currentProcessedFingerprints.length}`,
+        `head=${current.headRefOid}`,
+      ].join(" "),
+    );
   }
 
   return signals;

--- a/src/supervisor/supervisor-lifecycle.ts
+++ b/src/supervisor/supervisor-lifecycle.ts
@@ -306,14 +306,14 @@ function joinProgressValues(values: string[] | undefined): string | null {
 }
 
 function processedCurrentUnresolvedReviewThreadFingerprints(current: TrackedPrProgressSnapshot): string[] {
-  const unresolvedThreadIds = new Set(current.unresolvedReviewThreadIds);
+  const unresolvedThreadFingerprints = new Set(current.unresolvedReviewThreadFingerprints ?? []);
   return (current.processedReviewThreadFingerprints ?? []).filter((fingerprint) => {
-    const match = fingerprint.match(/^(.+)@([^#]+)#/);
+    const match = fingerprint.match(/^(.+)@([^#]+)#(.+)$/);
     if (!match) {
       return false;
     }
-    const [, threadId, headSha] = match;
-    return headSha === current.headRefOid && unresolvedThreadIds.has(threadId);
+    const [, threadId, headSha, latestCommentFingerprint] = match;
+    return headSha === current.headRefOid && unresolvedThreadFingerprints.has(`${threadId}#${latestCommentFingerprint}`);
   });
 }
 


### PR DESCRIPTION
## Summary
- Add provider-neutral no-progress review-loop detection to tracked PR progress summaries
- Switch `addressing_review_strategy` to root-cause analysis when generic review-loop evidence is present before provider-specific churn thresholds
- Preserve existing Codex Connector churn and stable dossier stop behavior while adding focused regression coverage

Closes #2343

## Verification
- `npx tsx --test src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-lifecycle.test.ts src/turn-execution-orchestration.test.ts`
- `npm run build`
