### PR TITLE
Extract post-publication review persistence helpers

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -104,6 +104,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "turn-execution-failure-helpers.ts",
     "turn-execution-orchestration.ts",
     "turn-execution-path-hygiene-persistence.ts",
+    "turn-execution-post-publication-review.ts",
     "turn-execution-publication-gate.ts",
     "turn-execution-same-turn-repair.ts",
     "turn-execution-test-helpers.ts",

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -31,18 +31,9 @@ import {
   shouldPreserveStaleStabilizingNoPrRecoveryTracking,
 } from "./no-pull-request-state";
 import {
-  hasCurrentTurnVerifiedNoSourceChangeReviewThreadEvidence,
-  nextProcessedReviewThreadPatch,
-  nextReviewFollowUpPatch,
   prepareCodexTurnPrompt,
-  selectVerifiedNoSourceChangeReviewThreads,
   shouldResumeAgentTurn,
 } from "./turn-execution-orchestration";
-import {
-  latestReviewThreadCommentFingerprint,
-  processedReviewThreadFingerprintKey,
-  processedReviewThreadKey,
-} from "./review-handling";
 import {
   FailureContext,
   GitHubIssue,
@@ -76,15 +67,17 @@ import {
 } from "./interrupted-turn-marker";
 import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate";
-import { upsertTimelineArtifact } from "./timeline-artifacts";
 import {
-  conciseCodexVerificationSummary,
   explicitPassingCodexTurnVerificationCommand,
 } from "./run-once-turn-verification-evidence";
 import {
   persistPublicationPathHygieneBlocked,
   persistPublicationPathHygieneRepairQueued,
 } from "./turn-execution-path-hygiene-persistence";
+import {
+  buildPostPublicationCodexVerificationTimelineArtifacts,
+  buildPostPublicationReviewPersistence,
+} from "./turn-execution-post-publication-review";
 import { runSameTurnDurableArtifactRepairRetry } from "./turn-execution-same-turn-repair";
 
 export {
@@ -110,19 +103,6 @@ export interface CodexTurnContext {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
   options: { dryRun: boolean };
-}
-
-function sameRepairTargets(left: string[] | null | undefined, right: string[] | null | undefined): boolean {
-  return sameStringList(left, right);
-}
-
-function sameStringList(left: string[] | null | undefined, right: string[] | null | undefined): boolean {
-  const normalizedLeft = left ?? [];
-  const normalizedRight = right ?? [];
-  return (
-    normalizedLeft.length === normalizedRight.length &&
-    normalizedLeft.every((target, index) => target === normalizedRight[index])
-  );
 }
 
 export interface CodexTurnResult {
@@ -887,40 +867,24 @@ export async function executeCodexTurnPhase(
                 turnStartHeadSha,
                 workspaceStatus.headSha,
               );
-        const verifiedNoSourceChangeReviewThreads =
-          preRunState === "local_review_fix"
-            ? selectVerifiedNoSourceChangeReviewThreads({
-                config,
-                localReviewRepairContext,
-                reviewThreads: reviewThreadsToProcess,
-              })
-            : [];
-        const canPersistVerifiedNoSourceChangeCurrentHead =
-          Boolean(codexVerificationCommand) &&
-          !workspaceStatus.hasUncommittedChanges &&
-          changedFilesAfterPublication.length === 0;
-        const processedReviewThreadPatch = nextProcessedReviewThreadPatch({
+        const postPublicationReviewPersistence = buildPostPublicationReviewPersistence({
           config,
           preRunState,
           record,
           currentPr: pr,
           evaluatedReviewHeadSha,
           reviewThreadsToProcess,
-          verifiedNoSourceChangeReviewThreads:
-            preRunState === "local_review_fix"
-              ? verifiedNoSourceChangeReviewThreads
-              : undefined,
-          persistVerifiedNoSourceChangeCurrentHead: canPersistVerifiedNoSourceChangeCurrentHead,
-        });
-        const reviewFollowUpPatch = nextReviewFollowUpPatch({
-          config,
-          preRunState,
-          record,
-          currentPr: pr,
-          evaluatedReviewHeadSha,
+          localReviewRepairContext,
           preRunReviewThreads: args.context.reviewThreads,
           postRunReviewThreads: reviewThreads,
+          codexVerificationCommand,
+          workspaceStatus,
+          changedFilesAfterPublication,
         });
+        const processedReviewThreadPatch =
+          postPublicationReviewPersistence.processedReviewThreadPatch;
+        const reviewFollowUpPatch =
+          postPublicationReviewPersistence.reviewFollowUpPatch;
         const postRunSnapshot = pr
           ? args.derivePullRequestLifecycleSnapshot(
               record,
@@ -937,81 +901,19 @@ export async function executeCodexTurnPhase(
           ? postRunSnapshot.nextState
           : (hintedState ??
             args.inferStateWithoutPullRequest(record, workspaceStatus));
-        const currentPrHeadSha = pr?.headRefOid ?? null;
-        const hasVerifiedNoSourceChangeReviewThreadEvidence =
-          hasCurrentTurnVerifiedNoSourceChangeReviewThreadEvidence({
-            preRunState,
-            currentPrHeadSha,
-            canPersistVerifiedNoSourceChangeCurrentHead,
-            verifiedNoSourceChangeReviewThreads,
-            processedReviewThreadIds: processedReviewThreadPatch.processed_review_thread_ids,
-          });
-        const codexTurnVerificationHeadSha =
-          pr &&
-          codexVerificationCommand &&
-          workspaceStatus.headSha === pr.headRefOid &&
-          postRunState !== "failed" &&
-          (postRunState !== "blocked" || hasVerifiedNoSourceChangeReviewThreadEvidence)
-            ? pr.headRefOid
-            : null;
-        const codexTurnVerificationRepairTargets = hasVerifiedNoSourceChangeReviewThreadEvidence
-          ? ["verified_no_source_change_review_thread_residue"]
-          : undefined;
-        const codexTurnVerificationReviewThreadIds =
-          codexTurnVerificationRepairTargets && currentPrHeadSha
-            ? verifiedNoSourceChangeReviewThreads.map((thread) =>
-                processedReviewThreadKey(thread.id, currentPrHeadSha),
-              )
-            : undefined;
-        const codexTurnVerificationReviewThreadFingerprints =
-          codexTurnVerificationRepairTargets && currentPrHeadSha
-            ? verifiedNoSourceChangeReviewThreads.flatMap((thread) => {
-                const fingerprint = latestReviewThreadCommentFingerprint(thread);
-                return fingerprint
-                  ? [processedReviewThreadFingerprintKey(thread.id, currentPrHeadSha, fingerprint)]
-                  : [];
-              })
-            : undefined;
         const codexTurnVerificationTimelineArtifacts =
-          pr &&
-          codexVerificationCommand &&
-          codexTurnVerificationHeadSha
-            ? upsertTimelineArtifact(
-                record,
-                {
-                  type: "verification_result",
-                  gate: "codex_turn",
-                  command: codexVerificationCommand,
-                  head_sha: codexTurnVerificationHeadSha,
-                  outcome: "passed",
-                  remediation_target: null,
-                  next_action: "continue",
-                  summary: conciseCodexVerificationSummary(
-                    structuredResult?.summary,
-                  ),
-                  recorded_at: new Date().toISOString(),
-                  ...(codexTurnVerificationRepairTargets
-                    ? {
-                        repair_targets: codexTurnVerificationRepairTargets,
-                        processed_review_thread_ids: codexTurnVerificationReviewThreadIds ?? [],
-                        processed_review_thread_fingerprints: codexTurnVerificationReviewThreadFingerprints ?? [],
-                      }
-                    : {}),
-                },
-                (candidate) =>
-                  candidate.type === "verification_result" &&
-                  candidate.gate === "codex_turn" &&
-                  candidate.outcome === "passed" &&
-                  candidate.head_sha === codexTurnVerificationHeadSha &&
-                  candidate.command === codexVerificationCommand &&
-                  sameRepairTargets(candidate.repair_targets, codexTurnVerificationRepairTargets) &&
-                  sameStringList(candidate.processed_review_thread_ids, codexTurnVerificationReviewThreadIds) &&
-                  sameStringList(
-                    candidate.processed_review_thread_fingerprints,
-                    codexTurnVerificationReviewThreadFingerprints,
-                  ),
-              )
-            : null;
+          buildPostPublicationCodexVerificationTimelineArtifacts({
+            record,
+            currentPr: pr,
+            codexVerificationCommand,
+            workspaceStatus,
+            structuredSummary: structuredResult?.summary,
+            postRunState,
+            hasVerifiedNoSourceChangeReviewThreadEvidence:
+              postPublicationReviewPersistence.hasVerifiedNoSourceChangeReviewThreadEvidence,
+            verifiedNoSourceChangeReviewThreads:
+              postPublicationReviewPersistence.verifiedNoSourceChangeReviewThreads,
+          });
         const preserveStaleNoPrRecoveryTracking =
           pr === null &&
           postRunSnapshot === null &&

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -1,0 +1,188 @@
+import type { LocalReviewRepairContext } from "./codex";
+import {
+  latestReviewThreadCommentFingerprint,
+  processedReviewThreadFingerprintKey,
+  processedReviewThreadKey,
+} from "./review-handling";
+import {
+  hasCurrentTurnVerifiedNoSourceChangeReviewThreadEvidence,
+  nextProcessedReviewThreadPatch,
+  nextReviewFollowUpPatch,
+  selectVerifiedNoSourceChangeReviewThreads,
+} from "./turn-execution-orchestration";
+import {
+  GitHubPullRequest,
+  IssueRunRecord,
+  ReviewThread,
+  SupervisorConfig,
+  TimelineArtifact,
+  WorkspaceStatus,
+} from "./core/types";
+import { upsertTimelineArtifact } from "./timeline-artifacts";
+import { conciseCodexVerificationSummary } from "./run-once-turn-verification-evidence";
+
+function sameStringList(left: string[] | null | undefined, right: string[] | null | undefined): boolean {
+  const normalizedLeft = left ?? [];
+  const normalizedRight = right ?? [];
+  return (
+    normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((target, index) => target === normalizedRight[index])
+  );
+}
+
+function sameRepairTargets(left: string[] | null | undefined, right: string[] | null | undefined): boolean {
+  return sameStringList(left, right);
+}
+
+export interface PostPublicationReviewPersistence {
+  processedReviewThreadPatch: Pick<
+    IssueRunRecord,
+    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "review_loop_retry_state"
+  >;
+  reviewFollowUpPatch: Pick<IssueRunRecord, "review_follow_up_head_sha" | "review_follow_up_remaining">;
+  hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
+  verifiedNoSourceChangeReviewThreads: ReviewThread[];
+}
+
+export function buildPostPublicationReviewPersistence(args: {
+  config: SupervisorConfig;
+  preRunState: IssueRunRecord["state"];
+  record: IssueRunRecord;
+  currentPr: GitHubPullRequest | null;
+  evaluatedReviewHeadSha: string;
+  reviewThreadsToProcess: ReviewThread[];
+  localReviewRepairContext: LocalReviewRepairContext | null;
+  preRunReviewThreads: ReviewThread[];
+  postRunReviewThreads: ReviewThread[];
+  codexVerificationCommand: string | null;
+  workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha">;
+  changedFilesAfterPublication: readonly string[];
+}): PostPublicationReviewPersistence {
+  const verifiedNoSourceChangeReviewThreads =
+    args.preRunState === "local_review_fix"
+      ? selectVerifiedNoSourceChangeReviewThreads({
+          config: args.config,
+          localReviewRepairContext: args.localReviewRepairContext,
+          reviewThreads: args.reviewThreadsToProcess,
+        })
+      : [];
+  const canPersistVerifiedNoSourceChangeCurrentHead =
+    Boolean(args.codexVerificationCommand) &&
+    !args.workspaceStatus.hasUncommittedChanges &&
+    args.changedFilesAfterPublication.length === 0;
+  const processedReviewThreadPatch = nextProcessedReviewThreadPatch({
+    config: args.config,
+    preRunState: args.preRunState,
+    record: args.record,
+    currentPr: args.currentPr,
+    evaluatedReviewHeadSha: args.evaluatedReviewHeadSha,
+    reviewThreadsToProcess: args.reviewThreadsToProcess,
+    verifiedNoSourceChangeReviewThreads:
+      args.preRunState === "local_review_fix"
+        ? verifiedNoSourceChangeReviewThreads
+        : undefined,
+    persistVerifiedNoSourceChangeCurrentHead: canPersistVerifiedNoSourceChangeCurrentHead,
+  });
+  const reviewFollowUpPatch = nextReviewFollowUpPatch({
+    config: args.config,
+    preRunState: args.preRunState,
+    record: args.record,
+    currentPr: args.currentPr,
+    evaluatedReviewHeadSha: args.evaluatedReviewHeadSha,
+    preRunReviewThreads: args.preRunReviewThreads,
+    postRunReviewThreads: args.postRunReviewThreads,
+  });
+  const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
+  const hasVerifiedNoSourceChangeReviewThreadEvidence =
+    hasCurrentTurnVerifiedNoSourceChangeReviewThreadEvidence({
+      preRunState: args.preRunState,
+      currentPrHeadSha,
+      canPersistVerifiedNoSourceChangeCurrentHead,
+      verifiedNoSourceChangeReviewThreads,
+      processedReviewThreadIds: processedReviewThreadPatch.processed_review_thread_ids,
+    });
+  return {
+    processedReviewThreadPatch,
+    reviewFollowUpPatch,
+    hasVerifiedNoSourceChangeReviewThreadEvidence,
+    verifiedNoSourceChangeReviewThreads,
+  };
+}
+
+export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
+  record: IssueRunRecord;
+  currentPr: GitHubPullRequest | null;
+  codexVerificationCommand: string | null;
+  workspaceStatus: Pick<WorkspaceStatus, "headSha">;
+  structuredSummary: string | null | undefined;
+  postRunState: IssueRunRecord["state"];
+  hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
+  verifiedNoSourceChangeReviewThreads: ReviewThread[];
+}): TimelineArtifact[] | null {
+  const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
+  const codexTurnVerificationHeadSha =
+    args.currentPr &&
+    args.codexVerificationCommand &&
+    args.workspaceStatus.headSha === args.currentPr.headRefOid &&
+    args.postRunState !== "failed" &&
+    (args.postRunState !== "blocked" || args.hasVerifiedNoSourceChangeReviewThreadEvidence)
+      ? args.currentPr.headRefOid
+      : null;
+  const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
+    ? ["verified_no_source_change_review_thread_residue"]
+    : undefined;
+  const codexTurnVerificationReviewThreadIds =
+    codexTurnVerificationRepairTargets && currentPrHeadSha
+      ? args.verifiedNoSourceChangeReviewThreads.map((thread) =>
+          processedReviewThreadKey(thread.id, currentPrHeadSha),
+        )
+      : undefined;
+  const codexTurnVerificationReviewThreadFingerprints =
+    codexTurnVerificationRepairTargets && currentPrHeadSha
+      ? args.verifiedNoSourceChangeReviewThreads.flatMap((thread) => {
+          const fingerprint = latestReviewThreadCommentFingerprint(thread);
+          return fingerprint
+            ? [processedReviewThreadFingerprintKey(thread.id, currentPrHeadSha, fingerprint)]
+            : [];
+        })
+      : undefined;
+  const codexTurnVerificationTimelineArtifacts =
+    args.currentPr &&
+    args.codexVerificationCommand &&
+    codexTurnVerificationHeadSha
+      ? upsertTimelineArtifact(
+          args.record,
+          {
+            type: "verification_result",
+            gate: "codex_turn",
+            command: args.codexVerificationCommand,
+            head_sha: codexTurnVerificationHeadSha,
+            outcome: "passed",
+            remediation_target: null,
+            next_action: "continue",
+            summary: conciseCodexVerificationSummary(args.structuredSummary),
+            recorded_at: new Date().toISOString(),
+            ...(codexTurnVerificationRepairTargets
+              ? {
+                  repair_targets: codexTurnVerificationRepairTargets,
+                  processed_review_thread_ids: codexTurnVerificationReviewThreadIds ?? [],
+                  processed_review_thread_fingerprints: codexTurnVerificationReviewThreadFingerprints ?? [],
+                }
+              : {}),
+          },
+          (candidate) =>
+            candidate.type === "verification_result" &&
+            candidate.gate === "codex_turn" &&
+            candidate.outcome === "passed" &&
+            candidate.head_sha === codexTurnVerificationHeadSha &&
+            candidate.command === args.codexVerificationCommand &&
+            sameRepairTargets(candidate.repair_targets, codexTurnVerificationRepairTargets) &&
+            sameStringList(candidate.processed_review_thread_ids, codexTurnVerificationReviewThreadIds) &&
+            sameStringList(
+              candidate.processed_review_thread_fingerprints,
+              codexTurnVerificationReviewThreadFingerprints,
+            ),
+        )
+      : null;
+  return codexTurnVerificationTimelineArtifacts;
+}


### PR DESCRIPTION
## Summary
- Extract post-publication review-thread persistence and follow-up patch preparation into `turn-execution-post-publication-review`.
- Move codex-turn verification timeline artifact assembly into the same post-publication review boundary.
- Keep `executeCodexTurnPhase` focused on orchestration while preserving current-head no-source-change review evidence behavior.

Closes #2366

## Verification
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsx --test src/run-once-turn-execution.test.ts src/post-turn-pull-request-codex-connector.test.ts`
- `npx tsx --test src/family-directory-layout.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2366 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`
- `git diff --check`