### PR TITLE
[codex] Preserve recovered Codex review residue readiness

### DIFF
--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -229,6 +229,52 @@ export function staleSameHeadCodexWaitHasOnlyOutdatedResidue(
   );
 }
 
+function recordForCodexStaleReviewMetadataClassification(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): IssueRunRecord | null {
+  if (args.record.blocked_reason === "stale_review_bot" || args.record.blocked_reason === "manual_review") {
+    return args.record;
+  }
+
+  if (args.record.blocked_reason !== null || !configuredReviewProviderKinds(args.config).includes("codex")) {
+    return null;
+  }
+
+  if (!pullRequestHeadMatchesRecord(args.record, args.pr)) {
+    return null;
+  }
+
+  const processedThreadEvidenceCount =
+    (args.record.processed_review_thread_ids ?? []).length +
+    (args.record.processed_review_thread_fingerprints ?? []).length;
+  if (processedThreadEvidenceCount === 0) {
+    return null;
+  }
+
+  const currentConfiguredThreads = configuredBotReviewThreads(args.config, args.reviewThreads)
+    .filter((thread) => !thread.isResolved && !thread.isOutdated);
+  if (currentConfiguredThreads.length === 0) {
+    return null;
+  }
+
+  if (!currentConfiguredThreads.every(hasCodexConnectorFindingReviewComment)) {
+    return null;
+  }
+
+  if (!currentConfiguredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))) {
+    return null;
+  }
+
+  return {
+    ...args.record,
+    blocked_reason: "stale_review_bot",
+  };
+}
+
 export function hasProvenCodexConnectorStaleReviewMetadata(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -236,9 +282,18 @@ export function hasProvenCodexConnectorStaleReviewMetadata(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): boolean {
+  if (!configuredReviewProviderKinds(args.config).includes("codex")) {
+    return false;
+  }
+
+  const recordForClassification = recordForCodexStaleReviewMetadataClassification(args);
+  if (!recordForClassification) {
+    return false;
+  }
+
   const remediation = buildStaleReviewBotRemediation({
     config: args.config,
-    record: args.record,
+    record: recordForClassification,
     pr: args.pr,
     checks: args.checks,
     reviewThreads: args.reviewThreads,

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -478,7 +478,8 @@ test("inferStateFromPullRequest advances past proven Codex Connector stale metad
     commentId: "comment-current-head-no-major",
     path: "src/current-head-proof.ts",
     line: 42,
-    commentBody: "P1: This older inline finding should not outvote current-head no-major evidence.",
+    severity: "P2",
+    commentBody: "P2: This older inline finding should not outvote current-head no-major evidence.",
     discussionUrl: "https://example.test/pr/117#discussion_r117",
     verifiedRepair: {
       summary: "Focused current-head verifier passed.",
@@ -499,6 +500,64 @@ test("inferStateFromPullRequest advances past proven Codex Connector stale metad
     ...scenario.recordPatch,
     copilot_review_timed_out_at: null,
     copilot_review_timeout_action: null,
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotLatestReviewedCommitSha: "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770",
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    "ready_to_merge",
+  );
+  assert.equal(
+    blockedReasonFromReviewState(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    null,
+  );
+});
+
+test("inferStateFromPullRequest keeps recovered Codex stale metadata residue merge-ready", () => {
+  const issueNumber = 2098;
+  const prNumber = 118;
+  const headSha = "9ba6e1cf234dd5630a2ee527cd575bebd02fbeec";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-recovered-metadata",
+    commentId: "comment-recovered-metadata",
+    path: "src/current-head-proof.ts",
+    line: 42,
+    severity: "P2",
+    commentBody: "P2: This current-head residue was already repaired and verified.",
+    discussionUrl: "https://example.test/pr/118#discussion_r118",
+    verifiedRepair: {
+      summary: "Configured local CI command passed before auto-merging PR #118.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npm run verify:pre-pr",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+    last_error: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+    repeated_failure_signature_count: 0,
+    last_recovery_reason:
+      `tracked_pr_lifecycle_recovered: resumed issue #${issueNumber} from blocked to ready_to_merge using fresh tracked PR #${prNumber} facts at head ${headSha}`,
+    last_recovery_at: "2026-05-15T00:19:00Z",
+    last_tracked_pr_progress_summary:
+      `no_progress_review_loop current_unresolved_threads=1 processed_review_threads=1 head=${headSha}`,
   });
   const pr = createPullRequest({
     ...scenario.pullRequestPatch,

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -252,6 +252,81 @@ test("derivePullRequestLifecycleSnapshot keeps queued ready-promotion path hygie
   assert.deepEqual(snapshot.failureContext?.details, ["Actionable file: docs/guide.md"]);
 });
 
+test("derivePullRequestLifecycleSnapshot keeps recovered Codex stale metadata residue merge-ready", () => {
+  const headSha = "9ba6e1cf234dd5630a2ee527cd575bebd02fbeec";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    issue_number: 391,
+    state: "ready_to_merge",
+    pr_number: 398,
+    last_head_sha: headSha,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+    repeated_failure_signature_count: 0,
+    processed_review_thread_ids: [`thread-recovered@${headSha}`],
+    processed_review_thread_fingerprints: [`thread-recovered@${headSha}#comment-recovered`],
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #398.",
+      ran_at: "2026-06-13T13:40:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+    codex_connector_review_requested_observed_at: "2026-06-13T13:34:00Z",
+    codex_connector_review_requested_head_sha: headSha,
+    last_recovery_reason:
+      `tracked_pr_lifecycle_recovered: resumed issue #391 from blocked to ready_to_merge using fresh tracked PR #398 facts at head ${headSha}`,
+    last_recovery_at: "2026-06-13T13:41:03Z",
+    last_tracked_pr_progress_summary:
+      `no_progress_review_loop current_unresolved_threads=5 processed_review_threads=5 head=${headSha}`,
+  });
+  const pr = createPullRequest({
+    number: 398,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-13T13:40:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-13T13:38:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770",
+    codexConnectorReviewRequestedAt: "2026-06-13T13:34:00Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+  });
+  const checks: PullRequestCheck[] = [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-recovered",
+      comments: {
+        nodes: [
+          {
+            id: "comment-recovered",
+            body: "P2: This current-head residue was already repaired and verified.",
+            createdAt: "2026-06-13T13:35:00Z",
+            url: "https://example.test/pr/398#discussion_recovered",
+            author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const snapshot = derivePullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads);
+
+  assert.equal(snapshot.nextState, "ready_to_merge");
+  assert.equal(snapshot.failureContext, null);
+  assert.equal(snapshot.recordForState.blocked_reason, null);
+});
+
 test("derivePullRequestLifecycleSnapshot keeps CodeRabbit repos in waiting_ci during the short current-head quiet period", () => {
   withStubbedDateNow("2026-03-13T02:04:03Z", () => {
     const config = createConfig({


### PR DESCRIPTION
## Summary
- Keep recovered Codex Connector stale-review metadata residue from being reclassified as actionable review work after `tracked_pr_lifecycle_recovered` clears `blocked_reason`.
- Extend state inference to classify processed current-head Codex residue even after the local stale blocker has been cleared, while preserving the existing P2/current-head verification gates.
- Add regression coverage at both pull-request state inference and supervisor lifecycle snapshot layers.

## Root cause
#2371 fixed the v2 decision path while the record was still `blocked_reason=stale_review_bot`. In the HRCore loop, recovery briefly moved #391 / PR #398 to `ready_to_merge` and cleared `blocked_reason`; the next lifecycle pass then lost the proven stale-metadata classification and treated the same unresolved GitHub review-thread metadata as fresh actionable work.

The first CI run also exposed a mixed-provider replay-corpus boundary: the new recovered-residue path must apply only to Codex Connector review comments, not to Copilot/CodeRabbit configured-bot threads. The branch now gates the recovered classification on actual Codex Connector finding comments.

## Validation
- `npx tsx src/index.ts replay-corpus`
- `npx tsx --test src/pull-request-state-policy.test.ts src/supervisor/supervisor-lifecycle.test.ts`
- `npx tsx --test src/pull-request-state-policy.test.ts src/supervisor/supervisor-lifecycle.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/post-turn-pull-request*.test.ts src/run-once*.test.ts src/supervisor/*status*.test.ts src/supervisor/*explain*.test.ts src/supervisor/replay-corpus.test.ts`
- `npx tsx --test src/decision-kernel-v2.test.ts src/decision-kernel/v2-pr-lifecycle-action.test.ts`
- `npm run build`

Follow-up to #2370 / #2371.