### PR TITLE
Extract publication path-hygiene failure persistence helpers

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -103,6 +103,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "tracked-pr-status-comment.ts",
     "turn-execution-failure-helpers.ts",
     "turn-execution-orchestration.ts",
+    "turn-execution-path-hygiene-persistence.ts",
     "turn-execution-publication-gate.ts",
     "turn-execution-test-helpers.ts",
     "verifier-guardrails.ts",

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -30,7 +30,6 @@ import {
   getStaleStabilizingNoPrRecoveryCount,
   shouldPreserveStaleStabilizingNoPrRecoveryTracking,
 } from "./no-pull-request-state";
-import * as trackedPrStatusComments from "./tracked-pr-status-comment";
 import {
   hasCurrentTurnVerifiedNoSourceChangeReviewThreadEvidence,
   nextProcessedReviewThreadPatch,
@@ -82,6 +81,10 @@ import {
   conciseCodexVerificationSummary,
   explicitPassingCodexTurnVerificationCommand,
 } from "./run-once-turn-verification-evidence";
+import {
+  persistPublicationPathHygieneBlocked,
+  persistPublicationPathHygieneRepairQueued,
+} from "./turn-execution-path-hygiene-persistence";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -606,37 +609,19 @@ export async function executeCodexTurnPhase(
                 workspaceStatus.headSha,
               );
 
-        const publishTrackedPrHostLocalBlockerComment = async (
-          failureContext: WorkstationLocalPathGateResult["failureContext"] | null,
-          remediationTarget: "manual_review" | "repair_already_queued",
-        ): Promise<{ record: IssueRunRecord; didPublish: boolean }> => {
-          if (!pr) {
-            return { record, didPublish: false };
-          }
-
-          const originalRecord = record;
-          const updatedRecord = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
-            github,
-            stateStore,
-            state,
-            record,
-            pr,
-            syncJournal,
-            gateType: "workstation_local_path_hygiene",
-            blockerSignature: failureContext?.signature ?? null,
-            failureClass: failureContext?.signature ?? null,
-            remediationTarget,
-            summary:
-              failureContext?.summary ??
-              "Tracked durable artifacts failed workstation-local path hygiene before publication.",
-            details: failureContext?.details,
-            localHeadSha: workspaceStatus.headSha,
-            remoteHeadSha: pr.headRefOid,
+        const syncPathHygieneExecutionMetrics = async (
+          nextRecord: IssueRunRecord,
+        ) => {
+          await syncExecutionMetricsRunSummarySafely({
+            previousRecord: args.context.record,
+            nextRecord,
+            issue,
+            pullRequest: pr,
+            retentionRootPath: executionMetricsRetentionRootPath(
+              args.config.stateFile,
+            ),
+            warningContext: "persisting",
           });
-          return {
-            record: updatedRecord,
-            didPublish: updatedRecord !== originalRecord,
-          };
         };
         if (
           (workspaceStatus.remoteAhead > 0 ||
@@ -701,44 +686,21 @@ export async function executeCodexTurnPhase(
                         `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
                       ],
                     });
-                  record = stateStore.touch(record, {
-                    state: "blocked",
-                    last_error: truncate(
-                      retryPersistenceFailureContext.summary,
-                      1000,
-                    ),
-                    last_failure_kind: null,
-                    last_failure_context: retryPersistenceFailureContext,
-                    ...args.applyFailureSignature(
+                  const persistenceResult =
+                    await persistPublicationPathHygieneBlocked({
+                      stateStore,
+                      state,
                       record,
-                      retryPersistenceFailureContext,
-                    ),
-                    blocked_reason: "verification",
-                    ...issueDefinitionFreshnessPatch(issue),
-                  });
-                  const { record: blockageRecord, didPublish } =
-                    await publishTrackedPrHostLocalBlockerComment(
-                      retryPersistenceFailureContext,
-                      "manual_review",
-                    );
-                  record = blockageRecord;
-                  if (!didPublish) {
-                    state.issues[String(record.issue_number)] = record;
-                    await stateStore.save(state);
-                  }
-                  await syncExecutionMetricsRunSummarySafely({
-                    previousRecord: args.context.record,
-                    nextRecord: record,
-                    issue,
-                    pullRequest: pr,
-                    retentionRootPath: executionMetricsRetentionRootPath(
-                      args.config.stateFile,
-                    ),
-                    warningContext: "persisting",
-                  });
-                  if (!didPublish) {
-                    await syncJournal(record);
-                  }
+                      issue,
+                      pr,
+                      github,
+                      syncJournal,
+                      failureContext: retryPersistenceFailureContext,
+                      applyFailureSignature: args.applyFailureSignature,
+                      workspaceHeadSha: workspaceStatus.headSha,
+                      syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
+                    });
+                  record = persistenceResult.record;
                   return {
                     kind: "returned",
                     message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
@@ -766,92 +728,42 @@ export async function executeCodexTurnPhase(
               continue;
             }
             if (repairFailureContext !== null) {
-              record = stateStore.touch(record, {
-                state: "repairing_ci",
-                timeline_artifacts: [
-                  ...(record.timeline_artifacts ?? []),
-                  {
-                    type: "path_hygiene_result",
-                    gate: "workstation_local_path_hygiene",
-                    command: repairFailureContext.command,
-                    head_sha: workspaceStatus.headSha,
-                    outcome: "repair_queued",
-                    remediation_target: "repair_already_queued",
-                    next_action: "wait_for_repair_turn",
-                    summary: repairFailureContext.summary,
-                    recorded_at: repairFailureContext.updated_at,
-                    repair_targets: [...actionablePublishableFilePaths].sort((left, right) => left.localeCompare(right)),
-                  },
-                ],
-                last_error: truncate(repairFailureContext.summary, 1000),
-                last_failure_kind: null,
-                last_failure_context: repairFailureContext,
-                ...args.applyFailureSignature(record, repairFailureContext),
-                blocked_reason: null,
-                ...issueDefinitionFreshnessPatch(issue),
-              });
-              state.issues[String(record.issue_number)] = record;
-              await stateStore.save(state);
-              await syncExecutionMetricsRunSummarySafely({
-                previousRecord: args.context.record,
-                nextRecord: record,
-                issue,
-                pullRequest: pr,
-                retentionRootPath: executionMetricsRetentionRootPath(
-                  args.config.stateFile,
-                ),
-                warningContext: "persisting",
-              });
-              const { record: blockageRecord, didPublish } =
-                await publishTrackedPrHostLocalBlockerComment(
-                  repairFailureContext,
-                  "repair_already_queued",
-                );
-              record = blockageRecord;
-              if (!didPublish) {
-                await syncJournal(record);
-              }
+              const persistenceResult =
+                await persistPublicationPathHygieneRepairQueued({
+                  stateStore,
+                  state,
+                  record,
+                  issue,
+                  pr,
+                  github,
+                  syncJournal,
+                  failureContext: repairFailureContext,
+                  actionablePublishableFilePaths,
+                  applyFailureSignature: args.applyFailureSignature,
+                  workspaceHeadSha: workspaceStatus.headSha,
+                  syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
+                });
+              record = persistenceResult.record;
               return {
                 kind: "returned",
                 message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
               };
             }
-            record = stateStore.touch(record, {
-              state: "blocked",
-              last_error: truncate(
-                failureContext?.summary ??
-                  "Tracked durable artifacts failed workstation-local path hygiene before publication.",
-                1000,
-              ),
-              last_failure_kind: null,
-              last_failure_context: failureContext,
-              ...args.applyFailureSignature(record, failureContext),
-              blocked_reason: "verification",
-              ...issueDefinitionFreshnessPatch(issue),
-            });
-            const { record: blockageRecord, didPublish } =
-              await publishTrackedPrHostLocalBlockerComment(
-              failureContext,
-              "manual_review",
-            );
-            record = blockageRecord;
-            if (!didPublish) {
-              state.issues[String(record.issue_number)] = record;
-              await stateStore.save(state);
-            }
-            await syncExecutionMetricsRunSummarySafely({
-              previousRecord: args.context.record,
-              nextRecord: record,
-              issue,
-              pullRequest: pr,
-              retentionRootPath: executionMetricsRetentionRootPath(
-                args.config.stateFile,
-              ),
-              warningContext: "persisting",
-            });
-            if (!didPublish) {
-              await syncJournal(record);
-            }
+            const persistenceResult =
+              await persistPublicationPathHygieneBlocked({
+                stateStore,
+                state,
+                record,
+                issue,
+                pr,
+                github,
+                syncJournal,
+                failureContext,
+                applyFailureSignature: args.applyFailureSignature,
+                workspaceHeadSha: workspaceStatus.headSha,
+                syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
+              });
+            record = persistenceResult.record;
             return {
               kind: "returned",
               message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
@@ -885,38 +797,21 @@ export async function executeCodexTurnPhase(
                   `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
                 ],
               });
-              record = stateStore.touch(record, {
-                state: "blocked",
-                last_error: truncate(failureContext.summary, 1000),
-                last_failure_kind: null,
-                last_failure_context: failureContext,
-                ...args.applyFailureSignature(record, failureContext),
-                blocked_reason: "verification",
-                ...issueDefinitionFreshnessPatch(issue),
-              });
-              const { record: blockageRecord, didPublish } =
-                await publishTrackedPrHostLocalBlockerComment(
-                failureContext,
-                "manual_review",
-              );
-              record = blockageRecord;
-              if (!didPublish) {
-                state.issues[String(record.issue_number)] = record;
-                await stateStore.save(state);
-              }
-              await syncExecutionMetricsRunSummarySafely({
-                previousRecord: args.context.record,
-                nextRecord: record,
-                issue,
-                pullRequest: pr,
-                retentionRootPath: executionMetricsRetentionRootPath(
-                  args.config.stateFile,
-                ),
-                warningContext: "persisting",
-              });
-              if (!didPublish) {
-                await syncJournal(record);
-              }
+              const persistenceResult =
+                await persistPublicationPathHygieneBlocked({
+                  stateStore,
+                  state,
+                  record,
+                  issue,
+                  pr,
+                  github,
+                  syncJournal,
+                  failureContext,
+                  applyFailureSignature: args.applyFailureSignature,
+                  workspaceHeadSha: workspaceStatus.headSha,
+                  syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
+                });
+              record = persistenceResult.record;
               return {
                 kind: "returned",
                 message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,

--- a/src/turn-execution-path-hygiene-persistence.ts
+++ b/src/turn-execution-path-hygiene-persistence.ts
@@ -1,0 +1,168 @@
+import { GitHubClient } from "./github";
+import { StateStore } from "./core/state-store";
+import {
+  FailureContext,
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  SupervisorStateFile,
+} from "./core/types";
+import { truncate } from "./core/utils";
+import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
+import { IssueJournalSync } from "./run-once-issue-preparation";
+import * as trackedPrStatusComments from "./tracked-pr-status-comment";
+
+const PUBLICATION_PATH_HYGIENE_BLOCKED_SUMMARY =
+  "Tracked durable artifacts failed workstation-local path hygiene before publication.";
+
+type PathHygieneRemediationTarget = "manual_review" | "repair_already_queued";
+
+type StateStoreLike = Pick<StateStore, "touch" | "save">;
+
+type PathHygieneGitHubLike = Partial<
+  Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">
+>;
+
+type IssueDefinitionLike = Pick<GitHubIssue, "body" | "labels" | "title" | "updatedAt">;
+
+type FailureSignaturePatch = Pick<
+  IssueRunRecord,
+  "last_failure_signature" | "repeated_failure_signature_count"
+>;
+
+interface BasePathHygienePersistenceArgs {
+  stateStore: StateStoreLike;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  issue: IssueDefinitionLike;
+  pr: GitHubPullRequest | null;
+  github: PathHygieneGitHubLike;
+  syncJournal: IssueJournalSync;
+  failureContext: FailureContext | null;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => FailureSignaturePatch;
+  workspaceHeadSha: string;
+  syncExecutionMetricsRunSummary: (record: IssueRunRecord) => Promise<void>;
+}
+
+export interface PathHygienePersistenceResult {
+  record: IssueRunRecord;
+  didPublishTrackedPrComment: boolean;
+}
+
+async function publishTrackedPrHostLocalBlockerComment(
+  args: BasePathHygienePersistenceArgs & {
+    record: IssueRunRecord;
+    remediationTarget: PathHygieneRemediationTarget;
+  },
+): Promise<PathHygienePersistenceResult> {
+  if (!args.pr) {
+    return { record: args.record, didPublishTrackedPrComment: false };
+  }
+
+  const updatedRecord = await trackedPrStatusComments.maybeCommentOnTrackedPrHostLocalBlocker({
+    github: args.github,
+    stateStore: args.stateStore,
+    state: args.state,
+    record: args.record,
+    pr: args.pr,
+    syncJournal: args.syncJournal,
+    gateType: "workstation_local_path_hygiene",
+    blockerSignature: args.failureContext?.signature ?? null,
+    failureClass: args.failureContext?.signature ?? null,
+    remediationTarget: args.remediationTarget,
+    summary: args.failureContext?.summary ?? PUBLICATION_PATH_HYGIENE_BLOCKED_SUMMARY,
+    details: args.failureContext?.details,
+    localHeadSha: args.workspaceHeadSha,
+    remoteHeadSha: args.pr.headRefOid,
+  });
+  return {
+    record: updatedRecord,
+    didPublishTrackedPrComment: updatedRecord !== args.record,
+  };
+}
+
+export async function persistPublicationPathHygieneBlocked(
+  args: BasePathHygienePersistenceArgs & {
+    summary?: string;
+  },
+): Promise<PathHygienePersistenceResult> {
+  const blockedRecord = args.stateStore.touch(args.record, {
+    state: "blocked",
+    last_error: truncate(
+      args.failureContext?.summary ?? args.summary ?? PUBLICATION_PATH_HYGIENE_BLOCKED_SUMMARY,
+      1000,
+    ),
+    last_failure_kind: null,
+    last_failure_context: args.failureContext,
+    ...args.applyFailureSignature(args.record, args.failureContext),
+    blocked_reason: "verification",
+    ...issueDefinitionFreshnessPatch(args.issue),
+  });
+  const commentResult = await publishTrackedPrHostLocalBlockerComment({
+    ...args,
+    record: blockedRecord,
+    remediationTarget: "manual_review",
+  });
+
+  if (!commentResult.didPublishTrackedPrComment) {
+    args.state.issues[String(commentResult.record.issue_number)] = commentResult.record;
+    await args.stateStore.save(args.state);
+  }
+  await args.syncExecutionMetricsRunSummary(commentResult.record);
+  if (!commentResult.didPublishTrackedPrComment) {
+    await args.syncJournal(commentResult.record);
+  }
+
+  return commentResult;
+}
+
+export async function persistPublicationPathHygieneRepairQueued(
+  args: BasePathHygienePersistenceArgs & {
+    failureContext: FailureContext;
+    actionablePublishableFilePaths: readonly string[];
+  },
+): Promise<PathHygienePersistenceResult> {
+  const repairQueuedRecord = args.stateStore.touch(args.record, {
+    state: "repairing_ci",
+    timeline_artifacts: [
+      ...(args.record.timeline_artifacts ?? []),
+      {
+        type: "path_hygiene_result",
+        gate: "workstation_local_path_hygiene",
+        command: args.failureContext.command,
+        head_sha: args.workspaceHeadSha,
+        outcome: "repair_queued",
+        remediation_target: "repair_already_queued",
+        next_action: "wait_for_repair_turn",
+        summary: args.failureContext.summary,
+        recorded_at: args.failureContext.updated_at,
+        repair_targets: [...args.actionablePublishableFilePaths].sort((left, right) =>
+          left.localeCompare(right),
+        ),
+      },
+    ],
+    last_error: truncate(args.failureContext.summary, 1000),
+    last_failure_kind: null,
+    last_failure_context: args.failureContext,
+    ...args.applyFailureSignature(args.record, args.failureContext),
+    blocked_reason: null,
+    ...issueDefinitionFreshnessPatch(args.issue),
+  });
+  args.state.issues[String(repairQueuedRecord.issue_number)] = repairQueuedRecord;
+  await args.stateStore.save(args.state);
+  await args.syncExecutionMetricsRunSummary(repairQueuedRecord);
+
+  const commentResult = await publishTrackedPrHostLocalBlockerComment({
+    ...args,
+    record: repairQueuedRecord,
+    remediationTarget: "repair_already_queued",
+  });
+  if (!commentResult.didPublishTrackedPrComment) {
+    await args.syncJournal(commentResult.record);
+  }
+
+  return commentResult;
+}


### PR DESCRIPTION
## Summary
- Extract publication path-hygiene blocked and repair-queued persistence into `turn-execution-path-hygiene-persistence.ts`.
- Keep `executeCodexTurnPhase` focused on orchestration while preserving blocked-state fields, issue-definition freshness, execution metrics sync, journal sync, and tracked PR blocker comment publication.
- Update the family directory layout allowlist for the new runtime module.

Closes #2364

## Verification
- `node dist/index.js issue-lint 2364 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts`
- `npx tsx --test src/family-directory-layout.test.ts`
- `npm run build`
- `git diff --check`