### PR TITLE
Extract same-turn durable artifact repair publication flow

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -105,6 +105,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "turn-execution-orchestration.ts",
     "turn-execution-path-hygiene-persistence.ts",
     "turn-execution-publication-gate.ts",
+    "turn-execution-same-turn-repair.ts",
     "turn-execution-test-helpers.ts",
     "verifier-guardrails.ts",
     "warning-formatting.ts",

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -85,6 +85,7 @@ import {
   persistPublicationPathHygieneBlocked,
   persistPublicationPathHygieneRepairQueued,
 } from "./turn-execution-path-hygiene-persistence";
+import { runSameTurnDurableArtifactRepairRetry } from "./turn-execution-same-turn-repair";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -656,75 +657,35 @@ export async function executeCodexTurnPhase(
                 changedFilesInCurrentTurn.includes(filePath),
               );
             if (sameTurnRepairEligible) {
-              const rewrittenTrackedPaths = [
-                ...(pathHygieneGate.rewrittenJournalPaths ?? []),
-                ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ??
-                  []),
-              ];
-              const presentRewrittenTrackedPaths =
-                await filterPresentTrackedFilePaths(
-                  workspacePath,
-                  rewrittenTrackedPaths,
-                );
-              if (presentRewrittenTrackedPaths.length > 0) {
-                try {
-                  await commitAndPushTrackedFiles({
-                    workspacePath,
-                    branch: record.branch,
-                    remoteBranchExists: workspaceStatus.remoteBranchExists,
-                    filePaths: presentRewrittenTrackedPaths,
-                    commitMessage:
-                      TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
-                  });
-                } catch (error) {
-                  const message =
-                    error instanceof Error ? error.message : String(error);
-                  const retryPersistenceFailureContext =
-                    buildWorkstationLocalPathFailureContext({
-                      gateLabel: "before publication",
-                      details: [
-                        `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
-                      ],
-                    });
-                  const persistenceResult =
-                    await persistPublicationPathHygieneBlocked({
-                      stateStore,
-                      state,
-                      record,
-                      issue,
-                      pr,
-                      github,
-                      syncJournal,
-                      failureContext: retryPersistenceFailureContext,
-                      applyFailureSignature: args.applyFailureSignature,
-                      workspaceHeadSha: workspaceStatus.headSha,
-                      syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
-                    });
-                  record = persistenceResult.record;
-                  return {
-                    kind: "returned",
-                    message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
-                  };
-                }
-                workspaceStatus = await getWorkspaceStatusImpl(
-                  workspacePath,
-                  record.branch,
-                  config.defaultBranch,
-                );
-                record = stateStore.touch(record, {
-                  last_head_sha: workspaceStatus.headSha,
-                });
-              }
-              usedSameTurnPathRepairRetry = true;
-              record = stateStore.touch(record, {
-                last_error: truncate(failureContext.summary, 1000),
-                last_failure_kind: null,
-                last_failure_context: failureContext,
-                ...args.applyFailureSignature(record, failureContext),
+              const retryResult = await runSameTurnDurableArtifactRepairRetry({
+                stateStore,
+                state,
+                record,
+                issue,
+                pr,
+                github,
+                syncJournal,
+                failureContext,
+                applyFailureSignature: args.applyFailureSignature,
+                workspacePath,
+                workspaceStatus,
+                defaultBranch: config.defaultBranch,
+                rewrittenTrackedPaths: [
+                  ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+                  ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+                ],
+                getWorkspaceStatus: getWorkspaceStatusImpl,
+                syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
               });
-              state.issues[String(record.issue_number)] = record;
-              await stateStore.save(state);
-              await syncJournal(record);
+              record = retryResult.record;
+              if (retryResult.kind === "blocked") {
+                return {
+                  kind: "returned",
+                  message: retryResult.message,
+                };
+              }
+              workspaceStatus = retryResult.workspaceStatus;
+              usedSameTurnPathRepairRetry = true;
               continue;
             }
             if (repairFailureContext !== null) {
@@ -877,85 +838,33 @@ export async function executeCodexTurnPhase(
         });
         record = publicationGate.record;
         if (publicationGate.kind === "same_turn_repair") {
-          const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(
+          const retryResult = await runSameTurnDurableArtifactRepairRetry({
+            stateStore,
+            state,
+            record,
+            issue,
+            pr,
+            github,
+            syncJournal,
+            failureContext: publicationGate.failureContext,
+            applyFailureSignature: args.applyFailureSignature,
             workspacePath,
-            publicationGate.rewrittenTrackedPaths,
-          );
-          if (presentRewrittenTrackedPaths.length > 0) {
-            try {
-              await commitAndPushTrackedFiles({
-                workspacePath,
-                branch: record.branch,
-                remoteBranchExists: workspaceStatus.remoteBranchExists,
-                filePaths: presentRewrittenTrackedPaths,
-                commitMessage:
-                  TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
-              });
-            } catch (error) {
-              const message =
-                error instanceof Error ? error.message : String(error);
-              const retryPersistenceFailureContext =
-                buildWorkstationLocalPathFailureContext({
-                  gateLabel: "before publication",
-                  details: [
-                    `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
-                  ],
-                });
-              record = stateStore.touch(record, {
-                state: "blocked",
-                last_error: truncate(
-                  retryPersistenceFailureContext.summary,
-                  1000,
-                ),
-                last_failure_kind: null,
-                last_failure_context: retryPersistenceFailureContext,
-                ...args.applyFailureSignature(
-                  record,
-                  retryPersistenceFailureContext,
-                ),
-                blocked_reason: "verification",
-                ...issueDefinitionFreshnessPatch(issue),
-              });
-              state.issues[String(record.issue_number)] = record;
-              await stateStore.save(state);
-              await syncExecutionMetricsRunSummarySafely({
-                previousRecord: args.context.record,
-                nextRecord: record,
-                issue,
-                pullRequest: pr,
-                retentionRootPath: executionMetricsRetentionRootPath(
-                  args.config.stateFile,
-                ),
-                warningContext: "persisting",
-              });
-              await syncJournal(record);
-              return {
-                kind: "returned",
-                message: `Workstation-local path hygiene blocked publication for issue #${record.issue_number}.`,
-              };
-            }
-            workspaceStatus = await getWorkspaceStatusImpl(
-              workspacePath,
-              record.branch,
-              config.defaultBranch,
-            );
-            record = stateStore.touch(record, {
-              last_head_sha: workspaceStatus.headSha,
-            });
-          }
-          usedSameTurnPathRepairRetry = true;
-          record = stateStore.touch(record, {
-            last_error: truncate(publicationGate.failureContext.summary, 1000),
-            last_failure_kind: null,
-            last_failure_context: publicationGate.failureContext,
-            ...args.applyFailureSignature(
-              record,
-              publicationGate.failureContext,
-            ),
+            workspaceStatus,
+            defaultBranch: config.defaultBranch,
+            rewrittenTrackedPaths: publicationGate.rewrittenTrackedPaths,
+            getWorkspaceStatus: getWorkspaceStatusImpl,
+            publishTrackedPrCommentOnFailure: false,
+            syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
           });
-          state.issues[String(record.issue_number)] = record;
-          await stateStore.save(state);
-          await syncJournal(record);
+          record = retryResult.record;
+          if (retryResult.kind === "blocked") {
+            return {
+              kind: "returned",
+              message: retryResult.message,
+            };
+          }
+          workspaceStatus = retryResult.workspaceStatus;
+          usedSameTurnPathRepairRetry = true;
           continue;
         }
         pr = publicationGate.pr;

--- a/src/turn-execution-path-hygiene-persistence.ts
+++ b/src/turn-execution-path-hygiene-persistence.ts
@@ -86,6 +86,7 @@ async function publishTrackedPrHostLocalBlockerComment(
 
 export async function persistPublicationPathHygieneBlocked(
   args: BasePathHygienePersistenceArgs & {
+    publishTrackedPrComment?: boolean;
     summary?: string;
   },
 ): Promise<PathHygienePersistenceResult> {
@@ -101,11 +102,14 @@ export async function persistPublicationPathHygieneBlocked(
     blocked_reason: "verification",
     ...issueDefinitionFreshnessPatch(args.issue),
   });
-  const commentResult = await publishTrackedPrHostLocalBlockerComment({
-    ...args,
-    record: blockedRecord,
-    remediationTarget: "manual_review",
-  });
+  const commentResult =
+    args.publishTrackedPrComment === false
+      ? { record: blockedRecord, didPublishTrackedPrComment: false }
+      : await publishTrackedPrHostLocalBlockerComment({
+          ...args,
+          record: blockedRecord,
+          remediationTarget: "manual_review",
+        });
 
   if (!commentResult.didPublishTrackedPrComment) {
     args.state.issues[String(commentResult.record.issue_number)] = commentResult.record;

--- a/src/turn-execution-same-turn-repair.ts
+++ b/src/turn-execution-same-turn-repair.ts
@@ -1,0 +1,142 @@
+import { GitHubClient } from "./github";
+import { StateStore } from "./core/state-store";
+import {
+  FailureContext,
+  GitHubIssue,
+  GitHubPullRequest,
+  IssueRunRecord,
+  SupervisorStateFile,
+  WorkspaceStatus,
+} from "./core/types";
+import { truncate } from "./core/utils";
+import {
+  commitAndPushTrackedFiles,
+  filterPresentTrackedFilePaths,
+  getWorkspaceStatus,
+} from "./core/workspace";
+import { IssueJournalSync } from "./run-once-issue-preparation";
+import { buildWorkstationLocalPathFailureContext } from "./workstation-local-path-gate";
+import { persistPublicationPathHygieneBlocked } from "./turn-execution-path-hygiene-persistence";
+
+const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
+  "Normalize trusted durable artifacts for path hygiene";
+
+type StateStoreLike = Pick<StateStore, "touch" | "save">;
+
+type SameTurnRepairGitHubLike = Partial<
+  Pick<GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "updateIssueComment">
+>;
+
+type IssueDefinitionLike = Pick<GitHubIssue, "body" | "labels" | "title" | "updatedAt">;
+
+type FailureSignaturePatch = Pick<
+  IssueRunRecord,
+  "last_failure_signature" | "repeated_failure_signature_count"
+>;
+
+export type SameTurnDurableArtifactRepairResult =
+  | {
+      kind: "retry";
+      record: IssueRunRecord;
+      workspaceStatus: WorkspaceStatus;
+    }
+  | {
+      kind: "blocked";
+      record: IssueRunRecord;
+      message: string;
+    };
+
+export async function runSameTurnDurableArtifactRepairRetry(args: {
+  stateStore: StateStoreLike;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  issue: IssueDefinitionLike;
+  pr: GitHubPullRequest | null;
+  github: SameTurnRepairGitHubLike;
+  syncJournal: IssueJournalSync;
+  failureContext: FailureContext;
+  applyFailureSignature: (
+    record: IssueRunRecord,
+    failureContext: FailureContext | null,
+  ) => FailureSignaturePatch;
+  workspacePath: string;
+  workspaceStatus: WorkspaceStatus;
+  defaultBranch: string;
+  rewrittenTrackedPaths: readonly string[];
+  getWorkspaceStatus?: typeof getWorkspaceStatus;
+  publishTrackedPrCommentOnFailure?: boolean;
+  syncExecutionMetricsRunSummary: (record: IssueRunRecord) => Promise<void>;
+}): Promise<SameTurnDurableArtifactRepairResult> {
+  const presentRewrittenTrackedPaths = await filterPresentTrackedFilePaths(
+    args.workspacePath,
+    [...args.rewrittenTrackedPaths],
+  );
+
+  let workspaceStatus = args.workspaceStatus;
+  let record = args.record;
+  if (presentRewrittenTrackedPaths.length > 0) {
+    try {
+      await commitAndPushTrackedFiles({
+        workspacePath: args.workspacePath,
+        branch: record.branch,
+        remoteBranchExists: workspaceStatus.remoteBranchExists,
+        filePaths: presentRewrittenTrackedPaths,
+        commitMessage: TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const retryPersistenceFailureContext =
+        buildWorkstationLocalPathFailureContext({
+          gateLabel: "before publication",
+          details: [
+            `durable artifact normalization persistence failed for ${presentRewrittenTrackedPaths.join(", ")}: ${message}`,
+          ],
+        });
+      const persistenceResult = await persistPublicationPathHygieneBlocked({
+        stateStore: args.stateStore,
+        state: args.state,
+        record,
+        issue: args.issue,
+        pr: args.pr,
+        github: args.github,
+        syncJournal: args.syncJournal,
+        failureContext: retryPersistenceFailureContext,
+        applyFailureSignature: args.applyFailureSignature,
+        workspaceHeadSha: workspaceStatus.headSha,
+        publishTrackedPrComment: args.publishTrackedPrCommentOnFailure,
+        syncExecutionMetricsRunSummary: args.syncExecutionMetricsRunSummary,
+      });
+      return {
+        kind: "blocked",
+        record: persistenceResult.record,
+        message: `Workstation-local path hygiene blocked publication for issue #${persistenceResult.record.issue_number}.`,
+      };
+    }
+
+    const getWorkspaceStatusImpl = args.getWorkspaceStatus ?? getWorkspaceStatus;
+    workspaceStatus = await getWorkspaceStatusImpl(
+      args.workspacePath,
+      record.branch,
+      args.defaultBranch,
+    );
+    record = args.stateStore.touch(record, {
+      last_head_sha: workspaceStatus.headSha,
+    });
+  }
+
+  record = args.stateStore.touch(record, {
+    last_error: truncate(args.failureContext.summary, 1000),
+    last_failure_kind: null,
+    last_failure_context: args.failureContext,
+    ...args.applyFailureSignature(record, args.failureContext),
+  });
+  args.state.issues[String(record.issue_number)] = record;
+  await args.stateStore.save(args.state);
+  await args.syncJournal(record);
+
+  return {
+    kind: "retry",
+    record,
+    workspaceStatus,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract same-turn durable artifact repair retry handling into `turn-execution-same-turn-repair.ts`.
- Preserve durable artifact normalization commits, refreshed workspace head tracking, retry guard behavior, and journal updates.
- Reuse the path-hygiene failure persistence helper for retry publication failures while preserving the existing tracked PR blocker comment boundary.
- Update the family directory layout allowlist for the new runtime module.

Closes #2365

## Verification
- `node dist/index.js issue-lint 2365 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-publication-gate.test.ts`
- `npx tsx --test src/family-directory-layout.test.ts`
- `npm run build`
- `git diff --check`