### PR TITLE
[codex] Fix CLEAN metadata-only review residue handling

### DIFF
--- a/src/decision-kernel-v2.test.ts
+++ b/src/decision-kernel-v2.test.ts
@@ -221,15 +221,23 @@ test("evaluateDecisionKernelV2ReadOnly snapshots normalized state", () => {
   assert.notEqual(decision.normalizedState.evidence, normalizedState.evidence);
 });
 
-test("evaluateDecisionKernelV2ReadOnly keeps metadata residue distinct from source repair", () => {
+test("evaluateDecisionKernelV2ReadOnly treats clean metadata-only residue as merge-ready", () => {
   const decision = evaluateDecisionKernelV2ReadOnly({
-    normalizedState: state(),
+    normalizedState: state({
+      reviewThreads: {
+        unresolvedManualThreadCount: 0,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+        stalePreviousHeadConfiguredBotThreadCount: 0,
+        metadataOnlyUnresolvedThreadCount: 1,
+      },
+    }),
     reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
   });
 
-  assert.equal(decision.action, "ask_operator");
-  assert.deepEqual(decision.reasons, ["metadata_only_review_residue"]);
-  assert.deepEqual(decision.requiredEvidence, ["resolved_metadata_residue"]);
+  assert.equal(decision.normalizedState.reviewPosture, "metadata_only_unresolved");
+  assert.equal(decision.action, "merge");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.deepEqual(decision.requiredEvidence, []);
 });
 
 test("evaluateDecisionKernelV2ReadOnly honors manual review blockers before bot repairs", () => {
@@ -395,12 +403,41 @@ test("evaluateDecisionKernelV2ReadOnly fails closed on mismatched review policy 
   assert.deepEqual(decision.requiredEvidence, ["matching_review_policy_input"]);
 });
 
-test("evaluateDecisionKernelV2ReadOnly treats configured-bot residue as metadata cleanup", () => {
+test("evaluateDecisionKernelV2ReadOnly does not block clean PRs on configured-bot metadata residue", () => {
   const decision = evaluateDecisionKernelV2ReadOnly({
     normalizedState: state(),
     reviewPolicyInput: reviewPolicyInput(["configured_bot_thread"]),
   });
 
+  assert.equal(decision.action, "merge");
+  assert.deepEqual(decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.deepEqual(decision.requiredEvidence, []);
+});
+
+test("evaluateDecisionKernelV2ReadOnly keeps metadata residue blocking when GitHub is not clean", () => {
+  const decision = evaluateDecisionKernelV2ReadOnly({
+    normalizedState: state({
+      pullRequest: {
+        number: 2300,
+        headSha: "head-current",
+        state: "OPEN",
+        isDraft: false,
+        mergeStateStatus: "BLOCKED",
+        mergeable: "MERGEABLE",
+        currentHeadReviewObservedAt: "2026-06-08T00:01:00.000Z",
+        currentHeadReviewHeadSha: "head-current",
+      },
+      reviewThreads: {
+        unresolvedManualThreadCount: 0,
+        unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+        stalePreviousHeadConfiguredBotThreadCount: 0,
+        metadataOnlyUnresolvedThreadCount: 1,
+      },
+    }),
+    reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+  });
+
+  assert.equal(decision.normalizedState.mergeability, "unknown");
   assert.equal(decision.action, "ask_operator");
   assert.deepEqual(decision.reasons, ["metadata_only_review_residue"]);
   assert.deepEqual(decision.requiredEvidence, ["resolved_metadata_residue"]);

--- a/src/decision-kernel-v2.ts
+++ b/src/decision-kernel-v2.ts
@@ -247,15 +247,6 @@ function selectReadOnlyDecision(
     return decision("wait", ["checks_unknown"], ["green_checks"], "Required check status is unknown.");
   }
 
-  if (state.reviewPosture === "metadata_only_unresolved" || reviewPolicy.metadataOnly > 0) {
-    return decision(
-      "ask_operator",
-      ["metadata_only_review_residue"],
-      ["resolved_metadata_residue"],
-      "Unresolved review metadata remains after source repair evidence.",
-    );
-  }
-
   if (state.reviewPosture === "stale_previous_head_review" || reviewPolicy.staleCommit > 0) {
     return decision(
       "wait",
@@ -270,7 +261,8 @@ function selectReadOnlyDecision(
     state.localStateFreshness === "fresh" &&
     (state.reviewPosture === "current_head_review_observed" ||
       state.reviewPosture === "no_unresolved_review" ||
-      (state.reviewPosture === "review_blocked" && reviewPolicyAllowsAdvisoryOnly(reviewPolicy))) &&
+      state.reviewPosture === "metadata_only_unresolved" ||
+      (state.reviewPosture === "review_blocked" && reviewPolicyAllowsNonBlockingReviewResidue(reviewPolicy))) &&
     (state.checkPosture === "green" || checkPolicy.noChecksAndNoLocalCi) &&
     !checkPolicy.mergeReadyBlockedByRequiredChecks &&
     !checkPolicy.mergeReadyBlockedByLocalCi &&
@@ -278,6 +270,18 @@ function selectReadOnlyDecision(
     state.mergeability === "mergeable"
   ) {
     return decision("merge", ["merge_ready_diagnostic_only"], [], "PR appears merge-ready.");
+  }
+
+  if (
+    (state.reviewPosture === "metadata_only_unresolved" || reviewPolicy.metadataOnly > 0) &&
+    state.mergeability !== "mergeable"
+  ) {
+    return decision(
+      "ask_operator",
+      ["metadata_only_review_residue"],
+      ["resolved_metadata_residue"],
+      "Unresolved review metadata remains after source repair evidence.",
+    );
   }
 
   return decision(
@@ -355,13 +359,12 @@ function isCurrentHeadMustFixBoundary(outcome: ReviewPolicyBoundaryOutcome): boo
   return outcome === "must_fix_current_head" || outcome === "escalated_p3";
 }
 
-function reviewPolicyAllowsAdvisoryOnly(reviewPolicy: ReviewPolicyBoundarySummary): boolean {
+function reviewPolicyAllowsNonBlockingReviewResidue(reviewPolicy: ReviewPolicyBoundarySummary): boolean {
   return (
     reviewPolicy.hasInput &&
     reviewPolicy.hasCodexProvider &&
     !reviewPolicy.inputMismatch &&
     reviewPolicy.currentHeadMustFix === 0 &&
-    reviewPolicy.metadataOnly === 0 &&
     reviewPolicy.manual === 0 &&
     reviewPolicy.staleCommit === 0
   );

--- a/src/decision-kernel/v2-pr-lifecycle-action.test.ts
+++ b/src/decision-kernel/v2-pr-lifecycle-action.test.ts
@@ -585,7 +585,46 @@ test("evaluateDecisionKernelV2PrLifecycleAction promotes stale review residue af
   });
 });
 
-test("evaluateDecisionKernelV2PrLifecycleAction treats processed metadata-only residue as terminal operator cleanup", () => {
+test("evaluateDecisionKernelV2PrLifecycleAction promotes CLEAN metadata-only residue to merge-ready", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        reviewThreads: {
+          unresolvedManualThreadCount: 0,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+          stalePreviousHeadConfiguredBotThreadCount: 0,
+          metadataOnlyUnresolvedThreadCount: 1,
+        },
+      }),
+    ),
+    reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+    checkPolicyInput: {
+      mergeReadyBlockedByRequiredChecks: false,
+      mergeReadyBlockedByLocalCi: false,
+      mergeReadyBlockedByFinalGuard: false,
+    },
+  });
+
+  assert.equal(decision.v2Decision.action, "merge");
+  assert.deepEqual(decision.v2Decision.reasons, ["merge_ready_diagnostic_only"]);
+  assert.equal(decision.v2Decision.normalizedState.reviewPosture, "metadata_only_unresolved");
+  assert.equal(decision.action, "merge");
+  assert.deepEqual(decision.reasons, ["v2_merge_ready"]);
+  assert.deepEqual(decision.evidenceTokens, [
+    "v2_reason=merge_ready_diagnostic_only",
+    "gate=head_sha:current_head",
+    "gate=local_state:fresh",
+    "gate=review:metadata_only_unresolved",
+    "gate=checks:green",
+    "gate=mergeability:mergeable",
+    "gate=required_checks:passed",
+    "gate=local_verification:passed",
+    "gate=final_guard:passed",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction still requires merge gate evidence for metadata-only residue", () => {
   const decision = evaluateDecisionKernelV2PrLifecycleAction({
     mode: "pr_lifecycle_action_taking",
     normalizedState: normalizePrLifecycleFacts(
@@ -601,6 +640,51 @@ test("evaluateDecisionKernelV2PrLifecycleAction treats processed metadata-only r
     reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
   });
 
+  assert.equal(decision.v2Decision.action, "merge");
+  assert.equal(decision.action, "ask_operator");
+  assert.deepEqual(decision.reasons, ["v2_merge_gate_evidence_missing"]);
+  assert.deepEqual(decision.evidenceTokens, [
+    "missing=merge_gate_input",
+    "v2_reason=merge_ready_diagnostic_only",
+    "gate=head_sha:current_head",
+    "gate=local_state:fresh",
+    "gate=review:metadata_only_unresolved",
+    "gate=checks:green",
+    "gate=mergeability:mergeable",
+    "gate=required_checks:missing",
+    "gate=local_verification:missing",
+    "gate=final_guard:missing",
+  ]);
+});
+
+test("evaluateDecisionKernelV2PrLifecycleAction keeps metadata-only residue terminal when GitHub is blocked", () => {
+  const decision = evaluateDecisionKernelV2PrLifecycleAction({
+    mode: "pr_lifecycle_action_taking",
+    normalizedState: normalizePrLifecycleFacts(
+      inventory({
+        pullRequest: {
+          number: 2312,
+          headSha: "head-current",
+          state: "OPEN",
+          isDraft: false,
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+          currentHeadReviewObservedAt: "2026-06-09T00:01:00.000Z",
+          currentHeadReviewHeadSha: "head-current",
+        },
+        reviewThreads: {
+          unresolvedManualThreadCount: 0,
+          unresolvedCurrentHeadConfiguredBotThreadCount: 0,
+          stalePreviousHeadConfiguredBotThreadCount: 0,
+          metadataOnlyUnresolvedThreadCount: 1,
+        },
+      }),
+    ),
+    reviewPolicyInput: reviewPolicyInput(["metadata_only_unresolved"]),
+  });
+
+  assert.equal(decision.v2Decision.action, "ask_operator");
+  assert.deepEqual(decision.v2Decision.reasons, ["metadata_only_review_residue"]);
   assert.equal(decision.action, "ask_operator");
   assert.deepEqual(decision.reasons, ["v2_metadata_terminal"]);
   assert.deepEqual(decision.evidenceTokens, [


### PR DESCRIPTION
## Summary

- Allow Decision Kernel v2 to treat verified metadata-only configured-bot residue as non-blocking when the PR is otherwise CLEAN / MERGEABLE and merge-safety gates pass.
- Keep metadata-only residue as a blocking terminal cleanup when GitHub is not clean, preserving the required-conversation-resolution blocker shape.
- Add read-only and PR lifecycle action regressions for the #2370 shape, including explicit merge-gate handling.

## Root Cause

The v2 policy vocabulary already distinguished metadata-only residue from current-head source-repair findings, but `evaluateDecisionKernelV2ReadOnly` evaluated `metadata_only_unresolved` before the merge-ready branch. That meant unresolved configured-bot metadata could become an operator-blocking terminal cleanup even when GitHub mergeability and Codex Connector convergence said the PR was ready.

## Validation

- `npx tsx --test src/decision-kernel-v2.test.ts src/decision-kernel/v2-pr-lifecycle-action.test.ts`
- `npx tsx --test src/codex-connector-review-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts`
- `npx tsx --test src/decision-kernel-v2*.test.ts src/decision-kernel/*.test.ts src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts src/supervisor/replay-corpus.test.ts src/run-once*.test.ts src/post-turn-pull-request*.test.ts`
- `npm run build`
- `node dist/index.js issue-lint 2370 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json`

Fixes #2370