### PR TITLE
[codex] Treat verified Codex review residue as merge-ready

### DIFF
--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -524,8 +524,9 @@ test("buildDecisionKernelV2ExplainDto requires Codex no-major evidence for Codex
       provider_success_head_sha: "head-current",
     }),
     pr: pullRequest({
-      configuredBotCurrentHeadObservedAt: null,
-      configuredBotCurrentHeadObservationSource: null,
+      configuredBotCurrentHeadObservedAt: "2026-06-08T00:06:00.000Z",
+      configuredBotCurrentHeadObservationSource: "review_thread",
+      configuredBotCurrentHeadStatusState: "SUCCESS",
       configuredBotLatestReviewedCommitSha: null,
     }),
     checks: [{ name: "build", state: "SUCCESS", bucket: "pass" }],
@@ -535,6 +536,44 @@ test("buildDecisionKernelV2ExplainDto requires Codex no-major evidence for Codex
   assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
   assert.equal(dto.decision?.action, "ask_operator");
   assert.deepEqual(dto.decision?.reasons, ["insufficient_merge_evidence"]);
+});
+
+test("buildDecisionKernelV2ExplainDto treats verified current-head repair residue as Codex no-major evidence", () => {
+  const dto = buildDecisionKernelV2ExplainDto({
+    config: codexConfig({
+      codexConnectorAutoMergeEnabled: true,
+      configuredBotInitialGraceWaitSeconds: 0,
+      configuredBotSettledWaitSeconds: 0,
+      verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+    }),
+    issueNumber: 2301,
+    title: "Phase 3.2",
+    record: record({
+      processed_review_thread_ids: ["thread-codex-p2@head-current"],
+      processed_review_thread_fingerprints: ["thread-codex-p2@head-current#comment-codex-p2"],
+      latest_local_ci_result: {
+        outcome: "passed",
+        summary: "Focused verifier passed after the repair commit.",
+        ran_at: "2026-06-08T00:06:00.000Z",
+        head_sha: "head-current",
+        execution_mode: "shell",
+        command: "npm test -- src/decision-kernel/v2-explain.test.ts",
+        failure_class: null,
+        remediation_target: null,
+      },
+    }),
+    pr: pullRequest({
+      configuredBotCurrentHeadObservedAt: "2026-06-08T00:06:00.000Z",
+      configuredBotCurrentHeadObservationSource: "review_thread",
+      configuredBotCurrentHeadStatusState: "SUCCESS",
+      configuredBotLatestReviewedCommitSha: null,
+    }),
+    checks: [{ name: "build", state: "SUCCESS", bucket: "pass" }],
+    reviewThreads: [codexMustFixThread()],
+  });
+
+  assert.equal(dto.decision?.normalizedState.reviewPosture, "current_head_review_observed");
+  assert.equal(dto.decision?.action, "merge");
 });
 
 test("buildDecisionKernelV2ExplainDto does not require Codex no-major evidence on configured-provider auto-merge paths", () => {

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -551,16 +551,19 @@ test("buildDecisionKernelV2ExplainDto treats verified current-head repair residu
     record: record({
       processed_review_thread_ids: ["thread-codex-p2@head-current"],
       processed_review_thread_fingerprints: ["thread-codex-p2@head-current#comment-codex-p2"],
-      latest_local_ci_result: {
-        outcome: "passed",
-        summary: "Focused verifier passed after the repair commit.",
-        ran_at: "2026-06-08T00:06:00.000Z",
-        head_sha: "head-current",
-        execution_mode: "shell",
-        command: "npm test -- src/decision-kernel/v2-explain.test.ts",
-        failure_class: null,
-        remediation_target: null,
-      },
+      timeline_artifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npm test -- src/decision-kernel/v2-explain.test.ts",
+          head_sha: "head-current",
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed after the repair commit.",
+          recorded_at: "2026-06-08T00:06:00.000Z",
+        },
+      ],
     }),
     pr: pullRequest({
       configuredBotCurrentHeadObservedAt: "2026-06-08T00:06:00.000Z",

--- a/src/decision-kernel/v2-explain.ts
+++ b/src/decision-kernel/v2-explain.ts
@@ -31,6 +31,7 @@ import {
 import {
   effectiveConfiguredBotReviewThreadsForState,
   hasConfiguredProviderSuccess,
+  hasVerifiedCurrentHeadRepairReviewMetadataResidue,
 } from "../pull-request-state-codex-residue-policy";
 import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
 import { mergeConflictDetected } from "../supervisor/supervisor-reporting";
@@ -466,12 +467,21 @@ function mergeReadyBlockedByFinalGuard(args: {
 
   const autoMergePath = autoMergePathForConfig(args.config);
   const requiresCodexNoMajor = autoMergePath === "codex_connector_no_major";
+  const currentHeadCodexNoMajor =
+    hasCurrentHeadCodexNoMajor(args.record, args.pr) ||
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads,
+    });
 
   if (args.config.humanReviewBlocksMerge && isBlockingHumanReviewDecision(args.pr, requiresCodexNoMajor)) {
     return true;
   }
 
-  if (requiresCodexNoMajor && !hasCurrentHeadCodexNoMajor(args.record, args.pr)) {
+  if (requiresCodexNoMajor && !currentHeadCodexNoMajor) {
     return true;
   }
 

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -311,7 +311,7 @@ test("selectStatusOperatorAction treats merge-ready verified current-head repair
       detailedStatusLines: [
         "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
         "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
-        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#391 pr=#398",
         "tracked_pr_mismatch issue=#391 pr=#398 recoverability=stale_already_handled github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes",
       ],
     }),
@@ -324,13 +324,53 @@ test("selectStatusOperatorAction treats merge-ready verified current-head repair
   );
 });
 
+test("selectStatusOperatorAction correlates verified current-head repair residue by PR", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
+        "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#392 pr=#399",
+        "tracked_pr_mismatch issue=#391 pr=#398 recoverability=stale_already_handled github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes",
+      ],
+    }),
+    {
+      action: "resolve_stale_review_bot",
+      source: "stale_review_bot_remediation",
+      priority: 72,
+      summary:
+        "Code or CI is green but configured-bot review thread metadata is still unresolved; inspect the exact thread and resolve it or leave a manual note without changing merge policy.",
+    },
+  );
+});
+
+test("selectStatusOperatorAction keeps manual stale-review action when verified repair residue is suppressed", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
+        "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=manual_or_unconfigured_review_threads",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#391 pr=#398",
+        "tracked_pr_mismatch issue=#391 pr=#398 recoverability=stale_already_handled github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes",
+      ],
+    }),
+    {
+      action: "resolve_stale_review_bot",
+      source: "stale_review_bot_remediation",
+      priority: 72,
+      summary:
+        "Code or CI is green but configured-bot review thread metadata is still unresolved; inspect the exact thread and resolve it or leave a manual note without changing merge policy.",
+    },
+  );
+});
+
 test("selectStatusOperatorAction keeps manual stale-review action when GitHub still blocks the PR", () => {
   assert.deepEqual(
     selectStatusOperatorAction({
       detailedStatusLines: [
         "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
         "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
-        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#391 pr=#398",
         "tracked_pr_mismatch issue=#391 pr=#398 recoverability=manual_attention_required github_state=blocked github_blocked_reason=stale_review_bot local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes",
       ],
     }),

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -343,6 +343,26 @@ test("selectStatusOperatorAction accepts terminal merge-ready evidence for manua
   );
 });
 
+test("selectStatusOperatorAction suppresses stale manual-review metrics for merge-ready verified repair residue", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
+        "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
+        "stale_review_bot_terminal_stop issue=#391 pr=#398 reason=metadata_only_review_thread_resolution_pending classification=verified_current_head_repair_pending_thread_resolution head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:5,must_fix:5,verified_residue:5 auto_repair_suppressed_reason=none next_action=merge_ready",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#391 pr=#398",
+        "execution_metrics terminal_state=blocked outcome=blocked reason=manual_review run_duration_ms=3600000 issue_lead_time_ms=4200000 issue_to_pr_created_ms=1200000 pr_open_duration_ms=none",
+      ],
+    }),
+    {
+      action: "continue",
+      source: "status",
+      priority: 0,
+      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+    },
+  );
+});
+
 test("selectStatusOperatorAction correlates verified current-head repair residue by PR", () => {
   assert.deepEqual(
     selectStatusOperatorAction({

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -305,6 +305,45 @@ test("selectStatusOperatorAction flags request-eligible Codex recovery instead o
   );
 });
 
+test("selectStatusOperatorAction treats merge-ready verified current-head repair residue as non-blocking", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
+        "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution",
+        "tracked_pr_mismatch issue=#391 pr=#398 recoverability=stale_already_handled github_state=ready_to_merge github_blocked_reason=none local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes",
+      ],
+    }),
+    {
+      action: "continue",
+      source: "status",
+      priority: 0,
+      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+    },
+  );
+});
+
+test("selectStatusOperatorAction keeps manual stale-review action when GitHub still blocks the PR", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
+        "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution",
+        "tracked_pr_mismatch issue=#391 pr=#398 recoverability=manual_attention_required github_state=blocked github_blocked_reason=stale_review_bot local_state=blocked local_blocked_reason=stale_review_bot stale_local_blocker=yes",
+      ],
+    }),
+    {
+      action: "resolve_stale_review_bot",
+      source: "stale_review_bot_remediation",
+      priority: 72,
+      summary:
+        "Code or CI is green but configured-bot review thread metadata is still unresolved; inspect the exact thread and resolve it or leave a manual note without changing merge policy.",
+    },
+  );
+});
+
 test("buildStatusOperatorCockpitViewModel carries the shared action contract and evidence", () => {
   assert.deepEqual(
     buildStatusOperatorCockpitViewModel({

--- a/src/operator-actions.test.ts
+++ b/src/operator-actions.test.ts
@@ -324,6 +324,25 @@ test("selectStatusOperatorAction treats merge-ready verified current-head repair
   );
 });
 
+test("selectStatusOperatorAction accepts terminal merge-ready evidence for manual-review residue", () => {
+  assert.deepEqual(
+    selectStatusOperatorAction({
+      detailedStatusLines: [
+        "stale_review_bot_remediation issue=#391 pr=#398 reason=stale_review_bot code_ci=green current_head_sha=head-current processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https://example.test/pr/398#discussion_r398 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Configured_local_CI_passed.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending",
+        "stale_review_bot_thread_diagnostics issue=#391 pr=#398 current_head_success=yes unresolved_current_threads=5 actionable_must_fix_threads=5 verified_stale_residue_threads=5 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=none",
+        "stale_review_bot_terminal_stop issue=#391 pr=#398 reason=metadata_only_review_thread_resolution_pending classification=verified_current_head_repair_pending_thread_resolution head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:5,must_fix:5,verified_residue:5 auto_repair_suppressed_reason=none next_action=merge_ready",
+        "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=head-current current_head_observed_at=2026-06-14T00:00:00Z latest_signal_head_sha=head-current highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#391 pr=#398",
+      ],
+    }),
+    {
+      action: "continue",
+      source: "status",
+      priority: 0,
+      summary: "No blocking operator action was detected; continue normal supervisor operation.",
+    },
+  );
+});
+
 test("selectStatusOperatorAction correlates verified current-head repair residue by PR", () => {
   assert.deepEqual(
     selectStatusOperatorAction({

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -301,6 +301,28 @@ function hasUnblockedActiveIssueState(lines: string[]): boolean {
   return lines.some((line) => /^blocked_reason=none$/u.test(line));
 }
 
+function hasVerifiedCurrentHeadRepairResidueMergeReadyDiagnostic(lines: string[]): boolean {
+  return (
+    lines.some((line) =>
+      /^tracked_pr_mismatch\b/u.test(line) &&
+        /\bgithub_state=ready_to_merge\b/u.test(line) &&
+        /\bgithub_blocked_reason=none\b/u.test(line),
+    ) &&
+    lines.some((line) =>
+      /^codex_connector_convergence\b/u.test(line) &&
+        /\bmerge_effect=ready\b/u.test(line) &&
+        /\bnext_action=merge_ready\b/u.test(line) &&
+        /\bstale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution\b/u.test(line),
+    ) &&
+    lines.some((line) =>
+      /^stale_review_bot_thread_diagnostics\b/u.test(line) &&
+        /\bverified_stale_residue_threads=[1-9]\d*\b/u.test(line) &&
+        /\bmissing_verification_evidence_threads=0\b/u.test(line) &&
+        /\bauto_repair_suppressed_reason=none\b/u.test(line),
+    )
+  );
+}
+
 export function parseOperatorActionLine(line: string): OperatorAction | null {
   if (!/^(operator_action|doctor_operator_action)\b/u.test(line)) {
     return null;
@@ -485,6 +507,7 @@ export function selectStatusOperatorAction(args: {
     requestEligibleRecoverySelectedIssues,
   );
   const ignoreStaleManualReviewExecutionMetrics = hasUnblockedActiveIssueState(contextLines);
+  const verifiedRepairResidueMergeReady = hasVerifiedCurrentHeadRepairResidueMergeReadyDiagnostic(contextLines);
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
@@ -588,6 +611,12 @@ export function selectStatusOperatorAction(args: {
     }
 
     if (/^stale_review_bot_remediation\b/.test(line)) {
+      if (
+        verifiedRepairResidueMergeReady &&
+        /\bclassification=verified_current_head_repair_pending_thread_resolution\b/u.test(line)
+      ) {
+        continue;
+      }
       actions.push({
         action: "resolve_stale_review_bot",
         source: "stale_review_bot_remediation",

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -328,6 +328,16 @@ function verifiedCurrentHeadRepairResidueMergeReadyDiagnosticKeys(lines: string[
     }
 
     if (
+      /^stale_review_bot_terminal_stop\b/u.test(line) &&
+      /\bclassification=verified_current_head_repair_pending_thread_resolution\b/u.test(line) &&
+      /\bauto_repair_suppressed_reason=none\b/u.test(line) &&
+      /\bnext_action=merge_ready\b/u.test(line)
+    ) {
+      readyGitHubPrKeys.add(issuePrKey);
+      continue;
+    }
+
+    if (
       /^codex_connector_convergence\b/u.test(line) &&
       /\bmerge_effect=ready\b/u.test(line) &&
       /\bnext_action=merge_ready\b/u.test(line) &&

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -364,6 +364,23 @@ function verifiedCurrentHeadRepairResidueMergeReadyDiagnosticKeys(lines: string[
   );
 }
 
+function hasVerifiedCurrentHeadRepairResidueMergeReadyKeyForLine(
+  line: string,
+  keys: ReadonlySet<string>,
+): boolean {
+  const issuePrKey = readIssuePrKey(line);
+  if (issuePrKey !== null) {
+    return keys.has(issuePrKey);
+  }
+
+  const issueNumber = readIssueNumberToken(line, "issue");
+  if (issueNumber !== null) {
+    return [...keys].some((key) => key.startsWith(`${issueNumber}:`));
+  }
+
+  return keys.size === 1;
+}
+
 export function parseOperatorActionLine(line: string): OperatorAction | null {
   if (!/^(operator_action|doctor_operator_action)\b/u.test(line)) {
     return null;
@@ -680,6 +697,12 @@ export function selectStatusOperatorAction(args: {
       isManualReviewExecutionMetrics
     ) {
       if (isManualReviewExecutionMetrics && ignoreStaleManualReviewExecutionMetrics) {
+        continue;
+      }
+      if (
+        isManualReviewExecutionMetrics &&
+        hasVerifiedCurrentHeadRepairResidueMergeReadyKeyForLine(line, verifiedRepairResidueMergeReadyKeys)
+      ) {
         continue;
       }
       const issueNumber = readIssueNumberToken(line, "issue");

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -301,25 +301,56 @@ function hasUnblockedActiveIssueState(lines: string[]): boolean {
   return lines.some((line) => /^blocked_reason=none$/u.test(line));
 }
 
-function hasVerifiedCurrentHeadRepairResidueMergeReadyDiagnostic(lines: string[]): boolean {
-  return (
-    lines.some((line) =>
+function readIssuePrKey(line: string): string | null {
+  const issueNumber = readIssueNumberToken(line, "issue");
+  const prNumber = readIssueNumberToken(line, "pr");
+  return issueNumber === null || prNumber === null ? null : `${issueNumber}:${prNumber}`;
+}
+
+function verifiedCurrentHeadRepairResidueMergeReadyDiagnosticKeys(lines: string[]): ReadonlySet<string> {
+  const readyGitHubPrKeys = new Set<string>();
+  const mergeReadyConvergenceKeys = new Set<string>();
+  const unsuppressedDiagnosticsKeys = new Set<string>();
+
+  for (const line of lines) {
+    const issuePrKey = readIssuePrKey(line);
+    if (issuePrKey === null) {
+      continue;
+    }
+
+    if (
       /^tracked_pr_mismatch\b/u.test(line) &&
-        /\bgithub_state=ready_to_merge\b/u.test(line) &&
-        /\bgithub_blocked_reason=none\b/u.test(line),
-    ) &&
-    lines.some((line) =>
+      /\bgithub_state=ready_to_merge\b/u.test(line) &&
+      /\bgithub_blocked_reason=none\b/u.test(line)
+    ) {
+      readyGitHubPrKeys.add(issuePrKey);
+      continue;
+    }
+
+    if (
       /^codex_connector_convergence\b/u.test(line) &&
-        /\bmerge_effect=ready\b/u.test(line) &&
-        /\bnext_action=merge_ready\b/u.test(line) &&
-        /\bstale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution\b/u.test(line),
-    ) &&
-    lines.some((line) =>
+      /\bmerge_effect=ready\b/u.test(line) &&
+      /\bnext_action=merge_ready\b/u.test(line) &&
+      /\bstale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution\b/u.test(line)
+    ) {
+      mergeReadyConvergenceKeys.add(issuePrKey);
+      continue;
+    }
+
+    if (
       /^stale_review_bot_thread_diagnostics\b/u.test(line) &&
-        /\bverified_stale_residue_threads=[1-9]\d*\b/u.test(line) &&
-        /\bmissing_verification_evidence_threads=0\b/u.test(line) &&
-        /\bauto_repair_suppressed_reason=none\b/u.test(line),
-    )
+      /\bverified_stale_residue_threads=[1-9]\d*\b/u.test(line) &&
+      /\bmissing_verification_evidence_threads=0\b/u.test(line) &&
+      /\bauto_repair_suppressed_reason=none\b/u.test(line)
+    ) {
+      unsuppressedDiagnosticsKeys.add(issuePrKey);
+    }
+  }
+
+  return new Set(
+    [...readyGitHubPrKeys].filter(
+      (issuePrKey) => mergeReadyConvergenceKeys.has(issuePrKey) && unsuppressedDiagnosticsKeys.has(issuePrKey),
+    ),
   );
 }
 
@@ -507,7 +538,7 @@ export function selectStatusOperatorAction(args: {
     requestEligibleRecoverySelectedIssues,
   );
   const ignoreStaleManualReviewExecutionMetrics = hasUnblockedActiveIssueState(contextLines);
-  const verifiedRepairResidueMergeReady = hasVerifiedCurrentHeadRepairResidueMergeReadyDiagnostic(contextLines);
+  const verifiedRepairResidueMergeReadyKeys = verifiedCurrentHeadRepairResidueMergeReadyDiagnosticKeys(contextLines);
 
   for (const line of args.detailedStatusLines) {
     const clusteredChurnManualReviewSummary = clusteredCodexChurnManualReviewSummary(line);
@@ -612,7 +643,7 @@ export function selectStatusOperatorAction(args: {
 
     if (/^stale_review_bot_remediation\b/.test(line)) {
       if (
-        verifiedRepairResidueMergeReady &&
+        verifiedRepairResidueMergeReadyKeys.has(readIssuePrKey(line) ?? "") &&
         /\bclassification=verified_current_head_repair_pending_thread_resolution\b/u.test(line)
       ) {
         continue;

--- a/src/operator-actions.ts
+++ b/src/operator-actions.ts
@@ -349,7 +349,9 @@ function verifiedCurrentHeadRepairResidueMergeReadyDiagnosticKeys(lines: string[
 
     if (
       /^stale_review_bot_thread_diagnostics\b/u.test(line) &&
-      /\bverified_stale_residue_threads=[1-9]\d*\b/u.test(line) &&
+      (/\bverified_stale_residue_threads=[1-9]\d*\b/u.test(line) ||
+        (/\bunresolved_current_threads=0\b/u.test(line) &&
+          /\bactionable_must_fix_threads=0\b/u.test(line))) &&
       /\bmissing_verification_evidence_threads=0\b/u.test(line) &&
       /\bauto_repair_suppressed_reason=none\b/u.test(line)
     ) {

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -13,6 +13,7 @@ import {
   CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
   createCodexConnectorTrackedReviewResidueScenario,
 } from "./codex-connector-tracked-pr-test-helpers";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./supervisor/stale-review-bot-remediation";
 import {
   SAMPLE_MACOS_WORKSTATION_PATH,
   SAMPLE_UNIX_WORKSTATION_PATH,
@@ -2356,6 +2357,15 @@ test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P
   assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-mechanical-repair"]);
   assert.deepEqual(resolveCalls, ["thread-codex-mechanical-repair"]);
   assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
+  assert.equal(
+    result.record.timeline_artifacts?.some(
+      (artifact) =>
+        artifact.head_sha === headSha &&
+        artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
+        artifact.processed_review_thread_ids?.includes(`thread-codex-mechanical-repair@${headSha}`) === true,
+    ),
+    true,
+  );
   assert.equal(requestComments.length, 0);
 });
 

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2231,6 +2231,130 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
   assert.equal(requestComments.length, 0);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase merges later same-head verified repair artifact keys", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue = createIssue({ title: "Merge same-head verified repair artifact keys" });
+  const headSha = "head-1989";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 1989,
+    headSha,
+    threadId: "thread-codex-repair-new",
+    commentId: "comment-codex-repair-new",
+    path: "src/review.ts",
+    line: 8,
+    severity: "P2",
+    commentBody: "P2: Verify the second repair residue before merge.",
+    discussionUrl: "https://example.test/pr/1989#discussion_r1989",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the second repair commit.",
+      ranAt: "2026-05-15T00:28:00Z",
+      command: "npm test -- src/post-turn-pull-request.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:22:00Z",
+      observedAt: "2026-05-15T00:27:00Z",
+    },
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        ...scenario.recordPatch,
+        timeline_artifacts: [
+          ...(scenario.recordPatch.timeline_artifacts ?? []),
+          {
+            type: "verification_result",
+            gate: "workspace_preparation",
+            command: null,
+            head_sha: headSha,
+            outcome: "passed",
+            remediation_target: null,
+            next_action: "continue",
+            summary: "Previous same-head verified repair residue was auto-resolved.",
+            recorded_at: "2026-05-15T00:21:00Z",
+            repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+            processed_review_thread_ids: [`thread-codex-repair-old@${headSha}`],
+            processed_review_thread_fingerprints: [`thread-codex-repair-old@${headSha}#comment-codex-repair-old`],
+          },
+        ],
+      }),
+    },
+  };
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  let snapshotLoads = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr,
+        checks: scenario.passingChecks,
+        reviewThreads: snapshotLoads <= 2 ? [scenario.reviewThread] : [],
+      };
+    },
+  });
+
+  const artifact = result.record.timeline_artifacts?.find(
+    (candidate) =>
+      candidate.head_sha === headSha &&
+      candidate.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+  );
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-repair-new"]);
+  assert.deepEqual(resolveCalls, ["thread-codex-repair-new"]);
+  assert.deepEqual(artifact?.processed_review_thread_ids?.sort(), [
+    `thread-codex-repair-new@${headSha}`,
+    `thread-codex-repair-old@${headSha}`,
+  ]);
+  assert.deepEqual(artifact?.processed_review_thread_fingerprints?.sort(), [
+    `thread-codex-repair-new@${headSha}#comment-codex-repair-new`,
+    `thread-codex-repair-old@${headSha}#comment-codex-repair-old`,
+  ]);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P2 repair residue without no-major signal", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -301,6 +301,32 @@ export function hasProvenCodexConnectorStaleReviewMetadata(args: {
   return remediation ? isProvenStaleReviewMetadataClassification(remediation.classification) : false;
 }
 
+export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  if (args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve !== true) {
+    return false;
+  }
+
+  const recordForClassification = recordForCodexStaleReviewMetadataClassification(args);
+  if (!recordForClassification) {
+    return false;
+  }
+
+  const remediation = buildStaleReviewBotRemediation({
+    config: args.config,
+    record: recordForClassification,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+  });
+  return remediation?.classification === "verified_current_head_repair_pending_thread_resolution";
+}
+
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -36,6 +36,7 @@ import {
   summarizeChecks,
 } from "./supervisor/supervisor-reporting";
 import {
+  buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
   isProvenStaleReviewMetadataClassification,
 } from "./supervisor/stale-review-bot-remediation";
@@ -324,7 +325,18 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     checks: args.checks,
     reviewThreads: args.reviewThreads,
   });
-  return remediation?.classification === "verified_current_head_repair_pending_thread_resolution";
+  if (remediation?.classification !== "verified_current_head_repair_pending_thread_resolution") {
+    return false;
+  }
+
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config: args.config,
+    record: recordForClassification,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+  });
+  return diagnostics?.autoRepairSuppressedReason === "none";
 }
 
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -38,6 +38,7 @@ import {
 import {
   buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
+  hasCurrentHeadVerifiedRepairResidueArtifact,
   isProvenStaleReviewMetadataClassification,
 } from "./supervisor/stale-review-bot-remediation";
 import {
@@ -326,6 +327,15 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
 
   if (!checksPresentAndGreen(args.checks)) {
     return false;
+  }
+
+  if (
+    configuredReviewProviderKinds(args.config).includes("codex") &&
+    pullRequestHeadMatchesRecord(args.record, args.pr) &&
+    codexConnectorMustFixReviewThreads(args.reviewThreads).length === 0 &&
+    hasCurrentHeadVerifiedRepairResidueArtifact(args.record, args.pr)
+  ) {
+    return true;
   }
 
   const recordForClassification = recordForCodexStaleReviewMetadataClassification(args);

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -11,6 +11,7 @@ import {
   evaluateCodexConnectorConvergencePolicy,
   hasCodexConnectorFindingReviewComment,
   hasCodexConnectorPrSuccessCurrentHeadObservation,
+  latestCodexConnectorPSeverity,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
 import {
@@ -30,6 +31,7 @@ import {
   configuredBotReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
+  nonActionableConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
 import {
   mergeConflictDetected,
@@ -51,6 +53,10 @@ import {
 function isIssueJournalThreadPath(thread: Pick<ReviewThread, "path">): boolean {
   const normalizedPath = thread.path?.replace(/\\/g, "/") ?? "";
   return /^\.codex-supervisor\/.+\/issue-journal\.md$/.test(normalizedPath);
+}
+
+function checksPresentAndGreen(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
+  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
 }
 
 function allowJournalOnlyConfiguredBotThreadException(
@@ -142,7 +148,14 @@ export function effectiveConfiguredBotReviewThreadsForState(
     pr,
     checks,
     reviewThreads,
-  })
+  }) ||
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    })
     ? []
     : effectiveConfiguredBotReviewThreads(config, record, pr, checks, reviewThreads);
 }
@@ -313,6 +326,10 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     return false;
   }
 
+  if (!checksPresentAndGreen(args.checks)) {
+    return false;
+  }
+
   const recordForClassification = recordForCodexStaleReviewMetadataClassification(args);
   if (!recordForClassification) {
     return false;
@@ -326,7 +343,10 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     reviewThreads: args.reviewThreads,
   });
   if (remediation?.classification !== "verified_current_head_repair_pending_thread_resolution") {
-    return false;
+    return hasExplicitVerifiedCurrentHeadRepairResidue({
+      ...args,
+      record: recordForClassification,
+    });
   }
 
   const diagnostics = buildStaleReviewBotThreadDiagnostics({
@@ -337,6 +357,76 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     reviewThreads: args.reviewThreads,
   });
   return diagnostics?.autoRepairSuppressedReason === "none";
+}
+
+function hasExplicitVerifiedCurrentHeadRepairResidue(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  if (!pullRequestHeadMatchesRecord(args.record, args.pr) || mergeConflictDetected(args.pr)) {
+    return false;
+  }
+
+  if (manualReviewThreads(args.config, args.reviewThreads).length > 0) {
+    return false;
+  }
+  if (nonActionableConfiguredBotReviewThreads(args.config, args.reviewThreads).length > 0) {
+    return false;
+  }
+
+  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads)
+    .filter((thread) => !thread.isResolved && !thread.isOutdated);
+  if (
+    configuredThreads.length === 0 ||
+    !configuredThreads.every(hasCodexConnectorFindingReviewComment) ||
+    !configuredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+  ) {
+    return false;
+  }
+
+  const mustFixThreads = codexConnectorMustFixReviewThreads(args.reviewThreads);
+  if (mustFixThreads.length === 0) {
+    return false;
+  }
+  if (!mustFixThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2")) {
+    return false;
+  }
+  if (!mustFixThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))) {
+    return false;
+  }
+
+  return hasExplicitCurrentHeadRepairVerification(args.record, args.pr);
+}
+
+function hasExplicitCurrentHeadRepairVerification(
+  record: Pick<IssueRunRecord, "latest_local_ci_result" | "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  const hasMarkedNoSourceChangeRepair = (record.timeline_artifacts ?? []).some(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") === true,
+  );
+  const hasCodexTurnRepairVerification = (record.timeline_artifacts ?? []).some(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true,
+  );
+  const hasLocalCiRepairVerification =
+    !hasMarkedNoSourceChangeRepair &&
+    record.latest_local_ci_result?.outcome === "passed" &&
+    record.latest_local_ci_result.head_sha === pr.headRefOid;
+
+  return hasCodexTurnRepairVerification || hasLocalCiRepairVerification;
 }
 
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -58,6 +58,11 @@ function checksPresentAndGreen(checks: Pick<PullRequestCheck, "bucket">[]): bool
   return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
 }
 
+function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolean {
+  const providerKinds = configuredReviewProviderKinds(config);
+  return providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex");
+}
+
 function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
@@ -338,8 +343,11 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     return false;
   }
 
+  if (!configuredReviewProvidersAreCodexOnly(args.config)) {
+    return false;
+  }
+
   if (
-    configuredReviewProviderKinds(args.config).includes("codex") &&
     pullRequestHeadMatchesRecord(args.record, args.pr) &&
     codexConnectorMustFixReviewThreads(args.reviewThreads).length === 0 &&
     unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads) &&

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -11,7 +11,6 @@ import {
   evaluateCodexConnectorConvergencePolicy,
   hasCodexConnectorFindingReviewComment,
   hasCodexConnectorPrSuccessCurrentHeadObservation,
-  latestCodexConnectorPSeverity,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
 import {
@@ -31,7 +30,6 @@ import {
   configuredBotReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
-  nonActionableConfiguredBotReviewThreads,
 } from "./review-thread-reporting";
 import {
   mergeConflictDetected,
@@ -343,10 +341,7 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     reviewThreads: args.reviewThreads,
   });
   if (remediation?.classification !== "verified_current_head_repair_pending_thread_resolution") {
-    return hasExplicitVerifiedCurrentHeadRepairResidue({
-      ...args,
-      record: recordForClassification,
-    });
+    return false;
   }
 
   const diagnostics = buildStaleReviewBotThreadDiagnostics({
@@ -357,76 +352,6 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     reviewThreads: args.reviewThreads,
   });
   return diagnostics?.autoRepairSuppressedReason === "none";
-}
-
-function hasExplicitVerifiedCurrentHeadRepairResidue(args: {
-  config: SupervisorConfig;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest;
-  checks: PullRequestCheck[];
-  reviewThreads: ReviewThread[];
-}): boolean {
-  if (!pullRequestHeadMatchesRecord(args.record, args.pr) || mergeConflictDetected(args.pr)) {
-    return false;
-  }
-
-  if (manualReviewThreads(args.config, args.reviewThreads).length > 0) {
-    return false;
-  }
-  if (nonActionableConfiguredBotReviewThreads(args.config, args.reviewThreads).length > 0) {
-    return false;
-  }
-
-  const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads)
-    .filter((thread) => !thread.isResolved && !thread.isOutdated);
-  if (
-    configuredThreads.length === 0 ||
-    !configuredThreads.every(hasCodexConnectorFindingReviewComment) ||
-    !configuredThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
-  ) {
-    return false;
-  }
-
-  const mustFixThreads = codexConnectorMustFixReviewThreads(args.reviewThreads);
-  if (mustFixThreads.length === 0) {
-    return false;
-  }
-  if (!mustFixThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2")) {
-    return false;
-  }
-  if (!mustFixThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))) {
-    return false;
-  }
-
-  return hasExplicitCurrentHeadRepairVerification(args.record, args.pr);
-}
-
-function hasExplicitCurrentHeadRepairVerification(
-  record: Pick<IssueRunRecord, "latest_local_ci_result" | "timeline_artifacts">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-): boolean {
-  const hasMarkedNoSourceChangeRepair = (record.timeline_artifacts ?? []).some(
-    (artifact) =>
-      artifact.type === "verification_result" &&
-      artifact.gate === "codex_turn" &&
-      artifact.outcome === "passed" &&
-      artifact.head_sha === pr.headRefOid &&
-      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") === true,
-  );
-  const hasCodexTurnRepairVerification = (record.timeline_artifacts ?? []).some(
-    (artifact) =>
-      artifact.type === "verification_result" &&
-      artifact.gate === "codex_turn" &&
-      artifact.outcome === "passed" &&
-      artifact.head_sha === pr.headRefOid &&
-      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true,
-  );
-  const hasLocalCiRepairVerification =
-    !hasMarkedNoSourceChangeRepair &&
-    record.latest_local_ci_result?.outcome === "passed" &&
-    record.latest_local_ci_result.head_sha === pr.headRefOid;
-
-  return hasCodexTurnRepairVerification || hasLocalCiRepairVerification;
 }
 
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -58,6 +58,15 @@ function checksPresentAndGreen(checks: Pick<PullRequestCheck, "bucket">[]): bool
   return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
 }
 
+function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): boolean {
+  return configuredBotReviewThreads(config, reviewThreads)
+    .filter((thread) => !thread.isResolved)
+    .every(hasCodexConnectorFindingReviewComment);
+}
+
 function allowJournalOnlyConfiguredBotThreadException(
   config: SupervisorConfig,
   pr: GitHubPullRequest,
@@ -333,6 +342,7 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
     configuredReviewProviderKinds(args.config).includes("codex") &&
     pullRequestHeadMatchesRecord(args.record, args.pr) &&
     codexConnectorMustFixReviewThreads(args.reviewThreads).length === 0 &&
+    unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads) &&
     hasCurrentHeadVerifiedRepairResidueArtifact(args.record, args.pr)
   ) {
     return true;
@@ -395,6 +405,10 @@ export function shouldWaitForCodexConnectorCurrentHeadReview(args: {
   unresolvedBotThreads: ReviewThread[];
   nowMs: number;
 }): boolean {
+  if (hasVerifiedCurrentHeadRepairReviewMetadataResidue(args)) {
+    return false;
+  }
+
   if (
     !configuredReviewProviderKinds(args.config).includes("codex") ||
     args.pr.isDraft ||
@@ -485,6 +499,18 @@ export function hasConfiguredProviderSuccess(
 ): boolean {
   if (!repoExpectsConfiguredBotReview(config) || !isMergeCriticalPullRequest(pr)) {
     return false;
+  }
+
+  if (
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    })
+  ) {
+    return true;
   }
 
   const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(config, pr, reviewThreads);

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -20,6 +20,7 @@ import {
   CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
   createCodexConnectorTrackedReviewResidueScenario,
 } from "./codex-connector-tracked-pr-test-helpers";
+import { hasVerifiedCurrentHeadRepairReviewMetadataResidue } from "./pull-request-state-codex-residue-policy";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
   const config = createConfig({
@@ -571,6 +572,71 @@ test("inferStateFromPullRequest keeps recovered Codex stale metadata residue mer
   assert.equal(
     blockedReasonFromReviewState(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
     null,
+  );
+});
+
+test("verified current-head repair residue evidence requires unsuppressed auto-repair diagnostics", () => {
+  const issueNumber = 2099;
+  const prNumber = 119;
+  const headSha = "3f1f51ea7ff5f861ae7dc7c8b43892ea20f5c119";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-repair-suppressed",
+    commentId: "comment-current-head-repair-suppressed",
+    path: "src/current-head-proof.ts",
+    line: 42,
+    severity: "P2",
+    commentBody: "P2: This current-head residue was already repaired and verified.",
+    discussionUrl: "https://example.test/pr/119#discussion_r119",
+    verifiedRepair: {
+      summary: "Focused current-head verifier passed.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npx tsx --test src/pull-request-state-policy.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotLatestReviewedCommitSha: "1bd7511632c6db5bf1f1bbe91f0b5c4cebad1770",
+    configuredBotCurrentHeadObservedAt: "2026-05-15T00:17:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+  });
+  const suppressedThread = {
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "comment-current-head-repair-human-follow-up",
+          body: "Leaving this unresolved until the operator confirms the thread outcome.",
+          createdAt: "2026-05-15T00:19:00Z",
+          url: "https://example.test/pr/119#discussion_r119_human",
+          author: {
+            login: "maintainer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  };
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [suppressedThread],
+    }),
+    false,
   );
 });
 

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -21,7 +21,10 @@ import {
   CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
   createCodexConnectorTrackedReviewResidueScenario,
 } from "./codex-connector-tracked-pr-test-helpers";
-import { hasVerifiedCurrentHeadRepairReviewMetadataResidue } from "./pull-request-state-codex-residue-policy";
+import {
+  hasConfiguredProviderSuccess,
+  hasVerifiedCurrentHeadRepairReviewMetadataResidue,
+} from "./pull-request-state-codex-residue-policy";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./supervisor/stale-review-bot-remediation";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
@@ -728,6 +731,79 @@ test("verified current-head repair artifact does not clear non-Codex configured 
     inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [codeRabbitThread]),
     "ready_to_merge",
   );
+});
+
+test("verified current-head repair artifact does not replace mixed-provider review signals", () => {
+  const issueNumber = 2102;
+  const prNumber = 122;
+  const headSha = "6f1f51ea7ff5f861ae7dc7c8b43892ea20f5c122";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-repair-mixed-provider",
+    commentId: "comment-current-head-repair-mixed-provider",
+    path: "src/current-head-proof.ts",
+    line: 47,
+    severity: "P2",
+    commentBody: "P2: Codex repair residue was already auto-resolved.",
+    discussionUrl: "https://example.test/pr/122#discussion_r122",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "coderabbitai[bot]"],
+    humanReviewBlocksMerge: true,
+    configuredBotRequireCurrentHeadSignal: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "pr_open",
+    blocked_reason: null,
+    review_wait_started_at: "2026-05-15T00:19:00Z",
+    review_wait_head_sha: headSha,
+    copilot_review_timed_out_at: null,
+    copilot_review_timeout_action: null,
+    copilot_review_timeout_reason: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "workspace_preparation",
+        command: null,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Codex repair residue was auto-resolved on this head.",
+        recorded_at: "2026-05-15T00:21:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    false,
+  );
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, []), false);
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, []), "ready_to_merge");
 });
 
 test("verified current-head repair residue can rely on persisted auto-resolve proof after threads clear", () => {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -575,6 +575,64 @@ test("inferStateFromPullRequest keeps recovered Codex stale metadata residue mer
   );
 });
 
+test("verified current-head repair residue evidence can replace Codex no-major evidence", () => {
+  const issueNumber = 2098;
+  const prNumber = 118;
+  const headSha = "2f1f51ea7ff5f861ae7dc7c8b43892ea20f5c118";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-repair-explicit",
+    commentId: "comment-current-head-repair-explicit",
+    path: "src/current-head-proof.ts",
+    line: 41,
+    severity: "P2",
+    commentBody: "P2: This current-head residue was already repaired and verified.",
+    discussionUrl: "https://example.test/pr/118#discussion_r118",
+    verifiedRepair: {
+      summary: "Focused current-head verifier passed.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npx tsx --test src/pull-request-state-policy.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-05-15T00:17:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: [],
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+});
+
 test("verified current-head repair residue evidence requires unsuppressed auto-repair diagnostics", () => {
   const issueNumber = 2099;
   const prNumber = 119;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   blockedReasonFromReviewState,
+  effectiveConfiguredBotReviewThreadsForState,
   inferGitHubWaitStep,
   inferStateFromPullRequest,
   syncCopilotReviewTimeoutState,
@@ -601,6 +602,8 @@ test("verified current-head repair residue evidence can replace Codex no-major e
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     humanReviewBlocksMerge: true,
+    configuredBotRequireCurrentHeadSignal: true,
+    configuredBotInitialGraceWaitSeconds: 0,
     verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
   });
   const record = createRecord(scenario.recordPatch);
@@ -631,6 +634,99 @@ test("verified current-head repair residue evidence can replace Codex no-major e
       reviewThreads: [scenario.reviewThread],
     }),
     false,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, []), "ready_to_merge");
+  assert.equal(inferGitHubWaitStep(config, record, pr, scenario.passingChecks, []), null);
+});
+
+test("verified current-head repair artifact does not clear non-Codex configured bot blockers", () => {
+  const issueNumber = 2101;
+  const prNumber = 121;
+  const headSha = "5f1f51ea7ff5f861ae7dc7c8b43892ea20f5c121";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-repair-codex-auto-resolved",
+    commentId: "comment-current-head-repair-codex-auto-resolved",
+    path: "src/current-head-proof.ts",
+    line: 46,
+    severity: "P2",
+    commentBody: "P2: Codex repair residue was already auto-resolved.",
+    discussionUrl: "https://example.test/pr/121#discussion_r121",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "coderabbitai[bot]"],
+    humanReviewBlocksMerge: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "workspace_preparation",
+        command: null,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Codex repair residue was auto-resolved on this head.",
+        recorded_at: "2026-05-15T00:21:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: null,
+  });
+  const codeRabbitThread = createReviewThread({
+    id: "thread-coderabbit-blocker",
+    path: "src/coderabbit-blocker.ts",
+    line: 33,
+    comments: {
+      nodes: [
+        {
+          id: "comment-coderabbit-blocker",
+          body: "Please address this CodeRabbit review thread.",
+          createdAt: "2026-05-15T00:22:00Z",
+          url: "https://example.test/pr/121#discussion_coderabbit",
+          author: {
+            login: "coderabbitai[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [codeRabbitThread],
+    }),
+    false,
+  );
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [
+      codeRabbitThread,
+    ]).map((thread) => thread.id),
+    ["thread-coderabbit-blocker"],
+  );
+  assert.notEqual(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [codeRabbitThread]),
+    "ready_to_merge",
   );
 });
 

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -21,6 +21,7 @@ import {
   createCodexConnectorTrackedReviewResidueScenario,
 } from "./codex-connector-tracked-pr-test-helpers";
 import { hasVerifiedCurrentHeadRepairReviewMetadataResidue } from "./pull-request-state-codex-residue-policy";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./supervisor/stale-review-bot-remediation";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
   const config = createConfig({
@@ -627,6 +628,76 @@ test("verified current-head repair residue evidence can replace Codex no-major e
       record,
       pr,
       checks: [],
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+});
+
+test("verified current-head repair residue can rely on persisted auto-resolve proof after threads clear", () => {
+  const issueNumber = 2100;
+  const prNumber = 120;
+  const headSha = "4f1f51ea7ff5f861ae7dc7c8b43892ea20f5c120";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-head-repair-auto-resolved",
+    commentId: "comment-current-head-repair-auto-resolved",
+    path: "src/current-head-proof.ts",
+    line: 45,
+    severity: "P2",
+    commentBody: "P2: This current-head residue was mechanically repaired and auto-resolved.",
+    discussionUrl: "https://example.test/pr/120#discussion_r120",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "workspace_preparation",
+        command: null,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "deterministic_repair_probe:path_present_in_requested_live_lists:docs/page.md:policy_scan",
+        recorded_at: "2026-05-15T00:21:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
       reviewThreads: [scenario.reviewThread],
     }),
     false,

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -54,6 +54,7 @@ import {
   effectiveConfiguredBotReviewThreadsForState,
   hasConfiguredProviderSuccess,
   hasProvenCodexConnectorStaleReviewMetadata,
+  hasVerifiedCurrentHeadRepairReviewMetadataResidue,
   processedCodexConnectorMustFixThreadsExhaustedRepeatBudget,
   shouldWaitForCodexConnectorCurrentHeadReview,
   staleSameHeadCodexWaitHasOnlyOutdatedResidue,
@@ -198,9 +199,17 @@ export function blockedReasonFromReviewState(
     checks,
     reviewThreads,
   });
+  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
+  const configuredReviewMetadataSatisfied = provenCodexStaleReviewMetadata || verifiedCurrentHeadRepairResidue;
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
   const staleBotThreads =
-    manualThreads.length === 0 && !provenCodexStaleReviewMetadata
+    manualThreads.length === 0 && !configuredReviewMetadataSatisfied
       ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads)
       : [];
   const checkSummary = summarizeChecks(checks);
@@ -215,7 +224,7 @@ export function blockedReasonFromReviewState(
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "block" &&
-    !provenCodexStaleReviewMetadata &&
+    !configuredReviewMetadataSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "review_bot_timeout";
@@ -277,6 +286,14 @@ export function inferStateFromPullRequest(
     checks,
     reviewThreads,
   });
+  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
+  const configuredReviewMetadataSatisfied = provenCodexStaleReviewMetadata || verifiedCurrentHeadRepairResidue;
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
   const codexConnectorMustFixThreadIds = new Set(codexConnectorMustFixThreads.map((thread) => thread.id));
@@ -315,7 +332,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
-    !provenCodexStaleReviewMetadata &&
+    !configuredReviewMetadataSatisfied &&
     shouldWaitForCodexConnectorCurrentHeadReview({
       config,
       record,
@@ -547,7 +564,7 @@ export function inferStateFromPullRequest(
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "block" &&
-    !provenCodexStaleReviewMetadata &&
+    !configuredReviewMetadataSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "blocked";
@@ -556,7 +573,7 @@ export function inferStateFromPullRequest(
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "request_review_comment" &&
-    !provenCodexStaleReviewMetadata &&
+    !configuredReviewMetadataSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "waiting_ci";
@@ -579,7 +596,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
-    !provenCodexStaleReviewMetadata &&
+    !configuredReviewMetadataSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue &&
     configuredBotCurrentHeadSignalPending(config, record, pr) &&
     !copilotTimeout.timedOut
@@ -647,7 +664,15 @@ export function inferGitHubWaitStep(
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
   const staleCodexWaitHasOnlyOutdatedResidue =
     reviewThreads.length > 0 && staleSameHeadCodexWaitHasOnlyOutdatedResidue(config, record, pr, checks, reviewThreads);
+  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
   if (
+    !verifiedCurrentHeadRepairResidue &&
     !staleCodexWaitHasOnlyOutdatedResidue &&
     configuredBotCurrentHeadSignalPending(config, record, pr) &&
     !copilotTimeout.timedOut

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -18,7 +18,6 @@ import { getWorkspaceStatus } from "./core/workspace";
 import { codexConnectorMustFixReviewThreads } from "./codex-connector-review-policy";
 import {
   buildStaleReviewBotRemediation,
-  hasCurrentHeadVerifiedRepairResidueArtifact,
   VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
 } from "./supervisor/stale-review-bot-remediation";
 import {
@@ -45,6 +44,7 @@ type RepositoryFileContents = Record<string, string | null | undefined>;
 
 const execFileAsync = promisify(execFile);
 const MAX_REPAIR_PROBE_FILE_BYTES = 512_000;
+const MAX_VERIFIED_REPAIR_RESIDUE_ARTIFACT_KEYS = 200;
 
 function normalizeReviewThreadPath(value: string | null | undefined): string | null {
   const normalized = value?.trim().replace(/\\/g, "/").replace(/^\.\/+/u, "");
@@ -181,6 +181,46 @@ function verifiedCurrentHeadRepairResidueArtifact(args: {
   };
 }
 
+function isCurrentHeadVerifiedRepairResidueArtifact(
+  artifact: TimelineArtifact,
+  headSha: string,
+): boolean {
+  return (
+    artifact.head_sha === headSha &&
+    artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true
+  );
+}
+
+function appendBoundedUniqueStrings(
+  existing: readonly string[] | null | undefined,
+  next: readonly string[] | null | undefined,
+): string[] {
+  return Array.from(new Set([...(existing ?? []), ...(next ?? [])])).slice(
+    -MAX_VERIFIED_REPAIR_RESIDUE_ARTIFACT_KEYS,
+  );
+}
+
+function mergeVerifiedCurrentHeadRepairResidueArtifact(
+  existing: TimelineArtifact | null,
+  next: TimelineArtifact,
+): TimelineArtifact {
+  if (!existing) {
+    return next;
+  }
+
+  return {
+    ...next,
+    processed_review_thread_ids: appendBoundedUniqueStrings(
+      existing.processed_review_thread_ids,
+      next.processed_review_thread_ids,
+    ),
+    processed_review_thread_fingerprints: appendBoundedUniqueStrings(
+      existing.processed_review_thread_fingerprints,
+      next.processed_review_thread_fingerprints,
+    ),
+  };
+}
+
 export async function handleStaleConfiguredBotReviewRemediation(args: {
   github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
   stateStore: Pick<StateStore, "touch" | "save">;
@@ -283,8 +323,7 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
   if (
     canResolveVerifiedCurrentHeadRepairThreadResolution &&
     staleReviewBotRemediation &&
-    (recoveryResult.status === "resolved" || recoveryResult.shouldRefreshPullRequest) &&
-    !hasCurrentHeadVerifiedRepairResidueArtifact(repliedRecord, args.pr)
+    (recoveryResult.status === "resolved" || recoveryResult.shouldRefreshPullRequest)
   ) {
     const artifact = verifiedCurrentHeadRepairResidueArtifact({
       pr: args.pr,
@@ -292,13 +331,15 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
       verificationEvidenceSummary: staleReviewBotRemediation.verificationEvidenceSummary,
     });
     if (artifact) {
+      const existingArtifact = (repliedRecord.timeline_artifacts ?? []).find((candidate) =>
+        isCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
+      ) ?? null;
+      const mergedArtifact = mergeVerifiedCurrentHeadRepairResidueArtifact(existingArtifact, artifact);
       repliedRecord = args.stateStore.touch(repliedRecord, {
         timeline_artifacts: upsertTimelineArtifact(
           repliedRecord,
-          artifact,
-          (candidate) =>
-            candidate.head_sha === args.pr.headRefOid &&
-            candidate.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+          mergedArtifact,
+          (candidate) => isCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
         ),
       });
       args.state.issues[String(repliedRecord.issue_number)] = repliedRecord;

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -12,13 +12,25 @@ import type {
   ReviewThread,
   SupervisorConfig,
   SupervisorStateFile,
+  TimelineArtifact,
 } from "./core/types";
 import { getWorkspaceStatus } from "./core/workspace";
-import { buildStaleReviewBotRemediation } from "./supervisor/stale-review-bot-remediation";
+import { codexConnectorMustFixReviewThreads } from "./codex-connector-review-policy";
+import {
+  buildStaleReviewBotRemediation,
+  hasCurrentHeadVerifiedRepairResidueArtifact,
+  VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+} from "./supervisor/stale-review-bot-remediation";
 import {
   recoverStaleConfiguredBotReviewThreads,
   STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
 } from "./supervisor/stale-review-bot-recovery";
+import {
+  latestReviewThreadCommentFingerprint,
+  processedReviewThreadFingerprintKey,
+  processedReviewThreadKey,
+} from "./review-handling";
+import { upsertTimelineArtifact } from "./timeline-artifacts";
 
 export interface StaleConfiguredBotConversationResolutionBlocker {
   failureContext: FailureContext;
@@ -133,6 +145,42 @@ async function loadReviewThreadFileContents(args: {
   return Object.keys(contents).length > 0 ? contents : undefined;
 }
 
+function verifiedCurrentHeadRepairResidueArtifact(args: {
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+  verificationEvidenceSummary: string | null;
+}): TimelineArtifact | null {
+  const repairThreads = codexConnectorMustFixReviewThreads(args.reviewThreads);
+  if (repairThreads.length === 0) {
+    return null;
+  }
+
+  const processedThreadIds = repairThreads.map((thread) => processedReviewThreadKey(thread.id, args.pr.headRefOid));
+  const processedThreadFingerprints = repairThreads.flatMap((thread) => {
+    const latestFingerprint = latestReviewThreadCommentFingerprint(thread);
+    return latestFingerprint
+      ? [processedReviewThreadFingerprintKey(thread.id, args.pr.headRefOid, latestFingerprint)]
+      : [];
+  });
+
+  return {
+    type: "verification_result",
+    gate: "workspace_preparation",
+    command: null,
+    head_sha: args.pr.headRefOid,
+    outcome: "passed",
+    remediation_target: null,
+    next_action: "continue",
+    summary:
+      args.verificationEvidenceSummary ??
+      "Verified current-head repair review residue was auto-resolved on this head.",
+    recorded_at: new Date().toISOString(),
+    repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+    processed_review_thread_ids: processedThreadIds,
+    processed_review_thread_fingerprints: processedThreadFingerprints,
+  };
+}
+
 export async function handleStaleConfiguredBotReviewRemediation(args: {
   github: Partial<Pick<GitHubClient, "replyToReviewThread" | "resolveReviewThread">>;
   stateStore: Pick<StateStore, "touch" | "save">;
@@ -231,7 +279,33 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
         ? "verified_no_source_change_auto_resolve"
         : STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
   });
-  const repliedRecord = recoveryResult.record;
+  let repliedRecord = recoveryResult.record;
+  if (
+    canResolveVerifiedCurrentHeadRepairThreadResolution &&
+    staleReviewBotRemediation &&
+    (recoveryResult.status === "resolved" || recoveryResult.shouldRefreshPullRequest) &&
+    !hasCurrentHeadVerifiedRepairResidueArtifact(repliedRecord, args.pr)
+  ) {
+    const artifact = verifiedCurrentHeadRepairResidueArtifact({
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+      verificationEvidenceSummary: staleReviewBotRemediation.verificationEvidenceSummary,
+    });
+    if (artifact) {
+      repliedRecord = args.stateStore.touch(repliedRecord, {
+        timeline_artifacts: upsertTimelineArtifact(
+          repliedRecord,
+          artifact,
+          (candidate) =>
+            candidate.head_sha === args.pr.headRefOid &&
+            candidate.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+        ),
+      });
+      args.state.issues[String(repliedRecord.issue_number)] = repliedRecord;
+      await args.stateStore.save(args.state);
+      await args.syncJournal(repliedRecord);
+    }
+  }
   const replyHandled =
     repliedRecord.last_stale_review_bot_reply_head_sha === args.pr.headRefOid &&
     repliedRecord.last_stale_review_bot_reply_signature ===

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -720,7 +720,11 @@ export function buildCodexConnectorDiagnosticBundle(args: {
           reviewThreads: args.reviewThreads,
         }),
     operatorDiagnosticSummary: staleReviewBotRemediation
-      ? formatStaleReviewResidueOperatorDiagnostic(staleReviewBotRemediation)
+      ? formatStaleReviewResidueOperatorDiagnostic({
+        remediation: staleReviewBotRemediation,
+        verifiedCurrentHeadRepairResidueMergeReady:
+          args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true,
+      })
       : formatCodexConnectorOperatorDiagnostic({
         config: args.config,
         record: args.record,

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -27,12 +27,11 @@ import {
 import { configuredBotCurrentHeadSignalWaitWindow } from "./review-bot-wait-windows";
 import { hasCodexConnectorReviewRequestCommentIdentity } from "../codex-connector-review-request-identity";
 import {
-  checksAllowMergeReadyAction,
   formatStaleReviewMetadataConvergenceDiagnostic,
   formatStaleReviewResidueOperatorDiagnostic,
-  githubPullRequestAllowsMergeReadyAction,
   shouldSuppressActionableCodexDiagnostics,
   shouldUseStaleReviewRemediationDiagnostic,
+  verifiedCurrentHeadRepairResidueAllowsMergeReadyAction,
 } from "./stale-review-bot-diagnostics-presenter";
 import {
   buildStaleReviewBotThreadDiagnostics,
@@ -680,13 +679,23 @@ export function buildCodexConnectorDiagnosticBundle(args: {
         remediation: staleReviewBotRemediation,
       })
     : null;
-  const verifiedCurrentHeadRepairResidueMergeReady = Boolean(
+  const verifiedCurrentHeadRepairResidueMergeReady =
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    verifiedCurrentHeadRepairResidueAllowsMergeReadyAction({
+      remediation: staleReviewBotRemediation,
+      diagnostics: staleReviewBotThreadDiagnostics,
+      pr: args.pr,
+      checks: args.checks,
+    });
+  const suppressStaleReviewMetadataConvergence =
     staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution" &&
-      args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
-      staleReviewBotThreadDiagnostics?.autoRepairSuppressedReason === "none" &&
-      githubPullRequestAllowsMergeReadyAction(args.pr) &&
-      checksAllowMergeReadyAction(args.checks),
-  );
+    !verifiedCurrentHeadRepairResidueMergeReady;
+  const staleReviewMetadataConvergenceSummary = staleReviewBotRemediation
+    ? formatStaleReviewMetadataConvergenceDiagnostic({
+      remediation: staleReviewBotRemediation,
+      pr: args.pr,
+    })
+    : null;
   return {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
     p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
@@ -723,10 +732,9 @@ export function buildCodexConnectorDiagnosticBundle(args: {
     }),
     convergenceSummary:
       staleReviewBotRemediation
-        ? formatStaleReviewMetadataConvergenceDiagnostic({
-          remediation: staleReviewBotRemediation,
-          pr: args.pr,
-        }) ??
+        ? suppressStaleReviewMetadataConvergence
+          ? null
+          : staleReviewMetadataConvergenceSummary ??
           (staleReviewBotRemediation.missingProbeReason
             ? null
             : formatCodexConnectorConvergenceDiagnostic({

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -27,6 +27,7 @@ import {
 import { configuredBotCurrentHeadSignalWaitWindow } from "./review-bot-wait-windows";
 import { hasCodexConnectorReviewRequestCommentIdentity } from "../codex-connector-review-request-identity";
 import {
+  checksAllowMergeReadyAction,
   formatStaleReviewMetadataConvergenceDiagnostic,
   formatStaleReviewResidueOperatorDiagnostic,
   githubPullRequestAllowsMergeReadyAction,
@@ -683,7 +684,8 @@ export function buildCodexConnectorDiagnosticBundle(args: {
     staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution" &&
       args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
       staleReviewBotThreadDiagnostics?.autoRepairSuppressedReason === "none" &&
-      githubPullRequestAllowsMergeReadyAction(args.pr),
+      githubPullRequestAllowsMergeReadyAction(args.pr) &&
+      checksAllowMergeReadyAction(args.checks),
   );
   return {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -1,6 +1,7 @@
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import { displayLocalCiCommand } from "../core/config-parsing";
 import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
 import {
   buildCodexConnectorReviewChurnDiagnostic,
   buildCodexConnectorReviewChurnHistory,
@@ -686,6 +687,8 @@ export function buildCodexConnectorDiagnosticBundle(args: {
       diagnostics: staleReviewBotThreadDiagnostics,
       pr: args.pr,
       checks: args.checks,
+      localCiAllowsMergeReady:
+        !hasConfiguredLocalCiCommand(args.config) || !currentHeadLocalCiMissing(args.record, args.pr),
     });
   const suppressStaleReviewMetadataConvergence =
     staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution" &&

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -29,10 +29,14 @@ import { hasCodexConnectorReviewRequestCommentIdentity } from "../codex-connecto
 import {
   formatStaleReviewMetadataConvergenceDiagnostic,
   formatStaleReviewResidueOperatorDiagnostic,
+  githubPullRequestAllowsMergeReadyAction,
   shouldSuppressActionableCodexDiagnostics,
   shouldUseStaleReviewRemediationDiagnostic,
 } from "./stale-review-bot-diagnostics-presenter";
-import { type StaleReviewBotRemediationDto } from "./stale-review-bot-remediation";
+import {
+  buildStaleReviewBotThreadDiagnostics,
+  type StaleReviewBotRemediationDto,
+} from "./stale-review-bot-remediation";
 
 function addMinutes(timestamp: string, minutes: number): string | null {
   const parsed = Date.parse(timestamp);
@@ -665,6 +669,22 @@ export function buildCodexConnectorDiagnosticBundle(args: {
       })
     : null;
   const stableSameFileChurn = detectStableSameFileCodexConnectorChurn(reviewChurnHistory);
+  const staleReviewBotThreadDiagnostics = staleReviewBotRemediation
+    ? buildStaleReviewBotThreadDiagnostics({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        checks: args.checks,
+        reviewThreads: args.reviewThreads,
+        remediation: staleReviewBotRemediation,
+      })
+    : null;
+  const verifiedCurrentHeadRepairResidueMergeReady = Boolean(
+    staleReviewBotRemediation?.classification === "verified_current_head_repair_pending_thread_resolution" &&
+      args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+      staleReviewBotThreadDiagnostics?.autoRepairSuppressedReason === "none" &&
+      githubPullRequestAllowsMergeReadyAction(args.pr),
+  );
   return {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
     p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
@@ -722,8 +742,7 @@ export function buildCodexConnectorDiagnosticBundle(args: {
     operatorDiagnosticSummary: staleReviewBotRemediation
       ? formatStaleReviewResidueOperatorDiagnostic({
         remediation: staleReviewBotRemediation,
-        verifiedCurrentHeadRepairResidueMergeReady:
-          args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true,
+        verifiedCurrentHeadRepairResidueMergeReady,
       })
       : formatCodexConnectorOperatorDiagnostic({
         config: args.config,

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -72,6 +72,7 @@ export interface StaleReviewBotClassificationPolicyArgs {
   hasExplicitCurrentHeadRepairVerification: boolean;
   repairAttemptCount: number;
   allMustFixRepairResidueThreadsAreP2: boolean;
+  requiresDeterministicRepairProbeEvidence: boolean;
   currentHeadSuccess: boolean;
 }
 
@@ -159,6 +160,17 @@ function classifyCodexReviewBotPolicy(
           classification: "verified_current_head_repair_pending_thread_resolution",
           summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
           verificationEvidenceSummary: `${args.verificationEvidenceSummary};${args.deterministicProbeEvidence}`,
+        };
+      }
+      if (
+        verifiedCurrentHeadRepair &&
+        args.allMustFixRepairResidueThreadsAreP2 &&
+        !args.requiresDeterministicRepairProbeEvidence
+      ) {
+        return {
+          classification: "verified_current_head_repair_pending_thread_resolution",
+          summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
+          verificationEvidenceSummary: args.verificationEvidenceSummary,
         };
       }
       return unknownNeedsOperator({

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -150,7 +150,21 @@ function classifyCodexReviewBotPolicy(
         missingProbeReason: "current_head_verification_evidence_missing",
       });
     }
+    const verifiedCurrentHeadRepair =
+      args.hasExplicitCurrentHeadRepairVerification ||
+      (!args.hasMarkedNoSourceChangeRepair && args.repairAttemptCount > 0);
     if (!args.noMajorSignalEvidence) {
+      if (
+        verifiedCurrentHeadRepair &&
+        args.allMustFixRepairResidueThreadsAreP2 &&
+        args.currentHeadSuccess
+      ) {
+        return {
+          classification: "verified_current_head_repair_pending_thread_resolution",
+          summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
+          verificationEvidenceSummary: args.verificationEvidenceSummary,
+        };
+      }
       if (args.deterministicProbeEvidence) {
         return {
           classification: "verified_current_head_repair_pending_thread_resolution",
@@ -164,9 +178,6 @@ function classifyCodexReviewBotPolicy(
       });
     }
 
-    const verifiedCurrentHeadRepair =
-      args.hasExplicitCurrentHeadRepairVerification ||
-      (!args.hasMarkedNoSourceChangeRepair && args.repairAttemptCount > 0);
     if (!verifiedCurrentHeadRepair && !args.verifiedNoSourceChangeRepair) {
       return unknownNeedsOperator({
         verificationEvidenceSummary: args.verificationEvidenceSummary,

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -163,7 +163,7 @@ function classifyCodexReviewBotPolicy(
         };
       }
       if (
-        verifiedCurrentHeadRepair &&
+        args.hasExplicitCurrentHeadRepairVerification &&
         args.allMustFixRepairResidueThreadsAreP2 &&
         !args.requiresDeterministicRepairProbeEvidence
       ) {

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -70,6 +70,7 @@ export interface StaleReviewBotClassificationPolicyArgs {
   hasMarkedNoSourceChangeRepair: boolean;
   verifiedNoSourceChangeRepair: boolean;
   hasExplicitCurrentHeadRepairVerification: boolean;
+  hasCurrentHeadRepairCheckVerification: boolean;
   repairAttemptCount: number;
   allMustFixRepairResidueThreadsAreP2: boolean;
   requiresDeterministicRepairProbeEvidence: boolean;
@@ -153,9 +154,10 @@ function classifyCodexReviewBotPolicy(
     }
     const verifiedCurrentHeadRepair =
       args.hasExplicitCurrentHeadRepairVerification ||
+      args.hasCurrentHeadRepairCheckVerification ||
       (!args.hasMarkedNoSourceChangeRepair && args.repairAttemptCount > 0);
     if (!args.noMajorSignalEvidence) {
-      if (args.deterministicProbeEvidence) {
+      if (args.deterministicProbeEvidence && args.allMustFixRepairResidueThreadsAreP2) {
         return {
           classification: "verified_current_head_repair_pending_thread_resolution",
           summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -154,17 +154,6 @@ function classifyCodexReviewBotPolicy(
       args.hasExplicitCurrentHeadRepairVerification ||
       (!args.hasMarkedNoSourceChangeRepair && args.repairAttemptCount > 0);
     if (!args.noMajorSignalEvidence) {
-      if (
-        verifiedCurrentHeadRepair &&
-        args.allMustFixRepairResidueThreadsAreP2 &&
-        args.currentHeadSuccess
-      ) {
-        return {
-          classification: "verified_current_head_repair_pending_thread_resolution",
-          summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
-          verificationEvidenceSummary: args.verificationEvidenceSummary,
-        };
-      }
       if (args.deterministicProbeEvidence) {
         return {
           classification: "verified_current_head_repair_pending_thread_resolution",

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -150,6 +150,8 @@ export function formatStaleReviewMetadataConvergenceDiagnostic(args: {
     "merge_effect=ready",
     "next_action=merge_ready",
     `stale_review_metadata_classification=${args.remediation.classification}`,
+    `issue=#${args.remediation.issueNumber}`,
+    `pr=${args.remediation.prNumber === null ? "none" : `#${args.remediation.prNumber}`}`,
   ].join(" ");
 }
 

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -4,7 +4,7 @@ import {
   type StaleReviewBotRemediationDto,
   type StaleReviewBotThreadDiagnosticsDto,
 } from "./stale-review-bot-remediation";
-import { GitHubPullRequest } from "../core/types";
+import { GitHubPullRequest, PullRequestCheck } from "../core/types";
 
 export function githubPullRequestAllowsMergeReadyAction(
   pr: Pick<
@@ -20,6 +20,16 @@ export function githubPullRequestAllowsMergeReadyAction(
       pr.mergeable === "MERGEABLE" &&
       pr.reviewDecision !== "CHANGES_REQUESTED" &&
       pr.reviewDecision !== "REVIEW_REQUIRED",
+  );
+}
+
+export function checksAllowMergeReadyAction(
+  checks: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null | undefined,
+): boolean {
+  return Boolean(
+    checks &&
+      checks.length > 0 &&
+      checks.every((check) => check.bucket === "pass" || check.bucket === "skipping"),
   );
 }
 
@@ -77,6 +87,7 @@ export function formatStaleReviewBotTerminalStopLine(args: {
     GitHubPullRequest,
     "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
   > | null;
+  checks?: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null;
 }): string | null {
   const { remediation, diagnostics } = args;
   const metadataTerminal =
@@ -97,7 +108,8 @@ export function formatStaleReviewBotTerminalStopLine(args: {
         ? "request_current_head_review"
       : remediation.classification === "verified_current_head_repair_pending_thread_resolution" &&
             diagnostics.autoRepairSuppressedReason === "none" &&
-            githubPullRequestAllowsMergeReadyAction(args.pr)
+            githubPullRequestAllowsMergeReadyAction(args.pr) &&
+            checksAllowMergeReadyAction(args.checks)
           ? "merge_ready"
         : remediation.classification === "verified_no_source_change_pending_thread_resolution" ||
             remediation.classification === "verified_current_head_repair_pending_thread_resolution"

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -6,6 +6,23 @@ import {
 } from "./stale-review-bot-remediation";
 import { GitHubPullRequest } from "../core/types";
 
+export function githubPullRequestAllowsMergeReadyAction(
+  pr: Pick<
+    GitHubPullRequest,
+    "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
+  > | null | undefined,
+): boolean {
+  return Boolean(
+    pr &&
+      pr.state === "OPEN" &&
+      !pr.isDraft &&
+      pr.mergeStateStatus === "CLEAN" &&
+      pr.mergeable === "MERGEABLE" &&
+      pr.reviewDecision !== "CHANGES_REQUESTED" &&
+      pr.reviewDecision !== "REVIEW_REQUIRED",
+  );
+}
+
 export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotRemediationDto): string {
   const tokens = [
     "stale_review_bot_remediation",
@@ -56,6 +73,10 @@ export function formatStaleReviewBotThreadDiagnosticsLine(
 export function formatStaleReviewBotTerminalStopLine(args: {
   remediation: StaleReviewBotRemediationDto;
   diagnostics: StaleReviewBotThreadDiagnosticsDto;
+  pr?: Pick<
+    GitHubPullRequest,
+    "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
+  > | null;
 }): string | null {
   const { remediation, diagnostics } = args;
   const metadataTerminal =
@@ -74,8 +95,9 @@ export function formatStaleReviewBotTerminalStopLine(args: {
       ? "manual_review_thread_handling"
       : remediation.classification === "metadata_only_missing_current_head_review"
         ? "request_current_head_review"
-        : remediation.classification === "verified_current_head_repair_pending_thread_resolution" &&
-            diagnostics.autoRepairSuppressedReason === "none"
+      : remediation.classification === "verified_current_head_repair_pending_thread_resolution" &&
+            diagnostics.autoRepairSuppressedReason === "none" &&
+            githubPullRequestAllowsMergeReadyAction(args.pr)
           ? "merge_ready"
         : remediation.classification === "verified_no_source_change_pending_thread_resolution" ||
             remediation.classification === "verified_current_head_repair_pending_thread_resolution"

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -41,12 +41,14 @@ export function verifiedCurrentHeadRepairResidueAllowsMergeReadyAction(args: {
     "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
   > | null | undefined;
   checks?: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null;
+  localCiAllowsMergeReady?: boolean;
 }): boolean {
   return Boolean(
     args.remediation?.classification === "verified_current_head_repair_pending_thread_resolution" &&
       args.diagnostics?.autoRepairSuppressedReason === "none" &&
       githubPullRequestAllowsMergeReadyAction(args.pr) &&
-      checksAllowMergeReadyAction(args.checks),
+      checksAllowMergeReadyAction(args.checks) &&
+      args.localCiAllowsMergeReady !== false,
   );
 }
 
@@ -105,6 +107,7 @@ export function formatStaleReviewBotTerminalStopLine(args: {
     "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
   > | null;
   checks?: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null;
+  localCiAllowsMergeReady?: boolean;
 }): string | null {
   const { remediation, diagnostics } = args;
   const metadataTerminal =
@@ -128,6 +131,7 @@ export function formatStaleReviewBotTerminalStopLine(args: {
           diagnostics,
           pr: args.pr,
           checks: args.checks,
+          localCiAllowsMergeReady: args.localCiAllowsMergeReady,
         })
           ? "merge_ready"
         : remediation.classification === "verified_no_source_change_pending_thread_resolution" ||

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -74,6 +74,9 @@ export function formatStaleReviewBotTerminalStopLine(args: {
       ? "manual_review_thread_handling"
       : remediation.classification === "metadata_only_missing_current_head_review"
         ? "request_current_head_review"
+        : remediation.classification === "verified_current_head_repair_pending_thread_resolution" &&
+            diagnostics.autoRepairSuppressedReason === "none"
+          ? "merge_ready"
         : remediation.classification === "verified_no_source_change_pending_thread_resolution" ||
             remediation.classification === "verified_current_head_repair_pending_thread_resolution"
           ? "resolve_verified_review_thread_metadata"
@@ -92,7 +95,17 @@ export function formatStaleReviewBotTerminalStopLine(args: {
   ].join(" ");
 }
 
-export function formatStaleReviewResidueOperatorDiagnostic(remediation: StaleReviewBotRemediationDto): string {
+export function formatStaleReviewResidueOperatorDiagnostic(
+  args:
+    | StaleReviewBotRemediationDto
+    | {
+        remediation: StaleReviewBotRemediationDto;
+        verifiedCurrentHeadRepairResidueMergeReady?: boolean;
+      },
+): string {
+  const remediation = "remediation" in args ? args.remediation : args;
+  const verifiedCurrentHeadRepairResidueMergeReady =
+    "remediation" in args && args.verifiedCurrentHeadRepairResidueMergeReady === true;
   const latestConfiguredBotReviewSha =
     remediation.processedOnCurrentHead === "yes" ? remediation.currentHeadSha : "none";
   const actionableCurrentDiffThreads =
@@ -103,6 +116,9 @@ export function formatStaleReviewResidueOperatorDiagnostic(remediation: StaleRev
     remediation.classification === "metadata_only_missing_current_head_review" &&
     remediation.codexCurrentHeadReviewState === "missing"
       ? "request_current_head_review"
+      : verifiedCurrentHeadRepairResidueMergeReady &&
+          remediation.classification === "verified_current_head_repair_pending_thread_resolution"
+        ? "merge_ready"
       : remediation.manualNextStep;
   return [
     "codex_connector_operator_diagnostic",

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -33,6 +33,23 @@ export function checksAllowMergeReadyAction(
   );
 }
 
+export function verifiedCurrentHeadRepairResidueAllowsMergeReadyAction(args: {
+  remediation: StaleReviewBotRemediationDto | null | undefined;
+  diagnostics: StaleReviewBotThreadDiagnosticsDto | null | undefined;
+  pr: Pick<
+    GitHubPullRequest,
+    "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
+  > | null | undefined;
+  checks?: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null;
+}): boolean {
+  return Boolean(
+    args.remediation?.classification === "verified_current_head_repair_pending_thread_resolution" &&
+      args.diagnostics?.autoRepairSuppressedReason === "none" &&
+      githubPullRequestAllowsMergeReadyAction(args.pr) &&
+      checksAllowMergeReadyAction(args.checks),
+  );
+}
+
 export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotRemediationDto): string {
   const tokens = [
     "stale_review_bot_remediation",
@@ -106,10 +123,12 @@ export function formatStaleReviewBotTerminalStopLine(args: {
       ? "manual_review_thread_handling"
       : remediation.classification === "metadata_only_missing_current_head_review"
         ? "request_current_head_review"
-      : remediation.classification === "verified_current_head_repair_pending_thread_resolution" &&
-            diagnostics.autoRepairSuppressedReason === "none" &&
-            githubPullRequestAllowsMergeReadyAction(args.pr) &&
-            checksAllowMergeReadyAction(args.checks)
+      : verifiedCurrentHeadRepairResidueAllowsMergeReadyAction({
+          remediation,
+          diagnostics,
+          pr: args.pr,
+          checks: args.checks,
+        })
           ? "merge_ready"
         : remediation.classification === "verified_no_source_change_pending_thread_resolution" ||
             remediation.classification === "verified_current_head_repair_pending_thread_resolution"

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -71,6 +71,23 @@ test("classifyStaleReviewBotRemediationPolicy accepts verified current-head repa
   );
 });
 
+test("classifyStaleReviewBotRemediationPolicy requires Codex no-major or deterministic repair evidence", () => {
+  assert.deepEqual(
+    policy({
+      verificationEvidenceSummary: "focused_verifier_passed",
+      hasExplicitCurrentHeadRepairVerification: true,
+      allMustFixRepairResidueThreadsAreP2: true,
+      currentHeadSuccess: true,
+    }),
+    {
+      classification: "unknown_needs_operator",
+      summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+      verificationEvidenceSummary: "focused_verifier_passed",
+      missingProbeReason: "current_head_codex_no_major_signal_missing",
+    },
+  );
+});
+
 test("classifyStaleReviewBotAutoRepairSuppressionPolicy preserves repeat-stop suppression reason", () => {
   assert.equal(
     classifyStaleReviewBotAutoRepairSuppressionPolicy({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -88,6 +88,23 @@ test("classifyStaleReviewBotRemediationPolicy accepts explicit P2 repair evidenc
   );
 });
 
+test("classifyStaleReviewBotRemediationPolicy rejects repair-attempt shortcut without Codex no-major", () => {
+  assert.deepEqual(
+    policy({
+      verificationEvidenceSummary: "current_head_checks_passed:build",
+      repairAttemptCount: 1,
+      allMustFixRepairResidueThreadsAreP2: true,
+      currentHeadSuccess: true,
+    }),
+    {
+      classification: "unknown_needs_operator",
+      summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+      verificationEvidenceSummary: "current_head_checks_passed:build",
+      missingProbeReason: "current_head_codex_no_major_signal_missing",
+    },
+  );
+});
+
 test("classifyStaleReviewBotAutoRepairSuppressionPolicy preserves repeat-stop suppression reason", () => {
   assert.equal(
     classifyStaleReviewBotAutoRepairSuppressionPolicy({
@@ -900,6 +917,42 @@ test("buildStaleReviewBotRemediation classifies explicit P2 repair evidence with
   assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
   assert.equal(remediation?.missingProbeReason, null);
   assert.equal(remediation?.verificationEvidenceSummary, "Focused current-head repair verifier passed.");
+});
+
+test("buildStaleReviewBotRemediation rejects repair-attempt-only P2 evidence without no-major signal", () => {
+  const issueNumber = 112;
+  const prNumber = 117;
+  const headSha = "e384c41883b831ab6b85bf3467a66a5c01fd49fc";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-p2-repair-attempt-only",
+    commentId: "comment-p2-repair-attempt-only",
+    path: "src/current-head-repair.ts",
+    line: 43,
+    severity: "P2",
+    commentBody: "P2: Verify this current-head repair before merge.",
+    discussionUrl: "https://example.test/pr/117#discussion_r117",
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    repair_attempt_count: 1,
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.equal(remediation?.verificationEvidenceSummary, "current_head_checks_passed:build");
 });
 
 test("buildStaleReviewBotRemediation verifies concrete P2 path-list repair without no-major signal", () => {

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -35,6 +35,7 @@ function policy(overrides: Partial<StaleReviewBotClassificationPolicyArgs> = {})
     hasExplicitCurrentHeadRepairVerification: false,
     repairAttemptCount: 0,
     allMustFixRepairResidueThreadsAreP2: true,
+    requiresDeterministicRepairProbeEvidence: false,
     currentHeadSuccess: true,
   };
 
@@ -71,7 +72,7 @@ test("classifyStaleReviewBotRemediationPolicy accepts verified current-head repa
   );
 });
 
-test("classifyStaleReviewBotRemediationPolicy requires Codex no-major or deterministic repair evidence", () => {
+test("classifyStaleReviewBotRemediationPolicy accepts explicit P2 repair evidence without Codex no-major", () => {
   assert.deepEqual(
     policy({
       verificationEvidenceSummary: "focused_verifier_passed",
@@ -80,10 +81,9 @@ test("classifyStaleReviewBotRemediationPolicy requires Codex no-major or determi
       currentHeadSuccess: true,
     }),
     {
-      classification: "unknown_needs_operator",
-      summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+      classification: "verified_current_head_repair_pending_thread_resolution",
+      summary: "verified_current_head_repair_configured_bot_thread_resolution_pending",
       verificationEvidenceSummary: "focused_verifier_passed",
-      missingProbeReason: "current_head_codex_no_major_signal_missing",
     },
   );
 });
@@ -860,6 +860,46 @@ test("buildStaleReviewBotRemediation fails closed when covered evidence lacks cu
   assert.equal(remediation?.classification, "unknown_needs_operator");
   assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
   assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+});
+
+test("buildStaleReviewBotRemediation classifies explicit P2 repair evidence without no-major signal", () => {
+  const issueNumber = 111;
+  const prNumber = 116;
+  const headSha = "d284c41883b831ab6b85bf3467a66a5c01fd49fb";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-p2-explicit-repair-no-major",
+    commentId: "comment-p2-explicit-repair-no-major",
+    path: "src/current-head-repair.ts",
+    line: 42,
+    severity: "P2",
+    commentBody: "P2: Verify this current-head repair before merge.",
+    discussionUrl: "https://example.test/pr/116#discussion_r116",
+    verifiedRepair: {
+      summary: "Focused current-head repair verifier passed.",
+      ranAt: "2026-05-21T11:10:00Z",
+      command: "npm test -- src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.equal(remediation?.verificationEvidenceSummary, "Focused current-head repair verifier passed.");
 });
 
 test("buildStaleReviewBotRemediation verifies concrete P2 path-list repair without no-major signal", () => {

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -33,6 +33,7 @@ function policy(overrides: Partial<StaleReviewBotClassificationPolicyArgs> = {})
     hasMarkedNoSourceChangeRepair: false,
     verifiedNoSourceChangeRepair: false,
     hasExplicitCurrentHeadRepairVerification: false,
+    hasCurrentHeadRepairCheckVerification: false,
     repairAttemptCount: 0,
     allMustFixRepairResidueThreadsAreP2: true,
     requiresDeterministicRepairProbeEvidence: false,
@@ -100,6 +101,23 @@ test("classifyStaleReviewBotRemediationPolicy rejects repair-attempt shortcut wi
       classification: "unknown_needs_operator",
       summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
       verificationEvidenceSummary: "current_head_checks_passed:build",
+      missingProbeReason: "current_head_codex_no_major_signal_missing",
+    },
+  );
+});
+
+test("classifyStaleReviewBotRemediationPolicy rejects deterministic high-severity repair proof without Codex no-major", () => {
+  assert.deepEqual(
+    policy({
+      verificationEvidenceSummary: "focused_verifier_passed",
+      deterministicProbeEvidence: "deterministic_repair_probe:path_present_in_requested_live_lists:src/app.ts:policy_scan",
+      allMustFixRepairResidueThreadsAreP2: false,
+      currentHeadSuccess: true,
+    }),
+    {
+      classification: "unknown_needs_operator",
+      summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+      verificationEvidenceSummary: "focused_verifier_passed",
       missingProbeReason: "current_head_codex_no_major_signal_missing",
     },
   );
@@ -917,6 +935,45 @@ test("buildStaleReviewBotRemediation classifies explicit P2 repair evidence with
   assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
   assert.equal(remediation?.missingProbeReason, null);
   assert.equal(remediation?.verificationEvidenceSummary, "Focused current-head repair verifier passed.");
+});
+
+test("buildStaleReviewBotRemediation rejects local-CI-only P2 repair evidence without no-major signal", () => {
+  const issueNumber = 113;
+  const prNumber = 118;
+  const headSha = "f484c41883b831ab6b85bf3467a66a5c01fd49fd";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-p2-local-ci-only-no-major",
+    commentId: "comment-p2-local-ci-only-no-major",
+    path: "src/current-head-repair.ts",
+    line: 44,
+    severity: "P2",
+    commentBody: "P2: Verify this current-head repair before merge.",
+    discussionUrl: "https://example.test/pr/118#discussion_r118",
+    verifiedRepair: {
+      summary: "Generic local CI passed.",
+      ranAt: "2026-05-21T11:12:00Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "latest_local_ci_result",
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
+  assert.equal(remediation?.verificationEvidenceSummary, "Generic local CI passed.");
 });
 
 test("buildStaleReviewBotRemediation rejects repair-attempt-only P2 evidence without no-major signal", () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -13,6 +13,7 @@ import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
+  hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
@@ -31,6 +32,7 @@ import {
 } from "../core/review-providers";
 import {
   STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
+  VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
   VERIFIED_CURRENT_HEAD_REPAIR_MANUAL_NEXT_STEP,
   VERIFIED_NO_SOURCE_CHANGE_MANUAL_NEXT_STEP,
   classifyStaleReviewBotAutoRepairSuppressionPolicy,
@@ -126,6 +128,20 @@ function codeCiState(
 
 function allChecksPassing(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
   return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+}
+
+function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolean {
+  const providerKinds = configuredReviewProviderKinds(config);
+  return providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex");
+}
+
+function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): boolean {
+  return configuredBotReviewThreads(config, reviewThreads)
+    .filter((thread) => !thread.isResolved)
+    .every(hasCodexConnectorFindingReviewComment);
 }
 
 function isConfiguredReviewBotCheck(
@@ -346,6 +362,42 @@ export function hasCurrentHeadVerifiedRepairResidueArtifact(
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
       (artifact.processed_review_thread_ids?.length ?? 0) > 0,
   );
+}
+
+function currentHeadVerifiedRepairResidueArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+) {
+  return (record.timeline_artifacts ?? []).find(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
+      (artifact.processed_review_thread_ids?.length ?? 0) > 0,
+  ) ?? null;
+}
+
+export function currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): string | null {
+  if (
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve !== true ||
+    !configuredReviewProvidersAreCodexOnly(args.config) ||
+    !allChecksPassing(args.checks) ||
+    args.record.last_head_sha !== args.pr.headRefOid ||
+    codexConnectorMustFixReviewThreads(args.reviewThreads).length > 0 ||
+    !unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads)
+  ) {
+    return null;
+  }
+
+  const artifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr);
+  return artifact?.summary || "verified_current_head_repair_review_thread_residue_artifact";
 }
 
 function hasCurrentHeadNoSourceChangeCodexTurnVerification(
@@ -869,6 +921,15 @@ function classifyCodexMetadataOnly(args: {
     args.checks,
     checkEvidenceCanProveRepair,
   );
+  const verifiedRepairArtifactEvidenceSummary =
+    currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args);
+  if (verifiedRepairArtifactEvidenceSummary) {
+    return {
+      classification: "verified_current_head_repair_pending_thread_resolution",
+      summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
+      verificationEvidenceSummary: verifiedRepairArtifactEvidenceSummary,
+    };
+  }
 
   return classifyStaleReviewBotRemediationPolicy({
     provider: "codex",

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -749,6 +749,16 @@ function deterministicRepairProbeEvidence(args: {
   return evidence.length > 0 ? evidence.join(";") : null;
 }
 
+function requiresDeterministicRepairProbeEvidence(reviewThreads: ReviewThread[]): boolean {
+  return codexConnectorMustFixReviewThreads(reviewThreads).some((thread) => {
+    const codexFindingBody = latestCodexConnectorReviewComment(thread)?.body ?? "";
+    return (
+      requestedPathListSelectors(codexFindingBody).length > 0 &&
+      extractConcreteRepoPaths(codexFindingBody).length > 0
+    );
+  });
+}
+
 function validTimestamp(value: string | null | undefined): string | null {
   if (!value || Number.isNaN(Date.parse(value))) {
     return null;
@@ -878,6 +888,7 @@ function classifyCodexMetadataOnly(args: {
       (!hasMarkedNoSourceChangeRepair && hasCurrentHeadLocalCiVerification(args.record, args.pr)),
     repairAttemptCount: args.record.repair_attempt_count,
     allMustFixRepairResidueThreadsAreP2: allCodexConnectorRepairResidueThreadsAreP2(mustFixReviewThreads),
+    requiresDeterministicRepairProbeEvidence: requiresDeterministicRepairProbeEvidence(args.reviewThreads),
     currentHeadSuccess: hasCurrentHeadSuccessSignal(args.pr),
   });
 }
@@ -913,6 +924,7 @@ function classifyRemediation(args: {
       hasExplicitCurrentHeadRepairVerification: false,
       repairAttemptCount: 0,
       allMustFixRepairResidueThreadsAreP2: false,
+      requiresDeterministicRepairProbeEvidence: false,
       currentHeadSuccess: false,
     });
   }
@@ -952,6 +964,7 @@ function classifyRemediation(args: {
     hasExplicitCurrentHeadRepairVerification: false,
     repairAttemptCount: record.repair_attempt_count,
     allMustFixRepairResidueThreadsAreP2: false,
+    requiresDeterministicRepairProbeEvidence: false,
     currentHeadSuccess: Boolean(pr.configuredBotCurrentHeadObservedAt && pr.configuredBotCurrentHeadStatusState === "SUCCESS"),
   });
 }

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -77,6 +77,9 @@ export interface StaleReviewBotThreadDiagnosticsDto {
 
 type RepositoryFileContents = Record<string, string | null | undefined>;
 
+export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
+  "verified_current_head_repair_review_thread_residue";
+
 export function formatStaleReviewBotTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
 }
@@ -329,6 +332,20 @@ function hasCurrentHeadLocalCiVerification(
   pr: Pick<GitHubPullRequest, "headRefOid">,
 ): boolean {
   return record.latest_local_ci_result?.outcome === "passed" && record.latest_local_ci_result.head_sha === pr.headRefOid;
+}
+
+export function hasCurrentHeadVerifiedRepairResidueArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  return (record.timeline_artifacts ?? []).some(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
+      (artifact.processed_review_thread_ids?.length ?? 0) > 0,
+  );
 }
 
 function hasCurrentHeadNoSourceChangeCodexTurnVerification(
@@ -843,6 +860,7 @@ function classifyCodexMetadataOnly(args: {
     args.record,
     args.pr,
   );
+  const hasCurrentHeadCodexTurnRepairVerification = hasCurrentHeadCodexTurnVerification(args.record, args.pr);
   const checkEvidenceCanProveRepair = args.record.repair_attempt_count > 0;
   const verificationEvidenceSummary = currentHeadVerificationEvidenceSummary(
     args.config,
@@ -883,9 +901,9 @@ function classifyCodexMetadataOnly(args: {
       args.pr,
       mustFixReviewThreads,
     ),
-    hasExplicitCurrentHeadRepairVerification:
-      hasCurrentHeadCodexTurnVerification(args.record, args.pr) ||
-      (!hasMarkedNoSourceChangeRepair && hasCurrentHeadLocalCiVerification(args.record, args.pr)),
+    hasExplicitCurrentHeadRepairVerification: hasCurrentHeadCodexTurnRepairVerification,
+    hasCurrentHeadRepairCheckVerification:
+      !hasMarkedNoSourceChangeRepair && hasCurrentHeadLocalCiVerification(args.record, args.pr),
     repairAttemptCount: args.record.repair_attempt_count,
     allMustFixRepairResidueThreadsAreP2: allCodexConnectorRepairResidueThreadsAreP2(mustFixReviewThreads),
     requiresDeterministicRepairProbeEvidence: requiresDeterministicRepairProbeEvidence(args.reviewThreads),
@@ -922,6 +940,7 @@ function classifyRemediation(args: {
       hasMarkedNoSourceChangeRepair: false,
       verifiedNoSourceChangeRepair: false,
       hasExplicitCurrentHeadRepairVerification: false,
+      hasCurrentHeadRepairCheckVerification: false,
       repairAttemptCount: 0,
       allMustFixRepairResidueThreadsAreP2: false,
       requiresDeterministicRepairProbeEvidence: false,
@@ -962,6 +981,7 @@ function classifyRemediation(args: {
     hasMarkedNoSourceChangeRepair: false,
     verifiedNoSourceChangeRepair: false,
     hasExplicitCurrentHeadRepairVerification: false,
+    hasCurrentHeadRepairCheckVerification: false,
     repairAttemptCount: record.repair_attempt_count,
     allMustFixRepairResidueThreadsAreP2: false,
     requiresDeterministicRepairProbeEvidence: false,

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -41,6 +41,7 @@ import { truncate } from "../core/utils";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
 import { buildConversationResolutionBlockerDiagnostic } from "../conversation-resolution-blocker-diagnostics";
 import { sanitizeStatusValue } from "./supervisor-detailed-status-formatting";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
 
 type ActiveDetailedStatusArgs = Omit<BuildDetailedStatusModelArgs, "latestRecord" | "trackedIssueCount"> & {
   activeRecord: NonNullable<BuildDetailedStatusModelArgs["activeRecord"]>;
@@ -191,7 +192,14 @@ export function buildActiveStaleReviewBotDiagnosticLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
-      const terminalStopLine = formatStaleReviewBotTerminalStopLine({ remediation, diagnostics, pr, checks });
+      const terminalStopLine = formatStaleReviewBotTerminalStopLine({
+        remediation,
+        diagnostics,
+        pr,
+        checks,
+        localCiAllowsMergeReady:
+          !hasConfiguredLocalCiCommand(config) || !currentHeadLocalCiMissing(activeRecord, pr),
+      });
       if (terminalStopLine) {
         lines.push(terminalStopLine);
       }

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -191,7 +191,7 @@ export function buildActiveStaleReviewBotDiagnosticLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
-      const terminalStopLine = formatStaleReviewBotTerminalStopLine({ remediation, diagnostics, pr });
+      const terminalStopLine = formatStaleReviewBotTerminalStopLine({ remediation, diagnostics, pr, checks });
       if (terminalStopLine) {
         lines.push(terminalStopLine);
       }

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -191,7 +191,7 @@ export function buildActiveStaleReviewBotDiagnosticLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
-      const terminalStopLine = formatStaleReviewBotTerminalStopLine({ remediation, diagnostics });
+      const terminalStopLine = formatStaleReviewBotTerminalStopLine({ remediation, diagnostics, pr });
       if (terminalStopLine) {
         lines.push(terminalStopLine);
       }

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -8,6 +8,7 @@ import {
 import {
   buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
+  currentHeadVerifiedRepairResidueArtifactEvidenceSummary,
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
@@ -159,11 +160,22 @@ export function buildInactiveDetailedStatusLines(
   ];
   let staleReviewBotRemediation: ReturnType<typeof buildStaleReviewBotRemediation> = null;
   const configTargetsCodex = configuredReviewProviderKinds(config).includes("codex");
+  const verifiedRepairArtifactEvidence =
+    latestRecord && pr
+      ? currentHeadVerifiedRepairResidueArtifactEvidenceSummary({
+          config,
+          record: latestRecord,
+          pr,
+          checks,
+          reviewThreads,
+        })
+      : null;
   if (
     latestRecord &&
     pr &&
     latestRecord.last_head_sha === pr.headRefOid &&
     (pr.configuredBotCurrentHeadStatusState === "SUCCESS" ||
+      verifiedRepairArtifactEvidence !== null ||
       (configTargetsCodex &&
         pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" &&
         Boolean(pr.configuredBotCurrentHeadObservedAt)))

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -19,6 +19,7 @@ import type { BuildDetailedStatusModelArgs } from "./supervisor-status-model";
 import { classifyStaleReviewBotRecoverability } from "./stale-diagnostic-recoverability";
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 import { formatLatestRecoveryStatusLine, sanitizeStatusValue } from "./supervisor-detailed-status-formatting";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
 
 export { buildActiveDetailedStatusLines } from "./supervisor-active-detailed-status-presenters";
 export { formatLatestRecoveryStatusLine, sanitizeStatusValue } from "./supervisor-detailed-status-formatting";
@@ -196,6 +197,8 @@ export function buildInactiveDetailedStatusLines(
         diagnostics,
         pr,
         checks,
+        localCiAllowsMergeReady:
+          !pr || !hasConfiguredLocalCiCommand(config) || !currentHeadLocalCiMissing(latestRecord, pr),
       });
       if (terminalStopLine) {
         lines.push(terminalStopLine);

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -195,6 +195,7 @@ export function buildInactiveDetailedStatusLines(
         remediation: staleReviewBotRemediation,
         diagnostics,
         pr,
+        checks,
       });
       if (terminalStopLine) {
         lines.push(terminalStopLine);

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -194,6 +194,7 @@ export function buildInactiveDetailedStatusLines(
       const terminalStopLine = formatStaleReviewBotTerminalStopLine({
         remediation: staleReviewBotRemediation,
         diagnostics,
+        pr,
       });
       if (terminalStopLine) {
         lines.push(terminalStopLine);

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1900,7 +1900,7 @@ test("status --why converges processed current-head Codex no-major review thread
     status,
     /^stale_review_bot_thread_diagnostics issue=#171 pr=#180 current_head_success=yes unresolved_current_threads=9 actionable_must_fix_threads=9 verified_stale_residue_threads=9 missing_verification_evidence_threads=0 repeat_stop_exhausted=no auto_repair_suppressed_reason=opt_in_disabled$/m,
   );
-  assert.match(
+  assert.doesNotMatch(
     status,
     /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 current_head_observed_at=2026-05-23T01:14:50Z latest_signal_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#171 pr=#180$/m,
   );

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1902,7 +1902,7 @@ test("status --why converges processed current-head Codex no-major review thread
   );
   assert.match(
     status,
-    /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 current_head_observed_at=2026-05-23T01:14:50Z latest_signal_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution$/m,
+    /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 current_head_observed_at=2026-05-23T01:14:50Z latest_signal_head_sha=12b099926c39c8b7502176339ea34750e6a807a4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#171 pr=#180$/m,
   );
   assert.match(
     status,

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -267,6 +267,7 @@ test("Codex connector operator diagnostic honors auto-repair suppression before 
     /next_action=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor$/,
   );
   assert.doesNotMatch(diagnostics.operatorDiagnosticSummary ?? "", /next_action=merge_ready$/);
+  assert.equal(diagnostics.convergenceSummary, null);
 
   const missingChecksDiagnostics = buildCodexConnectorDiagnosticBundle({
     config,
@@ -282,6 +283,7 @@ test("Codex connector operator diagnostic honors auto-repair suppression before 
     /next_action=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor$/,
   );
   assert.doesNotMatch(missingChecksDiagnostics.operatorDiagnosticSummary ?? "", /next_action=merge_ready$/);
+  assert.equal(missingChecksDiagnostics.convergenceSummary, null);
 });
 
 test("status --why classifies current-head processed configured-bot success as stale metadata remediation while idle", async (t) => {
@@ -544,7 +546,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
     status,
     /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
-  assert.match(
+  assert.doesNotMatch(
     status,
     /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#400 pr=#500$/m,
   );

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -169,8 +169,18 @@ test("stale review-bot terminal stop only reports merge-ready when GitHub is mer
       remediation,
       diagnostics,
       pr: createPullRequest(),
+      checks: [{ bucket: "pass" }],
     }) ?? "",
     /next_action=merge_ready$/,
+  );
+  assert.match(
+    formatStaleReviewBotTerminalStopLine({
+      remediation,
+      diagnostics,
+      pr: createPullRequest(),
+      checks: [],
+    }) ?? "",
+    /next_action=resolve_verified_review_thread_metadata$/,
   );
 });
 
@@ -257,6 +267,21 @@ test("Codex connector operator diagnostic honors auto-repair suppression before 
     /next_action=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor$/,
   );
   assert.doesNotMatch(diagnostics.operatorDiagnosticSummary ?? "", /next_action=merge_ready$/);
+
+  const missingChecksDiagnostics = buildCodexConnectorDiagnosticBundle({
+    config,
+    record,
+    pr,
+    checks: [],
+    reviewThreads: [scenario.reviewThread],
+    staleReviewBotRemediation: remediation,
+  });
+
+  assert.match(
+    missingChecksDiagnostics.operatorDiagnosticSummary ?? "",
+    /next_action=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor$/,
+  );
+  assert.doesNotMatch(missingChecksDiagnostics.operatorDiagnosticSummary ?? "", /next_action=merge_ready$/);
 });
 
 test("status --why classifies current-head processed configured-bot success as stale metadata remediation while idle", async (t) => {

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -31,7 +31,10 @@ import {
   buildCodexConnectorDiagnosticBundle,
   formatStaleReviewResidueOperatorDiagnostic,
 } from "./supervisor-status-review-bot";
-import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
+import {
+  buildStaleReviewBotRemediation,
+  VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+} from "./stale-review-bot-remediation";
 import {
   clearCurrentReconciliationPhase,
   writeCurrentReconciliationPhase,
@@ -489,6 +492,99 @@ test("status --why reports effective configured-bot thread diagnostics for outda
     status,
     /^review_thread_effective_diagnostics raw_configured_bot_unresolved=1 effective_configured_bot_unresolved=0 current_configured_bot_threads=0 outdated_configured_bot_residue=1 current_thread_ids=none$/m,
   );
+});
+
+test("status --why surfaces artifact-backed verified repair residue after threads clear while idle", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  fixture.config.verifiedCurrentHeadRepairReviewThreadAutoResolve = true;
+  const issueNumber = 405;
+  const prNumber = 505;
+  const headSha = "76060523f803ebe25832cb2c355aaaa9530502f6";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-405",
+    commentId: "comment-405",
+    path: "src/auth-boundary.ts",
+    line: 92,
+    severity: "P2",
+    commentBody: "P2: Prove the repaired auth boundary is covered before merge.",
+    discussionUrl: "https://example.test/pr/505#discussion_r405",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "workspace_preparation",
+            command: null,
+            head_sha: headSha,
+            outcome: "passed",
+            remediation_target: null,
+            next_action: "continue",
+            summary: "Verified repair residue was auto-resolved on this head.",
+            recorded_at: "2026-05-15T00:21:00Z",
+            repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+            processed_review_thread_ids: [`thread-405@${headSha}`],
+            processed_review_thread_fingerprints: [`thread-405@${headSha}#comment-405`],
+          },
+        ],
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const trackedIssue = createTrackedStatusIssue({
+    issueNumber,
+    title: "Status why idle artifact-backed Codex verified repair residue",
+    summary: "Status should surface artifact-backed verified repair residue after threads clear.",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: null,
+  });
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => scenario.passingChecks,
+    getUnresolvedReviewThreads: async () => [],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(status, /^No active issue\.$/m);
+  assert.match(
+    status,
+    /^no_active_tracked_record issue=#405 classification=stale_review_bot_remediation state=blocked reason=verified_current_head_repair_pending_thread_resolution$/m,
+  );
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#405 pr=#505 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f6 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/505#discussion_r405 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Verified_repair_residue_was_auto-resolved_on_this_head\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.match(
+    status,
+    /^stale_review_bot_terminal_stop issue=#405 pr=#505 reason=metadata_only_review_thread_resolution_pending classification=verified_current_head_repair_pending_thread_resolution .*auto_repair_suppressed_reason=none next_action=merge_ready$/m,
+  );
+  assert.match(status, /^codex_connector_operator_diagnostic .*next_action=merge_ready$/m);
+  assert.doesNotMatch(status, /^operator_action action=resolve_stale_review_bot /m);
+  assert.doesNotMatch(status, /^operator_action action=manual_review /m);
 });
 
 test("status --why uses the shared stale review-bot presenter for active verified repair residue", async (t) => {

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -182,6 +182,16 @@ test("stale review-bot terminal stop only reports merge-ready when GitHub is mer
     }) ?? "",
     /next_action=resolve_verified_review_thread_metadata$/,
   );
+  assert.match(
+    formatStaleReviewBotTerminalStopLine({
+      remediation,
+      diagnostics,
+      pr: createPullRequest(),
+      checks: [{ bucket: "pass" }],
+      localCiAllowsMergeReady: false,
+    }) ?? "",
+    /next_action=resolve_verified_review_thread_metadata$/,
+  );
 });
 
 test("Codex connector operator diagnostic honors auto-repair suppression before merge-ready", () => {

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -102,7 +102,7 @@ test("stale review-bot presenter keeps residue and metadata diagnostic lines sta
         configuredBotCurrentHeadObservedAt: "2026-05-15T00:17:00Z",
       }),
     }),
-    "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=deadbeef current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=deadbeef highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=metadata_only",
+    "codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=deadbeef current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=deadbeef highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=metadata_only issue=#366 pr=#44",
   );
   assert.equal(
     formatStaleReviewBotTerminalStopLine({
@@ -385,7 +385,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
   );
   assert.match(
     status,
-    /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution$/m,
+    /^codex_connector_convergence status=stale_review_metadata provider=codex current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 current_head_observed_at=2026-05-15T00:17:00Z latest_signal_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready stale_review_metadata_classification=verified_current_head_repair_pending_thread_resolution issue=#400 pr=#500$/m,
   );
   assert.doesNotMatch(status, /^codex_connector_convergence status=stale_head /m);
   assert.doesNotMatch(status, /^codex_connector_operator_diagnostic interpretation=actionable_current_diff /m);

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -8,6 +8,7 @@ import { renderSupervisorStatusDto } from "./supervisor-status-report";
 import { Supervisor } from "./supervisor";
 import {
   branchName,
+  createConfig,
   createRecord,
   createPullRequest,
   createSupervisorFixture,
@@ -26,7 +27,11 @@ import {
   formatStaleReviewMetadataConvergenceDiagnostic,
   formatStaleReviewBotTerminalStopLine,
 } from "./stale-review-bot-diagnostics-presenter";
-import { formatStaleReviewResidueOperatorDiagnostic } from "./supervisor-status-review-bot";
+import {
+  buildCodexConnectorDiagnosticBundle,
+  formatStaleReviewResidueOperatorDiagnostic,
+} from "./supervisor-status-review-bot";
+import { buildStaleReviewBotRemediation } from "./stale-review-bot-remediation";
 import {
   clearCurrentReconciliationPhase,
   writeCurrentReconciliationPhase,
@@ -121,6 +126,137 @@ test("stale review-bot presenter keeps residue and metadata diagnostic lines sta
     }),
     "stale_review_bot_terminal_stop issue=#366 pr=#44 reason=metadata_only_review_thread_resolution_pending classification=metadata_only_missing_current_head_review head_freshness=processed_on_current_head:yes,current_head_success:yes review_thread_classification=unresolved:1,must_fix:0,verified_residue:0 auto_repair_suppressed_reason=not_verified_stale_residue next_action=request_current_head_review",
   );
+});
+
+test("stale review-bot terminal stop only reports merge-ready when GitHub is merge-ready", () => {
+  const remediation = {
+    issueNumber: 401,
+    prNumber: 501,
+    reasonCode: "stale_review_bot" as const,
+    currentHeadSha: "head-401",
+    processedOnCurrentHead: "yes" as const,
+    codeCiState: "green" as const,
+    classification: "verified_current_head_repair_pending_thread_resolution" as const,
+    codexCurrentHeadReviewState: "observed" as const,
+    reviewThreadUrl: "https://example.test/pr/501#discussion_r401",
+    verificationEvidenceSummary: "focused_verifier_passed;codex_pr_success_comment_after_current_head_request",
+    missingProbeReason: null,
+    manualNextStep: "resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor",
+    summary: "verified_current_head_repair_configured_bot_thread_resolution_pending",
+  };
+  const diagnostics = {
+    issueNumber: 401,
+    prNumber: 501,
+    currentHeadSuccess: "yes" as const,
+    unresolvedCurrentThreads: 1,
+    actionableMustFixThreads: 1,
+    verifiedStaleResidueThreads: 1,
+    missingVerificationEvidenceThreads: 0,
+    repeatStopExhausted: "no" as const,
+    autoRepairSuppressedReason: "none" as const,
+  };
+
+  assert.match(
+    formatStaleReviewBotTerminalStopLine({
+      remediation,
+      diagnostics,
+      pr: createPullRequest({ reviewDecision: "CHANGES_REQUESTED" }),
+    }) ?? "",
+    /next_action=resolve_verified_review_thread_metadata$/,
+  );
+  assert.match(
+    formatStaleReviewBotTerminalStopLine({
+      remediation,
+      diagnostics,
+      pr: createPullRequest(),
+    }) ?? "",
+    /next_action=merge_ready$/,
+  );
+});
+
+test("Codex connector operator diagnostic honors auto-repair suppression before merge-ready", () => {
+  const issueNumber = 402;
+  const prNumber = 502;
+  const headSha = "76060523f803ebe25832cb2c355aaaa9530502f5";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-402",
+    commentId: "comment-402",
+    path: "src/auth-boundary.ts",
+    line: 91,
+    severity: "P2",
+    commentBody: "P2: Prove the repaired auth boundary is covered before merge.",
+    discussionUrl: "https://example.test/pr/502#discussion_r402",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-05-15T00:18:00Z",
+      command: "npx tsx --test src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-05-15T00:12:00Z",
+      observedAt: "2026-05-15T00:17:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    processed_review_thread_ids: [
+      ...(scenario.recordPatch.processed_review_thread_ids ?? []),
+      `thread-402@${headSha}`,
+    ],
+    processed_review_thread_fingerprints: [
+      ...(scenario.recordPatch.processed_review_thread_fingerprints ?? []),
+      `thread-402@${headSha}#comment-402-maintainer-follow-up`,
+    ],
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+  const suppressedThread = {
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "comment-402-maintainer-follow-up",
+          body: "Leaving this unresolved until the operator confirms the thread outcome.",
+          createdAt: "2026-05-15T00:19:00Z",
+          url: "https://example.test/pr/502#discussion_r402_human",
+          author: {
+            login: "maintainer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  };
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [suppressedThread],
+  });
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+
+  const diagnostics = buildCodexConnectorDiagnosticBundle({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [suppressedThread],
+    staleReviewBotRemediation: remediation,
+  });
+
+  assert.match(
+    diagnostics.operatorDiagnosticSummary ?? "",
+    /next_action=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor$/,
+  );
+  assert.doesNotMatch(diagnostics.operatorDiagnosticSummary ?? "", /next_action=merge_ready$/);
 });
 
 test("status --why classifies current-head processed configured-bot success as stale metadata remediation while idle", async (t) => {

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -392,6 +392,7 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
       summary: "Focused verifier passed after the repair commit.",
       ranAt: "2026-06-14T00:18:00Z",
       command: "npm test -- src/review-policy.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
     },
   });
   const pr = createPullRequest({
@@ -453,6 +454,102 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
     merged.last_auto_merge_guard_context?.details.join("\\n") ?? "",
     /codex_verified_current_head_repair_residue=yes/,
   );
+});
+
+test("handlePostTurnMergeAndCompletion does not auto-merge high-severity verified repair residue without Codex no-major", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 2375;
+  const branch = branchName(fixture.config, issueNumber);
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Keep high severity residue blocked",
+    body: runnableCodexIssueBody("Keep high severity residue blocked."),
+    createdAt: "2026-06-14T00:00:00Z",
+    updatedAt: "2026-06-14T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber: 3981,
+    headSha: "head-p1-verified-repair-residue",
+    branch,
+    threadId: "thread-p1-verified-repair-residue",
+    commentId: "comment-p1-verified-repair-residue",
+    path: "src/review-policy.ts",
+    line: 15,
+    severity: "P1",
+    commentBody: "P1: Keep high-severity repair residue behind a current-head no-major review.",
+    discussionUrl: "https://example.test/pr/3981#discussion_p1_verified_repair_residue",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-06-14T00:18:00Z",
+      command: "npm test -- src/review-policy.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-13T00:17:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        branch,
+        blocked_reason: null,
+        last_error: null,
+        last_failure_context: null,
+      }),
+    },
+  };
+  const comments: Array<{ issueNumber: number; body: string }> = [];
+  const autoMergeCalls: Array<{ prNumber: number; headSha: string }> = [];
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, 3981);
+    return { pr, checks: scenario.passingChecks, reviewThreads: [scenario.reviewThread] };
+  };
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    addIssueComment: async (commentIssueNumber: number, body: string) => {
+      comments.push({ issueNumber: commentIssueNumber, body });
+    },
+    enableAutoMerge: async (prNumber: number, headSha: string) => {
+      autoMergeCalls.push({ prNumber, headSha });
+    },
+  };
+
+  const merged = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(merged.state, "addressing_review");
+  assert.deepEqual(autoMergeCalls, []);
+  assert.equal(comments.length, 0);
 });
 
 test("handlePostTurnPullRequestTransitions refreshes PR state after marking ready", async () => {

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -7,8 +7,13 @@ import { syncCopilotReviewRequestObservation } from "../pull-request-state-sync"
 import { Supervisor } from "./supervisor";
 import { GitHubIssue, GitHubPullRequest, PullRequestCheck, ReviewThread, SupervisorStateFile } from "../core/types";
 import {
+  CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+  createCodexConnectorTrackedReviewResidueScenario,
+} from "../codex-connector-tracked-pr-test-helpers";
+import {
   branchName,
   createConfig,
+  createPullRequest,
   createRecord,
   createSupervisorFixture,
   executionReadyBody,
@@ -347,6 +352,107 @@ test("handlePostTurnPullRequestTransitions waits for Copilot propagation after m
   assert.equal(readyCalls, 1);
   assert.equal(autoMergeCalls, 0);
   assert.equal(snapshotLoads, 2);
+});
+
+test("handlePostTurnMergeAndCompletion treats verified current-head repair residue as Codex no-major evidence", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 2373;
+  const branch = branchName(fixture.config, issueNumber);
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Treat verified residue as merge ready",
+    body: runnableCodexIssueBody("Treat verified residue as merge ready."),
+    createdAt: "2026-06-14T00:00:00Z",
+    updatedAt: "2026-06-14T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber: 3980,
+    headSha: "head-verified-repair-residue",
+    branch,
+    threadId: "thread-verified-repair-residue",
+    commentId: "comment-verified-repair-residue",
+    path: "src/review-policy.ts",
+    line: 14,
+    severity: "P2",
+    commentBody: "P2: Verify this current-head repair before merge.",
+    discussionUrl: "https://example.test/pr/3980#discussion_verified_repair_residue",
+    verifiedRepair: {
+      summary: "Focused verifier passed after the repair commit.",
+      ranAt: "2026-06-14T00:18:00Z",
+      command: "npm test -- src/review-policy.test.ts",
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-13T00:17:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        branch,
+        blocked_reason: null,
+        last_error: null,
+        last_failure_context: null,
+      }),
+    },
+  };
+  const comments: Array<{ issueNumber: number; body: string }> = [];
+  const autoMergeCalls: Array<{ prNumber: number; headSha: string }> = [];
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, 3980);
+    return { pr, checks: scenario.passingChecks, reviewThreads: [scenario.reviewThread] };
+  };
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    addIssueComment: async (commentIssueNumber: number, body: string) => {
+      comments.push({ issueNumber: commentIssueNumber, body });
+    },
+    enableAutoMerge: async (prNumber: number, headSha: string) => {
+      autoMergeCalls.push({ prNumber, headSha });
+    },
+  };
+
+  const merged = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(merged.state, "merging");
+  assert.equal(merged.blocked_reason, null);
+  assert.deepEqual(autoMergeCalls, [{ prNumber: 3980, headSha: "head-verified-repair-residue" }]);
+  assert.equal(comments.length, 1);
+  assert.match(comments[0]?.body ?? "", /Final auto-merge guard passed for head/);
+  assert.doesNotMatch(merged.last_failure_signature ?? "", /missing_current_head_codex_no_major/);
+  assert.match(
+    merged.last_auto_merge_guard_context?.details.join("\\n") ?? "",
+    /codex_verified_current_head_repair_residue=yes/,
+  );
 });
 
 test("handlePostTurnPullRequestTransitions refreshes PR state after marking ready", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -121,6 +121,10 @@ export interface SupervisorExplainDto {
   staleDiagnosticSummary?: string | null;
   staleReviewBotRemediation?: StaleReviewBotRemediationDto | null;
   staleReviewBotThreadDiagnostics?: StaleReviewBotThreadDiagnosticsDto | null;
+  staleReviewBotPr?: Pick<
+    GitHubPullRequest,
+    "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
+  > | null;
   effectiveReviewThreadDiagnosticsSummary?: string | null;
   codexConnectorOperatorDiagnosticSummary?: string | null;
   codexConnectorPolicyBlockSummary?: string | null;
@@ -610,6 +614,7 @@ export async function buildIssueExplainDto(
     staleDiagnosticSummary,
     staleReviewBotRemediation,
     staleReviewBotThreadDiagnostics,
+    staleReviewBotPr: staleReviewBotRemediation && pr ? pr : null,
     effectiveReviewThreadDiagnosticsSummary,
     codexConnectorOperatorDiagnosticSummary: codexConnectorDiagnostics?.operatorDiagnosticSummary ?? null,
     codexConnectorPolicyBlockSummary: codexConnectorDiagnostics?.policyBlockSummary ?? null,
@@ -704,6 +709,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
           formatStaleReviewBotTerminalStopLine({
             remediation: dto.staleReviewBotRemediation,
             diagnostics: dto.staleReviewBotThreadDiagnostics,
+            pr: dto.staleReviewBotPr,
           }),
         ].filter((line): line is string => line !== null)
       : []),

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -125,6 +125,7 @@ export interface SupervisorExplainDto {
     GitHubPullRequest,
     "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
   > | null;
+  staleReviewBotChecks?: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null;
   effectiveReviewThreadDiagnosticsSummary?: string | null;
   codexConnectorOperatorDiagnosticSummary?: string | null;
   codexConnectorPolicyBlockSummary?: string | null;
@@ -615,6 +616,7 @@ export async function buildIssueExplainDto(
     staleReviewBotRemediation,
     staleReviewBotThreadDiagnostics,
     staleReviewBotPr: staleReviewBotRemediation && pr ? pr : null,
+    staleReviewBotChecks: staleReviewBotRemediation ? explainChecks : null,
     effectiveReviewThreadDiagnosticsSummary,
     codexConnectorOperatorDiagnosticSummary: codexConnectorDiagnostics?.operatorDiagnosticSummary ?? null,
     codexConnectorPolicyBlockSummary: codexConnectorDiagnostics?.policyBlockSummary ?? null,
@@ -710,6 +712,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
             remediation: dto.staleReviewBotRemediation,
             diagnostics: dto.staleReviewBotThreadDiagnostics,
             pr: dto.staleReviewBotPr,
+            checks: dto.staleReviewBotChecks,
           }),
         ].filter((line): line is string => line !== null)
       : []),

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -95,6 +95,7 @@ import {
   effectiveReviewThreadDiagnostics,
   formatEffectiveReviewThreadDiagnosticsLine,
 } from "../review-thread-reporting";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
 
 export type ExplainIssueGitHub =
   Pick<GitHubClient, "getIssue" | "listAllIssues" | "listCandidateIssues"> &
@@ -126,6 +127,7 @@ export interface SupervisorExplainDto {
     "state" | "isDraft" | "mergeStateStatus" | "mergeable" | "reviewDecision"
   > | null;
   staleReviewBotChecks?: ReadonlyArray<Pick<PullRequestCheck, "bucket">> | null;
+  staleReviewBotLocalCiAllowsMergeReady?: boolean;
   effectiveReviewThreadDiagnosticsSummary?: string | null;
   codexConnectorOperatorDiagnosticSummary?: string | null;
   codexConnectorPolicyBlockSummary?: string | null;
@@ -617,6 +619,10 @@ export async function buildIssueExplainDto(
     staleReviewBotThreadDiagnostics,
     staleReviewBotPr: staleReviewBotRemediation && pr ? pr : null,
     staleReviewBotChecks: staleReviewBotRemediation ? explainChecks : null,
+    staleReviewBotLocalCiAllowsMergeReady:
+      staleReviewBotRemediation && record && pr
+        ? !hasConfiguredLocalCiCommand(config) || !currentHeadLocalCiMissing(record, pr)
+        : true,
     effectiveReviewThreadDiagnosticsSummary,
     codexConnectorOperatorDiagnosticSummary: codexConnectorDiagnostics?.operatorDiagnosticSummary ?? null,
     codexConnectorPolicyBlockSummary: codexConnectorDiagnostics?.policyBlockSummary ?? null,
@@ -713,6 +719,7 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
             diagnostics: dto.staleReviewBotThreadDiagnostics,
             pr: dto.staleReviewBotPr,
             checks: dto.staleReviewBotChecks,
+            localCiAllowsMergeReady: dto.staleReviewBotLocalCiAllowsMergeReady,
           }),
         ].filter((line): line is string => line !== null)
       : []),

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -23,6 +23,7 @@ import {
   inferStateFromPullRequest,
   inferGitHubWaitStep,
 } from "../pull-request-state";
+import { hasVerifiedCurrentHeadRepairReviewMetadataResidue } from "../pull-request-state-codex-residue-policy";
 import { hasCodexConnectorPrSuccessCurrentHeadObservation } from "../codex-connector-review-policy";
 import {
   syncCopilotReviewRequestObservation,
@@ -268,7 +269,14 @@ function finalAutoMergeGuard(args: {
     reviewThreads,
   ).length;
   const effectiveHumanBlockers = config.humanReviewBlocksMerge ? manualReviewThreads(config, reviewThreads).length : 0;
-  const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr);
+  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+    config,
+    record,
+    pr: currentPr,
+    checks,
+    reviewThreads,
+  });
+  const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr) || verifiedCurrentHeadRepairResidue;
   const requiresCodexNoMajor = autoMergePath === "codex_connector_no_major";
   const aggregateHumanReviewBlocker =
     config.humanReviewBlocksMerge &&
@@ -289,6 +297,7 @@ function finalAutoMergeGuard(args: {
     requiresCodexNoMajor
       ? `codex_current_head_no_major=${currentHeadCodexNoMajor ? "yes" : "no"}`
       : "codex_current_head_no_major=not_required",
+    `codex_verified_current_head_repair_residue=${verifiedCurrentHeadRepairResidue ? "yes" : "no"}`,
     `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     `human_blockers=${effectiveHumanBlockers}`,
     `review_decision=${currentPr.reviewDecision ?? "none"}`,


### PR DESCRIPTION
## Summary

- Treat verified current-head Codex repair-review residue as merge-ready evidence instead of requiring a human to resolve stale review threads manually.
- Wire that evidence through the runtime final auto-merge guard, Decision Kernel v2 explain output, stale-review-bot classification, diagnostics, and operator-action suppression.
- Preserve the blocking path when GitHub still reports the PR as blocked, when verification evidence is missing, or when P0/P1 findings remain.

## Why

After #2370 and #2372, Supervisor could determine that the current head had no remaining actionable Codex review findings, while still cycling back to `blocked_reason=stale_review_bot` because old review-thread metadata remained unresolved. That leaves the loop dependent on manual Codex review-thread resolution even though the product concept is to let Supervisor advance when the current head is already verified clean.

This change treats that as a category-level Decision Kernel v2 behavior gap rather than a one-off exception for HRCore #398: verified current-head repair residue becomes explicit merge-ready evidence, while ambiguous or still-blocked states keep the existing manual intervention path.

## Notable changes

- Added shared residue policy detection for verified current-head repair-review metadata residue.
- Updated PR readiness and v2 explain logic to accept that residue as Codex no-major-equivalent evidence.
- Updated stale-review-bot classification and diagnostics to emit a merge-ready path only when verification is present and auto-repair is not suppressed.
- Updated operator actions so `resolve_stale_review_bot` is suppressed only when GitHub/local diagnostics agree the residue is non-blocking.
- Added regression coverage for runtime readiness, Decision Kernel v2 explain, and operator-action behavior.

## Verification

- `npx tsx --test --test-name-pattern 'verified current-head repair residue' src/decision-kernel/v2-explain.test.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `npx tsx --test src/operator-actions.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts`
- `npx tsx --test src/post-turn-pull-request-codex-connector.test.ts src/pull-request-state-codex-residue-policy.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-execution-orchestration.test.ts src/operator-actions.test.ts src/decision-kernel/v2-explain.test.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `npm run build`
- `npm run verify:supervisor-pre-pr`

Fixes #2373