### PR TITLE
Extract recovery event patch helpers

### DIFF
--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -22,7 +22,7 @@ import { buildIssueDefinitionFingerprint, issueDefinitionFreshnessPatch } from "
 import { RecoveryEvent } from "./run-once-cycle-prelude";
 import { StateStore } from "./core/state-store";
 import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, SupervisorStateFile } from "./core/types";
-import { nowIso, truncate } from "./core/utils";
+import { truncate } from "./core/utils";
 import { resetTrackedPrHeadScopedStateOnAdvance } from "./tracked-pr-lifecycle-projection";
 import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
 import { STALE_STABILIZING_NO_PR_RECOVERY_SIGNATURE } from "./no-pull-request-state";
@@ -53,6 +53,7 @@ import {
   shouldKeepCodexConnectorManualReviewChurnBlockQuiescent,
   shouldPreserveCodexConnectorManualReviewChurnBlock,
 } from "./recovery-codex-connector-churn";
+import { applyRecoveryEvent, buildRecoveryEvent, needsRecordUpdate } from "./recovery-event-patch";
 
 export { codexConnectorChurnStopEvidenceSource } from "./recovery-codex-connector-churn";
 
@@ -67,36 +68,6 @@ type RecoveryGitHubLike = Pick<
 > & Partial<
   Pick<import("./github").GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">
 >;
-
-function buildRecoveryEvent(issueNumber: number, reason: string): RecoveryEvent {
-  return {
-    issueNumber,
-    reason,
-    at: nowIso(),
-  };
-}
-
-function applyRecoveryEvent(
-  patch: Partial<IssueRunRecord>,
-  recoveryEvent: RecoveryEvent,
-): Partial<IssueRunRecord> {
-  return {
-    ...patch,
-    last_recovery_reason: recoveryEvent.reason,
-    last_recovery_at: recoveryEvent.at,
-  };
-}
-
-function needsRecordUpdate(record: IssueRunRecord, patch: Partial<IssueRunRecord>): boolean {
-  for (const [key, value] of Object.entries(patch)) {
-    const recordValue = record[key as keyof IssueRunRecord];
-    if (JSON.stringify(recordValue) !== JSON.stringify(value)) {
-      return true;
-    }
-  }
-
-  return false;
-}
 
 function latestFiniteTimestamp(...values: Array<string | null | undefined>): number | null {
   let latest: number | null = null;

--- a/src/recovery-event-patch.test.ts
+++ b/src/recovery-event-patch.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { IssueRunRecord } from "./core/types";
+import { applyRecoveryEvent, buildRecoveryEvent, needsRecordUpdate } from "./recovery-event-patch";
+
+test("buildRecoveryEvent and applyRecoveryEvent stamp recovery metadata onto a record patch", () => {
+  const event = buildRecoveryEvent(2357, "recovery_event_patch_test");
+  const patch = applyRecoveryEvent({ state: "queued" }, event);
+
+  assert.equal(event.issueNumber, 2357);
+  assert.equal(event.reason, "recovery_event_patch_test");
+  assert.equal(Number.isFinite(Date.parse(event.at)), true);
+  assert.deepEqual(patch, {
+    state: "queued",
+    last_recovery_reason: "recovery_event_patch_test",
+    last_recovery_at: event.at,
+  });
+});
+
+test("needsRecordUpdate compares recovery patches against existing record values", () => {
+  const record = {
+    state: "queued",
+    last_recovery_reason: "same_reason",
+    last_recovery_at: "2026-06-12T00:00:00.000Z",
+  } as IssueRunRecord;
+
+  assert.equal(
+    needsRecordUpdate(record, {
+      state: "queued",
+      last_recovery_reason: "same_reason",
+      last_recovery_at: "2026-06-12T00:00:00.000Z",
+    }),
+    false,
+  );
+  assert.equal(needsRecordUpdate(record, { last_recovery_reason: "different_reason" }), true);
+});

--- a/src/recovery-event-patch.ts
+++ b/src/recovery-event-patch.ts
@@ -1,0 +1,33 @@
+import type { IssueRunRecord } from "./core/types";
+import { nowIso } from "./core/utils";
+import type { RecoveryEvent } from "./run-once-cycle-prelude";
+
+export function buildRecoveryEvent(issueNumber: number, reason: string): RecoveryEvent {
+  return {
+    issueNumber,
+    reason,
+    at: nowIso(),
+  };
+}
+
+export function applyRecoveryEvent(
+  patch: Partial<IssueRunRecord>,
+  recoveryEvent: RecoveryEvent,
+): Partial<IssueRunRecord> {
+  return {
+    ...patch,
+    last_recovery_reason: recoveryEvent.reason,
+    last_recovery_at: recoveryEvent.at,
+  };
+}
+
+export function needsRecordUpdate(record: IssueRunRecord, patch: Partial<IssueRunRecord>): boolean {
+  for (const [key, value] of Object.entries(patch)) {
+    const recordValue = record[key as keyof IssueRunRecord];
+    if (JSON.stringify(recordValue) !== JSON.stringify(value)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- move blocked recovery event creation, event patching, and record patch comparison helpers into `src/recovery-event-patch.ts`
- update blocked issue reconciliation to consume the focused recovery helper module
- add direct helper coverage while preserving existing blocked recovery reconciliation behavior

## Verification
- npx tsx --test src/recovery-event-patch.test.ts src/recovery-blocked-issue-reconciliation.test.ts
- npm run build
- git diff --check
- node dist/index.js issue-lint 2357 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json

Closes #2357