### PR TITLE
Extract Codex Connector churn preservation helpers

### DIFF
--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -45,10 +45,10 @@ import {
   hasCodexConnectorFindingReviewComment,
 } from "./codex-connector-review-policy";
 import {
-  buildPreservedCodexConnectorChurnProgressSnapshot,
+  buildPreservedCodexConnectorManualReviewChurnPatch,
+  buildPreservedCodexConnectorManualReviewChurnReason,
   effectiveCurrentCodexConnectorMustFixBlockers,
   hasCodexConnectorChurnStopEvidence,
-  preservedCodexConnectorChurnProgressSummary,
   sameHeadCodexConnectorChurnBlockerUnchanged,
   shouldKeepCodexConnectorManualReviewChurnBlockQuiescent,
   shouldPreserveCodexConnectorManualReviewChurnBlock,
@@ -631,46 +631,30 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           nextState,
         })
       ) {
-        const previousHead = record.last_head_sha ?? "unknown";
         const recoveryEvent = buildRecoveryEvent(
           record.issue_number,
-          `tracked_pr_manual_review_preserved: preserved issue #${record.issue_number} manual-review block after tracked PR #${trackedPullRequest.number} advanced from ${previousHead} to ${trackedPullRequest.headRefOid} because unresolved configured-bot review evidence still exists`,
+          buildPreservedCodexConnectorManualReviewChurnReason({
+            issueNumber: record.issue_number,
+            pullRequestNumber: trackedPullRequest.number,
+            previousHeadSha: record.last_head_sha,
+            nextHeadSha: trackedPullRequest.headRefOid,
+          }),
         );
-        const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);
-        const preservedFailureContext = buildReviewFailureContext(
-          effectiveCurrentCodexConnectorReviewThreads,
-          config,
-          trackedPullRequest,
-        );
-        const preservedFailureSignaturePatch = applyFailureSignature({
-          ...record,
-          last_failure_signature: null,
-          repeated_failure_signature_count: 0,
-        }, preservedFailureContext);
-        const preservePatch = applyRecoveryEvent({
-          state: "blocked",
-          blocked_reason: "manual_review",
-          last_error: preservedFailureContext ? truncate(preservedFailureContext.summary, 1000) : null,
-          last_failure_kind: null,
-          last_failure_context: preservedFailureContext,
-          last_blocker_signature: null,
-          ...preservedFailureSignaturePatch,
-          pr_number: trackedPullRequest.number,
-          ...headAdvanceResetPatch,
-          last_head_sha: trackedPullRequest.headRefOid,
-          last_tracked_pr_progress_snapshot: buildPreservedCodexConnectorChurnProgressSnapshot({
+        const preservePatch = applyRecoveryEvent(
+          buildPreservedCodexConnectorManualReviewChurnPatch({
             config,
-            record: projection.recordForState,
+            record,
+            recordForSnapshot: projection.recordForState,
             pr: trackedPullRequest,
             checks,
             effectiveReviewThreads: effectiveCurrentCodexConnectorReviewThreads,
+            reviewWaitPatch: projection.reviewWaitPatch,
+            codexConnectorReviewRequestObservationPatch: projection.codexConnectorReviewRequestObservationPatch,
+            copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
+            copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
           }),
-          last_tracked_pr_progress_summary: preservedCodexConnectorChurnProgressSummary(record),
-          ...projection.reviewWaitPatch,
-          ...projection.codexConnectorReviewRequestObservationPatch,
-          ...projection.copilotReviewRequestObservationPatch,
-          ...projection.copilotReviewTimeoutPatch,
-        }, recoveryEvent);
+          recoveryEvent,
+        );
         if (needsRecordUpdate(record, preservePatch)) {
           const updated = stateStore.touch(record, preservePatch);
           state.issues[String(record.issue_number)] = updated;

--- a/src/recovery-codex-connector-churn.ts
+++ b/src/recovery-codex-connector-churn.ts
@@ -4,7 +4,11 @@ import {
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./core/types";
+import { truncate } from "./core/utils";
 import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state";
+import { buildReviewFailureContext } from "./review-thread-reporting";
+import { applyFailureSignature } from "./supervisor/supervisor-failure-helpers";
+import { resetTrackedPrHeadScopedStateOnAdvance } from "./tracked-pr-lifecycle-projection";
 
 export function hasCodexConnectorChurnStopEvidence(
   record: Pick<
@@ -229,4 +233,63 @@ export function shouldKeepCodexConnectorManualReviewChurnBlockQuiescent(args: {
     hasCodexConnectorChurnStopEvidence(args.record) &&
     args.effectiveReviewThreads.length > 0
   );
+}
+
+export function buildPreservedCodexConnectorManualReviewChurnReason(args: {
+  issueNumber: number;
+  pullRequestNumber: number;
+  previousHeadSha: string | null;
+  nextHeadSha: string;
+}): string {
+  return `tracked_pr_manual_review_preserved: preserved issue #${args.issueNumber} manual-review block after tracked PR #${args.pullRequestNumber} advanced from ${args.previousHeadSha ?? "unknown"} to ${args.nextHeadSha} because unresolved configured-bot review evidence still exists`;
+}
+
+export function buildPreservedCodexConnectorManualReviewChurnPatch(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  recordForSnapshot: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  effectiveReviewThreads: ReviewThread[];
+  reviewWaitPatch: Partial<IssueRunRecord>;
+  codexConnectorReviewRequestObservationPatch: Partial<IssueRunRecord>;
+  copilotReviewRequestObservationPatch: Partial<IssueRunRecord>;
+  copilotReviewTimeoutPatch: Partial<IssueRunRecord>;
+}): Partial<IssueRunRecord> {
+  const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(args.record, args.pr.headRefOid);
+  const preservedFailureContext = buildReviewFailureContext(
+    args.effectiveReviewThreads,
+    args.config,
+    args.pr,
+  );
+  const preservedFailureSignaturePatch = applyFailureSignature({
+    ...args.record,
+    last_failure_signature: null,
+    repeated_failure_signature_count: 0,
+  }, preservedFailureContext);
+
+  return {
+    state: "blocked",
+    blocked_reason: "manual_review",
+    last_error: preservedFailureContext ? truncate(preservedFailureContext.summary, 1000) : null,
+    last_failure_kind: null,
+    last_failure_context: preservedFailureContext,
+    last_blocker_signature: null,
+    ...preservedFailureSignaturePatch,
+    pr_number: args.pr.number,
+    ...headAdvanceResetPatch,
+    last_head_sha: args.pr.headRefOid,
+    last_tracked_pr_progress_snapshot: buildPreservedCodexConnectorChurnProgressSnapshot({
+      config: args.config,
+      record: args.recordForSnapshot,
+      pr: args.pr,
+      checks: args.checks,
+      effectiveReviewThreads: args.effectiveReviewThreads,
+    }),
+    last_tracked_pr_progress_summary: preservedCodexConnectorChurnProgressSummary(args.record),
+    ...args.reviewWaitPatch,
+    ...args.codexConnectorReviewRequestObservationPatch,
+    ...args.copilotReviewRequestObservationPatch,
+    ...args.copilotReviewTimeoutPatch,
+  };
 }


### PR DESCRIPTION
## Summary
- Move Codex Connector manual-review churn preservation reason and patch construction into `recovery-codex-connector-churn.ts`.
- Keep `recovery-blocked-issue-reconciliation.ts` focused on orchestration while preserving the same quiescent/preserved block behavior.
- Preserve existing recovery event plumbing and manual-review stop boundaries.

Closes #2359

## Verification
- `node dist/index.js issue-lint 2359 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsx --test src/recovery-blocked-issue-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts`
- `npm run build`
- `git diff --check`