### PR TITLE
Add provider-neutral review-loop analysis prompt

### DIFF
--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -98,7 +98,7 @@ export interface ReviewPolicyInput {
   threads: ReviewPolicyThreadInput[];
 }
 
-function latestCodexConnectorReviewCommentNode(thread: ReviewThread): ReviewThread["comments"]["nodes"][number] | null {
+export function latestCodexConnectorReviewCommentNode(thread: ReviewThread): ReviewThread["comments"]["nodes"][number] | null {
   for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
     const comment = thread.comments.nodes[index];
     const login = comment.author?.login;

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -940,7 +940,9 @@ test("buildCodexPrompt switches repeated addressing-review failures to root-caus
 test("buildCodexPrompt builds provider-neutral review-loop evidence from active threads when selected threads are exhausted", () => {
   const prompt = buildCodexPrompt({
     kind: "start",
-    config: createConfig(),
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
     repoSlug: "owner/repo",
     issue,
     branch: "codex/issue-46",
@@ -983,6 +985,25 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
           ],
         },
       }),
+      createReviewThread({
+        id: "thread-active-manual",
+        path: "src/manual-loop.ts",
+        line: 72,
+        comments: {
+          nodes: [
+            {
+              id: "comment-active-manual",
+              body: "A human reviewer left a manual note that should not enter configured-provider retry evidence.",
+              createdAt: "2026-03-11T00:06:00Z",
+              url: "https://example.test/pr/145#discussion_active_manual",
+              author: {
+                login: "human-reviewer",
+                typeName: "User",
+              },
+            },
+          ],
+        },
+      }),
     ],
     alwaysReadFiles: [],
     onDemandMemoryFiles: [],
@@ -995,6 +1016,8 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
   assert.match(prompt, /Thread thread-active-loop/);
   assert.match(prompt, /Affected files: src\/active-loop\.ts/);
   assert.match(prompt, /latest_comment_fingerprint=comment-active-loop/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-active-manual[\s\S]*External review miss context:/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*src\/manual-loop\.ts[\s\S]*External review miss context:/);
 });
 
 test("buildCodexPrompt uses the Codex Connector finding fingerprint for provider-neutral retry counts", () => {

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -937,6 +937,150 @@ test("buildCodexPrompt switches repeated addressing-review failures to root-caus
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-outdated[\s\S]*External review miss context:/);
 });
 
+test("buildCodexPrompt builds provider-neutral review-loop evidence from active threads when selected threads are exhausted", () => {
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig(),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 2,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_failure_signature: "1 unresolved automated review thread(s) remain.",
+      last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+      last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason: "provider_neutral_review_loop stalled on active current-head review threads",
+    },
+    pr: createPullRequest({
+      number: 145,
+      headRefOid: "head-review-active-145",
+      reviewDecision: "CHANGES_REQUESTED",
+    }),
+    checks: [],
+    reviewThreads: [],
+    activeReviewThreads: [
+      createReviewThread({
+        id: "thread-active-loop",
+        path: "src/active-loop.ts",
+        line: 64,
+        comments: {
+          nodes: [
+            {
+              id: "comment-active-loop",
+              body: "The current-head loop still needs file-level root-cause analysis.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/145#discussion_active_loop",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Provider-neutral review-loop evidence:/);
+  assert.match(prompt, /Current-head scope: head-review-active-145/);
+  assert.match(prompt, /Current-head unresolved configured-provider review threads: 1/);
+  assert.match(prompt, /Thread thread-active-loop/);
+  assert.match(prompt, /Affected files: src\/active-loop\.ts/);
+  assert.match(prompt, /latest_comment_fingerprint=comment-active-loop/);
+});
+
+test("buildCodexPrompt uses the Codex Connector finding fingerprint for provider-neutral retry counts", () => {
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 2,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_failure_signature: "1 unresolved automated review thread(s) remain.",
+      last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+      last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason: "provider_neutral_review_loop stalled on Codex Connector must-fix finding",
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=146|head=head-review-connector-146|thread=thread-connector-finding|comment=comment-connector-finding",
+          pr_number: 146,
+          head_sha: "head-review-connector-146",
+          thread_id: "thread-connector-finding",
+          latest_comment_fingerprint: "comment-connector-finding",
+          attempts: 3,
+          first_attempted_at: "2026-03-11T00:05:00Z",
+          last_attempted_at: "2026-03-11T00:25:00Z",
+        },
+      ],
+    },
+    pr: createPullRequest({
+      number: 146,
+      headRefOid: "head-review-connector-146",
+      reviewDecision: "CHANGES_REQUESTED",
+    }),
+    checks: [],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-connector-finding",
+        path: "src/connector-finding.ts",
+        line: 72,
+        comments: {
+          nodes: [
+            {
+              id: "comment-connector-finding",
+              body: "P2: Missing root-cause review-loop evidence lets repeated connector findings degrade into reply-only patching.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/146#discussion_connector_finding",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-later-reply",
+              body: "I pushed a small fix.",
+              createdAt: "2026-03-11T00:10:00Z",
+              url: "https://example.test/pr/146#discussion_later_reply",
+              author: {
+                login: "codex",
+                typeName: "User",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Provider-neutral review-loop evidence:/);
+  assert.match(prompt, /Thread thread-connector-finding/);
+  assert.match(prompt, /reviewer=chatgpt-codex-connector\[bot\]/);
+  assert.match(prompt, /latest_comment_fingerprint=comment-connector-finding/);
+  assert.match(prompt, /retry_count=3/);
+  assert.match(prompt, /url=https:\/\/example\.test\/pr\/146#discussion_connector_finding/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*latest_comment_fingerprint=comment-later-reply[\s\S]*External review miss context:/);
+});
+
 test("buildCodexPrompt adds structured Codex Connector must-fix guidance only for Codex Connector addressing_review", () => {
   const pr = createPullRequest({
     number: 144,

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -1026,6 +1026,35 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
         },
       }),
       createReviewThread({
+        id: "thread-active-mixed-provider",
+        path: "src/mixed-loop.ts",
+        line: 74,
+        comments: {
+          nodes: [
+            {
+              id: "comment-active-mixed-provider",
+              body: "The Copilot blocker should remain visible even if a later Codex P3 advisory is appended.",
+              createdAt: "2026-03-11T00:06:30Z",
+              url: "https://example.test/pr/145#discussion_active_mixed_provider",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-active-mixed-p3-advisory",
+              body: "P3: Consider clarifying this mixed-provider helper name in a follow-up.",
+              createdAt: "2026-03-11T00:07:00Z",
+              url: "https://example.test/pr/145#discussion_active_mixed_p3_advisory",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
         id: "thread-active-p3-advisory",
         path: "src/advisory-loop.ts",
         line: 76,
@@ -1052,11 +1081,14 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
 
   assert.match(prompt, /Provider-neutral review-loop evidence:/);
   assert.match(prompt, /Current-head scope: head-review-active-145/);
-  assert.match(prompt, /Current-head unresolved configured-provider review threads: 2/);
+  assert.match(prompt, /Current-head unresolved configured-provider review threads: 3/);
   assert.match(prompt, /Thread thread-active-loop/);
   assert.match(prompt, /Thread thread-active-other/);
-  assert.match(prompt, /Affected files: src\/active-loop\.ts, src\/other-loop\.ts/);
+  assert.match(prompt, /Thread thread-active-mixed-provider/);
+  assert.match(prompt, /Affected files: src\/active-loop\.ts, src\/other-loop\.ts, src\/mixed-loop\.ts/);
   assert.match(prompt, /latest_comment_fingerprint=comment-active-loop/);
+  assert.match(prompt, /latest_comment_fingerprint=comment-active-mixed-provider/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*latest_comment_fingerprint=comment-active-mixed-p3-advisory[\s\S]*External review miss context:/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-active-manual[\s\S]*External review miss context:/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*src\/manual-loop\.ts[\s\S]*External review miss context:/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-active-p3-advisory[\s\S]*External review miss context:/);
@@ -1169,11 +1201,11 @@ test("buildCodexPrompt anchors non-Codex provider-neutral evidence to provider c
       addressing_review_strategy_reason: "provider_neutral_review_loop stalled on a non-Codex provider finding",
       review_loop_retry_state: [
         {
-          fingerprint: "pr=147|head=head-review-provider-147|thread=thread-provider-finding|comment=comment-provider-finding",
+          fingerprint: "pr=147|head=head-review-provider-147|thread=thread-provider-finding|comment=comment-provider-later-reply",
           pr_number: 147,
           head_sha: "head-review-provider-147",
           thread_id: "thread-provider-finding",
-          latest_comment_fingerprint: "comment-provider-finding",
+          latest_comment_fingerprint: "comment-provider-later-reply",
           attempts: 2,
           first_attempted_at: "2026-03-11T00:05:00Z",
           last_attempted_at: "2026-03-11T00:15:00Z",

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -817,7 +817,9 @@ test("buildCodexPrompt suppresses stale handoff next actions during addressing_r
 test("buildCodexPrompt switches repeated addressing-review failures to root-cause analysis", () => {
   const prompt = buildCodexPrompt({
     kind: "start",
-    config: createConfig(),
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
     repoSlug: "owner/repo",
     issue,
     branch: "codex/issue-46",
@@ -986,6 +988,25 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
         },
       }),
       createReviewThread({
+        id: "thread-active-other",
+        path: "src/other-loop.ts",
+        line: 68,
+        comments: {
+          nodes: [
+            {
+              id: "comment-active-other",
+              body: "A second configured provider finding should stay visible in the active review-loop dossier.",
+              createdAt: "2026-03-11T00:05:30Z",
+              url: "https://example.test/pr/145#discussion_active_other",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
         id: "thread-active-manual",
         path: "src/manual-loop.ts",
         line: 72,
@@ -1004,6 +1025,25 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
           ],
         },
       }),
+      createReviewThread({
+        id: "thread-active-p3-advisory",
+        path: "src/advisory-loop.ts",
+        line: 76,
+        comments: {
+          nodes: [
+            {
+              id: "comment-active-p3-advisory",
+              body: "P3: Consider clarifying this helper name in a follow-up.",
+              createdAt: "2026-03-11T00:07:00Z",
+              url: "https://example.test/pr/145#discussion_active_p3_advisory",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
     ],
     alwaysReadFiles: [],
     onDemandMemoryFiles: [],
@@ -1012,12 +1052,15 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
 
   assert.match(prompt, /Provider-neutral review-loop evidence:/);
   assert.match(prompt, /Current-head scope: head-review-active-145/);
-  assert.match(prompt, /Current-head unresolved configured-provider review threads: 1/);
+  assert.match(prompt, /Current-head unresolved configured-provider review threads: 2/);
   assert.match(prompt, /Thread thread-active-loop/);
-  assert.match(prompt, /Affected files: src\/active-loop\.ts/);
+  assert.match(prompt, /Thread thread-active-other/);
+  assert.match(prompt, /Affected files: src\/active-loop\.ts, src\/other-loop\.ts/);
   assert.match(prompt, /latest_comment_fingerprint=comment-active-loop/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-active-manual[\s\S]*External review miss context:/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*src\/manual-loop\.ts[\s\S]*External review miss context:/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-active-p3-advisory[\s\S]*External review miss context:/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*src\/advisory-loop\.ts[\s\S]*External review miss context:/);
 });
 
 test("buildCodexPrompt uses the Codex Connector finding fingerprint for provider-neutral retry counts", () => {
@@ -1102,6 +1145,90 @@ test("buildCodexPrompt uses the Codex Connector finding fingerprint for provider
   assert.match(prompt, /retry_count=3/);
   assert.match(prompt, /url=https:\/\/example\.test\/pr\/146#discussion_connector_finding/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*latest_comment_fingerprint=comment-later-reply[\s\S]*External review miss context:/);
+});
+
+test("buildCodexPrompt anchors non-Codex provider-neutral evidence to provider comments after later replies", () => {
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig({
+      reviewBotLogins: ["copilot-pull-request-reviewer"],
+    }),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-46",
+    workspacePath: "/tmp/workspaces/issue-46",
+    state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 2,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_failure_signature: "1 unresolved automated review thread(s) remain.",
+      last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+      last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason: "provider_neutral_review_loop stalled on a non-Codex provider finding",
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=147|head=head-review-provider-147|thread=thread-provider-finding|comment=comment-provider-finding",
+          pr_number: 147,
+          head_sha: "head-review-provider-147",
+          thread_id: "thread-provider-finding",
+          latest_comment_fingerprint: "comment-provider-finding",
+          attempts: 2,
+          first_attempted_at: "2026-03-11T00:05:00Z",
+          last_attempted_at: "2026-03-11T00:15:00Z",
+        },
+      ],
+    },
+    pr: createPullRequest({
+      number: 147,
+      headRefOid: "head-review-provider-147",
+      reviewDecision: "CHANGES_REQUESTED",
+    }),
+    checks: [],
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-provider-finding",
+        path: "src/provider-finding.ts",
+        line: 88,
+        comments: {
+          nodes: [
+            {
+              id: "comment-provider-finding",
+              body: "The provider finding should remain the evidence anchor after a later reply.",
+              createdAt: "2026-03-11T00:05:00Z",
+              url: "https://example.test/pr/147#discussion_provider_finding",
+              author: {
+                login: "copilot-pull-request-reviewer",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-provider-later-reply",
+              body: "I tried a small local patch.",
+              createdAt: "2026-03-11T00:10:00Z",
+              url: "https://example.test/pr/147#discussion_provider_later_reply",
+              author: {
+                login: "codex",
+                typeName: "User",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-46/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Provider-neutral review-loop evidence:/);
+  assert.match(prompt, /Thread thread-provider-finding/);
+  assert.match(prompt, /reviewer=copilot-pull-request-reviewer/);
+  assert.match(prompt, /latest_comment_fingerprint=comment-provider-finding/);
+  assert.match(prompt, /retry_count=2/);
+  assert.match(prompt, /url=https:\/\/example\.test\/pr\/147#discussion_provider_finding/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*latest_comment_fingerprint=comment-provider-later-reply[\s\S]*External review miss context:/);
 });
 
 test("buildCodexPrompt adds structured Codex Connector must-fix guidance only for Codex Connector addressing_review", () => {

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -833,6 +833,18 @@ test("buildCodexPrompt switches repeated addressing-review failures to root-caus
       addressing_review_strategy: "root_cause_analysis",
       addressing_review_strategy_reason:
         "repeated_failure_signature_count=2; signature=1 unresolved automated review thread(s) remain.; tracked_pr_progress=no_meaningful_tracked_pr_progress; repeat_decision=retry_on_progress",
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=144|head=head-review-144|thread=thread-repeat|comment=comment-repeat",
+          pr_number: 144,
+          head_sha: "head-review-144",
+          thread_id: "thread-repeat",
+          latest_comment_fingerprint: "comment-repeat",
+          attempts: 2,
+          first_attempted_at: "2026-03-11T00:05:00Z",
+          last_attempted_at: "2026-03-11T00:15:00Z",
+        },
+      ],
     },
     pr: createPullRequest({
       number: 144,
@@ -860,6 +872,44 @@ test("buildCodexPrompt switches repeated addressing-review failures to root-caus
           ],
         },
       }),
+      createReviewThread({
+        id: "thread-resolved",
+        isResolved: true,
+        path: "src/resolved.ts",
+        comments: {
+          nodes: [
+            {
+              id: "comment-resolved",
+              body: "This resolved thread should not drive the current-head cluster.",
+              createdAt: "2026-03-11T00:01:00Z",
+              url: "https://example.test/pr/144#discussion_resolved",
+              author: {
+                login: "resolved-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+      createReviewThread({
+        id: "thread-outdated",
+        isOutdated: true,
+        path: "src/outdated.ts",
+        comments: {
+          nodes: [
+            {
+              id: "comment-outdated",
+              body: "This outdated thread should not drive the current-head cluster.",
+              createdAt: "2026-03-11T00:02:00Z",
+              url: "https://example.test/pr/144#discussion_outdated",
+              author: {
+                login: "outdated-reviewer",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
     ],
     alwaysReadFiles: [],
     onDemandMemoryFiles: [],
@@ -873,6 +923,18 @@ test("buildCodexPrompt switches repeated addressing-review failures to root-caus
   assert.match(prompt, /First reproduce the blocker or prove the unresolved-thread cluster from current code and tests\./);
   assert.match(prompt, /Group the repeated comments by root cause/);
   assert.match(prompt, /do not weaken attempt limits, merge gates, or configured review-bot requirements/);
+  assert.match(prompt, /Provider-neutral review-loop evidence:/);
+  assert.match(prompt, /Current-head scope: head-review-144/);
+  assert.match(prompt, /Current-head unresolved configured-provider review threads: 1/);
+  assert.match(prompt, /Provider\/reviewer identities: copilot-pull-request-reviewer/);
+  assert.match(prompt, /Affected files: src\/review\.ts/);
+  assert.match(prompt, /Thread thread-repeat/);
+  assert.match(prompt, /latest_comment_fingerprint=comment-repeat/);
+  assert.match(prompt, /retry_count=2/);
+  assert.match(prompt, /classify these comments by provider\/reviewer, affected file, repeated failure mode, and verifier expectation/);
+  assert.match(prompt, /Choose regression probes from representative current-head comments before changing code\./);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-resolved[\s\S]*External review miss context:/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-outdated[\s\S]*External review miss context:/);
 });
 
 test("buildCodexPrompt adds structured Codex Connector must-fix guidance only for Codex Connector addressing_review", () => {

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -1087,7 +1087,9 @@ test("buildCodexPrompt builds provider-neutral review-loop evidence from active 
   assert.match(prompt, /Thread thread-active-mixed-provider/);
   assert.match(prompt, /Affected files: src\/active-loop\.ts, src\/other-loop\.ts, src\/mixed-loop\.ts/);
   assert.match(prompt, /latest_comment_fingerprint=comment-active-loop/);
+  assert.match(prompt, /comment=The current-head loop still needs file-level root-cause analysis\./);
   assert.match(prompt, /latest_comment_fingerprint=comment-active-mixed-provider/);
+  assert.match(prompt, /comment=The Copilot blocker should remain visible even if a later Codex P3 advisory is appended\./);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*latest_comment_fingerprint=comment-active-mixed-p3-advisory[\s\S]*External review miss context:/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*thread-active-manual[\s\S]*External review miss context:/);
   assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:[\s\S]*src\/manual-loop\.ts[\s\S]*External review miss context:/);

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -440,75 +440,87 @@ function buildProviderNeutralReviewLoopEvidence(
   input: Pick<BuildCodexStartPromptInput, "config" | "record" | "pr" | "reviewThreads" | "activeReviewThreads">,
 ): string[] {
   const sourceReviewThreads = input.activeReviewThreads ?? input.reviewThreads;
-  const reviewThreads = input.config
-    ? configuredBotReviewThreads(input.config, sourceReviewThreads).filter(
-        (thread) => !isSoftenedCodexConnectorP3Thread(thread),
-      )
-    : [];
-  const currentHeadReviewThreads = reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-  if (currentHeadReviewThreads.length === 0) {
-    return [
-      "Provider-neutral review-loop evidence:",
-      "- Current-head unresolved configured-provider review threads: none selected.",
-    ];
-  }
-
+  const configuredThreads = input.config ? configuredBotReviewThreads(input.config, sourceReviewThreads) : [];
+  const currentHeadReviewThreads = configuredThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
   const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(currentHeadReviewThreads).map((thread) => thread.id));
-  const configuredProviderCommentForThread = (thread: ReviewThread) => {
+  const configuredProviderCommentForThread = (thread: ReviewThread): ReviewThread["comments"]["nodes"][number] | null => {
     if (!input.config) {
-      return latestReviewComment(thread);
+      return latestReviewComment(thread) ?? null;
     }
 
     const configuredLogins = new Set(configuredReviewBotLogins(input.config));
+    const softenedCodexConnectorCommentId = isSoftenedCodexConnectorP3Thread(thread)
+      ? latestCodexConnectorReviewCommentNode(thread)?.id ?? null
+      : null;
     for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
       const comment = thread.comments.nodes[index]!;
       const login = normalizeReviewProviderLogin(comment.author?.login);
+      if (softenedCodexConnectorCommentId && comment.id === softenedCodexConnectorCommentId) {
+        continue;
+      }
       if (login && configuredLogins.has(login)) {
         return comment;
       }
     }
 
-    return latestReviewComment(thread);
+    return null;
   };
   const evidenceCommentForThread = (thread: ReviewThread) =>
     codexMustFixThreadIds.has(thread.id)
-      ? latestCodexConnectorReviewCommentNode(thread) ?? latestReviewComment(thread)
+      ? latestCodexConnectorReviewCommentNode(thread) ?? latestReviewComment(thread) ?? null
       : configuredProviderCommentForThread(thread);
   const evidenceCommentFingerprintForThread = (thread: ReviewThread) =>
     codexMustFixThreadIds.has(thread.id)
       ? latestCodexConnectorReviewCommentFingerprint(thread) ?? latestReviewThreadCommentFingerprint(thread)
       : (evidenceCommentForThread(thread)?.id ?? evidenceCommentForThread(thread)?.createdAt ?? latestReviewThreadCommentFingerprint(thread));
-  const reviewerLogins = uniqueNonEmpty(
-    currentHeadReviewThreads.map((thread) => evidenceCommentForThread(thread)?.author?.login ?? "unknown"),
-  );
-  const affectedFiles = uniqueNonEmpty(currentHeadReviewThreads.map((thread) => thread.path ?? "unknown"));
-  const threadEvidence = currentHeadReviewThreads.slice(0, 6).map((thread) => {
+  const evidenceEntries = currentHeadReviewThreads.flatMap((thread) => {
     const evidenceComment = evidenceCommentForThread(thread);
-    const commentFingerprint = evidenceCommentFingerprintForThread(thread) ?? "none";
-    const retryCount =
+    const commentFingerprint = evidenceCommentFingerprintForThread(thread);
+    return evidenceComment && commentFingerprint ? [{ thread, evidenceComment, commentFingerprint }] : [];
+  });
+  if (evidenceEntries.length === 0) {
+    return [
+      "Provider-neutral review-loop evidence:",
+      "- Current-head unresolved configured-provider review threads: none selected.",
+    ];
+  }
+  const reviewerLogins = uniqueNonEmpty(
+    evidenceEntries.map((entry) => entry.evidenceComment.author?.login ?? "unknown"),
+  );
+  const affectedFiles = uniqueNonEmpty(evidenceEntries.map((entry) => entry.thread.path ?? "unknown"));
+  const threadEvidence = evidenceEntries.slice(0, 6).map(({ thread, evidenceComment, commentFingerprint }) => {
+    const trackedRetryCount =
       input.record && input.pr
-        ? reviewLoopRetryAttemptCountForThread(input.record, input.pr, thread, commentFingerprint)
+        ? Math.max(
+            reviewLoopRetryAttemptCountForThread(input.record, input.pr, thread, commentFingerprint),
+            reviewLoopRetryAttemptCountForThread(
+              input.record,
+              input.pr,
+              thread,
+              latestReviewThreadCommentFingerprint(thread),
+            ),
+          )
         : 0;
     return [
       `- Thread ${thread.id}`,
-      `  reviewer=${evidenceComment?.author?.login ?? "unknown"}`,
+      `  reviewer=${evidenceComment.author?.login ?? "unknown"}`,
       `  file=${thread.path ?? "unknown"}:${thread.line ?? "?"}`,
       `  latest_comment_fingerprint=${commentFingerprint}`,
-      `  retry_count=${retryCount > 0 ? String(retryCount) : "unknown"}`,
-      `  url=${evidenceComment?.url ?? "n/a"}`,
+      `  retry_count=${trackedRetryCount > 0 ? String(trackedRetryCount) : "unknown"}`,
+      `  url=${evidenceComment.url ?? "n/a"}`,
     ].join("\n");
   });
 
   return [
     "Provider-neutral review-loop evidence:",
     `- Current-head scope: ${input.pr?.headRefOid ?? "unknown"}`,
-    `- Current-head unresolved configured-provider review threads: ${currentHeadReviewThreads.length}`,
+    `- Current-head unresolved configured-provider review threads: ${evidenceEntries.length}`,
     `- Provider/reviewer identities: ${reviewerLogins.join(", ") || "unknown"}`,
     `- Affected files: ${affectedFiles.join(", ") || "unknown"}`,
     "- Current-head thread evidence:",
     ...threadEvidence,
-    ...(currentHeadReviewThreads.length > threadEvidence.length
-      ? [`- Additional current-head threads omitted: ${currentHeadReviewThreads.length - threadEvidence.length}`]
+    ...(evidenceEntries.length > threadEvidence.length
+      ? [`- Additional current-head threads omitted: ${evidenceEntries.length - threadEvidence.length}`]
       : []),
     "- Before editing, classify these comments by provider/reviewer, affected file, repeated failure mode, and verifier expectation.",
     "- Choose regression probes from representative current-head comments before changing code.",

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -23,7 +23,9 @@ import type {
   StartAgentTurnContext,
 } from "../supervisor/agent-runner";
 import {
+  configuredReviewBotLogins,
   configuredReviewProviderKinds,
+  normalizeReviewProviderLogin,
   reviewProviderProfileFromConfig,
   type ReviewProviderProfileSummary,
 } from "../core/review-providers";
@@ -35,6 +37,7 @@ import {
 } from "../codex-connector-review-churn";
 import {
   codexConnectorMustFixReviewThreads,
+  isSoftenedCodexConnectorP3Thread,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorReviewCommentNode,
 } from "../codex-connector-review-policy";
@@ -436,12 +439,12 @@ export interface BuildCodexStartPromptInput {
 function buildProviderNeutralReviewLoopEvidence(
   input: Pick<BuildCodexStartPromptInput, "config" | "record" | "pr" | "reviewThreads" | "activeReviewThreads">,
 ): string[] {
-  const reviewThreads =
-    input.reviewThreads.length > 0
-      ? input.reviewThreads
-      : input.config
-        ? configuredBotReviewThreads(input.config, input.activeReviewThreads ?? [])
-        : [];
+  const sourceReviewThreads = input.activeReviewThreads ?? input.reviewThreads;
+  const reviewThreads = input.config
+    ? configuredBotReviewThreads(input.config, sourceReviewThreads).filter(
+        (thread) => !isSoftenedCodexConnectorP3Thread(thread),
+      )
+    : [];
   const currentHeadReviewThreads = reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
   if (currentHeadReviewThreads.length === 0) {
     return [
@@ -451,14 +454,30 @@ function buildProviderNeutralReviewLoopEvidence(
   }
 
   const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(currentHeadReviewThreads).map((thread) => thread.id));
+  const configuredProviderCommentForThread = (thread: ReviewThread) => {
+    if (!input.config) {
+      return latestReviewComment(thread);
+    }
+
+    const configuredLogins = new Set(configuredReviewBotLogins(input.config));
+    for (let index = thread.comments.nodes.length - 1; index >= 0; index -= 1) {
+      const comment = thread.comments.nodes[index]!;
+      const login = normalizeReviewProviderLogin(comment.author?.login);
+      if (login && configuredLogins.has(login)) {
+        return comment;
+      }
+    }
+
+    return latestReviewComment(thread);
+  };
   const evidenceCommentForThread = (thread: ReviewThread) =>
     codexMustFixThreadIds.has(thread.id)
       ? latestCodexConnectorReviewCommentNode(thread) ?? latestReviewComment(thread)
-      : latestReviewComment(thread);
+      : configuredProviderCommentForThread(thread);
   const evidenceCommentFingerprintForThread = (thread: ReviewThread) =>
     codexMustFixThreadIds.has(thread.id)
       ? latestCodexConnectorReviewCommentFingerprint(thread) ?? latestReviewThreadCommentFingerprint(thread)
-      : latestReviewThreadCommentFingerprint(thread);
+      : (evidenceCommentForThread(thread)?.id ?? evidenceCommentForThread(thread)?.createdAt ?? latestReviewThreadCommentFingerprint(thread));
   const reviewerLogins = uniqueNonEmpty(
     currentHeadReviewThreads.map((thread) => evidenceCommentForThread(thread)?.author?.login ?? "unknown"),
   );

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -35,6 +35,8 @@ import {
 } from "../codex-connector-review-churn";
 import {
   codexConnectorMustFixReviewThreads,
+  latestCodexConnectorReviewCommentFingerprint,
+  latestCodexConnectorReviewCommentNode,
 } from "../codex-connector-review-policy";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 import {
@@ -431,9 +433,10 @@ export interface BuildCodexStartPromptInput {
 }
 
 function buildProviderNeutralReviewLoopEvidence(
-  input: Pick<BuildCodexStartPromptInput, "record" | "pr" | "reviewThreads">,
+  input: Pick<BuildCodexStartPromptInput, "record" | "pr" | "reviewThreads" | "activeReviewThreads">,
 ): string[] {
-  const currentHeadReviewThreads = input.reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+  const reviewThreads = input.reviewThreads.length > 0 ? input.reviewThreads : input.activeReviewThreads ?? [];
+  const currentHeadReviewThreads = reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
   if (currentHeadReviewThreads.length === 0) {
     return [
       "Provider-neutral review-loop evidence:",
@@ -441,24 +444,33 @@ function buildProviderNeutralReviewLoopEvidence(
     ];
   }
 
+  const codexMustFixThreadIds = new Set(codexConnectorMustFixReviewThreads(currentHeadReviewThreads).map((thread) => thread.id));
+  const evidenceCommentForThread = (thread: ReviewThread) =>
+    codexMustFixThreadIds.has(thread.id)
+      ? latestCodexConnectorReviewCommentNode(thread) ?? latestReviewComment(thread)
+      : latestReviewComment(thread);
+  const evidenceCommentFingerprintForThread = (thread: ReviewThread) =>
+    codexMustFixThreadIds.has(thread.id)
+      ? latestCodexConnectorReviewCommentFingerprint(thread) ?? latestReviewThreadCommentFingerprint(thread)
+      : latestReviewThreadCommentFingerprint(thread);
   const reviewerLogins = uniqueNonEmpty(
-    currentHeadReviewThreads.map((thread) => latestReviewComment(thread)?.author?.login ?? "unknown"),
+    currentHeadReviewThreads.map((thread) => evidenceCommentForThread(thread)?.author?.login ?? "unknown"),
   );
   const affectedFiles = uniqueNonEmpty(currentHeadReviewThreads.map((thread) => thread.path ?? "unknown"));
   const threadEvidence = currentHeadReviewThreads.slice(0, 6).map((thread) => {
-    const latestComment = latestReviewComment(thread);
-    const commentFingerprint = latestReviewThreadCommentFingerprint(thread) ?? "none";
+    const evidenceComment = evidenceCommentForThread(thread);
+    const commentFingerprint = evidenceCommentFingerprintForThread(thread) ?? "none";
     const retryCount =
       input.record && input.pr
         ? reviewLoopRetryAttemptCountForThread(input.record, input.pr, thread, commentFingerprint)
         : 0;
     return [
       `- Thread ${thread.id}`,
-      `  reviewer=${latestComment?.author?.login ?? "unknown"}`,
+      `  reviewer=${evidenceComment?.author?.login ?? "unknown"}`,
       `  file=${thread.path ?? "unknown"}:${thread.line ?? "?"}`,
       `  latest_comment_fingerprint=${commentFingerprint}`,
       `  retry_count=${retryCount > 0 ? String(retryCount) : "unknown"}`,
-      `  url=${latestComment?.url ?? "n/a"}`,
+      `  url=${evidenceComment?.url ?? "n/a"}`,
     ].join("\n");
   });
 
@@ -480,7 +492,7 @@ function buildProviderNeutralReviewLoopEvidence(
 }
 
 function buildAddressingReviewStrategySwitch(
-  input: Pick<BuildCodexStartPromptInput, "state" | "record" | "failureContext" | "pr" | "reviewThreads">,
+  input: Pick<BuildCodexStartPromptInput, "state" | "record" | "failureContext" | "pr" | "reviewThreads" | "activeReviewThreads">,
 ): string[] {
   if (input.state !== "addressing_review") {
     return [];

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -37,6 +37,10 @@ import {
   codexConnectorMustFixReviewThreads,
 } from "../codex-connector-review-policy";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
+import {
+  latestReviewThreadCommentFingerprint,
+  reviewLoopRetryAttemptCountForThread,
+} from "../review-handling";
 
 export interface LocalReviewRepairContext {
   repairIntent?: "same_pr_fix_blocked" | "same_pr_follow_up" | "same_pr_manual_review" | "high_severity_retry" | "unspecified";
@@ -404,6 +408,7 @@ export interface BuildCodexStartPromptInput {
       | "addressing_review_strategy"
       | "addressing_review_strategy_reason"
       | "codex_connector_stable_churn_dossier_consumed_signature"
+      | "review_loop_retry_state"
     >
   > | null;
   pr: GitHubPullRequest | null;
@@ -425,7 +430,58 @@ export interface BuildCodexStartPromptInput {
   reviewProviderProfile?: ReviewProviderProfileSummary;
 }
 
-function buildAddressingReviewStrategySwitch(input: Pick<BuildCodexStartPromptInput, "state" | "record" | "failureContext">): string[] {
+function buildProviderNeutralReviewLoopEvidence(
+  input: Pick<BuildCodexStartPromptInput, "record" | "pr" | "reviewThreads">,
+): string[] {
+  const currentHeadReviewThreads = input.reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+  if (currentHeadReviewThreads.length === 0) {
+    return [
+      "Provider-neutral review-loop evidence:",
+      "- Current-head unresolved configured-provider review threads: none selected.",
+    ];
+  }
+
+  const reviewerLogins = uniqueNonEmpty(
+    currentHeadReviewThreads.map((thread) => latestReviewComment(thread)?.author?.login ?? "unknown"),
+  );
+  const affectedFiles = uniqueNonEmpty(currentHeadReviewThreads.map((thread) => thread.path ?? "unknown"));
+  const threadEvidence = currentHeadReviewThreads.slice(0, 6).map((thread) => {
+    const latestComment = latestReviewComment(thread);
+    const commentFingerprint = latestReviewThreadCommentFingerprint(thread) ?? "none";
+    const retryCount =
+      input.record && input.pr
+        ? reviewLoopRetryAttemptCountForThread(input.record, input.pr, thread, commentFingerprint)
+        : 0;
+    return [
+      `- Thread ${thread.id}`,
+      `  reviewer=${latestComment?.author?.login ?? "unknown"}`,
+      `  file=${thread.path ?? "unknown"}:${thread.line ?? "?"}`,
+      `  latest_comment_fingerprint=${commentFingerprint}`,
+      `  retry_count=${retryCount > 0 ? String(retryCount) : "unknown"}`,
+      `  url=${latestComment?.url ?? "n/a"}`,
+    ].join("\n");
+  });
+
+  return [
+    "Provider-neutral review-loop evidence:",
+    `- Current-head scope: ${input.pr?.headRefOid ?? "unknown"}`,
+    `- Current-head unresolved configured-provider review threads: ${currentHeadReviewThreads.length}`,
+    `- Provider/reviewer identities: ${reviewerLogins.join(", ") || "unknown"}`,
+    `- Affected files: ${affectedFiles.join(", ") || "unknown"}`,
+    "- Current-head thread evidence:",
+    ...threadEvidence,
+    ...(currentHeadReviewThreads.length > threadEvidence.length
+      ? [`- Additional current-head threads omitted: ${currentHeadReviewThreads.length - threadEvidence.length}`]
+      : []),
+    "- Before editing, classify these comments by provider/reviewer, affected file, repeated failure mode, and verifier expectation.",
+    "- Choose regression probes from representative current-head comments before changing code.",
+    "- Patch the shared failure mode first; avoid one literal wording or line-local patch per comment unless the cluster truly has independent issues.",
+  ];
+}
+
+function buildAddressingReviewStrategySwitch(
+  input: Pick<BuildCodexStartPromptInput, "state" | "record" | "failureContext" | "pr" | "reviewThreads">,
+): string[] {
   if (input.state !== "addressing_review") {
     return [];
   }
@@ -456,6 +512,7 @@ function buildAddressingReviewStrategySwitch(input: Pick<BuildCodexStartPromptIn
     "- First reproduce the blocker or prove the unresolved-thread cluster from current code and tests.",
     "- Group the repeated comments by root cause, then make the smallest focused test update that would have caught the repeated failure.",
     "- Only after that root-cause grouping should you patch code, and do not weaken attempt limits, merge gates, or configured review-bot requirements.",
+    ...buildProviderNeutralReviewLoopEvidence(input),
   ];
 }
 

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -508,6 +508,7 @@ function buildProviderNeutralReviewLoopEvidence(
       `  latest_comment_fingerprint=${commentFingerprint}`,
       `  retry_count=${trackedRetryCount > 0 ? String(trackedRetryCount) : "unknown"}`,
       `  url=${evidenceComment.url ?? "n/a"}`,
+      `  comment=${truncate(evidenceComment.body.replace(/\s+/g, " ").trim(), 500) ?? ""}`,
     ].join("\n");
   });
 

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -43,6 +43,7 @@ import {
   latestReviewThreadCommentFingerprint,
   reviewLoopRetryAttemptCountForThread,
 } from "../review-handling";
+import { configuredBotReviewThreads } from "../review-thread-reporting";
 
 export interface LocalReviewRepairContext {
   repairIntent?: "same_pr_fix_blocked" | "same_pr_follow_up" | "same_pr_manual_review" | "high_severity_retry" | "unspecified";
@@ -433,9 +434,14 @@ export interface BuildCodexStartPromptInput {
 }
 
 function buildProviderNeutralReviewLoopEvidence(
-  input: Pick<BuildCodexStartPromptInput, "record" | "pr" | "reviewThreads" | "activeReviewThreads">,
+  input: Pick<BuildCodexStartPromptInput, "config" | "record" | "pr" | "reviewThreads" | "activeReviewThreads">,
 ): string[] {
-  const reviewThreads = input.reviewThreads.length > 0 ? input.reviewThreads : input.activeReviewThreads ?? [];
+  const reviewThreads =
+    input.reviewThreads.length > 0
+      ? input.reviewThreads
+      : input.config
+        ? configuredBotReviewThreads(input.config, input.activeReviewThreads ?? [])
+        : [];
   const currentHeadReviewThreads = reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
   if (currentHeadReviewThreads.length === 0) {
     return [
@@ -492,7 +498,7 @@ function buildProviderNeutralReviewLoopEvidence(
 }
 
 function buildAddressingReviewStrategySwitch(
-  input: Pick<BuildCodexStartPromptInput, "state" | "record" | "failureContext" | "pr" | "reviewThreads" | "activeReviewThreads">,
+  input: Pick<BuildCodexStartPromptInput, "config" | "state" | "record" | "failureContext" | "pr" | "reviewThreads" | "activeReviewThreads">,
 ): string[] {
   if (input.state !== "addressing_review") {
     return [];

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -49,6 +49,7 @@ interface AgentRunnerBaseRequest {
         | "addressing_review_strategy"
         | "addressing_review_strategy_reason"
         | "codex_connector_stable_churn_dossier_consumed_signature"
+        | "review_loop_retry_state"
       >
     > | null;
   repoSlug: string;


### PR DESCRIPTION
## Summary
- Add provider-neutral review-loop evidence to root-cause addressing-review prompts.
- Include current-head thread IDs, reviewer identities, affected files, comment fingerprints, and retry counts when available.
- Keep Codex Connector specialized churn guidance separate and preserve existing review policies.

Closes #2344

## Verification
- npx tsx --test src/codex/codex-prompt.test.ts src/turn-execution-orchestration.test.ts
- npm run build