### PR TITLE
Extract current-head recovery evidence helpers

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -63,7 +63,9 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "recovery-active-reconciliation.ts",
     "recovery-blocked-issue-reconciliation.ts",
     "recovery-codex-connector-churn.ts",
+    "recovery-current-head-evidence.ts",
     "recovery-entrypoint-result.ts",
+    "recovery-event-patch.ts",
     "recovery-historical-reconciliation.ts",
     "recovery-no-pr-reconciliation.ts",
     "recovery-parent-epic-reconciliation.ts",
@@ -112,12 +114,14 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
 
 const EXPECTED_FAMILY_FILES = {
   codex: [
+    "codex-connector-review-loop-prompt.ts",
     "codex-model-policy.ts",
     "codex-output-parser.ts",
     "codex-policy.ts",
     "codex-prompt.ts",
     "codex-runner.ts",
     "index.ts",
+    "review-loop-prompt-evidence.ts",
   ],
   core: [
     "command.ts",

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -21,7 +21,7 @@ import {
 import { buildIssueDefinitionFingerprint, issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { RecoveryEvent } from "./run-once-cycle-prelude";
 import { StateStore } from "./core/state-store";
-import { GitHubIssue, GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, SupervisorStateFile } from "./core/types";
+import { GitHubIssue, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig, SupervisorStateFile } from "./core/types";
 import { truncate } from "./core/utils";
 import { resetTrackedPrHeadScopedStateOnAdvance } from "./tracked-pr-lifecycle-projection";
 import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
@@ -53,6 +53,10 @@ import {
   shouldKeepCodexConnectorManualReviewChurnBlockQuiescent,
   shouldPreserveCodexConnectorManualReviewChurnBlock,
 } from "./recovery-codex-connector-churn";
+import {
+  isCurrentHeadReviewSignalRequestTimeout,
+  trackedHandoffExternalProgressEvidence,
+} from "./recovery-current-head-evidence";
 import { applyRecoveryEvent, buildRecoveryEvent, needsRecordUpdate } from "./recovery-event-patch";
 
 export { codexConnectorChurnStopEvidenceSource } from "./recovery-codex-connector-churn";
@@ -169,83 +173,6 @@ function shouldReconsiderGenericNoPrIssueDefinitionChange(
     Number.isFinite(issueUpdatedAtMs) &&
     localObservedAtMs !== null &&
     issueUpdatedAtMs > localObservedAtMs
-  );
-}
-
-function firstPassingCheckEvidence(checks: PullRequestCheck[]): string | null {
-  if (checks.length === 0) {
-    return null;
-  }
-
-  const checkSummary = summarizeChecks(checks);
-  if (!checkSummary.allPassing || checkSummary.hasPending || checkSummary.hasFailing) {
-    return null;
-  }
-
-  const firstCheckName = checks
-    .map((check) => check.name.trim())
-    .filter((name) => name.length > 0)
-    .sort()[0];
-
-  return `required_checks_green:${firstCheckName ?? "all"}`;
-}
-
-function currentHeadConfiguredBotEvidence(
-  pr: Pick<
-    GitHubPullRequest,
-    | "configuredBotCurrentHeadObservedAt"
-    | "configuredBotCurrentHeadStatusState"
-    | "configuredBotTopLevelReviewStrength"
-  >,
-): string | null {
-  if (!pr.configuredBotCurrentHeadObservedAt) {
-    return null;
-  }
-
-  const statusState = pr.configuredBotCurrentHeadStatusState?.toLowerCase() ?? null;
-  const statusPassed =
-    statusState === "success" ||
-    statusState === "pass" ||
-    statusState === "passed";
-  const topLevelPassed =
-    pr.configuredBotTopLevelReviewStrength === null ||
-    pr.configuredBotTopLevelReviewStrength === undefined ||
-    pr.configuredBotTopLevelReviewStrength === "nitpick_only";
-
-  if (!statusPassed && !topLevelPassed) {
-    return null;
-  }
-
-  return "configured_bot_current_head_passed";
-}
-
-function trackedHandoffExternalProgressEvidence(args: {
-  record: Pick<IssueRunRecord, "last_head_sha">;
-  pr: Pick<
-    GitHubPullRequest,
-    | "configuredBotCurrentHeadObservedAt"
-    | "configuredBotCurrentHeadStatusState"
-    | "configuredBotTopLevelReviewStrength"
-    | "headRefOid"
-  >;
-  checks: PullRequestCheck[];
-}): string | null {
-  if (!args.record.last_head_sha || args.record.last_head_sha === args.pr.headRefOid) {
-    return null;
-  }
-
-  return firstPassingCheckEvidence(args.checks) ?? currentHeadConfiguredBotEvidence(args.pr);
-}
-function isCurrentHeadReviewSignalRequestTimeout(
-  patch: Pick<
-    IssueRunRecord,
-    "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
-  >,
-): boolean {
-  return (
-    patch.copilot_review_timed_out_at !== null &&
-    patch.copilot_review_timeout_action === "request_review_comment" &&
-    patch.copilot_review_timeout_reason?.includes("current-head review signal") === true
   );
 }
 

--- a/src/recovery-current-head-evidence.test.ts
+++ b/src/recovery-current-head-evidence.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { PullRequestCheck } from "./core/types";
+import {
+  currentHeadConfiguredBotEvidence,
+  firstPassingCheckEvidence,
+  isCurrentHeadReviewSignalRequestTimeout,
+  trackedHandoffExternalProgressEvidence,
+} from "./recovery-current-head-evidence";
+
+function check(args: Partial<PullRequestCheck> & Pick<PullRequestCheck, "name" | "bucket" | "state">): PullRequestCheck {
+  return {
+    workflow: "CI",
+    ...args,
+  };
+}
+
+test("firstPassingCheckEvidence reports deterministic green-check evidence only when all checks pass", () => {
+  assert.equal(
+    firstPassingCheckEvidence([
+      check({ name: "test", bucket: "pass", state: "SUCCESS" }),
+      check({ name: "build", bucket: "pass", state: "SUCCESS" }),
+    ]),
+    "required_checks_green:build",
+  );
+  assert.equal(firstPassingCheckEvidence([check({ name: "build", bucket: "fail", state: "FAILURE" })]), null);
+  assert.equal(firstPassingCheckEvidence([]), null);
+});
+
+test("currentHeadConfiguredBotEvidence requires an observed current-head signal with a passing status or no blocking top-level review", () => {
+  assert.equal(
+    currentHeadConfiguredBotEvidence({
+      configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+      configuredBotTopLevelReviewStrength: "blocking",
+    }),
+    "configured_bot_current_head_passed",
+  );
+  assert.equal(
+    currentHeadConfiguredBotEvidence({
+      configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
+      configuredBotCurrentHeadStatusState: null,
+      configuredBotTopLevelReviewStrength: "nitpick_only",
+    }),
+    "configured_bot_current_head_passed",
+  );
+  assert.equal(
+    currentHeadConfiguredBotEvidence({
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+      configuredBotTopLevelReviewStrength: "nitpick_only",
+    }),
+    null,
+  );
+  assert.equal(
+    currentHeadConfiguredBotEvidence({
+      configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
+      configuredBotCurrentHeadStatusState: "FAILURE",
+      configuredBotTopLevelReviewStrength: "blocking",
+    }),
+    null,
+  );
+});
+
+test("trackedHandoffExternalProgressEvidence prefers green checks before configured-bot evidence after head advance", () => {
+  assert.equal(
+    trackedHandoffExternalProgressEvidence({
+      record: { last_head_sha: "old-head" },
+      pr: {
+        headRefOid: "new-head",
+        configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
+        configuredBotCurrentHeadStatusState: "SUCCESS",
+        configuredBotTopLevelReviewStrength: "nitpick_only",
+      },
+      checks: [check({ name: "build", bucket: "pass", state: "SUCCESS" })],
+    }),
+    "required_checks_green:build",
+  );
+  assert.equal(
+    trackedHandoffExternalProgressEvidence({
+      record: { last_head_sha: "same-head" },
+      pr: {
+        headRefOid: "same-head",
+        configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
+        configuredBotCurrentHeadStatusState: "SUCCESS",
+        configuredBotTopLevelReviewStrength: "nitpick_only",
+      },
+      checks: [check({ name: "build", bucket: "pass", state: "SUCCESS" })],
+    }),
+    null,
+  );
+});
+
+test("isCurrentHeadReviewSignalRequestTimeout identifies current-head review request timeout patches", () => {
+  assert.equal(
+    isCurrentHeadReviewSignalRequestTimeout({
+      copilot_review_timed_out_at: "2026-06-12T00:00:00Z",
+      copilot_review_timeout_action: "request_review_comment",
+      copilot_review_timeout_reason: "configured review bot missed current-head review signal",
+    }),
+    true,
+  );
+  assert.equal(
+    isCurrentHeadReviewSignalRequestTimeout({
+      copilot_review_timed_out_at: null,
+      copilot_review_timeout_action: "request_review_comment",
+      copilot_review_timeout_reason: "configured review bot missed current-head review signal",
+    }),
+    false,
+  );
+});

--- a/src/recovery-current-head-evidence.ts
+++ b/src/recovery-current-head-evidence.ts
@@ -1,0 +1,80 @@
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck } from "./core/types";
+import { summarizeChecks } from "./supervisor/supervisor-status-rendering";
+
+export function firstPassingCheckEvidence(checks: PullRequestCheck[]): string | null {
+  if (checks.length === 0) {
+    return null;
+  }
+
+  const checkSummary = summarizeChecks(checks);
+  if (!checkSummary.allPassing || checkSummary.hasPending || checkSummary.hasFailing) {
+    return null;
+  }
+
+  const firstCheckName = checks
+    .map((check) => check.name.trim())
+    .filter((name) => name.length > 0)
+    .sort()[0];
+
+  return `required_checks_green:${firstCheckName ?? "all"}`;
+}
+
+export function currentHeadConfiguredBotEvidence(
+  pr: Pick<
+    GitHubPullRequest,
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotCurrentHeadStatusState"
+    | "configuredBotTopLevelReviewStrength"
+  >,
+): string | null {
+  if (!pr.configuredBotCurrentHeadObservedAt) {
+    return null;
+  }
+
+  const statusState = pr.configuredBotCurrentHeadStatusState?.toLowerCase() ?? null;
+  const statusPassed =
+    statusState === "success" ||
+    statusState === "pass" ||
+    statusState === "passed";
+  const topLevelPassed =
+    pr.configuredBotTopLevelReviewStrength === null ||
+    pr.configuredBotTopLevelReviewStrength === undefined ||
+    pr.configuredBotTopLevelReviewStrength === "nitpick_only";
+
+  if (!statusPassed && !topLevelPassed) {
+    return null;
+  }
+
+  return "configured_bot_current_head_passed";
+}
+
+export function trackedHandoffExternalProgressEvidence(args: {
+  record: Pick<IssueRunRecord, "last_head_sha">;
+  pr: Pick<
+    GitHubPullRequest,
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotCurrentHeadStatusState"
+    | "configuredBotTopLevelReviewStrength"
+    | "headRefOid"
+  >;
+  checks: PullRequestCheck[];
+}): string | null {
+  if (!args.record.last_head_sha || args.record.last_head_sha === args.pr.headRefOid) {
+    return null;
+  }
+
+  return firstPassingCheckEvidence(args.checks) ?? currentHeadConfiguredBotEvidence(args.pr);
+}
+
+export function isCurrentHeadReviewSignalRequestTimeout(
+  patch: Pick<
+    IssueRunRecord,
+    "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"
+  >,
+): boolean {
+  return (
+    patch.copilot_review_timed_out_at !== null &&
+    patch.copilot_review_timeout_action === "request_review_comment" &&
+    patch.copilot_review_timeout_reason?.includes("current-head review signal") === true
+  );
+}


### PR DESCRIPTION
## Summary
- Extract current-head recovery evidence helpers from recovery reconciliation into `src/recovery-current-head-evidence.ts`.
- Add focused unit coverage for green-check evidence, configured-bot current-head evidence, handoff external progress evidence, and current-head review timeout detection.
- Keep reconciliation behavior and wording unchanged while reducing the reconciliation module surface.

Closes #2358

## Verification
- `npx tsx --test src/recovery-current-head-evidence.test.ts src/recovery-blocked-issue-reconciliation.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts`
- `npm run build`
- `git diff --check`
- `node dist/index.js issue-lint 2358 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`