### PR TITLE
Preserve Codex Connector churn as specialized review-loop evidence

### DIFF
--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -1480,6 +1480,18 @@ test("buildCodexPrompt routes concentrated Codex Connector P2 cascades to root-c
     branch: "codex/issue-2217",
     workspacePath: "/tmp/workspaces/issue-2217",
     state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 1,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+      last_failure_signature: "codex-review-churn:P2:scripts",
+      last_tracked_pr_progress_summary:
+        "no_progress_review_loop current_unresolved_threads=4 processed_review_threads=4 head=head-connector-1388",
+      last_tracked_pr_repeat_failure_decision: "retry_on_progress",
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason:
+        "trigger=provider_neutral_review_loop; tracked_pr_progress=no_progress_review_loop current_unresolved_threads=4 processed_review_threads=4 head=head-connector-1388",
+    },
     pr,
     checks: [],
     reviewThreads: threads,
@@ -1489,11 +1501,16 @@ test("buildCodexPrompt routes concentrated Codex Connector P2 cascades to root-c
   } satisfies AgentTurnContext);
 
   assert.match(prompt, /Codex Connector clustered root-cause repair:/);
+  assert.match(prompt, /Addressing-review strategy switch:/);
+  assert.match(prompt, /Specialized review-loop evidence present: Codex Connector clustered root-cause repair\./);
+  assert.match(prompt, /let the specialized Codex Connector sections define severity, must-fix gates, churn thresholds, dossier consumption, and manual-review stop semantics/);
+  assert.match(prompt, /Do not duplicate the specialized Codex Connector dossier as generic provider-neutral thread evidence\./);
   assert.match(prompt, /Triggered: review_churn must_fix=4 threshold=4/);
   assert.match(prompt, /Normalized categories: .*truth_source/);
   assert.match(prompt, /identify the common subject, verb, scope, and truth-category failure/);
   assert.match(prompt, /Prefer a generalized parser, table-driven verifier, or category-based guard/);
   assert.match(prompt, /P0\/P1\/P2 and escalated P3 Codex Connector findings are supervisor-enforced must-fix findings/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:/);
 });
 
 test("buildCodexPrompt adds a stable same-file Codex Connector churn repair dossier", () => {
@@ -1534,9 +1551,16 @@ test("buildCodexPrompt adds a stable same-file Codex Connector churn repair doss
     workspacePath: "/tmp/workspaces/issue-2250",
     state: "addressing_review" satisfies RunState,
     record: {
-      repeated_failure_signature_count: 0,
+      repeated_failure_signature_count: 1,
       blocked_verification_retry_count: 0,
       timeout_retry_count: 0,
+      last_failure_signature: "codex-review-churn:P2:src/release-readiness.ts",
+      last_tracked_pr_progress_summary:
+        "no_progress_review_loop current_unresolved_threads=2 processed_review_threads=2 head=head-current-2250",
+      last_tracked_pr_repeat_failure_decision: "retry_on_progress",
+      addressing_review_strategy: "root_cause_analysis",
+      addressing_review_strategy_reason:
+        "trigger=provider_neutral_review_loop; tracked_pr_progress=no_progress_review_loop current_unresolved_threads=2 processed_review_threads=2 head=head-current-2250",
       last_tracked_pr_progress_snapshot: JSON.stringify({
         headRefOid: "head-current-2250",
         reviewDecision: "CHANGES_REQUESTED",
@@ -1586,6 +1610,9 @@ test("buildCodexPrompt adds a stable same-file Codex Connector churn repair doss
   } satisfies AgentTurnContext);
 
   assert.match(prompt, /Codex Connector stable churn dossier:/);
+  assert.match(prompt, /Addressing-review strategy switch:/);
+  assert.match(prompt, /Specialized review-loop evidence present: Codex Connector stable churn dossier\./);
+  assert.match(prompt, /Do not duplicate the specialized Codex Connector dossier as generic provider-neutral thread evidence\./);
   assert.match(prompt, /Active PR head: head-current-2250/);
   assert.match(prompt, /Recent repair heads: head-previous-2250, head-middle-2250, head-current-2250/);
   assert.match(prompt, /Must-fix count trend: head-previous-2250:4 -> head-middle-2250:4 -> head-current-2250:5/);
@@ -1595,6 +1622,7 @@ test("buildCodexPrompt adds a stable same-file Codex Connector churn repair doss
   assert.match(prompt, /Representative URLs: https:\/\/example\.test\/pr\/2250#discussion_thread-current-0, https:\/\/example\.test\/pr\/2250#discussion_thread-current-1/);
   assert.match(prompt, /Route this as one root-cause repair dossier, not per-thread patching/);
   assert.match(prompt, /Read src\/release-readiness\.ts as a whole before editing/);
+  assert.doesNotMatch(prompt, /Provider-neutral review-loop evidence:/);
 });
 
 test("buildCodexPrompt detects Codex Connector churn from all active threads when repair selection is narrow", () => {

--- a/src/codex/codex-prompt.ts
+++ b/src/codex/codex-prompt.ts
@@ -531,6 +531,7 @@ function buildProviderNeutralReviewLoopEvidence(
 
 function buildAddressingReviewStrategySwitch(
   input: Pick<BuildCodexStartPromptInput, "config" | "state" | "record" | "failureContext" | "pr" | "reviewThreads" | "activeReviewThreads">,
+  options: { specializedReviewLoopEvidenceLabels?: string[] } = {},
 ): string[] {
   if (input.state !== "addressing_review") {
     return [];
@@ -553,6 +554,7 @@ function buildAddressingReviewStrategySwitch(
       `tracked_pr_progress=${record?.last_tracked_pr_progress_summary ?? "unknown"}`,
       `repeat_decision=${record?.last_tracked_pr_repeat_failure_decision ?? "pending"}`,
     ].join("; ");
+  const specializedReviewLoopEvidenceLabels = options.specializedReviewLoopEvidenceLabels ?? [];
 
   return [
     "Addressing-review strategy switch:",
@@ -562,7 +564,13 @@ function buildAddressingReviewStrategySwitch(
     "- First reproduce the blocker or prove the unresolved-thread cluster from current code and tests.",
     "- Group the repeated comments by root cause, then make the smallest focused test update that would have caught the repeated failure.",
     "- Only after that root-cause grouping should you patch code, and do not weaken attempt limits, merge gates, or configured review-bot requirements.",
-    ...buildProviderNeutralReviewLoopEvidence(input),
+    ...(specializedReviewLoopEvidenceLabels.length > 0
+      ? [
+          `- Specialized review-loop evidence present: ${specializedReviewLoopEvidenceLabels.join(", ")}.`,
+          "- Use the root-cause analysis frame, but let the specialized Codex Connector sections define severity, must-fix gates, churn thresholds, dossier consumption, and manual-review stop semantics.",
+          "- Do not duplicate the specialized Codex Connector dossier as generic provider-neutral thread evidence.",
+        ]
+      : buildProviderNeutralReviewLoopEvidence(input)),
   ];
 }
 
@@ -941,8 +949,14 @@ function buildCodexStartPrompt(input: BuildCodexStartPromptInput): string {
             : []),
         ]
       : [];
-  const addressingReviewStrategySwitch = buildAddressingReviewStrategySwitch(input);
   const stableSameFileChurnDossier = buildStableSameFileChurnDossier(input);
+  const specializedReviewLoopEvidenceLabels = [
+    ...(codexConnectorReviewChurn ? ["Codex Connector clustered root-cause repair"] : []),
+    ...(stableSameFileChurnDossier.length > 0 ? ["Codex Connector stable churn dossier"] : []),
+  ];
+  const addressingReviewStrategySwitch = buildAddressingReviewStrategySwitch(input, {
+    specializedReviewLoopEvidenceLabels,
+  });
   const journalOperatorOverrides = useCodexConnectorReviewThreadFastPath
     ? extractJournalOperatorOverrides(input.journalExcerpt)
     : [];


### PR DESCRIPTION
## Summary
- preserve Codex Connector churn and stable dossier signals as specialized review-loop evidence when generic root-cause strategy is active
- keep specialized severity, must-fix gates, churn thresholds, dossier consumption, and manual-review stop semantics ahead of provider-neutral evidence
- add prompt regressions for clustered churn and stable dossier precedence over generic provider-neutral review-loop evidence

## Verification
- npx tsx --test src/codex/codex-prompt.test.ts
- npx tsx --test src/codex/codex-prompt.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
- npm run build
- git diff --check
- node dist/index.js issue-lint 2345 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json

Closes #2345